### PR TITLE
Fix dataformat-json doctests

### DIFF
--- a/crates/dataformat-json/src/stream.rs
+++ b/crates/dataformat-json/src/stream.rs
@@ -879,7 +879,7 @@ pub enum ReadResult {
 /// # Example
 ///
 /// ```rust,no_run
-/// use dataformat_json::stream::{ArrayToNdjsonPush, ReadResult};
+/// use dataformat_json::{ArrayToNdjsonPush, ReadResult};
 ///
 /// let mut adapter = ArrayToNdjsonPush::new();
 ///
@@ -888,7 +888,7 @@ pub enum ReadResult {
 /// adapter.push_bytes(b"\"John\"}]").unwrap();
 ///
 /// // Read processed NDJSON
-/// match adapter.try_read().unwrap() {
+/// match adapter.try_read() {
 ///     ReadResult::Ready(data) => {
 ///         let output = std::str::from_utf8(&data).unwrap();
 ///         assert!(output.contains("{\"name\":\"John\"}"));
@@ -936,9 +936,6 @@ impl ArrayToNdjsonPush {
 
     /// Try to read processed NDJSON data
     ///
-    /// # Errors
-    ///
-    /// Returns an error if there are issues with the internal state or JSON parsing.
     pub fn try_read(&mut self) -> ReadResult {
         if self.pending.is_empty() {
             if matches!(self.state, ParsingState::Complete) {

--- a/crates/dataformat-json/src/unnest.rs
+++ b/crates/dataformat-json/src/unnest.rs
@@ -165,7 +165,7 @@ pub fn nest_struct_schema(flattened_schema: &Schema, separator: &str) -> Schema 
 ///
 /// // Find which column in the nested schema the flattened "person.name" field belongs to
 /// let person_name_field = flattened_schema.field(1); // "person.name"
-/// let col_index = find_col_index(person_name_field, &nested_schema).unwrap();
+/// let col_index = find_col_index(person_name_field, &nested_schema, ".").unwrap();
 /// assert_eq!(col_index, 1); // The "person" struct is at index 1
 /// ```
 #[must_use]
@@ -247,7 +247,7 @@ fn flatten_json(
 /// ];
 /// let filtered_flattened = Schema::new(subset_fields);
 ///
-/// let projected_nested = project_nested_schema(&filtered_flattened, &original_nested);
+/// let projected_nested = project_nested_schema(&filtered_flattened, &original_nested, ".");
 /// // Result: [person{name, age, email}, status] - complete original fields
 /// ```
 #[must_use]


### PR DESCRIPTION
Fix stale `dataformat-json` doctest examples so they match the current public API.

Summary:
- Import `ArrayToNdjsonPush` and `ReadResult` from the crate root in docs.
- Remove a stale `try_read` error-doc section and match on `ReadResult` directly.
- Pass the explicit separator argument in `unnest` doctest examples.

Testing:
- `cargo test -p dataformat-json --doc`
- `cargo test -p dataformat-json`
- `cargo fmt --check --package dataformat-json`
- `git diff --check`
- `make lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->