### PR TITLE
Fix Cayenne CDC schema mismatch error

### DIFF
--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -1084,4 +1084,96 @@ mod tests {
             .value(0);
         assert_eq!(value, 101, "Latest upserted value should be visible");
     }
+
+    /// Verifies that `CayenneDataSink::write_all` normalizes incoming batch schemas
+    /// to match the table schema. CDC (Debezium) batches can arrive with `NonNullable`
+    /// columns when the table schema declares them as `Nullable`, which would cause a
+    /// Vortex assertion failure without normalization.
+    #[tokio::test]
+    async fn test_insert_normalizes_nullable_schema_mismatch() {
+        let temp_dir = TempDir::new()
+            .expect("Failed to create temporary directory for schema normalization test");
+        let db_path = temp_dir.path().join("cayenne_schema_norm_test.db");
+        let connection_string = format!("sqlite://{}", db_path.to_string_lossy());
+
+        let catalog = Arc::new(
+            CayenneCatalog::new(&connection_string)
+                .expect("Failed to create CayenneCatalog instance"),
+        );
+        catalog.init().await.expect("to initialize catalog");
+
+        // Table schema: id NOT NULL, name NULLABLE
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let table_options = CreateTableOptions {
+            table_name: "schema_norm_test".to_string(),
+            schema: Arc::clone(&table_schema),
+            primary_key: vec![],
+            on_conflict: None,
+            base_path: temp_dir.path().to_string_lossy().to_string(),
+            partition_column: None,
+            vortex_config: crate::metadata::VortexConfig::default(),
+        };
+
+        let ctx = SessionContext::new();
+        let catalog_trait: Arc<dyn MetadataCatalog> =
+            Arc::clone(&catalog) as Arc<dyn MetadataCatalog>;
+        let provider =
+            CayenneTableProvider::create_table(catalog_trait, table_options, ctx.runtime_env())
+                .await
+                .expect("to create Cayenne table");
+
+        // Input schema: id NULLABLE (mismatches table's NOT NULL), name NULLABLE
+        // This simulates what CDC/Debezium sends — all columns as nullable.
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let input_batch = RecordBatch::try_new(
+            Arc::clone(&input_schema),
+            vec![
+                Arc::new(Int32Array::from(vec![Some(1), Some(2)])),
+                Arc::new(StringArray::from(vec![Some("Alice"), Some("Bob")])),
+            ],
+        )
+        .expect("to create input batch");
+
+        // Insert with mismatched nullability — should succeed after normalization
+        let input_exec =
+            MemorySourceConfig::try_new_exec(&[vec![input_batch]], Arc::clone(&input_schema), None)
+                .expect("to create MemorySourceConfig");
+
+        let insert_plan = provider
+            .insert_into(&ctx.state(), input_exec, InsertOp::Append)
+            .await
+            .expect("to insert into table with mismatched nullability");
+
+        collect(insert_plan, ctx.task_ctx())
+            .await
+            .expect("to execute insert");
+        // Verify the data is readable and the output schema matches the table schema
+        let scan_plan = provider
+            .scan(&ctx.state(), None, &[], None)
+            .await
+            .expect("to create scan plan after normalized insert");
+
+        let result = collect(scan_plan, ctx.task_ctx())
+            .await
+            .expect("to collect scan results");
+
+        let total_rows: usize = result.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total_rows, 2, "Expected 2 rows after insert");
+
+        // The output schema must match the table schema (Nullable for name),
+        // not the input schema
+        assert_eq!(
+            result[0].schema(),
+            table_schema,
+            "Output schema should match the table schema, not the input schema"
+        );
+    }
 }

--- a/crates/cayenne/src/provider/sink.rs
+++ b/crates/cayenne/src/provider/sink.rs
@@ -24,10 +24,12 @@ use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion::datasource::sink::DataSink;
 use datafusion::physical_plan::metrics::MetricsSet;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, SendableRecordBatchStream};
 use datafusion_common::Result as DFResult;
 use datafusion_execution::TaskContext;
 use datafusion_expr::dml::InsertOp;
+use futures::StreamExt;
 
 use super::constants::STAGING_DIR_NAME;
 use super::context::CayenneContext;
@@ -147,10 +149,25 @@ impl DataSink for CayenneDataSink {
         // prevent concurrent races on catalog state, snapshot IDs, and listing table.
         let _write_guard = self.table.write_lock().lock().await;
 
+        // Normalize incoming batches to the table schema (e.g. CDC nullability mismatches)
+        // causing Vortex assertion failures.
+        let target_schema = Arc::clone(&self.schema);
+        let normalized = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&target_schema),
+            data.map(move |batch_result| {
+                batch_result.and_then(|batch| {
+                    arrow_tools::record_batch::try_cast_to(batch, Arc::clone(&target_schema))
+                        .map_err(Into::into)
+                })
+            }),
+        ));
+
         if self.overwrite == InsertOp::Overwrite {
-            self.write_all_overwrite(data).await.map_err(Into::into)
+            self.write_all_overwrite(normalized)
+                .await
+                .map_err(Into::into)
         } else {
-            self.write_all_append(data, context)
+            self.write_all_append(normalized, context)
                 .await
                 .map_err(Into::into)
         }


### PR DESCRIPTION
## 📝 Summary

Debezium CDC batches arrive with `NonNullable` column nullability, while the Cayenne accelerated table schema declares columns as `Nullable`. Vortex asserts schema equality when reading sequential streams, causing a panic on nullability mismatch during CDC replication.

>thread 'tokio-runtime-worker' (47751066) panicked at /Users/sg/.cargo/git/checkouts/vortex-d03923adf7587b60/d694abd/vortex-layout/src/sequence.rs:313:13:
assertion `left == right` failed: Sequential stream of {id=i32?, name=utf8?, value=i32?} got chunk of {id=i32, name=utf8, value=i32}.
  left: Struct(StructFields { names: FieldNames([FieldName("id"), FieldName("name"), FieldName("value")]), dtypes: [FieldDType { inner: Owned(Primitive(I32, Nullable)) }, FieldDType { inner: Owned(Utf8(Nullable)) }, FieldDType { inner: Owned(Primitive(I32, Nullable)) }] }, NonNullable)
 right: Struct(StructFields { names: FieldNames([FieldName("id"), FieldName("name"), FieldName("value")]), dtypes: [FieldDType { inner: Owned(Primitive(I32, NonNullable)) }, FieldDType { inner: Owned(Utf8(NonNullable)) }, FieldDType { inner: Owned(Primitive(I32, NonNullable)) }] }, NonNullable)

PR normalizes incoming `RecordBatch` schemas in `CayenneDataSink::write_all` before writing. Each batch is passed through `try_cast_to` to coerce nullability (and types) to match the target table schema. Applied to both append and overwrite paths.

This is similar/concisten to recently added improvement to Arrow

https://github.com/spiceai/spiceai/blob/585bf553d2704d6d1092e20963818ca84a1925ee/crates/data_components/src/arrow/write.rs#L1200-L1201

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->