### PR TITLE
Persist MongoDB Change Stream resume tokens via spice_sys sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4108,6 +4108,7 @@ dependencies = [
  "paste",
  "runtime",
  "secrecy",
+ "serde_json",
  "snafu",
  "tokio",
  "tokio-stream",

--- a/crates/data-connectors/connector-mongodb/Cargo.toml
+++ b/crates/data-connectors/connector-mongodb/Cargo.toml
@@ -35,6 +35,7 @@ mongodb.workspace = true
 paste.workspace = true
 runtime = { path = "../../runtime", features = ["mongodb"] }
 secrecy.workspace = true
+serde_json.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/crates/data-connectors/connector-mongodb/src/changes.rs
+++ b/crates/data-connectors/connector-mongodb/src/changes.rs
@@ -15,10 +15,11 @@ limitations under the License.
 */
 
 use async_stream::try_stream;
+use async_trait::async_trait;
 use data_components::{
     cdc::{
-        ChangeEnvelope, ChangesStream, NoOpCommitter, build_ready_signal_envelope,
-        wrap_data_as_change_batch,
+        ChangeEnvelope, ChangesStream, CommitChange, CommitError, NoOpCommitter, StreamError,
+        build_ready_signal_envelope, wrap_data_as_change_batch,
     },
     mongodb::stream::{
         change_events_to_change_batch, default_unnest_parameters, truncate_change_batch,
@@ -40,6 +41,10 @@ use runtime::{
     component::dataset::{
         Dataset,
         acceleration::{Acceleration, Engine, OnConflictBehavior},
+    },
+    dataaccelerator::spice_sys::{
+        OpenOption,
+        mongodb::{MongoCheckpointMetadata, MongoSys},
     },
     federated_table::FederatedTable,
     parameters::{ExposedParamLookup, Parameters},
@@ -63,12 +68,13 @@ pub fn build_changes_stream(
         let schema = table_provider.schema();
         let primary_keys = resolve_primary_keys(&dataset.name, dataset.acceleration.as_ref(), &schema)?;
         let config = ChangeStreamConfig::from_params(&params)?;
+        let invalid_token_behavior = ResumeTokenInvalidBehavior::from_params(&params)?;
         let collection_name = dataset.path().to_string();
 
         let connection = pool
             .connect()
             .await
-            .map_err(|error| data_components::cdc::StreamError::External(format!(
+            .map_err(|error| StreamError::External(format!(
                 "Failed to connect to MongoDB Change Stream for dataset `{}` collection `{collection_name}`: {error}",
                 dataset.name
             )))?;
@@ -77,65 +83,149 @@ pub fn build_changes_stream(
             .database(&connection.db_name)
             .collection::<Document>(&collection_name);
 
-        let initial_change_stream = open_change_stream(
-            &collection,
-            &config,
-            &dataset.name,
-            &collection_name,
-            None,
-        )
-        .await?;
-        let resume_token = initial_change_stream.resume_token().ok_or_else(|| {
-            data_components::cdc::StreamError::External(format!(
-                "Failed to start MongoDB Change Stream for dataset `{}` collection `{collection_name}`: initial stream did not return a resume token",
-                dataset.name
-            ))
-        })?;
-        drop(initial_change_stream);
+        let mongo_sys = Arc::new(if dataset.is_file_accelerated() {
+            initialize_mongo_sys(&dataset).await
+        } else {
+            tracing::info!(
+                dataset = %dataset.name,
+                collection = %collection_name,
+                "MongoDB Change Stream dataset is not file-accelerated; resume token will not be persisted across restarts"
+            );
+            None
+        });
 
-        tracing::info!(
-            dataset = %dataset.name,
-            collection = %collection_name,
-            "MongoDB Change Stream started; bootstrapping accelerator from collection snapshot"
-        );
+        let current_schema_json = serialize_current_schema(&schema, &dataset.name);
+        let persisted = persisted_checkpoint(&mongo_sys, &dataset, &current_schema_json).await;
 
-        let truncate = truncate_change_batch(&schema)
-            .map_err(data_components::cdc::StreamError::MongoDB)?;
-        yield ChangeEnvelope::new(Box::new(NoOpCommitter), truncate, false);
+        let live_change_stream = if let Some(metadata) = persisted {
+            let resume_token = deserialize_resume_token(&metadata.resume_token_json)
+                .map_err(|error| StreamError::External(format!(
+                    "Failed to deserialize persisted MongoDB resume token for dataset `{}` collection `{collection_name}`: {error}. To recover, delete the dataset's row from `spice_sys_mongodb` or restart with `mongodb_resume_token_invalid_behavior: rebootstrap`.",
+                    dataset.name
+                )))?;
 
-        let mut snapshot_stream = snapshot_stream(table_provider).await?;
-        while let Some(batch) = FuturesStreamExt::next(&mut snapshot_stream).await {
-            let batch = batch.map_err(|error| data_components::cdc::StreamError::Arrow(error.to_string()))?;
-            if batch.num_rows() == 0 {
-                continue;
+            match try_open_change_stream(&collection, &config, Some(resume_token)).await {
+                Ok(stream) => {
+                    tracing::info!(
+                        dataset = %dataset.name,
+                        collection = %collection_name,
+                        "MongoDB Change Stream resumed from persisted resume token; skipping collection snapshot"
+                    );
+
+                    let ready = build_ready_signal_envelope(&schema)
+                        .map_err(|error| StreamError::Arrow(error.to_string()))?;
+                    yield ready;
+                    Some(stream)
+                }
+                Err(error) if is_stale_resume_token_error(&error) => match invalid_token_behavior {
+                    ResumeTokenInvalidBehavior::Error => Err(StreamError::External(format!(
+                        "MongoDB Change Stream resume token for dataset `{}` collection `{collection_name}` is past the oplog retention window or otherwise invalid (driver code {}). Set `mongodb_resume_token_invalid_behavior: rebootstrap` to drop the persisted token and re-snapshot the collection. Source: {error}",
+                        dataset.name,
+                        resume_token_error_code(&error).map_or_else(|| "unknown".to_string(), |c| c.to_string()),
+                    )))?,
+                    ResumeTokenInvalidBehavior::Rebootstrap => {
+                        tracing::warn!(
+                            dataset = %dataset.name,
+                            collection = %collection_name,
+                            error = %error,
+                            "MongoDB Change Stream resume token is stale; rebootstrap behavior enabled, falling back to cold bootstrap"
+                        );
+                        clear_persisted_token(&mongo_sys, &dataset).await;
+                        None
+                    }
+                },
+                Err(error) => Err(StreamError::External(format!(
+                    "Failed to start MongoDB Change Stream for dataset `{}` collection `{collection_name}` while resuming from persisted token: {error}",
+                    dataset.name
+                )))?,
+            }
+        } else {
+            None
+        };
+
+        let live_change_stream = if let Some(stream) = live_change_stream {
+            stream
+        } else {
+            let initial_change_stream = open_change_stream(
+                &collection,
+                &config,
+                &dataset.name,
+                &collection_name,
+                None,
+            )
+            .await?;
+            let resume_token = initial_change_stream.resume_token().ok_or_else(|| {
+                StreamError::External(format!(
+                    "Failed to start MongoDB Change Stream for dataset `{}` collection `{collection_name}`: initial stream did not return a resume token",
+                    dataset.name
+                ))
+            })?;
+            drop(initial_change_stream);
+
+            tracing::info!(
+                dataset = %dataset.name,
+                collection = %collection_name,
+                "MongoDB Change Stream started; bootstrapping accelerator from collection snapshot"
+            );
+
+            let truncate = truncate_change_batch(&schema)
+                .map_err(StreamError::MongoDB)?;
+            yield ChangeEnvelope::new(Box::new(NoOpCommitter), truncate, false);
+
+            let mut snapshot_stream = snapshot_stream(table_provider).await?;
+            while let Some(batch) = FuturesStreamExt::next(&mut snapshot_stream).await {
+                let batch = batch.map_err(|error| StreamError::Arrow(error.to_string()))?;
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+
+                let change_batch = wrap_data_as_change_batch(&schema, &batch)
+                    .map_err(|error| StreamError::Arrow(error.to_string()))?;
+                yield ChangeEnvelope::new(Box::new(NoOpCommitter), change_batch, false);
             }
 
-            let change_batch = wrap_data_as_change_batch(&schema, &batch)
-                .map_err(|error| data_components::cdc::StreamError::Arrow(error.to_string()))?;
-            yield ChangeEnvelope::new(Box::new(NoOpCommitter), change_batch, false);
-        }
+            // Commit the captured resume token piggy-backed on the ready signal envelope.
+            // The committer fires after the downstream has fully persisted the empty
+            // ready batch, which is the natural barrier between "bootstrap" and "live"
+            // phases. A crash any time before this commit leaves the sidecar empty, so
+            // the next start will re-bootstrap.
+            let initial_token_json = serialize_resume_token(&resume_token)
+                .map_err(|error| StreamError::External(format!(
+                    "Failed to serialize MongoDB resume token for dataset `{}` collection `{collection_name}`: {error}",
+                    dataset.name
+                )))?;
+            let ready = build_ready_signal_envelope(&schema)
+                .map_err(|error| StreamError::Arrow(error.to_string()))?;
+            let (_, batch, is_ready) = ready.into_parts();
+            let committer: Box<dyn CommitChange + Send + Sync> = match mongo_sys.as_ref() {
+                Some(_) => Box::new(MongoResumeTokenCommitter::new(
+                    Arc::clone(&mongo_sys),
+                    initial_token_json,
+                    None,
+                    current_schema_json.clone(),
+                )),
+                None => Box::new(NoOpCommitter),
+            };
+            yield ChangeEnvelope::from_parts(committer, batch, is_ready);
 
-        let ready = build_ready_signal_envelope(&schema)
-            .map_err(|error| data_components::cdc::StreamError::Arrow(error.to_string()))?;
-        yield ready;
+            tracing::info!(
+                dataset = %dataset.name,
+                collection = %collection_name,
+                "MongoDB collection snapshot complete; resuming Change Stream events from captured token"
+            );
 
-        tracing::info!(
-            dataset = %dataset.name,
-            collection = %collection_name,
-            "MongoDB collection snapshot complete; resuming Change Stream events"
-        );
-
-        let change_stream = open_change_stream(
-            &collection,
-            &config,
-            &dataset.name,
-            &collection_name,
-            Some(resume_token),
-        )
-        .await?;
+            open_change_stream(
+                &collection,
+                &config,
+                &dataset.name,
+                &collection_name,
+                Some(resume_token),
+            )
+            .await?
+        };
 
         let unnest_parameters = default_unnest_parameters(config.unnest_depth);
-        let event_batches = change_stream.chunks_timeout(
+        let event_batches = live_change_stream.chunks_timeout(
             config.batch_max_size,
             config.batch_max_duration,
         );
@@ -147,26 +237,231 @@ pub fn build_changes_stream(
             }
 
             let events = collect_change_events(batch, &dataset)?;
+
+            let tail_token = events.last().map(|event| event.id.clone());
+            let tail_cluster_time = events
+                .last()
+                .and_then(|event| event.cluster_time)
+                .map(|ts| i64::from(ts.time));
+
             if let Some(change_batch) = change_events_to_change_batch(
                 events,
                 &schema,
                 &primary_keys,
                 &unnest_parameters,
             )
-            .map_err(data_components::cdc::StreamError::MongoDB)? {
-                yield ChangeEnvelope::new(Box::new(NoOpCommitter), change_batch, true);
+            .map_err(StreamError::MongoDB)? {
+                let committer = build_batch_committer(
+                    &mongo_sys,
+                    tail_token,
+                    tail_cluster_time,
+                    &current_schema_json,
+                    &dataset.name,
+                );
+                yield ChangeEnvelope::new(committer, change_batch, true);
             }
         }
     })
 }
 
-async fn open_change_stream(
+async fn initialize_mongo_sys(dataset: &Dataset) -> Option<MongoSys> {
+    match MongoSys::try_new(dataset, OpenOption::OpenExisting).await {
+        Ok(sys) => Some(sys),
+        Err(error) => {
+            tracing::error!(
+                dataset = %dataset.name,
+                error = %error,
+                "Failed to initialize MongoDB resume-token sidecar; resume token will not be persisted across restarts"
+            );
+            None
+        }
+    }
+}
+
+async fn persisted_checkpoint(
+    mongo_sys: &Arc<Option<MongoSys>>,
+    dataset: &Dataset,
+    current_schema_json: &Option<String>,
+) -> Option<MongoCheckpointMetadata> {
+    let sys = mongo_sys.as_ref().as_ref()?;
+    let metadata = sys.get().await?;
+
+    // Warn (don't fail) on schema drift between runs. The connector schema is
+    // inferred from sampled documents and may legitimately evolve; treating
+    // drift as a hard error here would surprise operators. Followup work can
+    // make this behavior configurable.
+    if let (Some(persisted_schema_json), Some(current_schema_json)) =
+        (metadata.schema_json.as_ref(), current_schema_json.as_ref())
+        && persisted_schema_json != current_schema_json
+    {
+        tracing::warn!(
+            dataset = %dataset.name,
+            "MongoDB Change Stream resume detected schema drift between runs; continuing with the current schema. If new fields fail to populate, restart with `mongodb_resume_token_invalid_behavior: rebootstrap` to re-snapshot."
+        );
+    }
+
+    Some(metadata)
+}
+
+async fn clear_persisted_token(mongo_sys: &Arc<Option<MongoSys>>, dataset: &Dataset) {
+    if let Some(sys) = mongo_sys.as_ref()
+        && let Err(error) = sys.delete().await
+    {
+        tracing::warn!(
+            dataset = %dataset.name,
+            error = %error,
+            "Failed to clear stale MongoDB resume token; the subsequent bootstrap will overwrite it"
+        );
+    }
+}
+
+fn serialize_current_schema(
+    schema: &SchemaRef,
+    dataset_name: &datafusion::sql::TableReference,
+) -> Option<String> {
+    match MongoSys::serialize_schema(schema) {
+        Ok(json) => Some(json),
+        Err(error) => {
+            tracing::warn!(
+                dataset = %dataset_name,
+                error = %error,
+                "Failed to serialize MongoDB dataset schema for the resume-token sidecar; schema drift detection will be disabled for this run"
+            );
+            None
+        }
+    }
+}
+
+fn serialize_resume_token(token: &ResumeToken) -> Result<String, StreamError> {
+    serde_json::to_string(token).map_err(|error| {
+        StreamError::SerdeJsonError(format!("failed to serialize resume token: {error}"))
+    })
+}
+
+fn deserialize_resume_token(token_json: &str) -> Result<ResumeToken, StreamError> {
+    serde_json::from_str(token_json).map_err(|error| {
+        StreamError::SerdeJsonError(format!("failed to deserialize resume token: {error}"))
+    })
+}
+
+fn resume_token_error_code(error: &mongodb::error::Error) -> Option<i32> {
+    match error.kind.as_ref() {
+        mongodb::error::ErrorKind::Command(cmd) => Some(cmd.code),
+        _ => None,
+    }
+}
+
+fn build_batch_committer(
+    mongo_sys: &Arc<Option<MongoSys>>,
+    tail_token: Option<ResumeToken>,
+    tail_cluster_time: Option<i64>,
+    schema_json: &Option<String>,
+    dataset_name: &datafusion::sql::TableReference,
+) -> Box<dyn CommitChange + Send + Sync> {
+    if mongo_sys.as_ref().is_none() {
+        return Box::new(NoOpCommitter);
+    }
+
+    let Some(token) = tail_token else {
+        return Box::new(NoOpCommitter);
+    };
+
+    match serialize_resume_token(&token) {
+        Ok(token_json) => Box::new(MongoResumeTokenCommitter::new(
+            Arc::clone(mongo_sys),
+            token_json,
+            tail_cluster_time,
+            schema_json.clone(),
+        )),
+        Err(error) => {
+            tracing::warn!(
+                dataset = %dataset_name,
+                error = %error,
+                "Failed to serialize MongoDB resume token for batch checkpoint; falling back to NoOpCommitter for this batch"
+            );
+            Box::new(NoOpCommitter)
+        }
+    }
+}
+
+/// Behavior when the persisted resume token cannot be honored by the source
+/// (e.g. the oplog window has rolled past the token's position).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ResumeTokenInvalidBehavior {
+    /// Surface a clear error so the operator can decide. Recommended default
+    /// because a re-snapshot of a large collection should be opt-in.
+    #[default]
+    Error,
+    /// Drop the persisted token and fall through to the cold-bootstrap path,
+    /// re-snapshotting the collection.
+    Rebootstrap,
+}
+
+impl ResumeTokenInvalidBehavior {
+    fn from_params(params: &Parameters) -> Result<Self, StreamError> {
+        match optional_string(params, "mongodb_resume_token_invalid_behavior").as_deref() {
+            None => Ok(Self::default()),
+            Some(value) => match value.trim().to_ascii_lowercase().as_str() {
+                "error" => Ok(Self::Error),
+                "rebootstrap" => Ok(Self::Rebootstrap),
+                other => Err(invalid_parameter_error(
+                    params,
+                    "mongodb_resume_token_invalid_behavior",
+                    format!("must be 'error' or 'rebootstrap', got {other:?}"),
+                )),
+            },
+        }
+    }
+}
+
+pub(crate) struct MongoResumeTokenCommitter {
+    mongo_sys: Arc<Option<MongoSys>>,
+    resume_token_json: String,
+    cluster_time_ts: Option<i64>,
+    schema_json: Option<String>,
+}
+
+impl MongoResumeTokenCommitter {
+    fn new(
+        mongo_sys: Arc<Option<MongoSys>>,
+        resume_token_json: String,
+        cluster_time_ts: Option<i64>,
+        schema_json: Option<String>,
+    ) -> Self {
+        Self {
+            mongo_sys,
+            resume_token_json,
+            cluster_time_ts,
+            schema_json,
+        }
+    }
+}
+
+#[async_trait]
+impl CommitChange for MongoResumeTokenCommitter {
+    async fn commit(&self) -> Result<(), CommitError> {
+        let Some(sys) = self.mongo_sys.as_ref() else {
+            return Ok(());
+        };
+
+        sys.upsert(&MongoCheckpointMetadata {
+            resume_token_json: self.resume_token_json.clone(),
+            cluster_time_ts: self.cluster_time_ts,
+            schema_json: self.schema_json.clone(),
+            updated_at: None,
+        })
+        .await
+        .map_err(|error| CommitError::UnableToCommitChange {
+            source: Box::new(error),
+        })
+    }
+}
+
+async fn try_open_change_stream(
     collection: &Collection<Document>,
     config: &ChangeStreamConfig,
-    dataset_name: &datafusion::sql::TableReference,
-    collection_name: &str,
     resume_token: Option<ResumeToken>,
-) -> Result<ChangeStream<ChangeStreamEvent<Document>>, data_components::cdc::StreamError> {
+) -> mongodb::error::Result<ChangeStream<ChangeStreamEvent<Document>>> {
     let mut watch = collection
         .watch()
         .full_document(FullDocumentType::UpdateLookup)
@@ -177,11 +472,33 @@ async fn open_change_stream(
         watch = watch.resume_after(resume_token);
     }
 
-    watch.await.map_err(|error| {
-        data_components::cdc::StreamError::External(format!(
-            "Failed to start MongoDB Change Stream for dataset `{dataset_name}` collection `{collection_name}`: {error}"
-        ))
-    })
+    watch.await
+}
+
+async fn open_change_stream(
+    collection: &Collection<Document>,
+    config: &ChangeStreamConfig,
+    dataset_name: &datafusion::sql::TableReference,
+    collection_name: &str,
+    resume_token: Option<ResumeToken>,
+) -> Result<ChangeStream<ChangeStreamEvent<Document>>, StreamError> {
+    try_open_change_stream(collection, config, resume_token)
+        .await
+        .map_err(|error| {
+            StreamError::External(format!(
+                "Failed to start MongoDB Change Stream for dataset `{dataset_name}` collection `{collection_name}`: {error}"
+            ))
+        })
+}
+
+/// Returns `true` if the driver error indicates the resume token is past the
+/// oplog retention window (`ChangeStreamHistoryLost`, code 286) or the cursor
+/// is otherwise unresumable (`ChangeStreamFatalError`, code 280).
+fn is_stale_resume_token_error(error: &mongodb::error::Error) -> bool {
+    matches!(
+        error.kind.as_ref(),
+        mongodb::error::ErrorKind::Command(cmd) if matches!(cmd.code, 286 | 280)
+    )
 }
 
 async fn snapshot_stream(

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -133,6 +133,10 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("change_stream_batch_size")
         .description("Number of Change Stream events MongoDB should request from the server per batch.")
         .default("1000"),
+    ParameterSpec::runtime("mongodb_resume_token_invalid_behavior")
+        .description("Behavior when a persisted Change Stream resume token cannot be honored by the server (e.g. past the oplog retention window). 'error' surfaces a clear error so the operator can decide (recommended default; re-snapshotting a large collection should be opt-in). 'rebootstrap' drops the persisted token and re-snapshots the collection.")
+        .default("error")
+        .one_of(&["error", "rebootstrap"]),
 ];
 
 const IGNORED_IF_URI: &[&str] = &[

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -81,6 +81,9 @@ pub mod kafka;
 #[cfg(feature = "dynamodb")]
 pub mod dynamodb;
 
+#[cfg(feature = "mongodb")]
+pub mod mongodb;
+
 pub mod caching_engine;
 
 enum AccelerationConnection {
@@ -201,7 +204,8 @@ impl Error {
         feature = "duckdb",
         feature = "postgres",
         feature = "turso",
-        feature = "kafka"
+        feature = "kafka",
+        feature = "mongodb"
     ))]
     fn external(err: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
         Self::External { source: err.into() }

--- a/crates/runtime/src/dataaccelerator/spice_sys/mongodb/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mongodb/duckdb.rs
@@ -1,0 +1,245 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
+
+use super::{Error, MONGODB_TABLE_NAME, MongoCheckpointMetadata, MongoSys, Result};
+
+impl MongoSys {
+    pub(super) fn upsert_duckdb(
+        &self,
+        pool: &Arc<DuckDbConnectionPool>,
+        metadata: &MongoCheckpointMetadata,
+    ) -> Result<()> {
+        let mut db_conn = Arc::clone(pool).connect_sync().map_err(Error::external)?;
+        let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
+            .map_err(Error::external)?
+            .get_underlying_conn_mut();
+
+        let create_table = format!(
+            "CREATE TABLE IF NOT EXISTS {MONGODB_TABLE_NAME} (
+                dataset_name TEXT PRIMARY KEY,
+                resume_token_json TEXT NOT NULL,
+                cluster_time_ts BIGINT,
+                schema_json TEXT,
+                created_at TIMESTAMP,
+                updated_at TIMESTAMP
+            )"
+        );
+        duckdb_conn
+            .execute(&create_table, [])
+            .map_err(Error::external)?;
+
+        let upsert = format!(
+            "INSERT INTO {MONGODB_TABLE_NAME}
+                (dataset_name, resume_token_json, cluster_time_ts, schema_json, created_at, updated_at)
+             VALUES (?, ?, ?, ?, now(), now())
+             ON CONFLICT (dataset_name) DO UPDATE SET
+                resume_token_json = excluded.resume_token_json,
+                cluster_time_ts = excluded.cluster_time_ts,
+                schema_json = excluded.schema_json,
+                updated_at = now()"
+        );
+
+        duckdb_conn
+            .execute(
+                &upsert,
+                duckdb::params![
+                    self.dataset_name,
+                    metadata.resume_token_json,
+                    metadata.cluster_time_ts,
+                    metadata.schema_json,
+                ],
+            )
+            .map_err(Error::external)?;
+
+        Ok(())
+    }
+
+    pub(super) fn get_duckdb(
+        &self,
+        pool: &Arc<DuckDbConnectionPool>,
+    ) -> Option<MongoCheckpointMetadata> {
+        use std::time::{Duration, UNIX_EPOCH};
+
+        let mut db_conn = Arc::clone(pool).connect_sync().ok()?;
+        let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
+            .ok()?
+            .get_underlying_conn_mut();
+
+        let query = format!(
+            "SELECT resume_token_json, cluster_time_ts, schema_json, epoch(updated_at) FROM {MONGODB_TABLE_NAME} WHERE dataset_name = ?"
+        );
+        let mut stmt = duckdb_conn.prepare(&query).ok()?;
+        let mut rows = stmt.query([&self.dataset_name]).ok()?;
+
+        if let Some(row) = rows.next().ok()? {
+            let resume_token_json: String = row.get(0).ok()?;
+            let cluster_time_ts: Option<i64> = row.get(1).ok();
+            let schema_json: Option<String> = row.get(2).ok();
+            let updated_at_epoch: Option<f64> = row.get(3).ok();
+            let updated_at = updated_at_epoch
+                .and_then(|epoch| UNIX_EPOCH.checked_add(Duration::from_secs_f64(epoch)));
+
+            Some(MongoCheckpointMetadata {
+                resume_token_json,
+                cluster_time_ts,
+                schema_json,
+                updated_at,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn delete_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
+        let mut db_conn = Arc::clone(pool).connect_sync().map_err(Error::external)?;
+        let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
+            .map_err(Error::external)?
+            .get_underlying_conn_mut();
+
+        let delete = format!("DELETE FROM {MONGODB_TABLE_NAME} WHERE dataset_name = ?");
+        duckdb_conn
+            .execute(&delete, [&self.dataset_name])
+            .map_err(Error::external)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        builder::RuntimeBuilder,
+        component::dataset::{
+            Dataset,
+            acceleration::{Acceleration, Engine, Mode},
+            builder::DatasetBuilder,
+        },
+        dataaccelerator::spice_sys::OpenOption,
+    };
+    use tempfile::TempDir;
+
+    async fn create_test_dataset(ds_name: &str) -> (Dataset, TempDir) {
+        let app = app::AppBuilder::new("test").build();
+        let runtime = RuntimeBuilder::new().build().await;
+
+        let mut dataset = DatasetBuilder::try_new("spice.ai".to_string(), ds_name)
+            .expect("to create dataset builder")
+            .with_app(Arc::new(app))
+            .with_runtime(Arc::new(runtime))
+            .build()
+            .expect("to create dataset");
+
+        let temp_dir = TempDir::new().expect("to create temp dir");
+        let db_path = temp_dir.path().join("mongodb_duckdb_test.db");
+
+        dataset.acceleration = Some(Acceleration {
+            engine: Engine::DuckDB,
+            mode: Mode::File,
+            params: [(
+                "duckdb_file".to_string(),
+                db_path.to_string_lossy().to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        });
+
+        (dataset, temp_dir)
+    }
+
+    fn create_test_metadata() -> MongoCheckpointMetadata {
+        MongoCheckpointMetadata {
+            resume_token_json: r#"{"_data":"82650000000000000001"}"#.to_string(),
+            cluster_time_ts: Some(1_700_000_000),
+            schema_json: Some(r#"{"fields":[]}"#.to_string()),
+            updated_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_roundtrip() {
+        let (ds, _tmp) = create_test_dataset("test_mongodb_duckdb_roundtrip").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+
+        let metadata = create_test_metadata();
+        mongo_sys
+            .upsert(&metadata)
+            .await
+            .expect("to upsert metadata");
+
+        let retrieved = mongo_sys.get().await.expect("to retrieve metadata");
+        assert_eq!(retrieved.resume_token_json, metadata.resume_token_json);
+        assert_eq!(retrieved.cluster_time_ts, metadata.cluster_time_ts);
+        assert_eq!(retrieved.schema_json, metadata.schema_json);
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_metadata_overwrite() {
+        let (ds, _tmp) = create_test_dataset("test_mongodb_duckdb_overwrite").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+        let mut metadata = create_test_metadata();
+
+        mongo_sys
+            .upsert(&metadata)
+            .await
+            .expect("to upsert metadata");
+
+        metadata.resume_token_json = r#"{"_data":"82650000000000000002"}"#.to_string();
+        mongo_sys
+            .upsert(&metadata)
+            .await
+            .expect("to overwrite metadata");
+
+        let retrieved = mongo_sys.get().await.expect("to retrieve metadata");
+        assert_eq!(retrieved.resume_token_json, metadata.resume_token_json);
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_get_nonexistent() {
+        let (ds, _tmp) = create_test_dataset("test_mongodb_duckdb_get_nonexistent").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+
+        assert!(mongo_sys.get().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_delete() {
+        let (ds, _tmp) = create_test_dataset("test_mongodb_duckdb_delete").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+
+        mongo_sys
+            .upsert(&create_test_metadata())
+            .await
+            .expect("to upsert metadata");
+        assert!(mongo_sys.get().await.is_some());
+
+        mongo_sys.delete().await.expect("to delete");
+        assert!(mongo_sys.get().await.is_none());
+    }
+}

--- a/crates/runtime/src/dataaccelerator/spice_sys/mongodb/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mongodb/mod.rs
@@ -1,0 +1,190 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Durable sidecar storage for MongoDB Change Stream resume tokens.
+//!
+//! Mirrors `DynamoDBSys` and `KafkaSys`: one row per dataset in
+//! `spice_sys_mongodb`, holding the most recent resume token (canonical
+//! extended JSON of the raw BSON `ResumeToken`), an optional cluster time for
+//! `startAtOperationTime` fallback, and an optional Arrow schema snapshot for
+//! drift detection.
+//!
+//! ```sql
+//! CREATE TABLE spice_sys_mongodb (
+//!     dataset_name TEXT PRIMARY KEY,
+//!     resume_token_json TEXT NOT NULL,
+//!     cluster_time_ts INTEGER,
+//!     schema_json TEXT,
+//!     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+//!     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+//! );
+//! ```
+
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use serde::{Deserialize, Serialize};
+
+use super::{AccelerationConnection, Error, Result, acceleration_connection};
+use crate::{component::dataset::Dataset, dataaccelerator::spice_sys::OpenOption};
+
+#[cfg_attr(
+    not(any(
+        feature = "sqlite",
+        feature = "duckdb",
+        feature = "postgres-accel",
+        feature = "turso"
+    )),
+    expect(dead_code)
+)]
+const MONGODB_TABLE_NAME: &str = "spice_sys_mongodb";
+
+#[cfg(feature = "duckdb")]
+mod duckdb;
+#[cfg(feature = "postgres-accel")]
+mod postgres;
+#[cfg(feature = "sqlite")]
+mod sqlite;
+#[cfg(feature = "turso")]
+mod turso;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct MongoCheckpointMetadata {
+    /// Canonical extended JSON of the most recent `ResumeToken`'s raw BSON.
+    pub resume_token_json: String,
+    /// Optional cluster operation time (seconds since epoch) used as the
+    /// `startAtOperationTime` fallback when the resume token is past the
+    /// oplog window.
+    #[serde(default)]
+    pub cluster_time_ts: Option<i64>,
+    /// Optional serialized Arrow schema snapshot for detecting drift between
+    /// runs.
+    #[serde(default)]
+    pub schema_json: Option<String>,
+    /// When the row was last updated. Populated by the database layer on read.
+    #[serde(default)]
+    pub updated_at: Option<std::time::SystemTime>,
+}
+
+pub struct MongoSys {
+    #[cfg_attr(
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
+        expect(dead_code)
+    )]
+    dataset_name: String,
+    acceleration_connection: AccelerationConnection,
+}
+
+impl MongoSys {
+    pub async fn try_new(dataset: &Dataset, open_option: OpenOption) -> Result<Self> {
+        Ok(Self {
+            dataset_name: dataset.name.to_string(),
+            acceleration_connection: acceleration_connection(dataset, open_option).await?,
+        })
+    }
+
+    pub async fn get(&self) -> Option<MongoCheckpointMetadata> {
+        match &self.acceleration_connection {
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::DuckDB(pool) => self.get_duckdb(pool),
+            #[cfg(feature = "postgres-accel")]
+            AccelerationConnection::Postgres(pool) => self.get_postgres(pool).await,
+            #[cfg(feature = "sqlite")]
+            AccelerationConnection::SQLite(conn) => self.get_sqlite(conn).await,
+            #[cfg(feature = "turso")]
+            AccelerationConnection::Turso(pool) => self.get_turso(pool).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.get_sqlite(conn).await,
+            #[cfg(not(any(
+                feature = "sqlite",
+                feature = "duckdb",
+                feature = "postgres-accel",
+                feature = "turso"
+            )))]
+            _ => None,
+        }
+    }
+
+    pub async fn upsert(
+        &self,
+        #[cfg_attr(
+            not(any(
+                feature = "sqlite",
+                feature = "duckdb",
+                feature = "postgres-accel",
+                feature = "turso"
+            )),
+            expect(unused_variables)
+        )]
+        metadata: &MongoCheckpointMetadata,
+    ) -> Result<()> {
+        match &self.acceleration_connection {
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::DuckDB(pool) => self.upsert_duckdb(pool, metadata),
+            #[cfg(feature = "postgres-accel")]
+            AccelerationConnection::Postgres(pool) => self.upsert_postgres(pool, metadata).await,
+            #[cfg(feature = "sqlite")]
+            AccelerationConnection::SQLite(conn) => self.upsert_sqlite(conn, metadata).await,
+            #[cfg(feature = "turso")]
+            AccelerationConnection::Turso(pool) => self.upsert_turso(pool, metadata).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.upsert_sqlite(conn, metadata).await,
+            #[cfg(not(any(
+                feature = "sqlite",
+                feature = "duckdb",
+                feature = "postgres-accel",
+                feature = "turso"
+            )))]
+            _ => Err(Error::NoAccelerationConnection),
+        }
+    }
+
+    pub async fn delete(&self) -> Result<()> {
+        match &self.acceleration_connection {
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::DuckDB(pool) => self.delete_duckdb(pool),
+            #[cfg(feature = "postgres-accel")]
+            AccelerationConnection::Postgres(pool) => self.delete_postgres(pool).await,
+            #[cfg(feature = "sqlite")]
+            AccelerationConnection::SQLite(conn) => self.delete_sqlite(conn).await,
+            #[cfg(feature = "turso")]
+            AccelerationConnection::Turso(pool) => self.delete_turso(pool).await,
+            #[cfg(all(not(windows), feature = "sqlite"))]
+            AccelerationConnection::Cayenne(conn) => self.delete_sqlite(conn).await,
+            #[cfg(not(any(
+                feature = "sqlite",
+                feature = "duckdb",
+                feature = "postgres-accel",
+                feature = "turso"
+            )))]
+            _ => Err(Error::NoAccelerationConnection),
+        }
+    }
+
+    /// Serialize an Arrow schema to a JSON string for `schema_json` storage.
+    pub fn serialize_schema(schema: &SchemaRef) -> Result<String> {
+        serde_json::to_string(schema).map_err(Error::external)
+    }
+
+    /// Deserialize an Arrow schema from a `schema_json` string.
+    pub fn deserialize_schema(schema_json: &str) -> Result<SchemaRef> {
+        let schema: Schema = serde_json::from_str(schema_json).map_err(Error::external)?;
+        Ok(std::sync::Arc::new(schema))
+    }
+}

--- a/crates/runtime/src/dataaccelerator/spice_sys/mongodb/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mongodb/postgres.rs
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
+
+use super::{Error, MONGODB_TABLE_NAME, MongoCheckpointMetadata, MongoSys, Result};
+
+impl MongoSys {
+    pub(super) async fn upsert_postgres(
+        &self,
+        pool: &PostgresConnectionPool,
+        metadata: &MongoCheckpointMetadata,
+    ) -> Result<()> {
+        let conn = pool.connect_direct().await.map_err(Error::external)?;
+
+        let create_table = format!(
+            "CREATE TABLE IF NOT EXISTS {MONGODB_TABLE_NAME} (
+                dataset_name TEXT PRIMARY KEY,
+                resume_token_json TEXT NOT NULL,
+                cluster_time_ts BIGINT,
+                schema_json TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )"
+        );
+        conn.conn
+            .execute(&create_table, &[])
+            .await
+            .map_err(Error::external)?;
+
+        let upsert = format!(
+            "INSERT INTO {MONGODB_TABLE_NAME}
+             (dataset_name, resume_token_json, cluster_time_ts, schema_json, updated_at)
+             VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)
+             ON CONFLICT (dataset_name) DO UPDATE SET
+                resume_token_json = EXCLUDED.resume_token_json,
+                cluster_time_ts = EXCLUDED.cluster_time_ts,
+                schema_json = EXCLUDED.schema_json,
+                updated_at = CURRENT_TIMESTAMP"
+        );
+
+        conn.conn
+            .execute(
+                &upsert,
+                &[
+                    &self.dataset_name,
+                    &metadata.resume_token_json,
+                    &metadata.cluster_time_ts,
+                    &metadata.schema_json,
+                ],
+            )
+            .await
+            .map_err(Error::external)?;
+
+        Ok(())
+    }
+
+    pub(super) async fn get_postgres(
+        &self,
+        pool: &PostgresConnectionPool,
+    ) -> Option<MongoCheckpointMetadata> {
+        let conn = pool.connect_direct().await.ok()?;
+        let query = format!(
+            "SELECT resume_token_json, cluster_time_ts, schema_json, EXTRACT(EPOCH FROM updated_at) FROM {MONGODB_TABLE_NAME} WHERE dataset_name = $1"
+        );
+        let stmt = conn.conn.prepare(&query).await.ok()?;
+        let row = conn
+            .conn
+            .query_opt(&stmt, &[&self.dataset_name])
+            .await
+            .ok()??;
+
+        let resume_token_json: String = row.get(0);
+        let cluster_time_ts: Option<i64> = row.get(1);
+        let schema_json: Option<String> = row.get(2);
+        let updated_at_epoch: Option<f64> = row.get(3);
+        let updated_at = updated_at_epoch.and_then(|epoch| {
+            std::time::UNIX_EPOCH.checked_add(std::time::Duration::from_secs_f64(epoch))
+        });
+
+        Some(MongoCheckpointMetadata {
+            resume_token_json,
+            cluster_time_ts,
+            schema_json,
+            updated_at,
+        })
+    }
+
+    pub(super) async fn delete_postgres(&self, pool: &PostgresConnectionPool) -> Result<()> {
+        let conn = pool.connect_direct().await.map_err(Error::external)?;
+        let delete = format!("DELETE FROM {MONGODB_TABLE_NAME} WHERE dataset_name = $1");
+        conn.conn
+            .execute(&delete, &[&self.dataset_name])
+            .await
+            .map_err(Error::external)?;
+
+        Ok(())
+    }
+}

