### PR TITLE
Add range fallback for large join filters

### DIFF
--- a/crates/runtime-datafusion/Cargo.toml
+++ b/crates/runtime-datafusion/Cargo.toml
@@ -49,3 +49,7 @@ tokio.workspace = true
 [[bench]]
 harness = false
 name = "data_source_tree_display"
+
+[[bench]]
+harness = false
+name = "join_accumulator"

--- a/crates/runtime-datafusion/benches/join_accumulator.rs
+++ b/crates/runtime-datafusion/benches/join_accumulator.rs
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Microbenchmarks for `ExactLeftAccumulator` dynamic join filters.
+//!
+//! These measure the two important paths for Cayenne large joins:
+//! accumulating exact in-list keys while below the memory cap, and switching to
+//! the conservative range fallback when the exact key set would exceed it.
+//!
+//! Run with: `cargo bench -p runtime-datafusion --bench join_accumulator`
+
+#![allow(clippy::expect_used)]
+
+use std::{hint::black_box, sync::Arc};
+
+use arrow::{
+    array::{ArrayRef, UInt64Array},
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use datafusion::physical_plan::{
+    PhysicalExpr,
+    expressions::col,
+    joins::{CollectLeftAccumulator, ColumnBounds},
+};
+use runtime_datafusion::join_accumulator::ExactLeftAccumulator;
+
+fn schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "join_key",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
+fn batch_with_row_count(row_count: usize) -> RecordBatch {
+    let schema = schema();
+    let row_count = u64::try_from(row_count).expect("row count should fit in u64");
+    let values = UInt64Array::from_iter_values(0..row_count);
+    RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(values) as ArrayRef])
+        .expect("record batch should be valid")
+}
+
+fn join_key_expr(schema: &SchemaRef) -> Arc<dyn PhysicalExpr> {
+    col("join_key", schema).expect("join key column should exist")
+}
+
+fn exact_bounds(batch: &RecordBatch, expr: Arc<dyn PhysicalExpr>) -> Arc<dyn ColumnBounds> {
+    let mut accumulator = ExactLeftAccumulator::try_new(expr, &batch.schema())
+        .expect("accumulator should be created");
+    accumulator
+        .update_batch(batch)
+        .expect("batch should update exact accumulator");
+    accumulator
+        .evaluate()
+        .expect("exact accumulator should evaluate")
+}
+
+fn range_fallback_bounds(
+    batch: &RecordBatch,
+    expr: Arc<dyn PhysicalExpr>,
+) -> Arc<dyn ColumnBounds> {
+    let mut accumulator = ExactLeftAccumulator::new_with_memory_limit(expr, 0);
+    accumulator
+        .update_batch(batch)
+        .expect("batch should update range fallback accumulator");
+    accumulator
+        .evaluate()
+        .expect("range fallback accumulator should evaluate")
+}
+
+fn bench_update_batch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("join_accumulator_update_batch");
+
+    for row_count in [1_024usize, 16_384, 65_536] {
+        let batch = batch_with_row_count(row_count);
+        let expr = join_key_expr(&batch.schema());
+        group.throughput(Throughput::Elements(
+            u64::try_from(row_count).expect("row count should fit in u64"),
+        ));
+
+        group.bench_with_input(
+            BenchmarkId::new("exact_in_list", row_count),
+            &batch,
+            |b, batch| {
+                b.iter(|| {
+                    let schema = batch.schema();
+                    let mut accumulator =
+                        ExactLeftAccumulator::try_new(Arc::clone(&expr), black_box(&schema))
+                            .expect("accumulator should be created");
+                    accumulator
+                        .update_batch(black_box(batch))
+                        .expect("batch should update accumulator");
+                    black_box(accumulator);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("range_fallback", row_count),
+            &batch,
+            |b, batch| {
+                b.iter(|| {
+                    let mut accumulator =
+                        ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&expr), 0);
+                    accumulator
+                        .update_batch(black_box(batch))
+                        .expect("batch should update accumulator");
+                    black_box(accumulator);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_physical_expr(c: &mut Criterion) {
+    let mut group = c.benchmark_group("join_accumulator_physical_expr");
+
+    for row_count in [1_024usize, 16_384] {
+        let batch = batch_with_row_count(row_count);
+        let build_expr = join_key_expr(&batch.schema());
+        let probe_expr = join_key_expr(&batch.schema());
+        let exact_bounds = exact_bounds(&batch, Arc::clone(&build_expr));
+        let range_bounds = range_fallback_bounds(&batch, build_expr);
+
+        group.throughput(Throughput::Elements(
+            u64::try_from(row_count).expect("row count should fit in u64"),
+        ));
+
+        group.bench_with_input(
+            BenchmarkId::new("exact_in_list", row_count),
+            &exact_bounds,
+            |b, bounds| {
+                b.iter(|| {
+                    let physical_expr = bounds
+                        .physical_expr(Arc::clone(&probe_expr))
+                        .expect("exact physical expression should be created");
+                    black_box(physical_expr);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("range_fallback", row_count),
+            &range_bounds,
+            |b, bounds| {
+                b.iter(|| {
+                    let physical_expr = bounds
+                        .physical_expr(Arc::clone(&probe_expr))
+                        .expect("range fallback physical expression should be created");
+                    black_box(physical_expr);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_update_batch, bench_physical_expr);
+criterion_main!(benches);

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -82,27 +82,30 @@ impl CollectLeftAccumulator for ExactLeftAccumulator {
         // eagerly evaluate the expression and store the resulting array
         // this avoids storing the entire record batch in memory, only storing the evaluated column
         let array = self.expr.evaluate(batch)?.into_array(batch.num_rows())?;
-        self.range_bounds.update(array.as_ref())?;
 
         if self.exact_values_exceeded_memory_limit {
+            self.range_bounds.update(array.as_ref())?;
             return Ok(());
         }
 
-        self.total_memory_size = self
+        let total_memory_size = self
             .total_memory_size
             .saturating_add(array.get_array_memory_size());
 
-        if self.total_memory_size > self.max_inlist_memory_size {
+        if total_memory_size > self.max_inlist_memory_size {
             tracing::debug!(
                 "ExactLeftAccumulator exceeded maximum in-list memory size ({} bytes > {} bytes); using range fallback.",
-                self.total_memory_size,
+                total_memory_size,
                 self.max_inlist_memory_size
             );
+            self.range_bounds = self.range_bounds_from_collected_arrays(array.as_ref())?;
             self.arrays.clear();
+            self.total_memory_size = total_memory_size;
             self.exact_values_exceeded_memory_limit = true;
             return Ok(());
         }
 
+        self.total_memory_size = total_memory_size;
         self.arrays.push(array);
         Ok(())
     }
@@ -133,6 +136,18 @@ impl ExactLeftAccumulator {
             range_bounds: RangeBounds::default(),
             exact_values_exceeded_memory_limit: false,
         }
+    }
+
+    fn range_bounds_from_collected_arrays(
+        &self,
+        array: &dyn Array,
+    ) -> DataFusionResult<RangeBounds> {
+        let mut range_bounds = RangeBounds::default();
+        for collected_array in &self.arrays {
+            range_bounds.update(collected_array.as_ref())?;
+        }
+        range_bounds.update(array)?;
+        Ok(range_bounds)
     }
 }
 
@@ -549,6 +564,44 @@ mod tests {
         let probe_array: ArrayRef = Arc::new(UInt64Array::from(vec![0, 1, 3, 5, 6]));
         let probe_batch = RecordBatch::try_new(Arc::new(probe_schema), vec![probe_array])
             .expect("Should create probe record batch");
+        let actual_values = evaluate_boolean_expression(&physical_expr, &probe_batch);
+
+        assert_eq!(
+            vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
+            actual_values
+        );
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_defers_range_bounds_until_memory_limit_exceeded() {
+        let first_batch = create_uint64_batch(vec![10, 20]);
+        let second_batch = create_uint64_batch(vec![1, 30]);
+        let max_memory_size = first_batch.column(0).get_array_memory_size();
+
+        let left_expr = col("a", &first_batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), max_memory_size);
+
+        accumulator
+            .update_batch(&first_batch)
+            .expect("Should update first batch");
+        assert_eq!(1, accumulator.arrays.len());
+        assert!(accumulator.range_bounds.min_value.is_none());
+        assert!(accumulator.range_bounds.max_value.is_none());
+        assert!(!accumulator.exact_values_exceeded_memory_limit);
+
+        accumulator
+            .update_batch(&second_batch)
+            .expect("Should update second batch");
+        assert!(accumulator.arrays.is_empty());
+        assert!(accumulator.exact_values_exceeded_memory_limit);
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let probe_batch = create_uint64_batch(vec![0, 1, 15, 30, 31]);
         let actual_values = evaluate_boolean_expression(&physical_expr, &probe_batch);
 
         assert_eq!(

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -44,6 +44,7 @@ pub struct ExactLeftAccumulator {
     arrays: Vec<Arc<dyn Array>>,
     expr: Arc<dyn PhysicalExpr>,
     total_memory_size: usize,
+    max_inlist_memory_size: usize,
     range_bounds: RangeBounds,
     exact_values_exceeded_memory_limit: bool,
 }
@@ -61,36 +62,13 @@ impl CollectLeftAccumulator for ExactLeftAccumulator {
     }
 
     fn try_new(expr: Arc<dyn PhysicalExpr>, _schema: &SchemaRef) -> DataFusionResult<Self> {
-        tracing::debug!("Trying to build ExactLeftAccumulator.");
-        Ok(Self {
-            arrays: Vec::new(),
+        Ok(Self::new_with_memory_limit(
             expr,
-            total_memory_size: 0,
-            range_bounds: RangeBounds::default(),
-            exact_values_exceeded_memory_limit: false,
-        })
+            MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION,
+        ))
     }
 
     fn update_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
-        self.update_batch_with_memory_limit(batch, MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION)
-    }
-
-    fn evaluate(self) -> DataFusionResult<Arc<dyn ColumnBounds>> {
-        Ok(Arc::new(ExactColumnBounds {
-            arrays: self.arrays,
-            total_memory_size: self.total_memory_size,
-            range_bounds: self.range_bounds,
-            use_range_fallback: self.exact_values_exceeded_memory_limit,
-        }))
-    }
-}
-
-impl ExactLeftAccumulator {
-    fn update_batch_with_memory_limit(
-        &mut self,
-        batch: &RecordBatch,
-        max_memory_size: usize,
-    ) -> DataFusionResult<()> {
         if batch.num_rows() == 0 {
             tracing::debug!("ExactLeftAccumulator received empty batch, skipping.");
             return Ok(());
@@ -114,11 +92,11 @@ impl ExactLeftAccumulator {
             .total_memory_size
             .saturating_add(array.get_array_memory_size());
 
-        if self.total_memory_size > max_memory_size {
+        if self.total_memory_size > self.max_inlist_memory_size {
             tracing::debug!(
                 "ExactLeftAccumulator exceeded maximum in-list memory size ({} bytes > {} bytes); using range fallback.",
                 self.total_memory_size,
-                max_memory_size
+                self.max_inlist_memory_size
             );
             self.arrays.clear();
             self.exact_values_exceeded_memory_limit = true;
@@ -127,6 +105,34 @@ impl ExactLeftAccumulator {
 
         self.arrays.push(array);
         Ok(())
+    }
+
+    fn evaluate(self) -> DataFusionResult<Arc<dyn ColumnBounds>> {
+        Ok(Arc::new(ExactColumnBounds {
+            arrays: self.arrays,
+            total_memory_size: self.total_memory_size,
+            range_bounds: self.range_bounds,
+            use_range_fallback: self.exact_values_exceeded_memory_limit,
+        }))
+    }
+}
+
+impl ExactLeftAccumulator {
+    /// Creates an accumulator with a custom per-partition in-list memory limit.
+    #[must_use]
+    pub fn new_with_memory_limit(
+        expr: Arc<dyn PhysicalExpr>,
+        max_inlist_memory_size: usize,
+    ) -> Self {
+        tracing::debug!("Trying to build ExactLeftAccumulator.");
+        Self {
+            arrays: Vec::new(),
+            expr,
+            total_memory_size: 0,
+            max_inlist_memory_size,
+            range_bounds: RangeBounds::default(),
+            exact_values_exceeded_memory_limit: false,
+        }
     }
 }
 
@@ -146,7 +152,7 @@ impl ColumnBounds for ExactColumnBounds {
         left_expr: Arc<dyn PhysicalExpr>,
     ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
         if self.use_range_fallback {
-            return self.range_bounds.physical_expr(left_expr);
+            return Ok(self.range_bounds.physical_expr(left_expr));
         }
 
         let unique_values = self
@@ -245,7 +251,7 @@ impl RangeBounds {
                 continue;
             }
 
-            if !supports_range_comparison(value.data_type()) {
+            if !supports_range_comparison(&value) {
                 self.supports_range_filter = false;
                 return Ok(());
             }
@@ -283,15 +289,12 @@ impl RangeBounds {
         }
     }
 
-    fn physical_expr(
-        &self,
-        left_expr: Arc<dyn PhysicalExpr>,
-    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+    fn physical_expr(&self, left_expr: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
         let (Some(min_value), Some(max_value)) = (&self.min_value, &self.max_value) else {
             tracing::debug!(
                 "ExactLeftAccumulator range fallback has no non-null values, returning no-op filter."
             );
-            return Ok(literal_true());
+            return literal_true();
         };
 
         if self.contains_null || !self.supports_range_filter {
@@ -300,7 +303,7 @@ impl RangeBounds {
                 supports_range_filter = self.supports_range_filter,
                 "ExactLeftAccumulator could not create range fallback, returning no-op filter."
             );
-            return Ok(literal_true());
+            return literal_true();
         }
 
         let lower_bound = Arc::new(BinaryExpr::new(
@@ -318,41 +321,42 @@ impl RangeBounds {
             "ExactLeftAccumulator created range fallback from {min_value} to {max_value}."
         );
 
-        Ok(Arc::new(BinaryExpr::new(
-            lower_bound,
-            Operator::And,
-            upper_bound,
-        )))
+        Arc::new(BinaryExpr::new(lower_bound, Operator::And, upper_bound))
     }
 }
 
-fn supports_range_comparison(data_type: DataType) -> bool {
-    matches!(
-        data_type,
-        DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Float16
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Decimal32(_, _)
-            | DataType::Decimal64(_, _)
-            | DataType::Decimal128(_, _)
-            | DataType::Decimal256(_, _)
-            | DataType::Date32
-            | DataType::Date64
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Timestamp(_, _)
-            | DataType::Utf8
-            | DataType::LargeUtf8
-            | DataType::Utf8View
-    )
+fn supports_range_comparison(value: &ScalarValue) -> bool {
+    match value {
+        ScalarValue::Float16(Some(value)) => !value.is_nan(),
+        ScalarValue::Float32(Some(value)) => !value.is_nan(),
+        ScalarValue::Float64(Some(value)) => !value.is_nan(),
+        _ => matches!(
+            value.data_type(),
+            DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Float16
+                | DataType::Float32
+                | DataType::Float64
+                | DataType::Decimal32(_, _)
+                | DataType::Decimal64(_, _)
+                | DataType::Decimal128(_, _)
+                | DataType::Decimal256(_, _)
+                | DataType::Date32
+                | DataType::Date64
+                | DataType::Time32(_)
+                | DataType::Time64(_)
+                | DataType::Timestamp(_, _)
+                | DataType::Utf8
+                | DataType::LargeUtf8
+                | DataType::Utf8View
+        ),
+    }
 }
 
 fn literal_true() -> Arc<dyn PhysicalExpr> {
@@ -362,7 +366,9 @@ fn literal_true() -> Arc<dyn PhysicalExpr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{ArrayRef, BooleanArray, Int32Array, UInt64Array};
+    use arrow::array::{
+        ArrayRef, BooleanArray, Float64Array, Int32Array, StringArray, UInt64Array,
+    };
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::expressions::col;
 
@@ -370,6 +376,52 @@ mod tests {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let a: ArrayRef = Arc::new(Int32Array::from((0..10).collect::<Vec<i32>>()));
         RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+    }
+
+    fn create_uint64_batch(values: Vec<u64>) -> RecordBatch {
+        let schema = Schema::new(vec![Field::new("a", DataType::UInt64, false)]);
+        let a: ArrayRef = Arc::new(UInt64Array::from(values));
+        RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+    }
+
+    fn create_nullable_uint64_batch(values: Vec<Option<u64>>) -> RecordBatch {
+        let schema = Schema::new(vec![Field::new("a", DataType::UInt64, true)]);
+        let a: ArrayRef = Arc::new(UInt64Array::from(values));
+        RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+    }
+
+    fn assert_literal_true(physical_expr: &Arc<dyn PhysicalExpr>) {
+        let literal_expr = physical_expr
+            .as_any()
+            .downcast_ref::<Literal>()
+            .expect("Should downcast to Literal");
+        let expected_value = ScalarValue::Boolean(Some(true));
+        assert_eq!(literal_expr.value(), &expected_value);
+    }
+
+    fn evaluate_boolean_expression(
+        physical_expr: &Arc<dyn PhysicalExpr>,
+        batch: &RecordBatch,
+    ) -> Vec<Option<bool>> {
+        let result = physical_expr
+            .evaluate(batch)
+            .expect("Should evaluate expression")
+            .into_array(batch.num_rows())
+            .expect("Should produce boolean array");
+        let bool_result = result
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("Should downcast to BooleanArray");
+
+        (0..bool_result.len())
+            .map(|row_index| {
+                if bool_result.is_null(row_index) {
+                    None
+                } else {
+                    Some(bool_result.value(row_index))
+                }
+            })
+            .collect()
     }
 
     #[test]
@@ -439,30 +491,49 @@ mod tests {
             .physical_expr(left_expr)
             .expect("Should create physical expr");
 
-        // Validate the expression is a Literal true (no-op filter)
-        let literal_expr = physical_expr.as_any().downcast_ref::<Literal>();
-        let literal_expr = literal_expr.expect("Should downcast to Literal");
-        let expected_value = ScalarValue::Boolean(Some(true));
-        assert_eq!(literal_expr.value(), &expected_value);
+        assert_literal_true(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_uses_exact_values_at_memory_limit() {
+        let batch = create_uint64_batch(vec![1, 3, 5]);
+        let max_memory_size = batch.column(0).get_array_memory_size();
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), max_memory_size);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+        assert_eq!(1, accumulator.arrays.len());
+        assert!(!accumulator.exact_values_exceeded_memory_limit);
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        physical_expr
+            .as_any()
+            .downcast_ref::<InListExpr>()
+            .expect("Should downcast to InListExpr");
     }
 
     #[test]
     fn test_exact_left_accumulator_exceeds_memory() {
         // Test that when accumulated arrays exceed the in-list memory limit, we fallback to a range filter.
-        let schema = Schema::new(vec![Field::new("a", DataType::UInt64, false)]);
-        let join_key_array: ArrayRef = Arc::new(UInt64Array::from(vec![1, 3, 5]));
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![join_key_array])
-            .expect("Should create large record batch");
+        let batch = create_uint64_batch(vec![1, 3, 5]);
 
         let left_expr = col("a", &batch.schema()).expect("Should create column expr");
 
         let mut accumulator =
-            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema())
-                .expect("Should create accumulator");
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 1);
 
         accumulator
-            .update_batch_with_memory_limit(&batch, 1)
-            .expect("Should update with large batch");
+            .update_batch(&batch)
+            .expect("Should update with batch");
         assert!(accumulator.arrays.is_empty());
         assert!(accumulator.exact_values_exceeded_memory_limit);
 
@@ -478,24 +549,39 @@ mod tests {
         let probe_array: ArrayRef = Arc::new(UInt64Array::from(vec![0, 1, 3, 5, 6]));
         let probe_batch = RecordBatch::try_new(Arc::new(probe_schema), vec![probe_array])
             .expect("Should create probe record batch");
-        let result = physical_expr
-            .evaluate(&probe_batch)
-            .expect("Should evaluate range expression")
-            .into_array(probe_batch.num_rows())
-            .expect("Should produce boolean array");
-        let bool_result = result
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .expect("Should downcast to BooleanArray");
-        let actual_values = (0..bool_result.len())
-            .map(|row_index| {
-                if bool_result.is_null(row_index) {
-                    None
-                } else {
-                    Some(bool_result.value(row_index))
-                }
-            })
-            .collect::<Vec<_>>();
+        let actual_values = evaluate_boolean_expression(&physical_expr, &probe_batch);
+
+        assert_eq!(
+            vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
+            actual_values
+        );
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_range_fallback_updates_after_limit_exceeded() {
+        let first_batch = create_uint64_batch(vec![10, 20]);
+        let second_batch = create_uint64_batch(vec![1, 30]);
+
+        let left_expr = col("a", &first_batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 1);
+
+        accumulator
+            .update_batch(&first_batch)
+            .expect("Should update first batch");
+        accumulator
+            .update_batch(&second_batch)
+            .expect("Should update second batch");
+        assert!(accumulator.arrays.is_empty());
+        assert!(accumulator.exact_values_exceeded_memory_limit);
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let probe_batch = create_uint64_batch(vec![0, 1, 15, 30, 31]);
+        let actual_values = evaluate_boolean_expression(&physical_expr, &probe_batch);
 
         assert_eq!(
             vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
@@ -505,19 +591,15 @@ mod tests {
 
     #[test]
     fn test_exact_left_accumulator_range_fallback_with_nulls_returns_noop() {
-        let schema = Schema::new(vec![Field::new("a", DataType::UInt64, true)]);
-        let join_key_array: ArrayRef = Arc::new(UInt64Array::from(vec![Some(1), None, Some(3)]));
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![join_key_array])
-            .expect("Should create record batch");
+        let batch = create_nullable_uint64_batch(vec![Some(1), None, Some(3)]);
 
         let left_expr = col("a", &batch.schema()).expect("Should create column expr");
 
         let mut accumulator =
-            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema())
-                .expect("Should create accumulator");
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 1);
 
         accumulator
-            .update_batch_with_memory_limit(&batch, 1)
+            .update_batch(&batch)
             .expect("Should update with batch");
 
         let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
@@ -525,12 +607,107 @@ mod tests {
             .physical_expr(left_expr)
             .expect("Should create physical expr");
 
-        let literal_expr = physical_expr
-            .as_any()
-            .downcast_ref::<Literal>()
-            .expect("Should downcast to Literal");
-        let expected_value = ScalarValue::Boolean(Some(true));
-        assert_eq!(literal_expr.value(), &expected_value);
+        assert_literal_true(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_range_fallback_with_only_nulls_returns_noop() {
+        let batch = create_nullable_uint64_batch(vec![None, None]);
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 0);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        assert_literal_true(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_range_fallback_with_unsupported_type_returns_noop() {
+        let schema = Schema::new(vec![Field::new("a", DataType::Boolean, false)]);
+        let a: ArrayRef = Arc::new(BooleanArray::from(vec![true, false]));
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 0);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        assert_literal_true(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_range_fallback_with_nan_returns_noop() {
+        let schema = Schema::new(vec![Field::new("a", DataType::Float64, false)]);
+        let a: ArrayRef = Arc::new(Float64Array::from(vec![1.0, f64::NAN, 3.0]));
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 0);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        assert_literal_true(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_range_fallback_with_strings() {
+        let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
+        let a: ArrayRef = Arc::new(StringArray::from(vec!["delta", "bravo", "charlie"]));
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 0);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let probe_schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
+        let probe_array: ArrayRef = Arc::new(StringArray::from(vec![
+            "alpha", "bravo", "charlie", "delta", "zulu",
+        ]));
+        let probe_batch = RecordBatch::try_new(Arc::new(probe_schema), vec![probe_array])
+            .expect("Should create probe record batch");
+        let actual_values = evaluate_boolean_expression(&physical_expr, &probe_batch);
+
+        assert_eq!(
+            vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
+            actual_values
+        );
     }
 
     #[test]

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -258,13 +258,15 @@ impl RangeBounds {
             return Ok(());
         }
 
+        if array.null_count() > 0 {
+            // Short-circuit: physical_expr() returns a no-op when contains_null is true,
+            // so skip the O(n) per-row loop for this and all future batches.
+            self.contains_null = true;
+            return Ok(());
+        }
+
         for row_index in 0..array.len() {
             let value = ScalarValue::try_from_array(array, row_index)?;
-
-            if value.is_null() {
-                self.contains_null = true;
-                continue;
-            }
 
             if !supports_range_comparison(&value) {
                 self.supports_range_filter = false;

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -14,23 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashSet, sync::Arc};
+use std::{cmp::Ordering, collections::HashSet, sync::Arc};
 
 use arrow::{
     array::{Array, RecordBatch},
-    datatypes::{Field, Schema, SchemaRef},
+    datatypes::{DataType, Field, Schema, SchemaRef},
 };
 use datafusion::error::Result as DataFusionResult;
 use datafusion::{
+    logical_expr::Operator,
     physical_plan::{
         PhysicalExpr,
-        expressions::{InListExpr, Literal},
+        expressions::{BinaryExpr, InListExpr, Literal},
         joins::{CollectLeftAccumulator, ColumnBounds},
     },
     scalar::ScalarValue,
 };
 
-const MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION: usize = 128 * 1024 * 1024; // 128Mb - can store approximately 128 million i32 keys per partition calculated
+const MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION: usize = 128 * 1024 * 1024; // 128Mb - can store approximately 32 million i32 keys per partition
 // bounds are calculated per-partition, so total memory usage for bounds calculation is potentially num_partitions * MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION
 // similarly, because rows are distributed across partitions the rows per partition is total_rows / num_partitions
 
@@ -42,6 +43,9 @@ const MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION: usize = 128 * 1024 * 1024; // 1
 pub struct ExactLeftAccumulator {
     arrays: Vec<Arc<dyn Array>>,
     expr: Arc<dyn PhysicalExpr>,
+    total_memory_size: usize,
+    range_bounds: RangeBounds,
+    exact_values_exceeded_memory_limit: bool,
 }
 
 impl CollectLeftAccumulator for ExactLeftAccumulator {
@@ -61,10 +65,32 @@ impl CollectLeftAccumulator for ExactLeftAccumulator {
         Ok(Self {
             arrays: Vec::new(),
             expr,
+            total_memory_size: 0,
+            range_bounds: RangeBounds::default(),
+            exact_values_exceeded_memory_limit: false,
         })
     }
 
     fn update_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
+        self.update_batch_with_memory_limit(batch, MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION)
+    }
+
+    fn evaluate(self) -> DataFusionResult<Arc<dyn ColumnBounds>> {
+        Ok(Arc::new(ExactColumnBounds {
+            arrays: self.arrays,
+            total_memory_size: self.total_memory_size,
+            range_bounds: self.range_bounds,
+            use_range_fallback: self.exact_values_exceeded_memory_limit,
+        }))
+    }
+}
+
+impl ExactLeftAccumulator {
+    fn update_batch_with_memory_limit(
+        &mut self,
+        batch: &RecordBatch,
+        max_memory_size: usize,
+    ) -> DataFusionResult<()> {
         if batch.num_rows() == 0 {
             tracing::debug!("ExactLeftAccumulator received empty batch, skipping.");
             return Ok(());
@@ -78,20 +104,38 @@ impl CollectLeftAccumulator for ExactLeftAccumulator {
         // eagerly evaluate the expression and store the resulting array
         // this avoids storing the entire record batch in memory, only storing the evaluated column
         let array = self.expr.evaluate(batch)?.into_array(batch.num_rows())?;
+        self.range_bounds.update(array.as_ref())?;
+
+        if self.exact_values_exceeded_memory_limit {
+            return Ok(());
+        }
+
+        self.total_memory_size = self
+            .total_memory_size
+            .saturating_add(array.get_array_memory_size());
+
+        if self.total_memory_size > max_memory_size {
+            tracing::debug!(
+                "ExactLeftAccumulator exceeded maximum in-list memory size ({} bytes > {} bytes); using range fallback.",
+                self.total_memory_size,
+                max_memory_size
+            );
+            self.arrays.clear();
+            self.exact_values_exceeded_memory_limit = true;
+            return Ok(());
+        }
+
         self.arrays.push(array);
         Ok(())
-    }
-
-    fn evaluate(self) -> DataFusionResult<Arc<dyn ColumnBounds>> {
-        Ok(Arc::new(ExactColumnBounds {
-            arrays: self.arrays,
-        }))
     }
 }
 
 #[derive(Debug)]
 pub struct ExactColumnBounds {
     arrays: Vec<Arc<dyn Array>>,
+    total_memory_size: usize,
+    range_bounds: RangeBounds,
+    use_range_fallback: bool,
 }
 
 impl ColumnBounds for ExactColumnBounds {
@@ -101,20 +145,8 @@ impl ColumnBounds for ExactColumnBounds {
         &self,
         left_expr: Arc<dyn PhysicalExpr>,
     ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
-        let total_memory_size = self
-            .arrays
-            .iter()
-            .map(arrow::array::Array::get_array_memory_size)
-            .sum::<usize>();
-
-        if total_memory_size > MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION {
-            tracing::debug!(
-                "ExactLeftAccumulator exceeded maximum in-list memory size ({} bytes > {} bytes).",
-                total_memory_size,
-                MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION
-            );
-
-            return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true))))); // Fallback to a no-op filter (always true) - the default dynamic filter behaviour
+        if self.use_range_fallback {
+            return self.range_bounds.physical_expr(left_expr);
         }
 
         let unique_values = self
@@ -128,7 +160,7 @@ impl ColumnBounds for ExactColumnBounds {
         if unique_values.is_empty() {
             // No values collected - return a no-op filter (always true)
             tracing::debug!("ExactLeftAccumulator collected no values, returning no-op filter.");
-            return Ok(Arc::new(Literal::new(ScalarValue::Boolean(Some(true)))));
+            return Ok(literal_true());
         }
 
         let expr_values = unique_values
@@ -172,17 +204,165 @@ impl ColumnBounds for ExactColumnBounds {
         tracing::debug!(
             "ExactLeftAccumulator created InListExpr with {} values ({} bytes).",
             in_expr.list().len(),
-            total_memory_size,
+            self.total_memory_size,
         );
 
         Ok(in_expr)
     }
 }
 
+#[derive(Debug)]
+struct RangeBounds {
+    min_value: Option<ScalarValue>,
+    max_value: Option<ScalarValue>,
+    contains_null: bool,
+    supports_range_filter: bool,
+}
+
+impl Default for RangeBounds {
+    fn default() -> Self {
+        Self {
+            min_value: None,
+            max_value: None,
+            contains_null: false,
+            supports_range_filter: true,
+        }
+    }
+}
+
+impl RangeBounds {
+    fn update(&mut self, array: &dyn Array) -> DataFusionResult<()> {
+        if !self.supports_range_filter {
+            self.contains_null |= array.null_count() > 0;
+            return Ok(());
+        }
+
+        for row_index in 0..array.len() {
+            let value = ScalarValue::try_from_array(array, row_index)?;
+
+            if value.is_null() {
+                self.contains_null = true;
+                continue;
+            }
+
+            if !supports_range_comparison(value.data_type()) {
+                self.supports_range_filter = false;
+                return Ok(());
+            }
+
+            self.update_value(value);
+
+            if !self.supports_range_filter {
+                return Ok(());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn update_value(&mut self, value: ScalarValue) {
+        match &self.min_value {
+            Some(min_value) => match value.partial_cmp(min_value) {
+                Some(Ordering::Less) => self.min_value = Some(value.clone()),
+                Some(_) => {}
+                None => {
+                    self.supports_range_filter = false;
+                    return;
+                }
+            },
+            None => self.min_value = Some(value.clone()),
+        }
+
+        match &self.max_value {
+            Some(max_value) => match value.partial_cmp(max_value) {
+                Some(Ordering::Greater) => self.max_value = Some(value),
+                Some(_) => {}
+                None => self.supports_range_filter = false,
+            },
+            None => self.max_value = Some(value),
+        }
+    }
+
+    fn physical_expr(
+        &self,
+        left_expr: Arc<dyn PhysicalExpr>,
+    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let (Some(min_value), Some(max_value)) = (&self.min_value, &self.max_value) else {
+            tracing::debug!(
+                "ExactLeftAccumulator range fallback has no non-null values, returning no-op filter."
+            );
+            return Ok(literal_true());
+        };
+
+        if self.contains_null || !self.supports_range_filter {
+            tracing::debug!(
+                contains_null = self.contains_null,
+                supports_range_filter = self.supports_range_filter,
+                "ExactLeftAccumulator could not create range fallback, returning no-op filter."
+            );
+            return Ok(literal_true());
+        }
+
+        let lower_bound = Arc::new(BinaryExpr::new(
+            Arc::clone(&left_expr),
+            Operator::GtEq,
+            Arc::new(Literal::new(min_value.clone())),
+        ));
+        let upper_bound = Arc::new(BinaryExpr::new(
+            left_expr,
+            Operator::LtEq,
+            Arc::new(Literal::new(max_value.clone())),
+        ));
+
+        tracing::debug!(
+            "ExactLeftAccumulator created range fallback from {min_value} to {max_value}."
+        );
+
+        Ok(Arc::new(BinaryExpr::new(
+            lower_bound,
+            Operator::And,
+            upper_bound,
+        )))
+    }
+}
+
+fn supports_range_comparison(data_type: DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Decimal32(_, _)
+            | DataType::Decimal64(_, _)
+            | DataType::Decimal128(_, _)
+            | DataType::Decimal256(_, _)
+            | DataType::Date32
+            | DataType::Date64
+            | DataType::Time32(_)
+            | DataType::Time64(_)
+            | DataType::Timestamp(_, _)
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Utf8View
+    )
+}
+
+fn literal_true() -> Arc<dyn PhysicalExpr> {
+    Arc::new(Literal::new(ScalarValue::Boolean(Some(true))))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{ArrayRef, Int32Array, UInt64Array};
+    use arrow::array::{ArrayRef, BooleanArray, Int32Array, UInt64Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::expressions::col;
 
@@ -268,12 +448,10 @@ mod tests {
 
     #[test]
     fn test_exact_left_accumulator_exceeds_memory() {
-        // Test that when the accumulated arrays exceed the maximum in-list memory size, we fallback to a no-op filter
+        // Test that when accumulated arrays exceed the in-list memory limit, we fallback to a range filter.
         let schema = Schema::new(vec![Field::new("a", DataType::UInt64, false)]);
-        let large_array: ArrayRef = Arc::new(UInt64Array::from(
-            (0..(MAXIMUM_INLIST_MEMORY_BYTES_PER_PARTITION + 1) as u64).collect::<Vec<u64>>(),
-        ));
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![large_array])
+        let join_key_array: ArrayRef = Arc::new(UInt64Array::from(vec![1, 3, 5]));
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![join_key_array])
             .expect("Should create large record batch");
 
         let left_expr = col("a", &batch.schema()).expect("Should create column expr");
@@ -283,17 +461,74 @@ mod tests {
                 .expect("Should create accumulator");
 
         accumulator
-            .update_batch(&batch)
+            .update_batch_with_memory_limit(&batch, 1)
             .expect("Should update with large batch");
+        assert!(accumulator.arrays.is_empty());
+        assert!(accumulator.exact_values_exceeded_memory_limit);
 
         let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
         let physical_expr = column_bounds
             .physical_expr(left_expr)
             .expect("Should create physical expr");
 
-        // Validate the expression is a Literal true (no-op filter)
-        let literal_expr = physical_expr.as_any().downcast_ref::<Literal>();
-        let literal_expr = literal_expr.expect("Should downcast to Literal");
+        // Validate the expression is a range filter from 1 through 5, not a no-op filter.
+        assert!(physical_expr.as_any().downcast_ref::<Literal>().is_none());
+
+        let probe_schema = Schema::new(vec![Field::new("a", DataType::UInt64, false)]);
+        let probe_array: ArrayRef = Arc::new(UInt64Array::from(vec![0, 1, 3, 5, 6]));
+        let probe_batch = RecordBatch::try_new(Arc::new(probe_schema), vec![probe_array])
+            .expect("Should create probe record batch");
+        let result = physical_expr
+            .evaluate(&probe_batch)
+            .expect("Should evaluate range expression")
+            .into_array(probe_batch.num_rows())
+            .expect("Should produce boolean array");
+        let bool_result = result
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("Should downcast to BooleanArray");
+        let actual_values = (0..bool_result.len())
+            .map(|row_index| {
+                if bool_result.is_null(row_index) {
+                    None
+                } else {
+                    Some(bool_result.value(row_index))
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
+            actual_values
+        );
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_range_fallback_with_nulls_returns_noop() {
+        let schema = Schema::new(vec![Field::new("a", DataType::UInt64, true)]);
+        let join_key_array: ArrayRef = Arc::new(UInt64Array::from(vec![Some(1), None, Some(3)]));
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![join_key_array])
+            .expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch_with_memory_limit(&batch, 1)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let literal_expr = physical_expr
+            .as_any()
+            .downcast_ref::<Literal>()
+            .expect("Should downcast to Literal");
         let expected_value = ScalarValue::Boolean(Some(true));
         assert_eq!(literal_expr.value(), &expected_value);
     }


### PR DESCRIPTION
This improves large multi-table join behavior by keeping dynamic join filters useful after the exact in-list accumulator reaches its memory cap.

Summary:
- Track exact join key arrays only while they remain under the configured per-partition memory limit.
- Defer min/max range-bound calculation on the common exact in-list path; when the memory limit is exceeded, rebuild bounds from the already-collected exact arrays plus the overflowing batch and then keep updating range bounds for subsequent batches.
- Emit a conservative range predicate when the exact in-list would exceed the limit.
- Preserve correctness by returning the existing no-op filter fallback when range comparison is unsupported, collected build-side keys include nulls, or float keys include NaN.
- Add comprehensive unit coverage for exact memory-limit boundary behavior, lazy range-bound calculation, multi-batch range widening after fallback, null/all-null handling, unsupported types, NaN handling, string ranges, duplicates, empty batches, and multi-batch exact accumulation.
- Add a Criterion benchmark target for exact vs range-fallback accumulator updates and physical-expression construction.

Verification:
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo test -p runtime-datafusion join_accumulator`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo bench -p runtime-datafusion --bench join_accumulator --no-run`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 cargo bench -p runtime-datafusion --bench join_accumulator -- --quick`
- `RUSTC_WRAPPER= CARGO_INCREMENTAL=0 make lint`
