### PR TITLE
Update device login flow to use new OAuth endpoints

### DIFF
--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -1024,11 +1024,7 @@ async fn execute_apps(args: &AppsArgs) -> Result<()> {
         "CREATED",
     ]);
     for app in &apps {
-        let display_name = if app.org.is_empty() {
-            format!("{}/{}", context.org_name, app.name)
-        } else {
-            app.full_name()
-        };
+        let display_name = display_app_name(app, &context.org_name);
         table.add_row(vec![
             display_name,
             app.description.clone().unwrap_or_default(),
@@ -1042,6 +1038,23 @@ async fn execute_apps(args: &AppsArgs) -> Result<()> {
     table.print();
 
     Ok(())
+}
+
+/// Format an app's display name as `org/name`, falling back to the auth
+/// context org when the app payload does not include one. The Spice Cloud
+/// `/v1/apps` endpoint does not currently populate `org` on each app, so the
+/// auth context provides the only source of truth for the user's org.
+fn display_app_name(app: &spice_cloud_client::types::App, context_org: &str) -> String {
+    let org = if !app.org.is_empty() {
+        app.org.as_str()
+    } else {
+        context_org
+    };
+    if org.is_empty() {
+        app.name.clone()
+    } else {
+        format!("{org}/{}", app.name)
+    }
 }
 
 async fn execute_deployments(args: &DeploymentsArgs) -> Result<()> {
@@ -1728,5 +1741,37 @@ mod tests {
         unsafe { std::env::remove_var(env_var) };
 
         assert_eq!(value, "from-env");
+    }
+
+    fn test_app(org: &str, name: &str) -> spice_cloud_client::types::App {
+        spice_cloud_client::types::App {
+            id: 1,
+            name: name.to_string(),
+            org: org.to_string(),
+            description: None,
+            visibility: None,
+            created_at: None,
+            region: None,
+            production_branch: None,
+            config: None,
+        }
+    }
+
+    #[test]
+    fn display_app_name_uses_app_org_when_present() {
+        let app = test_app("analytics", "dashboard");
+        assert_eq!(display_app_name(&app, "fallback"), "analytics/dashboard");
+    }
+
+    #[test]
+    fn display_app_name_falls_back_to_context_org_when_app_org_is_empty() {
+        let app = test_app("", "dashboard");
+        assert_eq!(display_app_name(&app, "analytics"), "analytics/dashboard");
+    }
+
+    #[test]
+    fn display_app_name_omits_leading_slash_when_org_unavailable() {
+        let app = test_app("", "dashboard");
+        assert_eq!(display_app_name(&app, ""), "dashboard");
     }
 }

--- a/crates/spice-cloud-client/src/client.rs
+++ b/crates/spice-cloud-client/src/client.rs
@@ -681,7 +681,7 @@ mod tests {
     }
 
     #[test]
-    fn auth_url_uses_dashboard_path() {
+    fn auth_url_uses_oauth_token_path() {
         let client = CloudClient::new("https://api.spice.ai").expect("cloud client should build");
         assert_eq!(
             client.get_auth_url("ABCD1234"),

--- a/crates/spice-cloud-client/src/client.rs
+++ b/crates/spice-cloud-client/src/client.rs
@@ -23,11 +23,11 @@ use snafu::ResultExt;
 
 use crate::error::{self, HttpRequestSnafu, Result};
 use crate::types::{
-    ApiKeysResponse, App, AppsResponse, AuthContext, AuthExchangeResponse, ContainerImagesResponse,
-    CreateAppRequest, CreateDeploymentRequest, Deployment, DeploymentsResponse, LogsResponse,
-    MetricsResponse, OAuthTokenRequest, OAuthTokenResponse, RegenerateApiKeyRequest,
-    RegenerateApiKeyResponse, RegionsResponse, RollbackRequest, Secret, SecretsResponse,
-    SetSecretRequest, UpdateAppRequest,
+    ApiKeysResponse, App, AppsResponse, AuthContext, AuthContextRaw, AuthExchangeRequest,
+    AuthExchangeResponse, ContainerImagesResponse, CreateAppRequest, CreateDeploymentRequest,
+    Deployment, DeploymentsResponse, LogsResponse, MetricsResponse, OAuthTokenRequest,
+    OAuthTokenResponse, RegenerateApiKeyRequest, RegenerateApiKeyResponse, RegionsResponse,
+    RollbackRequest, Secret, SecretsResponse, SetSecretRequest, UpdateAppRequest,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.spice.ai";
@@ -104,24 +104,19 @@ impl CloudClient {
     /// Build the browser auth URL for the device login flow.
     #[must_use]
     pub fn get_auth_url(&self, auth_code: &str) -> String {
-        format!(
-            "{}/v1/auth/device?code={}",
-            self.oauth_base_url(),
-            auth_code
-        )
+        format!("{}/auth/token?code={}", self.oauth_base_url(), auth_code)
     }
 
     /// Exchange a device auth code for an access token.
     ///
     /// Returns `Ok(None)` while the user has not yet completed the browser flow.
     pub async fn exchange_code(&self, auth_code: &str) -> Result<Option<AuthExchangeResponse>> {
-        let url = format!(
-            "{}/v1/auth/device/exchange?code={}",
-            self.base_url, auth_code
-        );
+        let url = format!("{}/auth/token/exchange", self.oauth_base_url());
+        let request = AuthExchangeRequest { code: auth_code };
         let response = self
             .client
-            .get(&url)
+            .post(&url)
+            .json(&request)
             .send()
             .await
             .context(HttpRequestSnafu)?;
@@ -140,6 +135,10 @@ impl CloudClient {
         }
 
         let body: AuthExchangeResponse = response.json().await.context(HttpRequestSnafu)?;
+        // Pending: the server returned 200 but the code is not yet authorized.
+        if !body.access_denied && body.access_token.as_deref().is_none_or(|t| t.is_empty()) {
+            return Ok(None);
+        }
         Ok(Some(body))
     }
 
@@ -192,7 +191,7 @@ impl CloudClient {
 
     /// Get the authentication context for the current token.
     pub async fn get_auth_context(&self) -> Result<AuthContext> {
-        let url = format!("{}/v1/auth/context", self.base_url);
+        let url = format!("{}/api/spice-cli/auth", self.oauth_base_url());
         let response = self
             .client
             .get(&url)
@@ -201,7 +200,8 @@ impl CloudClient {
             .await
             .context(HttpRequestSnafu)?;
 
-        self.handle_response(response).await
+        let raw: AuthContextRaw = self.handle_response(response).await?;
+        Ok(raw.into())
     }
 
     // ========================================================================
@@ -657,6 +657,7 @@ fn oauth_host(host: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::CloudClient;
+    use crate::types::{AuthContext, AuthContextApp, AuthContextOrg, AuthContextRaw};
 
     #[test]
     fn oauth_base_url_rewrites_api_hosts() {
@@ -677,5 +678,60 @@ mod tests {
     fn oauth_base_url_leaves_non_api_hosts_unchanged() {
         let client = CloudClient::new("https://localhost:8090").expect("cloud client should build");
         assert_eq!(client.oauth_base_url(), "https://localhost:8090");
+    }
+
+    #[test]
+    fn auth_url_uses_dashboard_path() {
+        let client = CloudClient::new("https://api.spice.ai").expect("cloud client should build");
+        assert_eq!(
+            client.get_auth_url("ABCD1234"),
+            "https://spice.ai/auth/token?code=ABCD1234"
+        );
+    }
+
+    #[test]
+    fn auth_context_raw_flattens_nested_org_and_app() {
+        let raw = AuthContextRaw {
+            username: "ada".to_string(),
+            email: "ada@example.com".to_string(),
+            org: Some(AuthContextOrg {
+                name: Some("analytics".to_string()),
+            }),
+            app: Some(AuthContextApp {
+                name: Some("dashboard".to_string()),
+                api_key: Some("secret".to_string()),
+            }),
+        };
+        let ctx: AuthContext = raw.into();
+        assert_eq!(ctx.org_name, "analytics");
+        assert_eq!(ctx.app_name.as_deref(), Some("dashboard"));
+        assert_eq!(ctx.app_api_key.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn auth_context_raw_tolerates_missing_org_and_app() {
+        let raw: AuthContextRaw =
+            serde_json::from_str(r#"{"username":"ada","email":"ada@example.com"}"#)
+                .expect("parse minimal auth context");
+        let ctx: AuthContext = raw.into();
+        assert_eq!(ctx.username, "ada");
+        assert_eq!(ctx.org_name, "");
+        assert!(ctx.app_name.is_none());
+        assert!(ctx.app_api_key.is_none());
+    }
+
+    #[test]
+    fn auth_context_raw_parses_nested_wire_format() {
+        let body = r#"{
+            "username": "ada",
+            "email": "ada@example.com",
+            "org": {"name": "analytics"},
+            "app": {"name": "dashboard", "api_key": "secret"}
+        }"#;
+        let raw: AuthContextRaw = serde_json::from_str(body).expect("parse nested auth context");
+        let ctx: AuthContext = raw.into();
+        assert_eq!(ctx.org_name, "analytics");
+        assert_eq!(ctx.app_name.as_deref(), Some("dashboard"));
+        assert_eq!(ctx.app_api_key.as_deref(), Some("secret"));
     }
 }

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -347,14 +347,17 @@ pub struct RollbackRequest {
 // Auth
 // ============================================================================
 
-#[derive(Debug, Deserialize)]
+// Debug is intentionally not derived: access_token must not appear in logs or error output.
+#[derive(Deserialize)]
 pub struct AuthExchangeResponse {
     pub access_token: Option<String>,
     #[serde(default)]
     pub access_denied: bool,
 }
 
-#[derive(Debug, Serialize)]
+// Debug is intentionally not derived: the device auth `code` is short-lived but
+// exchangeable for an access token, so treat it like a secret.
+#[derive(Serialize)]
 pub struct AuthExchangeRequest<'a> {
     pub code: &'a str,
 }

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -350,7 +350,13 @@ pub struct RollbackRequest {
 #[derive(Debug, Deserialize)]
 pub struct AuthExchangeResponse {
     pub access_token: Option<String>,
+    #[serde(default)]
     pub access_denied: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthExchangeRequest<'a> {
+    pub code: &'a str,
 }
 
 // Debug is intentionally not derived: client_secret must not appear in logs or error output.
@@ -375,4 +381,47 @@ pub struct AuthContext {
     pub org_name: String,
     pub app_name: Option<String>,
     pub app_api_key: Option<String>,
+}
+
+/// Wire format for the Spice Cloud auth context endpoint, which returns
+/// `org` and `app` as nested objects. Flattened into [`AuthContext`] for the
+/// rest of the CLI.
+#[derive(Debug, Deserialize)]
+pub struct AuthContextRaw {
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub email: String,
+    #[serde(default)]
+    pub org: Option<AuthContextOrg>,
+    #[serde(default)]
+    pub app: Option<AuthContextApp>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AuthContextOrg {
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AuthContextApp {
+    pub name: Option<String>,
+    pub api_key: Option<String>,
+}
+
+impl From<AuthContextRaw> for AuthContext {
+    fn from(raw: AuthContextRaw) -> Self {
+        let org_name = raw.org.and_then(|o| o.name).unwrap_or_default();
+        let (app_name, app_api_key) = match raw.app {
+            Some(app) => (app.name, app.api_key),
+            None => (None, None),
+        };
+        Self {
+            username: raw.username,
+            email: raw.email,
+            org_name,
+            app_name,
+            app_api_key,
+        }
+    }
 }

--- a/docs/dev/cloud-login.md
+++ b/docs/dev/cloud-login.md
@@ -12,7 +12,7 @@ and the contracts each method has with the Spice Cloud API.
 `spice cloud login` authenticates the local CLI against Spice Cloud and writes
 a bearer token (and, when available, an app API key) to the local credential
 store. All methods converge on the same post-login path: write
-`SPICE_SPICEAI_TOKEN`, fetch `/v1/auth/context`, and (if present) write
+`SPICE_SPICEAI_TOKEN`, fetch `/api/spice-cli/auth`, and (if present) write
 `SPICE_SPICEAI_API_KEY`.
 
 There are three methods, addressed by Clap subcommands under
@@ -38,7 +38,7 @@ implemented in `execute_login_with_chooser`.
 - Subscription is the **default** human flow. `--device` is the
   headless/manual fallback for SSH or environments where `open::that`
   cannot launch a browser. Both modes use the same browser-mediated OAuth
-  flow against `/v1/auth/device`; they differ only in whether the CLI
+  flow against `/auth/token`; they differ only in whether the CLI
   auto-opens the URL.
 - PAT and API are **non-interactive**. They support env-only invocation for
   CI/headless use and never prompt when both stdin is non-TTY and the value
@@ -60,7 +60,7 @@ After a successful login, all methods call
    token that was just acquired.
 2. Calls `merge_auth_config("SPICEAI", &[("TOKEN", token)])` to persist
    `SPICE_SPICEAI_TOKEN` to `.env.local` (preferred) or `.env`.
-3. Calls `get_auth_context()` against `/v1/auth/context`. If the call
+3. Calls `get_auth_context()` against `/api/spice-cli/auth`. If the call
    succeeds and returns an `app_api_key`, writes
    `SPICE_SPICEAI_API_KEY` to the same env file.
 4. On failure, writes the token anyway and prints a yellow warning. The login
@@ -89,13 +89,15 @@ with `open_browser = !args.device`:
 
 1. Generates an 8-character `[A-Z0-9]` auth code locally.
 2. Builds the auth URL via `CloudClient::get_auth_url(auth_code)`, which
-   resolves to `{oauth_base_url}/v1/auth/device?code=<CODE>`.
+   resolves to `{oauth_base_url}/auth/token?code=<CODE>`.
 3. If `--device` is **not** set: auto-opens the URL in the system browser
    via `open::that`. If `--device` **is** set: only prints the URL and code,
    leaving it to the user to open them on another device.
-4. Polls `GET /v1/auth/device/exchange?code=<CODE>` once per second for up
-   to 5 minutes. The server returns `202 Accepted` while pending and
-   `200 OK` with `{ access_token, access_denied }` once complete.
+4. Polls `POST {oauth_base_url}/auth/token/exchange` with body
+   `{ "code": "<CODE>" }` once per second for up to 5 minutes. The server
+   returns `200 OK` with `{ access_token: null }` while pending (or
+   `202 Accepted`), and `200 OK` with `{ access_token, access_denied }`
+   once complete.
 5. On success, runs the shared post-login flow.
 
 User-facing characteristics:
@@ -191,10 +193,11 @@ Characteristics:
 
 ## OAuth host resolution
 
-The non-API OAuth host serves `/v1/auth/device` and `/api/oauth/token`. By
-contrast, `/v1/auth/device/exchange` polling uses the **API** base URL. When
-building non-API OAuth URLs, the data-plane API base URL contains an `api`
-segment that must be stripped.
+The non-API OAuth host serves `/auth/token`, `/auth/token/exchange`,
+`/api/spice-cli/auth`, and `/api/oauth/token`. The data-plane API base URL
+(used for `/v1/apps`, `/v1/regions`, etc.) is a separate host. When building
+non-API OAuth URLs, the data-plane API base URL contains an `api` segment
+that must be stripped.
 
 `CloudClient::oauth_base_url` parses with `reqwest::Url` and rewrites the
 host:
@@ -223,16 +226,21 @@ whatever that env var resolves to.
 Request:
 
 ```http
-GET {oauth_base}/v1/auth/device?code=ABCD1234
+GET {oauth_base}/auth/token?code=ABCD1234
 ```
 
 Polling:
 
 ```http
-GET {api_base}/v1/auth/device/exchange?code=ABCD1234
-202 Accepted                              # pending
-200 OK { "access_token": "...", "access_denied": false }   # done
-200 OK { "access_token": null, "access_denied": true }     # rejected
+POST {oauth_base}/auth/token/exchange
+Content-Type: application/json
+
+{ "code": "ABCD1234" }
+
+202 Accepted                                                 # pending
+200 OK { "access_token": null }                              # pending
+200 OK { "access_token": "...", "access_denied": false }     # done
+200 OK { "access_token": null, "access_denied": true }       # rejected
 ```
 
 ### Client credentials
@@ -257,21 +265,22 @@ token types fail loudly.
 ### Auth context (post-login probe)
 
 ```http
-GET {api_base}/v1/auth/context
+GET {oauth_base}/api/spice-cli/auth
 Authorization: Bearer <token>
 
 200 OK
 {
   "username": "...",
   "email": "...",
-  "org_name": "...",
-  "app_name": "...",          # optional
-  "app_api_key": "..."        # optional
+  "org":  { "name": "..." },
+  "app":  { "name": "...", "api_key": "..." }     # both optional
 }
 ```
 
-For client credentials logins, `username`/`email` may reflect the service
-principal rather than a person.
+The CLI flattens this into the in-memory `AuthContext` struct
+(`org_name`, `app_name`, `app_api_key`) via `AuthContextRaw::into()`. For
+client credentials logins, `username`/`email` may reflect the service
+principal rather than a person, and `app` may be absent.
 
 ## Adding a new login method
 


### PR DESCRIPTION
## 📝 Summary

Updates the device login flow to use new Spice Cloud OAuth endpoints and adjusts the auth context response handling to match the updated API contract.

**Key changes:**
- Device login now uses `POST /auth/token/exchange` with a JSON body instead of `GET /v1/auth/device/exchange?code=...`
- Auth URL generation updated to use `/auth/token?code=...` instead of `/v1/auth/device?code=...`
- Auth context endpoint changed from `/v1/auth/context` to `/api/spice-cli/auth`
- Added `AuthContextRaw` type to deserialize the nested wire format (`org` and `app` as objects) and implemented conversion to the flattened `AuthContext` struct
- Added `AuthExchangeRequest` type for the POST body
- Updated app display name logic to handle cases where the app payload doesn't include org information by falling back to the auth context org
- Updated documentation to reflect the new endpoint paths and request/response formats

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 📚 Docs

Updated `docs/dev/cloud-login.md` to document:
- New OAuth endpoint paths (`/auth/token`, `/auth/token/exchange`, `/api/spice-cli/auth`)
- Changed polling from GET query parameter to POST with JSON body
- Updated auth context response format (nested `org` and `app` objects)
- Clarified OAuth host resolution behavior

## 👀 Notes for Reviewers

- The `exchange_code` method now checks for `access_denied` flag and empty/null `access_token` to determine if the code is still pending authorization
- `AuthContextRaw::into()` flattens the nested response structure into the existing `AuthContext` struct for backward compatibility with the rest of the CLI
- Added comprehensive unit tests for `AuthContextRaw` deserialization and conversion, including edge cases with missing org/app fields
- Added tests for the new `display_app_name` helper function to ensure proper fallback behavior

https://claude.ai/code/session_015pR6hYhNCVdN3Tu1RnHePH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->