### PR TITLE
Add missing cayenne/duckdb[file] benchmark coverage

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -93,6 +93,7 @@ jobs:
 
       - name: Validate spicepods - TPCH - SF1
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/tpch/sf1/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -100,6 +101,7 @@ jobs:
 
       - name: Validate spicepods - TPCDS - SF1
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/tpcds/sf1/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -107,6 +109,7 @@ jobs:
 
       - name: Validate spicepods - ClickBench - SF1
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/clickbench/sf1/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -114,6 +117,7 @@ jobs:
 
       - name: Validate spicepods - TPCH - SF100
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/tpch/sf100/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -121,6 +125,7 @@ jobs:
 
       - name: Validate spicepods - TPCDS - SF100
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/tpcds/sf100/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -239,6 +244,7 @@ jobs:
 
       - name: Validate spicepods - TPCH - SF1
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/tpch/sf1/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -246,6 +252,7 @@ jobs:
 
       - name: Validate spicepods - TPCDS - SF1
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/tpcds/sf1/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -253,6 +260,7 @@ jobs:
 
       - name: Validate spicepods - ClickBench - SF1
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/clickbench/sf1/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -260,6 +268,7 @@ jobs:
 
       - name: Validate spicepods - TPCH - SF100
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/tpch/sf100/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
@@ -267,6 +276,7 @@ jobs:
 
       - name: Validate spicepods - TPCDS - SF100
         run: |
+          shopt -s globstar nullglob
           for file in ./test/spicepods/tpcds/sf100/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -119,6 +119,13 @@ jobs:
             "$SPICEPOD_VALIDATOR" "$file"
           done
 
+      - name: Validate spicepods - TPCDS - SF100
+        run: |
+          for file in ./test/spicepods/tpcds/sf100/**/*.yaml; do
+            echo "Validating $file"
+            "$SPICEPOD_VALIDATOR" "$file"
+          done
+
       - name: Dispatch Testoperator - Scheduled Bench - TPCH - SF1
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 --workflow bench
@@ -154,6 +161,14 @@ jobs:
       - name: Dispatch Testoperator - Scheduled Bench - TPCH - SF100
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf100 --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.branch }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - TPCDS - SF100
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf100 --workflow bench
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
@@ -250,6 +265,13 @@ jobs:
             "$SPICEPOD_VALIDATOR" "$file"
           done
 
+      - name: Validate spicepods - TPCDS - SF100
+        run: |
+          for file in ./test/spicepods/tpcds/sf100/**/*.yaml; do
+            echo "Validating $file"
+            "$SPICEPOD_VALIDATOR" "$file"
+          done
+
       - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - TPCH - SF1
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 \
@@ -283,6 +305,16 @@ jobs:
       - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - TPCH - SF100
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf100 \
+            --workflow ${{ github.event.inputs.workflow_type }} \
+            --update-snapshots ${{ github.event.inputs.update_snapshots }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}
+
+      - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - TPCDS - SF100
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf100 \
             --workflow ${{ github.event.inputs.workflow_type }} \
             --update-snapshots ${{ github.event.inputs.update_snapshots }}
         env:

--- a/test/spicepods/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
+++ b/test/spicepods/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
@@ -1,0 +1,12 @@
+version: v1
+kind: Spicepod
+name: file[parquet]-cayenne[file]-on_zero_results_small
+datasets:
+  - from: file:data/hits_0.parquet
+    name: hits
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_sql: "SELECT * FROM hits LIMIT 0"
+      on_zero_results: use_source

--- a/test/spicepods/tpcds/sf100/accelerated/s3[parquet]-duckdb[file].yaml
+++ b/test/spicepods/tpcds/sf100/accelerated/s3[parquet]-duckdb[file].yaml
@@ -1,0 +1,109 @@
+version: v1
+kind: Spicepod
+name: s3[parquet]-duckdb[file]
+datasets:
+  - from: s3://benchmarks/tpcds_sf100/catalog_sales/
+    name: catalog_sales
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: s3://benchmarks/tpcds_sf100/catalog_returns/
+    name: catalog_returns
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/inventory/
+    name: inventory
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/store_sales/
+    name: store_sales
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/store_returns/
+    name: store_returns
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/web_sales/
+    name: web_sales
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/web_returns/
+    name: web_returns
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/customer/
+    name: customer
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/customer_address/
+    name: customer_address
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/customer_demographics/
+    name: customer_demographics
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/date_dim/
+    name: date_dim
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/household_demographics/
+    name: household_demographics
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/item/
+    name: item
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/promotion/
+    name: promotion
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/ship_mode/
+    name: ship_mode
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/store/
+    name: store
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/time_dim/
+    name: time_dim
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/warehouse/
+    name: warehouse
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/web_page/
+    name: web_page
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/web_site/
+    name: web_site
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/reason/
+    name: reason
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/call_center/
+    name: call_center
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/income_band/
+    name: income_band
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf100/catalog_page/
+    name: catalog_page
+    params: *s3_params
+    acceleration: *acceleration

