### PR TITLE
Remove permanent errors from DynamoDB Streams

### DIFF
--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -27,7 +27,7 @@ use aws_sdk_dynamodb::types::AttributeValue as DynamoDbAttributeValue;
 use aws_sdk_dynamodbstreams::types::AttributeValue as StreamsAttributeValue;
 use aws_sdk_dynamodbstreams::types::OperationType;
 use datafusion::error::DataFusionError;
-use dynamodb_streams::StreamResult;
+use dynamodb_streams::DynamoDBStreamBatch;
 use dynamodb_streams::checkpoint::Checkpoint;
 use snafu::prelude::*;
 use std::collections::HashMap;
@@ -119,14 +119,13 @@ fn get_primary_keys_array(primary_keys: &[String], row_count: usize) -> ListArra
 // This function is used for processing stream batches which have checkpoints.
 // Incoming batches are from DynamoDB Streams.
 pub fn process_batch(
-    batch: StreamResult,
+    batch: DynamoDBStreamBatch,
     table_schema: &Arc<Schema>,
     primary_keys: &[String],
     unnest_depth: Option<usize>,
     time_format: &str,
     json_nesting: Option<&JsonNesting>,
 ) -> Result<(ChangeBatch, Checkpoint, Option<SystemTime>), StreamError> {
-    let batch = batch.context(FailedToReceiveMessageSnafu)?;
     let records = batch.records;
 
     let changes_schema = changes_schema(table_schema);
@@ -304,15 +303,14 @@ mod tests {
             .build()
     }
 
-    #[expect(clippy::unnecessary_wraps)]
-    fn create_stream_result(records: Vec<Record>) -> StreamResult {
-        Ok(DynamoDBStreamBatch {
+    fn create_stream_result(records: Vec<Record>) -> DynamoDBStreamBatch {
+        DynamoDBStreamBatch {
             records,
             checkpoint: Checkpoint {
                 shards: HashMap::default(),
             },
             watermark: None,
-        })
+        }
     }
 
     mod process_batch {

--- a/crates/dynamodb-streams/src/client.rs
+++ b/crates/dynamodb-streams/src/client.rs
@@ -121,6 +121,7 @@ impl Client {
         let retry_strategy = RetryBackoffBuilder::new()
             .method(BackoffMethod::Fibonacci)
             .max_retries(None)
+            .max_duration(Some(Duration::from_secs(60)))
             .build();
 
         let producer = DynamodbStreamProducer {

--- a/crates/dynamodb-streams/src/lib.rs
+++ b/crates/dynamodb-streams/src/lib.rs
@@ -33,8 +33,6 @@ pub use client::Client;
 pub use metrics::{Metrics, MetricsCollector};
 pub use stream::{DynamoDBStreamBatch, DynamodbStream};
 
-pub type StreamResult = Result<DynamoDBStreamBatch, Error>;
-
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
@@ -109,14 +107,6 @@ fn is_throttling_error_code(code: Option<&str>) -> bool {
 }
 
 impl Error {
-    #[must_use]
-    pub fn is_retriable(&self) -> bool {
-        matches!(
-            self,
-            Error::Timeout | Error::ConnectionFailure | Error::Throttled
-        )
-    }
-
     pub fn from_describe_table(err: SdkError<DescribeTableError>) -> Self {
         match err {
             SdkError::TimeoutError(_) => Error::Timeout,
@@ -202,96 +192,6 @@ impl Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    mod error_is_retriable {
-        use super::*;
-
-        #[test]
-        fn test_timeout_is_retriable() {
-            let err = Error::Timeout;
-            assert!(err.is_retriable());
-        }
-
-        #[test]
-        fn test_connection_failure_is_retriable() {
-            let err = Error::ConnectionFailure;
-            assert!(err.is_retriable());
-        }
-
-        #[test]
-        fn test_throttled_is_retriable() {
-            let err = Error::Throttled;
-            assert!(err.is_retriable());
-        }
-
-        #[test]
-        fn test_table_not_found_is_not_retriable() {
-            let err = Error::TableNotFound;
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_stream_not_found_is_not_retriable() {
-            let err = Error::StreamNotFound;
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_stream_description_not_found_is_not_retriable() {
-            let err = Error::StreamDescriptionNotFound {
-                stream_arn: "arn:aws:dynamodb:region:account:table/name/stream/time".to_string(),
-            };
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_shard_iterator_not_found_is_not_retriable() {
-            let err = Error::ShardIteratorNotFound {
-                shard_id: "shard-123".to_string(),
-            };
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_failed_to_initialize_checkpoint_is_not_retriable() {
-            let err = Error::FailedToInitializeCheckpoint;
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_stream_beyond_retention_is_not_retriable() {
-            let err = Error::StreamBeyondRetention;
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_shard_not_found_is_not_retriable() {
-            let err = Error::ShardNotFound;
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_missing_starting_sequence_number_is_not_retriable() {
-            let err = Error::MissingStaringSequenceNumber;
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_unexpected_shard_id_is_not_retriable() {
-            let err = Error::UnexpectedShardId {
-                shard_id: "shard-xyz".to_string(),
-            };
-            assert!(!err.is_retriable());
-        }
-
-        #[test]
-        fn test_iterator_expired_is_not_retriable() {
-            // Iterator expired is handled specially (reinitialization)
-            // but should NOT be in the retriable category
-            let err = Error::IteratorExpired;
-            assert!(!err.is_retriable());
-        }
-    }
 
     mod error_display {
         use super::*;

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -56,7 +56,7 @@ impl DynamodbStreamProducer {
         let mut had_error = false;
 
         // 1. Initialize shards that require iterators
-        self.initialize_shards_iterators().await;
+        had_error |= self.initialize_shards_iterators().await;
 
         // 2. Poll active shards
         let futures = self.state.get_active_shards().map(|shard| {
@@ -99,10 +99,11 @@ impl DynamodbStreamProducer {
         (combine_shard_batches(&poll_results), had_error)
     }
 
-    async fn initialize_shards_iterators(&mut self) {
+    async fn initialize_shards_iterators(&mut self) -> bool {
         let shards: Vec<InitializingShard> =
             self.state.get_initializing_shards().cloned().collect();
 
+        let mut had_error = false;
         for shard in shards {
             // Shards that were already polled use `After`.
             // Newly discovered shards use `At`.
@@ -125,6 +126,7 @@ impl DynamodbStreamProducer {
                     self.state.mark_active(shard.shard_id, iterator);
                 }
                 Err(e) => {
+                    had_error = true;
                     tracing::warn!(
                         "Failed to initialize shard. Will retry on next iteration: {}",
                         e
@@ -132,6 +134,7 @@ impl DynamodbStreamProducer {
                 }
             }
         }
+        had_error
     }
 
     pub async fn streaming(mut self) {

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -17,7 +17,6 @@ use crate::checkpoint::{Checkpoint, CheckpointPosition};
 use crate::client_sdk::SDKClient;
 use crate::metrics::MetricsCollector;
 use crate::stream_state::{InitializingShard, PollOutcome, ShardPollResult, StreamState};
-use crate::{Result, StreamResult};
 use aws_sdk_dynamodbstreams::types::{Record, ShardIteratorType};
 use futures::{Stream, future::join_all};
 use std::collections::HashMap;
@@ -37,7 +36,7 @@ pub struct DynamodbStreamProducer {
     pub stream_arn: String,
     pub state: StreamState,
     pub interval: Option<Duration>,
-    pub sender: mpsc::Sender<StreamResult>,
+    pub sender: mpsc::Sender<DynamoDBStreamBatch>,
     pub client: Arc<SDKClient>,
     pub retry_strategy: RetryBackoff,
     pub metrics_collector: Arc<MetricsCollector>,
@@ -52,13 +51,12 @@ pub struct DynamoDBStreamBatch {
 const DEFAULT_SLEEP_DURATION: Duration = Duration::from_millis(500);
 
 impl DynamodbStreamProducer {
-    async fn collect(&mut self) -> Result<(DynamoDBStreamBatch, bool)> {
+    async fn collect(&mut self) -> (DynamoDBStreamBatch, bool) {
         let mut poll_results = Vec::new();
-        let mut had_transient_error = false;
+        let mut had_error = false;
 
         // 1. Initialize shards that require iterators
-        // If permanent error is encountered, it is surfaced to the client.
-        self.initialize_shards_iterators().await?;
+        self.initialize_shards_iterators().await;
 
         // 2. Poll active shards
         let futures = self.state.get_active_shards().map(|shard| {
@@ -76,34 +74,32 @@ impl DynamodbStreamProducer {
         // 3. Process poll results
         for (shard_id, result) in results {
             let poll_result = match result {
-                Ok((next_iter, records)) => self
-                    .state
-                    .handle_poll_result(&shard_id, next_iter, records)?,
+                Ok((next_iter, records)) => {
+                    self.state.handle_poll_result(&shard_id, next_iter, records)
+                }
                 Err(e) => {
-                    had_transient_error = true;
-                    self.state.handle_poll_error(&shard_id, e)?
+                    had_error = true;
+                    self.state.handle_poll_error(&shard_id, e)
                 }
             };
-            poll_results.push(poll_result);
+            if let Some(poll_result) = poll_result {
+                poll_results.push(poll_result);
+            }
         }
 
         // 4. Discover new shards
-        // If permanent error is encountered, it is surfaced to the client.
         match self.client.get_all_shards(&self.stream_arn).await {
-            Ok(shards) => self.state.add_discovered(&shards)?,
+            Ok(shards) => self.state.add_discovered(&shards),
             Err(e) => {
-                if !e.is_retriable() {
-                    return Err(e);
-                }
-                had_transient_error = true;
+                had_error = true;
                 tracing::warn!("Failed to discover new shards. Will retry on next iteration: {e}");
             }
         }
 
-        Ok((combine_shard_batches(&poll_results), had_transient_error))
+        (combine_shard_batches(&poll_results), had_error)
     }
 
-    async fn initialize_shards_iterators(&mut self) -> Result<()> {
+    async fn initialize_shards_iterators(&mut self) {
         let shards: Vec<InitializingShard> =
             self.state.get_initializing_shards().cloned().collect();
 
@@ -129,18 +125,13 @@ impl DynamodbStreamProducer {
                     self.state.mark_active(shard.shard_id, iterator);
                 }
                 Err(e) => {
-                    if !e.is_retriable() {
-                        return Err(e);
-                    }
                     tracing::warn!(
-                        "Failed to initialize shard. Will retry on next iteration : {}",
+                        "Failed to initialize shard. Will retry on next iteration: {}",
                         e
                     );
                 }
             }
         }
-
-        Ok(())
     }
 
     pub async fn streaming(mut self) {
@@ -151,65 +142,50 @@ impl DynamodbStreamProducer {
                 *guard = self.state.get_active_shards().count();
             }
 
-            match self.collect().await {
-                Ok((batch, had_transient_error)) => {
-                    let is_batch_empty = batch.records.is_empty();
+            let (batch, had_error) = self.collect().await;
+            let is_batch_empty = batch.records.is_empty();
 
-                    self.metrics_collector
-                        .records
-                        .fetch_add(batch.records.len(), Ordering::Relaxed);
+            self.metrics_collector
+                .records
+                .fetch_add(batch.records.len(), Ordering::Relaxed);
 
-                    if let Some(watermark) = batch.watermark
-                        && let Ok(mut wm) = self.metrics_collector.watermark.write()
-                    {
-                        *wm = Some(watermark);
+            if let Some(watermark) = batch.watermark
+                && let Ok(mut wm) = self.metrics_collector.watermark.write()
+            {
+                *wm = Some(watermark);
+            }
+
+            if had_error {
+                self.metrics_collector
+                    .transient_errors
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+
+            // Send batch even if it's empty
+            if self.sender.send(batch).await.is_err() {
+                return;
+            }
+
+            if had_error {
+                if let Some(mut duration) = backoff.next_backoff() {
+                    if duration > Duration::from_secs(60) {
+                        duration = Duration::from_secs(1);
+                        backoff.reset();
                     }
-
-                    if had_transient_error {
-                        self.metrics_collector
-                            .transient_errors
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-
-                    // Send batch even if it's empty
-                    if self.sender.send(Ok(batch)).await.is_err() {
-                        return;
-                    }
-
-                    if had_transient_error {
-                        // Transient error occurred during collection - apply backoff
-                        if let Some(mut duration) = backoff.next_backoff() {
-                            // Avoid sleeping for more than 60 seconds
-                            if duration > Duration::from_secs(60) {
-                                duration = Duration::from_secs(1);
-                                backoff.reset();
-                            }
-                            tokio::time::sleep(duration).await;
-                        } else {
-                            // Backoff exhausted - transient errors persisted too long
-                            // Shouldn't happen as we should have infinite retries.
-                            return;
-                        }
-                    } else {
-                        // Clean success - reset backoff and use normal interval
-                        backoff = self.retry_strategy.clone();
-
-                        if is_batch_empty {
-                            // To avoid throttling - wait at least 500ms before polling again
-                            sleep(
-                                DEFAULT_SLEEP_DURATION
-                                    .max(self.interval.unwrap_or(Duration::from_secs(0))),
-                            )
-                            .await;
-                        } else if let Some(duration) = self.interval {
-                            sleep(duration).await;
-                        }
-                    }
+                    tokio::time::sleep(duration).await;
                 }
-                Err(e) => {
-                    // Permanent error - return immediately without retry
-                    let _ = self.sender.send(Err(e)).await;
-                    return;
+            } else {
+                // Clean cycle — reset backoff and use normal interval
+                backoff = self.retry_strategy.clone();
+
+                if is_batch_empty {
+                    // To avoid throttling - wait at least 500ms before polling again
+                    sleep(
+                        DEFAULT_SLEEP_DURATION.max(self.interval.unwrap_or(Duration::from_secs(0))),
+                    )
+                    .await;
+                } else if let Some(duration) = self.interval {
+                    sleep(duration).await;
                 }
             }
         }
@@ -290,11 +266,11 @@ fn combine_shard_batches(poll_results: &[ShardPollResult]) -> DynamoDBStreamBatc
 
 #[derive(Debug)]
 pub struct DynamodbStream {
-    pub receiver: mpsc::Receiver<StreamResult>,
+    pub receiver: mpsc::Receiver<DynamoDBStreamBatch>,
 }
 
 impl Stream for DynamodbStream {
-    type Item = StreamResult;
+    type Item = DynamoDBStreamBatch;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.receiver.poll_recv(cx)

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -79,7 +79,7 @@ impl DynamodbStreamProducer {
                 }
                 Err(e) => {
                     had_error = true;
-                    self.state.handle_poll_error(&shard_id, e)
+                    self.state.handle_poll_error(&shard_id, &e)
                 }
             };
             if let Some(poll_result) = poll_result {

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -170,11 +170,7 @@ impl DynamodbStreamProducer {
             }
 
             if had_error {
-                if let Some(mut duration) = backoff.next_backoff() {
-                    if duration > Duration::from_secs(60) {
-                        duration = Duration::from_secs(1);
-                        backoff.reset();
-                    }
+                if let Some(duration) = backoff.next_backoff() {
                     tokio::time::sleep(duration).await;
                 }
             } else {

--- a/crates/dynamodb-streams/src/stream_state.rs
+++ b/crates/dynamodb-streams/src/stream_state.rs
@@ -181,7 +181,7 @@ impl StreamState {
         })
     }
 
-    pub fn handle_poll_error(&mut self, shard_id: &str, error: Error) -> Option<ShardPollResult> {
+    pub fn handle_poll_error(&mut self, shard_id: &str, error: &Error) -> Option<ShardPollResult> {
         let Some(shard) = self.active.get(shard_id) else {
             tracing::warn!("Received poll error for unknown shard {shard_id}, skipping");
             return None;
@@ -1155,7 +1155,7 @@ mod tests {
         #[test]
         fn test_handle_poll_error_shard_not_found() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
-            let result = state.handle_poll_error("nonexistent-shard", Error::Timeout);
+            let result = state.handle_poll_error("nonexistent-shard", &Error::Timeout);
 
             assert!(result.is_none());
         }
@@ -1179,7 +1179,7 @@ mod tests {
                 },
             );
 
-            let result = state.handle_poll_error("shard-1", Error::Timeout);
+            let result = state.handle_poll_error("shard-1", &Error::Timeout);
 
             assert!(result.is_some());
             let poll_result = result.expect("result");
@@ -1211,7 +1211,7 @@ mod tests {
                 },
             );
 
-            let result = state.handle_poll_error("shard-1", Error::ConnectionFailure);
+            let result = state.handle_poll_error("shard-1", &Error::ConnectionFailure);
 
             result.expect("should be ok");
             assert!(state.active.contains_key("shard-1"));
@@ -1236,7 +1236,7 @@ mod tests {
                 },
             );
 
-            let result = state.handle_poll_error("shard-1", Error::Throttled);
+            let result = state.handle_poll_error("shard-1", &Error::Throttled);
 
             result.expect("should be ok");
             assert!(state.active.contains_key("shard-1"));
@@ -1262,7 +1262,7 @@ mod tests {
                 },
             );
 
-            let result = state.handle_poll_error("shard-1", Error::IteratorExpired);
+            let result = state.handle_poll_error("shard-1", &Error::IteratorExpired);
 
             assert!(result.is_some());
             let poll_result = result.expect("result");
@@ -1305,7 +1305,7 @@ mod tests {
 
             // All errors (including previously-permanent ones) return Ok(PollOutcome::Failed)
             // so the shard stays active and is retried on the next iteration.
-            let result = state.handle_poll_error("shard-1", Error::StreamBeyondRetention);
+            let result = state.handle_poll_error("shard-1", &Error::StreamBeyondRetention);
 
             assert!(result.is_some());
             assert!(matches!(
@@ -1335,7 +1335,7 @@ mod tests {
                 },
             );
 
-            let result = state.handle_poll_error("shard-1", Error::Timeout);
+            let result = state.handle_poll_error("shard-1", &Error::Timeout);
 
             assert!(result.is_some());
             let poll_result = result.expect("result");

--- a/crates/dynamodb-streams/src/stream_state.rs
+++ b/crates/dynamodb-streams/src/stream_state.rs
@@ -241,15 +241,6 @@ impl StreamState {
                 continue;
             }
 
-            self.historical.insert(
-                shard_id.clone(),
-                HistoricalShard {
-                    shard_id: shard_id.clone(),
-                    parent_shard_id: shard.parent_shard_id.clone(),
-                    created_at: SystemTime::now(),
-                },
-            );
-
             // Shards in DynamoDB Streams have a parent-child relationship.
             // Until we exhausted the parent shard, we don't want to read from its children.
             // As long as the parent of the discovered shard is either active/pending/initializing,
@@ -276,6 +267,17 @@ impl StreamState {
                 );
                 continue;
             };
+
+            // Insert into historical only after required fields are validated so a shard
+            // with missing metadata can be retried on the next discovery cycle.
+            self.historical.insert(
+                shard_id.clone(),
+                HistoricalShard {
+                    shard_id: shard_id.clone(),
+                    parent_shard_id: shard.parent_shard_id.clone(),
+                    created_at: SystemTime::now(),
+                },
+            );
             let checkpoint = ShardCheckpoint {
                 sequence_number,
                 parent_id: shard.parent_shard_id.clone(),

--- a/crates/dynamodb-streams/src/stream_state.rs
+++ b/crates/dynamodb-streams/src/stream_state.rs
@@ -109,11 +109,10 @@ impl StreamState {
         shard_id: &str,
         new_iterator: Option<String>,
         records: Vec<Record>,
-    ) -> Result<ShardPollResult> {
+    ) -> Option<ShardPollResult> {
         let Some(shard) = self.active.get(shard_id) else {
-            return Err(Error::UnexpectedShardId {
-                shard_id: shard_id.to_string(),
-            });
+            tracing::warn!("Received poll result for unknown shard {shard_id}, skipping");
+            return None;
         };
         let mut current_checkpoint = shard.last_checkpoint.clone();
         let mut current_watermark = shard.current_watermark;
@@ -174,7 +173,7 @@ impl StreamState {
             PollOutcome::Records { records }
         };
 
-        Ok(ShardPollResult {
+        Some(ShardPollResult {
             shard_id: shard_id.to_string(),
             outcome,
             last_checkpoint: current_checkpoint,
@@ -182,11 +181,10 @@ impl StreamState {
         })
     }
 
-    pub fn handle_poll_error(&mut self, shard_id: &str, error: Error) -> Result<ShardPollResult> {
+    pub fn handle_poll_error(&mut self, shard_id: &str, error: Error) -> Option<ShardPollResult> {
         let Some(shard) = self.active.get(shard_id) else {
-            return Err(Error::UnexpectedShardId {
-                shard_id: shard_id.to_string(),
-            });
+            tracing::warn!("Received poll error for unknown shard {shard_id}, skipping");
+            return None;
         };
 
         // Capture current state before any modifications
@@ -197,14 +195,7 @@ impl StreamState {
             current_watermark: shard.current_watermark,
         };
 
-        // Handle iterator expiration by reinitializing with current checkpoint
-        if error.is_retriable() {
-            tracing::warn!(
-                "Poll error for shard {}. Will retry on next iteration: {}",
-                shard_id,
-                error
-            );
-        } else if matches!(error, Error::IteratorExpired) {
+        if matches!(error, Error::IteratorExpired) {
             tracing::warn!(
                 "Iterator expired for shard {}, marking for reinitialization with checkpoint: {:?}",
                 shard_id,
@@ -212,10 +203,14 @@ impl StreamState {
             );
             self.reinitialize_shard_with_checkpoint(shard_id);
         } else {
-            return Err(error);
+            tracing::warn!(
+                "Poll error for shard {}. Will retry on next iteration: {}",
+                shard_id,
+                error
+            );
         }
 
-        Ok(result)
+        Some(result)
     }
 
     /// Reinitialize a shard when its iterator expires.
@@ -237,7 +232,7 @@ impl StreamState {
     }
 
     /// Add discovered shards, returns shard IDs that need initialization
-    pub fn add_discovered(&mut self, shards: &[ApiShard]) -> Result<()> {
+    pub fn add_discovered(&mut self, shards: &[ApiShard]) {
         for shard in shards.iter().cloned() {
             let shard_id = shard.shard_id.clone();
 
@@ -275,10 +270,14 @@ impl StreamState {
             tracing::debug!("Current state: {:#?}", self);
             tracing::debug!("Discovered shards: {:#?}", shards);
 
+            let Some(sequence_number) = shard.starting_sequence_number.clone() else {
+                tracing::warn!(
+                    "Skipping discovered shard {shard_id}: missing starting_sequence_number"
+                );
+                continue;
+            };
             let checkpoint = ShardCheckpoint {
-                sequence_number: shard
-                    .starting_sequence_number
-                    .context(MissingStaringSequenceNumberSnafu)?,
+                sequence_number,
                 parent_id: shard.parent_shard_id.clone(),
                 updated_at: SystemTime::now(),
                 position: CheckpointPosition::At,
@@ -305,8 +304,6 @@ impl StreamState {
                 );
             }
         }
-
-        Ok(())
     }
 
     /// Move shard from initializing to active with its iterator
@@ -544,7 +541,7 @@ mod tests {
                 vec![create_record("123")],
             );
 
-            assert!(result.is_err());
+            assert!(result.is_none());
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
             assert_eq!(state.initializing.len(), 0);
@@ -575,7 +572,7 @@ mod tests {
                 vec![create_record("123")],
             );
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("Expected result to be Ok");
             assert_eq!(result.shard_id, "shard-1");
             if let PollOutcome::Records { records } = result.outcome {
@@ -622,7 +619,7 @@ mod tests {
 
             let result = state.handle_poll_result("shard-1", None, vec![create_record("123")]);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("Expected result to be Ok");
             assert_eq!(result.shard_id, "shard-1");
             if let PollOutcome::Records { records } = result.outcome {
@@ -660,8 +657,8 @@ mod tests {
 
             let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), vec![]);
 
-            assert!(result.is_ok());
-            if let Ok(result) = result {
+            assert!(result.is_some());
+            if let Some(result) = result {
                 assert!(matches!(result.outcome, PollOutcome::Empty));
             }
 
@@ -784,7 +781,7 @@ mod tests {
 
             let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), records);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("Expected result to be Ok");
             assert_eq!(result.shard_id, "shard-1");
             if let PollOutcome::Records { records } = result.outcome {
@@ -852,7 +849,7 @@ mod tests {
             // Exhaust parent shard
             let result = state.handle_poll_result("parent", None, vec![create_record("100")]);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("Expected result to be Ok");
             assert_eq!(result.shard_id, "parent");
             assert_eq!(result.last_checkpoint.sequence_number, "100");
@@ -902,7 +899,7 @@ mod tests {
 
             let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), records);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("result");
 
             // Verify watermark is max timestamp (1010)
@@ -944,7 +941,7 @@ mod tests {
 
             let result = state.handle_poll_result("shard-1", Some("new-iter".to_string()), records);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("result");
 
             // Watermark should still be None
@@ -985,7 +982,7 @@ mod tests {
                 vec![create_record_without_seq()],
             );
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("result");
 
             // Checkpoint sequence should be unchanged
@@ -1029,7 +1026,7 @@ mod tests {
             // Shard exhausted (new_iterator = None) but has final records
             let result = state.handle_poll_result("shard-1", None, records);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("result");
 
             // Should have records
@@ -1077,7 +1074,7 @@ mod tests {
             // Shard exhausted with no records
             let result = state.handle_poll_result("shard-1", None, vec![]);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("result");
 
             // Should be empty
@@ -1158,12 +1155,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             let result = state.handle_poll_error("nonexistent-shard", Error::Timeout);
 
-            assert!(result.is_err());
-            if let Err(Error::UnexpectedShardId { shard_id }) = result {
-                assert_eq!(shard_id, "nonexistent-shard");
-            } else {
-                panic!("Expected UnexpectedShardId error");
-            }
+            assert!(result.is_none());
         }
 
         #[test]
@@ -1187,7 +1179,7 @@ mod tests {
 
             let result = state.handle_poll_error("shard-1", Error::Timeout);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let poll_result = result.expect("result");
             assert_eq!(poll_result.shard_id, "shard-1");
             assert!(matches!(poll_result.outcome, PollOutcome::Failed));
@@ -1270,7 +1262,7 @@ mod tests {
 
             let result = state.handle_poll_error("shard-1", Error::IteratorExpired);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let poll_result = result.expect("result");
             assert_eq!(poll_result.shard_id, "shard-1");
             assert!(matches!(poll_result.outcome, PollOutcome::Failed));
@@ -1291,7 +1283,7 @@ mod tests {
         }
 
         #[test]
-        fn test_handle_poll_error_permanent_error_returns_error() {
+        fn test_handle_poll_error_any_error_keeps_shard_active() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             state.active.insert(
                 "shard-1".to_string(),
@@ -1309,12 +1301,15 @@ mod tests {
                 },
             );
 
+            // All errors (including previously-permanent ones) return Ok(PollOutcome::Failed)
+            // so the shard stays active and is retried on the next iteration.
             let result = state.handle_poll_error("shard-1", Error::StreamBeyondRetention);
 
-            assert!(result.is_err());
-            assert!(matches!(result, Err(Error::StreamBeyondRetention)));
-
-            // Shard should still be active (error is propagated, not handled)
+            assert!(result.is_some());
+            assert!(matches!(
+                result.expect("result").outcome,
+                PollOutcome::Failed
+            ));
             assert!(state.active.contains_key("shard-1"));
         }
 
@@ -1340,7 +1335,7 @@ mod tests {
 
             let result = state.handle_poll_error("shard-1", Error::Timeout);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let poll_result = result.expect("result");
             assert_eq!(poll_result.current_watermark, Some(watermark));
         }
@@ -1459,7 +1454,7 @@ mod tests {
         #[test]
         fn test_add_discovered_empty_list() {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
-            state.add_discovered(&[]).expect("result");
+            state.add_discovered(&[]);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1474,7 +1469,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             let shards = vec![create_api_shard("shard-1", None, None)];
 
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1497,7 +1492,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
             let shards = vec![create_api_shard("shard-1", None, Some("999"))];
 
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             // Closed shards are ignored
             assert_eq!(state.active.len(), 0);
@@ -1539,7 +1534,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 1);
@@ -1580,7 +1575,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -1622,7 +1617,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("child", Some("parent"), None)];
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
@@ -1672,7 +1667,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             // Should not change existing active shard
             assert_eq!(state.active.len(), 1);
@@ -1719,7 +1714,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
@@ -1765,7 +1760,7 @@ mod tests {
             );
 
             let shards = vec![create_api_shard("shard-1", None, None)];
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
@@ -1810,7 +1805,7 @@ mod tests {
                 create_api_shard("child-2", Some("nonexistent"), None), // Should go to initializing
             ];
 
-            state.add_discovered(&shards).expect("result");
+            state.add_discovered(&shards);
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 1);
@@ -1912,7 +1907,7 @@ mod tests {
             create_api_shard("shard-A", None, Some("100")),
         ];
 
-        state.add_discovered(&discovered).expect("result");
+        state.add_discovered(&discovered);
 
         assert!(
             !state.initializing.contains_key("shard-A"),
@@ -2518,9 +2513,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
 
             // Discover initial shard
-            state
-                .add_discovered(&[create_api_shard("shard-1", None, None)])
-                .expect("result");
+            state.add_discovered(&[create_api_shard("shard-1", None, None)]);
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
             assert_eq!(state.initializing.len(), 1);
@@ -2562,7 +2555,7 @@ mod tests {
 
             // Exhaust shard
             let result = state.handle_poll_result("shard-1", None, vec![create_record("101")]);
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("Expected result to be Ok");
             assert_eq!(result.shard_id, "shard-1");
             assert_eq!(result.last_checkpoint.sequence_number, "101");
@@ -2578,12 +2571,10 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
 
             // Discover parent and child
-            state
-                .add_discovered(&[
-                    create_api_shard("parent", None, None),
-                    create_api_shard("child", Some("parent"), None),
-                ])
-                .expect("result");
+            state.add_discovered(&[
+                create_api_shard("parent", None, None),
+                create_api_shard("child", Some("parent"), None),
+            ]);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
@@ -2639,13 +2630,11 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
 
             // Add three generations
-            state
-                .add_discovered(&[
-                    create_api_shard("gen1", None, None),
-                    create_api_shard("gen2", Some("gen1"), None),
-                    create_api_shard("gen3", Some("gen2"), None),
-                ])
-                .expect("result");
+            state.add_discovered(&[
+                create_api_shard("gen1", None, None),
+                create_api_shard("gen2", Some("gen1"), None),
+                create_api_shard("gen3", Some("gen2"), None),
+            ]);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -2661,9 +2650,7 @@ mod tests {
             assert_eq!(state.initializing.len(), 0);
 
             // Exhaust gen1
-            state
-                .handle_poll_result("gen1", None, vec![create_record("100")])
-                .expect("result");
+            state.handle_poll_result("gen1", None, vec![create_record("100")]);
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 1);
             assert_eq!(state.initializing.len(), 1);
@@ -2677,9 +2664,7 @@ mod tests {
             assert_eq!(state.initializing.len(), 0);
 
             // Exhaust gen2
-            state
-                .handle_poll_result("gen2", None, vec![create_record("200")])
-                .expect("result");
+            state.handle_poll_result("gen2", None, vec![create_record("200")]);
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 0);
             assert_eq!(state.initializing.len(), 1);
@@ -2703,13 +2688,11 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
 
             // Parent splits into two children
-            state
-                .add_discovered(&[
-                    create_api_shard("parent", None, None),
-                    create_api_shard("child-a", Some("parent"), None),
-                    create_api_shard("child-b", Some("parent"), None),
-                ])
-                .expect("result");
+            state.add_discovered(&[
+                create_api_shard("parent", None, None),
+                create_api_shard("child-a", Some("parent"), None),
+                create_api_shard("child-b", Some("parent"), None),
+            ]);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -2725,9 +2708,7 @@ mod tests {
             assert!(state.blocked.contains_key("child-b"));
 
             // Exhaust parent
-            state
-                .handle_poll_result("parent", None, vec![create_record("100")])
-                .expect("result");
+            state.handle_poll_result("parent", None, vec![create_record("100")]);
 
             // Both children should now be initializing
             assert_eq!(state.active.len(), 0);
@@ -2768,9 +2749,7 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
 
             // Add initial shard
-            state
-                .add_discovered(&[create_api_shard("shard-1", None, None)])
-                .expect("result");
+            state.add_discovered(&[create_api_shard("shard-1", None, None)]);
             state.mark_active("shard-1".to_string(), "iter-1".to_string());
 
             assert_eq!(state.active.len(), 1);
@@ -2778,9 +2757,7 @@ mod tests {
             assert_eq!(state.initializing.len(), 0);
 
             // Rediscover same shard - should be ignored
-            state
-                .add_discovered(&[create_api_shard("shard-1", None, None)])
-                .expect("result");
+            state.add_discovered(&[create_api_shard("shard-1", None, None)]);
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 0);
@@ -2825,7 +2802,7 @@ mod tests {
 
             let result = state.handle_poll_result("shard-1", Some("iter-2".to_string()), records);
 
-            assert!(result.is_ok());
+            assert!(result.is_some());
             let result = result.expect("Expected result to be Ok");
             assert_eq!(result.shard_id, "shard-1");
             if let PollOutcome::Records { records } = result.outcome {
@@ -2914,14 +2891,12 @@ mod tests {
             let mut state = StreamState::new("arn:aws:stream:test".to_string());
 
             // Two independent parent-child chains
-            state
-                .add_discovered(&[
-                    create_api_shard("parent-1", None, None),
-                    create_api_shard("parent-2", None, None),
-                    create_api_shard("child-1", Some("parent-1"), None),
-                    create_api_shard("child-2", Some("parent-2"), None),
-                ])
-                .expect("result");
+            state.add_discovered(&[
+                create_api_shard("parent-1", None, None),
+                create_api_shard("parent-2", None, None),
+                create_api_shard("child-1", Some("parent-1"), None),
+                create_api_shard("child-2", Some("parent-2"), None),
+            ]);
 
             assert_eq!(state.active.len(), 0);
             assert_eq!(state.blocked.len(), 2);
@@ -2935,9 +2910,7 @@ mod tests {
             assert_eq!(state.initializing.len(), 0);
 
             // Exhaust parent-1
-            state
-                .handle_poll_result("parent-1", None, vec![create_record("100")])
-                .expect("result");
+            state.handle_poll_result("parent-1", None, vec![create_record("100")]);
 
             assert_eq!(state.active.len(), 1);
             assert_eq!(state.blocked.len(), 1);

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -760,7 +760,7 @@ fn resume_from_checkpoint_stream(
                     if lag_exceeds_behavior == LagExceedsShardRetentionBehavior::Error {
                         tracing::error!(
                             dataset = %dataset_name,
-                            "DynamoDB Stream data has exceeded 24h retention period. Configured behavior is 'error'"
+                            "DynamoDB Streams checkpoint is older than the stream retention window; ingestion cannot resume from the saved checkpoint."
                         );
                         Some(
                             stream::once(async move {
@@ -775,8 +775,8 @@ fn resume_from_checkpoint_stream(
                     } else {
                         tracing::info!(
                             dataset = %dataset_name,
-                            behavior = ?lag_exceeds_behavior,
-                            "DynamoDB Stream data has exceeded 24h retention period. Initiating table re-initialization"
+                            "DynamoDB Streams checkpoint is older than the stream retention window; \
+                             ingestion cannot resume from the saved checkpoint. Rebuilding the dataset from a fresh DynamoDB table scan."
                         );
                         rebootstrap_table(
                             &dynamodb,

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -50,8 +50,8 @@ use std::{any::Any, future::Future, pin::Pin, sync::Arc};
 use tokio::sync::Mutex;
 use util::time_format::is_valid_format;
 
-// If we get `ShardNotFound` error on startup and checkpoint is old enough, behavior will depend on
-// lag_exceeds_shard_retention_behavior param.
+// If we get `ShardNotFound` or `StreamBeyondRetention` on startup and checkpoint is old enough,
+// behavior will depend on lag_exceeds_shard_retention_behavior param.
 // DynamoDB retention is 24h, and shards expire every 4h. 2h are added for safety.
 const CHECKPOINT_EXPIRATION_HOURS: u64 = 18;
 
@@ -80,7 +80,7 @@ const DEFAULT_SCHEMA_INFER_MAX_RECORDS_STR: &str = "10";
 const SEGMENTS_AUTO_STR: &str = "auto";
 const DEFAULT_TIME_FORMAT: &str = "2006-01-02T15:04:05.000Z07:00";
 
-/// Behavior when the stream lag exceeds shard retention (`ShardNotFound` error).
+/// Behavior when the stream lag exceeds shard retention (`ShardNotFound` or `StreamBeyondRetention`).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum LagExceedsShardRetentionBehavior {
     /// Dataset is marked as Error state.
@@ -738,6 +738,45 @@ fn resume_from_checkpoint_stream(
                             lag_age = %humantime::format_duration(checkpoint_age),
                             behavior = ?lag_exceeds_behavior,
                             "DynamoDB table lag references expired shard. Initiating table re-initialization"
+                        );
+                        rebootstrap_table(
+                            &dynamodb,
+                            &dynamodb_sys,
+                            acceptable_lag,
+                            &dataset_name,
+                            accelerated_table_provider,
+                            accelerator_write_mutex,
+                            lag_exceeds_behavior,
+                            metrics_collector,
+                            cpu_runtime,
+                        )
+                        .await
+                    }
+                }
+                Err(Error::FailedToInitializeCheckpoint {
+                    source: dynamodb_streams::Error::StreamBeyondRetention,
+                }) => {
+                    // StreamBeyondRetention definitively means checkpoint is >24h old
+                    if lag_exceeds_behavior == LagExceedsShardRetentionBehavior::Error {
+                        tracing::error!(
+                            dataset = %dataset_name,
+                            "DynamoDB Stream data has exceeded 24h retention period. Configured behavior is 'error'"
+                        );
+                        Some(
+                            stream::once(async move {
+                                Err(StreamError::DynamoDB(
+                                    DynamoDBStreamError::FailedToReceiveMessage {
+                                        source: dynamodb_streams::Error::StreamBeyondRetention,
+                                    },
+                                ))
+                            })
+                            .boxed(),
+                        )
+                    } else {
+                        tracing::info!(
+                            dataset = %dataset_name,
+                            behavior = ?lag_exceeds_behavior,
+                            "DynamoDB Stream data has exceeded 24h retention period. Initiating table re-initialization"
                         );
                         rebootstrap_table(
                             &dynamodb,


### PR DESCRIPTION
## 📝 Summary

Closes https://github.com/spiceai/spiceai/issues/10755

Treat all errors as part of stream processing in `dynamodb-streams` as transient:
* No error shuts down the stream
* After each error retry with backoff is applied
* Apply same `LagExceedsShardRetentionBehavior` logic that we do for `ShardNotFoundError` to `StreamBeyondRetentionError`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->