--- a/crates/runtime/src/dataaccelerator/spice_sys/mongodb/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mongodb/sqlite.rs
@@ -1,0 +1,296 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use datafusion_table_providers::sql::db_connection_pool::{
+    dbconnection::sqliteconn::SqliteConnection, sqlitepool::SqliteConnectionPool,
+};
+
+use super::{Error, MONGODB_TABLE_NAME, MongoCheckpointMetadata, MongoSys, Result};
+
+impl MongoSys {
+    pub(super) async fn upsert_sqlite(
+        &self,
+        pool: &SqliteConnectionPool,
+        metadata: &MongoCheckpointMetadata,
+    ) -> Result<()> {
+        let dataset_name = self.dataset_name.clone();
+        let resume_token_json = metadata.resume_token_json.clone();
+        let cluster_time_ts = metadata.cluster_time_ts;
+        let schema_json = metadata.schema_json.clone();
+
+        let conn_sync = pool.connect_sync();
+        let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
+            return Err(Error::DowncastFailed {
+                target: "SqliteConnection",
+            });
+        };
+
+        conn.conn
+            .call(
+                move |conn: &mut rusqlite::Connection| -> Result<(), rusqlite::Error> {
+                    let create_table = format!(
+                        "CREATE TABLE IF NOT EXISTS {MONGODB_TABLE_NAME} (
+                            dataset_name TEXT PRIMARY KEY,
+                            resume_token_json TEXT NOT NULL,
+                            cluster_time_ts INTEGER,
+                            schema_json TEXT,
+                            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                        )"
+                    );
+                    conn.execute(&create_table, [])?;
+
+                    let upsert = format!(
+                        "INSERT INTO {MONGODB_TABLE_NAME}
+                         (dataset_name, resume_token_json, cluster_time_ts, schema_json, updated_at)
+                         VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP)
+                         ON CONFLICT (dataset_name) DO UPDATE SET
+                            resume_token_json = ?2,
+                            cluster_time_ts = ?3,
+                            schema_json = ?4,
+                            updated_at = CURRENT_TIMESTAMP"
+                    );
+
+                    conn.execute(
+                        &upsert,
+                        rusqlite::params![
+                            dataset_name,
+                            resume_token_json,
+                            cluster_time_ts,
+                            schema_json,
+                        ],
+                    )?;
+
+                    Ok::<(), rusqlite::Error>(())
+                },
+            )
+            .await
+            .map_err(Error::external)
+    }
+
+    pub(super) async fn get_sqlite(
+        &self,
+        pool: &SqliteConnectionPool,
+    ) -> Option<MongoCheckpointMetadata> {
+        let dataset_name = self.dataset_name.clone();
+
+        let conn_sync = pool.connect_sync();
+        let conn = conn_sync.as_any().downcast_ref::<SqliteConnection>()?;
+
+        conn.conn
+            .call(move |conn: &mut rusqlite::Connection| -> Result<MongoCheckpointMetadata, rusqlite::Error> {
+                let query = format!(
+                    "SELECT resume_token_json, cluster_time_ts, schema_json, strftime('%s', updated_at) FROM {MONGODB_TABLE_NAME} WHERE dataset_name = ?"
+                );
+                let mut stmt = conn.prepare(&query)?;
+                let mut rows = stmt.query([dataset_name])?;
+
+                if let Some(row) = rows.next()? {
+                    let resume_token_json: String = row.get(0)?;
+                    let cluster_time_ts: Option<i64> = row.get(1).ok();
+                    let schema_json: Option<String> = row.get(2).ok();
+                    let updated_at_epoch: Option<i64> = row.get(3).ok();
+                    let updated_at = updated_at_epoch.and_then(|epoch| {
+                        u64::try_from(epoch).ok().and_then(|e| {
+                            std::time::UNIX_EPOCH.checked_add(std::time::Duration::from_secs(e))
+                        })
+                    });
+
+                    Ok(MongoCheckpointMetadata {
+                        resume_token_json,
+                        cluster_time_ts,
+                        schema_json,
+                        updated_at,
+                    })
+                } else {
+                    Err(rusqlite::Error::QueryReturnedNoRows)
+                }
+            })
+            .await
+            .ok()
+    }
+
+    pub(super) async fn delete_sqlite(&self, pool: &SqliteConnectionPool) -> Result<()> {
+        let dataset_name = self.dataset_name.clone();
+
+        let conn_sync = pool.connect_sync();
+        let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
+            return Err(Error::DowncastFailed {
+                target: "SqliteConnection",
+            });
+        };
+
+        conn.conn
+            .call(
+                move |conn: &mut rusqlite::Connection| -> Result<(), rusqlite::Error> {
+                    let delete = format!(
+                        "DELETE FROM {MONGODB_TABLE_NAME} WHERE dataset_name = ?1"
+                    );
+                    conn.execute(&delete, [dataset_name])?;
+                    Ok::<(), rusqlite::Error>(())
+                },
+            )
+            .await
+            .map_err(Error::external)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        builder::RuntimeBuilder,
+        component::dataset::{
+            Dataset,
+            acceleration::{Acceleration, Engine, Mode},
+            builder::DatasetBuilder,
+        },
+        dataaccelerator::spice_sys::OpenOption,
+    };
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    async fn create_test_dataset(ds_name: &str) -> Dataset {
+        let app = app::AppBuilder::new("test").build();
+        let runtime = RuntimeBuilder::new().build().await;
+
+        let mut dataset = DatasetBuilder::try_new("spice.ai".to_string(), ds_name)
+            .expect("to create dataset builder")
+            .with_app(Arc::new(app))
+            .with_runtime(Arc::new(runtime))
+            .build()
+            .expect("to create dataset");
+
+        let db_file = format!(".spice/data/mongodb_sqlite_test_{ds_name}.db");
+        dataset.acceleration = Some(Acceleration {
+            engine: Engine::Sqlite,
+            mode: Mode::File,
+            params: [("sqlite_file".to_string(), db_file)].into_iter().collect(),
+            ..Default::default()
+        });
+
+        dataset
+    }
+
+    fn create_test_metadata() -> MongoCheckpointMetadata {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        MongoCheckpointMetadata {
+            resume_token_json: r#"{"_data":"82650000000000000001"}"#.to_string(),
+            cluster_time_ts: Some(1_700_000_000),
+            schema_json: Some(MongoSys::serialize_schema(&schema).expect("schema serializes")),
+            updated_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_roundtrip() {
+        let ds = create_test_dataset("test_mongodb_sqlite_roundtrip").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+
+        let metadata = create_test_metadata();
+        mongo_sys
+            .upsert(&metadata)
+            .await
+            .expect("to upsert metadata");
+
+        let retrieved = mongo_sys.get().await.expect("to retrieve metadata");
+        assert_eq!(retrieved.resume_token_json, metadata.resume_token_json);
+        assert_eq!(retrieved.cluster_time_ts, metadata.cluster_time_ts);
+        assert_eq!(retrieved.schema_json, metadata.schema_json);
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_metadata_overwrite() {
+        let ds = create_test_dataset("test_mongodb_sqlite_overwrite").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+
+        let mut metadata = create_test_metadata();
+        mongo_sys
+            .upsert(&metadata)
+            .await
+            .expect("to upsert metadata");
+
+        metadata.resume_token_json = r#"{"_data":"82650000000000000002"}"#.to_string();
+        metadata.cluster_time_ts = Some(1_700_000_500);
+        mongo_sys
+            .upsert(&metadata)
+            .await
+            .expect("to overwrite metadata");
+
+        let retrieved = mongo_sys.get().await.expect("to retrieve metadata");
+        assert_eq!(retrieved.resume_token_json, metadata.resume_token_json);
+        assert_eq!(retrieved.cluster_time_ts, metadata.cluster_time_ts);
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_get_nonexistent() {
+        let ds = create_test_dataset("test_mongodb_sqlite_get_nonexistent").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+
+        assert!(mongo_sys.get().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_delete() {
+        let ds = create_test_dataset("test_mongodb_sqlite_delete").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+
+        mongo_sys
+            .upsert(&create_test_metadata())
+            .await
+            .expect("to upsert metadata");
+        assert!(mongo_sys.get().await.is_some());
+
+        mongo_sys.delete().await.expect("to delete");
+        assert!(mongo_sys.get().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_null_optional_columns() {
+        let ds = create_test_dataset("test_mongodb_sqlite_null_optional").await;
+        let mongo_sys = MongoSys::try_new(&ds, OpenOption::CreateIfNotExists)
+            .await
+            .expect("to create MongoSys");
+
+        let metadata = MongoCheckpointMetadata {
+            resume_token_json: r#"{"_data":"abc"}"#.to_string(),
+            cluster_time_ts: None,
+            schema_json: None,
+            updated_at: None,
+        };
+        mongo_sys
+            .upsert(&metadata)
+            .await
+            .expect("to upsert metadata");
+
+        let retrieved = mongo_sys.get().await.expect("to retrieve metadata");
+        assert_eq!(retrieved.resume_token_json, metadata.resume_token_json);
+        assert!(retrieved.cluster_time_ts.is_none());
+        assert!(retrieved.schema_json.is_none());
+    }
+}

--- a/crates/runtime/src/dataaccelerator/spice_sys/mongodb/turso.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mongodb/turso.rs
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use super::{Error, MONGODB_TABLE_NAME, MongoCheckpointMetadata, MongoSys, Result};
+use crate::dataaccelerator::turso::TursoConnectionPool;
+
+impl MongoSys {
+    pub(super) async fn upsert_turso(
+        &self,
+        pool: &Arc<TursoConnectionPool>,
+        metadata: &MongoCheckpointMetadata,
+    ) -> Result<()> {
+        let dataset_name = self.dataset_name.clone();
+        let resume_token_json = metadata.resume_token_json.clone();
+        let cluster_time_ts = metadata.cluster_time_ts;
+        let schema_json = metadata.schema_json.clone();
+
+        let conn = pool.connect().await.map_err(Error::external)?;
+
+        let create_table = format!(
+            "CREATE TABLE IF NOT EXISTS {MONGODB_TABLE_NAME} (
+                dataset_name TEXT PRIMARY KEY,
+                resume_token_json TEXT NOT NULL,
+                cluster_time_ts INTEGER,
+                schema_json TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )"
+        );
+        conn.execute(&create_table, ())
+            .await
+            .map_err(Error::external)?;
+
+        let upsert = format!(
+            "INSERT INTO {MONGODB_TABLE_NAME}
+             (dataset_name, resume_token_json, cluster_time_ts, schema_json, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+             ON CONFLICT (dataset_name) DO UPDATE SET
+                resume_token_json = ?2,
+                cluster_time_ts = ?3,
+                schema_json = ?4,
+                updated_at = CURRENT_TIMESTAMP"
+        );
+
+        conn.execute(
+            &upsert,
+            turso::params![dataset_name, resume_token_json, cluster_time_ts, schema_json,],
+        )
+        .await
+        .map_err(Error::external)?;
+
+        Ok(())
+    }
+
+    pub(super) async fn get_turso(
+        &self,
+        pool: &Arc<TursoConnectionPool>,
+    ) -> Option<MongoCheckpointMetadata> {
+        let dataset_name = self.dataset_name.clone();
+        let conn = pool.connect().await.ok()?;
+        let query = format!(
+            "SELECT resume_token_json, cluster_time_ts, schema_json, strftime('%s', updated_at) FROM {MONGODB_TABLE_NAME} WHERE dataset_name = ?"
+        );
+
+        let mut rows = conn
+            .query(&query, turso::params![dataset_name])
+            .await
+            .ok()?;
+        let row = rows.next().await.ok()??;
+
+        let resume_token_json = row.get::<String>(0).ok()?;
+        let cluster_time_ts: Option<i64> = row.get::<i64>(1).ok();
+        let schema_json: Option<String> = row.get::<String>(2).ok();
+        let updated_at_epoch: Option<i64> = row.get::<i64>(3).ok();
+        let updated_at = updated_at_epoch.and_then(|epoch| {
+            u64::try_from(epoch)
+                .ok()
+                .and_then(|e| std::time::UNIX_EPOCH.checked_add(std::time::Duration::from_secs(e)))
+        });
+
+        Some(MongoCheckpointMetadata {
+            resume_token_json,
+            cluster_time_ts,
+            schema_json,
+            updated_at,
+        })
+    }
+
+    pub(super) async fn delete_turso(&self, pool: &Arc<TursoConnectionPool>) -> Result<()> {
+        let dataset_name = self.dataset_name.clone();
+        let conn = pool.connect().await.map_err(Error::external)?;
+        let delete = format!("DELETE FROM {MONGODB_TABLE_NAME} WHERE dataset_name = ?1");
+        conn.execute(&delete, turso::params![dataset_name])
+            .await
+            .map_err(Error::external)?;
+
+        Ok(())
+    }
+}

--- a/docs/features/mongodb-change-streams.md
+++ b/docs/features/mongodb-change-streams.md
@@ -50,8 +50,28 @@ These optional parameters live under dataset `params:` and are not prefixed with
 - `change_stream_batch_max_duration` (default `1s`): Maximum time to wait for a Change Stream batch to fill before applying it. Accepts [fundu](https://docs.rs/fundu) duration strings and must be greater than 0.
 - `change_stream_max_await_time` (default `1s`): Maximum time MongoDB waits for new Change Stream events before returning an empty server batch. Accepts [fundu](https://docs.rs/fundu) duration strings and must be greater than 0.
 - `change_stream_batch_size` (default `1000`): Number of Change Stream events MongoDB should request from the server per batch. Must fit in a `u32` and be greater than 0.
+- `mongodb_resume_token_invalid_behavior` (default `error`): Behavior when a persisted Change Stream resume token cannot be honored by the server (e.g. it is past the oplog retention window). `error` surfaces a clear error so the operator can decide; `rebootstrap` drops the persisted token and re-snapshots the collection.
 
 The existing `mongodb_unnest_depth` parameter also applies to Change Stream documents, so nested BSON documents are flattened the same way as normal MongoDB reads.
+
+## Resumability across restarts
+
+For file-accelerated datasets (acceleration `mode: file` / `file_create` / `file_update`, or `engine: postgres`), Spice persists the most recent Change Stream resume token in a sidecar table called `spice_sys_mongodb`, stored alongside the accelerator data. The schema is one row per dataset:
+
+| column              | type      | description                                                                                      |
+| ------------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `dataset_name`      | TEXT PK   | Dataset name.                                                                                    |
+| `resume_token_json` | TEXT      | Serialized MongoDB resume token (the `_id` field of the most recently processed change event).   |
+| `cluster_time_ts`   | INTEGER   | Optional unix-seconds cluster operation time, retained as a fallback for `startAtOperationTime`. |
+| `schema_json`       | TEXT      | Optional serialized Arrow schema snapshot, used to log a warning on schema drift between runs.   |
+| `created_at`        | TIMESTAMP | Row creation time.                                                                               |
+| `updated_at`        | TIMESTAMP | Last commit time.                                                                                |
+
+The token is written once after the initial collection snapshot completes (piggy-backed onto the dataset-ready signal so a crash mid-snapshot still triggers a clean re-bootstrap), then re-written after each live Change Stream batch is persisted to the accelerator. The committer fires only once the downstream accelerator write has succeeded, so the persisted token always reflects data already in the accelerator (at-least-once semantics).
+
+On restart with a persisted token, Spice resumes the Change Stream from that token and skips the collection snapshot. If MongoDB rejects the token (typical codes `ChangeStreamHistoryLost` 286 or `ChangeStreamFatalError` 280, e.g. when the oplog window has rolled past the token's position), the behavior is governed by `mongodb_resume_token_invalid_behavior` above. Re-snapshotting a large collection is opt-in by default.
+
+Datasets that are not file-accelerated (in-memory Arrow, etc.) do not get a sidecar row; restarts re-bootstrap from a fresh snapshot.
 
 ## Event mapping
 


### PR DESCRIPTION
## Summary

Layered on top of #10813. Adds a `spice_sys_mongodb` sidecar that persists the most recent Change Stream resume token to the accelerator alongside dataset data, so file-accelerated MongoDB CDC datasets resume from the last persisted position on restart instead of always re-snapshotting the collection.

- New `MongoSys` module under `crates/runtime/src/dataaccelerator/spice_sys/mongodb/` (`mod.rs` + per-engine `duckdb.rs` / `sqlite.rs` / `postgres.rs` / `turso.rs`), mirroring the existing `DynamoDBSys` / `KafkaSys` pattern. One row per dataset: `resume_token_json`, optional `cluster_time_ts`, optional `schema_json`, plus `created_at` / `updated_at`. API: `try_new` / `get` / `upsert` / `delete`.
- Wires a `MongoResumeTokenCommitter` into `connector-mongodb/src/changes.rs`. After each live Change Stream batch is durably written to the accelerator, the committer fires and upserts the tail event's resume token (and cluster time) to the sidecar — at-least-once, mirroring `DynamoDBStreamCommitter` and `LsnCommitter`.
- Forks `build_changes_stream` on startup. If the sidecar has a token, resume from it via `resume_after` and yield only the ready-signal envelope (no snapshot). Otherwise, run the existing cold-bootstrap path (truncate → snapshot → ready), then piggy-back the initial token commit onto the ready envelope so a crash mid-snapshot re-bootstraps cleanly on the next start (sidecar stays empty until the snapshot is fully durable).
- Detects stale-token errors from the driver (`ChangeStreamHistoryLost` 286 / `ChangeStreamFatalError` 280) on the resume open. New `mongodb_resume_token_invalid_behavior` parameter dispatches: `error` (default — surfaces a clear error so the operator decides; re-snapshotting a large collection should be opt-in) or `rebootstrap` (drop the token and fall through to cold bootstrap).
- Logs a warning if `schema_json` differs from the current inferred schema between runs (drift detection); does not fail the stream.
- Datasets that are not file-accelerated (in-memory Arrow, etc.) skip the sidecar entirely — behavior unchanged from #10813's baseline.

## Test plan

- [x] `cargo check -p connector-mongodb` clean
- [x] `cargo check -p runtime --features "mongodb,sqlite,duckdb,turso,postgres-accel" --lib` clean
- [x] `cargo check -p runtime --no-default-features --features mongodb --lib` clean (gates compile correctly when no engine features are enabled)
- [ ] `cargo test -p runtime --features "mongodb,sqlite,duckdb" --lib dataaccelerator::spice_sys::mongodb` — included unit tests for sqlite + duckdb round-trip, overwrite, get-nonexistent, delete, and NULL optional columns. CI to verify.
- [ ] Live runtime integration tests in `crates/runtime/tests/mongo/` covering cold start → restart → resume (no re-snapshot), stale-token rebootstrap behavior, and crash-between-snapshot-and-ready signal re-bootstrap — to add in a follow-up alongside the existing mongo integration harness.
- [ ] Manual smoke against a MongoDB replica set with a duckdb-accelerated dataset: insert during run, restart, verify no re-snapshot and that subsequent events appear.

## Notes for review

- The sidecar's `expect(unused_variables)` / `expect(dead_code)` cfg gates fire only when none of `sqlite`/`duckdb`/`postgres-accel`/`turso` are enabled — i.e. configurations where `MongoSys` cannot actually do anything. Same pattern used by `DynamoDBSys`.
- `Error::external` in `spice_sys.rs` had its cfg gate widened to include `feature = "mongodb"`. (The existing gate already included `kafka` and `dynamodb`'s engines.)
- Decisions called out in the original plan:
  - **Stale-token default**: `error` (operator opt-in to re-snapshot).
  - **Commit cadence**: per-batch, mirroring DynamoDB and postgres replication.
  - **`schema_json` column**: included, used for warning-level drift detection.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaYRccgu2Djp5Q6EFaAZi6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->