### PR TITLE
Add CH-benCH benchmark support to testoperator

### DIFF
--- a/.github/actions/setup-chbench-postgres/action.yml
+++ b/.github/actions/setup-chbench-postgres/action.yml
@@ -1,0 +1,31 @@
+name: Setup CH-benCH PostgreSQL
+description: 'Starts a PostgreSQL container configured for CH-benCH benchmarking'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Start PostgreSQL for CH-benCH
+      shell: bash
+      run: |
+        docker run -d --name chbench-pg \
+          -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=chbench \
+          -p 5432:5432 postgres:16 \
+          -c max_connections=150 \
+          -c wal_level=logical \
+          -c synchronous_commit=off \
+          -c max_replication_slots=20 \
+          -c max_wal_senders=20
+
+    - name: Wait for CH-benCH PostgreSQL
+      shell: bash
+      run: |
+        for _ in {1..30}; do
+          if docker exec chbench-pg pg_isready -U bench > /dev/null 2>&1; then
+            echo "PostgreSQL is ready"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "PostgreSQL did not become ready in time."
+        docker logs chbench-pg
+        exit 1

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -22,6 +22,7 @@ on:
           - 'tpch[parameterized]'
           - 'tpcds'
           - 'clickbench'
+          - 'chbench'
           - 'scenario'
       scenario_query_file:
         description: 'Path to scenario query file (required when query_set is scenario)'
@@ -226,6 +227,30 @@ jobs:
         uses: ./.github/actions/install-postgres
         with:
           pg-db: ducklake_catalog
+
+      - name: Start PostgreSQL for CH-benCH
+        if: ${{ github.event.inputs.query_set == 'chbench' }}
+        run: |
+          docker run -d --name chbench-pg \
+            -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=chbench \
+            -p 5432:5432 postgres:16 \
+            -c wal_level=logical \
+            -c max_replication_slots=20 \
+            -c max_wal_senders=20
+
+      - name: Wait for CH-benCH PostgreSQL
+        if: ${{ github.event.inputs.query_set == 'chbench' }}
+        run: |
+          for _ in {1..30}; do
+            if docker exec chbench-pg pg_isready -U bench > /dev/null 2>&1; then
+              echo "PostgreSQL is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "PostgreSQL did not become ready in time."
+          docker logs chbench-pg
+          exit 1
 
       - name: Start local MinIO for DuckLake
         if: ${{ contains(github.event.inputs.spicepod_path, 'ducklake') }}

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -228,29 +228,9 @@ jobs:
         with:
           pg-db: ducklake_catalog
 
-      - name: Start PostgreSQL for CH-benCH
+      - name: Setup CH-benCH PostgreSQL
         if: ${{ github.event.inputs.query_set == 'chbench' }}
-        run: |
-          docker run -d --name chbench-pg \
-            -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=chbench \
-            -p 5432:5432 postgres:16 \
-            -c wal_level=logical \
-            -c max_replication_slots=20 \
-            -c max_wal_senders=20
-
-      - name: Wait for CH-benCH PostgreSQL
-        if: ${{ github.event.inputs.query_set == 'chbench' }}
-        run: |
-          for _ in {1..30}; do
-            if docker exec chbench-pg pg_isready -U bench > /dev/null 2>&1; then
-              echo "PostgreSQL is ready"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "PostgreSQL did not become ready in time."
-          docker logs chbench-pg
-          exit 1
+        uses: ./.github/actions/setup-chbench-postgres
 
       - name: Start local MinIO for DuckLake
         if: ${{ contains(github.event.inputs.spicepod_path, 'ducklake') }}
@@ -278,7 +258,7 @@ jobs:
       - name: Bootstrap DuckLake TPCH SF1 catalog
         if: ${{ contains(github.event.inputs.spicepod_path, 'ducklake') }}
         run: |
-          python -m pip install --upgrade duckdb minio
+          python -m pip install --upgrade 'duckdb==1.4.4' minio
 
           python <<'PY'
           import duckdb

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -1,0 +1,110 @@
+name: HTAP(CH-benCHmark) tests
+run-name: htap - ${{ github.event.inputs.spicepod_path }} - SF${{ github.event.inputs.scale_factor }} - ${{ github.event.inputs.duration }}s
+
+on:
+  workflow_dispatch:
+    inputs:
+      spiced_commit:
+        description: 'spiced build commit'
+        required: false
+        type: string
+      spicepod_path:
+        description: 'The spicepod file to test with (relative to test/spicepods/chbench/sf{scale_factor}/)'
+        required: true
+        type: string
+      scale_factor:
+        description: 'Scale factor (warehouses). Terminals = scale_factor * 10.'
+        required: false
+        type: string
+        default: '1'
+      duration:
+        description: 'Duration of the HTAP workload in seconds'
+        required: false
+        type: string
+        default: '300'
+      ready_wait:
+        description: 'How long (in seconds) to wait for spiced to start'
+        required: true
+        default: '60'
+        type: string
+      runner_type:
+        description: 'Runner type'
+        required: true
+        default: 'spiceai-dev-runners'
+        type: choice
+        options:
+          - 'spiceai-dev-runners'
+          - 'spiceai-dev-large-runners'
+jobs:
+  run-htap:
+    name: Run HTAP(CH-benCHmark)
+    runs-on: ${{ github.event.inputs.runner_type }}
+    timeout-minutes: 600
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Rust toolchain
+        uses: ./.github/actions/setup-rust
+
+      - name: Set spicepod path
+        id: set_spicepod_path
+        run: |
+          SPICEPOD_PATH="./test/spicepods/chbench/sf${{ github.event.inputs.scale_factor }}/${{ github.event.inputs.spicepod_path }}"
+          echo "SPICEPOD_PATH=${SPICEPOD_PATH}" >> $GITHUB_OUTPUT
+
+      - name: Validate spicepod file exists
+        run: |
+          if [ ! -f "${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}" ]; then
+            echo "Error: Spicepod file not found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        id: setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
+
+      - name: Display spiced commit
+        run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
+
+      - name: Build Testoperator
+        uses: ./.github/actions/build-testoperator
+
+      - name: Start PostgreSQL for CH-benCH
+        run: |
+          docker run -d --name chbench-pg \
+            -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=chbench \
+            -p 5432:5432 postgres:16 \
+            -c wal_level=logical \
+            -c max_replication_slots=20 \
+            -c max_wal_senders=20
+
+      - name: Wait for CH-benCH PostgreSQL
+        run: |
+          for _ in {1..30}; do
+            if docker exec chbench-pg pg_isready -U bench > /dev/null 2>&1; then
+              echo "PostgreSQL is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "PostgreSQL did not become ready in time."
+          docker logs chbench-pg
+          exit 1
+
+      - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
+        run: |
+          testoperator run htap \
+            -s /usr/local/bin/spiced \
+            -p '${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}' \
+            --query-set chbench \
+            --scale-factor ${{ github.event.inputs.scale_factor }} \
+            --duration ${{ github.event.inputs.duration }} \
+            --ready-wait ${{ github.event.inputs.ready_wait }} \
+            --disable-progress-bars \
+            --metrics
+        env:
+          SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -72,27 +72,8 @@ jobs:
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
 
-      - name: Start PostgreSQL for CH-benCH
-        run: |
-          docker run -d --name chbench-pg \
-            -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=chbench \
-            -p 5432:5432 postgres:16 \
-            -c wal_level=logical \
-            -c max_replication_slots=20 \
-            -c max_wal_senders=20
-
-      - name: Wait for CH-benCH PostgreSQL
-        run: |
-          for _ in {1..30}; do
-            if docker exec chbench-pg pg_isready -U bench > /dev/null 2>&1; then
-              echo "PostgreSQL is ready"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "PostgreSQL did not become ready in time."
-          docker logs chbench-pg
-          exit 1
+      - name: Setup CH-benCH PostgreSQL
+        uses: ./.github/actions/setup-chbench-postgres
 
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,6 +3571,7 @@ dependencies = [
  "snafu",
  "tokio",
  "tokio-postgres",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,7 +3571,6 @@ dependencies = [
  "snafu",
  "tokio",
  "tokio-postgres",
- "tracing",
 ]
 
 [[package]]
@@ -18961,6 +18960,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-dynamodb",
  "bollard",
+ "chbench-driver",
  "clap",
  "duckdb",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,6 +3564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chbench-driver"
+version = "2.0.0-unstable"
+dependencies = [
+ "rand 0.8.5",
+ "snafu",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18969,7 +18969,6 @@ dependencies = [
  "aws-sdk-dynamodb",
  "bollard",
  "chbench-driver",
- "chrono",
  "clap",
  "duckdb",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18967,6 +18967,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "bollard",
  "chbench-driver",
+ "chrono",
  "clap",
  "duckdb",
  "futures",
@@ -18981,6 +18982,7 @@ dependencies = [
  "spicepod",
  "test-framework",
  "tokio",
+ "tokio-postgres",
  "tokio-util",
  "yaml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18983,7 +18983,6 @@ dependencies = [
  "spicepod",
  "test-framework",
  "tokio",
- "tokio-postgres",
  "tokio-util",
  "yaml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,6 +3567,8 @@ dependencies = [
 name = "chbench-driver"
 version = "2.0.0-unstable"
 dependencies = [
+ "async-trait",
+ "chrono",
  "rand 0.8.5",
  "snafu",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3569,7 +3569,7 @@ version = "2.0.0-unstable"
 dependencies = [
  "async-trait",
  "chrono",
- "rand 0.8.5",
+ "rand 0.10.1",
  "snafu",
  "tokio",
  "tokio-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ members = [
     "tools/spicepod-validator",
     "tools/spidapter",
     "tools/testoperator",
+    "tools/chbench-driver",
     "tools/parsley",
     "tools/pr-builds"
 ]

--- a/crates/test-framework/src/queries/chbench/q1.sql
+++ b/crates/test-framework/src/queries/chbench/q1.sql
@@ -1,0 +1,15 @@
+select
+    ol_number,
+    sum(ol_quantity) as sum_qty,
+    sum(ol_amount) as sum_amount,
+    avg(ol_quantity) as avg_qty,
+    avg(ol_amount) as avg_amount,
+    count(*) as count_order
+from
+    order_line
+where
+    ol_delivery_d > '2007-01-02 00:00:00.000000'
+group by
+    ol_number
+order by
+    ol_number;

--- a/crates/test-framework/src/queries/chbench/q10.sql
+++ b/crates/test-framework/src/queries/chbench/q10.sql
@@ -1,0 +1,18 @@
+select
+    c_id, c_last, sum(ol_amount) as revenue, c_city, c_phone, n_name
+from
+    customer, orders, order_line, nation
+where
+    c_id = o_c_id
+    and c_w_id = o_w_id
+    and c_d_id = o_d_id
+    and ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_o_id = o_id
+    and o_entry_d >= '2007-01-02 00:00:00.000000'
+    and o_entry_d <= ol_delivery_d
+    and n_nationkey = ascii(substr(c_state,1,1)) - 65
+group by
+    c_id, c_last, c_city, c_phone, n_name
+order by
+    revenue desc;

--- a/crates/test-framework/src/queries/chbench/q11.sql
+++ b/crates/test-framework/src/queries/chbench/q11.sql
@@ -1,0 +1,19 @@
+select
+    s_i_id, sum(s_order_cnt) as ordercount
+from
+    stock, supplier, nation
+where
+    mod((s_w_id * s_i_id),10000) = s_suppkey
+    and s_nationkey = n_nationkey
+    and n_name = 'CHINA'
+group by
+    s_i_id
+having
+    sum(s_order_cnt) >
+    (select sum(s_order_cnt) * .005
+     from stock, supplier, nation
+     where mod((s_w_id * s_i_id),10000) = s_suppkey
+       and s_nationkey = n_nationkey
+       and n_name = 'CHINA')
+order by
+    ordercount desc;

--- a/crates/test-framework/src/queries/chbench/q12.sql
+++ b/crates/test-framework/src/queries/chbench/q12.sql
@@ -1,0 +1,16 @@
+select
+    o_ol_cnt,
+    sum(case when o_carrier_id = 1 or o_carrier_id = 2 then 1 else 0 end) as high_line_count,
+    sum(case when o_carrier_id <> 1 and o_carrier_id <> 2 then 1 else 0 end) as low_line_count
+from
+    orders, order_line
+where
+    ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_o_id = o_id
+    and o_entry_d <= ol_delivery_d
+    and ol_delivery_d < '2030-01-01 00:00:00.000000'
+group by
+    o_ol_cnt
+order by
+    o_ol_cnt;

--- a/crates/test-framework/src/queries/chbench/q13.sql
+++ b/crates/test-framework/src/queries/chbench/q13.sql
@@ -1,0 +1,14 @@
+select
+    c_count, count(*) as custdist
+from
+    (select c_id, count(o_id) as c_count
+     from customer left outer join orders on (
+         c_w_id = o_w_id
+         and c_d_id = o_d_id
+         and c_id = o_c_id
+         and o_carrier_id > 8)
+     group by c_id) as c_orders
+group by
+    c_count
+order by
+    custdist desc, c_count desc;

--- a/crates/test-framework/src/queries/chbench/q14.sql
+++ b/crates/test-framework/src/queries/chbench/q14.sql
@@ -1,0 +1,8 @@
+select
+    100.00 * sum(case when i_data like 'PR%' then ol_amount else 0 end) / (1+sum(ol_amount)) as promo_revenue
+from
+    order_line, item
+where
+    ol_i_id = i_id
+    and ol_delivery_d >= '2007-01-02 00:00:00.000000'
+    and ol_delivery_d < '2030-01-02 00:00:00.000000';

--- a/crates/test-framework/src/queries/chbench/q16.sql
+++ b/crates/test-framework/src/queries/chbench/q16.sql
@@ -1,0 +1,18 @@
+select
+    i_name,
+    substr(i_data, 1, 3) as brand,
+    i_price,
+    count(distinct (mod((s_w_id * s_i_id),10000))) as supplier_cnt
+from
+    stock, item
+where
+    i_id = s_i_id
+    and i_data not like 'zz%'
+    and (mod((s_w_id * s_i_id),10000) not in
+         (select s_suppkey
+          from supplier
+          where s_comment like '%bad%'))
+group by
+    i_name, substr(i_data, 1, 3), i_price
+order by
+    supplier_cnt desc;

--- a/crates/test-framework/src/queries/chbench/q17.sql
+++ b/crates/test-framework/src/queries/chbench/q17.sql
@@ -1,0 +1,12 @@
+select
+    sum(ol_amount) / 2.0 as avg_yearly
+from
+    order_line,
+    (select   i_id, avg(ol_quantity) as a
+     from     item, order_line
+     where    i_data like '%b'
+       and ol_i_id = i_id
+     group by i_id) t
+where
+    ol_i_id = t.i_id
+    and ol_quantity < t.a;

--- a/crates/test-framework/src/queries/chbench/q18.sql
+++ b/crates/test-framework/src/queries/chbench/q18.sql
@@ -1,0 +1,17 @@
+select
+    c_last, c_id o_id, o_entry_d, o_ol_cnt, sum(ol_amount)
+from
+    customer, orders, order_line
+where
+    c_id = o_c_id
+    and c_w_id = o_w_id
+    and c_d_id = o_d_id
+    and ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_o_id = o_id
+group by
+    o_id, o_w_id, o_d_id, c_id, c_last, o_entry_d, o_ol_cnt
+having
+    sum(ol_amount) > 200
+order by
+    sum(ol_amount) desc, o_entry_d;

--- a/crates/test-framework/src/queries/chbench/q18.sql
+++ b/crates/test-framework/src/queries/chbench/q18.sql
@@ -1,5 +1,5 @@
 select
-    c_last, c_id o_id, o_entry_d, o_ol_cnt, sum(ol_amount)
+    c_last, c_id, o_id, o_entry_d, o_ol_cnt, sum(ol_amount)
 from
     customer, orders, order_line
 where

--- a/crates/test-framework/src/queries/chbench/q19.sql
+++ b/crates/test-framework/src/queries/chbench/q19.sql
@@ -1,0 +1,27 @@
+select
+    sum(ol_amount) as revenue
+from
+    order_line, item
+where
+    (
+        ol_i_id = i_id
+        and i_data like '%a'
+        and ol_quantity >= 1
+        and ol_quantity <= 10
+        and i_price between 1 and 400000
+        and ol_w_id in (1,2,3)
+    ) or (
+        ol_i_id = i_id
+        and i_data like '%b'
+        and ol_quantity >= 1
+        and ol_quantity <= 10
+        and i_price between 1 and 400000
+        and ol_w_id in (1,2,4)
+    ) or (
+        ol_i_id = i_id
+        and i_data like '%c'
+        and ol_quantity >= 1
+        and ol_quantity <= 10
+        and i_price between 1 and 400000
+        and ol_w_id in (1,5,3)
+    );

--- a/crates/test-framework/src/queries/chbench/q2.sql
+++ b/crates/test-framework/src/queries/chbench/q2.sql
@@ -1,0 +1,23 @@
+select
+    s_suppkey, s_name, n_name, i_id, i_name, s_address, s_phone, s_comment
+from
+    item, supplier, stock, nation, region,
+    (select s_i_id as m_i_id,
+            min(s_quantity) as m_s_quantity
+     from   stock, supplier, nation, region
+     where  mod((s_w_id*s_i_id),10000)=s_suppkey
+       and s_nationkey=n_nationkey
+       and n_regionkey=r_regionkey
+       and r_name like 'EUROP%'
+     group by s_i_id) m
+where
+    i_id = s_i_id
+    and mod((s_w_id * s_i_id), 10000) = s_suppkey
+    and s_nationkey = n_nationkey
+    and n_regionkey = r_regionkey
+    and i_data like '%b'
+    and r_name like 'EUROP%'
+    and i_id=m_i_id
+    and s_quantity = m_s_quantity
+order by
+    n_name, s_name, i_id;

--- a/crates/test-framework/src/queries/chbench/q20.sql
+++ b/crates/test-framework/src/queries/chbench/q20.sql
@@ -1,0 +1,20 @@
+select
+    s_name, s_address
+from
+    supplier, nation
+where
+    s_suppkey in
+    (select  mod(s_i_id * s_w_id, 10000)
+     from     stock, order_line
+     where    s_i_id in
+              (select i_id
+               from item
+               where i_data like 'co%')
+       and ol_i_id=s_i_id
+       and ol_delivery_d > '2010-05-23 12:00:00'
+     group by s_i_id, s_w_id, s_quantity
+     having   2*s_quantity > sum(ol_quantity))
+    and s_nationkey = n_nationkey
+    and n_name = 'CHINA'
+order by
+    s_name;

--- a/crates/test-framework/src/queries/chbench/q21.sql
+++ b/crates/test-framework/src/queries/chbench/q21.sql
@@ -1,0 +1,24 @@
+select
+    s_name, count(*) as numwait
+from
+    supplier, order_line l1, orders, stock, nation
+where
+    ol_o_id = o_id
+    and ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_w_id = s_w_id
+    and ol_i_id = s_i_id
+    and mod((s_w_id * s_i_id),10000) = s_suppkey
+    and l1.ol_delivery_d > o_entry_d
+    and not exists (select *
+                    from order_line l2
+                    where l2.ol_o_id = l1.ol_o_id
+                      and l2.ol_w_id = l1.ol_w_id
+                      and l2.ol_d_id = l1.ol_d_id
+                      and l2.ol_delivery_d > l1.ol_delivery_d)
+    and s_nationkey = n_nationkey
+    and n_name = 'CHINA'
+group by
+    s_name
+order by
+    numwait desc, s_name;

--- a/crates/test-framework/src/queries/chbench/q22.sql
+++ b/crates/test-framework/src/queries/chbench/q22.sql
@@ -1,0 +1,19 @@
+select
+    substr(c_state,1,1) as country,
+    count(*) as numcust,
+    sum(c_balance) as totacctbal
+from
+    customer
+where
+    substr(c_phone,1,1) in ('1','2','3','4','5','6','7')
+    and c_balance > (select avg(c_balance) from customer
+                     where c_balance > 0.00
+                       and substr(c_phone,1,1) in ('1','2','3','4','5','6','7'))
+    and not exists (select * from orders
+                    where o_c_id = c_id
+                      and o_w_id = c_w_id
+                      and o_d_id = c_d_id)
+group by
+    substr(c_state,1,1)
+order by
+    country;

--- a/crates/test-framework/src/queries/chbench/q3.sql
+++ b/crates/test-framework/src/queries/chbench/q3.sql
@@ -1,0 +1,21 @@
+select
+    ol_o_id, ol_w_id, ol_d_id,
+    sum(ol_amount) as revenue, o_entry_d
+from
+    customer, new_order, orders, order_line
+where
+    c_state like 'a%'
+    and c_id = o_c_id
+    and c_w_id = o_w_id
+    and c_d_id = o_d_id
+    and no_w_id = o_w_id
+    and no_d_id = o_d_id
+    and no_o_id = o_id
+    and ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_o_id = o_id
+    and o_entry_d > '2007-01-02 00:00:00.000000'
+group by
+    ol_o_id, ol_w_id, ol_d_id, o_entry_d
+order by
+    revenue desc, o_entry_d;

--- a/crates/test-framework/src/queries/chbench/q3.sql
+++ b/crates/test-framework/src/queries/chbench/q3.sql
@@ -4,7 +4,7 @@ select
 from
     customer, new_order, orders, order_line
 where
-    c_state like 'a%'
+    c_state like 'A%'
     and c_id = o_c_id
     and c_w_id = o_w_id
     and c_d_id = o_d_id

--- a/crates/test-framework/src/queries/chbench/q4.sql
+++ b/crates/test-framework/src/queries/chbench/q4.sql
@@ -1,0 +1,17 @@
+select
+    o_ol_cnt, count(*) as order_count
+from
+    orders
+where
+    o_entry_d >= '2007-01-02 00:00:00.000000'
+    and o_entry_d < '2032-01-02 00:00:00.000000'
+    and exists (select *
+                from order_line
+                where o_id = ol_o_id
+                  and o_w_id = ol_w_id
+                  and o_d_id = ol_d_id
+                  and ol_delivery_d >= o_entry_d)
+group by
+    o_ol_cnt
+order by
+    o_ol_cnt;

--- a/crates/test-framework/src/queries/chbench/q5.sql
+++ b/crates/test-framework/src/queries/chbench/q5.sql
@@ -1,0 +1,22 @@
+select
+    n_name,
+    sum(ol_amount) as revenue
+from
+    customer, orders, order_line, stock, supplier, nation, region
+where
+    c_id = o_c_id
+    and c_w_id = o_w_id
+    and c_d_id = o_d_id
+    and ol_o_id = o_id
+    and ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_w_id = s_w_id
+    and ol_i_id = s_i_id
+    and mod((s_w_id * s_i_id),10000) = s_suppkey
+    and ascii(substr(c_state,1,1)) - 65 = s_nationkey
+    and s_nationkey = n_nationkey
+    and n_regionkey = r_regionkey
+    and r_name = 'EUROPE'
+    and o_entry_d >= '2007-01-02 00:00:00.000000'
+group by
+    n_name;

--- a/crates/test-framework/src/queries/chbench/q6.sql
+++ b/crates/test-framework/src/queries/chbench/q6.sql
@@ -1,0 +1,8 @@
+select
+    sum(ol_amount) as revenue
+from
+    order_line
+where
+    ol_delivery_d >= '1997-01-01 00:00:00'
+    and ol_delivery_d < '2030-01-01 00:00:00'
+    and ol_quantity between 1 and 100000;

--- a/crates/test-framework/src/queries/chbench/q7.sql
+++ b/crates/test-framework/src/queries/chbench/q7.sql
@@ -1,0 +1,29 @@
+select
+    s_nationkey as supp_nation,
+    substr(c_state,1,1) as cust_nation,
+    extract(year from o_entry_d) as l_year,
+    sum(ol_amount) as revenue
+from
+    supplier, stock, order_line, orders, customer, nation n1, nation n2
+where
+    ol_supply_w_id = s_w_id
+    and ol_i_id = s_i_id
+    and mod((s_w_id * s_i_id), 10000) = s_suppkey
+    and ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_o_id = o_id
+    and c_id = o_c_id
+    and c_w_id = o_w_id
+    and c_d_id = o_d_id
+    and s_nationkey = n1.n_nationkey
+    and ascii(substr(c_state,1,1)) - 65 = n2.n_nationkey
+    and (
+        (n1.n_name = 'JAPAN' and n2.n_name = 'CHINA')
+        or
+        (n1.n_name = 'CHINA' and n2.n_name = 'JAPAN')
+    )
+    and ol_delivery_d between '2007-01-02 00:00:00.000000' and '2032-01-02 00:00:00.000000'
+group by
+    s_nationkey, substr(c_state,1,1), extract(year from o_entry_d)
+order by
+    s_nationkey, cust_nation, l_year;

--- a/crates/test-framework/src/queries/chbench/q8.sql
+++ b/crates/test-framework/src/queries/chbench/q8.sql
@@ -1,0 +1,27 @@
+select
+    extract(year from o_entry_d) as l_year,
+    sum(case when n2.n_name = 'INDIA' then ol_amount else 0 end) / sum(ol_amount) as mkt_share
+from
+    item, supplier, stock, order_line, orders, customer, nation n1, nation n2, region
+where
+    i_id = s_i_id
+    and ol_i_id = s_i_id
+    and ol_supply_w_id = s_w_id
+    and mod((s_w_id * s_i_id),10000) = s_suppkey
+    and ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_o_id = o_id
+    and c_id = o_c_id
+    and c_w_id = o_w_id
+    and c_d_id = o_d_id
+    and n1.n_nationkey = ascii(substr(c_state,1,1)) - 65
+    and n1.n_regionkey = r_regionkey
+    and ol_i_id < 1000
+    and r_name = 'ASIA'
+    and s_nationkey = n2.n_nationkey
+    and o_entry_d between '2007-01-02 00:00:00.000000' and '2032-01-02 00:00:00.000000'
+    and i_id = ol_i_id
+group by
+    extract(year from o_entry_d)
+order by
+    l_year;

--- a/crates/test-framework/src/queries/chbench/q9.sql
+++ b/crates/test-framework/src/queries/chbench/q9.sql
@@ -1,0 +1,18 @@
+select
+    n_name, extract(year from o_entry_d) as l_year, sum(ol_amount) as sum_profit
+from
+    item, stock, supplier, order_line, orders, nation
+where
+    ol_i_id = s_i_id
+    and ol_supply_w_id = s_w_id
+    and mod((s_w_id * s_i_id), 10000) = s_suppkey
+    and ol_w_id = o_w_id
+    and ol_d_id = o_d_id
+    and ol_o_id = o_id
+    and ol_i_id = i_id
+    and s_nationkey = n_nationkey
+    and i_data like '%BB'
+group by
+    n_name, extract(year from o_entry_d)
+order by
+    n_name, l_year desc;

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -387,7 +387,6 @@ impl QuerySet {
     #[must_use]
     pub fn row_counts(&self) -> Vec<TableWithRowCount> {
         match self {
-            QuerySet::Scenario { .. } => vec![],
             QuerySet::Tpch | QuerySet::ParameterizedTpch => [
                 ("customer", 150_000),
                 ("lineitem", 6_001_215),
@@ -434,14 +433,13 @@ impl QuerySet {
                 .iter()
                 .map(TableWithRowCount::from)
                 .collect(),
-            QuerySet::ChBench => vec![],
+            QuerySet::Scenario { .. } | QuerySet::ChBench => vec![],
         }
     }
 
     #[must_use]
     pub fn append_time_columns(&self) -> Vec<TableWithTimeColumn> {
         match self {
-            QuerySet::Scenario { .. } => vec![],
             QuerySet::Tpch | QuerySet::ParameterizedTpch => [
                 ("customer", "c_created_at"),
                 ("lineitem", "l_created_at"),
@@ -488,7 +486,7 @@ impl QuerySet {
                 .iter()
                 .map(TableWithTimeColumn::from)
                 .collect(),
-            QuerySet::ChBench => vec![],
+            QuerySet::Scenario { .. } | QuerySet::ChBench => vec![],
         }
     }
 

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -583,7 +583,29 @@ impl QuerySet {
             QuerySet::ChBench => {
                 // CH-benCH results are non-deterministic under concurrent OLTP load;
                 // skip row count validation for all queries
-                vec![]
+                vec![
+                    "chbench_q1",
+                    "chbench_q2",
+                    "chbench_q3",
+                    "chbench_q4",
+                    "chbench_q5",
+                    "chbench_q6",
+                    "chbench_q7",
+                    "chbench_q8",
+                    "chbench_q9",
+                    "chbench_q10",
+                    "chbench_q11",
+                    "chbench_q12",
+                    "chbench_q13",
+                    "chbench_q14",
+                    "chbench_q16",
+                    "chbench_q17",
+                    "chbench_q18",
+                    "chbench_q19",
+                    "chbench_q20",
+                    "chbench_q21",
+                    "chbench_q22",
+                ]
             }
             QuerySet::Scenario { .. } => vec![],
         }

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -603,7 +603,6 @@ impl QuerySet {
                     "chbench_q18",
                     "chbench_q19",
                     "chbench_q20",
-                    "chbench_q21",
                     "chbench_q22",
                 ]
             }
@@ -1217,9 +1216,10 @@ pub fn get_clickbench_test_queries(overrides: Option<QueryOverrides>) -> Vec<Que
 #[must_use]
 pub fn get_chbench_test_queries(overrides: Option<QueryOverrides>) -> Vec<Query> {
     let queries = generate_chbench_queries!(
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21, 22
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 22
     );
     // q15 excluded: requires a `revenue1` view
+    // q21 excluded: multi-way JOIN + anti-join exhausts HashJoin memory (can't spill)
 
     match overrides {
         // No engine-specific overrides yet

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -152,6 +152,20 @@ macro_rules! generate_clickbench_query_overrides {
   }
 }
 
+macro_rules! generate_chbench_queries {
+    ( $( $i:literal ),* ) => {
+        vec![
+            $(
+                Query::new(
+                    concat!("chbench_q", stringify!($i)).into(),
+                    include_str!(concat!("./chbench/q", stringify!($i), ".sql")).into(),
+                    false
+                )
+            ),*
+        ]
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Query {
     pub name: Arc<str>,
@@ -289,6 +303,7 @@ pub enum QuerySet {
     Tpch,
     Tpcds,
     Clickbench,
+    ChBench,
     ParameterizedTpch,
     /// Scenario query set loaded from a file
     Scenario {
@@ -337,6 +352,7 @@ impl QuerySet {
             QuerySet::Tpch => Ok(get_tpch_test_queries(overrides)),
             QuerySet::Tpcds => Ok(get_tpcds_test_queries(overrides)),
             QuerySet::Clickbench => Ok(get_clickbench_test_queries(overrides)),
+            QuerySet::ChBench => Ok(get_chbench_test_queries(overrides)),
             QuerySet::Scenario { queries, .. } => Ok(queries.clone()),
             QuerySet::ParameterizedTpch => {
                 let queries = generate_tpch_queries_override!(
@@ -418,6 +434,7 @@ impl QuerySet {
                 .iter()
                 .map(TableWithRowCount::from)
                 .collect(),
+            QuerySet::ChBench => vec![],
         }
     }
 
@@ -471,6 +488,7 @@ impl QuerySet {
                 .iter()
                 .map(TableWithTimeColumn::from)
                 .collect(),
+            QuerySet::ChBench => vec![],
         }
     }
 
@@ -562,6 +580,11 @@ impl QuerySet {
                     "clickbench_q43",
                 ]
             }
+            QuerySet::ChBench => {
+                // CH-benCH results are non-deterministic under concurrent OLTP load;
+                // skip row count validation for all queries
+                vec![]
+            }
             QuerySet::Scenario { .. } => vec![],
         }
     }
@@ -573,6 +596,7 @@ impl Display for QuerySet {
             QuerySet::Tpch => write!(f, "tpch"),
             QuerySet::Tpcds => write!(f, "tpcds"),
             QuerySet::Clickbench => write!(f, "clickbench"),
+            QuerySet::ChBench => write!(f, "chbench"),
             QuerySet::ParameterizedTpch => write!(f, "tpch[parameterized]"),
             QuerySet::Scenario { scenario_set, .. } => {
                 if let Some(name) = &scenario_set.name {
@@ -1166,6 +1190,19 @@ pub fn get_clickbench_test_queries(overrides: Option<QueryOverrides>) -> Vec<Que
     }
 
     queries
+}
+
+#[must_use]
+pub fn get_chbench_test_queries(overrides: Option<QueryOverrides>) -> Vec<Query> {
+    let queries = generate_chbench_queries!(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21, 22
+    );
+    // q15 excluded: requires a `revenue1` view
+
+    match overrides {
+        // No engine-specific overrides yet
+        Some(_) | None => queries,
+    }
 }
 
 #[cfg(test)]

--- a/crates/test-framework/src/spicetest/append/sources/file.rs
+++ b/crates/test-framework/src/spicetest/append/sources/file.rs
@@ -312,7 +312,7 @@ impl AppendableSource for FileAppendableSource {
 
                     dest_conn.execute_batch(setup_sql)?;
                 }
-                QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch => unimplemented!("Appendable file source is not implemented for Scenario or Parameterized TPC-H query sets"),
+                QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch | QuerySet::ChBench => unimplemented!("Appendable file source is not implemented for Scenario, Parameterized TPC-H, or CH-benCH query sets"),
             }
 
             drop(dest_conn);
@@ -361,8 +361,8 @@ impl AppendableSource for FileAppendableSource {
                 ),
                 QuerySet::Tpcds => generate_tpcds_sql(load_steps, load_index, &tables),
                 QuerySet::Clickbench => generate_clickbench_sql(load_steps, load_index),
-                QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch => {
-                    unimplemented!("Appendable file source is not implemented for Scenario or Parameterized query sets")
+                QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch | QuerySet::ChBench => {
+                    unimplemented!("Appendable file source is not implemented for Scenario, Parameterized, or CH-benCH query sets")
                 }
             };
 

--- a/crates/test-framework/src/spicetest/append/sources/file.rs
+++ b/crates/test-framework/src/spicetest/append/sources/file.rs
@@ -312,7 +312,7 @@ impl AppendableSource for FileAppendableSource {
 
                     dest_conn.execute_batch(setup_sql)?;
                 }
-                QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch | QuerySet::ChBench => unimplemented!("Appendable file source is not implemented for Scenario, Parameterized TPC-H, or CH-benCH query sets"),
+                QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch | QuerySet::ChBench => anyhow::bail!("Appendable file source is not implemented for Scenario, Parameterized TPC-H, or CH-benCH query sets"),
             }
 
             drop(dest_conn);
@@ -362,7 +362,7 @@ impl AppendableSource for FileAppendableSource {
                 QuerySet::Tpcds => generate_tpcds_sql(load_steps, load_index, &tables),
                 QuerySet::Clickbench => generate_clickbench_sql(load_steps, load_index),
                 QuerySet::Scenario { .. } | QuerySet::ParameterizedTpch | QuerySet::ChBench => {
-                    unimplemented!("Appendable file source is not implemented for Scenario, Parameterized, or CH-benCH query sets")
+                    anyhow::bail!("Appendable file source is not implemented for Scenario, Parameterized, or CH-benCH query sets")
                 }
             };
 

--- a/test/spicepods/chbench/sf1/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-arrow.yaml
@@ -7,7 +7,6 @@ runtime:
     sql_results:
       enabled: false
 
-
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 
@@ -24,8 +23,7 @@ datasets:
       pg_replication_initial_snapshot: "true"
     acceleration: &cayenne_accel
       enabled: true
-      engine: cayenne
-      mode: file
+      engine: arrow
       refresh_mode: changes
       primary_key: w_id
       on_conflict:

--- a/test/spicepods/chbench/sf1/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-arrow.yaml
@@ -2,11 +2,6 @@ version: v1
 kind: Spicepod
 name: postgres-arrow
 
-runtime:
-  caching:
-    sql_results:
-      enabled: false
-
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 
@@ -21,7 +16,7 @@ datasets:
       pg_sslmode: disable
       pg_replication_slot: spice_warehouse
       pg_replication_initial_snapshot: "true"
-    acceleration: &cayenne_accel
+    acceleration: &arrow_accel
       enabled: true
       engine: arrow
       refresh_mode: changes
@@ -35,7 +30,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_district
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: (d_w_id, d_id)
       on_conflict:
         (d_w_id, d_id): upsert
@@ -46,7 +41,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_customer
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: (c_w_id, c_d_id, c_id)
       on_conflict:
         (c_w_id, c_d_id, c_id): upsert
@@ -57,7 +52,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_new_order
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: (no_w_id, no_d_id, no_o_id)
       on_conflict:
         (no_w_id, no_d_id, no_o_id): upsert
@@ -68,7 +63,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_orders
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: (o_w_id, o_d_id, o_id)
       on_conflict:
         (o_w_id, o_d_id, o_id): upsert
@@ -79,7 +74,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_order_line
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
       on_conflict:
         (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
@@ -90,7 +85,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_item
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: i_id
       on_conflict:
         i_id: upsert
@@ -101,7 +96,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_stock
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: (s_w_id, s_i_id)
       on_conflict:
         (s_w_id, s_i_id): upsert
@@ -112,7 +107,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_region
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: r_regionkey
       on_conflict:
         r_regionkey: upsert
@@ -123,7 +118,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_nation
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: n_nationkey
       on_conflict:
         n_nationkey: upsert
@@ -134,7 +129,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_supplier
     acceleration:
-      <<: *cayenne_accel
+      <<: *arrow_accel
       primary_key: s_suppkey
       on_conflict:
         s_suppkey: upsert

--- a/test/spicepods/chbench/sf1/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres-cayenne[file]
+name: postgres-arrow
 
 runtime:
   caching:

--- a/test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file].yaml
@@ -1,0 +1,136 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]
+
+datasets:
+  # ---- TPC-C core tables (mutated by OLTP workload) ----
+
+  - from: postgres:warehouse
+    name: warehouse
+    params: &postgres_params
+      pg_host: 127.0.0.1
+      pg_port: 5432
+      pg_db: chbench
+      pg_user: bench
+      pg_pass: bench
+      pg_sslmode: disable
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: "true"
+    acceleration: &cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: w_id
+      on_conflict:
+        w_id: upsert
+
+  - from: postgres:district
+    name: district
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+
+  - from: postgres:customer
+    name: customer
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+
+  - from: postgres:new_order
+    name: new_order
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+
+  - from: postgres:orders
+    name: orders
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_orders
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+
+  - from: postgres:order_line
+    name: order_line
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_item
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+
+  - from: postgres:stock
+    name: stock
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+
+  - from: postgres:region
+    name: region
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_region
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+
+  - from: postgres:nation
+    name: nation
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_nation
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+
+  - from: postgres:supplier
+    name: supplier
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_supplier
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: s_suppkey
+      on_conflict:
+        s_suppkey: upsert

--- a/test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file].yaml
@@ -2,12 +2,6 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]
 
-runtime:
-  caching:
-    sql_results:
-      enabled: false
-
-
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 

--- a/test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres-cayenne[file]
+name: postgres-duckdb[file]
 
 runtime:
   caching:

--- a/test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml
@@ -24,7 +24,7 @@ datasets:
       pg_replication_initial_snapshot: "true"
     acceleration: &cayenne_accel
       enabled: true
-      engine: cayenne
+      engine: duckdb
       mode: file
       refresh_mode: changes
       primary_key: w_id

--- a/test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml
@@ -2,12 +2,6 @@ version: v1
 kind: Spicepod
 name: postgres-duckdb[file]
 
-runtime:
-  caching:
-    sql_results:
-      enabled: false
-
-
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 
@@ -22,7 +16,7 @@ datasets:
       pg_sslmode: disable
       pg_replication_slot: spice_warehouse
       pg_replication_initial_snapshot: "true"
-    acceleration: &cayenne_accel
+    acceleration: &duckdb_accel
       enabled: true
       engine: duckdb
       mode: file
@@ -37,7 +31,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_district
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: (d_w_id, d_id)
       on_conflict:
         (d_w_id, d_id): upsert
@@ -48,7 +42,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_customer
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: (c_w_id, c_d_id, c_id)
       on_conflict:
         (c_w_id, c_d_id, c_id): upsert
@@ -59,7 +53,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_new_order
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: (no_w_id, no_d_id, no_o_id)
       on_conflict:
         (no_w_id, no_d_id, no_o_id): upsert
@@ -70,7 +64,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_orders
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: (o_w_id, o_d_id, o_id)
       on_conflict:
         (o_w_id, o_d_id, o_id): upsert
@@ -81,7 +75,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_order_line
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
       on_conflict:
         (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
@@ -92,7 +86,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_item
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: i_id
       on_conflict:
         i_id: upsert
@@ -103,7 +97,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_stock
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: (s_w_id, s_i_id)
       on_conflict:
         (s_w_id, s_i_id): upsert
@@ -114,7 +108,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_region
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: r_regionkey
       on_conflict:
         r_regionkey: upsert
@@ -125,7 +119,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_nation
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: n_nationkey
       on_conflict:
         n_nationkey: upsert
@@ -136,7 +130,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_supplier
     acceleration:
-      <<: *cayenne_accel
+      <<: *duckdb_accel
       primary_key: s_suppkey
       on_conflict:
         s_suppkey: upsert

--- a/test/spicepods/chbench/sf1/federated/postgres.yaml
+++ b/test/spicepods/chbench/sf1/federated/postgres.yaml
@@ -2,6 +2,11 @@ version: v1
 kind: Spicepod
 name: postgres-federated
 
+runtime:
+  caching:
+    sql_results:
+      enabled: false
+
 datasets:
   - from: postgres:warehouse
     name: warehouse

--- a/test/spicepods/chbench/sf1/federated/postgres.yaml
+++ b/test/spicepods/chbench/sf1/federated/postgres.yaml
@@ -1,0 +1,48 @@
+version: v1
+kind: Spicepod
+name: postgres-federated
+
+datasets:
+  - from: postgres:warehouse
+    name: warehouse
+    params: &postgres_params
+      pg_host: 127.0.0.1
+      pg_port: 5432
+      pg_db: chbench
+      pg_user: bench
+      pg_pass: bench
+      pg_sslmode: disable
+      connection_pool_size: 20
+  - from: postgres:district
+    name: district
+    params: *postgres_params
+  - from: postgres:customer
+    name: customer
+    params: *postgres_params
+  - from: postgres:history
+    name: history
+    params: *postgres_params
+  - from: postgres:orders
+    name: orders
+    params: *postgres_params
+  - from: postgres:new_order
+    name: new_order
+    params: *postgres_params
+  - from: postgres:order_line
+    name: order_line
+    params: *postgres_params
+  - from: postgres:item
+    name: item
+    params: *postgres_params
+  - from: postgres:stock
+    name: stock
+    params: *postgres_params
+  - from: postgres:nation
+    name: nation
+    params: *postgres_params
+  - from: postgres:region
+    name: region
+    params: *postgres_params
+  - from: postgres:supplier
+    name: supplier
+    params: *postgres_params

--- a/test/spicepods/chbench/sf1/federated/postgres.yaml
+++ b/test/spicepods/chbench/sf1/federated/postgres.yaml
@@ -2,11 +2,6 @@ version: v1
 kind: Spicepod
 name: postgres-federated
 
-runtime:
-  caching:
-    sql_results:
-      enabled: false
-
 datasets:
   - from: postgres:warehouse
     name: warehouse

--- a/tools/chbench-driver/Cargo.toml
+++ b/tools/chbench-driver/Cargo.toml
@@ -6,6 +6,8 @@ rust-version.workspace = true
 license-file.workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
+chrono = { workspace = true }
 rand = "0.8"
 snafu = "0.8"
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/tools/chbench-driver/Cargo.toml
+++ b/tools/chbench-driver/Cargo.toml
@@ -10,3 +10,4 @@ rand = "0.8"
 snafu = "0.8"
 tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-postgres = { workspace = true }
+tokio-util = { workspace = true }

--- a/tools/chbench-driver/Cargo.toml
+++ b/tools/chbench-driver/Cargo.toml
@@ -10,4 +10,3 @@ rand = "0.8"
 snafu = "0.8"
 tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-postgres = { workspace = true }
-tracing = { workspace = true }

--- a/tools/chbench-driver/Cargo.toml
+++ b/tools/chbench-driver/Cargo.toml
@@ -10,6 +10,6 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
 snafu = "0.8"
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 tokio-postgres = { workspace = true }
 tokio-util = { workspace = true }

--- a/tools/chbench-driver/Cargo.toml
+++ b/tools/chbench-driver/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "chbench-driver"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file.workspace = true
+
+[dependencies]
+rand = "0.8"
+snafu = "0.8"
+tokio = { workspace = true, features = ["macros", "rt"] }
+tokio-postgres = { workspace = true }
+tracing = { workspace = true }

--- a/tools/chbench-driver/Cargo.toml
+++ b/tools/chbench-driver/Cargo.toml
@@ -8,7 +8,7 @@ license-file.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
-rand = "0.8"
+rand = { workspace = true }
 snafu = "0.8"
 tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-postgres = { workspace = true }

--- a/tools/chbench-driver/Cargo.toml
+++ b/tools/chbench-driver/Cargo.toml
@@ -9,7 +9,7 @@ license-file.workspace = true
 async-trait = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
-snafu = "0.8"
+snafu = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 tokio-postgres = { workspace = true }
 tokio-util = { workspace = true }

--- a/tools/chbench-driver/src/config.rs
+++ b/tools/chbench-driver/src/config.rs
@@ -37,6 +37,16 @@ pub struct ChBenchConfig {
 
     /// PostgreSQL password.
     pub pg_pass: String,
+
+    /// Number of concurrent OLTP terminals for the HTAP workload.
+    pub terminals: usize,
+
+    /// Duration of the OLTP workload.
+    pub duration: std::time::Duration,
+
+    /// Transaction mix weights: [NewOrder, Payment, Delivery, OrderStatus, StockLevel].
+    /// Must sum to 100.
+    pub mix: [u32; 5],
 }
 
 /// Default RNG seed for deterministic data generation.
@@ -52,6 +62,9 @@ impl Default for ChBenchConfig {
             pg_db: "chbench".into(),
             pg_user: "bench".into(),
             pg_pass: "bench".into(),
+            terminals: 10,
+            duration: std::time::Duration::from_secs(60),
+            mix: crate::txn::DEFAULT_MIX,
         }
     }
 }

--- a/tools/chbench-driver/src/config.rs
+++ b/tools/chbench-driver/src/config.rs
@@ -63,7 +63,7 @@ impl Default for ChBenchConfig {
             pg_user: "bench".into(),
             pg_pass: "bench".into(),
             terminals: 10,
-            duration: std::time::Duration::from_secs(60),
+            duration: std::time::Duration::from_secs(300),
             mix: crate::txn::DEFAULT_MIX,
         }
     }

--- a/tools/chbench-driver/src/config.rs
+++ b/tools/chbench-driver/src/config.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Source-agnostic workload configuration for CH-benCH.
+/// Configuration for the CH-benCH driver.
 pub struct ChBenchConfig {
     /// Number of TPC-C warehouses (scale factor). Each warehouse ≈ 100 MB seed data.
     pub warehouses: usize,

--- a/tools/chbench-driver/src/config.rs
+++ b/tools/chbench-driver/src/config.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Configuration for the CH-benCH driver.
+/// Source-agnostic workload configuration for CH-benCH.
 pub struct ChBenchConfig {
     /// Number of TPC-C warehouses (scale factor). Each warehouse ≈ 100 MB seed data.
     pub warehouses: usize,
@@ -22,21 +22,6 @@ pub struct ChBenchConfig {
     /// Optional RNG seed for deterministic data generation.
     /// When `Some(seed)`, the same seed produces the exact same dataset.
     pub seed: Option<u64>,
-
-    /// PostgreSQL host.
-    pub pg_host: String,
-
-    /// PostgreSQL port.
-    pub pg_port: u16,
-
-    /// PostgreSQL database name.
-    pub pg_db: String,
-
-    /// PostgreSQL user (must have REPLICATION privilege for Spice CDC).
-    pub pg_user: String,
-
-    /// PostgreSQL password.
-    pub pg_pass: String,
 
     /// Number of concurrent OLTP terminals for the HTAP workload.
     pub terminals: usize,
@@ -57,11 +42,6 @@ impl Default for ChBenchConfig {
         Self {
             warehouses: 1,
             seed: Some(DEFAULT_SEED),
-            pg_host: "127.0.0.1".into(),
-            pg_port: 5432,
-            pg_db: "chbench".into(),
-            pg_user: "bench".into(),
-            pg_pass: "bench".into(),
             terminals: 10,
             duration: std::time::Duration::from_secs(300),
             mix: crate::txn::DEFAULT_MIX,
@@ -69,12 +49,42 @@ impl Default for ChBenchConfig {
     }
 }
 
-impl ChBenchConfig {
+/// PostgreSQL-specific connection configuration.
+pub struct PostgresSourceConfig {
+    /// PostgreSQL host.
+    pub host: String,
+
+    /// PostgreSQL port.
+    pub port: u16,
+
+    /// PostgreSQL database name.
+    pub db: String,
+
+    /// PostgreSQL user (must have REPLICATION privilege for Spice CDC).
+    pub user: String,
+
+    /// PostgreSQL password.
+    pub pass: String,
+}
+
+impl Default for PostgresSourceConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".into(),
+            port: 5432,
+            db: "chbench".into(),
+            user: "bench".into(),
+            pass: "bench".into(),
+        }
+    }
+}
+
+impl PostgresSourceConfig {
     /// Build a `tokio-postgres` connection string from this config.
-    pub fn pg_connection_string(&self) -> String {
+    pub fn connection_string(&self) -> String {
         format!(
             "host={} port={} dbname={} user={} password={}",
-            self.pg_host, self.pg_port, self.pg_db, self.pg_user, self.pg_pass,
+            self.host, self.port, self.db, self.user, self.pass,
         )
     }
 }

--- a/tools/chbench-driver/src/config.rs
+++ b/tools/chbench-driver/src/config.rs
@@ -29,7 +29,7 @@ pub struct ChBenchConfig {
     /// Duration of the OLTP workload.
     pub duration: std::time::Duration,
 
-    /// Transaction mix weights: [NewOrder, Payment, Delivery, OrderStatus, StockLevel].
+    /// Transaction mix weights: \[`NewOrder`, Payment, Delivery, `OrderStatus`, `StockLevel`\].
     /// Must sum to 100.
     pub mix: [u32; 5],
 }
@@ -49,21 +49,21 @@ impl Default for ChBenchConfig {
     }
 }
 
-/// PostgreSQL-specific connection configuration.
+/// Postgres-specific connection configuration.
 pub struct PostgresSourceConfig {
-    /// PostgreSQL host.
+    /// Postgres host.
     pub host: String,
 
-    /// PostgreSQL port.
+    /// Postgres port.
     pub port: u16,
 
-    /// PostgreSQL database name.
+    /// Postgres database name.
     pub db: String,
 
-    /// PostgreSQL user (must have REPLICATION privilege for Spice CDC).
+    /// Postgres user (must have REPLICATION privilege for Spice CDC).
     pub user: String,
 
-    /// PostgreSQL password.
+    /// Postgres password.
     pub pass: String,
 }
 
@@ -81,6 +81,7 @@ impl Default for PostgresSourceConfig {
 
 impl PostgresSourceConfig {
     /// Build a `tokio-postgres` connection string from this config.
+    #[must_use]
     pub fn connection_string(&self) -> String {
         format!(
             "host={} port={} dbname={} user={} password={}",

--- a/tools/chbench-driver/src/config.rs
+++ b/tools/chbench-driver/src/config.rs
@@ -1,0 +1,67 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// Configuration for the CH-benCH driver.
+pub struct ChBenchConfig {
+    /// Number of TPC-C warehouses (scale factor). Each warehouse ≈ 100 MB seed data.
+    pub warehouses: usize,
+
+    /// Optional RNG seed for deterministic data generation.
+    /// When `Some(seed)`, the same seed produces the exact same dataset.
+    pub seed: Option<u64>,
+
+    /// PostgreSQL host.
+    pub pg_host: String,
+
+    /// PostgreSQL port.
+    pub pg_port: u16,
+
+    /// PostgreSQL database name.
+    pub pg_db: String,
+
+    /// PostgreSQL user (must have REPLICATION privilege for Spice CDC).
+    pub pg_user: String,
+
+    /// PostgreSQL password.
+    pub pg_pass: String,
+}
+
+/// Default RNG seed for deterministic data generation.
+const DEFAULT_SEED: u64 = 42;
+
+impl Default for ChBenchConfig {
+    fn default() -> Self {
+        Self {
+            warehouses: 1,
+            seed: Some(DEFAULT_SEED),
+            pg_host: "127.0.0.1".into(),
+            pg_port: 5432,
+            pg_db: "chbench".into(),
+            pg_user: "bench".into(),
+            pg_pass: "bench".into(),
+        }
+    }
+}
+
+impl ChBenchConfig {
+    /// Build a `tokio-postgres` connection string from this config.
+    pub(crate) fn pg_connection_string(&self) -> String {
+        format!(
+            "host={} port={} dbname={} user={} password={}",
+            self.pg_host, self.pg_port, self.pg_db, self.pg_user, self.pg_pass,
+        )
+    }
+}

--- a/tools/chbench-driver/src/config.rs
+++ b/tools/chbench-driver/src/config.rs
@@ -71,7 +71,7 @@ impl Default for ChBenchConfig {
 
 impl ChBenchConfig {
     /// Build a `tokio-postgres` connection string from this config.
-    pub(crate) fn pg_connection_string(&self) -> String {
+    pub fn pg_connection_string(&self) -> String {
         format!(
             "host={} port={} dbname={} user={} password={}",
             self.pg_host, self.pg_port, self.pg_db, self.pg_user, self.pg_pass,

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -49,7 +49,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Source-agnostic interface for CH-benCH benchmarks.
 ///
-/// Each source (Postgres, MySQL, DynamoDB, etc.) implements this trait to
+/// Each source (Postgres, `MySQL`, `DynamoDB`, etc.) implements this trait to
 /// provide schema setup, OLTP workload execution, and staleness probing.
 #[async_trait]
 pub trait ChBenchDriver: Send + Sync {
@@ -82,7 +82,11 @@ pub struct PostgresChBenchDriver {
 }
 
 impl PostgresChBenchDriver {
-    /// Connect to PostgreSQL using the provided configuration.
+    /// Connect to Postgres using the provided configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection cannot be established.
     pub async fn connect(config: ChBenchConfig, source: PostgresSourceConfig) -> Result<Self> {
         let conn_str = source.connection_string();
         let (client, connection) = tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
@@ -164,7 +168,7 @@ impl ChBenchDriver for PostgresChBenchDriver {
         for handle in handles {
             match handle.await {
                 Ok(Ok(terminal_metrics)) => {
-                    combined.merge(terminal_metrics);
+                    combined.merge(&terminal_metrics);
                 }
                 Ok(Err(e)) => {
                     eprintln!("Terminal error: {e}");

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -72,7 +72,7 @@ impl ChBenchDriver {
 
         tokio::spawn(async move {
             if let Err(e) = connection.await {
-                tracing::error!("CH-benCH source PostgreSQL connection error: {e}");
+                eprintln!("CH-benCH source PostgreSQL connection error: {e}");
             }
         });
 
@@ -81,7 +81,7 @@ impl ChBenchDriver {
 
     /// Drop and recreate all 12 CH-benCH tables, then load seed data.
     pub async fn prepare(&self) -> Result<()> {
-        tracing::info!(
+        println!(
             "Preparing CH-benCH schema with {} warehouse(s)",
             self.config.warehouses,
         );
@@ -90,7 +90,7 @@ impl ChBenchDriver {
         schema::create_tables(&self.client).await?;
         loader::load_all(&self.client, self.config.warehouses, self.config.seed).await?;
 
-        tracing::info!("CH-benCH prepare complete");
+        println!("CH-benCH prepare complete");
         Ok(())
     }
 }

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -140,10 +140,8 @@ impl ChBenchDriver for PostgresChBenchDriver {
         let base_seed = self.config.seed.unwrap_or(42);
 
         println!(
-            "Starting OLTP workload: {} terminals, {}s duration, mix={:?}",
-            terminals,
-            duration.as_secs(),
-            mix,
+            "Starting OLTP workload: {warehouses} warehouse(s), {terminals} terminals, {duration}s duration, mix={mix:?}",
+            duration = duration.as_secs()
         );
 
         // Spawn a task that cancels after the configured duration

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -1,0 +1,96 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! CH-benCH driver — TPC-C schema + seed data loader for PostgreSQL.
+//!
+//! Creates 12 tables (9 TPC-C + 3 CH supplemental) and loads seed data
+//! for the given number of warehouses.
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! use chbench_driver::{ChBenchConfig, ChBenchDriver};
+//!
+//! # async fn example() -> chbench_driver::Result<()> {
+//! let config = ChBenchConfig { warehouses: 1, ..Default::default() };
+//! let driver = ChBenchDriver::connect(config).await?;
+//! driver.prepare().await?;
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod config;
+pub mod loader;
+pub mod rand;
+pub mod schema;
+
+pub use config::ChBenchConfig;
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to {action}: {source}"))]
+    Sql {
+        action: String,
+        source: tokio_postgres::Error,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// CH-benCH driver for TPC-C schema setup and data loading.
+pub struct ChBenchDriver {
+    client: tokio_postgres::Client,
+    config: ChBenchConfig,
+}
+
+impl ChBenchDriver {
+    /// Connect to PostgreSQL using the provided configuration.
+    pub async fn connect(config: ChBenchConfig) -> Result<Self> {
+        let conn_str = config.pg_connection_string();
+        let (client, connection) =
+            tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
+                .await
+                .map_err(|source| Error::Sql {
+                    action: "connect to PostgreSQL".into(),
+                    source,
+                })?;
+
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                tracing::error!("CH-benCH source PostgreSQL connection error: {e}");
+            }
+        });
+
+        Ok(Self { client, config })
+    }
+
+    /// Drop and recreate all 12 CH-benCH tables, then load seed data.
+    pub async fn prepare(&self) -> Result<()> {
+        tracing::info!(
+            "Preparing CH-benCH schema with {} warehouse(s)",
+            self.config.warehouses,
+        );
+
+        schema::drop_tables(&self.client).await?;
+        schema::create_tables(&self.client).await?;
+        loader::load_all(&self.client, self.config.warehouses, self.config.seed).await?;
+
+        tracing::info!("CH-benCH prepare complete");
+        Ok(())
+    }
+}

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -18,19 +18,6 @@ limitations under the License.
 //!
 //! Creates 12 tables (9 TPC-C + 3 CH supplemental), loads seed data,
 //! and runs a TPC-C OLTP workload with configurable terminals and duration.
-//!
-//! # Usage
-//!
-//! ```rust,no_run
-//! use chbench_driver::{ChBenchConfig, PostgresChBenchDriver};
-//!
-//! # async fn example() -> chbench_driver::Result<()> {
-//! let config = ChBenchConfig { warehouses: 1, ..Default::default() };
-//! let driver = PostgresChBenchDriver::connect(config).await?;
-//! driver.prepare().await?;
-//! # Ok(())
-//! # }
-//! ```
 
 pub mod config;
 pub mod loader;

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -43,8 +43,8 @@ pub use config::{ChBenchConfig, PostgresSourceConfig};
 pub use metrics::OltpReport;
 pub use txn::TxnType;
 
-use ::rand::rngs::StdRng;
 use ::rand::SeedableRng;
+use ::rand::rngs::StdRng;
 use async_trait::async_trait;
 use snafu::Snafu;
 use tokio_util::sync::CancellationToken;
@@ -98,13 +98,12 @@ impl PostgresChBenchDriver {
     /// Connect to PostgreSQL using the provided configuration.
     pub async fn connect(config: ChBenchConfig, source: PostgresSourceConfig) -> Result<Self> {
         let conn_str = source.connection_string();
-        let (client, connection) =
-            tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
-                .await
-                .map_err(|source| Error::Sql {
-                    action: "connect to PostgreSQL".into(),
-                    source,
-                })?;
+        let (client, connection) = tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
+            .await
+            .map_err(|source| Error::Sql {
+                action: "connect to PostgreSQL".into(),
+                source,
+            })?;
 
         tokio::spawn(async move {
             if let Err(e) = connection.await {
@@ -112,7 +111,11 @@ impl PostgresChBenchDriver {
             }
         });
 
-        Ok(Self { client, config, source })
+        Ok(Self {
+            client,
+            config,
+            source,
+        })
     }
 }
 

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -33,7 +33,7 @@ pub use txn::TxnType;
 use ::rand::SeedableRng;
 use ::rand::rngs::StdRng;
 use async_trait::async_trait;
-use snafu::Snafu;
+use snafu::{Snafu, ensure};
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Snafu)]
@@ -43,6 +43,11 @@ pub enum Error {
         action: String,
         source: tokio_postgres::Error,
     },
+
+    #[snafu(display(
+        "{failed}/{total} OLTP terminal(s) failed — benchmark results are unreliable"
+    ))]
+    OltpTerminalFailures { failed: usize, total: usize },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -163,6 +168,7 @@ impl ChBenchDriver for PostgresChBenchDriver {
 
         // Collect results from all terminals
         let mut combined = metrics::OltpMetrics::new();
+        let mut failed_terminals: usize = 0;
         for handle in handles {
             match handle.await {
                 Ok(Ok(terminal_metrics)) => {
@@ -170,12 +176,22 @@ impl ChBenchDriver for PostgresChBenchDriver {
                 }
                 Ok(Err(e)) => {
                     eprintln!("Terminal error: {e}");
+                    failed_terminals += 1;
                 }
                 Err(e) => {
                     eprintln!("Terminal join error: {e}");
+                    failed_terminals += 1;
                 }
             }
         }
+
+        ensure!(
+            failed_terminals == 0,
+            OltpTerminalFailuresSnafu {
+                failed: failed_terminals,
+                total: terminals,
+            }
+        );
 
         let report = combined.finish();
         Ok(report)

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! CH-benCH driver — TPC-C schema + seed data loader for PostgreSQL.
+//! CH-benCH driver — TPC-C schema + seed data loader and OLTP workload driver for PostgreSQL.
 //!
-//! Creates 12 tables (9 TPC-C + 3 CH supplemental) and loads seed data
-//! for the given number of warehouses.
+//! Creates 12 tables (9 TPC-C + 3 CH supplemental), loads seed data,
+//! and runs a TPC-C OLTP workload with configurable terminals and duration.
 //!
 //! # Usage
 //!
@@ -34,12 +34,21 @@ limitations under the License.
 
 pub mod config;
 pub mod loader;
+pub mod metrics;
 pub mod rand;
 pub mod schema;
+pub mod txn;
 
 pub use config::ChBenchConfig;
+pub use metrics::OltpReport;
+pub use txn::TxnType;
 
+use std::time::Instant;
+
+use ::rand::rngs::StdRng;
+use ::rand::SeedableRng;
 use snafu::Snafu;
+use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -52,7 +61,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// CH-benCH driver for TPC-C schema setup and data loading.
+/// CH-benCH driver for TPC-C schema setup, data loading, and OLTP workload.
 pub struct ChBenchDriver {
     client: tokio_postgres::Client,
     config: ChBenchConfig,
@@ -93,4 +102,115 @@ impl ChBenchDriver {
         println!("CH-benCH prepare complete");
         Ok(())
     }
+
+    /// Run the TPC-C OLTP workload until the cancellation token is triggered
+    /// or `config.duration` elapses.
+    ///
+    /// Each terminal opens its own Postgres connection and runs transactions
+    /// in a tight loop with the configured mix weights.
+    pub async fn run(&self, cancel: CancellationToken) -> Result<OltpReport> {
+        let terminals = self.config.terminals;
+        let duration = self.config.duration;
+        let mix = self.config.mix;
+        let warehouses = i32::try_from(self.config.warehouses).unwrap_or(1);
+        let base_seed = self.config.seed.unwrap_or(42);
+
+        println!(
+            "Starting OLTP workload: {} terminals, {}s duration, mix={:?}",
+            terminals,
+            duration.as_secs(),
+            mix,
+        );
+
+        // Spawn a task that cancels after the configured duration
+        let duration_cancel = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(duration).await;
+            duration_cancel.cancel();
+        });
+
+        let mut handles = Vec::with_capacity(terminals);
+        for terminal_id in 0..terminals {
+            let conn_str = self.config.pg_connection_string();
+            let cancel = cancel.clone();
+
+            handles.push(tokio::spawn(async move {
+                run_terminal(terminal_id, &conn_str, cancel, warehouses, mix, base_seed).await
+            }));
+        }
+
+        // Collect results from all terminals
+        let mut combined = metrics::OltpMetrics::new();
+        for handle in handles {
+            match handle.await {
+                Ok(Ok(terminal_metrics)) => {
+                    combined.merge(terminal_metrics);
+                }
+                Ok(Err(e)) => {
+                    eprintln!("Terminal error: {e}");
+                }
+                Err(e) => {
+                    eprintln!("Terminal join error: {e}");
+                }
+            }
+        }
+
+        let report = combined.finish();
+        report.print_summary();
+        Ok(report)
+    }
+}
+
+/// Run a single OLTP terminal loop until cancelled.
+async fn run_terminal(
+    terminal_id: usize,
+    conn_str: &str,
+    cancel: CancellationToken,
+    warehouses: i32,
+    mix: [u32; 5],
+    base_seed: u64,
+) -> Result<metrics::OltpMetrics> {
+    let (mut client, connection) = tokio_postgres::connect(conn_str, tokio_postgres::NoTls)
+        .await
+        .map_err(|source| Error::Sql {
+            action: format!("connect terminal {terminal_id}"),
+            source,
+        })?;
+
+    let cancel_conn = cancel.clone();
+    tokio::spawn(async move {
+        tokio::select! {
+            result = connection => {
+                if let Err(e) = result {
+                    eprintln!("Terminal {terminal_id} connection error: {e}");
+                }
+            }
+            () = cancel_conn.cancelled() => {}
+        }
+    });
+
+    let mut rng = StdRng::seed_from_u64(base_seed.wrapping_add(terminal_id as u64));
+    let mut metrics = metrics::OltpMetrics::new();
+
+    loop {
+        if cancel.is_cancelled() {
+            break;
+        }
+
+        let txn_type = txn::pick_txn_type(&mut rng, &mix);
+        let start = Instant::now();
+
+        match txn::execute(&mut client, &mut rng, txn_type, warehouses).await {
+            Ok(()) => {
+                metrics.record_success(txn_type, start.elapsed());
+            }
+            Err(e) => {
+                metrics.record_abort(txn_type, start.elapsed());
+                // Log at debug level — aborts are expected in TPC-C
+                eprintln!("Terminal {terminal_id} {txn_type} error: {e}");
+            }
+        }
+    }
+
+    Ok(metrics)
 }

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -43,8 +43,6 @@ pub use config::ChBenchConfig;
 pub use metrics::OltpReport;
 pub use txn::TxnType;
 
-use std::time::Instant;
-
 use ::rand::rngs::StdRng;
 use ::rand::SeedableRng;
 use snafu::Snafu;
@@ -197,16 +195,18 @@ async fn run_terminal(
         }
 
         let txn_type = txn::pick_txn_type(&mut rng, &mix);
-        let start = Instant::now();
 
         match txn::execute(&mut client, &mut rng, txn_type, warehouses).await {
             Ok(()) => {
-                metrics.record_success(txn_type, start.elapsed());
+                metrics.record_success(txn_type);
             }
             Err(e) => {
-                metrics.record_abort(txn_type, start.elapsed());
-                // Log at debug level — aborts are expected in TPC-C
-                eprintln!("Terminal {terminal_id} {txn_type} error: {e}");
+                metrics.record_abort();
+                if !cancel.is_cancelled() {
+                    // Log only if not shutting down — connection-closed errors
+                    // during cancellation are expected and noisy.
+                    eprintln!("Terminal {terminal_id} {txn_type} error: {e}");
+                }
             }
         }
     }

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! CH-benCH driver — TPC-C schema + seed data loader and OLTP workload driver for PostgreSQL.
+//! CH-benCH driver — TPC-C schema + seed data loader and OLTP workload driver.
 //!
 //! Creates 12 tables (9 TPC-C + 3 CH supplemental), loads seed data,
 //! and runs a TPC-C OLTP workload with configurable terminals and duration.
@@ -22,11 +22,11 @@ limitations under the License.
 //! # Usage
 //!
 //! ```rust,no_run
-//! use chbench_driver::{ChBenchConfig, ChBenchDriver};
+//! use chbench_driver::{ChBenchConfig, PostgresChBenchDriver};
 //!
 //! # async fn example() -> chbench_driver::Result<()> {
 //! let config = ChBenchConfig { warehouses: 1, ..Default::default() };
-//! let driver = ChBenchDriver::connect(config).await?;
+//! let driver = PostgresChBenchDriver::connect(config).await?;
 //! driver.prepare().await?;
 //! # Ok(())
 //! # }
@@ -39,12 +39,13 @@ pub mod rand;
 pub mod schema;
 pub mod txn;
 
-pub use config::ChBenchConfig;
+pub use config::{ChBenchConfig, PostgresSourceConfig};
 pub use metrics::OltpReport;
 pub use txn::TxnType;
 
 use ::rand::rngs::StdRng;
 use ::rand::SeedableRng;
+use async_trait::async_trait;
 use snafu::Snafu;
 use tokio_util::sync::CancellationToken;
 
@@ -59,16 +60,44 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// CH-benCH driver for TPC-C schema setup, data loading, and OLTP workload.
-pub struct ChBenchDriver {
-    client: tokio_postgres::Client,
-    config: ChBenchConfig,
+/// Source-agnostic interface for CH-benCH benchmarks.
+///
+/// Each source (Postgres, MySQL, DynamoDB, etc.) implements this trait to
+/// provide schema setup, OLTP workload execution, and staleness probing.
+#[async_trait]
+pub trait ChBenchDriver: Send + Sync {
+    /// Set up the schema, seed data, and any source-specific instrumentation
+    /// (e.g. `_bench_ts` triggers).
+    async fn prepare(&self) -> Result<()>;
+
+    /// Run the TPC-C OLTP workload until `cancel` fires or the configured
+    /// duration elapses.
+    async fn run(&self, cancel: CancellationToken) -> Result<OltpReport>;
+
+    /// Tables to probe for staleness measurement.
+    ///
+    /// Returns a subset of mutated tables chosen for CDC path diversity
+    /// (e.g. small-table updates, high-volume inserts, deletes).
+    fn probe_tables(&self) -> &[&str];
+
+    /// Read `MAX(_bench_ts)` from the *source* for a given table.
+    ///
+    /// Returns microseconds since Unix epoch, or `None` if the table is empty
+    /// or the column doesn't exist.
+    async fn max_bench_ts(&self, table: &str) -> Result<Option<i64>>;
 }
 
-impl ChBenchDriver {
+/// Postgres-backed CH-benCH driver.
+pub struct PostgresChBenchDriver {
+    client: tokio_postgres::Client,
+    config: ChBenchConfig,
+    source: PostgresSourceConfig,
+}
+
+impl PostgresChBenchDriver {
     /// Connect to PostgreSQL using the provided configuration.
-    pub async fn connect(config: ChBenchConfig) -> Result<Self> {
-        let conn_str = config.pg_connection_string();
+    pub async fn connect(config: ChBenchConfig, source: PostgresSourceConfig) -> Result<Self> {
+        let conn_str = source.connection_string();
         let (client, connection) =
             tokio_postgres::connect(&conn_str, tokio_postgres::NoTls)
                 .await
@@ -83,11 +112,14 @@ impl ChBenchDriver {
             }
         });
 
-        Ok(Self { client, config })
+        Ok(Self { client, config, source })
     }
+}
 
+#[async_trait]
+impl ChBenchDriver for PostgresChBenchDriver {
     /// Drop and recreate all 12 CH-benCH tables, then load seed data.
-    pub async fn prepare(&self) -> Result<()> {
+    async fn prepare(&self) -> Result<()> {
         println!(
             "Preparing CH-benCH schema with {} warehouse(s)",
             self.config.warehouses,
@@ -106,7 +138,7 @@ impl ChBenchDriver {
     ///
     /// Each terminal opens its own Postgres connection and runs transactions
     /// in a tight loop with the configured mix weights.
-    pub async fn run(&self, cancel: CancellationToken) -> Result<OltpReport> {
+    async fn run(&self, cancel: CancellationToken) -> Result<OltpReport> {
         let terminals = self.config.terminals;
         let duration = self.config.duration;
         let mix = self.config.mix;
@@ -129,7 +161,7 @@ impl ChBenchDriver {
 
         let mut handles = Vec::with_capacity(terminals);
         for terminal_id in 0..terminals {
-            let conn_str = self.config.pg_connection_string();
+            let conn_str = self.source.connection_string();
             let cancel = cancel.clone();
 
             handles.push(tokio::spawn(async move {
@@ -155,6 +187,27 @@ impl ChBenchDriver {
 
         let report = combined.finish();
         Ok(report)
+    }
+
+    fn probe_tables(&self) -> &[&str] {
+        schema::STALENESS_PROBE_TABLES
+    }
+
+    async fn max_bench_ts(&self, table: &str) -> Result<Option<i64>> {
+        let query = format!("SELECT MAX(_bench_ts) FROM {table}");
+        let rows = self
+            .client
+            .query(&query, &[])
+            .await
+            .map_err(|source| Error::Sql {
+                action: format!("query MAX(_bench_ts) from {table}"),
+                source,
+            })?;
+        if rows.is_empty() {
+            return Ok(None);
+        }
+        let ts: Option<chrono::DateTime<chrono::Utc>> = rows[0].get(0);
+        Ok(ts.map(|t| t.timestamp_micros()))
     }
 }
 

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -156,7 +156,6 @@ impl ChBenchDriver {
         }
 
         let report = combined.finish();
-        report.print_summary();
         Ok(report)
     }
 }

--- a/tools/chbench-driver/src/loader.rs
+++ b/tools/chbench-driver/src/loader.rs
@@ -1,0 +1,526 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Seed data loader for TPC-C + CH-benCH supplemental tables.
+//!
+//! Mirrors go-tpc's loading logic: for each warehouse, loads warehouse, district,
+//! stock, customer, history, orders, new_order, and order_line. Also loads the
+//! static item, nation, region, and supplier tables.
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use tokio_postgres::Client;
+
+use crate::rand as tpcc_rand;
+use crate::Result;
+
+const MAX_ITEMS: i32 = 100_000;
+const STOCK_PER_WAREHOUSE: i32 = 100_000;
+const DISTRICTS_PER_WAREHOUSE: i32 = 10;
+const CUSTOMERS_PER_DISTRICT: i32 = 3_000;
+const ORDERS_PER_DISTRICT: i32 = 3_000;
+const NEW_ORDERS_PER_DISTRICT: i32 = 900;
+
+const INIT_LOAD_TIME: &str = "2007-01-02 15:04:05";
+const BATCH_SIZE: usize = 500;
+
+/// Load all seed data for the given number of warehouses.
+///
+/// When `seed` is `Some`, a deterministic RNG is used so that the same seed
+/// always produces the same dataset.
+pub async fn load_all(client: &Client, warehouses: usize, seed: Option<u64>) -> Result<()> {
+    let mut rng: StdRng = match seed {
+        Some(s) => StdRng::seed_from_u64(s),
+        None => StdRng::from_rng(rand::thread_rng()).unwrap_or_else(|_| StdRng::seed_from_u64(0)),
+    };
+    let c_load: usize = rng.gen_range(0..256);
+
+    load_item(client, &mut rng).await?;
+    load_nation(client).await?;
+    load_region(client).await?;
+    load_supplier(client, &mut rng).await?;
+
+    for w in 1..=warehouses {
+        let w_id = i32::try_from(w).unwrap_or(i32::MAX);
+        load_warehouse(client, &mut rng, w_id).await?;
+        load_district(client, &mut rng, w_id).await?;
+        load_stock(client, &mut rng, w_id).await?;
+
+        for d in 1..=DISTRICTS_PER_WAREHOUSE {
+            load_customer(client, &mut rng, w_id, d, c_load).await?;
+            load_history(client, &mut rng, w_id, d).await?;
+            let ol_cnts = load_orders(client, &mut rng, w_id, d).await?;
+            load_new_order(client, w_id, d).await?;
+            load_order_line(client, &mut rng, w_id, d, &ol_cnts).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn load_item(client: &Client, rng: &mut impl Rng) -> Result<()> {
+    tracing::info!("loading item ({MAX_ITEMS} rows)");
+    let stmt = client
+        .prepare("INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES ($1, $2, $3, $4, $5)")
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare item insert".into(), source })?;
+
+    for batch_start in (1..=MAX_ITEMS).step_by(BATCH_SIZE) {
+        let batch_end = (batch_start + i32::try_from(BATCH_SIZE).unwrap_or(i32::MAX) - 1).min(MAX_ITEMS);
+        for i in batch_start..=batch_end {
+            let i_im_id: i32 = rng.gen_range(1..=10_000);
+            let i_price: f64 = f64::from(rng.gen_range(100..=10_000)) / 100.0;
+            let i_name = tpcc_rand::rand_chars(rng, 14, 24);
+            let i_data = tpcc_rand::rand_original_string(rng);
+
+            client
+                .execute(&stmt, &[&i, &i_im_id, &i_name, &i_price, &i_data])
+                .await
+                .map_err(|source| crate::Error::Sql { action: format!("insert item {i}"), source })?;
+        }
+    }
+    Ok(())
+}
+
+async fn load_warehouse(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
+    tracing::info!("loading warehouse {w_id}");
+    let w_name = tpcc_rand::rand_chars(rng, 6, 10);
+    let w_street_1 = tpcc_rand::rand_chars(rng, 10, 20);
+    let w_street_2 = tpcc_rand::rand_chars(rng, 10, 20);
+    let w_city = tpcc_rand::rand_chars(rng, 10, 20);
+    let w_state = tpcc_rand::rand_state(rng);
+    let w_zip = tpcc_rand::rand_zip(rng);
+    let w_tax = tpcc_rand::rand_tax(rng);
+    let w_ytd: f64 = 300_000.00;
+
+    client
+        .execute(
+            "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            &[&w_id, &w_name, &w_street_1, &w_street_2, &w_city, &w_state, &w_zip, &w_tax, &w_ytd],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql { action: format!("insert warehouse {w_id}"), source })?;
+
+    Ok(())
+}
+
+async fn load_district(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
+    tracing::info!("loading district for warehouse {w_id}");
+    let stmt = client
+        .prepare(
+            "INSERT INTO district (d_id, d_w_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+        )
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare district insert".into(), source })?;
+
+    for d in 1..=DISTRICTS_PER_WAREHOUSE {
+        let d_name = tpcc_rand::rand_chars(rng, 6, 10);
+        let d_street_1 = tpcc_rand::rand_chars(rng, 10, 20);
+        let d_street_2 = tpcc_rand::rand_chars(rng, 10, 20);
+        let d_city = tpcc_rand::rand_chars(rng, 10, 20);
+        let d_state = tpcc_rand::rand_state(rng);
+        let d_zip = tpcc_rand::rand_zip(rng);
+        let d_tax = tpcc_rand::rand_tax(rng);
+        let d_ytd: f64 = 30_000.00;
+        let d_next_o_id: i32 = 3001;
+
+        client
+            .execute(
+                &stmt,
+                &[&d, &w_id, &d_name, &d_street_1, &d_street_2, &d_city, &d_state, &d_zip, &d_tax, &d_ytd, &d_next_o_id],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert district {d} warehouse {w_id}"), source })?;
+    }
+    Ok(())
+}
+
+async fn load_stock(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
+    tracing::info!("loading stock for warehouse {w_id} ({STOCK_PER_WAREHOUSE} rows)");
+    let stmt = client
+        .prepare(
+            "INSERT INTO stock (s_i_id, s_w_id, s_quantity, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
+        )
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare stock insert".into(), source })?;
+
+    for i in 1..=STOCK_PER_WAREHOUSE {
+        let s_quantity: i32 = rng.gen_range(10..=100);
+        let s_dist_01 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_02 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_03 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_04 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_05 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_06 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_07 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_08 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_09 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_dist_10 = tpcc_rand::rand_letters(rng, 24, 24);
+        let s_ytd: i32 = 0;
+        let s_order_cnt: i32 = 0;
+        let s_remote_cnt: i32 = 0;
+        let s_data = tpcc_rand::rand_original_string(rng);
+
+        client
+            .execute(
+                &stmt,
+                &[
+                    &i, &w_id, &s_quantity,
+                    &s_dist_01, &s_dist_02, &s_dist_03, &s_dist_04, &s_dist_05,
+                    &s_dist_06, &s_dist_07, &s_dist_08, &s_dist_09, &s_dist_10,
+                    &s_ytd, &s_order_cnt, &s_remote_cnt, &s_data,
+                ],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert stock i_id={i} w_id={w_id}"), source })?;
+    }
+    Ok(())
+}
+
+async fn load_customer(
+    client: &Client,
+    rng: &mut impl Rng,
+    w_id: i32,
+    d_id: i32,
+    c_load: usize,
+) -> Result<()> {
+    tracing::info!("loading customer for warehouse {w_id} district {d_id}");
+    let stmt = client
+        .prepare(
+            "INSERT INTO customer (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)",
+        )
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare customer insert".into(), source })?;
+
+    for i in 1..=CUSTOMERS_PER_DISTRICT {
+        let c_last = if i <= 1000 {
+            tpcc_rand::c_last_syllables(usize::try_from(i - 1).unwrap_or(0))
+        } else {
+            tpcc_rand::rand_c_last(rng, c_load)
+        };
+        let c_first = tpcc_rand::rand_chars(rng, 8, 16);
+        let c_middle = "OE";
+        let c_street_1 = tpcc_rand::rand_chars(rng, 10, 20);
+        let c_street_2 = tpcc_rand::rand_chars(rng, 10, 20);
+        let c_city = tpcc_rand::rand_chars(rng, 10, 20);
+        let c_state = tpcc_rand::rand_state(rng);
+        let c_zip = tpcc_rand::rand_zip(rng);
+        let c_phone = tpcc_rand::rand_numbers(rng, 16, 16);
+        let c_since = INIT_LOAD_TIME;
+        let c_credit = if rng.gen_range(0..10) == 0 { "BC" } else { "GC" };
+        let c_credit_lim: f64 = 50_000.00;
+        let c_discount: f64 = f64::from(rng.gen_range(0..=5_000)) / 10_000.0;
+        let c_balance: f64 = -10.00;
+        let c_ytd_payment: f64 = 10.00;
+        let c_payment_cnt: i32 = 1;
+        let c_delivery_cnt: i32 = 0;
+        let c_data = tpcc_rand::rand_chars(rng, 300, 500);
+
+        client
+            .execute(
+                &stmt,
+                &[
+                    &i, &d_id, &w_id, &c_first, &c_middle, &c_last,
+                    &c_street_1, &c_street_2, &c_city, &c_state, &c_zip, &c_phone,
+                    &c_since, &c_credit, &c_credit_lim, &c_discount, &c_balance,
+                    &c_ytd_payment, &c_payment_cnt, &c_delivery_cnt, &c_data,
+                ],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert customer {i} d={d_id} w={w_id}"), source })?;
+    }
+    Ok(())
+}
+
+async fn load_history(client: &Client, rng: &mut impl Rng, w_id: i32, d_id: i32) -> Result<()> {
+    tracing::info!("loading history for warehouse {w_id} district {d_id}");
+    let stmt = client
+        .prepare(
+            "INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        )
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare history insert".into(), source })?;
+
+    for i in 1..=CUSTOMERS_PER_DISTRICT {
+        let h_amount: f64 = 10.00;
+        let h_data = tpcc_rand::rand_chars(rng, 12, 24);
+
+        client
+            .execute(&stmt, &[&i, &d_id, &w_id, &d_id, &w_id, &INIT_LOAD_TIME, &h_amount, &h_data])
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert history c={i} d={d_id} w={w_id}"), source })?;
+    }
+    Ok(())
+}
+
+/// Load orders and return per-order `ol_cnt` values (needed by `load_order_line`).
+async fn load_orders(
+    client: &Client,
+    rng: &mut impl Rng,
+    w_id: i32,
+    d_id: i32,
+) -> Result<Vec<i32>> {
+    tracing::info!("loading orders for warehouse {w_id} district {d_id}");
+    let stmt = client
+        .prepare(
+            "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        )
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare orders insert".into(), source })?;
+
+    // Random permutation of customer IDs
+    let mut cids: Vec<i32> = (1..=ORDERS_PER_DISTRICT).collect();
+    for i in (1..cids.len()).rev() {
+        let j = rng.gen_range(0..=i);
+        cids.swap(i, j);
+    }
+
+    let mut ol_cnts = Vec::with_capacity(usize::try_from(ORDERS_PER_DISTRICT).unwrap_or(0));
+
+    for i in 0..ORDERS_PER_DISTRICT {
+        let o_id = i + 1;
+        let o_c_id = cids[usize::try_from(i).unwrap_or(0)];
+        let o_carrier_id: Option<i32> = if o_id < 2101 {
+            Some(rng.gen_range(1..=10))
+        } else {
+            None
+        };
+        let o_ol_cnt: i32 = rng.gen_range(5..=15);
+        ol_cnts.push(o_ol_cnt);
+        let o_all_local: i32 = 1;
+
+        client
+            .execute(
+                &stmt,
+                &[&o_id, &d_id, &w_id, &o_c_id, &INIT_LOAD_TIME, &o_carrier_id, &o_ol_cnt, &o_all_local],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert order {o_id} d={d_id} w={w_id}"), source })?;
+    }
+
+    Ok(ol_cnts)
+}
+
+async fn load_new_order(client: &Client, w_id: i32, d_id: i32) -> Result<()> {
+    tracing::info!("loading new_order for warehouse {w_id} district {d_id}");
+    let stmt = client
+        .prepare("INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES ($1, $2, $3)")
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare new_order insert".into(), source })?;
+
+    for i in 0..NEW_ORDERS_PER_DISTRICT {
+        let no_o_id = 2101 + i;
+        client
+            .execute(&stmt, &[&no_o_id, &d_id, &w_id])
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert new_order {no_o_id} d={d_id} w={w_id}"), source })?;
+    }
+    Ok(())
+}
+
+async fn load_order_line(
+    client: &Client,
+    rng: &mut impl Rng,
+    w_id: i32,
+    d_id: i32,
+    ol_cnts: &[i32],
+) -> Result<()> {
+    tracing::info!("loading order_line for warehouse {w_id} district {d_id}");
+    let stmt = client
+        .prepare(
+            "INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+        )
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare order_line insert".into(), source })?;
+
+    for (i, &ol_cnt) in ol_cnts.iter().enumerate() {
+        let o_id = i32::try_from(i).unwrap_or(0) + 1;
+
+        for j in 1..=ol_cnt {
+            let ol_i_id: i32 = rng.gen_range(1..=100_000);
+            let ol_quantity: i32 = 5;
+
+            let (ol_delivery_d, ol_amount): (Option<&str>, f64) = if o_id < 2101 {
+                (Some(INIT_LOAD_TIME), 0.00)
+            } else {
+                (None, f64::from(rng.gen_range(1..=999_999)) / 100.0)
+            };
+            let ol_dist_info = tpcc_rand::rand_chars(rng, 24, 24);
+
+            client
+                .execute(
+                    &stmt,
+                    &[&o_id, &d_id, &w_id, &j, &ol_i_id, &w_id, &ol_delivery_d, &ol_quantity, &ol_amount, &ol_dist_info],
+                )
+                .await
+                .map_err(|source| crate::Error::Sql {
+                    action: format!("insert order_line o={o_id} ol={j} d={d_id} w={w_id}"),
+                    source,
+                })?;
+        }
+    }
+    Ok(())
+}
+
+// ─── CH-benCH supplemental tables (static data) ──────────────────────────────
+
+/// TPC-H nation data. 25 nations with region keys.
+/// Column order: (n_nationkey, n_name, n_regionkey).
+const NATIONS: &[(i64, &str, i64)] = &[
+    (0, "ALGERIA", 0),
+    (1, "ARGENTINA", 1),
+    (2, "BRAZIL", 1),
+    (3, "CANADA", 1),
+    (4, "EGYPT", 4),
+    (5, "ETHIOPIA", 0),
+    (6, "FRANCE", 3),
+    (7, "GERMANY", 3),
+    (8, "INDIA", 2),
+    (9, "INDONESIA", 2),
+    (10, "IRAN", 4),
+    (11, "IRAQ", 4),
+    (12, "JAPAN", 2),
+    (13, "JORDAN", 4),
+    (14, "KENYA", 0),
+    (15, "MOROCCO", 0),
+    (16, "MOZAMBIQUE", 0),
+    (17, "PERU", 1),
+    (18, "CHINA", 2),
+    (19, "ROMANIA", 3),
+    (20, "SAUDI ARABIA", 4),
+    (21, "VIETNAM", 2),
+    (22, "RUSSIA", 3),
+    (23, "UNITED KINGDOM", 3),
+    (24, "UNITED STATES", 1),
+];
+
+/// CH-benCH extends the 25 TPC-H nations with 37 additional nations for more
+/// diverse customer-state mapping (total 62, matching go-tpc).
+const EXTRA_NATIONS: &[(i64, &str, i64)] = &[
+    (25, "AUSTRALIA", 2),
+    (26, "BANGLADESH", 2),
+    (27, "BELGIUM", 3),
+    (28, "BOLIVIA", 1),
+    (29, "CAMEROON", 0),
+    (30, "CHILE", 1),
+    (31, "COLOMBIA", 1),
+    (32, "CONGO", 0),
+    (33, "COSTA RICA", 1),
+    (34, "CUBA", 1),
+    (35, "CZECH REPUBLIC", 3),
+    (36, "DENMARK", 3),
+    (37, "DOMINICAN REPUBLIC", 1),
+    (38, "ECUADOR", 1),
+    (39, "EL SALVADOR", 1),
+    (40, "FINLAND", 3),
+    (41, "GREECE", 3),
+    (42, "GUATEMALA", 1),
+    (43, "HONDURAS", 1),
+    (44, "HUNGARY", 3),
+    (45, "ICELAND", 3),
+    (46, "IRELAND", 3),
+    (47, "ISRAEL", 4),
+    (48, "ITALY", 3),
+    (49, "JAMAICA", 1),
+    (50, "SOUTH KOREA", 2),
+    (51, "MALAYSIA", 2),
+    (52, "MEXICO", 1),
+    (53, "NEPAL", 2),
+    (54, "NEW ZEALAND", 2),
+    (55, "NICARAGUA", 1),
+    (56, "NORWAY", 3),
+    (57, "PAKISTAN", 2),
+    (58, "PANAMA", 1),
+    (59, "PHILIPPINES", 2),
+    (60, "POLAND", 3),
+    (61, "SOUTH AFRICA", 0),
+];
+
+const REGIONS: &[(i64, &str)] = &[
+    (0, "AFRICA"),
+    (1, "AMERICA"),
+    (2, "ASIA"),
+    (3, "EUROPE"),
+    (4, "MIDDLE EAST"),
+];
+
+async fn load_nation(client: &Client) -> Result<()> {
+    let total = NATIONS.len() + EXTRA_NATIONS.len();
+    tracing::info!("loading nation ({total} rows)");
+    let stmt = client
+        .prepare("INSERT INTO nation (n_nationkey, n_name, n_regionkey, n_comment) VALUES ($1, $2, $3, $4)")
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare nation insert".into(), source })?;
+
+    let comment: Option<&str> = None;
+    for &(key, name, region) in NATIONS.iter().chain(EXTRA_NATIONS.iter()) {
+        client
+            .execute(&stmt, &[&key, &name, &region, &comment])
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert nation {key}"), source })?;
+    }
+    Ok(())
+}
+
+async fn load_region(client: &Client) -> Result<()> {
+    tracing::info!("loading region ({} rows)", REGIONS.len());
+    let stmt = client
+        .prepare("INSERT INTO region (r_regionkey, r_name, r_comment) VALUES ($1, $2, $3)")
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare region insert".into(), source })?;
+
+    let comment: Option<&str> = None;
+    for &(key, name) in REGIONS {
+        client
+            .execute(&stmt, &[&key, &name, &comment])
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert region {key}"), source })?;
+    }
+    Ok(())
+}
+
+/// Load 10,000 supplier rows (matching go-tpc / TPC-H dbgen at SF1).
+async fn load_supplier(client: &Client, rng: &mut impl Rng) -> Result<()> {
+    const SUPPLIER_COUNT: i64 = 10_000;
+    tracing::info!("loading supplier ({SUPPLIER_COUNT} rows)");
+    let stmt = client
+        .prepare("INSERT INTO supplier (s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment) VALUES ($1, $2, $3, $4, $5, $6, $7)")
+        .await
+        .map_err(|source| crate::Error::Sql { action: "prepare supplier insert".into(), source })?;
+
+    let nation_count = i64::try_from(NATIONS.len()).unwrap_or(25);
+
+    for i in 1..=SUPPLIER_COUNT {
+        let s_name = format!("Supplier#{i:09}");
+        let s_address = tpcc_rand::rand_chars(rng, 10, 25);
+        let s_nationkey: i64 = rng.gen_range(0..nation_count);
+        let s_phone = format!(
+            "{:02}-{}-{}-{}",
+            (s_nationkey + 10),
+            rng.gen_range(100..=999),
+            rng.gen_range(100..=999),
+            rng.gen_range(1000..=9999),
+        );
+        let s_acctbal: f64 = f64::from(rng.gen_range(-99_999..=999_999)) / 100.0;
+        let s_comment = tpcc_rand::rand_chars(rng, 25, 63);
+
+        client
+            .execute(&stmt, &[&i, &s_name, &s_address, &s_nationkey, &s_phone, &s_acctbal, &s_comment])
+            .await
+            .map_err(|source| crate::Error::Sql { action: format!("insert supplier {i}"), source })?;
+    }
+    Ok(())
+}

--- a/tools/chbench-driver/src/loader.rs
+++ b/tools/chbench-driver/src/loader.rs
@@ -25,8 +25,8 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use tokio_postgres::Client;
 
-use crate::rand as tpcc_rand;
 use crate::Result;
+use crate::rand as tpcc_rand;
 
 const MAX_ITEMS: i32 = 100_000;
 const STOCK_PER_WAREHOUSE: i32 = 100_000;
@@ -79,10 +79,13 @@ impl BatchSink {
         if self.buffered_rows == 0 {
             return Ok(());
         }
-        client.execute(self.buf.as_str(), &[]).await.map_err(|source| crate::Error::Sql {
-            action: format!("batch insert into {table}"),
-            source,
-        })?;
+        client
+            .execute(self.buf.as_str(), &[])
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: format!("batch insert into {table}"),
+                source,
+            })?;
         self.buf.clear();
         self.buffered_rows = 0;
         Ok(())
@@ -162,9 +165,8 @@ pub async fn load_all(client: &Client, warehouses: usize, seed: Option<u64>) -> 
 
 async fn load_item(client: &Client, rng: &mut impl Rng) -> Result<()> {
     println!("  loading item ({MAX_ITEMS} rows)");
-    let mut sink = BatchSink::new(
-        "INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES",
-    );
+    let mut sink =
+        BatchSink::new("INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES");
     let mut row = String::new();
 
     for i in 1..=MAX_ITEMS {
@@ -174,7 +176,12 @@ async fn load_item(client: &Client, rng: &mut impl Rng) -> Result<()> {
         let i_data = tpcc_rand::rand_original_string(rng);
 
         row.clear();
-        let _ = write!(row, "({i}, {i_im_id}, {}, {i_price}, {})", sql_str(&i_name), sql_str(&i_data));
+        let _ = write!(
+            row,
+            "({i}, {i_im_id}, {}, {i_price}, {})",
+            sql_str(&i_name),
+            sql_str(&i_data)
+        );
         sink.write_row(&row);
         sink.maybe_flush(client, "item").await?;
     }
@@ -182,7 +189,6 @@ async fn load_item(client: &Client, rng: &mut impl Rng) -> Result<()> {
 }
 
 async fn load_warehouse(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
-
     let mut sink = BatchSink::new(
         "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES",
     );
@@ -198,15 +204,18 @@ async fn load_warehouse(client: &Client, rng: &mut impl Rng, w_id: i32) -> Resul
 
     let row = format!(
         "({w_id}, {}, {}, {}, {}, {}, {}, {w_tax}, {w_ytd})",
-        sql_str(&w_name), sql_str(&w_street_1), sql_str(&w_street_2),
-        sql_str(&w_city), sql_str(&w_state), sql_str(&w_zip),
+        sql_str(&w_name),
+        sql_str(&w_street_1),
+        sql_str(&w_street_2),
+        sql_str(&w_city),
+        sql_str(&w_state),
+        sql_str(&w_zip),
     );
     sink.write_row(&row);
     sink.flush(client, "warehouse").await
 }
 
 async fn load_district(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
-
     let mut sink = BatchSink::new(
         "INSERT INTO district (d_id, d_w_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES",
     );
@@ -224,9 +233,14 @@ async fn load_district(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result
 
         row.clear();
         let _ = write!(
-            row, "({d}, {w_id}, {}, {}, {}, {}, {}, {}, {d_tax}, {d_ytd}, 3001)",
-            sql_str(&d_name), sql_str(&d_street_1), sql_str(&d_street_2),
-            sql_str(&d_city), sql_str(&d_state), sql_str(&d_zip),
+            row,
+            "({d}, {w_id}, {}, {}, {}, {}, {}, {}, {d_tax}, {d_ytd}, 3001)",
+            sql_str(&d_name),
+            sql_str(&d_street_1),
+            sql_str(&d_street_2),
+            sql_str(&d_city),
+            sql_str(&d_state),
+            sql_str(&d_zip),
         );
         sink.write_row(&row);
         sink.maybe_flush(client, "district").await?;
@@ -235,7 +249,6 @@ async fn load_district(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result
 }
 
 async fn load_stock(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
-
     let mut sink = BatchSink::new(
         "INSERT INTO stock (s_i_id, s_w_id, s_quantity, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES",
     );
@@ -257,11 +270,19 @@ async fn load_stock(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()
 
         row.clear();
         let _ = write!(
-            row, "({i}, {w_id}, {s_quantity}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, 0, 0, 0, {})",
-            sql_str(&s_dist_01), sql_str(&s_dist_02), sql_str(&s_dist_03),
-            sql_str(&s_dist_04), sql_str(&s_dist_05), sql_str(&s_dist_06),
-            sql_str(&s_dist_07), sql_str(&s_dist_08), sql_str(&s_dist_09),
-            sql_str(&s_dist_10), sql_str(&s_data),
+            row,
+            "({i}, {w_id}, {s_quantity}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, 0, 0, 0, {})",
+            sql_str(&s_dist_01),
+            sql_str(&s_dist_02),
+            sql_str(&s_dist_03),
+            sql_str(&s_dist_04),
+            sql_str(&s_dist_05),
+            sql_str(&s_dist_06),
+            sql_str(&s_dist_07),
+            sql_str(&s_dist_08),
+            sql_str(&s_dist_09),
+            sql_str(&s_dist_10),
+            sql_str(&s_data),
         );
         sink.write_row(&row);
         sink.maybe_flush(client, "stock").await?;
@@ -276,7 +297,6 @@ async fn load_customer(
     d_id: i32,
     c_load: usize,
 ) -> Result<()> {
-
     let mut sink = BatchSink::new(
         "INSERT INTO customer (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES",
     );
@@ -295,7 +315,11 @@ async fn load_customer(
         let c_state = tpcc_rand::rand_state(rng);
         let c_zip = tpcc_rand::rand_zip(rng);
         let c_phone = tpcc_rand::rand_numbers(rng, 16, 16);
-        let c_credit = if rng.gen_range(0..10) == 0 { "BC" } else { "GC" };
+        let c_credit = if rng.gen_range(0..10) == 0 {
+            "BC"
+        } else {
+            "GC"
+        };
         let c_credit_lim: f64 = 50_000.00;
         let c_discount: f64 = f64::from(rng.gen_range(0..=5_000)) / 10_000.0;
         let c_balance: f64 = -10.00;
@@ -306,10 +330,16 @@ async fn load_customer(
         let _ = write!(
             row,
             "({i}, {d_id}, {w_id}, {}, 'OE', {}, {}, {}, {}, {}, {}, {}, {}, {}, {c_credit_lim}, {c_discount}, {c_balance}, {c_ytd_payment}, 1, 0, {})",
-            sql_str(&c_first), sql_str(&c_last),
-            sql_str(&c_street_1), sql_str(&c_street_2), sql_str(&c_city),
-            sql_str(&c_state), sql_str(&c_zip), sql_str(&c_phone),
-            sql_str(INIT_LOAD_TIME), sql_str(c_credit),
+            sql_str(&c_first),
+            sql_str(&c_last),
+            sql_str(&c_street_1),
+            sql_str(&c_street_2),
+            sql_str(&c_city),
+            sql_str(&c_state),
+            sql_str(&c_zip),
+            sql_str(&c_phone),
+            sql_str(INIT_LOAD_TIME),
+            sql_str(c_credit),
             sql_str(&c_data),
         );
         sink.write_row(&row);
@@ -319,7 +349,6 @@ async fn load_customer(
 }
 
 async fn load_history(client: &Client, rng: &mut impl Rng, w_id: i32, d_id: i32) -> Result<()> {
-
     let mut sink = BatchSink::new(
         "INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES",
     );
@@ -330,8 +359,10 @@ async fn load_history(client: &Client, rng: &mut impl Rng, w_id: i32, d_id: i32)
 
         row.clear();
         let _ = write!(
-            row, "({i}, {d_id}, {w_id}, {d_id}, {w_id}, {}, 10.00, {})",
-            sql_str(INIT_LOAD_TIME), sql_str(&h_data),
+            row,
+            "({i}, {d_id}, {w_id}, {d_id}, {w_id}, {}, 10.00, {})",
+            sql_str(INIT_LOAD_TIME),
+            sql_str(&h_data),
         );
         sink.write_row(&row);
         sink.maybe_flush(client, "history").await?;
@@ -346,7 +377,6 @@ async fn load_orders(
     w_id: i32,
     d_id: i32,
 ) -> Result<Vec<i32>> {
-
     let mut sink = BatchSink::new(
         "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES",
     );
@@ -374,8 +404,10 @@ async fn load_orders(
 
         row.clear();
         let _ = write!(
-            row, "({o_id}, {d_id}, {w_id}, {o_c_id}, {}, {}, {o_ol_cnt}, 1)",
-            sql_str(INIT_LOAD_TIME), sql_opt_i32(o_carrier_id),
+            row,
+            "({o_id}, {d_id}, {w_id}, {o_c_id}, {}, {}, {o_ol_cnt}, 1)",
+            sql_str(INIT_LOAD_TIME),
+            sql_opt_i32(o_carrier_id),
         );
         sink.write_row(&row);
         sink.maybe_flush(client, "orders").await?;
@@ -386,10 +418,7 @@ async fn load_orders(
 }
 
 async fn load_new_order(client: &Client, w_id: i32, d_id: i32) -> Result<()> {
-
-    let mut sink = BatchSink::new(
-        "INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES",
-    );
+    let mut sink = BatchSink::new("INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES");
     let mut row = String::new();
 
     for i in 0..NEW_ORDERS_PER_DISTRICT {
@@ -409,7 +438,6 @@ async fn load_order_line(
     d_id: i32,
     ol_cnts: &[i32],
 ) -> Result<()> {
-
     let mut sink = BatchSink::new(
         "INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES",
     );
@@ -430,8 +458,10 @@ async fn load_order_line(
 
             row.clear();
             let _ = write!(
-                row, "({o_id}, {d_id}, {w_id}, {j}, {ol_i_id}, {w_id}, {}, 5, {ol_amount}, {})",
-                sql_opt_str(ol_delivery_d), sql_str(&ol_dist_info),
+                row,
+                "({o_id}, {d_id}, {w_id}, {j}, {ol_i_id}, {w_id}, {}, 5, {ol_amount}, {})",
+                sql_opt_str(ol_delivery_d),
+                sql_str(&ol_dist_info),
             );
             sink.write_row(&row);
             sink.maybe_flush(client, "order_line").await?;
@@ -525,9 +555,8 @@ const REGIONS: &[(i64, &str)] = &[
 async fn load_nation(client: &Client) -> Result<()> {
     let total = NATIONS.len() + EXTRA_NATIONS.len();
     println!("  loading nation ({total} rows)");
-    let mut sink = BatchSink::new(
-        "INSERT INTO nation (n_nationkey, n_name, n_regionkey, n_comment) VALUES",
-    );
+    let mut sink =
+        BatchSink::new("INSERT INTO nation (n_nationkey, n_name, n_regionkey, n_comment) VALUES");
     let mut row = String::new();
 
     for &(key, name, region) in NATIONS.iter().chain(EXTRA_NATIONS.iter()) {
@@ -541,9 +570,7 @@ async fn load_nation(client: &Client) -> Result<()> {
 
 async fn load_region(client: &Client) -> Result<()> {
     println!("  loading region ({} rows)", REGIONS.len());
-    let mut sink = BatchSink::new(
-        "INSERT INTO region (r_regionkey, r_name, r_comment) VALUES",
-    );
+    let mut sink = BatchSink::new("INSERT INTO region (r_regionkey, r_name, r_comment) VALUES");
     let mut row = String::new();
 
     for &(key, name) in REGIONS {
@@ -581,8 +608,12 @@ async fn load_supplier(client: &Client, rng: &mut impl Rng) -> Result<()> {
 
         row.clear();
         let _ = write!(
-            row, "({i}, {}, {}, {s_nationkey}, {}, {s_acctbal}, {})",
-            sql_str(&s_name), sql_str(&s_address), sql_str(&s_phone), sql_str(&s_comment),
+            row,
+            "({i}, {}, {}, {s_nationkey}, {}, {s_acctbal}, {})",
+            sql_str(&s_name),
+            sql_str(&s_address),
+            sql_str(&s_phone),
+            sql_str(&s_comment),
         );
         sink.write_row(&row);
         sink.maybe_flush(client, "supplier").await?;

--- a/tools/chbench-driver/src/loader.rs
+++ b/tools/chbench-driver/src/loader.rs
@@ -16,9 +16,10 @@ limitations under the License.
 
 //! Seed data loader for TPC-C + CH-benCH supplemental tables.
 //!
-//! Mirrors go-tpc's loading logic: for each warehouse, loads warehouse, district,
-//! stock, customer, history, orders, new_order, and order_line. Also loads the
-//! static item, nation, region, and supplier tables.
+//! Uses batched multi-row `INSERT ... VALUES (...), (...), ...` statements
+//! (1024 rows per batch) for faster inserts.
+
+use std::fmt::Write as _;
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -35,7 +36,86 @@ const ORDERS_PER_DISTRICT: i32 = 3_000;
 const NEW_ORDERS_PER_DISTRICT: i32 = 900;
 
 const INIT_LOAD_TIME: &str = "2007-01-02 15:04:05";
-const BATCH_SIZE: usize = 500;
+const BATCH_SIZE: usize = 1024;
+
+// ─── Batch sink ───────────────────────────────────────────────────────────────
+
+/// Accumulates rows as SQL value-tuple strings and flushes them as multi-row
+/// `INSERT ... VALUES (...), (...), ...` statements.
+struct BatchSink {
+    insert_hint: String,
+    buf: String,
+    buffered_rows: usize,
+    max_batch_rows: usize,
+}
+
+impl BatchSink {
+    fn new(insert_hint: &str) -> Self {
+        Self {
+            insert_hint: insert_hint.to_owned(),
+            buf: String::with_capacity(64 * 1024),
+            buffered_rows: 0,
+            max_batch_rows: BATCH_SIZE,
+        }
+    }
+
+    fn write_row(&mut self, row: &str) {
+        if self.buffered_rows == 0 {
+            self.buf.push_str(&self.insert_hint);
+            self.buf.push(' ');
+            self.buf.push_str(row);
+        } else {
+            self.buf.push_str(", ");
+            self.buf.push_str(row);
+        }
+        self.buffered_rows += 1;
+    }
+
+    fn needs_flush(&self) -> bool {
+        self.buffered_rows >= self.max_batch_rows
+    }
+
+    async fn flush(&mut self, client: &Client, table: &str) -> Result<()> {
+        if self.buffered_rows == 0 {
+            return Ok(());
+        }
+        client.execute(self.buf.as_str(), &[]).await.map_err(|source| crate::Error::Sql {
+            action: format!("batch insert into {table}"),
+            source,
+        })?;
+        self.buf.clear();
+        self.buffered_rows = 0;
+        Ok(())
+    }
+
+    async fn maybe_flush(&mut self, client: &Client, table: &str) -> Result<()> {
+        if self.needs_flush() {
+            self.flush(client, table).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Escape a string value for SQL literal inclusion (single-quote escaping).
+fn sql_str(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}
+
+fn sql_opt_str(s: Option<&str>) -> String {
+    match s {
+        Some(v) => sql_str(v),
+        None => "NULL".to_owned(),
+    }
+}
+
+fn sql_opt_i32(v: Option<i32>) -> String {
+    match v {
+        Some(n) => n.to_string(),
+        None => "NULL".to_owned(),
+    }
+}
+
+// ─── Public entry point ───────────────────────────────────────────────────────
 
 /// Load all seed data for the given number of warehouses.
 ///
@@ -55,6 +135,13 @@ pub async fn load_all(client: &Client, warehouses: usize, seed: Option<u64>) -> 
 
     for w in 1..=warehouses {
         let w_id = i32::try_from(w).unwrap_or(i32::MAX);
+        println!(
+            "  loading warehouse {w_id}: {DISTRICTS_PER_WAREHOUSE} districts, \
+             {}K customers, {}K orders, ~{}K order lines",
+            DISTRICTS_PER_WAREHOUSE * CUSTOMERS_PER_DISTRICT / 1000,
+            DISTRICTS_PER_WAREHOUSE * ORDERS_PER_DISTRICT / 1000,
+            DISTRICTS_PER_WAREHOUSE * ORDERS_PER_DISTRICT * 10 / 1000,
+        );
         load_warehouse(client, &mut rng, w_id).await?;
         load_district(client, &mut rng, w_id).await?;
         load_stock(client, &mut rng, w_id).await?;
@@ -71,32 +158,35 @@ pub async fn load_all(client: &Client, warehouses: usize, seed: Option<u64>) -> 
     Ok(())
 }
 
+// ─── Per-table loaders ────────────────────────────────────────────────────────
+
 async fn load_item(client: &Client, rng: &mut impl Rng) -> Result<()> {
-    tracing::info!("loading item ({MAX_ITEMS} rows)");
-    let stmt = client
-        .prepare("INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES ($1, $2, $3, $4, $5)")
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare item insert".into(), source })?;
+    println!("  loading item ({MAX_ITEMS} rows)");
+    let mut sink = BatchSink::new(
+        "INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES",
+    );
+    let mut row = String::new();
 
-    for batch_start in (1..=MAX_ITEMS).step_by(BATCH_SIZE) {
-        let batch_end = (batch_start + i32::try_from(BATCH_SIZE).unwrap_or(i32::MAX) - 1).min(MAX_ITEMS);
-        for i in batch_start..=batch_end {
-            let i_im_id: i32 = rng.gen_range(1..=10_000);
-            let i_price: f64 = f64::from(rng.gen_range(100..=10_000)) / 100.0;
-            let i_name = tpcc_rand::rand_chars(rng, 14, 24);
-            let i_data = tpcc_rand::rand_original_string(rng);
+    for i in 1..=MAX_ITEMS {
+        let i_im_id: i32 = rng.gen_range(1..=10_000);
+        let i_price: f64 = f64::from(rng.gen_range(100..=10_000)) / 100.0;
+        let i_name = tpcc_rand::rand_chars(rng, 14, 24);
+        let i_data = tpcc_rand::rand_original_string(rng);
 
-            client
-                .execute(&stmt, &[&i, &i_im_id, &i_name, &i_price, &i_data])
-                .await
-                .map_err(|source| crate::Error::Sql { action: format!("insert item {i}"), source })?;
-        }
+        row.clear();
+        let _ = write!(row, "({i}, {i_im_id}, {}, {i_price}, {})", sql_str(&i_name), sql_str(&i_data));
+        sink.write_row(&row);
+        sink.maybe_flush(client, "item").await?;
     }
-    Ok(())
+    sink.flush(client, "item").await
 }
 
 async fn load_warehouse(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
-    tracing::info!("loading warehouse {w_id}");
+
+    let mut sink = BatchSink::new(
+        "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES",
+    );
+
     let w_name = tpcc_rand::rand_chars(rng, 6, 10);
     let w_street_1 = tpcc_rand::rand_chars(rng, 10, 20);
     let w_street_2 = tpcc_rand::rand_chars(rng, 10, 20);
@@ -106,25 +196,21 @@ async fn load_warehouse(client: &Client, rng: &mut impl Rng, w_id: i32) -> Resul
     let w_tax = tpcc_rand::rand_tax(rng);
     let w_ytd: f64 = 300_000.00;
 
-    client
-        .execute(
-            "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
-            &[&w_id, &w_name, &w_street_1, &w_street_2, &w_city, &w_state, &w_zip, &w_tax, &w_ytd],
-        )
-        .await
-        .map_err(|source| crate::Error::Sql { action: format!("insert warehouse {w_id}"), source })?;
-
-    Ok(())
+    let row = format!(
+        "({w_id}, {}, {}, {}, {}, {}, {}, {w_tax}, {w_ytd})",
+        sql_str(&w_name), sql_str(&w_street_1), sql_str(&w_street_2),
+        sql_str(&w_city), sql_str(&w_state), sql_str(&w_zip),
+    );
+    sink.write_row(&row);
+    sink.flush(client, "warehouse").await
 }
 
 async fn load_district(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
-    tracing::info!("loading district for warehouse {w_id}");
-    let stmt = client
-        .prepare(
-            "INSERT INTO district (d_id, d_w_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
-        )
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare district insert".into(), source })?;
+
+    let mut sink = BatchSink::new(
+        "INSERT INTO district (d_id, d_w_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES",
+    );
+    let mut row = String::new();
 
     for d in 1..=DISTRICTS_PER_WAREHOUSE {
         let d_name = tpcc_rand::rand_chars(rng, 6, 10);
@@ -135,27 +221,25 @@ async fn load_district(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result
         let d_zip = tpcc_rand::rand_zip(rng);
         let d_tax = tpcc_rand::rand_tax(rng);
         let d_ytd: f64 = 30_000.00;
-        let d_next_o_id: i32 = 3001;
 
-        client
-            .execute(
-                &stmt,
-                &[&d, &w_id, &d_name, &d_street_1, &d_street_2, &d_city, &d_state, &d_zip, &d_tax, &d_ytd, &d_next_o_id],
-            )
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert district {d} warehouse {w_id}"), source })?;
+        row.clear();
+        let _ = write!(
+            row, "({d}, {w_id}, {}, {}, {}, {}, {}, {}, {d_tax}, {d_ytd}, 3001)",
+            sql_str(&d_name), sql_str(&d_street_1), sql_str(&d_street_2),
+            sql_str(&d_city), sql_str(&d_state), sql_str(&d_zip),
+        );
+        sink.write_row(&row);
+        sink.maybe_flush(client, "district").await?;
     }
-    Ok(())
+    sink.flush(client, "district").await
 }
 
 async fn load_stock(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()> {
-    tracing::info!("loading stock for warehouse {w_id} ({STOCK_PER_WAREHOUSE} rows)");
-    let stmt = client
-        .prepare(
-            "INSERT INTO stock (s_i_id, s_w_id, s_quantity, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
-        )
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare stock insert".into(), source })?;
+
+    let mut sink = BatchSink::new(
+        "INSERT INTO stock (s_i_id, s_w_id, s_quantity, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES",
+    );
+    let mut row = String::new();
 
     for i in 1..=STOCK_PER_WAREHOUSE {
         let s_quantity: i32 = rng.gen_range(10..=100);
@@ -169,25 +253,20 @@ async fn load_stock(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()
         let s_dist_08 = tpcc_rand::rand_letters(rng, 24, 24);
         let s_dist_09 = tpcc_rand::rand_letters(rng, 24, 24);
         let s_dist_10 = tpcc_rand::rand_letters(rng, 24, 24);
-        let s_ytd: i32 = 0;
-        let s_order_cnt: i32 = 0;
-        let s_remote_cnt: i32 = 0;
         let s_data = tpcc_rand::rand_original_string(rng);
 
-        client
-            .execute(
-                &stmt,
-                &[
-                    &i, &w_id, &s_quantity,
-                    &s_dist_01, &s_dist_02, &s_dist_03, &s_dist_04, &s_dist_05,
-                    &s_dist_06, &s_dist_07, &s_dist_08, &s_dist_09, &s_dist_10,
-                    &s_ytd, &s_order_cnt, &s_remote_cnt, &s_data,
-                ],
-            )
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert stock i_id={i} w_id={w_id}"), source })?;
+        row.clear();
+        let _ = write!(
+            row, "({i}, {w_id}, {s_quantity}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, 0, 0, 0, {})",
+            sql_str(&s_dist_01), sql_str(&s_dist_02), sql_str(&s_dist_03),
+            sql_str(&s_dist_04), sql_str(&s_dist_05), sql_str(&s_dist_06),
+            sql_str(&s_dist_07), sql_str(&s_dist_08), sql_str(&s_dist_09),
+            sql_str(&s_dist_10), sql_str(&s_data),
+        );
+        sink.write_row(&row);
+        sink.maybe_flush(client, "stock").await?;
     }
-    Ok(())
+    sink.flush(client, "stock").await
 }
 
 async fn load_customer(
@@ -197,13 +276,11 @@ async fn load_customer(
     d_id: i32,
     c_load: usize,
 ) -> Result<()> {
-    tracing::info!("loading customer for warehouse {w_id} district {d_id}");
-    let stmt = client
-        .prepare(
-            "INSERT INTO customer (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)",
-        )
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare customer insert".into(), source })?;
+
+    let mut sink = BatchSink::new(
+        "INSERT INTO customer (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES",
+    );
+    let mut row = String::new();
 
     for i in 1..=CUSTOMERS_PER_DISTRICT {
         let c_last = if i <= 1000 {
@@ -212,58 +289,54 @@ async fn load_customer(
             tpcc_rand::rand_c_last(rng, c_load)
         };
         let c_first = tpcc_rand::rand_chars(rng, 8, 16);
-        let c_middle = "OE";
         let c_street_1 = tpcc_rand::rand_chars(rng, 10, 20);
         let c_street_2 = tpcc_rand::rand_chars(rng, 10, 20);
         let c_city = tpcc_rand::rand_chars(rng, 10, 20);
         let c_state = tpcc_rand::rand_state(rng);
         let c_zip = tpcc_rand::rand_zip(rng);
         let c_phone = tpcc_rand::rand_numbers(rng, 16, 16);
-        let c_since = INIT_LOAD_TIME;
         let c_credit = if rng.gen_range(0..10) == 0 { "BC" } else { "GC" };
         let c_credit_lim: f64 = 50_000.00;
         let c_discount: f64 = f64::from(rng.gen_range(0..=5_000)) / 10_000.0;
         let c_balance: f64 = -10.00;
         let c_ytd_payment: f64 = 10.00;
-        let c_payment_cnt: i32 = 1;
-        let c_delivery_cnt: i32 = 0;
         let c_data = tpcc_rand::rand_chars(rng, 300, 500);
 
-        client
-            .execute(
-                &stmt,
-                &[
-                    &i, &d_id, &w_id, &c_first, &c_middle, &c_last,
-                    &c_street_1, &c_street_2, &c_city, &c_state, &c_zip, &c_phone,
-                    &c_since, &c_credit, &c_credit_lim, &c_discount, &c_balance,
-                    &c_ytd_payment, &c_payment_cnt, &c_delivery_cnt, &c_data,
-                ],
-            )
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert customer {i} d={d_id} w={w_id}"), source })?;
+        row.clear();
+        let _ = write!(
+            row,
+            "({i}, {d_id}, {w_id}, {}, 'OE', {}, {}, {}, {}, {}, {}, {}, {}, {}, {c_credit_lim}, {c_discount}, {c_balance}, {c_ytd_payment}, 1, 0, {})",
+            sql_str(&c_first), sql_str(&c_last),
+            sql_str(&c_street_1), sql_str(&c_street_2), sql_str(&c_city),
+            sql_str(&c_state), sql_str(&c_zip), sql_str(&c_phone),
+            sql_str(INIT_LOAD_TIME), sql_str(c_credit),
+            sql_str(&c_data),
+        );
+        sink.write_row(&row);
+        sink.maybe_flush(client, "customer").await?;
     }
-    Ok(())
+    sink.flush(client, "customer").await
 }
 
 async fn load_history(client: &Client, rng: &mut impl Rng, w_id: i32, d_id: i32) -> Result<()> {
-    tracing::info!("loading history for warehouse {w_id} district {d_id}");
-    let stmt = client
-        .prepare(
-            "INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-        )
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare history insert".into(), source })?;
+
+    let mut sink = BatchSink::new(
+        "INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES",
+    );
+    let mut row = String::new();
 
     for i in 1..=CUSTOMERS_PER_DISTRICT {
-        let h_amount: f64 = 10.00;
         let h_data = tpcc_rand::rand_chars(rng, 12, 24);
 
-        client
-            .execute(&stmt, &[&i, &d_id, &w_id, &d_id, &w_id, &INIT_LOAD_TIME, &h_amount, &h_data])
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert history c={i} d={d_id} w={w_id}"), source })?;
+        row.clear();
+        let _ = write!(
+            row, "({i}, {d_id}, {w_id}, {d_id}, {w_id}, {}, 10.00, {})",
+            sql_str(INIT_LOAD_TIME), sql_str(&h_data),
+        );
+        sink.write_row(&row);
+        sink.maybe_flush(client, "history").await?;
     }
-    Ok(())
+    sink.flush(client, "history").await
 }
 
 /// Load orders and return per-order `ol_cnt` values (needed by `load_order_line`).
@@ -273,13 +346,11 @@ async fn load_orders(
     w_id: i32,
     d_id: i32,
 ) -> Result<Vec<i32>> {
-    tracing::info!("loading orders for warehouse {w_id} district {d_id}");
-    let stmt = client
-        .prepare(
-            "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-        )
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare orders insert".into(), source })?;
+
+    let mut sink = BatchSink::new(
+        "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES",
+    );
+    let mut row = String::new();
 
     // Random permutation of customer IDs
     let mut cids: Vec<i32> = (1..=ORDERS_PER_DISTRICT).collect();
@@ -300,35 +371,35 @@ async fn load_orders(
         };
         let o_ol_cnt: i32 = rng.gen_range(5..=15);
         ol_cnts.push(o_ol_cnt);
-        let o_all_local: i32 = 1;
 
-        client
-            .execute(
-                &stmt,
-                &[&o_id, &d_id, &w_id, &o_c_id, &INIT_LOAD_TIME, &o_carrier_id, &o_ol_cnt, &o_all_local],
-            )
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert order {o_id} d={d_id} w={w_id}"), source })?;
+        row.clear();
+        let _ = write!(
+            row, "({o_id}, {d_id}, {w_id}, {o_c_id}, {}, {}, {o_ol_cnt}, 1)",
+            sql_str(INIT_LOAD_TIME), sql_opt_i32(o_carrier_id),
+        );
+        sink.write_row(&row);
+        sink.maybe_flush(client, "orders").await?;
     }
+    sink.flush(client, "orders").await?;
 
     Ok(ol_cnts)
 }
 
 async fn load_new_order(client: &Client, w_id: i32, d_id: i32) -> Result<()> {
-    tracing::info!("loading new_order for warehouse {w_id} district {d_id}");
-    let stmt = client
-        .prepare("INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES ($1, $2, $3)")
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare new_order insert".into(), source })?;
+
+    let mut sink = BatchSink::new(
+        "INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES",
+    );
+    let mut row = String::new();
 
     for i in 0..NEW_ORDERS_PER_DISTRICT {
         let no_o_id = 2101 + i;
-        client
-            .execute(&stmt, &[&no_o_id, &d_id, &w_id])
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert new_order {no_o_id} d={d_id} w={w_id}"), source })?;
+        row.clear();
+        let _ = write!(row, "({no_o_id}, {d_id}, {w_id})");
+        sink.write_row(&row);
+        sink.maybe_flush(client, "new_order").await?;
     }
-    Ok(())
+    sink.flush(client, "new_order").await
 }
 
 async fn load_order_line(
@@ -338,20 +409,17 @@ async fn load_order_line(
     d_id: i32,
     ol_cnts: &[i32],
 ) -> Result<()> {
-    tracing::info!("loading order_line for warehouse {w_id} district {d_id}");
-    let stmt = client
-        .prepare(
-            "INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
-        )
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare order_line insert".into(), source })?;
+
+    let mut sink = BatchSink::new(
+        "INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES",
+    );
+    let mut row = String::new();
 
     for (i, &ol_cnt) in ol_cnts.iter().enumerate() {
         let o_id = i32::try_from(i).unwrap_or(0) + 1;
 
         for j in 1..=ol_cnt {
             let ol_i_id: i32 = rng.gen_range(1..=100_000);
-            let ol_quantity: i32 = 5;
 
             let (ol_delivery_d, ol_amount): (Option<&str>, f64) = if o_id < 2101 {
                 (Some(INIT_LOAD_TIME), 0.00)
@@ -360,19 +428,16 @@ async fn load_order_line(
             };
             let ol_dist_info = tpcc_rand::rand_chars(rng, 24, 24);
 
-            client
-                .execute(
-                    &stmt,
-                    &[&o_id, &d_id, &w_id, &j, &ol_i_id, &w_id, &ol_delivery_d, &ol_quantity, &ol_amount, &ol_dist_info],
-                )
-                .await
-                .map_err(|source| crate::Error::Sql {
-                    action: format!("insert order_line o={o_id} ol={j} d={d_id} w={w_id}"),
-                    source,
-                })?;
+            row.clear();
+            let _ = write!(
+                row, "({o_id}, {d_id}, {w_id}, {j}, {ol_i_id}, {w_id}, {}, 5, {ol_amount}, {})",
+                sql_opt_str(ol_delivery_d), sql_str(&ol_dist_info),
+            );
+            sink.write_row(&row);
+            sink.maybe_flush(client, "order_line").await?;
         }
     }
-    Ok(())
+    sink.flush(client, "order_line").await
 }
 
 // ─── CH-benCH supplemental tables (static data) ──────────────────────────────
@@ -459,47 +524,44 @@ const REGIONS: &[(i64, &str)] = &[
 
 async fn load_nation(client: &Client) -> Result<()> {
     let total = NATIONS.len() + EXTRA_NATIONS.len();
-    tracing::info!("loading nation ({total} rows)");
-    let stmt = client
-        .prepare("INSERT INTO nation (n_nationkey, n_name, n_regionkey, n_comment) VALUES ($1, $2, $3, $4)")
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare nation insert".into(), source })?;
+    println!("  loading nation ({total} rows)");
+    let mut sink = BatchSink::new(
+        "INSERT INTO nation (n_nationkey, n_name, n_regionkey, n_comment) VALUES",
+    );
+    let mut row = String::new();
 
-    let comment: Option<&str> = None;
     for &(key, name, region) in NATIONS.iter().chain(EXTRA_NATIONS.iter()) {
-        client
-            .execute(&stmt, &[&key, &name, &region, &comment])
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert nation {key}"), source })?;
+        row.clear();
+        let _ = write!(row, "({key}, {}, {region}, NULL)", sql_str(name));
+        sink.write_row(&row);
+        sink.maybe_flush(client, "nation").await?;
     }
-    Ok(())
+    sink.flush(client, "nation").await
 }
 
 async fn load_region(client: &Client) -> Result<()> {
-    tracing::info!("loading region ({} rows)", REGIONS.len());
-    let stmt = client
-        .prepare("INSERT INTO region (r_regionkey, r_name, r_comment) VALUES ($1, $2, $3)")
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare region insert".into(), source })?;
+    println!("  loading region ({} rows)", REGIONS.len());
+    let mut sink = BatchSink::new(
+        "INSERT INTO region (r_regionkey, r_name, r_comment) VALUES",
+    );
+    let mut row = String::new();
 
-    let comment: Option<&str> = None;
     for &(key, name) in REGIONS {
-        client
-            .execute(&stmt, &[&key, &name, &comment])
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert region {key}"), source })?;
+        row.clear();
+        let _ = write!(row, "({key}, {}, NULL)", sql_str(name));
+        sink.write_row(&row);
     }
-    Ok(())
+    sink.flush(client, "region").await
 }
 
 /// Load 10,000 supplier rows (matching go-tpc / TPC-H dbgen at SF1).
 async fn load_supplier(client: &Client, rng: &mut impl Rng) -> Result<()> {
     const SUPPLIER_COUNT: i64 = 10_000;
-    tracing::info!("loading supplier ({SUPPLIER_COUNT} rows)");
-    let stmt = client
-        .prepare("INSERT INTO supplier (s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment) VALUES ($1, $2, $3, $4, $5, $6, $7)")
-        .await
-        .map_err(|source| crate::Error::Sql { action: "prepare supplier insert".into(), source })?;
+    println!("  loading supplier ({SUPPLIER_COUNT} rows)");
+    let mut sink = BatchSink::new(
+        "INSERT INTO supplier (s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment) VALUES",
+    );
+    let mut row = String::new();
 
     let nation_count = i64::try_from(NATIONS.len()).unwrap_or(25);
 
@@ -517,10 +579,13 @@ async fn load_supplier(client: &Client, rng: &mut impl Rng) -> Result<()> {
         let s_acctbal: f64 = f64::from(rng.gen_range(-99_999..=999_999)) / 100.0;
         let s_comment = tpcc_rand::rand_chars(rng, 25, 63);
 
-        client
-            .execute(&stmt, &[&i, &s_name, &s_address, &s_nationkey, &s_phone, &s_acctbal, &s_comment])
-            .await
-            .map_err(|source| crate::Error::Sql { action: format!("insert supplier {i}"), source })?;
+        row.clear();
+        let _ = write!(
+            row, "({i}, {}, {}, {s_nationkey}, {}, {s_acctbal}, {})",
+            sql_str(&s_name), sql_str(&s_address), sql_str(&s_phone), sql_str(&s_comment),
+        );
+        sink.write_row(&row);
+        sink.maybe_flush(client, "supplier").await?;
     }
-    Ok(())
+    sink.flush(client, "supplier").await
 }

--- a/tools/chbench-driver/src/loader.rs
+++ b/tools/chbench-driver/src/loader.rs
@@ -22,7 +22,7 @@ limitations under the License.
 use std::fmt::Write as _;
 
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use tokio_postgres::Client;
 
 use crate::Result;
@@ -127,9 +127,9 @@ fn sql_opt_i32(v: Option<i32>) -> String {
 pub async fn load_all(client: &Client, warehouses: usize, seed: Option<u64>) -> Result<()> {
     let mut rng: StdRng = match seed {
         Some(s) => StdRng::seed_from_u64(s),
-        None => StdRng::from_rng(rand::thread_rng()).unwrap_or_else(|_| StdRng::seed_from_u64(0)),
+        None => StdRng::from_rng(&mut rand::rng()),
     };
-    let c_load: usize = rng.gen_range(0..256);
+    let c_load: usize = rng.random_range(0..256);
 
     load_item(client, &mut rng).await?;
     load_nation(client).await?;
@@ -170,8 +170,8 @@ async fn load_item(client: &Client, rng: &mut impl Rng) -> Result<()> {
     let mut row = String::new();
 
     for i in 1..=MAX_ITEMS {
-        let i_im_id: i32 = rng.gen_range(1..=10_000);
-        let i_price: f64 = f64::from(rng.gen_range(100..=10_000)) / 100.0;
+        let i_im_id: i32 = rng.random_range(1..=10_000);
+        let i_price: f64 = f64::from(rng.random_range(100..=10_000)) / 100.0;
         let i_name = tpcc_rand::rand_chars(rng, 14, 24);
         let i_data = tpcc_rand::rand_original_string(rng);
 
@@ -255,7 +255,7 @@ async fn load_stock(client: &Client, rng: &mut impl Rng, w_id: i32) -> Result<()
     let mut row = String::new();
 
     for i in 1..=STOCK_PER_WAREHOUSE {
-        let s_quantity: i32 = rng.gen_range(10..=100);
+        let s_quantity: i32 = rng.random_range(10..=100);
         let s_dist_01 = tpcc_rand::rand_letters(rng, 24, 24);
         let s_dist_02 = tpcc_rand::rand_letters(rng, 24, 24);
         let s_dist_03 = tpcc_rand::rand_letters(rng, 24, 24);
@@ -315,13 +315,13 @@ async fn load_customer(
         let c_state = tpcc_rand::rand_state(rng);
         let c_zip = tpcc_rand::rand_zip(rng);
         let c_phone = tpcc_rand::rand_numbers(rng, 16, 16);
-        let c_credit = if rng.gen_range(0..10) == 0 {
+        let c_credit = if rng.random_range(0..10) == 0 {
             "BC"
         } else {
             "GC"
         };
         let c_credit_lim: f64 = 50_000.00;
-        let c_discount: f64 = f64::from(rng.gen_range(0..=5_000)) / 10_000.0;
+        let c_discount: f64 = f64::from(rng.random_range(0..=5_000)) / 10_000.0;
         let c_balance: f64 = -10.00;
         let c_ytd_payment: f64 = 10.00;
         let c_data = tpcc_rand::rand_chars(rng, 300, 500);
@@ -385,7 +385,7 @@ async fn load_orders(
     // Random permutation of customer IDs
     let mut cids: Vec<i32> = (1..=ORDERS_PER_DISTRICT).collect();
     for i in (1..cids.len()).rev() {
-        let j = rng.gen_range(0..=i);
+        let j = rng.random_range(0..=i);
         cids.swap(i, j);
     }
 
@@ -395,11 +395,11 @@ async fn load_orders(
         let o_id = i + 1;
         let o_c_id = cids[usize::try_from(i).unwrap_or(0)];
         let o_carrier_id: Option<i32> = if o_id < 2101 {
-            Some(rng.gen_range(1..=10))
+            Some(rng.random_range(1..=10))
         } else {
             None
         };
-        let o_ol_cnt: i32 = rng.gen_range(5..=15);
+        let o_ol_cnt: i32 = rng.random_range(5..=15);
         ol_cnts.push(o_ol_cnt);
 
         row.clear();
@@ -447,12 +447,12 @@ async fn load_order_line(
         let o_id = i32::try_from(i).unwrap_or(0) + 1;
 
         for j in 1..=ol_cnt {
-            let ol_i_id: i32 = rng.gen_range(1..=100_000);
+            let ol_i_id: i32 = rng.random_range(1..=100_000);
 
             let (ol_delivery_d, ol_amount): (Option<&str>, f64) = if o_id < 2101 {
                 (Some(INIT_LOAD_TIME), 0.00)
             } else {
-                (None, f64::from(rng.gen_range(1..=999_999)) / 100.0)
+                (None, f64::from(rng.random_range(1..=999_999)) / 100.0)
             };
             let ol_dist_info = tpcc_rand::rand_chars(rng, 24, 24);
 
@@ -595,15 +595,15 @@ async fn load_supplier(client: &Client, rng: &mut impl Rng) -> Result<()> {
     for i in 1..=SUPPLIER_COUNT {
         let s_name = format!("Supplier#{i:09}");
         let s_address = tpcc_rand::rand_chars(rng, 10, 25);
-        let s_nationkey: i64 = rng.gen_range(0..nation_count);
+        let s_nationkey: i64 = rng.random_range(0..nation_count);
         let s_phone = format!(
             "{:02}-{}-{}-{}",
             (s_nationkey + 10),
-            rng.gen_range(100..=999),
-            rng.gen_range(100..=999),
-            rng.gen_range(1000..=9999),
+            rng.random_range(100..=999),
+            rng.random_range(100..=999),
+            rng.random_range(1000..=9999),
         );
-        let s_acctbal: f64 = f64::from(rng.gen_range(-99_999..=999_999)) / 100.0;
+        let s_acctbal: f64 = f64::from(rng.random_range(-99_999..=999_999)) / 100.0;
         let s_comment = tpcc_rand::rand_chars(rng, 25, 63);
 
         row.clear();

--- a/tools/chbench-driver/src/loader.rs
+++ b/tools/chbench-driver/src/loader.rs
@@ -124,6 +124,10 @@ fn sql_opt_i32(v: Option<i32>) -> String {
 ///
 /// When `seed` is `Some`, a deterministic RNG is used so that the same seed
 /// always produces the same dataset.
+///
+/// # Errors
+///
+/// Returns an error if any database operation fails.
 pub async fn load_all(client: &Client, warehouses: usize, seed: Option<u64>) -> Result<()> {
     let mut rng: StdRng = match seed {
         Some(s) => StdRng::seed_from_u64(s),
@@ -473,7 +477,7 @@ async fn load_order_line(
 // ─── CH-benCH supplemental tables (static data) ──────────────────────────────
 
 /// TPC-H nation data. 25 nations with region keys.
-/// Column order: (n_nationkey, n_name, n_regionkey).
+/// Column order: (`n_nationkey`, `n_name`, `n_regionkey`).
 const NATIONS: &[(i64, &str, i64)] = &[
     (0, "ALGERIA", 0),
     (1, "ARGENTINA", 1),

--- a/tools/chbench-driver/src/metrics.rs
+++ b/tools/chbench-driver/src/metrics.rs
@@ -27,7 +27,7 @@ use crate::txn::TxnType;
 /// Collected OLTP metrics from a benchmark run.
 #[derive(Debug)]
 pub struct OltpReport {
-    /// NewOrder committed transactions per minute.
+    /// `NewOrder` committed transactions per minute.
     pub tpmc: f64,
     /// Total committed transactions.
     pub total_committed: u64,
@@ -47,7 +47,14 @@ pub struct OltpMetrics {
     aborted: u64,
 }
 
+impl Default for OltpMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl OltpMetrics {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             start: Instant::now(),
@@ -71,26 +78,33 @@ impl OltpMetrics {
     }
 
     /// Merge another terminal's metrics into this one.
-    pub fn merge(&mut self, other: Self) {
+    pub fn merge(&mut self, other: &Self) {
         self.new_order_committed += other.new_order_committed;
         self.committed += other.committed;
         self.aborted += other.aborted;
     }
 
     /// Finalize and produce the report.
+    #[must_use]
     pub fn finish(self) -> OltpReport {
         let duration = self.start.elapsed();
         let minutes = duration.as_secs_f64() / 60.0;
 
         let tpmc = if minutes > 0.0 {
-            self.new_order_committed as f64 / minutes
+            #[expect(clippy::cast_precision_loss)]
+            {
+                self.new_order_committed as f64 / minutes
+            }
         } else {
             0.0
         };
 
         let total = self.committed + self.aborted;
         let abort_rate = if total > 0 {
-            self.aborted as f64 / total as f64
+            #[expect(clippy::cast_precision_loss)]
+            {
+                self.aborted as f64 / total as f64
+            }
         } else {
             0.0
         };

--- a/tools/chbench-driver/src/metrics.rs
+++ b/tools/chbench-driver/src/metrics.rs
@@ -1,0 +1,221 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! OLTP metrics: per-transaction latency tracking and tpmC calculation.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::txn::TxnType;
+
+/// Per-transaction-type latency histogram (simple sorted-list approach).
+#[derive(Debug, Default)]
+pub struct LatencyHistogram {
+    samples: Vec<Duration>,
+}
+
+impl LatencyHistogram {
+    pub fn record(&mut self, d: Duration) {
+        self.samples.push(d);
+    }
+
+    pub fn count(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// Merge samples from another histogram into this one.
+    pub fn merge(&mut self, other: Self) {
+        self.samples.extend(other.samples);
+    }
+
+    fn sorted(&self) -> Vec<Duration> {
+        let mut s = self.samples.clone();
+        s.sort();
+        s
+    }
+
+    /// Return the percentile value. `p` should be 0.0..=1.0.
+    pub fn percentile(&self, p: f64) -> Duration {
+        let sorted = self.sorted();
+        if sorted.is_empty() {
+            return Duration::ZERO;
+        }
+        let idx = ((sorted.len() as f64) * p).ceil() as usize;
+        sorted[idx.min(sorted.len()) - 1]
+    }
+
+    pub fn p50(&self) -> Duration {
+        self.percentile(0.50)
+    }
+
+    pub fn p90(&self) -> Duration {
+        self.percentile(0.90)
+    }
+
+    pub fn p95(&self) -> Duration {
+        self.percentile(0.95)
+    }
+
+    pub fn p99(&self) -> Duration {
+        self.percentile(0.99)
+    }
+
+    pub fn min(&self) -> Duration {
+        self.samples.iter().copied().min().unwrap_or(Duration::ZERO)
+    }
+
+    pub fn max(&self) -> Duration {
+        self.samples.iter().copied().max().unwrap_or(Duration::ZERO)
+    }
+}
+
+/// Collected OLTP metrics from a benchmark run.
+#[derive(Debug)]
+pub struct OltpReport {
+    /// NewOrder committed transactions per minute.
+    pub tpmc: f64,
+    /// Per-transaction-type latency histograms.
+    pub latencies: HashMap<TxnType, LatencyHistogram>,
+    /// Total committed transactions.
+    pub total_committed: u64,
+    /// Total aborted/failed transactions.
+    pub total_aborted: u64,
+    /// Abort rate (0.0..1.0).
+    pub abort_rate: f64,
+    /// Wall-clock duration of the OLTP run.
+    pub duration: Duration,
+}
+
+/// Accumulates metrics during an OLTP run.
+pub struct OltpMetrics {
+    start: Instant,
+    latencies: HashMap<TxnType, LatencyHistogram>,
+    committed: u64,
+    aborted: u64,
+}
+
+impl OltpMetrics {
+    pub fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            latencies: HashMap::new(),
+            committed: 0,
+            aborted: 0,
+        }
+    }
+
+    /// Record a successful transaction.
+    pub fn record_success(&mut self, txn_type: TxnType, latency: Duration) {
+        self.latencies
+            .entry(txn_type)
+            .or_default()
+            .record(latency);
+        self.committed += 1;
+    }
+
+    /// Record a failed/aborted transaction.
+    pub fn record_abort(&mut self, txn_type: TxnType, latency: Duration) {
+        self.latencies
+            .entry(txn_type)
+            .or_default()
+            .record(latency);
+        self.aborted += 1;
+    }
+
+    /// Merge another terminal's metrics into this one.
+    pub fn merge(&mut self, other: Self) {
+        for (txn_type, hist) in other.latencies {
+            self.latencies
+                .entry(txn_type)
+                .or_default()
+                .merge(hist);
+        }
+        self.committed += other.committed;
+        self.aborted += other.aborted;
+    }
+
+    /// Finalize and produce the report.
+    pub fn finish(self) -> OltpReport {
+        let duration = self.start.elapsed();
+        let minutes = duration.as_secs_f64() / 60.0;
+
+        // tpmC = NewOrder committed per minute
+        let new_order_committed = self
+            .latencies
+            .get(&TxnType::NewOrder)
+            .map_or(0, |h| h.count());
+
+        let tpmc = if minutes > 0.0 {
+            new_order_committed as f64 / minutes
+        } else {
+            0.0
+        };
+
+        let total = self.committed + self.aborted;
+        let abort_rate = if total > 0 {
+            self.aborted as f64 / total as f64
+        } else {
+            0.0
+        };
+
+        OltpReport {
+            tpmc,
+            latencies: self.latencies,
+            total_committed: self.committed,
+            total_aborted: self.aborted,
+            abort_rate,
+            duration,
+        }
+    }
+}
+
+impl OltpReport {
+    /// Print a human-readable summary.
+    pub fn print_summary(&self) {
+        println!("OLTP Report ({:.1}s)", self.duration.as_secs_f64());
+        println!("  tpmC (NewOrder/min): {:.1}", self.tpmc);
+        println!(
+            "  transactions: {} committed, {} aborted ({:.2}% abort rate)",
+            self.total_committed,
+            self.total_aborted,
+            self.abort_rate * 100.0,
+        );
+
+        let types = [
+            TxnType::NewOrder,
+            TxnType::Payment,
+            TxnType::Delivery,
+            TxnType::OrderStatus,
+            TxnType::StockLevel,
+        ];
+
+        for txn_type in &types {
+            if let Some(hist) = self.latencies.get(txn_type) {
+                println!(
+                    "  {}: {} txns, p50={:.1}ms p90={:.1}ms p95={:.1}ms p99={:.1}ms min={:.1}ms max={:.1}ms",
+                    txn_type,
+                    hist.count(),
+                    hist.p50().as_secs_f64() * 1000.0,
+                    hist.p90().as_secs_f64() * 1000.0,
+                    hist.p95().as_secs_f64() * 1000.0,
+                    hist.p99().as_secs_f64() * 1000.0,
+                    hist.min().as_secs_f64() * 1000.0,
+                    hist.max().as_secs_f64() * 1000.0,
+                );
+            }
+        }
+    }
+}

--- a/tools/chbench-driver/src/metrics.rs
+++ b/tools/chbench-driver/src/metrics.rs
@@ -14,81 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! OLTP metrics: per-transaction latency tracking and tpmC calculation.
+//! OLTP metrics: tpmC and abort rate tracking.
+//!
+//! Per-transaction-type latency histograms are intentionally omitted — they measure
+//! Postgres performance, not Spice. The metrics that matter for Spice benchmarking are
+//! tpmC (CDC input intensity), the analytical query latencies, and staleness gap reported by testoperator.
 
-use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crate::txn::TxnType;
-
-/// Per-transaction-type latency histogram (simple sorted-list approach).
-#[derive(Debug, Default)]
-pub struct LatencyHistogram {
-    samples: Vec<Duration>,
-}
-
-impl LatencyHistogram {
-    pub fn record(&mut self, d: Duration) {
-        self.samples.push(d);
-    }
-
-    pub fn count(&self) -> usize {
-        self.samples.len()
-    }
-
-    /// Merge samples from another histogram into this one.
-    pub fn merge(&mut self, other: Self) {
-        self.samples.extend(other.samples);
-    }
-
-    fn sorted(&self) -> Vec<Duration> {
-        let mut s = self.samples.clone();
-        s.sort();
-        s
-    }
-
-    /// Return the percentile value. `p` should be 0.0..=1.0.
-    pub fn percentile(&self, p: f64) -> Duration {
-        let sorted = self.sorted();
-        if sorted.is_empty() {
-            return Duration::ZERO;
-        }
-        let idx = ((sorted.len() as f64) * p).ceil() as usize;
-        sorted[idx.min(sorted.len()) - 1]
-    }
-
-    pub fn p50(&self) -> Duration {
-        self.percentile(0.50)
-    }
-
-    pub fn p90(&self) -> Duration {
-        self.percentile(0.90)
-    }
-
-    pub fn p95(&self) -> Duration {
-        self.percentile(0.95)
-    }
-
-    pub fn p99(&self) -> Duration {
-        self.percentile(0.99)
-    }
-
-    pub fn min(&self) -> Duration {
-        self.samples.iter().copied().min().unwrap_or(Duration::ZERO)
-    }
-
-    pub fn max(&self) -> Duration {
-        self.samples.iter().copied().max().unwrap_or(Duration::ZERO)
-    }
-}
 
 /// Collected OLTP metrics from a benchmark run.
 #[derive(Debug)]
 pub struct OltpReport {
     /// NewOrder committed transactions per minute.
     pub tpmc: f64,
-    /// Per-transaction-type latency histograms.
-    pub latencies: HashMap<TxnType, LatencyHistogram>,
     /// Total committed transactions.
     pub total_committed: u64,
     /// Total aborted/failed transactions.
@@ -102,7 +42,7 @@ pub struct OltpReport {
 /// Accumulates metrics during an OLTP run.
 pub struct OltpMetrics {
     start: Instant,
-    latencies: HashMap<TxnType, LatencyHistogram>,
+    new_order_committed: u64,
     committed: u64,
     aborted: u64,
 }
@@ -111,38 +51,28 @@ impl OltpMetrics {
     pub fn new() -> Self {
         Self {
             start: Instant::now(),
-            latencies: HashMap::new(),
+            new_order_committed: 0,
             committed: 0,
             aborted: 0,
         }
     }
 
     /// Record a successful transaction.
-    pub fn record_success(&mut self, txn_type: TxnType, latency: Duration) {
-        self.latencies
-            .entry(txn_type)
-            .or_default()
-            .record(latency);
+    pub fn record_success(&mut self, txn_type: TxnType) {
+        if txn_type == TxnType::NewOrder {
+            self.new_order_committed += 1;
+        }
         self.committed += 1;
     }
 
     /// Record a failed/aborted transaction.
-    pub fn record_abort(&mut self, txn_type: TxnType, latency: Duration) {
-        self.latencies
-            .entry(txn_type)
-            .or_default()
-            .record(latency);
+    pub fn record_abort(&mut self) {
         self.aborted += 1;
     }
 
     /// Merge another terminal's metrics into this one.
     pub fn merge(&mut self, other: Self) {
-        for (txn_type, hist) in other.latencies {
-            self.latencies
-                .entry(txn_type)
-                .or_default()
-                .merge(hist);
-        }
+        self.new_order_committed += other.new_order_committed;
         self.committed += other.committed;
         self.aborted += other.aborted;
     }
@@ -152,14 +82,8 @@ impl OltpMetrics {
         let duration = self.start.elapsed();
         let minutes = duration.as_secs_f64() / 60.0;
 
-        // tpmC = NewOrder committed per minute
-        let new_order_committed = self
-            .latencies
-            .get(&TxnType::NewOrder)
-            .map_or(0, |h| h.count());
-
         let tpmc = if minutes > 0.0 {
-            new_order_committed as f64 / minutes
+            self.new_order_committed as f64 / minutes
         } else {
             0.0
         };
@@ -173,7 +97,6 @@ impl OltpMetrics {
 
         OltpReport {
             tpmc,
-            latencies: self.latencies,
             total_committed: self.committed,
             total_aborted: self.aborted,
             abort_rate,
@@ -193,29 +116,5 @@ impl OltpReport {
             self.total_aborted,
             self.abort_rate * 100.0,
         );
-
-        let types = [
-            TxnType::NewOrder,
-            TxnType::Payment,
-            TxnType::Delivery,
-            TxnType::OrderStatus,
-            TxnType::StockLevel,
-        ];
-
-        for txn_type in &types {
-            if let Some(hist) = self.latencies.get(txn_type) {
-                println!(
-                    "  {}: {} txns, p50={:.1}ms p90={:.1}ms p95={:.1}ms p99={:.1}ms min={:.1}ms max={:.1}ms",
-                    txn_type,
-                    hist.count(),
-                    hist.p50().as_secs_f64() * 1000.0,
-                    hist.p90().as_secs_f64() * 1000.0,
-                    hist.p95().as_secs_f64() * 1000.0,
-                    hist.p99().as_secs_f64() * 1000.0,
-                    hist.min().as_secs_f64() * 1000.0,
-                    hist.max().as_secs_f64() * 1000.0,
-                );
-            }
-        }
     }
 }

--- a/tools/chbench-driver/src/rand.rs
+++ b/tools/chbench-driver/src/rand.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 //! TPC-C random data generators (spec §2.1.6 / §4.3.2).
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 const CHARACTERS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 const LETTERS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -29,25 +29,25 @@ const C_LAST_TOKENS: &[&str] = &[
 
 /// Generate a random string of characters in `[min_len, max_len]` (spec §4.3.2.2).
 pub fn rand_chars(rng: &mut impl Rng, min_len: usize, max_len: usize) -> String {
-    let len = rng.gen_range(min_len..=max_len);
+    let len = rng.random_range(min_len..=max_len);
     (0..len)
-        .map(|_| CHARACTERS[rng.gen_range(0..CHARACTERS.len())] as char)
+        .map(|_| CHARACTERS[rng.random_range(0..CHARACTERS.len())] as char)
         .collect()
 }
 
 /// Generate a random string of uppercase letters in `[min_len, max_len]`.
 pub fn rand_letters(rng: &mut impl Rng, min_len: usize, max_len: usize) -> String {
-    let len = rng.gen_range(min_len..=max_len);
+    let len = rng.random_range(min_len..=max_len);
     (0..len)
-        .map(|_| LETTERS[rng.gen_range(0..LETTERS.len())] as char)
+        .map(|_| LETTERS[rng.random_range(0..LETTERS.len())] as char)
         .collect()
 }
 
 /// Generate a random string of digits in `[min_len, max_len]`.
 pub fn rand_numbers(rng: &mut impl Rng, min_len: usize, max_len: usize) -> String {
-    let len = rng.gen_range(min_len..=max_len);
+    let len = rng.random_range(min_len..=max_len);
     (0..len)
-        .map(|_| NUMBERS[rng.gen_range(0..NUMBERS.len())] as char)
+        .map(|_| NUMBERS[rng.random_range(0..NUMBERS.len())] as char)
         .collect()
 }
 
@@ -65,7 +65,7 @@ pub fn rand_zip(rng: &mut impl Rng) -> String {
 
 /// Generate a random tax rate in `[0.0000, 0.2000]` (spec §2.4.1).
 pub fn rand_tax(rng: &mut impl Rng) -> f64 {
-    f64::from(rng.gen_range(0..=2000)) / 10_000.0
+    f64::from(rng.random_range(0..=2000)) / 10_000.0
 }
 
 /// Generate a random "original" string (spec §4.3.3.1).
@@ -74,9 +74,9 @@ pub fn rand_tax(rng: &mut impl Rng) -> f64 {
 /// at a random position within the string.
 pub fn rand_original_string(rng: &mut impl Rng) -> String {
     let mut s = rand_chars(rng, 26, 50);
-    if rng.gen_range(0..10) == 0 {
+    if rng.random_range(0..10) == 0 {
         let mut bytes = s.into_bytes();
-        let pos = rng.gen_range(0..bytes.len().saturating_sub(8));
+        let pos = rng.random_range(0..bytes.len().saturating_sub(8));
         bytes[pos..pos + 8].copy_from_slice(b"ORIGINAL");
         s = String::from_utf8(bytes).unwrap_or_default();
     }
@@ -94,15 +94,15 @@ pub fn c_last_syllables(n: usize) -> String {
 
 /// Generate a random C-Last name using NURand (spec §2.1.6).
 pub fn rand_c_last(rng: &mut impl Rng, c_load: usize) -> String {
-    let a = rng.gen_range(0..256);
-    let x = rng.gen_range(0..1000);
+    let a = rng.random_range(0..256);
+    let x = rng.random_range(0..1000);
     c_last_syllables(((a | x) + c_load) % 1000)
 }
 
 /// Generate a random customer ID using NURand(1023, 1, 3000) (spec §2.1.6).
 pub fn rand_customer_id(rng: &mut impl Rng) -> i32 {
-    let a = rng.gen_range(0..1024);
-    let x = rng.gen_range(1..=3000);
-    let c = rng.gen_range(0..1024);
+    let a = rng.random_range(0..1024);
+    let x = rng.random_range(1..=3000);
+    let c = rng.random_range(0..1024);
     ((a | x) + c) % 3000 + 1
 }

--- a/tools/chbench-driver/src/rand.rs
+++ b/tools/chbench-driver/src/rand.rs
@@ -73,14 +73,14 @@ pub fn rand_tax(rng: &mut impl Rng) -> f64 {
 /// Returns a random a-string `[26..50]`. For 10% of rows, "ORIGINAL" is placed
 /// at a random position within the string.
 pub fn rand_original_string(rng: &mut impl Rng) -> String {
-    let mut s = rand_chars(rng, 26, 50);
+    let mut bytes = rand_chars(rng, 26, 50).into_bytes();
     if rng.random_range(0..10) == 0 {
-        let mut bytes = s.into_bytes();
         let pos = rng.random_range(0..bytes.len().saturating_sub(8));
         bytes[pos..pos + 8].copy_from_slice(b"ORIGINAL");
-        s = String::from_utf8(bytes).unwrap_or_default();
     }
-    s
+    // SAFETY (infallible): `rand_chars` produces ASCII-only bytes and "ORIGINAL" is ASCII,
+    // so the buffer is always valid UTF-8.
+    String::from_utf8(bytes).unwrap_or_default()
 }
 
 /// Generate a C-Last name from syllables (spec §4.3.2.3).

--- a/tools/chbench-driver/src/rand.rs
+++ b/tools/chbench-driver/src/rand.rs
@@ -1,0 +1,99 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-C random data generators (spec §2.1.6 / §4.3.2).
+
+use rand::Rng;
+
+const CHARACTERS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+const LETTERS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const NUMBERS: &[u8] = b"1234567890";
+
+/// TPC-C C-Last syllable table (spec §4.3.2.3).
+const C_LAST_TOKENS: &[&str] = &[
+    "BAR", "OUGHT", "ABLE", "PRI", "PRES", "ESE", "ANTI", "CALLY", "ATION", "EING",
+];
+
+/// Generate a random string of characters in `[min_len, max_len]` (spec §4.3.2.2).
+pub fn rand_chars(rng: &mut impl Rng, min_len: usize, max_len: usize) -> String {
+    let len = rng.gen_range(min_len..=max_len);
+    (0..len)
+        .map(|_| CHARACTERS[rng.gen_range(0..CHARACTERS.len())] as char)
+        .collect()
+}
+
+/// Generate a random string of uppercase letters in `[min_len, max_len]`.
+pub fn rand_letters(rng: &mut impl Rng, min_len: usize, max_len: usize) -> String {
+    let len = rng.gen_range(min_len..=max_len);
+    (0..len)
+        .map(|_| LETTERS[rng.gen_range(0..LETTERS.len())] as char)
+        .collect()
+}
+
+/// Generate a random string of digits in `[min_len, max_len]`.
+pub fn rand_numbers(rng: &mut impl Rng, min_len: usize, max_len: usize) -> String {
+    let len = rng.gen_range(min_len..=max_len);
+    (0..len)
+        .map(|_| NUMBERS[rng.gen_range(0..NUMBERS.len())] as char)
+        .collect()
+}
+
+/// Generate a random state code (2 uppercase letters).
+pub fn rand_state(rng: &mut impl Rng) -> String {
+    rand_letters(rng, 2, 2)
+}
+
+/// Generate a random zip code: 4 random digits + "11111" (spec §4.3.2.7).
+pub fn rand_zip(rng: &mut impl Rng) -> String {
+    let mut s = rand_numbers(rng, 4, 4);
+    s.push_str("11111");
+    s
+}
+
+/// Generate a random tax rate in `[0.0000, 0.2000]` (spec §2.4.1).
+pub fn rand_tax(rng: &mut impl Rng) -> f64 {
+    f64::from(rng.gen_range(0..=2000)) / 10_000.0
+}
+
+/// Generate a random "original" string (spec §4.3.3.1).
+///
+/// Returns a random a-string `[26..50]`. For 10% of rows, "ORIGINAL" is placed
+/// at a random position within the string.
+pub fn rand_original_string(rng: &mut impl Rng) -> String {
+    let mut s = rand_chars(rng, 26, 50);
+    if rng.gen_range(0..10) == 0 {
+        let bytes = unsafe { s.as_bytes_mut() };
+        let pos = rng.gen_range(0..bytes.len().saturating_sub(8));
+        bytes[pos..pos + 8].copy_from_slice(b"ORIGINAL");
+    }
+    s
+}
+
+/// Generate a C-Last name from syllables (spec §4.3.2.3).
+pub fn c_last_syllables(n: usize) -> String {
+    let mut s = String::with_capacity(15);
+    s.push_str(C_LAST_TOKENS[n / 100]);
+    s.push_str(C_LAST_TOKENS[(n / 10) % 10]);
+    s.push_str(C_LAST_TOKENS[n % 10]);
+    s
+}
+
+/// Generate a random C-Last name using NURand (spec §2.1.6).
+pub fn rand_c_last(rng: &mut impl Rng, c_load: usize) -> String {
+    let a = rng.gen_range(0..256);
+    let x = rng.gen_range(0..1000);
+    c_last_syllables(((a | x) + c_load) % 1000)
+}

--- a/tools/chbench-driver/src/rand.rs
+++ b/tools/chbench-driver/src/rand.rs
@@ -84,6 +84,7 @@ pub fn rand_original_string(rng: &mut impl Rng) -> String {
 }
 
 /// Generate a C-Last name from syllables (spec §4.3.2.3).
+#[must_use]
 pub fn c_last_syllables(n: usize) -> String {
     let mut s = String::with_capacity(15);
     s.push_str(C_LAST_TOKENS[n / 100]);
@@ -92,7 +93,7 @@ pub fn c_last_syllables(n: usize) -> String {
     s
 }
 
-/// Generate a random C-Last name using NURand (spec §2.1.6).
+/// Generate a random C-Last name using `NURand` (spec §2.1.6).
 pub fn rand_c_last(rng: &mut impl Rng, c_load: usize) -> String {
     let a = rng.random_range(0..256);
     let x = rng.random_range(0..1000);

--- a/tools/chbench-driver/src/rand.rs
+++ b/tools/chbench-driver/src/rand.rs
@@ -75,9 +75,10 @@ pub fn rand_tax(rng: &mut impl Rng) -> f64 {
 pub fn rand_original_string(rng: &mut impl Rng) -> String {
     let mut s = rand_chars(rng, 26, 50);
     if rng.gen_range(0..10) == 0 {
-        let bytes = unsafe { s.as_bytes_mut() };
+        let mut bytes = s.into_bytes();
         let pos = rng.gen_range(0..bytes.len().saturating_sub(8));
         bytes[pos..pos + 8].copy_from_slice(b"ORIGINAL");
+        s = String::from_utf8(bytes).unwrap_or_default();
     }
     s
 }

--- a/tools/chbench-driver/src/rand.rs
+++ b/tools/chbench-driver/src/rand.rs
@@ -97,3 +97,11 @@ pub fn rand_c_last(rng: &mut impl Rng, c_load: usize) -> String {
     let x = rng.gen_range(0..1000);
     c_last_syllables(((a | x) + c_load) % 1000)
 }
+
+/// Generate a random customer ID using NURand(1023, 1, 3000) (spec §2.1.6).
+pub fn rand_customer_id(rng: &mut impl Rng) -> i32 {
+    let a = rng.gen_range(0..1024);
+    let x = rng.gen_range(1..=3000);
+    let c = rng.gen_range(0..1024);
+    ((a | x) + c) % 3000 + 1
+}

--- a/tools/chbench-driver/src/schema.rs
+++ b/tools/chbench-driver/src/schema.rs
@@ -91,12 +91,13 @@ pub async fn drop_tables(client: &Client) -> Result<()> {
     println!("  dropping {} tables", ALL_TABLES.len());
     for table in ALL_TABLES.iter().rev() {
         let sql = format!("DROP TABLE IF EXISTS {table} CASCADE");
-        client.execute(&sql, &[]).await.map_err(|source| {
-            crate::Error::Sql {
+        client
+            .execute(&sql, &[])
+            .await
+            .map_err(|source| crate::Error::Sql {
                 action: format!("drop table {table}"),
                 source,
-            }
-        })?;
+            })?;
     }
     Ok(())
 }
@@ -286,12 +287,13 @@ pub async fn create_tables(client: &Client) -> Result<()> {
 
     println!("  creating {} tables + 4 indexes", ddl_statements.len());
     for (table, ddl) in ddl_statements {
-        client.execute(*ddl, &[]).await.map_err(|source| {
-            crate::Error::Sql {
+        client
+            .execute(*ddl, &[])
+            .await
+            .map_err(|source| crate::Error::Sql {
                 action: format!("create table {table}"),
                 source,
-            }
-        })?;
+            })?;
     }
 
     // Indexes (matching go-tpc Postgres DDL)
@@ -315,12 +317,13 @@ pub async fn create_tables(client: &Client) -> Result<()> {
     ];
 
     for (name, ddl) in indexes {
-        client.execute(*ddl, &[]).await.map_err(|source| {
-            crate::Error::Sql {
+        client
+            .execute(*ddl, &[])
+            .await
+            .map_err(|source| crate::Error::Sql {
                 action: format!("create index {name}"),
                 source,
-            }
-        })?;
+            })?;
     }
 
     // Add _bench_ts column and trigger to all mutated TPC-C tables.
@@ -377,22 +380,24 @@ async fn add_bench_ts_column_and_triggers(client: &Client) -> Result<()> {
         let add_col = format!(
             "ALTER TABLE {table} ADD COLUMN IF NOT EXISTS _bench_ts TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()"
         );
-        client.execute(&add_col, &[]).await.map_err(|source| {
-            crate::Error::Sql {
+        client
+            .execute(&add_col, &[])
+            .await
+            .map_err(|source| crate::Error::Sql {
                 action: format!("add _bench_ts column to {table}"),
                 source,
-            }
-        })?;
+            })?;
 
         // Attach the trigger (idempotent via DROP IF EXISTS + CREATE).
         let trigger_name = format!("trg_bench_ts_{table}");
         let drop_trg = format!("DROP TRIGGER IF EXISTS {trigger_name} ON {table}");
-        client.execute(&drop_trg, &[]).await.map_err(|source| {
-            crate::Error::Sql {
+        client
+            .execute(&drop_trg, &[])
+            .await
+            .map_err(|source| crate::Error::Sql {
                 action: format!("drop trigger {trigger_name}"),
                 source,
-            }
-        })?;
+            })?;
 
         let create_trg = format!(
             "CREATE TRIGGER {trigger_name} BEFORE INSERT OR UPDATE ON {table} FOR EACH ROW EXECUTE FUNCTION bench_ts_trigger()"

--- a/tools/chbench-driver/src/schema.rs
+++ b/tools/chbench-driver/src/schema.rs
@@ -1,0 +1,278 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-C + CH-benCH DDL for PostgreSQL.
+
+use tokio_postgres::Client;
+
+use crate::Result;
+
+/// All table names in creation order (respects implicit FK dependencies).
+pub const ALL_TABLES: &[&str] = &[
+    "warehouse",
+    "district",
+    "item",
+    "stock",
+    "customer",
+    "history",
+    "orders",
+    "new_order",
+    "order_line",
+    "nation",
+    "region",
+    "supplier",
+];
+
+/// Drop all CH-benCH tables (reverse order).
+pub async fn drop_tables(client: &Client) -> Result<()> {
+    for table in ALL_TABLES.iter().rev() {
+        let sql = format!("DROP TABLE IF EXISTS {table} CASCADE");
+        tracing::info!("dropping table {table}");
+        client.execute(&sql, &[]).await.map_err(|source| {
+            crate::Error::Sql {
+                action: format!("drop table {table}"),
+                source,
+            }
+        })?;
+    }
+    Ok(())
+}
+
+/// Create all 12 CH-benCH tables (9 TPC-C + 3 supplemental).
+pub async fn create_tables(client: &Client) -> Result<()> {
+    let ddl_statements: &[(&str, &str)] = &[
+        (
+            "warehouse",
+            "CREATE TABLE IF NOT EXISTS warehouse (
+                w_id INT NOT NULL,
+                w_name VARCHAR(10),
+                w_street_1 VARCHAR(20),
+                w_street_2 VARCHAR(20),
+                w_city VARCHAR(20),
+                w_state CHAR(2),
+                w_zip CHAR(9),
+                w_tax DECIMAL(4, 4),
+                w_ytd DECIMAL(12, 2),
+                PRIMARY KEY (w_id)
+            )",
+        ),
+        (
+            "district",
+            "CREATE TABLE IF NOT EXISTS district (
+                d_id INT NOT NULL,
+                d_w_id INT NOT NULL,
+                d_name VARCHAR(10),
+                d_street_1 VARCHAR(20),
+                d_street_2 VARCHAR(20),
+                d_city VARCHAR(20),
+                d_state CHAR(2),
+                d_zip CHAR(9),
+                d_tax DECIMAL(4, 4),
+                d_ytd DECIMAL(12, 2),
+                d_next_o_id INT,
+                PRIMARY KEY (d_w_id, d_id)
+            )",
+        ),
+        (
+            "customer",
+            "CREATE TABLE IF NOT EXISTS customer (
+                c_id INT NOT NULL,
+                c_d_id INT NOT NULL,
+                c_w_id INT NOT NULL,
+                c_first VARCHAR(16),
+                c_middle CHAR(2),
+                c_last VARCHAR(16),
+                c_street_1 VARCHAR(20),
+                c_street_2 VARCHAR(20),
+                c_city VARCHAR(20),
+                c_state CHAR(2),
+                c_zip CHAR(9),
+                c_phone CHAR(16),
+                c_since TIMESTAMP,
+                c_credit CHAR(2),
+                c_credit_lim DECIMAL(12, 2),
+                c_discount DECIMAL(4, 4),
+                c_balance DECIMAL(12, 2),
+                c_ytd_payment DECIMAL(12, 2),
+                c_payment_cnt INT,
+                c_delivery_cnt INT,
+                c_data VARCHAR(500),
+                PRIMARY KEY (c_w_id, c_d_id, c_id)
+            )",
+        ),
+        (
+            "history",
+            "CREATE TABLE IF NOT EXISTS history (
+                h_c_id INT NOT NULL,
+                h_c_d_id INT NOT NULL,
+                h_c_w_id INT NOT NULL,
+                h_d_id INT NOT NULL,
+                h_w_id INT NOT NULL,
+                h_date TIMESTAMP,
+                h_amount DECIMAL(6, 2),
+                h_data VARCHAR(24)
+            )",
+        ),
+        (
+            "new_order",
+            "CREATE TABLE IF NOT EXISTS new_order (
+                no_o_id INT NOT NULL,
+                no_d_id INT NOT NULL,
+                no_w_id INT NOT NULL,
+                PRIMARY KEY (no_w_id, no_d_id, no_o_id)
+            )",
+        ),
+        (
+            "orders",
+            "CREATE TABLE IF NOT EXISTS orders (
+                o_id INT NOT NULL,
+                o_d_id INT NOT NULL,
+                o_w_id INT NOT NULL,
+                o_c_id INT,
+                o_entry_d TIMESTAMP,
+                o_carrier_id INT,
+                o_ol_cnt INT,
+                o_all_local INT,
+                PRIMARY KEY (o_w_id, o_d_id, o_id)
+            )",
+        ),
+        (
+            "order_line",
+            "CREATE TABLE IF NOT EXISTS order_line (
+                ol_o_id INT NOT NULL,
+                ol_d_id INT NOT NULL,
+                ol_w_id INT NOT NULL,
+                ol_number INT NOT NULL,
+                ol_i_id INT NOT NULL,
+                ol_supply_w_id INT,
+                ol_delivery_d TIMESTAMP,
+                ol_quantity INT,
+                ol_amount DECIMAL(6, 2),
+                ol_dist_info CHAR(24),
+                PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number)
+            )",
+        ),
+        (
+            "stock",
+            "CREATE TABLE IF NOT EXISTS stock (
+                s_i_id INT NOT NULL,
+                s_w_id INT NOT NULL,
+                s_quantity INT,
+                s_dist_01 CHAR(24),
+                s_dist_02 CHAR(24),
+                s_dist_03 CHAR(24),
+                s_dist_04 CHAR(24),
+                s_dist_05 CHAR(24),
+                s_dist_06 CHAR(24),
+                s_dist_07 CHAR(24),
+                s_dist_08 CHAR(24),
+                s_dist_09 CHAR(24),
+                s_dist_10 CHAR(24),
+                s_ytd INT,
+                s_order_cnt INT,
+                s_remote_cnt INT,
+                s_data VARCHAR(50),
+                PRIMARY KEY (s_w_id, s_i_id)
+            )",
+        ),
+        (
+            "item",
+            "CREATE TABLE IF NOT EXISTS item (
+                i_id INT NOT NULL,
+                i_im_id INT,
+                i_name VARCHAR(24),
+                i_price DECIMAL(5, 2),
+                i_data VARCHAR(50),
+                PRIMARY KEY (i_id)
+            )",
+        ),
+        // CH-benCH supplemental tables
+        (
+            "nation",
+            "CREATE TABLE IF NOT EXISTS nation (
+                n_nationkey BIGINT NOT NULL,
+                n_name CHAR(25) NOT NULL,
+                n_regionkey BIGINT NOT NULL,
+                n_comment VARCHAR(152),
+                PRIMARY KEY (n_nationkey)
+            )",
+        ),
+        (
+            "region",
+            "CREATE TABLE IF NOT EXISTS region (
+                r_regionkey BIGINT NOT NULL,
+                r_name CHAR(25) NOT NULL,
+                r_comment VARCHAR(152),
+                PRIMARY KEY (r_regionkey)
+            )",
+        ),
+        (
+            "supplier",
+            "CREATE TABLE IF NOT EXISTS supplier (
+                s_suppkey BIGINT NOT NULL,
+                s_name CHAR(25) NOT NULL,
+                s_address VARCHAR(40) NOT NULL,
+                s_nationkey BIGINT NOT NULL,
+                s_phone CHAR(15) NOT NULL,
+                s_acctbal DECIMAL(15, 2) NOT NULL,
+                s_comment VARCHAR(101) NOT NULL,
+                PRIMARY KEY (s_suppkey)
+            )",
+        ),
+    ];
+
+    for (table, ddl) in ddl_statements {
+        tracing::info!("creating table {table}");
+        client.execute(*ddl, &[]).await.map_err(|source| {
+            crate::Error::Sql {
+                action: format!("create table {table}"),
+                source,
+            }
+        })?;
+    }
+
+    // Indexes (matching go-tpc Postgres DDL)
+    let indexes: &[(&str, &str)] = &[
+        (
+            "idx_customer",
+            "CREATE INDEX IF NOT EXISTS idx_customer ON customer (c_w_id, c_d_id, c_last, c_first)",
+        ),
+        (
+            "idx_h_w_id",
+            "CREATE INDEX IF NOT EXISTS idx_h_w_id ON history (h_w_id)",
+        ),
+        (
+            "idx_h_c_w_id",
+            "CREATE INDEX IF NOT EXISTS idx_h_c_w_id ON history (h_c_w_id)",
+        ),
+        (
+            "idx_order",
+            "CREATE INDEX IF NOT EXISTS idx_order ON orders (o_w_id, o_d_id, o_c_id, o_id)",
+        ),
+    ];
+
+    for (name, ddl) in indexes {
+        tracing::info!("creating index {name}");
+        client.execute(*ddl, &[]).await.map_err(|source| {
+            crate::Error::Sql {
+                action: format!("create index {name}"),
+                source,
+            }
+        })?;
+    }
+
+    Ok(())
+}

--- a/tools/chbench-driver/src/schema.rs
+++ b/tools/chbench-driver/src/schema.rs
@@ -39,7 +39,7 @@ pub const ALL_TABLES: &[&str] = &[
 /// Drop stale Spice replication slots and publications left from previous runs (if any).
 pub async fn drop_replication_artifacts(client: &Client) -> Result<()> {
     // Drop replication slots named spice_*
-    let rows = client
+    let slot_rows = client
         .query(
             "SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE 'spice_%'",
             &[],
@@ -50,14 +50,14 @@ pub async fn drop_replication_artifacts(client: &Client) -> Result<()> {
             source,
         })?;
 
-    for row in &rows {
+    for row in &slot_rows {
         let slot_name: &str = row.get(0);
         let sql = format!("SELECT pg_drop_replication_slot('{slot_name}')");
         let _unused = client.execute(&sql, &[]).await;
     }
 
     // Drop publications named spice_*
-    let rows = client
+    let pub_rows = client
         .query(
             "SELECT pubname FROM pg_publication WHERE pubname LIKE 'spice_%'",
             &[],
@@ -68,17 +68,17 @@ pub async fn drop_replication_artifacts(client: &Client) -> Result<()> {
             source,
         })?;
 
-    for row in &rows {
+    for row in &pub_rows {
         let pubname: &str = row.get(0);
         let sql = format!("DROP PUBLICATION IF EXISTS {pubname}");
         let _unused = client.execute(&sql, &[]).await;
     }
 
-    if !rows.is_empty() {
+    if !slot_rows.is_empty() || !pub_rows.is_empty() {
         println!(
             "  cleaned up {} replication slots, {} publications",
-            rows.len(),
-            rows.len()
+            slot_rows.len(),
+            pub_rows.len()
         );
     }
 
@@ -348,7 +348,7 @@ const MUTATED_TABLES: &[&str] = &[
 
 /// Tables probed for staleness gap measurement.
 /// Selected for diversity: district (small, baseline), order_line (high volume),
-/// new_order (DELETE path), history (append-only, no PK).
+/// new_order (DELETE path).
 pub const STALENESS_PROBE_TABLES: &[&str] = &["district", "order_line", "new_order"];
 
 /// Add `_bench_ts TIMESTAMPTZ` column with `clock_timestamp()` default and

--- a/tools/chbench-driver/src/schema.rs
+++ b/tools/chbench-driver/src/schema.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! TPC-C + CH-benCH DDL for PostgreSQL.
+//! TPC-C + CH-benCH DDL for Postgres.
 
 use tokio_postgres::Client;
 
@@ -37,6 +37,10 @@ pub const ALL_TABLES: &[&str] = &[
 ];
 
 /// Drop stale Spice replication slots and publications left from previous runs (if any).
+///
+/// # Errors
+///
+/// Returns an error if querying or dropping replication artifacts fails.
 pub async fn drop_replication_artifacts(client: &Client) -> Result<()> {
     // Drop replication slots named spice_*
     let slot_rows = client
@@ -86,6 +90,10 @@ pub async fn drop_replication_artifacts(client: &Client) -> Result<()> {
 }
 
 /// Drop all CH-benCH tables (reverse order).
+///
+/// # Errors
+///
+/// Returns an error if any table cannot be dropped.
 pub async fn drop_tables(client: &Client) -> Result<()> {
     drop_replication_artifacts(client).await?;
     println!("  dropping {} tables", ALL_TABLES.len());
@@ -103,6 +111,11 @@ pub async fn drop_tables(client: &Client) -> Result<()> {
 }
 
 /// Create all 12 CH-benCH tables (9 TPC-C + 3 supplemental).
+///
+/// # Errors
+///
+/// Returns an error if any table or index cannot be created.
+#[expect(clippy::too_many_lines)]
 pub async fn create_tables(client: &Client) -> Result<()> {
     let ddl_statements: &[(&str, &str)] = &[
         (
@@ -347,8 +360,8 @@ const MUTATED_TABLES: &[&str] = &[
 ];
 
 /// Tables probed for staleness gap measurement.
-/// Selected for diversity: district (small, baseline), order_line (high volume),
-/// new_order (DELETE path).
+/// Selected for diversity: district (small, baseline), `order_line` (high volume),
+/// `new_order` (DELETE path).
 pub const STALENESS_PROBE_TABLES: &[&str] = &["district", "order_line", "new_order"];
 
 /// Add `_bench_ts TIMESTAMPTZ` column with `clock_timestamp()` default and

--- a/tools/chbench-driver/src/schema.rs
+++ b/tools/chbench-driver/src/schema.rs
@@ -323,5 +323,92 @@ pub async fn create_tables(client: &Client) -> Result<()> {
         })?;
     }
 
+    // Add _bench_ts column and trigger to all mutated TPC-C tables.
+    // Used for staleness gap measurement between Postgres and Spice accelerated copy.
+    add_bench_ts_column_and_triggers(client).await?;
+
+    Ok(())
+}
+
+/// Tables mutated by TPC-C transactions. `_bench_ts` is added only to these.
+/// `item`, `nation`, `region`, `supplier` are static reference tables.
+const MUTATED_TABLES: &[&str] = &[
+    "warehouse",
+    "district",
+    "customer",
+    "history",
+    "new_order",
+    "orders",
+    "order_line",
+    "stock",
+];
+
+/// Tables probed for staleness gap measurement.
+/// Selected for diversity: district (small, baseline), order_line (high volume),
+/// new_order (DELETE path), history (append-only, no PK).
+pub const STALENESS_PROBE_TABLES: &[&str] = &["district", "order_line", "new_order"];
+
+/// Add `_bench_ts TIMESTAMPTZ` column with `clock_timestamp()` default and
+/// a `BEFORE INSERT OR UPDATE` trigger to all mutated TPC-C tables.
+///
+/// Uses `clock_timestamp()` (wall-clock time per statement) instead of `now()`
+/// (transaction-start time) for accurate per-row timing.
+async fn add_bench_ts_column_and_triggers(client: &Client) -> Result<()> {
+    // Create the shared trigger function once.
+    client
+        .execute(
+            "CREATE OR REPLACE FUNCTION bench_ts_trigger()
+             RETURNS TRIGGER AS $$
+             BEGIN
+                 NEW._bench_ts := clock_timestamp();
+                 RETURN NEW;
+             END;
+             $$ LANGUAGE plpgsql",
+            &[],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "create bench_ts_trigger function".into(),
+            source,
+        })?;
+
+    for table in MUTATED_TABLES {
+        // Add column with default for seed data rows.
+        let add_col = format!(
+            "ALTER TABLE {table} ADD COLUMN IF NOT EXISTS _bench_ts TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()"
+        );
+        client.execute(&add_col, &[]).await.map_err(|source| {
+            crate::Error::Sql {
+                action: format!("add _bench_ts column to {table}"),
+                source,
+            }
+        })?;
+
+        // Attach the trigger (idempotent via DROP IF EXISTS + CREATE).
+        let trigger_name = format!("trg_bench_ts_{table}");
+        let drop_trg = format!("DROP TRIGGER IF EXISTS {trigger_name} ON {table}");
+        client.execute(&drop_trg, &[]).await.map_err(|source| {
+            crate::Error::Sql {
+                action: format!("drop trigger {trigger_name}"),
+                source,
+            }
+        })?;
+
+        let create_trg = format!(
+            "CREATE TRIGGER {trigger_name} BEFORE INSERT OR UPDATE ON {table} FOR EACH ROW EXECUTE FUNCTION bench_ts_trigger()"
+        );
+        client
+            .execute(&create_trg, &[])
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: format!("create trigger {trigger_name}"),
+                source,
+            })?;
+    }
+
+    println!(
+        "  added _bench_ts column + trigger to {} tables",
+        MUTATED_TABLES.len()
+    );
     Ok(())
 }

--- a/tools/chbench-driver/src/schema.rs
+++ b/tools/chbench-driver/src/schema.rs
@@ -36,11 +36,61 @@ pub const ALL_TABLES: &[&str] = &[
     "supplier",
 ];
 
+/// Drop stale Spice replication slots and publications left from previous runs (if any).
+pub async fn drop_replication_artifacts(client: &Client) -> Result<()> {
+    // Drop replication slots named spice_*
+    let rows = client
+        .query(
+            "SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE 'spice_%'",
+            &[],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "list replication slots".into(),
+            source,
+        })?;
+
+    for row in &rows {
+        let slot_name: &str = row.get(0);
+        let sql = format!("SELECT pg_drop_replication_slot('{slot_name}')");
+        let _unused = client.execute(&sql, &[]).await;
+    }
+
+    // Drop publications named spice_*
+    let rows = client
+        .query(
+            "SELECT pubname FROM pg_publication WHERE pubname LIKE 'spice_%'",
+            &[],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "list publications".into(),
+            source,
+        })?;
+
+    for row in &rows {
+        let pubname: &str = row.get(0);
+        let sql = format!("DROP PUBLICATION IF EXISTS {pubname}");
+        let _unused = client.execute(&sql, &[]).await;
+    }
+
+    if !rows.is_empty() {
+        println!(
+            "  cleaned up {} replication slots, {} publications",
+            rows.len(),
+            rows.len()
+        );
+    }
+
+    Ok(())
+}
+
 /// Drop all CH-benCH tables (reverse order).
 pub async fn drop_tables(client: &Client) -> Result<()> {
+    drop_replication_artifacts(client).await?;
+    println!("  dropping {} tables", ALL_TABLES.len());
     for table in ALL_TABLES.iter().rev() {
         let sql = format!("DROP TABLE IF EXISTS {table} CASCADE");
-        tracing::info!("dropping table {table}");
         client.execute(&sql, &[]).await.map_err(|source| {
             crate::Error::Sql {
                 action: format!("drop table {table}"),
@@ -64,8 +114,8 @@ pub async fn create_tables(client: &Client) -> Result<()> {
                 w_city VARCHAR(20),
                 w_state CHAR(2),
                 w_zip CHAR(9),
-                w_tax DECIMAL(4, 4),
-                w_ytd DECIMAL(12, 2),
+                w_tax DOUBLE PRECISION,
+                w_ytd DOUBLE PRECISION,
                 PRIMARY KEY (w_id)
             )",
         ),
@@ -80,8 +130,8 @@ pub async fn create_tables(client: &Client) -> Result<()> {
                 d_city VARCHAR(20),
                 d_state CHAR(2),
                 d_zip CHAR(9),
-                d_tax DECIMAL(4, 4),
-                d_ytd DECIMAL(12, 2),
+                d_tax DOUBLE PRECISION,
+                d_ytd DOUBLE PRECISION,
                 d_next_o_id INT,
                 PRIMARY KEY (d_w_id, d_id)
             )",
@@ -103,10 +153,10 @@ pub async fn create_tables(client: &Client) -> Result<()> {
                 c_phone CHAR(16),
                 c_since TIMESTAMP,
                 c_credit CHAR(2),
-                c_credit_lim DECIMAL(12, 2),
-                c_discount DECIMAL(4, 4),
-                c_balance DECIMAL(12, 2),
-                c_ytd_payment DECIMAL(12, 2),
+                c_credit_lim DOUBLE PRECISION,
+                c_discount DOUBLE PRECISION,
+                c_balance DOUBLE PRECISION,
+                c_ytd_payment DOUBLE PRECISION,
                 c_payment_cnt INT,
                 c_delivery_cnt INT,
                 c_data VARCHAR(500),
@@ -122,7 +172,7 @@ pub async fn create_tables(client: &Client) -> Result<()> {
                 h_d_id INT NOT NULL,
                 h_w_id INT NOT NULL,
                 h_date TIMESTAMP,
-                h_amount DECIMAL(6, 2),
+                h_amount DOUBLE PRECISION,
                 h_data VARCHAR(24)
             )",
         ),
@@ -160,7 +210,7 @@ pub async fn create_tables(client: &Client) -> Result<()> {
                 ol_supply_w_id INT,
                 ol_delivery_d TIMESTAMP,
                 ol_quantity INT,
-                ol_amount DECIMAL(6, 2),
+                ol_amount DOUBLE PRECISION,
                 ol_dist_info CHAR(24),
                 PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number)
             )",
@@ -194,7 +244,7 @@ pub async fn create_tables(client: &Client) -> Result<()> {
                 i_id INT NOT NULL,
                 i_im_id INT,
                 i_name VARCHAR(24),
-                i_price DECIMAL(5, 2),
+                i_price DOUBLE PRECISION,
                 i_data VARCHAR(50),
                 PRIMARY KEY (i_id)
             )",
@@ -227,15 +277,15 @@ pub async fn create_tables(client: &Client) -> Result<()> {
                 s_address VARCHAR(40) NOT NULL,
                 s_nationkey BIGINT NOT NULL,
                 s_phone CHAR(15) NOT NULL,
-                s_acctbal DECIMAL(15, 2) NOT NULL,
+                s_acctbal DOUBLE PRECISION NOT NULL,
                 s_comment VARCHAR(101) NOT NULL,
                 PRIMARY KEY (s_suppkey)
             )",
         ),
     ];
 
+    println!("  creating {} tables + 4 indexes", ddl_statements.len());
     for (table, ddl) in ddl_statements {
-        tracing::info!("creating table {table}");
         client.execute(*ddl, &[]).await.map_err(|source| {
             crate::Error::Sql {
                 action: format!("create table {table}"),
@@ -265,7 +315,6 @@ pub async fn create_tables(client: &Client) -> Result<()> {
     ];
 
     for (name, ddl) in indexes {
-        tracing::info!("creating index {name}");
         client.execute(*ddl, &[]).await.map_err(|source| {
             crate::Error::Sql {
                 action: format!("create index {name}"),

--- a/tools/chbench-driver/src/txn/delivery.rs
+++ b/tools/chbench-driver/src/txn/delivery.rs
@@ -26,6 +26,9 @@ use tokio_postgres::Client;
 
 use crate::Result;
 
+/// # Errors
+///
+/// Returns an error if any database operation fails.
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.random_range(1..=warehouses);
     let o_carrier_id = rng.random_range(1..=10);

--- a/tools/chbench-driver/src/txn/delivery.rs
+++ b/tools/chbench-driver/src/txn/delivery.rs
@@ -21,14 +21,14 @@ limitations under the License.
 
 use std::time::SystemTime;
 
-use ::rand::Rng;
+use ::rand::{Rng, RngExt};
 use tokio_postgres::Client;
 
 use crate::Result;
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
-    let w_id = rng.gen_range(1..=warehouses);
-    let o_carrier_id = rng.gen_range(1..=10);
+    let w_id = rng.random_range(1..=warehouses);
+    let o_carrier_id = rng.random_range(1..=10);
 
     let tx = client
         .transaction()

--- a/tools/chbench-driver/src/txn/delivery.rs
+++ b/tools/chbench-driver/src/txn/delivery.rs
@@ -19,12 +19,12 @@ limitations under the License.
 //! Delivers the oldest pending order for each of 10 districts.
 //! CDC impact: ~30 rows per transaction (10 DELETEs + 10+10 UPDATEs + up to 10 customer UPDATEs).
 
+use std::time::SystemTime;
+
 use ::rand::Rng;
 use tokio_postgres::Client;
 
 use crate::Result;
-
-const TIME_FORMAT: &str = "2026-01-02 15:04:05";
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.gen_range(1..=warehouses);
@@ -94,9 +94,10 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
         let o_c_id: i32 = o_row.get(0);
 
         // 5. UPDATE order_line delivery date
+        let delivery_d = SystemTime::now();
         tx.execute(
             "UPDATE order_line SET ol_delivery_d = $1 WHERE ol_w_id = $2 AND ol_d_id = $3 AND ol_o_id = $4",
-            &[&TIME_FORMAT, &w_id, &d_id, &no_o_id],
+            &[&delivery_d, &w_id, &d_id, &no_o_id],
         )
         .await
         .map_err(|source| crate::Error::Sql {

--- a/tools/chbench-driver/src/txn/delivery.rs
+++ b/tools/chbench-driver/src/txn/delivery.rs
@@ -1,0 +1,139 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-C Delivery transaction (4% default mix).
+//!
+//! Delivers the oldest pending order for each of 10 districts.
+//! CDC impact: ~30 rows per transaction (10 DELETEs + 10+10 UPDATEs + up to 10 customer UPDATEs).
+
+use ::rand::Rng;
+use tokio_postgres::Client;
+
+use crate::Result;
+
+const TIME_FORMAT: &str = "2026-01-02 15:04:05";
+
+pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
+    let w_id = rng.gen_range(1..=warehouses);
+    let o_carrier_id = rng.gen_range(1..=10);
+
+    let tx = client
+        .transaction()
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "begin delivery transaction".into(),
+            source,
+        })?;
+
+    for d_id in 1..=10i32 {
+        // 1. Find oldest undelivered order
+        let rows = tx
+            .query(
+                "SELECT no_o_id FROM new_order WHERE no_w_id = $1 AND no_d_id = $2 ORDER BY no_o_id ASC LIMIT 1 FOR UPDATE",
+                &[&w_id, &d_id],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "delivery: select new_order".into(),
+                source,
+            })?;
+
+        if rows.is_empty() {
+            continue;
+        }
+
+        let no_o_id: i32 = rows[0].get(0);
+
+        // 2. DELETE from new_order
+        tx.execute(
+            "DELETE FROM new_order WHERE no_w_id = $1 AND no_d_id = $2 AND no_o_id = $3",
+            &[&w_id, &d_id, &no_o_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "delivery: delete new_order".into(),
+            source,
+        })?;
+
+        // 3. UPDATE orders with carrier
+        tx.execute(
+            "UPDATE orders SET o_carrier_id = $1 WHERE o_w_id = $2 AND o_d_id = $3 AND o_id = $4",
+            &[&o_carrier_id, &w_id, &d_id, &no_o_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "delivery: update orders".into(),
+            source,
+        })?;
+
+        // 4. Get customer ID for this order
+        let o_row = tx
+            .query_one(
+                "SELECT o_c_id FROM orders WHERE o_w_id = $1 AND o_d_id = $2 AND o_id = $3",
+                &[&w_id, &d_id, &no_o_id],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "delivery: select orders c_id".into(),
+                source,
+            })?;
+
+        let o_c_id: i32 = o_row.get(0);
+
+        // 5. UPDATE order_line delivery date
+        tx.execute(
+            "UPDATE order_line SET ol_delivery_d = $1 WHERE ol_w_id = $2 AND ol_d_id = $3 AND ol_o_id = $4",
+            &[&TIME_FORMAT, &w_id, &d_id, &no_o_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "delivery: update order_line".into(),
+            source,
+        })?;
+
+        // 6. SUM order_line amounts
+        let sum_row = tx
+            .query_one(
+                "SELECT COALESCE(SUM(ol_amount), 0) FROM order_line WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3",
+                &[&w_id, &d_id, &no_o_id],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "delivery: sum order_line amount".into(),
+                source,
+            })?;
+
+        let total_amount: f64 = sum_row.get(0);
+
+        // 7. UPDATE customer balance
+        tx.execute(
+            "UPDATE customer SET c_balance = c_balance + $1, c_delivery_cnt = c_delivery_cnt + 1 WHERE c_w_id = $2 AND c_d_id = $3 AND c_id = $4",
+            &[&total_amount, &w_id, &d_id, &o_c_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "delivery: update customer".into(),
+            source,
+        })?;
+    }
+
+    tx.commit().await.map_err(|source| crate::Error::Sql {
+        action: "delivery: commit".into(),
+        source,
+    })?;
+
+    Ok(())
+}

--- a/tools/chbench-driver/src/txn/mod.rs
+++ b/tools/chbench-driver/src/txn/mod.rs
@@ -1,0 +1,102 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-C transaction implementations for the CH-benCH OLTP driver.
+//!
+//! Five transaction types with standard 45/43/4/4/4 mix:
+//! - **NewOrder** (45%): Insert an order with 5-15 line items, update stock and district.
+//! - **Payment** (43%): Update warehouse/district/customer balances, insert history.
+//! - **Delivery** (4%): Deliver oldest pending order for each of 10 districts.
+//! - **OrderStatus** (4%): Read-only — look up latest order for a customer.
+//! - **StockLevel** (4%): Read-only — count low-stock items in recent orders.
+
+pub mod delivery;
+pub mod new_order;
+pub mod order_status;
+pub mod payment;
+pub mod stock_level;
+
+use std::fmt;
+
+use ::rand::Rng;
+use tokio_postgres::Client;
+
+use crate::Result;
+
+/// The five TPC-C transaction types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TxnType {
+    NewOrder,
+    Payment,
+    Delivery,
+    OrderStatus,
+    StockLevel,
+}
+
+impl fmt::Display for TxnType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NewOrder => write!(f, "new_order"),
+            Self::Payment => write!(f, "payment"),
+            Self::Delivery => write!(f, "delivery"),
+            Self::OrderStatus => write!(f, "order_status"),
+            Self::StockLevel => write!(f, "stock_level"),
+        }
+    }
+}
+
+/// Standard TPC-C transaction mix weights (must sum to 100).
+/// Index order: NewOrder, Payment, Delivery, OrderStatus, StockLevel.
+pub const DEFAULT_MIX: [u32; 5] = [45, 43, 4, 4, 4];
+
+/// All transaction types in mix-weight index order.
+const TXN_TYPES: [TxnType; 5] = [
+    TxnType::NewOrder,
+    TxnType::Payment,
+    TxnType::Delivery,
+    TxnType::OrderStatus,
+    TxnType::StockLevel,
+];
+
+/// Select a random transaction type according to the given mix weights.
+pub fn pick_txn_type(rng: &mut impl Rng, mix: &[u32; 5]) -> TxnType {
+    let total: u32 = mix.iter().sum();
+    let roll = rng.gen_range(0..total);
+    let mut cumulative = 0;
+    for (i, &weight) in mix.iter().enumerate() {
+        cumulative += weight;
+        if roll < cumulative {
+            return TXN_TYPES[i];
+        }
+    }
+    TxnType::NewOrder
+}
+
+/// Execute one TPC-C transaction of the given type.
+pub async fn execute(
+    client: &mut Client,
+    rng: &mut impl Rng,
+    txn_type: TxnType,
+    warehouses: i32,
+) -> Result<()> {
+    match txn_type {
+        TxnType::NewOrder => new_order::run(client, rng, warehouses).await,
+        TxnType::Payment => payment::run(client, rng, warehouses).await,
+        TxnType::Delivery => delivery::run(client, rng, warehouses).await,
+        TxnType::OrderStatus => order_status::run(client, rng, warehouses).await,
+        TxnType::StockLevel => stock_level::run(client, rng, warehouses).await,
+    }
+}

--- a/tools/chbench-driver/src/txn/mod.rs
+++ b/tools/chbench-driver/src/txn/mod.rs
@@ -17,11 +17,11 @@ limitations under the License.
 //! TPC-C transaction implementations for the CH-benCH OLTP driver.
 //!
 //! Five transaction types with standard 45/43/4/4/4 mix:
-//! - **NewOrder** (45%): Insert an order with 5-15 line items, update stock and district.
+//! - **`NewOrder`** (45%): Insert an order with 5-15 line items, update stock and district.
 //! - **Payment** (43%): Update warehouse/district/customer balances, insert history.
 //! - **Delivery** (4%): Deliver oldest pending order for each of 10 districts.
-//! - **OrderStatus** (4%): Read-only — look up latest order for a customer.
-//! - **StockLevel** (4%): Read-only — count low-stock items in recent orders.
+//! - **`OrderStatus`** (4%): Read-only — look up latest order for a customer.
+//! - **`StockLevel`** (4%): Read-only — count low-stock items in recent orders.
 
 pub mod delivery;
 pub mod new_order;
@@ -59,7 +59,7 @@ impl fmt::Display for TxnType {
 }
 
 /// Standard TPC-C transaction mix weights (must sum to 100).
-/// Index order: NewOrder, Payment, Delivery, OrderStatus, StockLevel.
+/// Index order: `NewOrder`, Payment, Delivery, `OrderStatus`, `StockLevel`.
 pub const DEFAULT_MIX: [u32; 5] = [45, 43, 4, 4, 4];
 
 /// All transaction types in mix-weight index order.
@@ -86,6 +86,10 @@ pub fn pick_txn_type(rng: &mut impl Rng, mix: &[u32; 5]) -> TxnType {
 }
 
 /// Execute one TPC-C transaction of the given type.
+///
+/// # Errors
+///
+/// Returns an error if the transaction fails.
 pub async fn execute(
     client: &mut Client,
     rng: &mut impl Rng,

--- a/tools/chbench-driver/src/txn/mod.rs
+++ b/tools/chbench-driver/src/txn/mod.rs
@@ -31,7 +31,7 @@ pub mod stock_level;
 
 use std::fmt;
 
-use ::rand::Rng;
+use ::rand::{Rng, RngExt};
 use tokio_postgres::Client;
 
 use crate::Result;
@@ -74,7 +74,7 @@ const TXN_TYPES: [TxnType; 5] = [
 /// Select a random transaction type according to the given mix weights.
 pub fn pick_txn_type(rng: &mut impl Rng, mix: &[u32; 5]) -> TxnType {
     let total: u32 = mix.iter().sum();
-    let roll = rng.gen_range(0..total);
+    let roll = rng.random_range(0..total);
     let mut cumulative = 0;
     for (i, &weight) in mix.iter().enumerate() {
         cumulative += weight;

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -1,0 +1,217 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-C NewOrder transaction (45% default mix).
+//!
+//! Inserts an order with 5-15 line items. Updates district.d_next_o_id and stock quantities.
+//! CDC impact: ~15-35 rows per transaction.
+
+use ::rand::Rng;
+use tokio_postgres::Client;
+
+use crate::rand as tpcc_rand;
+use crate::Result;
+
+const TIME_FORMAT: &str = "2026-01-02 15:04:05";
+
+pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
+    let w_id = rng.gen_range(1..=warehouses);
+    let d_id = rng.gen_range(1..=10);
+    let c_id = tpcc_rand::rand_customer_id(rng);
+    let ol_cnt = rng.gen_range(5..=15);
+    let rbk = rng.gen_range(1..=100);
+
+    // Generate order items
+    let mut items: Vec<(i32, i32, i32, i32)> = Vec::with_capacity(ol_cnt as usize); // (ol_i_id, ol_supply_w_id, ol_quantity, remote)
+    let mut all_local = 1i32;
+
+    for i in 0..ol_cnt {
+        let ol_i_id = if i == ol_cnt - 1 && rbk == 1 {
+            // 1% rollback: invalid item ID
+            -1
+        } else {
+            rng.gen_range(1..=100_000)
+        };
+
+        let (ol_supply_w_id, remote) = if warehouses == 1 || rng.gen_range(1..=100) != 1 {
+            (w_id, 0)
+        } else {
+            let mut other = rng.gen_range(1..=warehouses);
+            while other == w_id {
+                other = rng.gen_range(1..=warehouses);
+            }
+            all_local = 0;
+            (other, 1)
+        };
+
+        let ol_quantity = rng.gen_range(1..=10);
+        items.push((ol_i_id, ol_supply_w_id, ol_quantity, remote));
+    }
+
+    let tx = client
+        .transaction()
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "begin new_order transaction".into(),
+            source,
+        })?;
+
+    // 1. SELECT customer + warehouse info
+    let _customer_row = tx
+        .query_one(
+            "SELECT c_discount, c_last, c_credit, w_tax FROM customer, warehouse WHERE w_id = $1 AND c_w_id = w_id AND c_d_id = $2 AND c_id = $3",
+            &[&w_id, &d_id, &c_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "new_order: select customer".into(),
+            source,
+        })?;
+
+    let c_discount: f64 = _customer_row.get(0);
+    let w_tax: f64 = _customer_row.get(3);
+
+    // 2. SELECT district FOR UPDATE
+    let district_row = tx
+        .query_one(
+            "SELECT d_next_o_id, d_tax FROM district WHERE d_id = $1 AND d_w_id = $2 FOR UPDATE",
+            &[&d_id, &w_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "new_order: select district".into(),
+            source,
+        })?;
+
+    let d_next_o_id: i32 = district_row.get(0);
+    let d_tax: f64 = district_row.get(1);
+
+    // 3. UPDATE district d_next_o_id
+    tx.execute(
+        "UPDATE district SET d_next_o_id = $1 + 1 WHERE d_id = $2 AND d_w_id = $3",
+        &[&d_next_o_id, &d_id, &w_id],
+    )
+    .await
+    .map_err(|source| crate::Error::Sql {
+        action: "new_order: update district".into(),
+        source,
+    })?;
+
+    let o_id = d_next_o_id;
+    let now = TIME_FORMAT;
+
+    // 4. INSERT orders
+    tx.execute(
+        "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        &[&o_id, &d_id, &w_id, &c_id, &now, &ol_cnt, &all_local],
+    )
+    .await
+    .map_err(|source| crate::Error::Sql {
+        action: "new_order: insert orders".into(),
+        source,
+    })?;
+
+    // 5. INSERT new_order
+    tx.execute(
+        "INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES ($1, $2, $3)",
+        &[&o_id, &d_id, &w_id],
+    )
+    .await
+    .map_err(|source| crate::Error::Sql {
+        action: "new_order: insert new_order".into(),
+        source,
+    })?;
+
+    // 6-9. Process each order line: select item, select/update stock, insert order_line
+    for (ol_number_0, &(ol_i_id, ol_supply_w_id, ol_quantity, remote)) in items.iter().enumerate()
+    {
+        let ol_number = i32::try_from(ol_number_0).unwrap_or(0) + 1;
+
+        // Check for rollback item
+        if ol_i_id < 0 {
+            tx.execute("ROLLBACK", &[]).await.ok();
+            return Ok(());
+        }
+
+        // Select item
+        let item_row = tx
+            .query_one(
+                "SELECT i_price, i_name, i_data FROM item WHERE i_id = $1",
+                &[&ol_i_id],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "new_order: select item".into(),
+                source,
+            })?;
+
+        let i_price: f64 = item_row.get(0);
+
+        // Select stock FOR UPDATE
+        let dist_col = format!("s_dist_{d_id:02}");
+        let stock_sql = format!(
+            "SELECT s_quantity, s_data, {dist_col} FROM stock WHERE s_i_id = $1 AND s_w_id = $2 FOR UPDATE"
+        );
+        let stock_row = tx
+            .query_one(&stock_sql, &[&ol_i_id, &ol_supply_w_id])
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "new_order: select stock".into(),
+                source,
+            })?;
+
+        let mut s_quantity: i32 = stock_row.get(0);
+        let ol_dist_info: String = stock_row.get(2);
+
+        s_quantity -= ol_quantity;
+        if s_quantity < 10 {
+            s_quantity += 91;
+        }
+
+        // Update stock
+        tx.execute(
+            "UPDATE stock SET s_quantity = $1, s_ytd = s_ytd + $2, s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + $3 WHERE s_i_id = $4 AND s_w_id = $5",
+            &[&s_quantity, &ol_quantity, &remote, &ol_i_id, &ol_supply_w_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "new_order: update stock".into(),
+            source,
+        })?;
+
+        // Calculate amount
+        let ol_amount =
+            f64::from(ol_quantity) * i_price * (1.0 + w_tax + d_tax) * (1.0 - c_discount);
+
+        // Insert order_line
+        tx.execute(
+            "INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            &[&o_id, &d_id, &w_id, &ol_number, &ol_i_id, &ol_supply_w_id, &ol_quantity, &ol_amount, &ol_dist_info],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "new_order: insert order_line".into(),
+            source,
+        })?;
+    }
+
+    tx.commit().await.map_err(|source| crate::Error::Sql {
+        action: "new_order: commit".into(),
+        source,
+    })?;
+
+    Ok(())
+}

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -141,7 +141,10 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
 
         // Check for rollback item
         if ol_i_id < 0 {
-            tx.execute("ROLLBACK", &[]).await.ok();
+            tx.rollback().await.map_err(|source| crate::Error::Sql {
+                action: "new_order: rollback".into(),
+                source,
+            })?;
             return Ok(());
         }
 

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -24,8 +24,8 @@ use std::time::SystemTime;
 use ::rand::Rng;
 use tokio_postgres::Client;
 
-use crate::rand as tpcc_rand;
 use crate::Result;
+use crate::rand as tpcc_rand;
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.gen_range(1..=warehouses);
@@ -136,8 +136,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     })?;
 
     // 6-9. Process each order line: select item, select/update stock, insert order_line
-    for (ol_number_0, &(ol_i_id, ol_supply_w_id, ol_quantity, remote)) in items.iter().enumerate()
-    {
+    for (ol_number_0, &(ol_i_id, ol_supply_w_id, ol_quantity, remote)) in items.iter().enumerate() {
         let ol_number = i32::try_from(ol_number_0).unwrap_or(0) + 1;
 
         // Check for rollback item

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! TPC-C NewOrder transaction (45% default mix).
+//! TPC-C `NewOrder` transaction (45% default mix).
 //!
-//! Inserts an order with 5-15 line items. Updates district.d_next_o_id and stock quantities.
+//! Inserts an order with 5-15 line items. Updates `district.d_next_o_id` and stock quantities.
 //! CDC impact: ~15-35 rows per transaction.
 
 use std::time::SystemTime;
@@ -27,6 +27,9 @@ use tokio_postgres::Client;
 use crate::Result;
 use crate::rand as tpcc_rand;
 
+/// # Errors
+///
+/// Returns an error if any database operation fails.
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.random_range(1..=warehouses);
     let d_id = rng.random_range(1..=10);
@@ -35,6 +38,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     let rbk = rng.random_range(1..=100);
 
     // Generate order items
+    #[expect(clippy::cast_sign_loss)]
     let mut items: Vec<(i32, i32, i32, i32)> = Vec::with_capacity(ol_cnt as usize); // (ol_i_id, ol_supply_w_id, ol_quantity, remote)
     let mut all_local = 1i32;
 
@@ -70,7 +74,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
         })?;
 
     // 1. SELECT customer + warehouse info
-    let _customer_row = tx
+    let customer_row = tx
         .query_one(
             "SELECT c_discount, c_last, c_credit, w_tax FROM customer, warehouse WHERE w_id = $1 AND c_w_id = w_id AND c_d_id = $2 AND c_id = $3",
             &[&w_id, &d_id, &c_id],
@@ -81,8 +85,8 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
             source,
         })?;
 
-    let c_discount: f64 = _customer_row.get(0);
-    let w_tax: f64 = _customer_row.get(3);
+    let c_discount: f64 = customer_row.get(0);
+    let w_tax: f64 = customer_row.get(3);
 
     // 2. SELECT district FOR UPDATE
     let district_row = tx

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -21,18 +21,18 @@ limitations under the License.
 
 use std::time::SystemTime;
 
-use ::rand::Rng;
+use ::rand::{Rng, RngExt};
 use tokio_postgres::Client;
 
 use crate::Result;
 use crate::rand as tpcc_rand;
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
-    let w_id = rng.gen_range(1..=warehouses);
-    let d_id = rng.gen_range(1..=10);
+    let w_id = rng.random_range(1..=warehouses);
+    let d_id = rng.random_range(1..=10);
     let c_id = tpcc_rand::rand_customer_id(rng);
-    let ol_cnt = rng.gen_range(5..=15);
-    let rbk = rng.gen_range(1..=100);
+    let ol_cnt = rng.random_range(5..=15);
+    let rbk = rng.random_range(1..=100);
 
     // Generate order items
     let mut items: Vec<(i32, i32, i32, i32)> = Vec::with_capacity(ol_cnt as usize); // (ol_i_id, ol_supply_w_id, ol_quantity, remote)
@@ -43,21 +43,21 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
             // 1% rollback: invalid item ID
             -1
         } else {
-            rng.gen_range(1..=100_000)
+            rng.random_range(1..=100_000)
         };
 
-        let (ol_supply_w_id, remote) = if warehouses == 1 || rng.gen_range(1..=100) != 1 {
+        let (ol_supply_w_id, remote) = if warehouses == 1 || rng.random_range(1..=100) != 1 {
             (w_id, 0)
         } else {
-            let mut other = rng.gen_range(1..=warehouses);
+            let mut other = rng.random_range(1..=warehouses);
             while other == w_id {
-                other = rng.gen_range(1..=warehouses);
+                other = rng.random_range(1..=warehouses);
             }
             all_local = 0;
             (other, 1)
         };
 
-        let ol_quantity = rng.gen_range(1..=10);
+        let ol_quantity = rng.random_range(1..=10);
         items.push((ol_i_id, ol_supply_w_id, ol_quantity, remote));
     }
 

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -19,13 +19,13 @@ limitations under the License.
 //! Inserts an order with 5-15 line items. Updates district.d_next_o_id and stock quantities.
 //! CDC impact: ~15-35 rows per transaction.
 
+use std::time::SystemTime;
+
 use ::rand::Rng;
 use tokio_postgres::Client;
 
 use crate::rand as tpcc_rand;
 use crate::Result;
-
-const TIME_FORMAT: &str = "2026-01-02 15:04:05";
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.gen_range(1..=warehouses);
@@ -111,7 +111,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     })?;
 
     let o_id = d_next_o_id;
-    let now = TIME_FORMAT;
+    let now = SystemTime::now();
 
     // 4. INSERT orders
     tx.execute(

--- a/tools/chbench-driver/src/txn/order_status.rs
+++ b/tools/chbench-driver/src/txn/order_status.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! TPC-C OrderStatus transaction (4% default mix).
+//! TPC-C `OrderStatus` transaction (4% default mix).
 //!
 //! Read-only: look up the most recent order for a customer.
 //! No WAL events — included for spec-compliant tpmC measurement.
@@ -25,6 +25,9 @@ use tokio_postgres::Client;
 use crate::Result;
 use crate::rand as tpcc_rand;
 
+/// # Errors
+///
+/// Returns an error if any database operation fails.
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.random_range(1..=warehouses);
     let d_id = rng.random_range(1..=10);
@@ -81,6 +84,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
             return Ok(());
         }
 
+        #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let idx = ((target / 2) as usize).min(rows.len()) - 1;
         rows[idx.min(rows.len().saturating_sub(1))].get(3)
     } else {

--- a/tools/chbench-driver/src/txn/order_status.rs
+++ b/tools/chbench-driver/src/txn/order_status.rs
@@ -1,0 +1,136 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-C OrderStatus transaction (4% default mix).
+//!
+//! Read-only: look up the most recent order for a customer.
+//! No WAL events — included for spec-compliant tpmC measurement.
+
+use ::rand::Rng;
+use tokio_postgres::Client;
+
+use crate::rand as tpcc_rand;
+use crate::Result;
+
+pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
+    let w_id = rng.gen_range(1..=warehouses);
+    let d_id = rng.gen_range(1..=10);
+
+    // 60% by last name, 40% by customer ID (spec 2.6.1.2)
+    let by_name = rng.gen_range(0..100) < 60;
+    let c_load: usize = rng.gen_range(0..256);
+
+    let tx = client
+        .transaction()
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "begin order_status transaction".into(),
+            source,
+        })?;
+
+    let c_id: i32 = if by_name {
+        let c_last = tpcc_rand::rand_c_last(rng, c_load);
+
+        // Get count for name
+        let cnt_row = tx
+            .query_one(
+                "SELECT count(c_id) FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3",
+                &[&w_id, &d_id, &c_last],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "order_status: count customer by last".into(),
+                source,
+            })?;
+
+        let name_cnt: i64 = cnt_row.get(0);
+        let mut target = name_cnt;
+        if target % 2 == 1 {
+            target += 1;
+        }
+
+        let rows = tx
+            .query(
+                "SELECT c_balance, c_first, c_middle, c_id FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3 ORDER BY c_first",
+                &[&w_id, &d_id, &c_last],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "order_status: select customer by last".into(),
+                source,
+            })?;
+
+        if rows.is_empty() {
+            tx.commit().await.map_err(|source| crate::Error::Sql {
+                action: "order_status: commit (no customer)".into(),
+                source,
+            })?;
+            return Ok(());
+        }
+
+        let idx = ((target / 2) as usize).min(rows.len()) - 1;
+        rows[idx.min(rows.len().saturating_sub(1))].get(3)
+    } else {
+        tpcc_rand::rand_customer_id(rng)
+    };
+
+    // SELECT customer
+    let _c_row = tx
+        .query_opt(
+            "SELECT c_balance, c_first, c_middle, c_last FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3",
+            &[&w_id, &d_id, &c_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "order_status: select customer by id".into(),
+            source,
+        })?;
+
+    // SELECT latest order
+    let o_row = tx
+        .query_opt(
+            "SELECT o_id, o_carrier_id, o_entry_d FROM orders WHERE o_w_id = $1 AND o_d_id = $2 AND o_c_id = $3 ORDER BY o_id DESC LIMIT 1",
+            &[&w_id, &d_id, &c_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "order_status: select latest order".into(),
+            source,
+        })?;
+
+    if let Some(o_row) = o_row {
+        let o_id: i32 = o_row.get(0);
+
+        // SELECT order lines
+        let _ol_rows = tx
+            .query(
+                "SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d FROM order_line WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3",
+                &[&w_id, &d_id, &o_id],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "order_status: select order_line".into(),
+                source,
+            })?;
+    }
+
+    tx.commit().await.map_err(|source| crate::Error::Sql {
+        action: "order_status: commit".into(),
+        source,
+    })?;
+
+    Ok(())
+}

--- a/tools/chbench-driver/src/txn/order_status.rs
+++ b/tools/chbench-driver/src/txn/order_status.rs
@@ -22,8 +22,8 @@ limitations under the License.
 use ::rand::Rng;
 use tokio_postgres::Client;
 
-use crate::rand as tpcc_rand;
 use crate::Result;
+use crate::rand as tpcc_rand;
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.gen_range(1..=warehouses);

--- a/tools/chbench-driver/src/txn/order_status.rs
+++ b/tools/chbench-driver/src/txn/order_status.rs
@@ -19,19 +19,19 @@ limitations under the License.
 //! Read-only: look up the most recent order for a customer.
 //! No WAL events — included for spec-compliant tpmC measurement.
 
-use ::rand::Rng;
+use ::rand::{Rng, RngExt};
 use tokio_postgres::Client;
 
 use crate::Result;
 use crate::rand as tpcc_rand;
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
-    let w_id = rng.gen_range(1..=warehouses);
-    let d_id = rng.gen_range(1..=10);
+    let w_id = rng.random_range(1..=warehouses);
+    let d_id = rng.random_range(1..=10);
 
     // 60% by last name, 40% by customer ID (spec 2.6.1.2)
-    let by_name = rng.gen_range(0..100) < 60;
-    let c_load: usize = rng.gen_range(0..256);
+    let by_name = rng.random_range(0..100) < 60;
+    let c_load: usize = rng.random_range(0..256);
 
     let tx = client
         .transaction()

--- a/tools/chbench-driver/src/txn/payment.rs
+++ b/tools/chbench-driver/src/txn/payment.rs
@@ -19,13 +19,13 @@ limitations under the License.
 //! Updates warehouse/district/customer balances and inserts a history record.
 //! CDC impact: 4 rows per transaction (3 UPDATEs + 1 INSERT).
 
+use std::time::SystemTime;
+
 use ::rand::Rng;
 use tokio_postgres::Client;
 
 use crate::rand as tpcc_rand;
 use crate::Result;
-
-const TIME_FORMAT: &str = "2026-01-02 15:04:05";
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.gen_range(1..=warehouses);
@@ -170,8 +170,12 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
             })?;
 
         let old_data: String = c_data_row.get(0);
+        let now_secs = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         let new_prefix = format!(
-            "| {c_id:4} {c_d_id:2} {c_w_id:4} {d_id:2} {w_id:4} ${h_amount:7.2} {TIME_FORMAT}"
+            "| {c_id:4} {c_d_id:2} {c_w_id:4} {d_id:2} {w_id:4} ${h_amount:7.2} {now_secs}"
         );
         let mut new_data = new_prefix;
         let remaining = 500 - new_data.len().min(500);
@@ -203,9 +207,10 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
 
     // 9. INSERT history
     let h_data = format!("{w_name:>10}    {d_name:>10}");
+    let h_date = SystemTime::now();
     tx.execute(
         "INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-        &[&c_d_id, &c_w_id, &c_id, &d_id, &w_id, &TIME_FORMAT, &h_amount, &h_data],
+        &[&c_d_id, &c_w_id, &c_id, &d_id, &w_id, &h_date, &h_amount, &h_data],
     )
     .await
     .map_err(|source| crate::Error::Sql {

--- a/tools/chbench-driver/src/txn/payment.rs
+++ b/tools/chbench-driver/src/txn/payment.rs
@@ -1,0 +1,222 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-C Payment transaction (43% default mix).
+//!
+//! Updates warehouse/district/customer balances and inserts a history record.
+//! CDC impact: 4 rows per transaction (3 UPDATEs + 1 INSERT).
+
+use ::rand::Rng;
+use tokio_postgres::Client;
+
+use crate::rand as tpcc_rand;
+use crate::Result;
+
+const TIME_FORMAT: &str = "2026-01-02 15:04:05";
+
+pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
+    let w_id = rng.gen_range(1..=warehouses);
+    let d_id = rng.gen_range(1..=10);
+    let h_amount: f64 = f64::from(rng.gen_range(100..=500_000)) / 100.0;
+
+    // 60% by last name, 40% by customer ID (spec 2.5.1.2)
+    let by_name = rng.gen_range(0..100) < 60;
+    let c_last = if by_name {
+        let c_load: usize = rng.gen_range(0..256);
+        Some(tpcc_rand::rand_c_last(rng, c_load))
+    } else {
+        None
+    };
+    let mut c_id = if by_name {
+        0
+    } else {
+        tpcc_rand::rand_customer_id(rng)
+    };
+
+    // 85% local, 15% remote (spec 2.5.1.2)
+    let (c_w_id, c_d_id) = if warehouses == 1 || rng.gen_range(0..100) < 85 {
+        (w_id, d_id)
+    } else {
+        let mut other = rng.gen_range(1..=warehouses);
+        while other == w_id {
+            other = rng.gen_range(1..=warehouses);
+        }
+        (other, rng.gen_range(1..=10))
+    };
+
+    let tx = client
+        .transaction()
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "begin payment transaction".into(),
+            source,
+        })?;
+
+    // 1. UPDATE warehouse
+    tx.execute(
+        "UPDATE warehouse SET w_ytd = w_ytd + $1 WHERE w_id = $2",
+        &[&h_amount, &w_id],
+    )
+    .await
+    .map_err(|source| crate::Error::Sql {
+        action: "payment: update warehouse".into(),
+        source,
+    })?;
+
+    // 2. SELECT warehouse
+    let w_row = tx
+        .query_one(
+            "SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name FROM warehouse WHERE w_id = $1",
+            &[&w_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "payment: select warehouse".into(),
+            source,
+        })?;
+
+    let w_name: String = w_row.get(5);
+
+    // 3. UPDATE district
+    tx.execute(
+        "UPDATE district SET d_ytd = d_ytd + $1 WHERE d_w_id = $2 AND d_id = $3",
+        &[&h_amount, &w_id, &d_id],
+    )
+    .await
+    .map_err(|source| crate::Error::Sql {
+        action: "payment: update district".into(),
+        source,
+    })?;
+
+    // 4. SELECT district
+    let d_row = tx
+        .query_one(
+            "SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name FROM district WHERE d_w_id = $1 AND d_id = $2",
+            &[&w_id, &d_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "payment: select district".into(),
+            source,
+        })?;
+
+    let d_name: String = d_row.get(5);
+
+    // 5. Resolve customer ID if by last name
+    if by_name {
+        let rows = tx
+            .query(
+                "SELECT c_id FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3 ORDER BY c_first",
+                &[&c_w_id, &c_d_id, &c_last.as_deref().unwrap_or("")],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "payment: select customer by last name".into(),
+                source,
+            })?;
+
+        if rows.is_empty() {
+            // Customer not found — skip (can happen with random data)
+            tx.commit().await.map_err(|source| crate::Error::Sql {
+                action: "payment: commit (no customer)".into(),
+                source,
+            })?;
+            return Ok(());
+        }
+
+        // Pick the middle customer (spec 2.5.2.2)
+        let idx = (rows.len() + 1) / 2 - 1;
+        c_id = rows[idx].get(0);
+    }
+
+    // 6. SELECT customer FOR UPDATE
+    let c_row = tx
+        .query_one(
+            "SELECT c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_since FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3 FOR UPDATE",
+            &[&c_w_id, &c_d_id, &c_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "payment: select customer for update".into(),
+            source,
+        })?;
+
+    let c_credit: String = c_row.get(9);
+
+    // 7-8. Update customer (with data for "BC" credit)
+    if c_credit.trim() == "BC" {
+        let c_data_row = tx
+            .query_one(
+                "SELECT c_data FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3",
+                &[&c_w_id, &c_d_id, &c_id],
+            )
+            .await
+            .map_err(|source| crate::Error::Sql {
+                action: "payment: select customer data".into(),
+                source,
+            })?;
+
+        let old_data: String = c_data_row.get(0);
+        let new_prefix = format!(
+            "| {c_id:4} {c_d_id:2} {c_w_id:4} {d_id:2} {w_id:4} ${h_amount:7.2} {TIME_FORMAT}"
+        );
+        let mut new_data = new_prefix;
+        let remaining = 500 - new_data.len().min(500);
+        if remaining > 0 {
+            let end = remaining.min(old_data.len());
+            new_data.push_str(&old_data[..end]);
+        }
+
+        tx.execute(
+            "UPDATE customer SET c_balance = c_balance - $1, c_ytd_payment = c_ytd_payment + $2, c_payment_cnt = c_payment_cnt + 1, c_data = $3 WHERE c_w_id = $4 AND c_d_id = $5 AND c_id = $6",
+            &[&h_amount, &h_amount, &new_data, &c_w_id, &c_d_id, &c_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "payment: update customer with data".into(),
+            source,
+        })?;
+    } else {
+        tx.execute(
+            "UPDATE customer SET c_balance = c_balance - $1, c_ytd_payment = c_ytd_payment + $2, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $3 AND c_d_id = $4 AND c_id = $5",
+            &[&h_amount, &h_amount, &c_w_id, &c_d_id, &c_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "payment: update customer".into(),
+            source,
+        })?;
+    }
+
+    // 9. INSERT history
+    let h_data = format!("{w_name:>10}    {d_name:>10}");
+    tx.execute(
+        "INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        &[&c_d_id, &c_w_id, &c_id, &d_id, &w_id, &TIME_FORMAT, &h_amount, &h_data],
+    )
+    .await
+    .map_err(|source| crate::Error::Sql {
+        action: "payment: insert history".into(),
+        source,
+    })?;
+
+    tx.commit().await.map_err(|source| crate::Error::Sql {
+        action: "payment: commit".into(),
+        source,
+    })?;
+
+    Ok(())
+}

--- a/tools/chbench-driver/src/txn/payment.rs
+++ b/tools/chbench-driver/src/txn/payment.rs
@@ -27,6 +27,9 @@ use tokio_postgres::Client;
 use crate::Result;
 use crate::rand as tpcc_rand;
 
+/// # Errors
+///
+/// Returns an error if any database operation fails.
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.random_range(1..=warehouses);
     let d_id = rng.random_range(1..=10);
@@ -47,7 +50,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     };
 
     // 85% local, 15% remote (spec 2.5.1.2)
-    let (c_w_id, c_d_id) = if warehouses == 1 || rng.random_range(0..100) < 85 {
+    let (customer_wh, customer_dist) = if warehouses == 1 || rng.random_range(0..100) < 85 {
         (w_id, d_id)
     } else {
         let mut other = rng.random_range(1..=warehouses);
@@ -120,7 +123,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
         let rows = tx
             .query(
                 "SELECT c_id FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3 ORDER BY c_first",
-                &[&c_w_id, &c_d_id, &c_last.as_deref().unwrap_or("")],
+                &[&customer_wh, &customer_dist, &c_last.as_deref().unwrap_or("")],
             )
             .await
             .map_err(|source| crate::Error::Sql {
@@ -138,7 +141,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
         }
 
         // Pick the middle customer (spec 2.5.2.2)
-        let idx = (rows.len() + 1) / 2 - 1;
+        let idx = rows.len().div_ceil(2) - 1;
         c_id = rows[idx].get(0);
     }
 
@@ -146,7 +149,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     let c_row = tx
         .query_one(
             "SELECT c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_since FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3 FOR UPDATE",
-            &[&c_w_id, &c_d_id, &c_id],
+            &[&customer_wh, &customer_dist, &c_id],
         )
         .await
         .map_err(|source| crate::Error::Sql {
@@ -161,7 +164,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
         let c_data_row = tx
             .query_one(
                 "SELECT c_data FROM customer WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3",
-                &[&c_w_id, &c_d_id, &c_id],
+                &[&customer_wh, &customer_dist, &c_id],
             )
             .await
             .map_err(|source| crate::Error::Sql {
@@ -175,7 +178,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
             .unwrap_or_default()
             .as_secs();
         let new_prefix = format!(
-            "| {c_id:4} {c_d_id:2} {c_w_id:4} {d_id:2} {w_id:4} ${h_amount:7.2} {now_secs}"
+            "| {c_id:4} {customer_dist:2} {customer_wh:4} {d_id:2} {w_id:4} ${h_amount:7.2} {now_secs}"
         );
         let mut new_data = new_prefix;
         let remaining = 500 - new_data.len().min(500);
@@ -186,7 +189,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
 
         tx.execute(
             "UPDATE customer SET c_balance = c_balance - $1, c_ytd_payment = c_ytd_payment + $2, c_payment_cnt = c_payment_cnt + 1, c_data = $3 WHERE c_w_id = $4 AND c_d_id = $5 AND c_id = $6",
-            &[&h_amount, &h_amount, &new_data, &c_w_id, &c_d_id, &c_id],
+            &[&h_amount, &h_amount, &new_data, &customer_wh, &customer_dist, &c_id],
         )
         .await
         .map_err(|source| crate::Error::Sql {
@@ -196,7 +199,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     } else {
         tx.execute(
             "UPDATE customer SET c_balance = c_balance - $1, c_ytd_payment = c_ytd_payment + $2, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $3 AND c_d_id = $4 AND c_id = $5",
-            &[&h_amount, &h_amount, &c_w_id, &c_d_id, &c_id],
+            &[&h_amount, &h_amount, &customer_wh, &customer_dist, &c_id],
         )
         .await
         .map_err(|source| crate::Error::Sql {
@@ -206,11 +209,11 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     }
 
     // 9. INSERT history
-    let h_data = format!("{w_name:>10}    {d_name:>10}");
-    let h_date = SystemTime::now();
+    let history_data = format!("{w_name:>10}    {d_name:>10}");
+    let history_ts = SystemTime::now();
     tx.execute(
         "INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-        &[&c_d_id, &c_w_id, &c_id, &d_id, &w_id, &h_date, &h_amount, &h_data],
+        &[&customer_dist, &customer_wh, &c_id, &d_id, &w_id, &history_ts, &h_amount, &history_data],
     )
     .await
     .map_err(|source| crate::Error::Sql {

--- a/tools/chbench-driver/src/txn/payment.rs
+++ b/tools/chbench-driver/src/txn/payment.rs
@@ -21,21 +21,21 @@ limitations under the License.
 
 use std::time::SystemTime;
 
-use ::rand::Rng;
+use ::rand::{Rng, RngExt};
 use tokio_postgres::Client;
 
 use crate::Result;
 use crate::rand as tpcc_rand;
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
-    let w_id = rng.gen_range(1..=warehouses);
-    let d_id = rng.gen_range(1..=10);
-    let h_amount: f64 = f64::from(rng.gen_range(100..=500_000)) / 100.0;
+    let w_id = rng.random_range(1..=warehouses);
+    let d_id = rng.random_range(1..=10);
+    let h_amount: f64 = f64::from(rng.random_range(100..=500_000)) / 100.0;
 
     // 60% by last name, 40% by customer ID (spec 2.5.1.2)
-    let by_name = rng.gen_range(0..100) < 60;
+    let by_name = rng.random_range(0..100) < 60;
     let c_last = if by_name {
-        let c_load: usize = rng.gen_range(0..256);
+        let c_load: usize = rng.random_range(0..256);
         Some(tpcc_rand::rand_c_last(rng, c_load))
     } else {
         None
@@ -47,14 +47,14 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     };
 
     // 85% local, 15% remote (spec 2.5.1.2)
-    let (c_w_id, c_d_id) = if warehouses == 1 || rng.gen_range(0..100) < 85 {
+    let (c_w_id, c_d_id) = if warehouses == 1 || rng.random_range(0..100) < 85 {
         (w_id, d_id)
     } else {
-        let mut other = rng.gen_range(1..=warehouses);
+        let mut other = rng.random_range(1..=warehouses);
         while other == w_id {
-            other = rng.gen_range(1..=warehouses);
+            other = rng.random_range(1..=warehouses);
         }
-        (other, rng.gen_range(1..=10))
+        (other, rng.random_range(1..=10))
     };
 
     let tx = client

--- a/tools/chbench-driver/src/txn/payment.rs
+++ b/tools/chbench-driver/src/txn/payment.rs
@@ -24,8 +24,8 @@ use std::time::SystemTime;
 use ::rand::Rng;
 use tokio_postgres::Client;
 
-use crate::rand as tpcc_rand;
 use crate::Result;
+use crate::rand as tpcc_rand;
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.gen_range(1..=warehouses);

--- a/tools/chbench-driver/src/txn/stock_level.rs
+++ b/tools/chbench-driver/src/txn/stock_level.rs
@@ -19,15 +19,15 @@ limitations under the License.
 //! Read-only: count distinct items in recent orders with stock below threshold.
 //! No WAL events — included for spec-compliant tpmC measurement.
 
-use ::rand::Rng;
+use ::rand::{Rng, RngExt};
 use tokio_postgres::Client;
 
 use crate::Result;
 
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
-    let w_id = rng.gen_range(1..=warehouses);
-    let d_id = rng.gen_range(1..=10);
-    let threshold = rng.gen_range(10..=20);
+    let w_id = rng.random_range(1..=warehouses);
+    let d_id = rng.random_range(1..=10);
+    let threshold = rng.random_range(10..=20);
 
     let tx = client
         .transaction()

--- a/tools/chbench-driver/src/txn/stock_level.rs
+++ b/tools/chbench-driver/src/txn/stock_level.rs
@@ -1,0 +1,72 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! TPC-C StockLevel transaction (4% default mix).
+//!
+//! Read-only: count distinct items in recent orders with stock below threshold.
+//! No WAL events — included for spec-compliant tpmC measurement.
+
+use ::rand::Rng;
+use tokio_postgres::Client;
+
+use crate::Result;
+
+pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
+    let w_id = rng.gen_range(1..=warehouses);
+    let d_id = rng.gen_range(1..=10);
+    let threshold = rng.gen_range(10..=20);
+
+    let tx = client
+        .transaction()
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "begin stock_level transaction".into(),
+            source,
+        })?;
+
+    // SELECT d_next_o_id
+    let d_row = tx
+        .query_one(
+            "SELECT d_next_o_id FROM district WHERE d_w_id = $1 AND d_id = $2",
+            &[&w_id, &d_id],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "stock_level: select district".into(),
+            source,
+        })?;
+
+    let o_id: i32 = d_row.get(0);
+
+    // Count low-stock items in last 20 orders
+    let _count_row = tx
+        .query_one(
+            "SELECT COUNT(DISTINCT s_i_id) FROM order_line, stock WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id < $3 AND ol_o_id >= $3 - 20 AND s_w_id = $1 AND s_i_id = ol_i_id AND s_quantity < $4",
+            &[&w_id, &d_id, &o_id, &threshold],
+        )
+        .await
+        .map_err(|source| crate::Error::Sql {
+            action: "stock_level: count low stock".into(),
+            source,
+        })?;
+
+    tx.commit().await.map_err(|source| crate::Error::Sql {
+        action: "stock_level: commit".into(),
+        source,
+    })?;
+
+    Ok(())
+}

--- a/tools/chbench-driver/src/txn/stock_level.rs
+++ b/tools/chbench-driver/src/txn/stock_level.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! TPC-C StockLevel transaction (4% default mix).
+//! TPC-C `StockLevel` transaction (4% default mix).
 //!
 //! Read-only: count distinct items in recent orders with stock below threshold.
 //! No WAL events — included for spec-compliant tpmC measurement.
@@ -24,6 +24,9 @@ use tokio_postgres::Client;
 
 use crate::Result;
 
+/// # Errors
+///
+/// Returns an error if any database operation fails.
 pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Result<()> {
     let w_id = rng.random_range(1..=warehouses);
     let d_id = rng.random_range(1..=10);

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -17,7 +17,6 @@ aws-credential-types.workspace = true
 aws-sdk-dynamodb.workspace = true
 bollard = "0.18.1"
 chbench-driver = { path = "../chbench-driver" }
-chrono = { workspace = true }
 clap.workspace = true
 duckdb = { workspace = true, features = ["bundled"] }
 futures.workspace = true

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -17,6 +17,7 @@ aws-credential-types.workspace = true
 aws-sdk-dynamodb.workspace = true
 bollard = "0.18.1"
 chbench-driver = { path = "../chbench-driver" }
+chrono = { workspace = true }
 clap.workspace = true
 duckdb = { workspace = true, features = ["bundled"] }
 futures.workspace = true
@@ -32,6 +33,7 @@ spicepod = { path = "../../crates/spicepod" }
 test-framework = { path = "../../crates/test-framework" }
 rand.workspace = true
 tokio.workspace = true
+tokio-postgres = { workspace = true }
 tokio-util.workspace = true
 
 [features]

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -32,7 +32,6 @@ spicepod = { path = "../../crates/spicepod" }
 test-framework = { path = "../../crates/test-framework" }
 rand.workspace = true
 tokio.workspace = true
-tokio-postgres = { workspace = true }
 tokio-util.workspace = true
 
 [features]

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -16,6 +16,7 @@ aws-config.workspace = true
 aws-credential-types.workspace = true
 aws-sdk-dynamodb.workspace = true
 bollard = "0.18.1"
+chbench-driver = { path = "../chbench-driver" }
 clap.workspace = true
 duckdb = { workspace = true, features = ["bundled"] }
 futures.workspace = true

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -117,6 +117,9 @@ pub enum QuerySetArg {
     Tpch,
     Tpcds,
     Clickbench,
+    #[value(name = "chbench")]
+    #[serde(rename = "chbench")]
+    ChBench,
     #[value(name = "tpch[parameterized]")]
     #[serde(rename = "tpch[parameterized]")]
     ParameterizedTpch,
@@ -198,6 +201,7 @@ impl From<QuerySetArg> for QuerySet {
             QuerySetArg::Tpch => QuerySet::Tpch,
             QuerySetArg::Tpcds => QuerySet::Tpcds,
             QuerySetArg::Clickbench => QuerySet::Clickbench,
+            QuerySetArg::ChBench => QuerySet::ChBench,
             QuerySetArg::ParameterizedTpch => QuerySet::ParameterizedTpch,
             QuerySetArg::Scenario => {
                 // This should never be reached - callers must use DatasetTestArgs::load_query_set()
@@ -217,6 +221,7 @@ impl PartialEq<QuerySet> for QuerySetArg {
             (QuerySetArg::Tpch, QuerySet::Tpch)
                 | (QuerySetArg::Tpcds, QuerySet::Tpcds)
                 | (QuerySetArg::Clickbench, QuerySet::Clickbench)
+                | (QuerySetArg::ChBench, QuerySet::ChBench)
                 | (QuerySetArg::ParameterizedTpch, QuerySet::ParameterizedTpch)
                 | (QuerySetArg::Scenario, QuerySet::Scenario { .. })
         )

--- a/tools/testoperator/src/args/htap.rs
+++ b/tools/testoperator/src/args/htap.rs
@@ -1,0 +1,39 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use clap::Parser;
+
+use super::DatasetTestArgs;
+
+/// Arguments for the HTAP (Hybrid Transactional/Analytical Processing) test.
+///
+/// Runs a TPC-C OLTP workload against the source
+/// concurrently with CH-benCH analytical queries against spiced,
+/// measuring analytical query freshness under write load.
+#[derive(Parser, Debug, Clone)]
+pub struct HtapArgs {
+    #[command(flatten)]
+    pub(crate) test_args: DatasetTestArgs,
+
+    /// Number of TPC-C warehouses (scale factor). Each warehouse ≈ 100 MB of seed data.
+    #[arg(long, default_value = "1")]
+    pub(crate) warehouses: usize,
+
+    /// Number of concurrent OLTP terminals writing to the source database.
+    /// TPC-C spec recommends 10 per warehouse for realistic contention.
+    #[arg(long, default_value = "10")]
+    pub(crate) terminals: usize,
+}

--- a/tools/testoperator/src/args/htap.rs
+++ b/tools/testoperator/src/args/htap.rs
@@ -23,17 +23,12 @@ use super::DatasetTestArgs;
 /// Runs a TPC-C OLTP workload against the source
 /// concurrently with CH-benCH analytical queries against spiced,
 /// measuring analytical query freshness under write load.
+///
+/// CH-benCH convention: `--scale-factor` maps to warehouses (SF1 = 1 warehouse
+/// ≈ 100 MB seed data). The TPC-C terminal count is `warehouses * 10`, matching
+/// the spec's requirement of 10 terminals per warehouse.
 #[derive(Parser, Debug, Clone)]
 pub struct HtapArgs {
     #[command(flatten)]
     pub(crate) test_args: DatasetTestArgs,
-
-    /// Number of TPC-C warehouses (scale factor). Each warehouse ≈ 100 MB of seed data.
-    #[arg(long, default_value = "1")]
-    pub(crate) warehouses: usize,
-
-    /// Number of concurrent OLTP terminals writing to the source database.
-    /// TPC-C spec recommends 10 per warehouse for realistic contention.
-    #[arg(long, default_value = "10")]
-    pub(crate) terminals: usize,
 }

--- a/tools/testoperator/src/args/mod.rs
+++ b/tools/testoperator/src/args/mod.rs
@@ -38,6 +38,9 @@ pub use text_to_sql::TextToSqlArgs;
 mod schema;
 pub use schema::SchemaTestArgs;
 
+mod htap;
+pub use htap::HtapArgs;
+
 mod streaming;
 pub use streaming::{StreamingDynamodbArgs, StreamingDynamodbCorrectnessArgs};
 
@@ -76,6 +79,8 @@ pub enum TestCommands {
     StreamingDynamodbCorrectness(StreamingDynamodbCorrectnessArgs),
     /// Validate catalog connector schema discovery via `information_schema`
     Schema(SchemaTestArgs),
+    /// Run an HTAP test: concurrent TPC-C OLTP workload + CH-benCH analytical queries
+    Htap(HtapArgs),
 }
 
 /// Arguments Common to all [`TestCommands`].

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -41,7 +41,7 @@ use test_framework::{
     utils::{observe_memory, recursively_get_dir_size},
 };
 
-fn emit_acceleration_size_if_applicable(app: &App, app_path: &Path) -> anyhow::Result<()> {
+pub(crate) fn emit_acceleration_size_if_applicable(app: &App, app_path: &Path) -> anyhow::Result<()> {
     // determine if any dataset has acceleration enabled with a file mode engine
     if !app.datasets.iter().any(|ds| {
         ds.acceleration.as_ref().is_some_and(|accel| {
@@ -74,7 +74,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let query_set = args.load_query_set()?;
     if query_set == test_framework::queries::QuerySet::ChBench {
         println!("Preparing chbench source database...");
-        let config = chbench_config_from_env();
+        let config = chbench_config_from_env()?;
         let driver = chbench_driver::ChBenchDriver::connect(config).await?;
         driver.prepare().await?;
         println!("chbench source database ready");
@@ -253,15 +253,15 @@ fn snapshot_predicate(query_name: &str) -> bool {
 /// | `CHBENCH_PG_DB` | `chbench` |
 /// | `CHBENCH_PG_USER` | `bench` |
 /// | `CHBENCH_PG_PASS` | `bench` |
-fn chbench_config_from_env() -> chbench_driver::config::ChBenchConfig {
+pub(crate) fn chbench_config_from_env() -> anyhow::Result<chbench_driver::config::ChBenchConfig> {
     let mut cfg = chbench_driver::config::ChBenchConfig::default();
     if let Ok(v) = std::env::var("CHBENCH_PG_HOST") {
         cfg.pg_host = v;
     }
     if let Ok(v) = std::env::var("CHBENCH_PG_PORT") {
-        if let Ok(p) = v.parse() {
-            cfg.pg_port = p;
-        }
+        cfg.pg_port = v
+            .parse()
+            .map_err(|e| anyhow::anyhow!("CHBENCH_PG_PORT={v:?} is not a valid port number: {e}"))?;
     }
     if let Ok(v) = std::env::var("CHBENCH_PG_DB") {
         cfg.pg_db = v;
@@ -273,5 +273,5 @@ fn chbench_config_from_env() -> chbench_driver::config::ChBenchConfig {
         cfg.pg_pass = v;
     }
 
-    cfg
+    Ok(cfg)
 }

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -42,7 +42,10 @@ use test_framework::{
     utils::{observe_memory, recursively_get_dir_size},
 };
 
-pub(crate) fn emit_acceleration_size_if_applicable(app: &App, app_path: &Path) -> anyhow::Result<()> {
+pub(crate) fn emit_acceleration_size_if_applicable(
+    app: &App,
+    app_path: &Path,
+) -> anyhow::Result<()> {
     // determine if any dataset has acceleration enabled with a file mode engine
     if !app.datasets.iter().any(|ds| {
         ds.acceleration.as_ref().is_some_and(|accel| {
@@ -254,17 +257,19 @@ fn snapshot_predicate(query_name: &str) -> bool {
 /// | `CHBENCH_PG_DB` | `chbench` |
 /// | `CHBENCH_PG_USER` | `bench` |
 /// | `CHBENCH_PG_PASS` | `bench` |
-pub(crate) fn chbench_config_from_env(
-) -> anyhow::Result<(chbench_driver::ChBenchConfig, chbench_driver::PostgresSourceConfig)> {
+pub(crate) fn chbench_config_from_env() -> anyhow::Result<(
+    chbench_driver::ChBenchConfig,
+    chbench_driver::PostgresSourceConfig,
+)> {
     let workload = chbench_driver::ChBenchConfig::default();
     let mut source = chbench_driver::PostgresSourceConfig::default();
     if let Ok(v) = std::env::var("CHBENCH_PG_HOST") {
         source.host = v;
     }
     if let Ok(v) = std::env::var("CHBENCH_PG_PORT") {
-        source.port = v
-            .parse()
-            .map_err(|e| anyhow::anyhow!("CHBENCH_PG_PORT={v:?} is not a valid port number: {e}"))?;
+        source.port = v.parse().map_err(|e| {
+            anyhow::anyhow!("CHBENCH_PG_PORT={v:?} is not a valid port number: {e}")
+        })?;
     }
     if let Ok(v) = std::env::var("CHBENCH_PG_DB") {
         source.db = v;

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -69,6 +69,17 @@ fn emit_acceleration_size_if_applicable(app: &App, app_path: &Path) -> anyhow::R
 
 pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let (app, start_request) = get_app_and_start_request(&args.common).await?;
+
+    // For chbench, prepare the Postgres source database (schema + seed data) before starting spiced.
+    let query_set = args.load_query_set()?;
+    if query_set == test_framework::queries::QuerySet::ChBench {
+        println!("Preparing chbench source database...");
+        let config = chbench_config_from_env();
+        let driver = chbench_driver::ChBenchDriver::connect(config).await?;
+        driver.prepare().await?;
+        println!("chbench source database ready");
+    }
+
     let mut spiced_instance = SpicedInstance::start(start_request).await?;
     let ready_wait_start = Instant::now();
 
@@ -90,7 +101,6 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let testoperator_commit_sha = git::get_commit_sha();
     let branch_name = git::get_branch_name();
 
-    let query_set = args.load_query_set()?;
     let benchmark_resource = Resource::builder_empty()
         .with_attributes(vec![
             KeyValue::new("service.name", "testoperator"),
@@ -134,12 +144,17 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     )
     .await?;
 
-    let benchmark_test = SpiceTest::new(app.name.clone(), test_builder)
+    let mut benchmark_test = SpiceTest::new(app.name.clone(), test_builder)
         .with_spiced_instance(spiced_instance)
-        .with_explain_plan_snapshot()
         .with_results_snapshot(snapshot_predicate)
-        .with_progress_bars(!args.common.disable_progress_bars)
-        .start()?;
+        .with_progress_bars(!args.common.disable_progress_bars);
+
+    if query_set != test_framework::queries::QuerySet::ChBench {
+        // Skip explain plan snapshot for CH-benCH
+        benchmark_test = benchmark_test.with_explain_plan_snapshot();
+    }
+
+    let benchmark_test = benchmark_test.start()?;
 
     let test = wait_test_and_memory!(benchmark_test, memory_token, memory_readings);
 
@@ -227,4 +242,36 @@ const DISABLED_SNAPSHOT_QUERIES: &[&str] = &[
 fn snapshot_predicate(query_name: &str) -> bool {
     (query_name.starts_with("tpch_q") || query_name.starts_with("tpcds_q"))
         && !DISABLED_SNAPSHOT_QUERIES.contains(&query_name)
+}
+
+/// Build a [`chbench_driver::config::ChBenchConfig`] from environment variables with sensible defaults.
+///
+/// | Variable | Default |
+/// |----------|---------|
+/// | `CHBENCH_PG_HOST` | `127.0.0.1` |
+/// | `CHBENCH_PG_PORT` | `5432` |
+/// | `CHBENCH_PG_DB` | `chbench` |
+/// | `CHBENCH_PG_USER` | `bench` |
+/// | `CHBENCH_PG_PASS` | `bench` |
+fn chbench_config_from_env() -> chbench_driver::config::ChBenchConfig {
+    let mut cfg = chbench_driver::config::ChBenchConfig::default();
+    if let Ok(v) = std::env::var("CHBENCH_PG_HOST") {
+        cfg.pg_host = v;
+    }
+    if let Ok(v) = std::env::var("CHBENCH_PG_PORT") {
+        if let Ok(p) = v.parse() {
+            cfg.pg_port = p;
+        }
+    }
+    if let Ok(v) = std::env::var("CHBENCH_PG_DB") {
+        cfg.pg_db = v;
+    }
+    if let Ok(v) = std::env::var("CHBENCH_PG_USER") {
+        cfg.pg_user = v;
+    }
+    if let Ok(v) = std::env::var("CHBENCH_PG_PASS") {
+        cfg.pg_pass = v;
+    }
+
+    cfg
 }

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     args::DatasetTestArgs, health::HealthMonitor, spiced_metrics::MetricsScraper,
     wait_test_and_memory,
 };
+use chbench_driver::ChBenchDriver as _;
 use std::{
     path::Path,
     time::{Duration, Instant},
@@ -74,8 +75,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let query_set = args.load_query_set()?;
     if query_set == test_framework::queries::QuerySet::ChBench {
         println!("Preparing chbench source database...");
-        let config = chbench_config_from_env()?;
-        let driver = chbench_driver::ChBenchDriver::connect(config).await?;
+        let (config, source) = chbench_config_from_env()?;
+        let driver = chbench_driver::PostgresChBenchDriver::connect(config, source).await?;
         driver.prepare().await?;
         println!("chbench source database ready");
     }
@@ -244,7 +245,7 @@ fn snapshot_predicate(query_name: &str) -> bool {
         && !DISABLED_SNAPSHOT_QUERIES.contains(&query_name)
 }
 
-/// Build a [`chbench_driver::config::ChBenchConfig`] from environment variables with sensible defaults.
+/// Build CH-benCH configs from environment variables with sensible defaults.
 ///
 /// | Variable | Default |
 /// |----------|---------|
@@ -253,25 +254,27 @@ fn snapshot_predicate(query_name: &str) -> bool {
 /// | `CHBENCH_PG_DB` | `chbench` |
 /// | `CHBENCH_PG_USER` | `bench` |
 /// | `CHBENCH_PG_PASS` | `bench` |
-pub(crate) fn chbench_config_from_env() -> anyhow::Result<chbench_driver::config::ChBenchConfig> {
-    let mut cfg = chbench_driver::config::ChBenchConfig::default();
+pub(crate) fn chbench_config_from_env(
+) -> anyhow::Result<(chbench_driver::ChBenchConfig, chbench_driver::PostgresSourceConfig)> {
+    let workload = chbench_driver::ChBenchConfig::default();
+    let mut source = chbench_driver::PostgresSourceConfig::default();
     if let Ok(v) = std::env::var("CHBENCH_PG_HOST") {
-        cfg.pg_host = v;
+        source.host = v;
     }
     if let Ok(v) = std::env::var("CHBENCH_PG_PORT") {
-        cfg.pg_port = v
+        source.port = v
             .parse()
             .map_err(|e| anyhow::anyhow!("CHBENCH_PG_PORT={v:?} is not a valid port number: {e}"))?;
     }
     if let Ok(v) = std::env::var("CHBENCH_PG_DB") {
-        cfg.pg_db = v;
+        source.db = v;
     }
     if let Ok(v) = std::env::var("CHBENCH_PG_USER") {
-        cfg.pg_user = v;
+        source.user = v;
     }
     if let Ok(v) = std::env::var("CHBENCH_PG_PASS") {
-        cfg.pg_pass = v;
+        source.pass = v;
     }
 
-    Ok(cfg)
+    Ok((workload, source))
 }

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -245,7 +245,7 @@ fn snapshot_predicate(query_name: &str) -> bool {
         && !DISABLED_SNAPSHOT_QUERIES.contains(&query_name)
 }
 
-/// Build CH-benCH PostgreSQL source config from environment variables.
+/// Build CH-benCH Postgres source config from environment variables.
 ///
 /// | Variable | Default |
 /// |----------|---------|
@@ -277,7 +277,7 @@ fn chbench_source_from_env() -> anyhow::Result<chbench_driver::PostgresSourceCon
 }
 
 /// Validate scale factor, build the CH-benCH config, connect to the source
-/// PostgreSQL, create the schema and load seed data.
+/// Postgres, create the schema and load seed data.
 ///
 /// `scale_factor` maps to TPC-C warehouses (must be a positive integer >= 1).
 /// `duration` overrides the default OLTP workload duration when set.
@@ -292,6 +292,8 @@ pub(crate) async fn prepare_chbench_source(
         );
     }
 
+    // Scale factor is validated >= 1.0 and integer above, so the cast is safe.
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let warehouses = scale_factor as usize;
     let terminals = warehouses * 10;
     let mut config = chbench_driver::ChBenchConfig {
@@ -303,7 +305,9 @@ pub(crate) async fn prepare_chbench_source(
         config.duration = d;
     }
 
-    println!("Preparing chbench source (SF{scale_factor}: {warehouses} warehouse(s), {terminals} terminal(s))...");
+    println!(
+        "Preparing chbench source (SF{scale_factor}: {warehouses} warehouse(s), {terminals} terminal(s))..."
+    );
 
     let source = chbench_source_from_env()?;
     let driver = chbench_driver::PostgresChBenchDriver::connect(config, source).await?;

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -77,11 +77,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     // For chbench, prepare the Postgres source database (schema + seed data) before starting spiced.
     let query_set = args.load_query_set()?;
     if query_set == test_framework::queries::QuerySet::ChBench {
-        println!("Preparing chbench source database...");
-        let (config, source) = chbench_config_from_env()?;
-        let driver = chbench_driver::PostgresChBenchDriver::connect(config, source).await?;
-        driver.prepare().await?;
-        println!("chbench source database ready");
+        let scale_factor = args.scale_factor.unwrap_or(1.0);
+        prepare_chbench_source(scale_factor, None).await?;
     }
 
     let mut spiced_instance = SpicedInstance::start(start_request).await?;
@@ -248,7 +245,7 @@ fn snapshot_predicate(query_name: &str) -> bool {
         && !DISABLED_SNAPSHOT_QUERIES.contains(&query_name)
 }
 
-/// Build CH-benCH configs from environment variables with sensible defaults.
+/// Build CH-benCH PostgreSQL source config from environment variables.
 ///
 /// | Variable | Default |
 /// |----------|---------|
@@ -257,11 +254,7 @@ fn snapshot_predicate(query_name: &str) -> bool {
 /// | `CHBENCH_PG_DB` | `chbench` |
 /// | `CHBENCH_PG_USER` | `bench` |
 /// | `CHBENCH_PG_PASS` | `bench` |
-pub(crate) fn chbench_config_from_env() -> anyhow::Result<(
-    chbench_driver::ChBenchConfig,
-    chbench_driver::PostgresSourceConfig,
-)> {
-    let workload = chbench_driver::ChBenchConfig::default();
+fn chbench_source_from_env() -> anyhow::Result<chbench_driver::PostgresSourceConfig> {
     let mut source = chbench_driver::PostgresSourceConfig::default();
     if let Ok(v) = std::env::var("CHBENCH_PG_HOST") {
         source.host = v;
@@ -280,6 +273,42 @@ pub(crate) fn chbench_config_from_env() -> anyhow::Result<(
     if let Ok(v) = std::env::var("CHBENCH_PG_PASS") {
         source.pass = v;
     }
+    Ok(source)
+}
 
-    Ok((workload, source))
+/// Validate scale factor, build the CH-benCH config, connect to the source
+/// PostgreSQL, create the schema and load seed data.
+///
+/// `scale_factor` maps to TPC-C warehouses (must be a positive integer >= 1).
+/// `duration` overrides the default OLTP workload duration when set.
+pub(crate) async fn prepare_chbench_source(
+    scale_factor: f64,
+    duration: Option<Duration>,
+) -> anyhow::Result<chbench_driver::PostgresChBenchDriver> {
+    if scale_factor < 1.0 || scale_factor.fract() != 0.0 {
+        anyhow::bail!(
+            "CH-benCH --scale-factor must be a positive integer (>= 1), got {scale_factor}. \
+             Scale factor maps directly to TPC-C warehouse count."
+        );
+    }
+
+    let warehouses = scale_factor as usize;
+    let terminals = warehouses * 10;
+    let mut config = chbench_driver::ChBenchConfig {
+        warehouses,
+        terminals,
+        ..Default::default()
+    };
+    if let Some(d) = duration {
+        config.duration = d;
+    }
+
+    println!("Preparing chbench source (SF{scale_factor}: {warehouses} warehouse(s), {terminals} terminal(s))...");
+
+    let source = chbench_source_from_env()?;
+    let driver = chbench_driver::PostgresChBenchDriver::connect(config, source).await?;
+    driver.prepare().await?;
+
+    println!("chbench source is ready");
+    Ok(driver)
 }

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -17,12 +17,15 @@ limitations under the License.
 //! HTAP test command — runs concurrent TPC-C OLTP workload against the source
 //! PostgreSQL database while executing CH-benCH analytical queries through spiced.
 
+mod staleness;
+
 use std::time::{Duration, Instant};
 
 use test_framework::{
     TestType, anyhow,
+    arrow::util::pretty::print_batches,
     git,
-    metrics::{MetricCollector, NoExtendedMetrics, QueryMetrics},
+    metrics::{MetricCollector, NoExtendedMetrics, QueryMetrics, QueryStatus},
     opentelemetry::KeyValue,
     opentelemetry_sdk::Resource,
     spiced::SpicedInstance,
@@ -44,7 +47,13 @@ use crate::{
 
 pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     let test_args = &args.test_args;
-    let (app, start_request) = super::get_app_and_start_request(&test_args.common).await?;
+    let (app, mut start_request) = super::get_app_and_start_request(&test_args.common).await?;
+
+    // Always enable the metrics endpoint in HTAP mode for replication metrics.
+    if !test_args.common.scrape_spiced_metrics {
+        start_request = start_request
+            .with_additional_args(vec!["--metrics".to_string(), "127.0.0.1:9090".to_string()]);
+    }
 
     // 1. Prepare the source (schema + seed data).
     println!("Preparing chbench source...");
@@ -52,6 +61,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     config.warehouses = args.warehouses;
     config.terminals = args.terminals;
     config.duration = Duration::from_secs(test_args.common.duration);
+    let pg_connection_string = config.pg_connection_string();
     let driver = chbench_driver::ChBenchDriver::connect(config).await?;
     driver.prepare().await?;
     println!("chbench source is ready");
@@ -67,7 +77,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         .wait_for_ready(Duration::from_secs(test_args.common.ready_wait))
         .await?;
 
-    let _ready_wait_duration = ready_wait_start.elapsed();
+    let ready_wait_duration = ready_wait_start.elapsed();
 
     // Build telemetry resource.
     let spiced_version = spiced_instance.version().to_string();
@@ -95,11 +105,8 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
 
     let health_monitor = HealthMonitor::spawn()?;
 
-    let metrics_scraper = if test_args.common.scrape_spiced_metrics {
-        Some(MetricsScraper::spawn()?)
-    } else {
-        None
-    };
+    // Always scrape spiced metrics in HTAP mode — replication metrics are essential.
+    let metrics_scraper = Some(MetricsScraper::spawn()?);
 
     // 3. Start the OLTP workload in the background.
     let oltp_cancel = CancellationToken::new();
@@ -107,6 +114,14 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         let cancel = oltp_cancel.clone();
         tokio::spawn(async move { driver.run(cancel).await })
     };
+
+    // 3b. Start staleness probe alongside the OLTP workload.
+    let staleness_spice_client = spiced_instance.spice_client(None, false).await?;
+    let staleness_handle = staleness::spawn_staleness_probe(
+        pg_connection_string,
+        staleness_spice_client,
+        oltp_cancel.clone(),
+    );
 
     // 4. Run analytical queries through spiced concurrently with the OLTP load.
     println!("Running HTAP analytical queries under OLTP load");
@@ -134,56 +149,59 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
 
     let test = wait_test_and_memory!(benchmark_test, memory_token, memory_readings);
 
-    // 5. Stop OLTP and collect results.
+    // 5. Capture replication metrics while OLTP is still running.
+    //    lag_ms = now() − commit_time(last_processed_txn), so it inflates with idle time
+    //    after OLTP stops. Stopping the scraper here gives accurate under-load values.
+    let spiced_metrics =
+        super::process_spiced_metrics(metrics_scraper, test_args.common.metrics, &[]).await;
+
+    // 6. Stop OLTP and collect results.
     oltp_cancel.cancel();
     let oltp_result = oltp_handle.await;
+    let staleness_result = staleness_handle.await;
 
     // Skip row count consistency validation — OLTP mutations cause row counts to vary between iterations.
-    let _metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Benchmark)?;
+    let metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Benchmark)?;
     let test_succeeded = test.succeeded();
     let mut spiced_instance = test.end()?;
-    let (_max_memory, _median_memory) = observe_memory(memory_token, memory_readings).await?;
+    let (max_memory, median_memory) = observe_memory(memory_token, memory_readings).await?;
 
     // 6. Report analytical query metrics.
-    // TODO: Re-enable metrics reporting after reviewing/adjusting for HTAP workload.
-    let failures: Vec<String> = Vec::new();
-    // for query in &metrics.metrics {
-    //     let query_name = &query.query_name;
-    //     let row_count = row_counts.get(query_name).unwrap_or(&0);
-    //     let attributes = vec![KeyValue::new("query_name", query_name.to_string())];
+    let mut failures: Vec<String> = Vec::new();
+    for query in &metrics.metrics {
+        let query_name = &query.query_name;
+        let attributes = vec![KeyValue::new("query_name", query_name.to_string())];
 
-    //     let status: u64 = u64::from(match &query.query_status {
-    //         QueryStatus::Passed => true,
-    //         QueryStatus::Failed(reason) => {
-    //             if let Some(reason) = reason {
-    //                 failures.push(format!("{query_name}: {reason}"));
-    //             } else {
-    //                 failures.push(format!("{query_name}: failed with an undetermined error"));
-    //             }
-    //             false
-    //         }
-    //     });
+        let status: u64 = u64::from(match &query.query_status {
+            QueryStatus::Passed => true,
+            QueryStatus::Failed(reason) => {
+                if let Some(reason) = reason {
+                    failures.push(format!("{query_name}: {reason}"));
+                } else {
+                    failures.push(format!("{query_name}: failed with an undetermined error"));
+                }
+                false
+            }
+        });
 
-    //     crate::metrics::QUERY_STATUS.record(status, &attributes);
-    //     crate::metrics::MEDIAN_DURATION.record(query.median_duration_ms, &attributes);
-    //     crate::metrics::MIN_DURATION.record(query.min_duration_ms, &attributes);
-    //     crate::metrics::MAX_DURATION.record(query.max_duration_ms, &attributes);
-    //     crate::metrics::ITERATIONS.record(query.iterations.try_into()?, &attributes);
-    //     crate::metrics::P90_DURATION.record(query.percentile_90_duration_ms, &attributes);
-    //     crate::metrics::P95_DURATION.record(query.percentile_95_duration_ms, &attributes);
-    //     crate::metrics::P99_DURATION.record(query.percentile_99_duration_ms, &attributes);
-    // }
+        crate::metrics::QUERY_STATUS.record(status, &attributes);
+        crate::metrics::MEDIAN_DURATION.record(query.median_duration_ms, &attributes);
+        crate::metrics::MIN_DURATION.record(query.min_duration_ms, &attributes);
+        crate::metrics::MAX_DURATION.record(query.max_duration_ms, &attributes);
+        crate::metrics::ITERATIONS.record(query.iterations.try_into()?, &attributes);
+        crate::metrics::P90_DURATION.record(query.percentile_90_duration_ms, &attributes);
+        crate::metrics::P95_DURATION.record(query.percentile_95_duration_ms, &attributes);
+        crate::metrics::P99_DURATION.record(query.percentile_99_duration_ms, &attributes);
+    }
 
-    // crate::metrics::READY_DURATION.record(ready_wait_duration.as_millis().try_into()?, &[]);
-    // crate::metrics::TEST_DURATION
-    //     .record((metrics.finished_at - metrics.started_at).try_into()?, &[]);
-    // crate::metrics::PEAK_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
-    // crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
+    crate::metrics::READY_DURATION.record(ready_wait_duration.as_millis().try_into()?, &[]);
+    crate::metrics::TEST_DURATION
+        .record((metrics.finished_at - metrics.started_at).try_into()?, &[]);
+    crate::metrics::PEAK_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
+    crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
 
-    // super::bench::emit_acceleration_size_if_applicable(&app, &spiced_instance.get_tempdir_path()?)?;
-
-    // let records = metrics.with_memory_usage(max_memory).build_records()?;
-    // print_batches(&records)?;
+    let records = metrics.with_memory_usage(max_memory).build_records()?;
+    print_batches(&records)?;
 
     // 7. Report OLTP results.
     match oltp_result {
@@ -199,8 +217,26 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         }
     }
 
+    // 8. Report staleness gap.
+    match staleness_result {
+        Ok(Ok(report)) => {
+            report.print_summary();
+        }
+        Ok(Err(e)) => {
+            eprintln!("Staleness probe error: {e}");
+        }
+        Err(e) => {
+            eprintln!("Staleness probe join error: {e}");
+        }
+    }
+
     let health_report = health_monitor.stop().await;
-    super::process_spiced_metrics(metrics_scraper, test_args.common.metrics, &[]).await;
+
+    // 10. Report native replication metrics from spiced /metrics endpoint.
+    if let Some(ref metrics) = spiced_metrics {
+        print_replication_metrics(metrics);
+    }
+
     telemetry.emit().await?;
     spiced_instance.stop()?;
 
@@ -223,4 +259,86 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Print per-dataset Postgres replication metrics scraped from spiced's `/metrics` endpoint.
+fn print_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
+    use std::collections::BTreeMap;
+
+    // Collect replication metrics per dataset from scraped samples.
+    // Gauges (lag_ms, lag_bytes): use the last observed value — represents the
+    // pipeline state when the scraper stopped (while OLTP was still active).
+    // Counters (inserts, updates, deletes): use the last value (monotonic total).
+    let mut lag_ms: BTreeMap<String, f64> = BTreeMap::new();
+    let mut lag_bytes: BTreeMap<String, f64> = BTreeMap::new();
+    let mut inserts: BTreeMap<String, f64> = BTreeMap::new();
+    let mut updates: BTreeMap<String, f64> = BTreeMap::new();
+    let mut deletes: BTreeMap<String, f64> = BTreeMap::new();
+
+    let gauge_metrics = [
+        ("dataset_postgres_replication_lag_ms", &mut lag_ms as &mut BTreeMap<String, f64>),
+        ("dataset_postgres_replication_lag_bytes", &mut lag_bytes),
+    ];
+    let counter_metrics = [
+        ("dataset_postgres_replication_inserts_total", &mut inserts as &mut BTreeMap<String, f64>),
+        ("dataset_postgres_replication_updates_total", &mut updates),
+        ("dataset_postgres_replication_deletes_total", &mut deletes),
+    ];
+
+    for (metric_name, map) in gauge_metrics {
+        if let Some(samples) = metrics.samples.get(metric_name) {
+            for sample in samples {
+                let dataset = sample
+                    .labels
+                    .get("name")
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
+                // Gauge: last value wins (overwrites previous).
+                map.insert(dataset, sample.value);
+            }
+        }
+    }
+
+    for (metric_name, map) in counter_metrics {
+        if let Some(samples) = metrics.samples.get(metric_name) {
+            for sample in samples {
+                let dataset = sample
+                    .labels
+                    .get("name")
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
+                // Counter: last observed value is the total.
+                map.insert(dataset, sample.value);
+            }
+        }
+    }
+
+    if lag_ms.is_empty() && inserts.is_empty() {
+        return;
+    }
+
+    println!("\n--- Replication Metrics (from spiced /metrics) ---");
+    // Header
+    println!(
+        "  {:<14} {:>10} {:>12} {:>10} {:>10} {:>10}",
+        "dataset", "lag_ms", "lag_bytes", "inserts", "updates", "deletes"
+    );
+
+    let all_datasets: BTreeMap<&String, ()> = lag_ms
+        .keys()
+        .chain(inserts.keys())
+        .map(|k| (k, ()))
+        .collect();
+
+    for dataset in all_datasets.keys() {
+        let l_ms = lag_ms.get(*dataset).copied().unwrap_or(0.0);
+        let l_bytes = lag_bytes.get(*dataset).copied().unwrap_or(0.0);
+        let ins = inserts.get(*dataset).copied().unwrap_or(0.0);
+        let upd = updates.get(*dataset).copied().unwrap_or(0.0);
+        let del = deletes.get(*dataset).copied().unwrap_or(0.0);
+        println!(
+            "  {:<14} {:>10.0} {:>12.0} {:>10.0} {:>10.0} {:>10.0}",
+            dataset, l_ms, l_bytes, ins, upd, del
+        );
+    }
 }

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -236,7 +236,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     let health_report = health_monitor.stop().await;
 
     if let Some(ref metrics) = spiced_metrics {
-        print_replication_metrics(metrics);
+        emit_replication_metrics(metrics);
     }
 
     telemetry.emit().await?;
@@ -263,8 +263,8 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Print per-dataset Postgres replication metrics scraped from spiced's `/metrics` endpoint.
-fn print_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
+/// Emits replication metrics scraped from spiced's `/metrics` endpoint.
+fn emit_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
     use std::collections::{BTreeMap, BTreeSet};
 
     // Collect replication metrics per dataset from scraped samples.
@@ -334,6 +334,7 @@ fn print_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
 
     let all_datasets: BTreeSet<&String> = lag_ms.keys().chain(inserts.keys()).collect();
 
+    let mut worst_lag_ms: f64 = 0.0;
     for dataset in &all_datasets {
         let l_ms = lag_ms.get(*dataset).copied().unwrap_or(0.0);
         let l_bytes = lag_bytes.get(*dataset).copied().unwrap_or(0.0);
@@ -343,5 +344,14 @@ fn print_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
         println!(
             "  {dataset:<14} {l_ms:>10.0} {l_bytes:>12.0} {ins:>10.0} {upd:>10.0} {del:>10.0}",
         );
+
+        crate::metrics::REPLICATION_LAG_MS
+            .record(l_ms, &[KeyValue::new("dataset", (*dataset).clone())]);
+        if l_ms > worst_lag_ms {
+            worst_lag_ms = l_ms;
+        }
     }
+
+    // Headline: worst replication lag across all datasets.
+    crate::metrics::REPLICATION_LAG_MS.record(worst_lag_ms, &[]);
 }

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -1,0 +1,226 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! HTAP test command — runs concurrent TPC-C OLTP workload against the source
+//! PostgreSQL database while executing CH-benCH analytical queries through spiced.
+
+use std::time::{Duration, Instant};
+
+use test_framework::{
+    TestType, anyhow,
+    git,
+    metrics::{MetricCollector, NoExtendedMetrics, QueryMetrics},
+    opentelemetry::KeyValue,
+    opentelemetry_sdk::Resource,
+    spiced::SpicedInstance,
+    spicetest::{
+        SpiceTest,
+        datasets::{EndCondition, NotStarted},
+    },
+    tokio_util::sync::CancellationToken,
+    utils::observe_memory,
+};
+
+use crate::{
+    args::HtapArgs,
+    commands::bench::chbench_config_from_env,
+    health::HealthMonitor,
+    spiced_metrics::MetricsScraper,
+    wait_test_and_memory,
+};
+
+pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
+    let test_args = &args.test_args;
+    let (app, start_request) = super::get_app_and_start_request(&test_args.common).await?;
+
+    // 1. Prepare the source (schema + seed data).
+    println!("Preparing chbench source...");
+    let mut config = chbench_config_from_env()?;
+    config.warehouses = args.warehouses;
+    config.terminals = args.terminals;
+    config.duration = Duration::from_secs(test_args.common.duration);
+    let driver = chbench_driver::ChBenchDriver::connect(config).await?;
+    driver.prepare().await?;
+    println!("chbench source is ready");
+
+    // 2. Start spiced.
+    let mut spiced_instance = SpicedInstance::start(start_request).await?;
+    let ready_wait_start = Instant::now();
+
+    let memory_token = CancellationToken::new();
+    let memory_readings = spiced_instance.process()?.watch_memory(&memory_token);
+
+    spiced_instance
+        .wait_for_ready(Duration::from_secs(test_args.common.ready_wait))
+        .await?;
+
+    let _ready_wait_duration = ready_wait_start.elapsed();
+
+    // Build telemetry resource.
+    let spiced_version = spiced_instance.version().to_string();
+    let spiced_commit_sha =
+        std::env::var("SPICED_COMMIT").unwrap_or_else(|_| "unknown".to_string());
+    let testoperator_commit_sha = git::get_commit_sha();
+    let branch_name = git::get_branch_name();
+    let query_set = test_args.load_query_set()?;
+
+    let benchmark_resource = Resource::builder_empty()
+        .with_attributes(vec![
+            KeyValue::new("service.name", "testoperator"),
+            KeyValue::new("type", "htap"),
+            KeyValue::new("name", app.name.clone()),
+            KeyValue::new("spiced_version", spiced_version),
+            KeyValue::new("query_set", query_set.to_string()),
+            KeyValue::new("testoperator_commit_sha", testoperator_commit_sha),
+            KeyValue::new("spiced_commit_sha", spiced_commit_sha),
+            KeyValue::new("branch_name", branch_name),
+        ])
+        .build();
+
+    let telemetry =
+        super::create_telemetry_with_resource(&test_args.common, benchmark_resource);
+
+    let health_monitor = HealthMonitor::spawn()?;
+
+    let metrics_scraper = if test_args.common.scrape_spiced_metrics {
+        Some(MetricsScraper::spawn()?)
+    } else {
+        None
+    };
+
+    // 3. Start the OLTP workload in the background.
+    let oltp_cancel = CancellationToken::new();
+    let oltp_handle = {
+        let cancel = oltp_cancel.clone();
+        tokio::spawn(async move { driver.run(cancel).await })
+    };
+
+    // 4. Run analytical queries through spiced concurrently with the OLTP load.
+    println!("Running HTAP analytical queries under OLTP load");
+
+    let executor = super::create_query_executor(test_args, &spiced_instance).await?;
+
+    let (_, test_builder) = super::build_test_with_validation(
+        test_args,
+        NotStarted::new()
+            .with_parallel_count(1)
+            .with_end_condition(EndCondition::Duration(Duration::from_secs(
+                test_args.common.duration,
+            )))
+            .with_validate(test_args.validate)
+            .with_scale_factor(test_args.scale_factor.unwrap_or(1.0))
+            .with_query_executor(executor),
+    )
+    .await?;
+
+    let benchmark_test = SpiceTest::new(app.name.clone(), test_builder)
+        .with_spiced_instance(spiced_instance)
+        .with_results_snapshot(|_| false) // No snapshots for HTAP — results change under OLTP
+        .with_progress_bars(!test_args.common.disable_progress_bars)
+        .start()?;
+
+    let test = wait_test_and_memory!(benchmark_test, memory_token, memory_readings);
+
+    // 5. Stop OLTP and collect results.
+    oltp_cancel.cancel();
+    let oltp_result = oltp_handle.await;
+
+    // Skip row count consistency validation — OLTP mutations cause row counts to vary between iterations.
+    let _metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Benchmark)?;
+    let test_succeeded = test.succeeded();
+    let mut spiced_instance = test.end()?;
+    let (_max_memory, _median_memory) = observe_memory(memory_token, memory_readings).await?;
+
+    // 6. Report analytical query metrics.
+    // TODO: Re-enable metrics reporting after reviewing/adjusting for HTAP workload.
+    let failures: Vec<String> = Vec::new();
+    // for query in &metrics.metrics {
+    //     let query_name = &query.query_name;
+    //     let row_count = row_counts.get(query_name).unwrap_or(&0);
+    //     let attributes = vec![KeyValue::new("query_name", query_name.to_string())];
+
+    //     let status: u64 = u64::from(match &query.query_status {
+    //         QueryStatus::Passed => true,
+    //         QueryStatus::Failed(reason) => {
+    //             if let Some(reason) = reason {
+    //                 failures.push(format!("{query_name}: {reason}"));
+    //             } else {
+    //                 failures.push(format!("{query_name}: failed with an undetermined error"));
+    //             }
+    //             false
+    //         }
+    //     });
+
+    //     crate::metrics::QUERY_STATUS.record(status, &attributes);
+    //     crate::metrics::MEDIAN_DURATION.record(query.median_duration_ms, &attributes);
+    //     crate::metrics::MIN_DURATION.record(query.min_duration_ms, &attributes);
+    //     crate::metrics::MAX_DURATION.record(query.max_duration_ms, &attributes);
+    //     crate::metrics::ITERATIONS.record(query.iterations.try_into()?, &attributes);
+    //     crate::metrics::P90_DURATION.record(query.percentile_90_duration_ms, &attributes);
+    //     crate::metrics::P95_DURATION.record(query.percentile_95_duration_ms, &attributes);
+    //     crate::metrics::P99_DURATION.record(query.percentile_99_duration_ms, &attributes);
+    // }
+
+    // crate::metrics::READY_DURATION.record(ready_wait_duration.as_millis().try_into()?, &[]);
+    // crate::metrics::TEST_DURATION
+    //     .record((metrics.finished_at - metrics.started_at).try_into()?, &[]);
+    // crate::metrics::PEAK_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
+    // crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
+
+    // super::bench::emit_acceleration_size_if_applicable(&app, &spiced_instance.get_tempdir_path()?)?;
+
+    // let records = metrics.with_memory_usage(max_memory).build_records()?;
+    // print_batches(&records)?;
+
+    // 7. Report OLTP results.
+    match oltp_result {
+        Ok(Ok(report)) => {
+            println!("\n--- OLTP Workload Summary ---");
+            report.print_summary();
+        }
+        Ok(Err(e)) => {
+            eprintln!("OLTP workload error: {e}");
+        }
+        Err(e) => {
+            eprintln!("OLTP task join error: {e}");
+        }
+    }
+
+    let health_report = health_monitor.stop().await;
+    super::process_spiced_metrics(metrics_scraper, test_args.common.metrics, &[]).await;
+    telemetry.emit().await?;
+    spiced_instance.stop()?;
+
+    let health_report = health_report?;
+    let mut error_messages = Vec::new();
+
+    if !test_succeeded {
+        error_messages.push(format!(
+            "HTAP test failed due to failed queries:\n{}",
+            failures.join("\n")
+        ));
+    }
+
+    if let Some(message) = health_report.failure_message() {
+        eprintln!("Warning: {message}");
+    }
+
+    if !error_messages.is_empty() {
+        return Err(anyhow::anyhow!(error_messages.join("\n")));
+    }
+
+    Ok(())
+}

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 //! HTAP test command — runs concurrent TPC-C OLTP workload against the source
-//! PostgreSQL database while executing CH-benCH analytical queries through spiced.
+//! Postgres database while executing CH-benCH analytical queries through spiced.
 
 mod staleness;
 
@@ -265,7 +265,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
 
 /// Print per-dataset Postgres replication metrics scraped from spiced's `/metrics` endpoint.
 fn print_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     // Collect replication metrics per dataset from scraped samples.
     // Gauges (lag_ms, lag_bytes): use the last observed value — represents the
@@ -332,21 +332,16 @@ fn print_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
         "dataset", "lag_ms", "lag_bytes", "inserts", "updates", "deletes"
     );
 
-    let all_datasets: BTreeMap<&String, ()> = lag_ms
-        .keys()
-        .chain(inserts.keys())
-        .map(|k| (k, ()))
-        .collect();
+    let all_datasets: BTreeSet<&String> = lag_ms.keys().chain(inserts.keys()).collect();
 
-    for dataset in all_datasets.keys() {
+    for dataset in &all_datasets {
         let l_ms = lag_ms.get(*dataset).copied().unwrap_or(0.0);
         let l_bytes = lag_bytes.get(*dataset).copied().unwrap_or(0.0);
         let ins = inserts.get(*dataset).copied().unwrap_or(0.0);
         let upd = updates.get(*dataset).copied().unwrap_or(0.0);
         let del = deletes.get(*dataset).copied().unwrap_or(0.0);
         println!(
-            "  {:<14} {:>10.0} {:>12.0} {:>10.0} {:>10.0} {:>10.0}",
-            dataset, l_ms, l_bytes, ins, upd, del
+            "  {dataset:<14} {l_ms:>10.0} {l_bytes:>12.0} {ins:>10.0} {upd:>10.0} {del:>10.0}",
         );
     }
 }

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -19,6 +19,7 @@ limitations under the License.
 
 mod staleness;
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use test_framework::{
@@ -38,11 +39,8 @@ use test_framework::{
 };
 
 use crate::{
-    args::HtapArgs,
-    commands::bench::chbench_config_from_env,
-    health::HealthMonitor,
-    spiced_metrics::MetricsScraper,
-    wait_test_and_memory,
+    args::HtapArgs, commands::bench::chbench_config_from_env, health::HealthMonitor,
+    spiced_metrics::MetricsScraper, wait_test_and_memory,
 };
 
 pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
@@ -56,13 +54,20 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     }
 
     // 1. Prepare the source (schema + seed data).
-    println!("Preparing chbench source...");
-    let mut config = chbench_config_from_env()?;
-    config.warehouses = args.warehouses;
-    config.terminals = args.terminals;
+    // CH-benCH convention: scale_factor = warehouses, terminals = warehouses * 10.
+    let scale_factor = test_args.scale_factor.unwrap_or(1.0);
+    let warehouses = scale_factor as usize;
+    let terminals = warehouses * 10;
+
+    println!(
+        "Preparing chbench source (SF{scale_factor}: {warehouses} warehouse(s), {terminals} terminals)..."
+    );
+    let (mut config, source) = chbench_config_from_env()?;
+    config.warehouses = warehouses;
+    config.terminals = terminals;
     config.duration = Duration::from_secs(test_args.common.duration);
-    let pg_connection_string = config.pg_connection_string();
-    let driver = chbench_driver::ChBenchDriver::connect(config).await?;
+    let driver: Arc<dyn chbench_driver::ChBenchDriver> =
+        Arc::new(chbench_driver::PostgresChBenchDriver::connect(config, source).await?);
     driver.prepare().await?;
     println!("chbench source is ready");
 
@@ -97,11 +102,11 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
             KeyValue::new("testoperator_commit_sha", testoperator_commit_sha),
             KeyValue::new("spiced_commit_sha", spiced_commit_sha),
             KeyValue::new("branch_name", branch_name),
+            KeyValue::new("scale_factor", scale_factor.to_string()),
         ])
         .build();
 
-    let telemetry =
-        super::create_telemetry_with_resource(&test_args.common, benchmark_resource);
+    let telemetry = super::create_telemetry_with_resource(&test_args.common, benchmark_resource);
 
     let health_monitor = HealthMonitor::spawn()?;
 
@@ -112,13 +117,14 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     let oltp_cancel = CancellationToken::new();
     let oltp_handle = {
         let cancel = oltp_cancel.clone();
+        let driver = Arc::clone(&driver);
         tokio::spawn(async move { driver.run(cancel).await })
     };
 
     // 3b. Start staleness probe alongside the OLTP workload.
     let staleness_spice_client = spiced_instance.spice_client(None, false).await?;
     let staleness_handle = staleness::spawn_staleness_probe(
-        pg_connection_string,
+        Arc::clone(&driver),
         staleness_spice_client,
         oltp_cancel.clone(),
     );
@@ -201,12 +207,13 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
 
     let records = metrics.with_memory_usage(max_memory).build_records()?;
+    println!("\n=== Analytical Queries ===");
     print_batches(&records)?;
 
     // 7. Report OLTP results.
+    println!("\n=== TPC-C OLTP ===");
     match oltp_result {
         Ok(Ok(report)) => {
-            println!("\n--- OLTP Workload Summary ---");
             report.print_summary();
         }
         Ok(Err(e)) => {
@@ -217,10 +224,10 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         }
     }
 
-    // 8. Report staleness gap.
+    // 8. Report data freshness and replication metrics.
     match staleness_result {
         Ok(Ok(report)) => {
-            report.print_summary();
+            report.emit();
         }
         Ok(Err(e)) => {
             eprintln!("Staleness probe error: {e}");
@@ -232,7 +239,6 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
 
     let health_report = health_monitor.stop().await;
 
-    // 10. Report native replication metrics from spiced /metrics endpoint.
     if let Some(ref metrics) = spiced_metrics {
         print_replication_metrics(metrics);
     }
@@ -276,11 +282,17 @@ fn print_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
     let mut deletes: BTreeMap<String, f64> = BTreeMap::new();
 
     let gauge_metrics = [
-        ("dataset_postgres_replication_lag_ms", &mut lag_ms as &mut BTreeMap<String, f64>),
+        (
+            "dataset_postgres_replication_lag_ms",
+            &mut lag_ms as &mut BTreeMap<String, f64>,
+        ),
         ("dataset_postgres_replication_lag_bytes", &mut lag_bytes),
     ];
     let counter_metrics = [
-        ("dataset_postgres_replication_inserts_total", &mut inserts as &mut BTreeMap<String, f64>),
+        (
+            "dataset_postgres_replication_inserts_total",
+            &mut inserts as &mut BTreeMap<String, f64>,
+        ),
         ("dataset_postgres_replication_updates_total", &mut updates),
         ("dataset_postgres_replication_deletes_total", &mut deletes),
     ];
@@ -317,7 +329,7 @@ fn print_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
         return;
     }
 
-    println!("\n--- Replication Metrics (from spiced /metrics) ---");
+    println!("\nReplication Metrics (last scrape from spiced)");
     // Header
     println!(
         "  {:<14} {:>10} {:>12} {:>10} {:>10} {:>10}",

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -29,6 +29,7 @@ use test_framework::{
     metrics::{MetricCollector, NoExtendedMetrics, QueryMetrics, QueryStatus},
     opentelemetry::KeyValue,
     opentelemetry_sdk::Resource,
+    queries::QuerySet,
     spiced::SpicedInstance,
     spicetest::{
         SpiceTest,
@@ -39,13 +40,21 @@ use test_framework::{
 };
 
 use crate::{
-    args::HtapArgs, commands::bench::chbench_config_from_env, health::HealthMonitor,
+    args::HtapArgs, commands::bench::prepare_chbench_source, health::HealthMonitor,
     spiced_metrics::MetricsScraper, wait_test_and_memory,
 };
 
 pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     let test_args = &args.test_args;
     let (app, mut start_request) = super::get_app_and_start_request(&test_args.common).await?;
+
+    let query_set = test_args.load_query_set()?;
+    if !matches!(query_set, QuerySet::ChBench) {
+        anyhow::bail!(
+            "HTAP command requires the 'chbench' query set, but got '{query_set}'. \
+             Use '--query-set chbench' or run 'testoperator run bench' for other query sets."
+        );
+    }
 
     // Always enable the metrics endpoint in HTAP mode for replication metrics.
     if !test_args.common.scrape_spiced_metrics {
@@ -54,22 +63,10 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     }
 
     // 1. Prepare the source (schema + seed data).
-    // CH-benCH convention: scale_factor = warehouses, terminals = warehouses * 10.
     let scale_factor = test_args.scale_factor.unwrap_or(1.0);
-    let warehouses = scale_factor as usize;
-    let terminals = warehouses * 10;
-
-    println!(
-        "Preparing chbench source (SF{scale_factor}: {warehouses} warehouse(s), {terminals} terminals)..."
-    );
-    let (mut config, source) = chbench_config_from_env()?;
-    config.warehouses = warehouses;
-    config.terminals = terminals;
-    config.duration = Duration::from_secs(test_args.common.duration);
+    let duration = Duration::from_secs(test_args.common.duration);
     let driver: Arc<dyn chbench_driver::ChBenchDriver> =
-        Arc::new(chbench_driver::PostgresChBenchDriver::connect(config, source).await?);
-    driver.prepare().await?;
-    println!("chbench source is ready");
+        Arc::new(prepare_chbench_source(scale_factor, Some(duration)).await?);
 
     // 2. Start spiced.
     let mut spiced_instance = SpicedInstance::start(start_request).await?;
@@ -90,7 +87,6 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         std::env::var("SPICED_COMMIT").unwrap_or_else(|_| "unknown".to_string());
     let testoperator_commit_sha = git::get_commit_sha();
     let branch_name = git::get_branch_name();
-    let query_set = test_args.load_query_set()?;
 
     let benchmark_resource = Resource::builder_empty()
         .with_attributes(vec![

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -99,6 +99,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
             KeyValue::new("spiced_commit_sha", spiced_commit_sha),
             KeyValue::new("branch_name", branch_name),
             KeyValue::new("scale_factor", scale_factor.to_string()),
+            KeyValue::new("duration_secs", duration.as_secs().to_string()),
         ])
         .build();
 

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -118,7 +118,8 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     };
 
     // 3b. Start staleness probe alongside the OLTP workload.
-    let staleness_spice_client = spiced_instance.spice_client(None, false).await?;
+    // Disable caching so MAX(_bench_ts) always reflects the latest replicated data.
+    let staleness_spice_client = spiced_instance.spice_client(None, true).await?;
     let staleness_handle = staleness::spawn_staleness_probe(
         Arc::clone(&driver),
         staleness_spice_client,
@@ -168,7 +169,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     let mut spiced_instance = test.end()?;
     let (max_memory, median_memory) = observe_memory(memory_token, memory_readings).await?;
 
-    // 6. Report analytical query metrics.
+    // 7. Report analytical query metrics.
     let mut failures: Vec<String> = Vec::new();
     for query in &metrics.metrics {
         let query_name = &query.query_name;
@@ -206,7 +207,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     println!("\n=== Analytical Queries ===");
     print_batches(&records)?;
 
-    // 7. Report OLTP results.
+    // 8. Report OLTP results.
     println!("\n=== TPC-C OLTP ===");
     match oltp_result {
         Ok(Ok(report)) => {
@@ -220,7 +221,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         }
     }
 
-    // 8. Report data freshness and replication metrics.
+    // 9. Report data freshness and replication metrics.
     match staleness_result {
         Ok(Ok(report)) => {
             report.emit();

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -69,15 +69,17 @@ impl StalenessReport {
                     stats.max.as_millis(),
                     stats.samples,
                 );
-                crate::metrics::DATA_FRESHNESS_P99.record(
-                    stats.p99.as_millis() as f64,
-                    &[KeyValue::new("table", table.clone())],
-                );
+                #[expect(clippy::cast_precision_loss)]
+                let p99_ms = stats.p99.as_millis() as f64;
+                crate::metrics::DATA_FRESHNESS_P99
+                    .record(p99_ms, &[KeyValue::new("table", table.clone())]);
             }
         }
         println!("  ─────────────────");
         println!("  worst P99:     {}ms", self.worst_p99.as_millis());
-        crate::metrics::DATA_FRESHNESS_P99.record(self.worst_p99.as_millis() as f64, &[]);
+        #[expect(clippy::cast_precision_loss)]
+        let worst_ms = self.worst_p99.as_millis() as f64;
+        crate::metrics::DATA_FRESHNESS_P99.record(worst_ms, &[]);
     }
 }
 
@@ -221,10 +223,15 @@ fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -
 
         gaps.sort_unstable();
         let n = gaps.len();
-        let p50 = Duration::from_micros(gaps[n / 2] as u64);
+        let p50 = Duration::from_micros(gaps[n / 2].cast_unsigned());
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
         let p99_idx = (n as f64 * 0.99).ceil() as usize;
-        let p99 = Duration::from_micros(gaps[p99_idx.min(n - 1)] as u64);
-        let max = Duration::from_micros(gaps[n - 1] as u64);
+        let p99 = Duration::from_micros(gaps[p99_idx.min(n - 1)].cast_unsigned());
+        let max = Duration::from_micros(gaps[n - 1].cast_unsigned());
 
         if p99 > worst_p99 {
             worst_p99 = p99;

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -28,7 +28,6 @@ use std::time::Duration;
 
 use arrow::array::{Array, TimestampMicrosecondArray};
 use arrow::datatypes::DataType;
-use arrow::record_batch::RecordBatch;
 use chbench_driver::ChBenchDriver;
 use futures::TryStreamExt;
 use test_framework::anyhow;
@@ -161,10 +160,9 @@ async fn query_max_bench_ts_spice(
     table: &str,
 ) -> anyhow::Result<Option<i64>> {
     let query = format!("SELECT MAX(_bench_ts) AS max_ts FROM {table}");
-    let stream = client.sql(&query).await?;
-    let batches = stream.try_collect::<Vec<RecordBatch>>().await?;
+    let mut stream = client.sql(&query).await?;
 
-    for batch in &batches {
+    while let Some(batch) = stream.try_next().await? {
         if batch.num_rows() == 0 {
             continue;
         }

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -71,7 +71,7 @@ impl StalenessReport {
                 #[expect(clippy::cast_precision_loss)]
                 let p99_ms = stats.p99.as_millis() as f64;
                 crate::metrics::DATA_FRESHNESS_P99
-                    .record(p99_ms, &[KeyValue::new("table", table.clone())]);
+                    .record(p99_ms, &[KeyValue::new("dataset", table.clone())]);
             }
         }
         println!("  ─────────────────");

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -221,14 +221,20 @@ fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -
 
         gaps.sort_unstable();
         let n = gaps.len();
-        let p50 = Duration::from_micros(gaps[n / 2].cast_unsigned());
-        #[expect(
-            clippy::cast_precision_loss,
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss
-        )]
-        let p99_idx = (n as f64 * 0.99).ceil() as usize;
-        let p99 = Duration::from_micros(gaps[p99_idx.min(n - 1)].cast_unsigned());
+
+        // Use the same nearest-rank percentile formula as `QueryLiveness::percentile`.
+        let pct = |p: f64| -> usize {
+            #[expect(
+                clippy::cast_precision_loss,
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss
+            )]
+            let idx = (p * (n - 1) as f64).round() as usize;
+            idx.min(n - 1)
+        };
+
+        let p50 = Duration::from_micros(gaps[pct(0.50)].cast_unsigned());
+        let p99 = Duration::from_micros(gaps[pct(0.99)].cast_unsigned());
         let max = Duration::from_micros(gaps[n - 1].cast_unsigned());
 
         if p99 > worst_p99 {

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -1,0 +1,276 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Staleness gap measurement for HTAP benchmarks.
+//!
+//! Probes 4 TPC-C tables every ~100ms by comparing `MAX(_bench_ts)` between the
+//! Postgres source and the Spice accelerated copy. The gap is the replication
+//! staleness — how far behind Spice is from the source at any given moment.
+//!
+//! Probe tables (selected for diversity of CDC code paths):
+//! - `district`: small (10 rows), pipeline baseline
+//! - `order_line`: high write volume (300K+ rows), 4-column PK
+//! - `new_order`: exercises DELETE path (Delivery removes oldest orders)
+//! - `history`: append-only, no primary key
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use arrow::array::{Array, TimestampMicrosecondArray};
+use arrow::datatypes::DataType;
+use arrow::record_batch::RecordBatch;
+use chbench_driver::schema::STALENESS_PROBE_TABLES;
+use futures::TryStreamExt;
+use test_framework::anyhow;
+use tokio_util::sync::CancellationToken;
+
+/// Per-table staleness statistics.
+#[derive(Debug, Clone)]
+pub struct StalenessStats {
+    pub p50: Duration,
+    pub p99: Duration,
+    pub max: Duration,
+    pub samples: u64,
+}
+
+/// Staleness report across all probed tables.
+#[derive(Debug)]
+pub struct StalenessReport {
+    /// Per-table staleness statistics.
+    pub tables: HashMap<String, StalenessStats>,
+    /// Headline metric: worst-case P99 across all tables.
+    pub headline_p99: Duration,
+}
+
+impl StalenessReport {
+    /// Print a human-readable staleness summary.
+    pub fn print_summary(&self) {
+        println!("\n--- Staleness Gap ---");
+        for table in STALENESS_PROBE_TABLES {
+            if let Some(stats) = self.tables.get(*table) {
+                println!(
+                    "  {:<14} P50={:>5}ms  P99={:>5}ms  max={:>5}ms  ({} samples)",
+                    format!("{table}:"),
+                    stats.p50.as_millis(),
+                    stats.p99.as_millis(),
+                    stats.max.as_millis(),
+                    stats.samples,
+                );
+            }
+        }
+        println!("  ─────────────────");
+        println!(
+            "  headline P99:  {}ms (worst-case)",
+            self.headline_p99.as_millis()
+        );
+    }
+}
+
+/// Spawn a background task that probes staleness until cancelled.
+///
+/// Returns a `JoinHandle` that resolves to a `StalenessReport`.
+pub fn spawn_staleness_probe(
+    pg_connection_string: String,
+    spice_client: spiceai::Client,
+    cancel: CancellationToken,
+) -> tokio::task::JoinHandle<anyhow::Result<StalenessReport>> {
+    tokio::spawn(async move {
+        run_staleness_probe(&pg_connection_string, spice_client, cancel).await
+    })
+}
+
+/// Core probe loop. Runs until cancelled, collecting gap samples for each table.
+async fn run_staleness_probe(
+    pg_conn_str: &str,
+    spice_client: spiceai::Client,
+    cancel: CancellationToken,
+) -> anyhow::Result<StalenessReport> {
+    let poll_interval = Duration::from_millis(100);
+
+    // Connect to Postgres source.
+    let (pg_client, pg_connection) =
+        tokio_postgres::connect(pg_conn_str, tokio_postgres::NoTls).await?;
+    let pg_cancel = cancel.clone();
+    tokio::spawn(async move {
+        tokio::select! {
+            result = pg_connection => {
+                if let Err(e) = result {
+                    eprintln!("Staleness probe Postgres connection error: {e}");
+                }
+            }
+            () = pg_cancel.cancelled() => {}
+        }
+    });
+
+    // Per-table gap samples (microseconds).
+    let mut samples: HashMap<String, Vec<i64>> = STALENESS_PROBE_TABLES
+        .iter()
+        .map(|t| ((*t).to_string(), Vec::new()))
+        .collect();
+
+    // Wait briefly for initial data to be loaded and replicated before probing.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    loop {
+        if cancel.is_cancelled() {
+            break;
+        }
+
+        for table in STALENESS_PROBE_TABLES {
+            // Query both endpoints concurrently.
+            let (pg_result, spice_result) = tokio::join!(
+                query_max_bench_ts_pg(&pg_client, table),
+                query_max_bench_ts_spice(&spice_client, table),
+            );
+
+            // After awaiting queries, re-check cancellation to avoid
+            // logging benign "connection closed" errors during shutdown.
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            match (pg_result, spice_result) {
+                (Ok(Some(pg_ts)), Ok(Some(spice_ts))) => {
+                    let gap_us = (pg_ts - spice_ts).max(0);
+                    if let Some(table_samples) = samples.get_mut(*table) {
+                        table_samples.push(gap_us);
+                    }
+                }
+                (pg, spice) => {
+                    eprintln!("Staleness probe: {table} pg={pg:?} spice={spice:?}");
+                }
+            }
+        }
+
+        tokio::select! {
+            () = tokio::time::sleep(poll_interval) => {}
+            () = cancel.cancelled() => { break; }
+        }
+    }
+
+    Ok(build_report(samples))
+}
+
+/// Query `MAX(_bench_ts)` from Postgres, returning microseconds since epoch.
+///
+/// Retrieves the `TIMESTAMPTZ` value directly (via `tokio-postgres`'s `with-chrono-0_4`
+/// feature) and converts to microseconds.
+async fn query_max_bench_ts_pg(
+    client: &tokio_postgres::Client,
+    table: &str,
+) -> anyhow::Result<Option<i64>> {
+    let query = format!("SELECT MAX(_bench_ts) FROM {table}");
+    let rows = client.query(&query, &[]).await?;
+    if rows.is_empty() {
+        return Ok(None);
+    }
+    let ts: Option<chrono::DateTime<chrono::Utc>> = rows[0].get(0);
+    Ok(ts.map(|t| t.timestamp_micros()))
+}
+
+/// Query `MAX(_bench_ts)` from Spice via Flight SQL, returning microseconds since epoch.
+async fn query_max_bench_ts_spice(
+    client: &spiceai::Client,
+    table: &str,
+) -> anyhow::Result<Option<i64>> {
+    let query = format!("SELECT MAX(_bench_ts) AS max_ts FROM {table}");
+    let stream = client.sql(&query).await?;
+    let batches = stream.try_collect::<Vec<RecordBatch>>().await?;
+
+    for batch in &batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let col = batch.column(0);
+
+        // Handle both Timestamp(Microsecond, _) and Timestamp(Nanosecond, _).
+        match col.data_type() {
+            DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, _) => {
+                let arr = col
+                    .as_any()
+                    .downcast_ref::<TimestampMicrosecondArray>()
+                    .ok_or_else(|| anyhow::anyhow!("unexpected array type for _bench_ts"))?;
+                if !arr.is_null(0) {
+                    return Ok(Some(arr.value(0)));
+                }
+            }
+            DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, _) => {
+                let arr = col
+                    .as_any()
+                    .downcast_ref::<arrow::array::TimestampNanosecondArray>()
+                    .ok_or_else(|| anyhow::anyhow!("unexpected array type for _bench_ts"))?;
+                if !arr.is_null(0) {
+                    // Convert nanoseconds to microseconds.
+                    return Ok(Some(arr.value(0) / 1_000));
+                }
+            }
+            other => {
+                return Err(anyhow::anyhow!(
+                    "unexpected data type for MAX(_bench_ts): {other:?}"
+                ));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Build the final report from raw gap samples (in microseconds).
+fn build_report(samples: HashMap<String, Vec<i64>>) -> StalenessReport {
+    let mut tables = HashMap::new();
+    let mut worst_p99 = Duration::ZERO;
+
+    for (table, mut gaps) in samples {
+        if gaps.is_empty() {
+            tables.insert(
+                table,
+                StalenessStats {
+                    p50: Duration::ZERO,
+                    p99: Duration::ZERO,
+                    max: Duration::ZERO,
+                    samples: 0,
+                },
+            );
+            continue;
+        }
+
+        gaps.sort_unstable();
+        let n = gaps.len();
+        let p50 = Duration::from_micros(gaps[n / 2] as u64);
+        let p99_idx = (n as f64 * 0.99).ceil() as usize;
+        let p99 = Duration::from_micros(gaps[p99_idx.min(n - 1)] as u64);
+        let max = Duration::from_micros(gaps[n - 1] as u64);
+
+        if p99 > worst_p99 {
+            worst_p99 = p99;
+        }
+
+        tables.insert(
+            table,
+            StalenessStats {
+                p50,
+                p99,
+                max,
+                samples: n as u64,
+            },
+        );
+    }
+
+    StalenessReport {
+        tables,
+        headline_p99: worst_p99,
+    }
+}

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -16,25 +16,23 @@ limitations under the License.
 
 //! Staleness gap measurement for HTAP benchmarks.
 //!
-//! Probes 4 TPC-C tables every ~100ms by comparing `MAX(_bench_ts)` between the
-//! Postgres source and the Spice accelerated copy. The gap is the replication
+//! Probes TPC-C tables every ~100ms by comparing `MAX(_bench_ts)` between the
+//! source and the Spice accelerated copy. The gap is the replication
 //! staleness — how far behind Spice is from the source at any given moment.
 //!
-//! Probe tables (selected for diversity of CDC code paths):
-//! - `district`: small (10 rows), pipeline baseline
-//! - `order_line`: high write volume (300K+ rows), 4-column PK
-//! - `new_order`: exercises DELETE path (Delivery removes oldest orders)
-//! - `history`: append-only, no primary key
+//! Which tables are probed is determined by the driver's `probe_tables()` method.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use arrow::array::{Array, TimestampMicrosecondArray};
 use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
-use chbench_driver::schema::STALENESS_PROBE_TABLES;
+use chbench_driver::ChBenchDriver;
 use futures::TryStreamExt;
 use test_framework::anyhow;
+use test_framework::opentelemetry::KeyValue;
 use tokio_util::sync::CancellationToken;
 
 /// Per-table staleness statistics.
@@ -46,21 +44,23 @@ pub struct StalenessStats {
     pub samples: u64,
 }
 
-/// Staleness report across all probed tables.
+/// Data freshness report across all probed tables.
 #[derive(Debug)]
 pub struct StalenessReport {
     /// Per-table staleness statistics.
     pub tables: HashMap<String, StalenessStats>,
-    /// Headline metric: worst-case P99 across all tables.
-    pub headline_p99: Duration,
+    /// Ordered list of probed table names (for consistent output).
+    pub probe_tables: Vec<String>,
+    /// Worst-case P99 across all tables.
+    pub worst_p99: Duration,
 }
 
 impl StalenessReport {
-    /// Print a human-readable staleness summary.
-    pub fn print_summary(&self) {
-        println!("\n--- Staleness Gap ---");
-        for table in STALENESS_PROBE_TABLES {
-            if let Some(stats) = self.tables.get(*table) {
+    /// Print a human-readable data freshness summary and record OTEL metrics.
+    pub fn emit(&self) {
+        println!("\nData Freshness");
+        for table in &self.probe_tables {
+            if let Some(stats) = self.tables.get(table.as_str()) {
                 println!(
                     "  {:<14} P50={:>5}ms  P99={:>5}ms  max={:>5}ms  ({} samples)",
                     format!("{table}:"),
@@ -69,12 +69,20 @@ impl StalenessReport {
                     stats.max.as_millis(),
                     stats.samples,
                 );
+                crate::metrics::DATA_FRESHNESS_P99.record(
+                    stats.p99.as_millis() as f64,
+                    &[KeyValue::new("table", table.clone())],
+                );
             }
         }
         println!("  ─────────────────");
         println!(
-            "  headline P99:  {}ms (worst-case)",
-            self.headline_p99.as_millis()
+            "  worst P99:     {}ms",
+            self.worst_p99.as_millis()
+        );
+        crate::metrics::DATA_FRESHNESS_P99.record(
+            self.worst_p99.as_millis() as f64,
+            &[],
         );
     }
 }
@@ -83,43 +91,32 @@ impl StalenessReport {
 ///
 /// Returns a `JoinHandle` that resolves to a `StalenessReport`.
 pub fn spawn_staleness_probe(
-    pg_connection_string: String,
+    driver: Arc<dyn ChBenchDriver>,
     spice_client: spiceai::Client,
     cancel: CancellationToken,
 ) -> tokio::task::JoinHandle<anyhow::Result<StalenessReport>> {
     tokio::spawn(async move {
-        run_staleness_probe(&pg_connection_string, spice_client, cancel).await
+        run_staleness_probe(driver, spice_client, cancel).await
     })
 }
 
 /// Core probe loop. Runs until cancelled, collecting gap samples for each table.
 async fn run_staleness_probe(
-    pg_conn_str: &str,
+    driver: Arc<dyn ChBenchDriver>,
     spice_client: spiceai::Client,
     cancel: CancellationToken,
 ) -> anyhow::Result<StalenessReport> {
     let poll_interval = Duration::from_millis(100);
-
-    // Connect to Postgres source.
-    let (pg_client, pg_connection) =
-        tokio_postgres::connect(pg_conn_str, tokio_postgres::NoTls).await?;
-    let pg_cancel = cancel.clone();
-    tokio::spawn(async move {
-        tokio::select! {
-            result = pg_connection => {
-                if let Err(e) = result {
-                    eprintln!("Staleness probe Postgres connection error: {e}");
-                }
-            }
-            () = pg_cancel.cancelled() => {}
-        }
-    });
+    let probe_tables = driver.probe_tables();
 
     // Per-table gap samples (microseconds).
-    let mut samples: HashMap<String, Vec<i64>> = STALENESS_PROBE_TABLES
+    let mut samples: HashMap<String, Vec<i64>> = probe_tables
         .iter()
         .map(|t| ((*t).to_string(), Vec::new()))
         .collect();
+
+    // Ordered list of table names for consistent report output.
+    let probe_table_names: Vec<String> = probe_tables.iter().map(|t| (*t).to_string()).collect();
 
     // Wait briefly for initial data to be loaded and replicated before probing.
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -129,10 +126,10 @@ async fn run_staleness_probe(
             break;
         }
 
-        for table in STALENESS_PROBE_TABLES {
+        for table in probe_tables {
             // Query both endpoints concurrently.
-            let (pg_result, spice_result) = tokio::join!(
-                query_max_bench_ts_pg(&pg_client, table),
+            let (source_result, spice_result) = tokio::join!(
+                driver.max_bench_ts(table),
                 query_max_bench_ts_spice(&spice_client, table),
             );
 
@@ -142,15 +139,15 @@ async fn run_staleness_probe(
                 break;
             }
 
-            match (pg_result, spice_result) {
-                (Ok(Some(pg_ts)), Ok(Some(spice_ts))) => {
-                    let gap_us = (pg_ts - spice_ts).max(0);
+            match (source_result, spice_result) {
+                (Ok(Some(source_ts)), Ok(Some(spice_ts))) => {
+                    let gap_us = (source_ts - spice_ts).max(0);
                     if let Some(table_samples) = samples.get_mut(*table) {
                         table_samples.push(gap_us);
                     }
                 }
-                (pg, spice) => {
-                    eprintln!("Staleness probe: {table} pg={pg:?} spice={spice:?}");
+                (source, spice) => {
+                    eprintln!("Staleness probe: {table} source={source:?} spice={spice:?}");
                 }
             }
         }
@@ -161,24 +158,7 @@ async fn run_staleness_probe(
         }
     }
 
-    Ok(build_report(samples))
-}
-
-/// Query `MAX(_bench_ts)` from Postgres, returning microseconds since epoch.
-///
-/// Retrieves the `TIMESTAMPTZ` value directly (via `tokio-postgres`'s `with-chrono-0_4`
-/// feature) and converts to microseconds.
-async fn query_max_bench_ts_pg(
-    client: &tokio_postgres::Client,
-    table: &str,
-) -> anyhow::Result<Option<i64>> {
-    let query = format!("SELECT MAX(_bench_ts) FROM {table}");
-    let rows = client.query(&query, &[]).await?;
-    if rows.is_empty() {
-        return Ok(None);
-    }
-    let ts: Option<chrono::DateTime<chrono::Utc>> = rows[0].get(0);
-    Ok(ts.map(|t| t.timestamp_micros()))
+    Ok(build_report(samples, probe_table_names))
 }
 
 /// Query `MAX(_bench_ts)` from Spice via Flight SQL, returning microseconds since epoch.
@@ -229,7 +209,7 @@ async fn query_max_bench_ts_spice(
 }
 
 /// Build the final report from raw gap samples (in microseconds).
-fn build_report(samples: HashMap<String, Vec<i64>>) -> StalenessReport {
+fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -> StalenessReport {
     let mut tables = HashMap::new();
     let mut worst_p99 = Duration::ZERO;
 
@@ -271,6 +251,7 @@ fn build_report(samples: HashMap<String, Vec<i64>>) -> StalenessReport {
 
     StalenessReport {
         tables,
-        headline_p99: worst_p99,
+        probe_tables,
+        worst_p99,
     }
 }

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -76,14 +76,8 @@ impl StalenessReport {
             }
         }
         println!("  ─────────────────");
-        println!(
-            "  worst P99:     {}ms",
-            self.worst_p99.as_millis()
-        );
-        crate::metrics::DATA_FRESHNESS_P99.record(
-            self.worst_p99.as_millis() as f64,
-            &[],
-        );
+        println!("  worst P99:     {}ms", self.worst_p99.as_millis());
+        crate::metrics::DATA_FRESHNESS_P99.record(self.worst_p99.as_millis() as f64, &[]);
     }
 }
 
@@ -95,9 +89,7 @@ pub fn spawn_staleness_probe(
     spice_client: spiceai::Client,
     cancel: CancellationToken,
 ) -> tokio::task::JoinHandle<anyhow::Result<StalenessReport>> {
-    tokio::spawn(async move {
-        run_staleness_probe(driver, spice_client, cancel).await
-    })
+    tokio::spawn(async move { run_staleness_probe(driver, spice_client, cancel).await })
 }
 
 /// Core probe loop. Runs until cancelled, collecting gap samples for each table.

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod append;
 pub(crate) mod bench;
 pub(crate) mod data_consistency;
 pub(crate) mod dispatch;
+pub(crate) mod htap;
 pub(crate) mod load;
 pub(crate) mod query;
 pub(crate) mod schema;

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -24,8 +24,8 @@ mod metrics;
 mod spiced_metrics;
 
 use args::{
-    Commands, DataConsistencyArgs, DatasetTestArgs, LoadTestArgs, SchemaTestArgs, TestCommands,
-    TextToSqlArgs,
+    Commands, DataConsistencyArgs, DatasetTestArgs, HtapArgs, LoadTestArgs, SchemaTestArgs,
+    TestCommands, TextToSqlArgs,
 };
 
 use crate::args::SearchTestArgs;
@@ -56,6 +56,10 @@ async fn main() -> anyhow::Result<()> {
             | TestCommands::TextToSql(TextToSqlArgs { common, .. })
             | TestCommands::Schema(SchemaTestArgs { common, .. })
             | TestCommands::DataConsistency(DataConsistencyArgs {
+                test_args: DatasetTestArgs { common, .. },
+                ..
+            })
+            | TestCommands::Htap(HtapArgs {
                 test_args: DatasetTestArgs { common, .. },
                 ..
             }),
@@ -103,6 +107,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Run(TestCommands::Schema(args)) => {
             commands::schema::run(&args).await?;
+        }
+        Commands::Run(TestCommands::Htap(args)) => {
+            commands::htap::run(&args).await?;
         }
         Commands::Export(TestCommands::StreamingDynamodbCorrectness(_)) => {
             return Err(anyhow::anyhow!(

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -528,3 +528,13 @@ pub static CORRECTNESS_ROUNDS_FAILED: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .with_unit("rounds")
         .build()
 });
+
+// HTAP data freshness metrics
+
+pub static DATA_FRESHNESS_P99: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("data_freshness_p99_ms")
+        .with_description("P99 data freshness gap between source and accelerator. Use 'table' attribute for per-table values; omit for worst-case across all tables.")
+        .with_unit("ms")
+        .build()
+});

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -530,11 +530,10 @@ pub static CORRECTNESS_ROUNDS_FAILED: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 });
 
 // HTAP data freshness metrics
-
 pub static DATA_FRESHNESS_P99: LazyLock<Gauge<f64>> = LazyLock::new(|| {
     meter()
         .f64_gauge("data_freshness_p99_ms")
-        .with_description("P99 data freshness gap between source and accelerator. Use 'table' attribute for per-table values; omit for worst-case across all tables.")
+        .with_description("P99 data freshness gap between source and accelerator.")
         .with_unit("ms")
         .build()
 });

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -533,7 +533,15 @@ pub static CORRECTNESS_ROUNDS_FAILED: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 pub static DATA_FRESHNESS_P99: LazyLock<Gauge<f64>> = LazyLock::new(|| {
     meter()
         .f64_gauge("data_freshness_p99_ms")
-        .with_description("P99 data freshness gap between source and accelerator.")
+        .with_description("P99 data freshness gap between source and accelerator per dataset.")
+        .with_unit("ms")
+        .build()
+});
+
+pub static REPLICATION_LAG_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("replication_lag_ms")
+        .with_description("Replication lag from source to accelerator per dataset.")
         .with_unit("ms")
         .build()
 });

--- a/tools/testoperator/src/spiced_metrics.rs
+++ b/tools/testoperator/src/spiced_metrics.rs
@@ -28,7 +28,6 @@ const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 #[derive(Debug, Clone)]
 pub struct MetricSample {
     pub name: String,
-    #[cfg_attr(not(test), expect(dead_code))]
     pub labels: HashMap<String, String>,
     pub value: f64,
     pub metric_type: MetricType,


### PR DESCRIPTION
## 📝 Summary

Adds initial support for CH-benCHmark (HTAP) — a mixed OLTP/OLAP benchmark that runs TPC-C transactional workload (data modification that is replicated to Spice via changes stream) concurrently with 22 TPC-H-derived analytical queries against the Spice accelerated tables, measuring data freshness and CDC/replication performance under sustained RW load.

 - https://dl.acm.org/doi/epdf/10.1145/1988842.1988850
 - https://github.com/spiceai/spiceai/issues/10790

## What's included

### `chbench-driver` crate (new)
Simulates a TPC-C OLTP workload (NewOrder/Payment/Delivery/OrderStatus/StockLevel). Currently supports Postgres as the data source. The driver injects a `_bench_ts` column via a trigger for replication/CDC freshness measurement.

### `testoperator run htap` (new command)
- Concurrent OLTP + analytical query execution against one spiced instance
- Data freshness probe (100ms polling of `MAX(_bench_ts)` across source and accelerator)
- Replication metrics scraping from spiced `/metrics` endpoint
- OTEL metrics: per-query latencies, `data_freshness_p99_ms`, tpmC, memory

### `testoperator run bench --query-set chbench` (extended)
Analytical-only mode against a pre-loaded CH-benCH schema (no OLTP). Useful for baseline performance and query correctness validation.

### Query set & spicepods
- 22 CH-benCH analytical queries (Q1–Q22)
- Spicepods: `postgres-arrow`, `postgres-cayenne[file]`, `postgres-duckdb[file]`, `postgres` (federated)

### CI workflow
- `testoperator_run_htap.yml` — dedicated HTAP workflow with scale factor and duration inputs

## Scale factor convention

`--scale-factor` maps to TPC-C warehouses (SF1 = 1 warehouse ≈ 100 MB). Terminals = warehouses × 10 (per TPC-C spec).

##  Metrics

1. Data Freshness (`data_freshness_p99_ms`) — headline metric
 - Measures the **actual staleness a query user experiences** by comparing `MAX(_bench_ts)` between source and Spice (accelerator). A `_bench_ts TIMESTAMPTZ` column + `BEFORE INSERT OR UPDATE` trigger on each mutated table stamps `clock_timestamp()` on every row.
 - Every 100ms: `gap = source_ts - spice_ts` across tables (`district`, `order_line`, `new_order`)
 - data_freshness_p99_ms - `worst_p99 = max(P99 across all tables)`

2. Replication Metrics (scraped from spiced `/metrics`): last-observed values from periodic scraping during the OLTP workload:
- Gauges: `dataset_postgres_replication_lag_ms`, `dataset_postgres_replication_lag_bytes`
- Counters: `dataset_postgres_replication_{inserts,updates,deletes}_total`


3. Why two freshness signals

| Metric | Formula | What it covers |
|--------|---------|---------------|
| `replication_lag_ms` | `now() - commit_time(last processed WAL txn)` | WAL decode only — grows when WAL decoding is slow or accelerator backpressure stalls the consumer |
| `data_freshness_p99_ms` | `MAX(_bench_ts) in PG - MAX(_bench_ts) in Spice` | End-to-end: WAL decode + change buffering + accelerator write + query visibility |

`data_freshness >= replication_lag` — after Spice records the commit watermark, changes may still be buffered (batch accumulation before flush), then written by the accelerator, and finally become query-visible. If accelerator writes or buffering cause backpressure, `replication_lag_ms` also grows (slightly delayed).

## 🔗 Related

Part of 
- https://github.com/spiceai/spiceai/issues/10790

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

1. SF10 (10 warehouses and 100 terminals) reaches ~10K rows/s mutations so CH-benCHmark+Postgres covers realistic HTAP benchmarking (thousands of rows/s), but finding Spice's CDC ingestion ceiling may need a simpler bulk-write driver that bypasses TPC-C's lock contention. Note - benchmark also needs improvement to use prepared statements.

1. Why own crate for TPC-C OLTP  - no solid and easy to use implementation were foudn for TPC-C, convention/spec is easy to implement, provides flexibility (extending schema with `_bench_ts` column + population for freshness logic)

1. htap is added as a separate command because BenchArgs is already at the GitHub Actions workflow_dispatch 10-input limit — adding --warehouses/--terminals would require a separate dispatch workflow regardless and has specific logic (running an additional workload against the source). This matches the pattern used by append/streaming-dynamodb/etc. Future work may unify these under a single streaming-bench command.

1. To test locally

```
docker run -d --name chbench-pg \
  -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=chbench \
  -p 5432:5432 postgres:16 \
  -c wal_level=logical \
  -c max_replication_slots=20 \
  -c max_wal_senders=20 && \
sleep 3 && docker exec chbench-pg pg_isready
```

```
cargo run -p testoperator -- run htap \
  -p './test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file].yaml' \
  --query-set chbench \
  --scale-factor 1.0 \
  --duration 90
```

Example run for DuckDB

```
cargo run -p testoperator -- run htap \
  -p './test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml' \
  --query-set chbench \
  --scale-factor 1.0 \
  --duration 90
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.55s
     Running `target/debug/testoperator run htap -p './test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml' --query-set chbench --scale-factor 1.0 --duration 90`
Preparing chbench source (SF1: 1 warehouse(s), 10 terminal(s))...
Preparing CH-benCH schema with 1 warehouse(s)
  cleaned up 11 replication slots, 11 publications
  dropping 12 tables
  creating 12 tables + 4 indexes
  added _bench_ts column + trigger to 8 tables
  loading item (100000 rows)
  loading nation (62 rows)
  loading region (5 rows)
  loading supplier (10000 rows)
  loading warehouse 1: 10 districts, 30K customers, 30K orders, ~300K order lines
CH-benCH prepare complete
chbench source is ready
2026-05-13T16:26:12.037478Z  INFO spiced: Starting runtime v2.0.0-unstable-build.226370fe78+models
2026-05-13T16:26:12.038841Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
2026-05-13T16:26:12.038870Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
2026-05-13T16:26:12.040261Z  INFO spiced: TLS reload: SIGHUP handler installed
2026-05-13T16:26:12.040352Z  WARN spiced: Usage telemetry is anonymous and aggregated. In Spice.ai Open Source, setting runtime.telemetry.enabled: false in a Spicepod or passing --telemetry-enabled=false does not disable anonymous usage telemetry. To remove anonymous telemetry from an Open Source build, build from source without the anonymous_telemetry feature, or consider using Spice.ai Enterprise. Learn more at https://docs.spice.ai/docs/enterprise
2026-05-13T16:26:12.040516Z  INFO runtime::init::task_history: Task history enabled: retention_period=28800s, retention_check_interval=900s
2026-05-13T16:26:12.048486Z  INFO runtime::init::dataset: Dataset orders initializing...
2026-05-13T16:26:12.048499Z  INFO runtime::init::dataset: Dataset item initializing...
2026-05-13T16:26:12.048490Z  INFO runtime::init::dataset: Dataset nation initializing...
2026-05-13T16:26:12.048484Z  INFO runtime::init::dataset: Loading datasets: 11 tasks dispatched, 0 skipped at accelerator init (of 11 total; localpod datasets may be chained).
2026-05-13T16:26:12.048516Z  INFO runtime::init::dataset: Dataset new_order initializing...
2026-05-13T16:26:12.048508Z  INFO runtime::init::dataset: Dataset customer initializing...
2026-05-13T16:26:12.048514Z  INFO runtime::init::dataset: Dataset stock initializing...
2026-05-13T16:26:12.048513Z  INFO runtime::init::dataset: Dataset warehouse initializing...
2026-05-13T16:26:12.048526Z  INFO runtime::init::dataset: Dataset region initializing...
2026-05-13T16:26:12.048528Z  INFO runtime::init::dataset: Dataset district initializing...
2026-05-13T16:26:12.048540Z  INFO runtime::init::dataset: Dataset order_line initializing...
2026-05-13T16:26:12.048525Z  INFO runtime::init::dataset: Dataset supplier initializing...
2026-05-13T16:26:12.100736Z  INFO runtime::init::dataset: Dataset item registered (postgres:item), acceleration (duckdb:file, changes). duration_ms=7
2026-05-13T16:26:12.100983Z  INFO runtime::init::dataset: Dataset nation registered (postgres:nation), acceleration (duckdb:file, changes). duration_ms=6
2026-05-13T16:26:12.101147Z  INFO runtime::init::dataset: Dataset district registered (postgres:district), acceleration (duckdb:file, changes). duration_ms=6
2026-05-13T16:26:12.101807Z  INFO runtime::init::dataset: Dataset new_order registered (postgres:new_order), acceleration (duckdb:file, changes). duration_ms=7
2026-05-13T16:26:12.102140Z  INFO runtime::init::dataset: Dataset orders registered (postgres:orders), acceleration (duckdb:file, changes). duration_ms=7
2026-05-13T16:26:12.102232Z  INFO runtime::init::dataset: Dataset stock registered (postgres:stock), acceleration (duckdb:file, changes). duration_ms=7
2026-05-13T16:26:12.103578Z  INFO runtime::init::dataset: Dataset order_line registered (postgres:order_line), acceleration (duckdb:file, changes). duration_ms=7
2026-05-13T16:26:12.103744Z  INFO runtime::init::dataset: Dataset supplier registered (postgres:supplier), acceleration (duckdb:file, changes). duration_ms=8
2026-05-13T16:26:12.104648Z  INFO runtime::init::dataset: Dataset customer registered (postgres:customer), acceleration (duckdb:file, changes). duration_ms=5
2026-05-13T16:26:12.107434Z  INFO runtime::init::dataset: Dataset region registered (postgres:region), acceleration (duckdb:file, changes). duration_ms=4
2026-05-13T16:26:12.107479Z  INFO runtime::init::dataset: Dataset warehouse registered (postgres:warehouse), acceleration (duckdb:file, changes). duration_ms=4
2026-05-13T16:26:12.140415Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_item publication=spice_item_f03f9e_pub consistent_lsn=1/7D3E3E10 snapshot=1/7D3E3E10
2026-05-13T16:26:12.147867Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_nation publication=spice_nation_2ba29c_pub consistent_lsn=1/7D3E3E48 snapshot=1/7D3E3E48
2026-05-13T16:26:12.153662Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=nation rows=62
2026-05-13T16:26:12.161329Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_order_line publication=spice_order_line_65aed1_pub consistent_lsn=1/7D3E3E80 snapshot=1/7D3E3E80
2026-05-13T16:26:12.172200Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_new_order publication=spice_new_order_31174b_pub consistent_lsn=1/7D3E3EB8 snapshot=1/7D3E3EB8
2026-05-13T16:26:12.176673Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=item rows=100000
2026-05-13T16:26:12.177744Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_customer publication=spice_customer_687fce_pub consistent_lsn=1/7D3E3EF0 snapshot=1/7D3E3EF0
2026-05-13T16:26:12.182967Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=new_order rows=9000
2026-05-13T16:26:12.195956Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_orders publication=spice_orders_fa4974_pub consistent_lsn=1/7D3E3F28 snapshot=1/7D3E3F28
2026-05-13T16:26:12.221252Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=orders rows=30000
2026-05-13T16:26:12.224971Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=customer rows=30000
2026-05-13T16:26:12.225512Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_stock publication=spice_stock_4f8060_pub consistent_lsn=1/7D3E3F60 snapshot=1/7D3E3F60
2026-05-13T16:26:12.236019Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_region publication=spice_region_e9b84a_pub consistent_lsn=1/7D3E3F98 snapshot=1/7D3E3F98
2026-05-13T16:26:12.240655Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
2026-05-13T16:26:12.240702Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
2026-05-13T16:26:12.240979Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
2026-05-13T16:26:12.242166Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=region rows=5
2026-05-13T16:26:12.247244Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_warehouse publication=spice_warehouse_0cb2df_pub consistent_lsn=1/7D3E4030 snapshot=1/7D3E4030
2026-05-13T16:26:12.248116Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_district publication=spice_district_9ab25b_pub consistent_lsn=1/7D3E4068 snapshot=1/7D3E4068
2026-05-13T16:26:12.248907Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_supplier publication=spice_supplier_556644_pub consistent_lsn=1/7D3E4068 snapshot=1/7D3E4068
2026-05-13T16:26:12.253169Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=warehouse rows=1
2026-05-13T16:26:12.254544Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=district rows=10
2026-05-13T16:26:12.259539Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=supplier rows=10000
2026-05-13T16:26:12.280490Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=order_line rows=299479
2026-05-13T16:26:12.327306Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=stock rows=100000
2026-05-13T16:26:13.022309Z  INFO runtime: All components are loaded. Spice runtime is ready!
Starting OLTP workload: 1 warehouse(s), 10 terminals, 90s duration, mix=[45, 43, 4, 4, 4]
Running HTAP analytical queries under OLTP load
███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 2853/82026-05-13T16:26:42.049413Z  INFO runtime::init::dataset: Dataset load summary (after 30s): 13/13 ready, 0 unhealthy, 0 still initializing.

==============================
Spiced Runtime Metrics:
==============================
Peak Active Connections: 2
==============================
Max memory usage: 1.18 GB
Median memory usage: 1.09 GB

=== Analytical Queries ===
+--------------------------------------+----------------+---------------+---------------+-------------+--------+-----------------+-----------------+------------+------------------+-----------------------+--------------------+---------------------------+---------------------------+---------------------------+-----------------------+
| run_id                               | spiced_version | started_at    | finished_at   | query_name  | status | min_duration_ms | max_duration_ms | iterations | commit_sha       | branch_name           | median_duration_ms | percentile_99_duration_ms | percentile_95_duration_ms | percentile_90_duration_ms | name                  |
+--------------------------------------+----------------+---------------+---------------+-------------+--------+-----------------+-----------------+------------+------------------+-----------------------+--------------------+---------------------------+---------------------------+---------------------------+-----------------------+
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q1  | passed | 2               | 10              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 3                  | 8                         | 6                         | 4                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q10 | passed | 20              | 110             | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 26                 | 33                        | 31                        | 29                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q11 | passed | 2               | 11              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 3                  | 7                         | 4                         | 4                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q12 | passed | 5               | 10              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 6                  | 9                         | 7                         | 7                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q13 | passed | 2               | 10              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 3                  | 7                         | 4                         | 3                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q14 | passed | 9               | 27              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 12                 | 18                        | 16                        | 14                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q16 | passed | 28              | 42              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 31                 | 37                        | 35                        | 33                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q17 | passed | 6               | 19              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 7                  | 12                        | 9                         | 8                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q18 | passed | 12              | 34              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 15                 | 21                        | 19                        | 18                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q19 | passed | 7               | 17              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 8                  | 14                        | 11                        | 10                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q2  | passed | 9               | 33              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 10                 | 17                        | 14                        | 12                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q20 | passed | 6               | 26              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 17                 | 24                        | 23                        | 21                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q22 | passed | 4               | 13              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 6                  | 9                         | 7                         | 7                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q3  | passed | 4               | 13              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 5                  | 11                        | 9                         | 8                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q4  | passed | 6               | 16              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 8                  | 14                        | 11                        | 10                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q5  | passed | 4               | 27              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 5                  | 11                        | 7                         | 6                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q6  | passed | 1               | 8               | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 2                  | 6                         | 4                         | 3                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q7  | passed | 4               | 21              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 6                  | 11                        | 8                         | 7                         | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q8  | passed | 6               | 16              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 8                  | 14                        | 11                        | 10                        | postgres-duckdb[file] |
| 6f9fbc7f-5817-40c0-8695-2c39ca867e2e | v2.0.0         | 1778689573749 | 1778689663831 | chbench_q9  | passed | 9               | 17              | 437        | 0ea052cd0e-dirty | sgrebnov/0513-chbench | 10                 | 16                        | 13                        | 12                        | postgres-duckdb[file] |
+--------------------------------------+----------------+---------------+---------------+-------------+--------+-----------------+-----------------+------------+------------------+-----------------------+--------------------+---------------------------+---------------------------+---------------------------+-----------------------+

=== TPC-C OLTP ===
OLTP Report (90.0s)
  tpmC (NewOrder/min): 9246.6
  transactions: 30634 committed, 10 aborted (0.03% abort rate)

Data Freshness
  district:      P50=  138ms  P99=  216ms  max=  236ms  (750 samples)
  order_line:    P50=  122ms  P99=  214ms  max=  229ms  (750 samples)
  new_order:     P50=  116ms  P99=  218ms  max=  227ms  (750 samples)
  ─────────────────
  worst P99:     218ms

Replication Metrics (last scrape from spiced)
  dataset            lag_ms    lag_bytes    inserts    updates    deletes
  customer              117       467360          0      24965          0
  district              117       467360          0      26635          0
  item                    0            0          0          0          0
  nation                  0            0          0          0          0
  new_order             117       467360      13630          0      11960
  order_line            117       467360     136453     119488          0
  orders                117       467360      13630      11960          0
  region                  0            0          0          0          0
  stock                 117       467360          0     136453          0
  supplier                0            0          0          0          0
  warehouse             117       467360          0      13005          0
No API key provided, telemetry is disabled
2026-05-13T16:27:44.132197Z  INFO runtime: Shutdown initiated; waiting up to 30s for connections to drain
2026-05-13T16:27:44.132790Z  INFO spiced: Goodbye!
```