--- a/tools/testoperator/dispatch/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
+++ b/tools/testoperator/dispatch/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
@@ -1,0 +1,6 @@
+tests:
+  bench:
+    spicepod_path: accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
+    query_set: clickbench
+    runner_type: spiceai-dev-large-runners
+    ready_wait: 1800

--- a/tools/testoperator/dispatch/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
+++ b/tools/testoperator/dispatch/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
@@ -2,5 +2,6 @@ tests:
   bench:
     spicepod_path: accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
     query_set: clickbench
+    query_overrides: duckdb
     runner_type: spiceai-dev-large-runners
     ready_wait: 1800

--- a/tools/testoperator/dispatch/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
+++ b/tools/testoperator/dispatch/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
@@ -2,6 +2,5 @@ tests:
   bench:
     spicepod_path: accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml
     query_set: clickbench
-    query_overrides: duckdb
     runner_type: spiceai-dev-large-runners
     ready_wait: 1800

--- a/tools/testoperator/dispatch/tpcds/sf100/accelerated/s3[parquet]-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/tpcds/sf100/accelerated/s3[parquet]-duckdb[file].yaml
@@ -1,0 +1,8 @@
+tests:
+  bench:
+    spicepod_path: accelerated/s3[parquet]-duckdb[file].yaml
+    query_set: tpcds
+    query_overrides: duckdb
+    runner_type: spiceai-dev-large-runners
+    ready_wait: 6000
+    scale_factor: 100


### PR DESCRIPTION
## Summary

Audited the testoperator benchmark dispatch coverage for the `cayenne` and `duckdb[file]` accelerators across all benchmark types (TPCH, TPCDS, ClickBench) at SF1 and SF100, and filled the missing slots.

### Coverage matrix (before this PR)

| Benchmark | SF | cayenne[file] | duckdb[file] |
|-----------|----|---------------|--------------|
| TPCH      | 1  | yes           | yes          |
| TPCH      | 100| yes           | yes          |
| TPCDS     | 1  | yes           | yes          |
| TPCDS     | 100| yes           | **MISSING**  |
| ClickBench| 1  | yes           | yes          |

For the `on_zero_results` variant at SF1, TPCH and TPCDS had both engines but ClickBench only had `duckdb[file]`.

The scheduled `testoperator dispatch` workflow also never ran `tpcds/sf100` even though a dispatch directory existed.

### Changes

- Add `test/spicepods/tpcds/sf100/accelerated/s3[parquet]-duckdb[file].yaml`
- Add `tools/testoperator/dispatch/tpcds/sf100/accelerated/s3[parquet]-duckdb[file].yaml`
- Add `test/spicepods/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml`
- Add `tools/testoperator/dispatch/clickbench/sf1/accelerated/on_zero_results/file[parquet]-cayenne[file]-on_zero_results_small.yaml`
- Wire `tpcds/sf100` into `.github/workflows/testoperator_dispatch.yml` (both the scheduled and `workflow_dispatch` jobs: validation + bench dispatch)

## Test plan

- [ ] Verify the scheduled `testoperator dispatch` run picks up the new `tpcds/sf100` bench job
- [ ] Verify the new `tpcds/sf100` duckdb[file] benchmark passes end-to-end
- [ ] Verify the new ClickBench cayenne[file] `on_zero_results` benchmark passes end-to-end
- [ ] Confirm spicepod validator accepts the new yaml files

https://claude.ai/code/session_01NtBHhPp31i5hhWWj5GiqeA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtBHhPp31i5hhWWj5GiqeA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->