### PR TITLE
feat(testoperator): run cluster benchmarks via system adapters

### DIFF
--- a/.github/workflows/testoperator_run_cluster_bench.yml
+++ b/.github/workflows/testoperator_run_cluster_bench.yml
@@ -1,0 +1,267 @@
+name: cluster benchmark e2e tests
+run-name: cluster-bench - ${{ github.event.inputs.query_set }} - ${{ github.event.inputs.spicepod_path }}
+
+# Cluster-mode counterpart to `testoperator_run_bench.yml`. Instead of spawning a
+# local `spiced` process, testoperator drives the benchmark against a SUT
+# acquired via the system-adapter JSON-RPC protocol — here, the `spidapter`
+# docker image deploying a Spice Cloud clustered app. Mirrors the
+# `run_spicebench.yml` plumbing in the spicebench repo.
+
+on:
+  workflow_dispatch:
+    inputs:
+      spicepod_path:
+        description: 'The spicepod file to test with (relative to test/spicepods/{query_set}/sf{scale_factor}/)'
+        required: true
+        type: string
+      query_set:
+        description: 'Query set'
+        required: true
+        default: 'tpch'
+        type: choice
+        options:
+          - 'tpch'
+          - 'tpch[parameterized]'
+          - 'tpcds'
+          - 'clickbench'
+          - 'scenario'
+      scenario_query_file:
+        description: 'Path to scenario query file (required when query_set is scenario)'
+        required: false
+        type: string
+        default: ''
+      query_transport:
+        description: 'Which distributed path inside the cluster to exercise'
+        required: true
+        default: 'flightsql'
+        type: choice
+        options:
+          - 'flightsql'   # Distributed accelerations (Flight SQL gRPC)
+          - 'v1-queries'  # Ballista distributed query (HTTP /v1/queries) — sets --distributed
+      executor_replicas:
+        description: 'Number of spidapter executor replicas'
+        required: true
+        default: '4'
+        type: string
+      channel:
+        description: 'Spice runtime image channel passed to spidapter'
+        required: true
+        default: 'nightly'
+        type: choice
+        options:
+          - 'nightly'
+          - 'preview'
+          - 'stable'
+          - 'internal'
+      scale_factor:
+        description: 'Scale factor for the benchmark'
+        required: false
+        type: string
+        default: '1'
+      validate_results:
+        description: 'Validate query results against expected (where supported)'
+        required: false
+        type: boolean
+        default: false
+      update_snapshots:
+        description: |
+          How to handle insta snapshot mismatches. `default` decides based on
+          the branch (release/* → no, anything else → always). `always` creates
+          new baselines on mismatch (use this on a brand-new spicepod that
+          has no snapshots yet). `no` fails on any drift, matching production
+          benchmark behavior. Mirrors `testoperator_run_bench.yml`.
+        required: false
+        default: 'default'
+        type: choice
+        options:
+          - 'default'
+          - 'always'
+          - 'no'
+      ready_wait:
+        description: 'Seconds to wait for the cluster to become ready'
+        required: true
+        default: '600'
+        type: string
+      runner_type:
+        description: 'Runner type'
+        required: true
+        default: 'spiceai-dev-runners'
+        type: choice
+        options:
+          - 'spiceai-dev-runners'
+          - 'spiceai-dev-large-runners'
+
+permissions:
+  contents: read
+  packages: read
+
+# Centralized defaults so push-triggered runs (where github.event.inputs.* is
+# empty) and workflow_dispatch runs share the same fallback chain. Configured
+# for a Ballista distributed-query smoke test against the public-S3 TPC-H
+# spicepod by default.
+env:
+  CB_SPICEPOD_PATH: ${{ github.event.inputs.spicepod_path || 'federated/s3-public[parquet].yaml' }}
+  CB_QUERY_SET: ${{ github.event.inputs.query_set || 'tpch' }}
+  CB_SCENARIO_QUERY_FILE: ${{ github.event.inputs.scenario_query_file || '' }}
+  CB_QUERY_TRANSPORT: ${{ github.event.inputs.query_transport || 'v1-queries' }}
+  CB_EXECUTOR_REPLICAS: ${{ github.event.inputs.executor_replicas || '3' }}
+  CB_CHANNEL: ${{ github.event.inputs.channel || 'nightly' }}
+  CB_SCALE_FACTOR: ${{ github.event.inputs.scale_factor || '1' }}
+  CB_VALIDATE_RESULTS: ${{ github.event.inputs.validate_results || 'false' }}
+  CB_UPDATE_SNAPSHOTS: ${{ github.event.inputs.update_snapshots || 'default' }}
+  CB_READY_WAIT: ${{ github.event.inputs.ready_wait || '600' }}
+  CB_RUNNER_TYPE: ${{ github.event.inputs.runner_type || 'spiceai-dev-runners' }}
+
+jobs:
+  run-cluster-bench:
+    name: Run cluster benchmark
+    runs-on: ${{ github.event.inputs.runner_type || 'spiceai-dev-runners' }}
+    timeout-minutes: 600
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Rust toolchain
+        uses: ./.github/actions/setup-rust
+
+      - name: Determine snapshot update mode
+        id: determine_update_snapshots
+        run: |
+          # `default` → branch-based: release/* never updates, anything else
+          # always updates. Mirrors testoperator_run_bench.yml so cluster-bench
+          # snapshot policy is consistent with the single-node bench.
+          update_mode="${CB_UPDATE_SNAPSHOTS}"
+          if [ "${update_mode}" = "default" ] || [ -z "${update_mode}" ]; then
+            branch_name="${{ github.ref_name }}"
+            if [[ "${branch_name}" == "release/"* ]]; then
+              update_mode="no"
+            else
+              update_mode="always"
+            fi
+          fi
+
+          echo "Using update_snapshots=${update_mode}" >&2
+          echo "update_snapshots=${update_mode}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set spicepod path
+        id: set_spicepod_path
+        run: |
+          query_set="${CB_QUERY_SET}"
+          query_set="${query_set%%\[*\]*}"
+          SPICEPOD_PATH="./test/spicepods/${query_set}/sf${CB_SCALE_FACTOR}/${CB_SPICEPOD_PATH}"
+          echo "SPICEPOD_PATH=${SPICEPOD_PATH}" >> $GITHUB_OUTPUT
+
+      - name: Validate spicepod file exists
+        run: |
+          if [ ! -f "${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}" ]; then
+            echo "Error: Spicepod file not found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+
+      - name: Install MinIO
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
+      - name: Build spicepod validator
+        uses: ./.github/actions/build-spicepod-validator
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
+      - name: Validate spicepod
+        run: |
+          spicepod-validator "${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+
+      - name: Build Testoperator
+        uses: ./.github/actions/build-testoperator
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
+      - name: Setup Testoperator
+        uses: ./.github/actions/setup-testoperator-data
+        with:
+          query_set: ${{ env.CB_QUERY_SET }}
+
+      - name: Build Spidapter
+        uses: ./.github/actions/build-spidapter
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
+      - name: Management login (prod)
+        uses: ./.github/actions/management-login
+        with:
+          token-url: https://spice.ai/api/oauth/token
+          client-id: ${{ secrets.SPICE_MANAGEMENT_CLIENT_ID_PROD }}
+          client-secret: ${{ secrets.SPICE_MANAGEMENT_CLIENT_SECRET_PROD }}
+          # Exports SPICEAI_API_KEY for subsequent steps. Same prod creds
+          # spicebench's run_spicebench.yml uses.
+
+      - name: Run the cluster benchmark - ${{ env.CB_SPICEPOD_PATH }}
+        env:
+          SPICEAI_API_KEY: ${{ env.SPICEAI_API_KEY }}
+          SPICE_CLOUD_API_URL: https://api.spice.ai
+          S3_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          S3_KEY: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          S3_SECRET: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ICEBERG_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ICEBERG_SECRET_ACCESS_KEY }}
+          SCHEDULER_STATE_LOCATION: 's3://spiceai-testing-cluster-state/testoperator-cluster-bench-${{ github.run_id }}/'
+          SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
+          EXECUTOR_REPLICAS: ${{ env.CB_EXECUTOR_REPLICAS }}
+          CHANNEL: ${{ env.CB_CHANNEL }}
+          QUERY_SET: ${{ env.CB_QUERY_SET }}
+          QUERY_TRANSPORT: ${{ env.CB_QUERY_TRANSPORT }}
+          SCALE_FACTOR: ${{ env.CB_SCALE_FACTOR }}
+          VALIDATE_RESULTS: ${{ env.CB_VALIDATE_RESULTS }}
+          READY_WAIT: ${{ env.CB_READY_WAIT }}
+          INSTA_UPDATE: ${{ steps.determine_update_snapshots.outputs.update_snapshots }}
+          SPICEPOD_PATH: ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}
+          SCENARIO_QUERY_FILE: ${{ env.CB_SCENARIO_QUERY_FILE }}
+        run: |
+          set -euo pipefail
+
+          # Translate the abstract transport name into the concrete testoperator
+          # flag. `--distributed` selects the existing DistributedExecutor that
+          # POSTs to /v1/queries; the default (no flag) keeps the Flight SQL
+          # path that exercises distributed accelerations.
+          TRANSPORT_FLAG=""
+          if [ "${QUERY_TRANSPORT}" = "v1-queries" ]; then
+            TRANSPORT_FLAG="--distributed"
+          fi
+
+          # Optional scenario query file (only used when --query-set scenario).
+          SCENARIO_ARG=""
+          if [ -n "${SCENARIO_QUERY_FILE}" ]; then
+            SCENARIO_ARG="--scenario-query-file ./test/scenario/${SCENARIO_QUERY_FILE}"
+          fi
+
+          # Run the freshly-built spidapter binary as the JSON-RPC adapter.
+          # spidapter reads its config from SPIDAPTER_*/SPICEAI_*/AWS_*/SCHEDULER_*
+          # env vars, which testoperator's child process inherits from this step's
+          # env block.
+          export SPIDAPTER_EXECUTOR_REPLICAS="${EXECUTOR_REPLICAS}"
+
+          rm -rf .spice/data
+          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" testoperator run bench \
+            -p "${SPICEPOD_PATH}" \
+            --query-set "${QUERY_SET}" \
+            --scale-factor "${SCALE_FACTOR}" \
+            --ready-wait "${READY_WAIT}" \
+            --disable-progress-bars \
+            --validate="${VALIDATE_RESULTS}" \
+            --metrics \
+            ${TRANSPORT_FLAG} \
+            ${SCENARIO_ARG} \
+            --system-adapter-stdio-cmd spidapter \
+            --system-adapter-stdio-args "stdio --verbose --channel ${CHANNEL}" \
+            --system-adapter-param channel="${CHANNEL}" \
+            --system-adapter-param executor_replicas="${EXECUTOR_REPLICAS}" \
+            --system-adapter-param query_transport="${QUERY_TRANSPORT}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17996,6 +17996,7 @@ dependencies = [
  "spice-cloud-client",
  "spicepod",
  "system-adapter-protocol",
+ "tempfile",
  "tokio",
  "tonic",
  "url",
@@ -18568,7 +18569,7 @@ dependencies = [
 [[package]]
 name = "system-adapter-protocol"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/spicebench.git?rev=6327983bc1a90123e0c754b79781b931c969831e#6327983bc1a90123e0c754b79781b931c969831e"
+source = "git+https://github.com/spiceai/spicebench.git?rev=0152edc7ba5a6c0fd471c0ef6ef074cce8b8f830#0152edc7ba5a6c0fd471c0ef6ef074cce8b8f830"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -18990,9 +18991,12 @@ dependencies = [
  "serde_json",
  "spiceai",
  "spicepod",
+ "system-adapter-protocol",
  "test-framework",
  "tokio",
  "tokio-util",
+ "url",
+ "uuid 1.21.0",
  "yaml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ sqlparser = "0.59.0"
 ssh2 = { version = "0.9.5" }
 suppaftp = { version = "6.3.0", features = ["async"] }
 sysinfo = "0.38.4"
-system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "6327983bc1a90123e0c754b79781b931c969831e", features = ["server"] }
+system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "0152edc7ba5a6c0fd471c0ef6ef074cce8b8f830", features = ["client", "server"] }
 tantivy = "0.26.0"
 tempfile = "3"
 tiberius = { version = "0.12.3", default-features = false, features = [

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -915,7 +915,7 @@ mod tests {
     }
 
     /// Cayenne rewrites `HashJoinExec` to use a custom accumulator type, so it
-    /// must run after DataFusion's built-in physical optimizer rules that
+    /// must run after `DataFusion`'s built-in physical optimizer rules that
     /// downcast to the default `HashJoinExec` type.
     #[test]
     #[cfg(not(windows))]

--- a/crates/test-framework/src/execution/mod.rs
+++ b/crates/test-framework/src/execution/mod.rs
@@ -362,14 +362,20 @@ impl QueryExecutor for DistributedExecutor {
             }
 
             let status_json: serde_json::Value = status_response.json().await?;
-            let state = status_json
-                .get("state")
+            // The /v1/queries status response uses JSON field `status` (not
+            // `state`) with values serialized as SCREAMING_SNAKE_CASE
+            // (see `runtime/src/jobs/state.rs::JobStatus`). Matching either
+            // the wrong key or the wrong casing makes every poll fall through
+            // to "keep waiting" and the query never exits the loop until the
+            // hard timeout.
+            let status = status_json
+                .get("status")
                 .and_then(serde_json::Value::as_str)
-                .unwrap_or("unknown");
+                .unwrap_or("UNKNOWN");
 
-            match state {
-                "succeeded" => break,
-                "failed" => {
+            match status {
+                "SUCCEEDED" => break,
+                "FAILED" => {
                     let error_msg = status_json
                         .get("error")
                         .and_then(|e| e.get("message"))
@@ -377,44 +383,46 @@ impl QueryExecutor for DistributedExecutor {
                         .unwrap_or("Unknown error");
                     anyhow::bail!("Query distributed execution failed: {error_msg}");
                 }
-                "cancelled" => anyhow::bail!("Query was cancelled"),
-                "closed" => anyhow::bail!("Query results expired before retrieval"),
-                "pending" | "running" => {
+                "CANCELLED" => anyhow::bail!("Query was cancelled"),
+                "CLOSED" => anyhow::bail!("Query results expired before retrieval"),
+                "PENDING" | "RUNNING" => {
                     // Continue polling with exponential backoff
                     tokio::time::sleep(poll_interval).await;
                     poll_interval = std::cmp::min(poll_interval * 2, MAX_POLL_INTERVAL);
                 }
                 _ => {
-                    // Unknown state, continue polling
+                    // Unknown status, continue polling
                     tokio::time::sleep(poll_interval).await;
                     poll_interval = std::cmp::min(poll_interval * 2, MAX_POLL_INTERVAL);
                 }
             }
         }
 
-        // Step 3: Fetch results (first chunk to get row count)
-        let results_url = format!("{queries_url}/{query_id}/results");
-        let results_response = self.client.get(&results_url).send().await?;
+        // Step 3: Fetch total row count from the full query response.
+        // `/results` returns a ChunkResponse with per-chunk counts; the manifest
+        // (with `total_row_count`) lives on the query-level response at
+        // `GET /v1/queries/{id}`. See `runtime/src/http/v1/queries.rs::QueryResponse`.
+        let query_url = format!("{queries_url}/{query_id}");
+        let query_response = self.client.get(&query_url).send().await?;
 
-        let results_status = results_response.status();
-        if !results_status.is_success() {
-            let error_text = results_response.text().await.unwrap_or_default();
-            anyhow::bail!("Query results fetch failed: {results_status} - {error_text}");
+        let query_status = query_response.status();
+        if !query_status.is_success() {
+            let error_text = query_response.text().await.unwrap_or_default();
+            anyhow::bail!("Query info fetch failed: {query_status} - {error_text}");
         }
 
-        let results_json: serde_json::Value = results_response.json().await?;
+        let query_json: serde_json::Value = query_response.json().await?;
 
-        // Get total row count from manifest
-        let manifest = results_json
+        let manifest = query_json
             .get("manifest")
-            .ok_or_else(|| anyhow::anyhow!("Query results response missing 'manifest' field"))?;
+            .ok_or_else(|| anyhow::anyhow!("Query response missing 'manifest' field"))?;
 
-        let total_row_count_value = manifest.get("total_row_count").ok_or_else(|| {
-            anyhow::anyhow!("Query results manifest missing 'total_row_count' field")
-        })?;
+        let total_row_count_value = manifest
+            .get("total_row_count")
+            .ok_or_else(|| anyhow::anyhow!("Query manifest missing 'total_row_count' field"))?;
 
         let total_row_count_u64 = total_row_count_value.as_u64().ok_or_else(|| {
-            anyhow::anyhow!("Query results manifest 'total_row_count' field is not a valid u64")
+            anyhow::anyhow!("Query manifest 'total_row_count' field is not a valid u64")
         })?;
 
         #[expect(clippy::cast_possible_truncation)]

--- a/crates/test-framework/src/spiced/mod.rs
+++ b/crates/test-framework/src/spiced/mod.rs
@@ -278,7 +278,15 @@ impl SpicedInstance {
     ) -> Result<SpiceClient> {
         let mut spice_client = ClientBuilder::new();
 
-        if let Some(key) = api_key {
+        // Caller-supplied key wins; otherwise fall back to whatever was stashed
+        // on the External variant (e.g. by the system-adapter setup response).
+        let effective_key = api_key.or_else(|| match self {
+            Self::External {
+                api_key: Some(key), ..
+            } => Some(key.clone()),
+            _ => None,
+        });
+        if let Some(key) = effective_key {
             spice_client = spice_client.api_key(key.as_str());
         }
 

--- a/tools/spidapter/Cargo.toml
+++ b/tools/spidapter/Cargo.toml
@@ -27,3 +27,7 @@ rustls.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros"] }

--- a/tools/spidapter/src/cayenne_server.rs
+++ b/tools/spidapter/src/cayenne_server.rs
@@ -171,6 +171,7 @@ impl Handler for CayenneFlightsqlHandler {
             db_kwargs,
             catalog_namespace,
             read_driver: None,
+            endpoints: std::collections::HashMap::new(),
         };
 
         self.runs.insert(run_id, state);

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -129,6 +129,10 @@ struct SetupConfig {
     region: Option<String>,
     endpoint: Option<String>,
     sink_type: Option<EtlSinkType>,
+    /// Absolute path to a spicepod the client wants deployed verbatim
+    /// (testoperator's cluster-bench path passes this; spicebench leaves it
+    /// empty and relies on the `datasets` JSON-RPC parameter instead).
+    spicepod_path: Option<String>,
 }
 
 impl SetupConfig {
@@ -137,6 +141,7 @@ impl SetupConfig {
             region: metadata_string(metadata, "etl_region"),
             endpoint: metadata_string(metadata, "etl_endpoint"),
             sink_type: None,
+            spicepod_path: metadata_string(metadata, "spicepod_path"),
         }
     }
 
@@ -281,6 +286,30 @@ impl Handler for SpidapterHandler {
             );
         }
 
+        // Advertise the cluster's HTTP query endpoint so testoperator (or any
+        // other client) can drive the Ballista `/v1/queries` path and the
+        // `/v1/ready` probe at the correct region URL. Without this the client
+        // would have to guess the URL from the Flight host, which fails for
+        // region-prefixed Spice Cloud deployments.
+        let mut endpoints: std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, serde_json::Value>,
+        > = std::collections::HashMap::new();
+        let http_base = state.sql_url().trim_end_matches("/v1/sql").to_string();
+        let mut queries_kwargs: std::collections::HashMap<String, serde_json::Value> =
+            std::collections::HashMap::new();
+        queries_kwargs.insert(
+            "url".to_string(),
+            serde_json::Value::String(format!("{http_base}/v1/queries")),
+        );
+        if let Some(api_key) = state.api_key() {
+            queries_kwargs.insert(
+                "authorization_header".to_string(),
+                serde_json::Value::String(format!("Bearer {api_key}")),
+            );
+        }
+        endpoints.insert("spice.http.v1.queries".to_string(), queries_kwargs);
+
         let response = SetupResponse {
             driver: AdbcDriver::Flightsql,
             db_kwargs,
@@ -289,6 +318,7 @@ impl Handler for SpidapterHandler {
                 .filter(|sink_type| matches!(sink_type, EtlSinkType::Adbc))
                 .map(|_| "spicebench.bench".to_string()),
             read_driver: None,
+            endpoints,
         };
 
         self.runs.insert(run_id, state);
@@ -697,7 +727,7 @@ async fn provision_spice_cloud_app(
 
     eprintln!("[stdio] App ID: {app_id}");
 
-    let spicepod = generate_initial_spicepod(&run_id, setup_config, datasets, None, args)?;
+    let spicepod = generate_initial_spicepod(&run_id, setup_config, datasets, None, args).await?;
     let spicepod_yaml = serialize_spicepod(&spicepod)?;
     eprintln!("[stdio] Generated spicepod:\n{spicepod_yaml}");
 
@@ -839,7 +869,8 @@ async fn provision_local_spiced_cluster(
             datasets,
             local_flight_api_key.as_deref(),
             args,
-        )?;
+        )
+        .await?;
         let spicepod_path = write_local_spicepod(&spicepod, &working_dir, "spicepod.yaml").await?;
 
         let run_id_str = run_id.to_string();
@@ -1493,6 +1524,26 @@ async fn cleanup_local_artifacts(working_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Read a spicepod YAML file from disk and rename it to the per-run app name
+/// before deploying. Used by testoperator's cluster-bench path: the client
+/// passes a `spicepod_path` in setup metadata; we deploy whatever's there
+/// (datasets, runtime config, etc.) verbatim, only overriding the `name`.
+async fn load_spicepod_from_path(path: &str, run_id: &Uuid) -> anyhow::Result<SpicepodDefinition> {
+    let contents = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to read spicepod from `{path}`: {e}"))?;
+    parse_and_rename_spicepod(&contents, run_id)
+        .map_err(|e| anyhow::anyhow!("failed to parse spicepod YAML at `{path}`: {e}"))
+}
+
+fn parse_and_rename_spicepod(yaml_str: &str, run_id: &Uuid) -> anyhow::Result<SpicepodDefinition> {
+    let mut spicepod: SpicepodDefinition = yaml::from_str(yaml_str)?;
+    let run_id_str = run_id.to_string();
+    let short_id = run_id_str.split('-').next().unwrap_or_default();
+    spicepod.name = format!("spidapter-{short_id}");
+    Ok(spicepod)
+}
+
 fn generate_hive_spicepod(
     run_id: &Uuid,
     setup_config: &SetupConfig,
@@ -1626,7 +1677,7 @@ fn generate_adbc_spicepod(
 }
 
 /// Generate the initial [`SpicepodDefinition`] for the benchmark run.
-fn generate_initial_spicepod(
+async fn generate_initial_spicepod(
     run_id: &Uuid,
     setup_config: &SetupConfig,
     datasets: &HashMap<String, DatasetConfig>,
@@ -1636,10 +1687,19 @@ fn generate_initial_spicepod(
     let scheduler_state_location = args.scheduler_state_location.as_deref();
     let aws_region = args.aws_region.as_deref();
 
-    let mut spicepod = match setup_config.sink_type {
-        Some(EtlSinkType::Adbc) => Ok(generate_adbc_spicepod(run_id, flight_api_key, args)),
-        _ => generate_hive_spicepod(run_id, setup_config, datasets, aws_region),
-    }?;
+    // If the client supplied a spicepod path in setup metadata
+    // (testoperator's cluster-bench path), use the contents of that file
+    // verbatim as the deployable spicepod and only layer scheduler config on
+    // top. The spicebench `datasets` HashMap path is only consulted when no
+    // spicepod_path is provided.
+    let mut spicepod = if let Some(path) = setup_config.spicepod_path.as_deref() {
+        load_spicepod_from_path(path, run_id).await?
+    } else {
+        match setup_config.sink_type {
+            Some(EtlSinkType::Adbc) => Ok(generate_adbc_spicepod(run_id, flight_api_key, args)),
+            _ => generate_hive_spicepod(run_id, setup_config, datasets, aws_region),
+        }?
+    };
 
     if let Some(loc) = scheduler_state_location {
         let mut path = loc.trim();
@@ -1648,12 +1708,25 @@ fn generate_initial_spicepod(
         }
         let state_location = format!("{path}/{run_id}");
         if !path.is_empty() {
+            // Wire `s3_key`/`s3_secret` through `${secrets:...}` references
+            // so the runtime's cluster-secret lookup resolves them against
+            // the AWS_*-named secrets `set_spicepod_secrets` already uploads.
+            // Without these references, the scheduler's S3 client asks the
+            // cluster secret store for literal keys `s3_key`/`s3_secret` and
+            // fails ("Secret not found").
             let mut sched = Scheduler {
                 state_location,
-                params: Some(Params::from_string_map(HashMap::from([(
-                    "s3_auth".to_string(),
-                    "key".to_string(),
-                )]))),
+                params: Some(Params::from_string_map(HashMap::from([
+                    ("s3_auth".to_string(), "key".to_string()),
+                    (
+                        "s3_key".to_string(),
+                        "${secrets:AWS_ACCESS_KEY_ID}".to_string(),
+                    ),
+                    (
+                        "s3_secret".to_string(),
+                        "${secrets:AWS_SECRET_ACCESS_KEY}".to_string(),
+                    ),
+                ]))),
                 partition_assignment_interval: default_partition_assignment_interval(),
                 max_partition_assignments_per_interval:
                     default_max_partition_assignments_per_interval(),
@@ -1747,12 +1820,13 @@ mod tests {
         BackendMode::from_str("unexpected", true).expect("'BackendMode' should be constructed");
     }
 
-    #[test]
-    fn generate_spicepod_includes_dataset_entries() {
+    #[tokio::test]
+    async fn generate_spicepod_includes_dataset_entries() {
         let setup_config = SetupConfig {
             region: Some("us-west-2".to_string()),
             endpoint: Some("http://localhost:9000".to_string()),
             sink_type: None,
+            spicepod_path: None,
         };
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
@@ -1770,6 +1844,7 @@ mod tests {
         let args = test_stdio_args();
         let spicepod =
             generate_initial_spicepod(&Uuid::nil(), &setup_config, &datasets, None, &args)
+                .await
                 .expect("spicepod should generate");
         let spicepod_yaml =
             serialize_spicepod(&spicepod).expect("spicepod should serialize to YAML");
@@ -1791,12 +1866,13 @@ mod tests {
         assert!(spicepod_yaml.contains("s3_auth: key"));
     }
 
-    #[test]
-    fn generate_spicepod_errors_on_missing_dataset_source() {
+    #[tokio::test]
+    async fn generate_spicepod_errors_on_missing_dataset_source() {
         let setup_config = SetupConfig {
             region: None,
             endpoint: None,
             sink_type: None,
+            spicepod_path: None,
         };
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
@@ -1813,10 +1889,50 @@ mod tests {
 
         let args = test_stdio_args();
         let err = generate_initial_spicepod(&Uuid::nil(), &setup_config, &datasets, None, &args)
+            .await
             .expect_err("missing source should fail");
         assert!(
             err.to_string().contains("missing_table"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_initial_spicepod_uses_loaded_spicepod_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("input.yaml");
+        // Original name is intentionally different from the per-run name so we
+        // can assert the override below.
+        tokio::fs::write(
+            &path,
+            "version: v1\nkind: Spicepod\nname: user-supplied\ndatasets:\n  - from: s3://public-bucket/customer.parquet\n    name: customer\n    params:\n      file_format: parquet\n      s3_auth: public\n",
+        )
+        .await
+        .expect("write yaml");
+
+        let setup_config = SetupConfig {
+            region: None,
+            endpoint: None,
+            sink_type: None,
+            spicepod_path: Some(path.to_string_lossy().into_owned()),
+        };
+        let datasets: HashMap<String, DatasetConfig> = HashMap::new();
+        let args = test_stdio_args();
+        let run_id = Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").expect("parse uuid");
+
+        let spicepod = generate_initial_spicepod(&run_id, &setup_config, &datasets, None, &args)
+            .await
+            .expect("spicepod loads from disk");
+
+        assert_eq!(spicepod.name, "spidapter-01234567");
+        let yaml = serialize_spicepod(&spicepod).expect("serialize");
+        assert!(
+            yaml.contains("customer.parquet"),
+            "dataset from file is missing in deployed spicepod: {yaml}"
+        );
+        assert!(
+            yaml.contains("s3_auth: public"),
+            "public auth from file is missing: {yaml}"
         );
     }
 

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -29,10 +29,13 @@ serde_json.workspace = true
 yaml = { path = "../../crates/yaml" }
 spiceai.workspace = true
 spicepod = { path = "../../crates/spicepod" }
+system-adapter-protocol.workspace = true
 test-framework = { path = "../../crates/test-framework" }
 rand.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+url.workspace = true
+uuid.workspace = true
 
 [features]
 default = ["append"]

--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -336,3 +336,55 @@ testoperator run query --query-set tpch --query-overrides duckdb
 ```
 
 Testoperator will run without explain plan or result snapshotting. Result validation is supported with `--validate`. Telemetry and metrics emission is not supported.
+
+### Driving a distributed cluster via a system adapter
+
+Testoperator can acquire its SUT through an out-of-process JSON-RPC adapter (the same protocol [spicebench](https://github.com/spiceai/spicebench) uses). This is how cluster benchmarks — distributed accelerations and Ballista-style distributed query — are wired up: the adapter provisions the cluster (k8s, Spice Cloud, local docker-compose, …) and returns the Flight SQL URL (and optionally an HTTP base URL) for testoperator to drive queries against.
+
+When `--system-adapter-stdio-cmd` or `--system-adapter-http-url` is set, testoperator skips the local-spawn path entirely: it calls `setup()` on the adapter, runs the benchmark against the returned URLs, and calls `teardown()` at the end (even on failure). The adapter receives the resolved spicepod path and any `--system-adapter-param` key/values in the setup metadata so it can deploy that spicepod to the cluster.
+
+System-adapter mode is supported today by `run bench` and `run throughput`.
+
+#### System Adapter Options
+
+- `--system-adapter-stdio-cmd <CMD>`: Command to spawn as a stdio JSON-RPC adapter (mutually exclusive with `--system-adapter-http-url`).
+- `--system-adapter-stdio-args <STR>`: Space-delimited argument string for the stdio command.
+- `--system-adapter-http-url <URL>`: URL of an already-running HTTP JSON-RPC adapter.
+- `--system-adapter-param KEY=VALUE`: Adapter-specific parameter; passed in the `setup()` metadata map. Repeatable.
+- `--system-adapter-env KEY=VALUE`: Environment variable for the stdio adapter subprocess. Repeatable; stdio-only.
+- `--system-adapter-name <NAME>`: Logical name surfaced as a metric attribute and forwarded to the adapter. Defaults to `system_adapter`.
+
+#### Query Transport Selection
+
+Cluster SUTs typically expose two query interfaces from the scheduler:
+
+- Flight SQL gRPC — exercises the distributed-acceleration code path. This is the default; nothing extra to set.
+- HTTP `POST /v1/queries` — exercises the Ballista (distributed-query) submit-and-poll path. Select this with the existing `--distributed` flag.
+
+The HTTP base URL used by `--distributed` comes from the adapter's `setup` response: testoperator looks for an entry under `endpoints["spice.http.v1.queries"]`, and falls back to deriving the base URL from the Flight URL if the adapter doesn't provide one.
+
+#### Example: distributed accelerations against a local cluster
+
+```sh
+testoperator run bench \
+    -p ./test/spicepods/tpch/sf1/accelerated/distributed/cayenne.yaml \
+    --system-adapter-stdio-cmd ./target/debug/spidapter \
+    --system-adapter-stdio-args "local-spiced" \
+    --system-adapter-param executor_replicas=3 \
+    --query-set tpch \
+    --validate
+```
+
+#### Example: Ballista distributed query against the same cluster
+
+```sh
+testoperator run bench \
+    -p ./test/spicepods/tpch/sf1/distributed/ballista.yaml \
+    --system-adapter-stdio-cmd ./target/debug/spidapter \
+    --system-adapter-stdio-args "local-spiced" \
+    --system-adapter-param executor_replicas=3 \
+    --query-set tpch \
+    --distributed
+```
+
+Local-spawn-only side metrics (process memory, on-disk acceleration size) are skipped when running through a system adapter — the adapter's `metrics()` RPC is the canonical source of SUT-side resource usage for cluster benches.

--- a/tools/testoperator/src/args/mod.rs
+++ b/tools/testoperator/src/args/mod.rs
@@ -133,6 +133,40 @@ pub struct CommonArgs {
     /// Additional OTLP headers in key=value form. Can be repeated.
     #[arg(long, value_parser = parse_key_val, action = ArgAction::Append, requires = "otlp_endpoint", value_name = "KEY=VALUE")]
     pub(crate) otlp_header: Vec<(String, String)>,
+
+    /// Logical name for the system adapter connection. Surfaced as a metric
+    /// attribute and to the adapter via setup metadata.
+    #[arg(long, default_value = "system_adapter", env = "SYSTEM_ADAPTER")]
+    pub(crate) system_adapter_name: String,
+
+    /// Command to run for a stdio JSON-RPC system adapter. When set, testoperator
+    /// acquires its SUT through the adapter's `setup()` response instead of spawning
+    /// a local spiced or connecting via `--spiced-path`. Mutually exclusive with
+    /// `--system-adapter-http-url`.
+    #[arg(long, group = "system_adapter_option")]
+    pub(crate) system_adapter_stdio_cmd: Option<String>,
+
+    /// Space-delimited argument string passed to the stdio system adapter command.
+    #[arg(long, requires = "system_adapter_stdio_cmd")]
+    pub(crate) system_adapter_stdio_args: Option<String>,
+
+    /// HTTP URL for a remote JSON-RPC system adapter.
+    #[arg(
+        long,
+        conflicts_with = "system_adapter_stdio_cmd",
+        group = "system_adapter_option"
+    )]
+    pub(crate) system_adapter_http_url: Option<String>,
+
+    /// Additional system adapter parameters in key=value form. Forwarded to the
+    /// adapter inside the `setup()` metadata map. Can be repeated.
+    #[arg(long, value_parser = parse_key_val, action = ArgAction::Append, value_name = "KEY=VALUE", requires = "system_adapter_option")]
+    pub(crate) system_adapter_param: Vec<(String, String)>,
+
+    /// Environment variables for stdio system adapter in key=value form. Can be
+    /// repeated. Only applies when --system-adapter-stdio-cmd is set.
+    #[arg(long, value_parser = parse_key_val, action = ArgAction::Append, value_name = "KEY=VALUE", requires = "system_adapter_stdio_cmd")]
+    pub(crate) system_adapter_env: Vec<(String, String)>,
 }
 
 impl CommonArgs {
@@ -140,6 +174,16 @@ impl CommonArgs {
     #[must_use]
     pub fn is_external_instance(&self) -> bool {
         self.spiced_path.starts_with("http://") || self.spiced_path.starts_with("https://")
+    }
+
+    /// Check whether a system adapter has been configured to acquire the SUT.
+    ///
+    /// When true, testoperator drives `setup()` / `teardown()` over JSON-RPC and
+    /// uses the returned Flight URL instead of spawning a local spiced or honoring
+    /// `--spiced-path`.
+    #[must_use]
+    pub fn is_system_adapter(&self) -> bool {
+        self.system_adapter_stdio_cmd.is_some() || self.system_adapter_http_url.is_some()
     }
 
     /// Get the spiced path as a `PathBuf` (only valid when not an external instance)

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -14,11 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::{RowCounts, get_app_and_start_request};
-use crate::{
-    args::DatasetTestArgs, health::HealthMonitor, spiced_metrics::MetricsScraper,
-    wait_test_and_memory,
-};
+use super::{RowCounts, get_app_and_start_request, load_app};
+use crate::{args::DatasetTestArgs, health::HealthMonitor, spiced_metrics::MetricsScraper};
 use chbench_driver::ChBenchDriver as _;
 use std::{
     path::Path,
@@ -72,20 +69,57 @@ pub(crate) fn emit_acceleration_size_if_applicable(
 }
 
 pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
-    let (app, start_request) = get_app_and_start_request(&args.common).await?;
+    // Two SUT acquisition paths: when a system adapter is configured, delegate
+    // setup() to it over JSON-RPC; otherwise spawn a local `spiced` as before.
+    // The rest of the benchmark flow is identical apart from a few
+    // local-spawn-only side metrics (process memory, on-disk acceleration size)
+    // that we skip when the SUT lives elsewhere.
+    let (app, spiced_instance, system_adapter_session) = if args.common.is_system_adapter() {
+        let app = load_app(&args.common).await?;
+        let (instance, session) = crate::system_adapter::acquire(&args.common).await?;
+        (app, instance, Some(session))
+    } else {
+        let (app, start_request) = get_app_and_start_request(&args.common).await?;
 
-    // For chbench, prepare the Postgres source database (schema + seed data) before starting spiced.
-    let query_set = args.load_query_set()?;
-    if query_set == test_framework::queries::QuerySet::ChBench {
-        let scale_factor = args.scale_factor.unwrap_or(1.0);
-        prepare_chbench_source(scale_factor).await?;
+        // For chbench, prepare the Postgres source database (schema + seed data) before starting spiced.
+        let query_set = args.load_query_set()?;
+        if query_set == test_framework::queries::QuerySet::ChBench {
+            let scale_factor = args.scale_factor.unwrap_or(1.0);
+            prepare_chbench_source(scale_factor).await?;
+        }
+
+        let instance = SpicedInstance::start(start_request).await?;
+        (app, instance, None)
+    };
+
+    // From here on, we may early-return on errors but must still run adapter
+    // teardown if one was opened. Wrap the rest of the run in an inner helper
+    // whose `Result` we hold onto, run teardown unconditionally, then return.
+    let result = run_inner(args, app, spiced_instance).await;
+
+    if let Some(session) = system_adapter_session {
+        session.teardown().await;
     }
 
-    let mut spiced_instance = SpicedInstance::start(start_request).await?;
+    result
+}
+
+async fn run_inner(
+    args: &DatasetTestArgs,
+    app: App,
+    mut spiced_instance: SpicedInstance,
+) -> anyhow::Result<RowCounts> {
     let ready_wait_start = Instant::now();
 
+    // Process-memory tracking is only meaningful when testoperator owns the
+    // spiced subprocess. For SUTs acquired via a system adapter, the
+    // adapter's `metrics()` RPC is the canonical source of SUT-side resource
+    // usage, so we skip the local watcher entirely.
     let memory_token = CancellationToken::new();
-    let memory_readings = spiced_instance.process()?.watch_memory(&memory_token);
+    let memory_readings = spiced_instance
+        .process()
+        .ok()
+        .map(|process| process.watch_memory(&memory_token));
 
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
@@ -102,18 +136,21 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let testoperator_commit_sha = git::get_commit_sha();
     let branch_name = git::get_branch_name();
 
+    let query_set = args.load_query_set()?;
+    let mut benchmark_attributes = vec![
+        KeyValue::new("service.name", "testoperator"),
+        KeyValue::new("type", "benchmark_query"),
+        KeyValue::new("name", app.name.clone()),
+        KeyValue::new("spiced_version", spiced_version),
+        KeyValue::new("query_set", query_set.to_string()),
+        KeyValue::new("testoperator_commit_sha", testoperator_commit_sha),
+        KeyValue::new("spiced_commit_sha", spiced_commit_sha),
+        KeyValue::new("branch_name", branch_name),
+        KeyValue::new("scale_factor", args.scale_factor.unwrap_or(1.0).to_string()),
+    ];
+    benchmark_attributes.extend(super::run_mode_attributes(&args.common, args));
     let benchmark_resource = Resource::builder_empty()
-        .with_attributes(vec![
-            KeyValue::new("service.name", "testoperator"),
-            KeyValue::new("type", "benchmark_query"),
-            KeyValue::new("name", app.name.clone()),
-            KeyValue::new("spiced_version", spiced_version),
-            KeyValue::new("query_set", query_set.to_string()),
-            KeyValue::new("testoperator_commit_sha", testoperator_commit_sha),
-            KeyValue::new("spiced_commit_sha", spiced_commit_sha),
-            KeyValue::new("branch_name", branch_name),
-            KeyValue::new("scale_factor", args.scale_factor.unwrap_or(1.0).to_string()),
-        ])
+        .with_attributes(benchmark_attributes)
         .build();
 
     // Create telemetry with resource upfront, before any metrics calls
@@ -157,13 +194,31 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     let benchmark_test = benchmark_test.start()?;
 
-    let test = wait_test_and_memory!(benchmark_test, memory_token, memory_readings);
+    let test = match benchmark_test.wait().await {
+        Ok(test) => test,
+        Err(e) => {
+            // Best-effort memory drain on failure, mirroring `wait_test_and_memory!`
+            // for the local-spawn case. For adapter-acquired SUTs there's no local
+            // process being watched, so skip the call entirely.
+            if let Some(handle) = memory_readings {
+                let _ = observe_memory(memory_token, handle).await;
+            }
+            return Err(e);
+        }
+    };
 
     let row_counts = test.validate_returned_row_counts()?;
     let metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Benchmark)?;
     let test_succeeded = test.succeeded();
     let mut spiced_instance = test.end()?;
-    let (max_memory, median_memory) = observe_memory(memory_token, memory_readings).await?;
+    // Only present when a local spiced subprocess is being watched. For
+    // adapter-acquired SUTs we deliberately leave this as `None` rather than
+    // recording a misleading 0.0 — the adapter's own metrics RPC is the right
+    // source of SUT-side resource numbers.
+    let memory_usage = match memory_readings {
+        Some(handle) => Some(observe_memory(memory_token, handle).await?),
+        None => None,
+    };
 
     let mut failures = Vec::new();
     for query in &metrics.metrics {
@@ -197,12 +252,23 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     crate::metrics::READY_DURATION.record(ready_wait_duration.as_millis().try_into()?, &[]);
     crate::metrics::TEST_DURATION
         .record((metrics.finished_at - metrics.started_at).try_into()?, &[]);
-    crate::metrics::PEAK_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
-    crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
+    if let Some((max_memory, median_memory)) = memory_usage {
+        crate::metrics::PEAK_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
+        crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
+    }
 
-    emit_acceleration_size_if_applicable(&app, &spiced_instance.get_tempdir_path()?)?;
+    // On-disk acceleration size only applies to the local-spawn path (the SUT
+    // tempdir is testoperator's own). When the SUT lives elsewhere there's
+    // nothing to measure from here.
+    if let Ok(tempdir_path) = spiced_instance.get_tempdir_path() {
+        emit_acceleration_size_if_applicable(&app, &tempdir_path)?;
+    }
 
-    let records = metrics.with_memory_usage(max_memory).build_records()?;
+    let metrics = match memory_usage {
+        Some((max_memory, _)) => metrics.with_memory_usage(max_memory),
+        None => metrics,
+    };
+    let records = metrics.build_records()?;
     print_batches(&records)?;
 
     let health_report = health_monitor.stop().await;
@@ -213,6 +279,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     telemetry.emit().await?;
 
     spiced_instance.stop()?;
+
     let health_report = health_report?;
     let mut error_messages = Vec::new();
 

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -136,24 +136,90 @@ pub(crate) async fn run_or_connect_spiced(
     Ok((app, instance))
 }
 
+/// Load the test [`App`] from the configured spicepod (and its declared
+/// dependencies). Shared by both the local-spawn and system-adapter SUT paths,
+/// since testoperator always needs the spicepod-derived dataset info for query
+/// construction regardless of where the SUT actually runs.
+/// Build resource attributes that describe how this run acquired its SUT and
+/// which query transport it exercised. Lets downstream dashboards distinguish
+/// cluster benchmarks (via a system adapter) from the traditional single-node
+/// `spiced` runs, and split the cluster results by query path (Flight SQL for
+/// distributed accelerations vs HTTP `/v1/queries` for Ballista).
+pub(crate) fn run_mode_attributes(
+    common: &CommonArgs,
+    dataset_args: &DatasetTestArgs,
+) -> Vec<test_framework::opentelemetry::KeyValue> {
+    use test_framework::opentelemetry::KeyValue;
+
+    let mut attrs = Vec::with_capacity(4);
+
+    let (mode, transport) = if common.is_system_adapter() {
+        let transport = if dataset_args.distributed {
+            "http_v1_queries"
+        } else if dataset_args.http_clients {
+            "http_v1_sql"
+        } else {
+            "flightsql"
+        };
+        ("cluster", transport)
+    } else if common.is_external_instance() {
+        ("external", "flightsql")
+    } else {
+        ("single_node", "flightsql")
+    };
+
+    attrs.push(KeyValue::new("mode", mode));
+    attrs.push(KeyValue::new("query_transport", transport));
+
+    if common.is_system_adapter() {
+        attrs.push(KeyValue::new(
+            "system_adapter_name",
+            common.system_adapter_name.clone(),
+        ));
+        // Mirror any executor-count hint the user passed via
+        // --system-adapter-param so dashboards can group runs by cluster size
+        // without inspecting the spicepod or the adapter's reply.
+        if let Some(replicas) = common
+            .system_adapter_param
+            .iter()
+            .find(|(k, _)| k == "executor_replicas")
+            .map(|(_, v)| v.clone())
+        {
+            attrs.push(KeyValue::new("cluster_executor_replicas", replicas));
+        }
+    }
+
+    attrs
+}
+
+pub(crate) async fn load_app(args: &CommonArgs) -> anyhow::Result<App> {
+    let mut spicepod = Spicepod::load_exact(args.spicepod_path.clone()).await?;
+
+    // Resolve dependencies up-front from the original list, then strip them
+    // before handing the spicepod to the builder — otherwise the App carries a
+    // dangling `dependencies:` list that no longer matches what got loaded.
+    let mut dependencies = Vec::new();
+    if let Some(dependencies_root) = &args.spicepod_dependencies {
+        for dependency in &spicepod.dependencies {
+            dependencies.push(Spicepod::load(&dependencies_root.join(dependency)).await?);
+        }
+    }
+    spicepod.dependencies = vec![];
+
+    let mut app_builder = AppBuilder::new(spicepod.name.clone()).with_spicepod(spicepod);
+    for dependent_spicepod in dependencies {
+        app_builder = app_builder.with_spicepod_dependency(dependent_spicepod);
+    }
+    Ok(app_builder.build())
+}
+
 pub(crate) async fn get_app_and_start_request(
     args: &CommonArgs,
 ) -> anyhow::Result<(App, StartRequest)> {
     // When metrics are disabled, no Telemetry is created, so METER_PROVIDER_ONCE
     // remains unset and all metric operations are no-ops.
 
-    let mut spicepod = Spicepod::load_exact(args.spicepod_path.clone()).await?;
-    let mut app_builder = AppBuilder::new(spicepod.name.clone()).with_spicepod(spicepod.clone());
-
-    if let Some(dependencies_root) = &args.spicepod_dependencies {
-        for dependency in &spicepod.dependencies {
-            let dependent_spicepod = Spicepod::load(&dependencies_root.join(dependency)).await?;
-            app_builder = app_builder.with_spicepod_dependency(dependent_spicepod);
-        }
-    }
-    // After we've loaded dependencies, remove.
-    spicepod.dependencies = vec![];
-    let app = app_builder.build();
+    let app = load_app(args).await?;
 
     let mut start_request = StartRequest::new(args.spiced_path_buf(), from_app(app.clone()))?;
 

--- a/tools/testoperator/src/commands/throughput/mod.rs
+++ b/tools/testoperator/src/commands/throughput/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::get_app_and_start_request;
-use crate::{args::DatasetTestArgs, health::HealthMonitor, wait_test_and_memory};
+use super::{get_app_and_start_request, load_app};
+use crate::{args::DatasetTestArgs, health::HealthMonitor};
 use std::time::Duration;
 use test_framework::{
     TestType, anyhow,
+    app::App,
     arrow::util::pretty::print_batches,
     metrics::{MetricCollector, QueryMetrics, ThroughputMetrics},
     spiced::SpicedInstance,
@@ -37,9 +38,32 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
         ));
     }
 
-    let (app, start_request) = get_app_and_start_request(&args.common).await?;
-    let mut spiced_instance = SpicedInstance::start(start_request).await?;
+    let (app, spiced_instance, system_adapter_session) = if args.common.is_system_adapter() {
+        let app = load_app(&args.common).await?;
+        let (instance, session) = crate::system_adapter::acquire(&args.common).await?;
+        (app, instance, Some(session))
+    } else {
+        let (app, start_request) = get_app_and_start_request(&args.common).await?;
+        let instance = SpicedInstance::start(start_request).await?;
+        (app, instance, None)
+    };
 
+    // Mirror bench's finally-block pattern so adapter teardown runs even if
+    // the inner flow bails on an error.
+    let result = run_inner(args, app, spiced_instance).await;
+
+    if let Some(session) = system_adapter_session {
+        session.teardown().await;
+    }
+
+    result
+}
+
+async fn run_inner(
+    args: &DatasetTestArgs,
+    app: App,
+    mut spiced_instance: SpicedInstance,
+) -> anyhow::Result<()> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
@@ -68,7 +92,12 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     let test = baseline_test.wait().await?;
     let spiced_instance = test.end()?;
     let memory_token = CancellationToken::new();
-    let memory_readings = spiced_instance.process()?.watch_memory(&memory_token);
+    // Process-memory watching only applies to the local-spawn path. See
+    // bench/mod.rs for context.
+    let memory_readings = spiced_instance
+        .process()
+        .ok()
+        .map(|process| process.watch_memory(&memory_token));
 
     // throughput test
     println!("Running throughput test");
@@ -87,19 +116,37 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
         .with_progress_bars(!args.common.disable_progress_bars)
         .start()?;
 
-    let test = wait_test_and_memory!(throughput_test, memory_token, memory_readings);
+    let test = match throughput_test.wait().await {
+        Ok(test) => test,
+        Err(e) => {
+            if let Some(handle) = memory_readings {
+                let _ = observe_memory(memory_token, handle).await;
+            }
+            return Err(e);
+        }
+    };
     let throughput_metric = test.get_throughput_metric(args.scale_factor.unwrap_or(1.0))?;
     let metrics: QueryMetrics<_, ThroughputMetrics> = test
         .collect(TestType::Throughput)?
         .with_run_metric(ThroughputMetrics::new(throughput_metric));
     let mut spiced_instance = test.end()?;
-    let (max_memory, _) = observe_memory(memory_token, memory_readings).await?;
+    // Leave as `None` when the SUT isn't local — recording 0 would skew
+    // memory dashboards.
+    let memory_usage = match memory_readings {
+        Some(handle) => Some(observe_memory(memory_token, handle).await?),
+        None => None,
+    };
 
     let records = metrics.build_records()?;
     print_batches(&records)?;
-    metrics.with_memory_usage(max_memory).show_run(None)?; // no additional test pass logic applies
+    let metrics = match memory_usage {
+        Some((max_memory, _)) => metrics.with_memory_usage(max_memory),
+        None => metrics,
+    };
+    metrics.show_run(None)?; // no additional test pass logic applies
     let health_report = health_monitor.stop().await;
     spiced_instance.stop()?;
+
     let health_report = health_report?;
 
     if let Some(message) = health_report.failure_message() {

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -22,6 +22,7 @@ mod commands;
 mod health;
 mod metrics;
 mod spiced_metrics;
+mod system_adapter;
 
 use args::{
     Commands, DataConsistencyArgs, DatasetTestArgs, HtapArgs, LoadTestArgs, SchemaTestArgs,

--- a/tools/testoperator/src/system_adapter.rs
+++ b/tools/testoperator/src/system_adapter.rs
@@ -1,0 +1,260 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! System-adapter integration for testoperator.
+//!
+//! When `--system-adapter-stdio-cmd` or `--system-adapter-http-url` is set,
+//! testoperator delegates SUT acquisition to an out-of-process JSON-RPC adapter
+//! (the same protocol spicebench uses). The adapter's `setup()` response carries
+//! a Flight SQL URL in `db_kwargs` and, for clusters that expose Spice's HTTP
+//! query APIs, an additional `endpoints` entry under `spice.http.v1.queries`.
+//!
+//! Lifecycle:
+//!   1. `acquire()` — spawn or connect to the adapter, call `setup`, build a
+//!      [`SpicedInstance::External`] from the response, return a paired
+//!      [`SystemAdapterSession`] for teardown.
+//!   2. Run the test workload as usual (existing engine path).
+//!   3. `SystemAdapterSession::teardown()` — call `teardown` on the adapter.
+//!      Best-effort: errors are logged, not propagated, since the test result
+//!      should already be reported by this point.
+
+use std::collections::HashMap;
+
+use test_framework::{anyhow, spiced::SpicedInstance};
+use uuid::Uuid;
+
+use crate::args::CommonArgs;
+
+/// JSON-RPC client + per-run identifier, retained so teardown can be invoked
+/// after the test completes. `teardown` consumes `self`, so the client lives
+/// here directly without `Arc<Mutex<_>>` indirection.
+pub struct SystemAdapterSession {
+    client: system_adapter_protocol::Client,
+    run_id: Uuid,
+    transport: &'static str,
+}
+
+impl SystemAdapterSession {
+    /// Call `teardown` on the adapter. Errors are logged but not returned, so
+    /// callers can always run teardown in their cleanup path regardless of
+    /// whether the test succeeded.
+    pub async fn teardown(mut self) {
+        match self.client.teardown(self.run_id).await {
+            Ok(response) if response.ok => {
+                println!(
+                    "System adapter teardown ({transport}, run_id={run_id}): ok",
+                    transport = self.transport,
+                    run_id = self.run_id,
+                );
+            }
+            Ok(response) => {
+                // Transport succeeded but the adapter reported failure; surface
+                // it as a warning rather than burying it in normal output.
+                eprintln!(
+                    "Warning: system adapter teardown reported failure \
+                     (transport={}, run_id={}, ok={})",
+                    self.transport, self.run_id, response.ok,
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: system adapter teardown failed (transport={}, run_id={}): {e}",
+                    self.transport, self.run_id,
+                );
+            }
+        }
+    }
+}
+
+/// Acquire a SUT via the configured system adapter.
+///
+/// Spawns (or connects to) the adapter, sends a `setup` request including the
+/// resolved spicepod path and any `--system-adapter-param` values in the
+/// metadata map, and returns a paired [`SpicedInstance::External`] + session
+/// handle. The caller is responsible for calling [`SystemAdapterSession::teardown`]
+/// in its cleanup path.
+///
+/// # Errors
+/// - The adapter command can't be spawned, or the HTTP endpoint is unreachable
+/// - `setup` returns an error or an unexpected driver (anything other than
+///   `flightsql`)
+/// - The response is missing the required `uri` kwarg
+pub async fn acquire(args: &CommonArgs) -> anyhow::Result<(SpicedInstance, SystemAdapterSession)> {
+    let mut client = build_client(args)?;
+    let run_id = Uuid::new_v4();
+    let transport = client.transport_name();
+
+    let metadata = build_setup_metadata(args)?;
+
+    println!("System adapter setup ({transport}, run_id={run_id})");
+
+    let response = client
+        .setup(run_id, metadata, HashMap::new(), None)
+        .await
+        .map_err(|e| anyhow::anyhow!("system adapter setup failed: {e}"))?;
+
+    // From this point on the adapter has provisioned resources. If anything
+    // below fails (unsupported driver, missing uri, …) we still need to call
+    // teardown so the SUT doesn't leak. Build the session first, then try to
+    // interpret the response.
+    let session = SystemAdapterSession {
+        client,
+        run_id,
+        transport,
+    };
+
+    match interpret_setup_response(&response) {
+        Ok((flight_url, api_key, http_base_url)) => {
+            let instance = match http_base_url {
+                Some(http_url) => SpicedInstance::external_with_http(flight_url, http_url),
+                None => SpicedInstance::external(flight_url),
+            };
+            let instance = instance.with_api_key(api_key);
+            Ok((instance, session))
+        }
+        Err(e) => {
+            session.teardown().await;
+            Err(e)
+        }
+    }
+}
+
+/// Validate the setup response and extract `(flight_url, api_key, http_base_url)`.
+fn interpret_setup_response(
+    response: &system_adapter_protocol::SetupResponse,
+) -> anyhow::Result<(String, Option<String>, Option<String>)> {
+    if !matches!(
+        response.driver,
+        system_adapter_protocol::AdbcDriver::Flightsql
+    ) {
+        anyhow::bail!(
+            "system adapter returned unsupported driver `{driver}`; testoperator only \
+             drives `flightsql` SUTs today",
+            driver = response.driver,
+        );
+    }
+
+    let flight_url = response
+        .db_kwargs
+        .get("uri")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "system adapter setup response missing required `uri` in db_kwargs \
+                 for driver=flightsql"
+            )
+        })?
+        .to_string();
+
+    let http_base_url = http_base_url_from_endpoints(&response.endpoints)
+        .or_else(|| derive_http_base_url(&flight_url));
+
+    // Spice Cloud + spidapter return the cluster's API key in the standard
+    // FlightSQL ADBC kwarg `password`. We stash it on the SpicedInstance so the
+    // HTTP readiness probe and Flight SQL client both authenticate properly.
+    let api_key = response
+        .db_kwargs
+        .get("password")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    Ok((flight_url, api_key, http_base_url))
+}
+
+fn build_client(args: &CommonArgs) -> anyhow::Result<system_adapter_protocol::Client> {
+    if let Some(cmd) = &args.system_adapter_stdio_cmd {
+        let stdio_args = args
+            .system_adapter_stdio_args
+            .as_deref()
+            .map(|s| s.split_whitespace().map(str::to_string).collect::<Vec<_>>())
+            .unwrap_or_default();
+        let env: HashMap<String, String> = args.system_adapter_env.iter().cloned().collect();
+        return system_adapter_protocol::Client::stdio(cmd, stdio_args, env)
+            .map_err(|e| anyhow::anyhow!("failed to start stdio system adapter `{cmd}`: {e}"));
+    }
+
+    if let Some(url) = &args.system_adapter_http_url {
+        return Ok(system_adapter_protocol::Client::http(url));
+    }
+
+    anyhow::bail!(
+        "no system adapter configured (expected --system-adapter-stdio-cmd or \
+         --system-adapter-http-url)"
+    )
+}
+
+fn build_setup_metadata(args: &CommonArgs) -> anyhow::Result<HashMap<String, serde_json::Value>> {
+    let mut metadata: HashMap<String, serde_json::Value> = HashMap::new();
+
+    let spicepod_path = args
+        .spicepod_path
+        .canonicalize()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to resolve spicepod path `{}` to an absolute path for the \
+                 system adapter: {e}",
+                args.spicepod_path.display()
+            )
+        })?
+        .to_string_lossy()
+        .into_owned();
+
+    metadata.insert("spicepod_path".to_string(), spicepod_path.into());
+    metadata.insert(
+        "system_adapter_name".to_string(),
+        args.system_adapter_name.clone().into(),
+    );
+
+    for (key, value) in &args.system_adapter_param {
+        metadata.insert(key.clone(), value.clone().into());
+    }
+
+    Ok(metadata)
+}
+
+/// Pull an HTTP base URL out of the optional `spice.http.v1.queries` endpoint.
+///
+/// The endpoint's `url` kwarg is the full Ballista submit URL
+/// (e.g. `http://scheduler:8090/v1/queries`); we want the base URL with the
+/// `/v1/queries` path component stripped so callers can re-append the right
+/// suffix (`/v1/ready`, `/v1/queries`, …). Parse as a URL so trailing slashes,
+/// query strings, and any future API-version drift don't desync.
+fn http_base_url_from_endpoints(
+    endpoints: &HashMap<String, HashMap<String, serde_json::Value>>,
+) -> Option<String> {
+    let entry = endpoints.get("spice.http.v1.queries")?;
+    let raw = entry.get("url")?.as_str()?;
+    let mut url = url::Url::parse(raw).ok()?;
+    // Drop everything past the origin — path/query/fragment — leaving just
+    // `scheme://host[:port]`.
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    let s = url.as_str().trim_end_matches('/').to_string();
+    Some(s)
+}
+
+/// Mirror of `SpicedInstance::external`'s URL inference, exposed here so we can
+/// fall back to a derived HTTP base URL when the adapter doesn't return one.
+fn derive_http_base_url(flight_url: &str) -> Option<String> {
+    if flight_url.contains("flight.spiceai.io") {
+        return Some("https://data.spiceai.io".to_string());
+    }
+    flight_url
+        .rfind(':')
+        .map(|last_colon| format!("{base}:8090", base = &flight_url[..last_colon]))
+}


### PR DESCRIPTION
## Summary

Adds system-adapter support to `testoperator` so benchmarks can run against runtime instances provisioned by adapters, including Spice Cloud clusters managed by `spidapter`.

When `--system-adapter-stdio-cmd` or `--system-adapter-http-url` is set, `testoperator` now:

1. loads the spicepod and sends its absolute path to the adapter in `setup()` metadata;
2. uses the adapter's Flight SQL URL, API key, and optional HTTP `/v1/queries` endpoint;
3. runs `bench` or `throughput` with the existing query executors;
4. calls adapter `teardown()` at the end, even if the run fails.

Local `spiced` subprocess mode and existing external-URL mode are unchanged.

## Existing local `spiced` flow

```text
testoperator run bench/throughput
        |
        v
Load spicepod and dependencies
        |
        v
Create temp app directory
write spicepod.yaml
link optional data dir
        |
        v
Spawn local spiced subprocess
        |
        v
Poll local /v1/ready
        |
        v
Run queries
  - default: Flight SQL on localhost:50051
  - --http-clients: HTTP /v1/sql on localhost:8090
  - --distributed: HTTP /v1/queries on localhost:8090
        |
        v
Collect local-only metrics
  - process memory
  - on-disk acceleration size
        |
        v
Stop local spiced
```

## New system-adapter flow

```text
testoperator run bench/throughput --system-adapter-...
        |
        v
Load spicepod for benchmark metadata
canonicalize spicepod path
collect --system-adapter-param values
        |
        v
JSON-RPC setup(run_id, metadata)
        |
        v
System adapter, e.g. spidapter
  - deploys the spicepod to a cluster or Spice Cloud
  - returns Flight SQL URL in db_kwargs.uri
  - returns API key in db_kwargs.password
  - returns optional HTTP endpoint:
      endpoints["spice.http.v1.queries"].url
        |
        v
Build SpicedInstance::External
  - Flight SQL URL
  - HTTP base URL
  - API key
        |
        v
Poll cluster /v1/ready
        |
        v
Run queries
  - default: Flight SQL
  - --http-clients: HTTP /v1/sql
  - --distributed: HTTP /v1/queries
        |
        v
JSON-RPC teardown(run_id)
(runs even if the benchmark fails)
```

## What changed

- Adds system-adapter CLI flags to `testoperator`:
  - `--system-adapter-stdio-cmd`
  - `--system-adapter-stdio-args`
  - `--system-adapter-http-url`
  - `--system-adapter-param KEY=VALUE`
  - `--system-adapter-env KEY=VALUE`
  - `--system-adapter-name`
- Wires system-adapter acquisition into `run bench` and `run throughput`.
- Stores adapter-provided API keys on `SpicedInstance` so readiness checks, Flight SQL, and HTTP query clients authenticate.
- Adds benchmark resource attributes: `mode`, `query_transport`, `system_adapter_name`, and `cluster_executor_replicas`.
- Updates `spidapter` to deploy a caller-provided `spicepod_path` and return `endpoints["spice.http.v1.queries"]`.
- Fixes `DistributedExecutor` so `--distributed` works with `/v1/queries`:
  - reads `status` instead of `state`;
  - matches `SCREAMING_SNAKE_CASE` job statuses;
  - reads the result manifest from `GET /v1/queries/{id}`.
- Adds a `cluster benchmark e2e tests` workflow for running cluster benches through `spidapter`.

## Notes

- This pairs with spiceai/spicebench#246, which added the optional `endpoints` field to `SetupResponse`.
- Runtime instances acquired through adapters skip local process-memory and acceleration-size tracking. Cluster resource metrics should come from the adapter `metrics()` RPC.
- `run load` and a dedicated distributed dispatch tree are follow-ups.
- **Before merge:** remove the temporary `push:` trigger from `.github/workflows/testoperator_run_cluster_bench.yml`; only `workflow_dispatch` should remain.

## Test plan

- [x] `cargo clippy -p testoperator -p test-framework -p spidapter --all-targets -- -D warnings`
- [x] Cluster benchmark workflow reached setup → bench → teardown against Spice Cloud: https://github.com/spiceai/spiceai/actions/runs/25833132153
- [x] Q1–Q6 succeeded via `/v1/queries` with 3 executors
- [ ] CI

## Out of scope

The end-to-end run exposed a separate Ballista shuffle-fetch issue on Q7+. That runtime issue is not fixed in this PR.
