### PR TITLE
Fix CH-BenCHmark replication lag metrics calculation

### DIFF
--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -284,6 +284,7 @@ impl SpiceTestQueryWorker {
                                 &mut query_statuses,
                                 &mut row_counts,
                                 queries_to_run,
+                                &start,
                             )
                             .await?
                         {
@@ -435,8 +436,17 @@ impl SpiceTestQueryWorker {
         query_statuses: &mut BTreeMap<Arc<str>, QueryStatus>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
         queries: &[Query],
+        start: &Instant,
     ) -> Result<bool> {
         for query in queries {
+            // Stop submitting new queries once the duration has elapsed or shutdown
+            // was requested, so the test finishes close to the scheduled duration.
+            if self.shutdown_token.is_cancelled()
+                || matches!(self.end_condition, EndCondition::Duration(d) if start.elapsed() >= d)
+            {
+                break;
+            }
+
             let QueryRunResult {
                 connection_failed,
                 query_failure,

--- a/tools/chbench-driver/src/config.rs
+++ b/tools/chbench-driver/src/config.rs
@@ -26,9 +26,6 @@ pub struct ChBenchConfig {
     /// Number of concurrent OLTP terminals for the HTAP workload.
     pub terminals: usize,
 
-    /// Duration of the OLTP workload.
-    pub duration: std::time::Duration,
-
     /// Transaction mix weights: \[`NewOrder`, Payment, Delivery, `OrderStatus`, `StockLevel`\].
     /// Must sum to 100.
     pub mix: [u32; 5],
@@ -43,7 +40,6 @@ impl Default for ChBenchConfig {
             warehouses: 1,
             seed: Some(DEFAULT_SEED),
             terminals: 10,
-            duration: std::time::Duration::from_secs(300),
             mix: crate::txn::DEFAULT_MIX,
         }
     }

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -17,8 +17,7 @@ limitations under the License.
 //! CH-benCH driver — TPC-C schema + seed data loader and OLTP workload driver.
 //!
 //! Creates 12 tables (9 TPC-C + 3 CH supplemental), loads seed data,
-//! and runs a TPC-C OLTP workload with configurable terminals and duration.
-
+/// and runs a TPC-C OLTP workload with configurable terminals.
 pub mod config;
 pub mod loader;
 pub mod metrics;
@@ -62,9 +61,10 @@ pub trait ChBenchDriver: Send + Sync {
     /// (e.g. `_bench_ts` triggers).
     async fn prepare(&self) -> Result<()>;
 
-    /// Run the TPC-C OLTP workload until `cancel` fires or the configured
-    /// duration elapses.
-    async fn run(&self, cancel: CancellationToken) -> Result<OltpReport>;
+    /// Run the TPC-C OLTP workload until `stop` is triggered.
+    ///
+    /// The caller controls lifetime — trigger the token to stop the workload.
+    async fn run(&self, stop: CancellationToken) -> Result<OltpReport>;
 
     /// Tables to probe for staleness measurement.
     ///
@@ -132,37 +132,28 @@ impl ChBenchDriver for PostgresChBenchDriver {
         Ok(())
     }
 
-    /// Run the TPC-C OLTP workload until the cancellation token is triggered
-    /// or `config.duration` elapses.
+    /// Run the TPC-C OLTP workload until `stop` is triggered.
     ///
     /// Each terminal opens its own Postgres connection and runs transactions
-    /// in a tight loop with the configured mix weights.
-    async fn run(&self, cancel: CancellationToken) -> Result<OltpReport> {
+    /// in a tight loop with the configured mix weights. The caller controls
+    /// lifetime by triggering the token.
+    async fn run(&self, stop: CancellationToken) -> Result<OltpReport> {
         let terminals = self.config.terminals;
-        let duration = self.config.duration;
         let mix = self.config.mix;
         let warehouses = i32::try_from(self.config.warehouses).unwrap_or(1);
         let base_seed = self.config.seed.unwrap_or(42);
 
         println!(
-            "Starting OLTP workload: {warehouses} warehouse(s), {terminals} terminals, {duration}s duration, mix={mix:?}",
-            duration = duration.as_secs()
+            "Starting OLTP workload: {warehouses} warehouse(s), {terminals} terminals, mix={mix:?}",
         );
-
-        // Spawn a task that cancels after the configured duration
-        let duration_cancel = cancel.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(duration).await;
-            duration_cancel.cancel();
-        });
 
         let mut handles = Vec::with_capacity(terminals);
         for terminal_id in 0..terminals {
             let conn_str = self.source.connection_string();
-            let cancel = cancel.clone();
+            let stop = stop.clone();
 
             handles.push(tokio::spawn(async move {
-                run_terminal(terminal_id, &conn_str, cancel, warehouses, mix, base_seed).await
+                run_terminal(terminal_id, &conn_str, stop, warehouses, mix, base_seed).await
             }));
         }
 
@@ -223,7 +214,7 @@ impl ChBenchDriver for PostgresChBenchDriver {
 async fn run_terminal(
     terminal_id: usize,
     conn_str: &str,
-    cancel: CancellationToken,
+    stop: CancellationToken,
     warehouses: i32,
     mix: [u32; 5],
     base_seed: u64,
@@ -235,7 +226,7 @@ async fn run_terminal(
             source,
         })?;
 
-    let cancel_conn = cancel.clone();
+    let stop_conn = stop.clone();
     tokio::spawn(async move {
         tokio::select! {
             result = connection => {
@@ -243,7 +234,7 @@ async fn run_terminal(
                     eprintln!("Terminal {terminal_id} connection error: {e}");
                 }
             }
-            () = cancel_conn.cancelled() => {}
+            () = stop_conn.cancelled() => {}
         }
     });
 
@@ -251,7 +242,7 @@ async fn run_terminal(
     let mut metrics = metrics::OltpMetrics::new();
 
     loop {
-        if cancel.is_cancelled() {
+        if stop.is_cancelled() {
             break;
         }
 
@@ -263,9 +254,9 @@ async fn run_terminal(
             }
             Err(e) => {
                 metrics.record_abort();
-                if !cancel.is_cancelled() {
+                if !stop.is_cancelled() {
                     // Log only if not shutting down — connection-closed errors
-                    // during cancellation are expected and noisy.
+                    // during shutdown are expected and noisy.
                     eprintln!("Terminal {terminal_id} {txn_type} error: {e}");
                 }
             }

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -78,7 +78,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let query_set = args.load_query_set()?;
     if query_set == test_framework::queries::QuerySet::ChBench {
         let scale_factor = args.scale_factor.unwrap_or(1.0);
-        prepare_chbench_source(scale_factor, None).await?;
+        prepare_chbench_source(scale_factor).await?;
     }
 
     let mut spiced_instance = SpicedInstance::start(start_request).await?;
@@ -280,10 +280,8 @@ fn chbench_source_from_env() -> anyhow::Result<chbench_driver::PostgresSourceCon
 /// Postgres, create the schema and load seed data.
 ///
 /// `scale_factor` maps to TPC-C warehouses (must be a positive integer >= 1).
-/// `duration` overrides the default OLTP workload duration when set.
 pub(crate) async fn prepare_chbench_source(
     scale_factor: f64,
-    duration: Option<Duration>,
 ) -> anyhow::Result<chbench_driver::PostgresChBenchDriver> {
     if scale_factor < 1.0 || scale_factor.fract() != 0.0 {
         anyhow::bail!(
@@ -296,14 +294,11 @@ pub(crate) async fn prepare_chbench_source(
     #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let warehouses = scale_factor as usize;
     let terminals = warehouses * 10;
-    let mut config = chbench_driver::ChBenchConfig {
+    let config = chbench_driver::ChBenchConfig {
         warehouses,
         terminals,
         ..Default::default()
     };
-    if let Some(d) = duration {
-        config.duration = d;
-    }
 
     println!(
         "Preparing chbench source (SF{scale_factor}: {warehouses} warehouse(s), {terminals} terminal(s))..."

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -66,7 +66,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     let scale_factor = test_args.scale_factor.unwrap_or(1.0);
     let duration = Duration::from_secs(test_args.common.duration);
     let driver: Arc<dyn chbench_driver::ChBenchDriver> =
-        Arc::new(prepare_chbench_source(scale_factor, Some(duration)).await?);
+        Arc::new(prepare_chbench_source(scale_factor).await?);
 
     // 2. Start spiced.
     let mut spiced_instance = SpicedInstance::start(start_request).await?;
@@ -111,11 +111,11 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     let metrics_scraper = Some(MetricsScraper::spawn()?);
 
     // 3. Start the OLTP workload in the background.
-    let oltp_cancel = CancellationToken::new();
+    let oltp_stop = CancellationToken::new();
     let oltp_handle = {
-        let cancel = oltp_cancel.clone();
+        let stop = oltp_stop.clone();
         let driver = Arc::clone(&driver);
-        tokio::spawn(async move { driver.run(cancel).await })
+        tokio::spawn(async move { driver.run(stop).await })
     };
 
     // 3b. Start staleness probe alongside the OLTP workload.
@@ -124,7 +124,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     let staleness_handle = staleness::spawn_staleness_probe(
         Arc::clone(&driver),
         staleness_spice_client,
-        oltp_cancel.clone(),
+        oltp_stop.clone(),
     );
 
     // 4. Run analytical queries through spiced concurrently with the OLTP load.
@@ -160,7 +160,7 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         super::process_spiced_metrics(metrics_scraper, test_args.common.metrics, &[]).await;
 
     // 6. Stop OLTP and collect results.
-    oltp_cancel.cancel();
+    oltp_stop.cancel();
     let oltp_result = oltp_handle.await;
     let staleness_result = staleness_handle.await;
 


### PR DESCRIPTION
## 📝 Summary


CH-BenCHmark replication lag was reported far higher than actual under-load performance. Two issues caused this:

1. Analytical queries overran the scheduled duration:  The worker only checked `EndCondition::Duration` between full query set iterations (20 queries), not individual queries. Under OLTP load a single iteration might took several minutes 

2. OLTP stopped before analytical queries finished: The driver had its own internal duration timer that stopped mutations independently. Analytical queries continued running after OLTP ceased, measuring "cooldown" replication lag (clock keeps ticking, no new writes) rather than lag under active load.

### Fix

- Check `EndCondition::Duration` between individual queries in `run_query_set`, bounding overrun to one query worse case.
- Remove `duration` from `ChBenchConfig` / OLTP driver — the HTAP orchestrator now controls both lifetimes: analytical queries run for the configured duration, then OLTP is stopped afterward. This ensures mutations are active for the entire measurement window.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->