### PR TITLE
Bump ballista to detect and report stuck queries (#10832)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=383e165a080d648c313a2530a3a53eae6077fdba#383e165a080d648c313a2530a3a53eae6077fdba"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=8afc1b74a60599d1decd5768c9cb55874cc530a9#8afc1b74a60599d1decd5768c9cb55874cc530a9"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=383e165a080d648c313a2530a3a53eae6077fdba#383e165a080d648c313a2530a3a53eae6077fdba"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=8afc1b74a60599d1decd5768c9cb55874cc530a9#8afc1b74a60599d1decd5768c9cb55874cc530a9"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=383e165a080d648c313a2530a3a53eae6077fdba#383e165a080d648c313a2530a3a53eae6077fdba"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=8afc1b74a60599d1decd5768c9cb55874cc530a9#8afc1b74a60599d1decd5768c9cb55874cc530a9"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -8213,7 +8213,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -8774,6 +8774,8 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -13664,7 +13666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.5.0",
+ "hashbrown 0.17.0",
  "parking_lot 0.12.5",
  "rand 0.8.5",
 ]
@@ -14150,7 +14152,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -17559,7 +17561,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -19046,7 +19048,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,8 +24,8 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46b169525a7c41670fe95874103c7c6ce713ac699123f81a200bc31f9ad3b02e"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-schema 57.2.0",
 ]
 
 [[package]]
@@ -36,8 +36,8 @@ checksum = "12aa1ae565ec6d45cfe71c20b5c2b3cbd6ba5d7176ecd0c0a448e970a93c35e4"
 dependencies = [
  "adbc_core",
  "adbc_ffi",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-schema 57.2.0",
  "libloading 0.8.9",
  "path-slash",
  "regex",
@@ -53,8 +53,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6851c2ab953511cf7a244aadcbc0586442fd3c67dfe371457369048880dd513"
 dependencies = [
  "adbc_core",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-schema 57.2.0",
 ]
 
 [[package]]
@@ -444,7 +444,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -476,19 +476,19 @@ name = "arrow"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
+ "arrow-arith 57.2.0",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-cast 57.2.0",
  "arrow-csv",
- "arrow-data",
+ "arrow-data 57.2.0",
  "arrow-ipc",
  "arrow-json",
- "arrow-ord",
+ "arrow-ord 57.2.0",
  "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
+ "arrow-string 57.2.0",
 ]
 
 [[package]]
@@ -496,10 +496,24 @@ name = "arrow-arith"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-schema 57.2.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
  "num-traits",
 ]
@@ -510,13 +524,31 @@ version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
  "ahash 0.8.12",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-schema 57.2.0",
  "chrono",
  "chrono-tz 0.10.4",
  "half",
  "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "chrono",
+ "half",
+ "hashbrown 0.17.0",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -534,16 +566,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-ord 57.2.0",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -555,13 +599,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-cast"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
 name = "arrow-csv"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-cast 57.2.0",
+ "arrow-schema 57.2.0",
  "chrono",
  "csv",
  "csv-core",
@@ -573,8 +638,21 @@ name = "arrow-data"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 57.2.0",
+ "arrow-schema 57.2.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+dependencies = [
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
  "half",
  "num-integer",
  "num-traits",
@@ -585,17 +663,17 @@ name = "arrow-flight"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
+ "arrow-arith 57.2.0",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-cast 57.2.0",
+ "arrow-data 57.2.0",
  "arrow-ipc",
- "arrow-ord",
+ "arrow-ord 57.2.0",
  "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
+ "arrow-string 57.2.0",
  "base64 0.22.1",
  "bytes",
  "futures",
@@ -612,11 +690,11 @@ name = "arrow-ipc"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
  "flatbuffers",
  "lz4_flex 0.12.1",
  "zstd",
@@ -627,11 +705,11 @@ name = "arrow-json"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-cast 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-schema 57.2.0",
  "chrono",
  "half",
  "indexmap 2.14.0",
@@ -663,11 +741,24 @@ name = "arrow-ord"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
 ]
 
 [[package]]
@@ -675,10 +766,10 @@ name = "arrow-row"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-schema 57.2.0",
  "half",
 ]
 
@@ -694,15 +785,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-schema"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "arrow-select"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-schema 57.2.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "num-traits",
 ]
 
@@ -711,11 +825,28 @@ name = "arrow-string"
 version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "memchr",
  "num-traits",
  "regex",
@@ -741,9 +872,9 @@ name = "arrow_tools"
 version = "2.0.0-unstable"
 dependencies = [
  "arrow",
- "arrow-cast",
+ "arrow-cast 57.2.0",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "datafusion",
  "insta",
  "serde_json",
@@ -824,7 +955,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure 0.13.2",
 ]
 
@@ -847,7 +978,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1019,7 +1150,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.27.2",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
@@ -1122,7 +1253,7 @@ source = "git+https://github.com/spiceai/async-openai?rev=8dbb88bcd14b70dfd92ddd
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1151,7 +1282,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1217,7 +1348,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1234,7 +1365,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1302,7 +1433,7 @@ dependencies = [
  "derive_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1980,7 +2111,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2118,7 +2249,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2181,7 +2312,7 @@ checksum = "190d6e0622d17e2a28239b55d2829d98b348269adcd4ab86a21d3304aa3500cb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tracing",
 ]
 
@@ -2320,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=8afc1b74a60599d1decd5768c9cb55874cc530a9#8afc1b74a60599d1decd5768c9cb55874cc530a9"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=6b96f6a937bf8b07e8632f53716ae3d1decb35e3#6b96f6a937bf8b07e8632f53716ae3d1decb35e3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2361,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=8afc1b74a60599d1decd5768c9cb55874cc530a9#8afc1b74a60599d1decd5768c9cb55874cc530a9"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=6b96f6a937bf8b07e8632f53716ae3d1decb35e3#6b96f6a937bf8b07e8632f53716ae3d1decb35e3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2394,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=8afc1b74a60599d1decd5768c9cb55874cc530a9#8afc1b74a60599d1decd5768c9cb55874cc530a9"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=6b96f6a937bf8b07e8632f53716ae3d1decb35e3#6b96f6a937bf8b07e8632f53716ae3d1decb35e3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2561,7 +2692,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "which 4.4.2",
 ]
 
@@ -2582,7 +2713,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2600,7 +2731,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2869,7 +3000,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2892,7 +3023,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3049,7 +3180,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3146,7 +3277,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3393,7 +3524,7 @@ dependencies = [
  "arrow-flight",
  "arrow-ipc",
  "arrow-row",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "arrow_tools",
  "async-stream",
  "async-trait",
@@ -3732,7 +3863,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4941,7 +5072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5080,7 +5211,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5184,7 +5315,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5198,7 +5329,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5211,7 +5342,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5244,7 +5375,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5255,7 +5386,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5266,7 +5397,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5304,8 +5435,8 @@ version = "2.0.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
  "arrow-flight",
  "arrow-row",
  "arrow_tools",
@@ -5432,7 +5563,7 @@ version = "52.5.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=06e4b624c6073c40c7b2127ce620e281ec1979ae#06e4b624c6073c40c7b2127ce620e281ec1979ae"
 dependencies = [
  "arrow",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "async-trait",
  "bytes",
  "bzip2",
@@ -5790,7 +5921,7 @@ dependencies = [
  "arrow",
  "arrow-flight",
  "arrow-ipc",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "arrow_tools",
  "async-stream",
  "bytes",
@@ -5817,7 +5948,7 @@ version = "52.5.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=06e4b624c6073c40c7b2127ce620e281ec1979ae#06e4b624c6073c40c7b2127ce620e281ec1979ae"
 dependencies = [
  "arrow",
- "arrow-buffer",
+ "arrow-buffer 57.2.0",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -5891,7 +6022,7 @@ version = "52.5.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=06e4b624c6073c40c7b2127ce620e281ec1979ae#06e4b624c6073c40c7b2127ce620e281ec1979ae"
 dependencies = [
  "arrow",
- "arrow-ord",
+ "arrow-ord 57.2.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -5955,7 +6086,7 @@ source = "git+https://github.com/spiceai/datafusion.git?rev=06e4b624c6073c40c7b2
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6086,8 +6217,8 @@ source = "git+https://github.com/spiceai/datafusion.git?rev=06e4b624c6073c40c7b2
 dependencies = [
  "ahash 0.8.12",
  "arrow",
- "arrow-ord",
- "arrow-schema",
+ "arrow-ord 57.2.0",
+ "arrow-schema 57.2.0",
  "async-trait",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -6246,7 +6377,7 @@ dependencies = [
  "adbc_driver_manager",
  "arrow",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "async-stream",
  "async-trait",
  "bb8",
@@ -6413,7 +6544,7 @@ source = "git+https://github.com/spiceai/delta-kernel-rs.git?rev=47034733a0477f7
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6494,7 +6625,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6505,7 +6636,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6516,7 +6647,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6527,7 +6658,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6548,7 +6679,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6558,7 +6689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6580,7 +6711,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -6592,7 +6723,7 @@ checksum = "ccfae181bab5ab6c5478b2ccb69e4c68a02f8c3ec72f6616bfec9dbc599d2ee0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6713,7 +6844,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7095,7 +7226,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7115,7 +7246,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7135,7 +7266,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7182,7 +7313,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7487,7 +7618,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7585,9 +7716,9 @@ dependencies = [
 name = "flight-cookie-server"
 version = "2.0.0-unstable"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.2.0",
  "arrow-flight",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "bytes",
  "clap",
  "futures",
@@ -7712,7 +7843,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7892,7 +8023,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8213,8 +8344,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -8694,10 +8825,10 @@ name = "hash-index"
 version = "2.0.0-unstable"
 dependencies = [
  "arrow",
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
  "arrow-row",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "criterion 0.6.0",
  "parking_lot 0.12.5",
  "rand 0.10.1",
@@ -9340,7 +9471,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -9360,14 +9491,14 @@ dependencies = [
  "anyhow",
  "apache-avro",
  "array-init",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 57.2.0",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-cast 57.2.0",
+ "arrow-ord 57.2.0",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
+ "arrow-string 57.2.0",
  "as-any",
  "async-trait",
  "backon",
@@ -9774,7 +9905,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9849,7 +9980,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10023,7 +10154,7 @@ checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10249,7 +10380,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10548,7 +10679,7 @@ checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10610,7 +10741,7 @@ checksum = "de66c928222984aea59fcaed8ba627f388aaac3c1f57dcb05cc25495ef8faefe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10745,7 +10876,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10911,7 +11042,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10925,7 +11056,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10936,7 +11067,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10947,7 +11078,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11193,7 +11324,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11426,7 +11557,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11639,7 +11770,7 @@ dependencies = [
  "macro_magic",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11661,7 +11792,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11715,7 +11846,7 @@ checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "target-features",
 ]
 
@@ -11744,7 +11875,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "termcolor",
  "thiserror 2.0.18",
 ]
@@ -12161,7 +12292,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12249,7 +12380,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12842,7 +12973,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13069,7 +13200,7 @@ name = "otel-arrow"
 version = "2.0.0-unstable"
 dependencies = [
  "arrow",
- "arrow-buffer",
+ "arrow-buffer 57.2.0",
  "async-trait",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -13107,7 +13238,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13259,13 +13390,13 @@ version = "57.2.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=96190c47f7a1ab90af53800a2c6c2ba4e0726f74#96190c47f7a1ab90af53800a2c6c2ba4e0726f74"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-cast 57.2.0",
+ "arrow-data 57.2.0",
  "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -13472,7 +13603,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13597,7 +13728,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13644,7 +13775,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13666,8 +13797,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.0",
- "parking_lot 0.12.5",
+ "hashbrown 0.5.0",
+ "parking_lot 0.11.2",
  "rand 0.8.5",
 ]
 
@@ -13988,7 +14119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
- "termtree",
+ "termtree 0.5.1",
 ]
 
 [[package]]
@@ -14004,7 +14135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14053,7 +14184,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14073,7 +14204,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -14108,7 +14239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14152,8 +14283,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -14163,7 +14294,7 @@ dependencies = [
  "pulldown-cmark 0.13.0",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -14187,10 +14318,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14303,7 +14434,7 @@ checksum = "00c6433917e3789605b1f4cd2a589f637ff17212344e7fa5ba99544625ba52c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14399,7 +14530,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14412,7 +14543,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14981,7 +15112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15054,7 +15185,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15130,7 +15261,7 @@ checksum = "d7ef12e84481ab4006cb942f8682bba28ece7270743e649442027c5db87df126"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15532,7 +15663,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -15550,7 +15681,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -15580,7 +15711,7 @@ dependencies = [
  "arrow-flight",
  "arrow-ipc",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "arrow_tools",
  "async-graphql",
  "async-graphql-axum",
@@ -15796,7 +15927,7 @@ version = "2.0.0-unstable"
 dependencies = [
  "anyhow",
  "arrow",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "arrow_tools",
  "async-trait",
  "aws-sdk-credential-bridge",
@@ -15876,7 +16007,7 @@ dependencies = [
  "arrow",
  "arrow-flight",
  "arrow-ipc",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "arrow_tools",
  "async-stream",
  "async-trait",
@@ -15912,7 +16043,7 @@ name = "runtime-datafusion"
 version = "2.0.0-unstable"
 dependencies = [
  "arrow",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "arrow_tools",
  "async-stream",
  "async-trait",
@@ -15968,7 +16099,7 @@ dependencies = [
  "arrow",
  "arrow-ipc",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "async-openai",
  "async-stream",
  "async-trait",
@@ -16140,7 +16271,7 @@ name = "runtime-table-partition"
 version = "2.0.0-unstable"
 dependencies = [
  "arrow",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "async-trait",
  "chrono",
  "criterion 0.5.1",
@@ -16193,7 +16324,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.114",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -16506,7 +16637,7 @@ checksum = "5d66de233f908aebf9cc30ac75ef9103185b4b715c6f2fb7a626aa5e5ede53ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16712,7 +16843,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16724,7 +16855,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16829,7 +16960,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16853,7 +16984,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror 1.0.69",
 ]
 
@@ -16869,7 +17000,7 @@ version = "2.0.0-unstable"
 dependencies = [
  "arrow",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "async-stream",
  "async-trait",
  "chunking",
@@ -17044,7 +17175,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -17093,7 +17224,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17104,7 +17235,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17160,7 +17291,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17181,7 +17312,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17224,7 +17355,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17561,10 +17692,10 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17596,9 +17727,9 @@ name = "snowflake-api"
 version = "0.14.0"
 source = "git+https://github.com/spiceai/snowflake-rs.git?rev=3d2e6fb4290c751d07e62c5f18705b934ca182ee#3d2e6fb4290c751d07e62c5f18705b934ca182ee"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.2.0",
  "arrow-ipc",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "async-stream",
  "async-trait",
  "base64 0.22.1",
@@ -18058,7 +18189,7 @@ checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18239,7 +18370,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18252,7 +18383,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18264,7 +18395,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18287,7 +18418,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "syn 2.0.114",
+ "syn 2.0.117",
  "typify",
  "walkdir",
 ]
@@ -18462,9 +18593,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18500,7 +18631,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18550,7 +18681,7 @@ name = "system-adapter-protocol"
 version = "0.1.0"
 source = "git+https://github.com/spiceai/spicebench.git?rev=6327983bc1a90123e0c754b79781b931c969831e#6327983bc1a90123e0c754b79781b931c969831e"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "async-trait",
  "reqwest 0.12.24",
  "serde",
@@ -18873,6 +19004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "termtree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9"
+
+[[package]]
 name = "test-framework"
 version = "2.0.0-unstable"
 dependencies = [
@@ -18880,7 +19017,7 @@ dependencies = [
  "app",
  "arrow",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "arrow_tools",
  "async-channel 2.5.0",
  "async-openai",
@@ -18943,7 +19080,7 @@ checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19087,7 +19224,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19098,7 +19235,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19408,7 +19545,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19678,7 +19815,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19716,7 +19853,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build",
 ]
@@ -19852,7 +19989,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19940,7 +20077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -20220,7 +20357,7 @@ checksum = "9c846c30c3cb085884a8bbaba7760bdcc406ff2176cbde1e51d41b6057171fd4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -20262,7 +20399,7 @@ checksum = "4b90fe1bcada9dda8b8e20900f744bdd52f641cccc179f1507e83f8f2ec0b1dc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -20350,7 +20487,7 @@ checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -20361,7 +20498,7 @@ checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -20430,7 +20567,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -20454,7 +20591,7 @@ checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -20482,7 +20619,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -20500,7 +20637,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.114",
+ "syn 2.0.117",
  "typify-impl",
 ]
 
@@ -20759,7 +20896,7 @@ name = "util"
 version = "2.0.0-unstable"
 dependencies = [
  "arrow",
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "backoff",
  "chrono",
  "ctrlc",
@@ -20798,7 +20935,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -20962,25 +21099,25 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
  "arcref",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "arrow-string 58.3.0",
  "async-lock",
  "bytes",
  "cfg-if",
  "enum-iterator",
  "flatbuffers",
  "futures",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "half",
  "humansize",
  "inventory",
@@ -20993,12 +21130,14 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "prost 0.14.3",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustc-hash 2.1.1",
  "simdutf8",
  "static_assertions",
- "termtree",
+ "termtree 1.0.0",
  "tracing",
+ "uuid 1.21.0",
+ "vortex-array-macros",
  "vortex-buffer 0.1.0 (git+https://github.com/spiceai/vortex?branch=spiceai-52)",
  "vortex-error 0.1.0 (git+https://github.com/spiceai/vortex?branch=spiceai-52)",
  "vortex-flatbuffers 0.1.0 (git+https://github.com/spiceai/vortex?branch=spiceai-52)",
@@ -21014,15 +21153,15 @@ version = "0.1.0"
 source = "git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e#d694abda6cf4081a7a6e93b08da1bba28204f41e"
 dependencies = [
  "arcref",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 57.2.0",
+ "arrow-array 57.2.0",
+ "arrow-buffer 57.2.0",
+ "arrow-cast 57.2.0",
+ "arrow-data 57.2.0",
+ "arrow-ord 57.2.0",
+ "arrow-schema 57.2.0",
+ "arrow-select 57.2.0",
+ "arrow-string 57.2.0",
  "async-lock",
  "bytes",
  "cfg-if",
@@ -21046,7 +21185,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "simdutf8",
  "static_assertions",
- "termtree",
+ "termtree 0.5.1",
  "tracing",
  "vortex-buffer 0.1.0 (git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e)",
  "vortex-error 0.1.0 (git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e)",
@@ -21055,6 +21194,16 @@ dependencies = [
  "vortex-proto 0.1.0 (git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e)",
  "vortex-session 0.1.0 (git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e)",
  "vortex-utils 0.1.0 (git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e)",
+]
+
+[[package]]
+name = "vortex-array-macros"
+version = "0.1.0"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -21091,9 +21240,9 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
- "arrow-buffer",
+ "arrow-buffer 58.3.0",
  "bitvec",
  "bytes",
  "itertools 0.14.0",
@@ -21106,7 +21255,7 @@ name = "vortex-buffer"
 version = "0.1.0"
 source = "git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e#d694abda6cf4081a7a6e93b08da1bba28204f41e"
 dependencies = [
- "arrow-buffer",
+ "arrow-buffer 57.2.0",
  "bitvec",
  "bytes",
  "itertools 0.14.0",
@@ -21131,7 +21280,7 @@ name = "vortex-datafusion"
 version = "0.1.0"
 source = "git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e#d694abda6cf4081a7a6e93b08da1bba28204f41e"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -21187,9 +21336,9 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 58.3.0",
  "flatbuffers",
  "jiff",
  "prost 0.14.3",
@@ -21200,7 +21349,7 @@ name = "vortex-error"
 version = "0.1.0"
 source = "git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e#d694abda6cf4081a7a6e93b08da1bba28204f41e"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 57.2.0",
  "flatbuffers",
  "jiff",
  "object_store",
@@ -21275,7 +21424,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
  "flatbuffers",
  "vortex-buffer 0.1.0 (git+https://github.com/spiceai/vortex?branch=spiceai-52)",
@@ -21340,7 +21489,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -21391,7 +21540,7 @@ dependencies = [
  "pin-project-lite",
  "prost 0.14.3",
  "rustc-hash 2.1.1",
- "termtree",
+ "termtree 0.5.1",
  "tokio",
  "tracing",
  "uuid 1.21.0",
@@ -21411,7 +21560,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer 0.1.0 (git+https://github.com/spiceai/vortex?branch=spiceai-52)",
@@ -21455,7 +21604,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
  "prost 0.14.3",
  "prost-types",
@@ -21475,7 +21624,7 @@ name = "vortex-runend"
 version = "0.1.0"
 source = "git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e#d694abda6cf4081a7a6e93b08da1bba28204f41e"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.2.0",
  "itertools 0.14.0",
  "num-traits",
  "prost 0.14.3",
@@ -21491,8 +21640,8 @@ name = "vortex-scan"
 version = "0.1.0"
 source = "git+https://github.com/spiceai/vortex.git?rev=d694abda6cf4081a7a6e93b08da1bba28204f41e#d694abda6cf4081a7a6e93b08da1bba28204f41e"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 57.2.0",
+ "arrow-schema 57.2.0",
  "async-trait",
  "bit-vec 0.8.0",
  "futures",
@@ -21529,7 +21678,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
  "arcref",
  "dashmap",
@@ -21568,7 +21717,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#c536c9aedc8fdf8e3787a31c43c8e41318cf3956"
+source = "git+https://github.com/spiceai/vortex?branch=spiceai-52#2ec7499c324e3c79413ca412a2dfa3098ff8adf9"
 dependencies = [
  "dashmap",
  "hashbrown 0.16.1",
@@ -21747,7 +21896,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -22052,7 +22201,7 @@ checksum = "2a9b9165fc45d42c81edfe3e9cb458e58720594ad5db6553c4079ea041a4a581"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -22216,7 +22365,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -22333,7 +22482,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -22344,7 +22493,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -22874,7 +23023,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -22890,7 +23039,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -23129,7 +23278,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure 0.13.2",
 ]
 
@@ -23141,7 +23290,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure 0.13.2",
 ]
 
@@ -23168,7 +23317,7 @@ checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -23188,7 +23337,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure 0.13.2",
 ]
 
@@ -23209,7 +23358,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -23242,7 +23391,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,9 +424,9 @@ datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev 
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b798c391b6566c172d44361f8acc8472c958ca75" } # spiceai-52
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "383e165a080d648c313a2530a3a53eae6077fdba" }      # spiceai-52.5
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "383e165a080d648c313a2530a3a53eae6077fdba" } # spiceai-52.5
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "383e165a080d648c313a2530a3a53eae6077fdba" } # spiceai-52.5
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "8afc1b74a60599d1decd5768c9cb55874cc530a9" }      # spiceai-52.5
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "8afc1b74a60599d1decd5768c9cb55874cc530a9" } # spiceai-52.5
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "8afc1b74a60599d1decd5768c9cb55874cc530a9" } # spiceai-52.5
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,9 +424,9 @@ datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev 
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b798c391b6566c172d44361f8acc8472c958ca75" } # spiceai-52
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "8afc1b74a60599d1decd5768c9cb55874cc530a9" }      # spiceai-52.5
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "8afc1b74a60599d1decd5768c9cb55874cc530a9" } # spiceai-52.5
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "8afc1b74a60599d1decd5768c9cb55874cc530a9" } # spiceai-52.5
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "6b96f6a937bf8b07e8632f53716ae3d1decb35e3" }      # spiceai-52.5
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "6b96f6a937bf8b07e8632f53716ae3d1decb35e3" } # spiceai-52.5
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "6b96f6a937bf8b07e8632f53716ae3d1decb35e3" } # spiceai-52.5
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -59,6 +59,7 @@ pub mod error_code;
 mod handle;
 mod metrics;
 pub mod registry;
+mod stage_history;
 mod tracker;
 
 pub use handle::{DistributedJobStatus, QueryHandle, QueryHandleError};
@@ -299,18 +300,13 @@ impl Query {
     /// - Job submission fails
     pub async fn submit_distributed(self, job_id: &str) -> Result<QueryHandle> {
         let request_context = RequestContext::current(AsyncMarker::new().await);
-        self.submit_distributed_internal(job_id, request_context)
-            .await
-    }
 
-    /// Internal implementation for submitting a distributed query.
-    async fn submit_distributed_internal(
-        self,
-        job_id: &str,
-        request_context: Arc<RequestContext>,
-    ) -> Result<QueryHandle> {
-        crate::metrics::telemetry::track_query_count(&request_context.to_dimensions());
-
+        // Create the `task_history` span here so it survives the early
+        // error paths inside `submit_distributed_internal`. On success the
+        // span moves into `QueryHandle` and closes when the job
+        // terminates; on failure (planning, validation, submission) we
+        // emit an error event on it here so the row's `error_message` is
+        // populated. Mirrors the sync `run_internal` shape.
         let span = tracing::span!(
             target: "task_history",
             tracing::Level::INFO,
@@ -318,12 +314,37 @@ impl Query {
             input = %self.sql,
             runtime_query = false,
             distributed = true,
-            job_id = %job_id
+            job_id = %job_id,
+            // Distributed-job summary labels — recorded at completion by
+            // `crate::datafusion::query::stage_history::record_stage_history`.
+            ballista_job_id = tracing::field::Empty,
+            stage_count = tracing::field::Empty,
+            executor_count = tracing::field::Empty,
+            total_tasks = tracing::field::Empty,
+            total_executor_ms = tracing::field::Empty,
         );
 
         if let Some(traceparent) = request_context.trace_parent() {
             crate::http::traceparent::override_task_history_with_trace_parent(&span, traceparent);
         }
+
+        let result = self
+            .submit_distributed_internal(job_id, request_context, span.clone())
+            .await;
+        if let Err(e) = &result {
+            tracing::error!(target: "task_history", parent: &span, "{e}");
+        }
+        result
+    }
+
+    /// Internal implementation for submitting a distributed query.
+    async fn submit_distributed_internal(
+        self,
+        job_id: &str,
+        request_context: Arc<RequestContext>,
+        span: Span,
+    ) -> Result<QueryHandle> {
+        crate::metrics::telemetry::track_query_count(&request_context.to_dimensions());
 
         // Get the scheduler server
         let scheduler = Self::get_scheduler_server(&self.df)?;
@@ -506,6 +527,7 @@ impl Query {
             cache_key,
             tracker,
             request_context,
+            span,
         ))
     }
 

--- a/crates/runtime/src/datafusion/query/handle.rs
+++ b/crates/runtime/src/datafusion/query/handle.rs
@@ -45,6 +45,7 @@ use runtime_request_context::RequestContext;
 use snafu::Snafu;
 use tokio::time::{Duration, sleep};
 use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, Span};
 
 /// Default max message size (16MB matches typical default).
 const MAX_PARTITION_RETRIEVAL_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
@@ -157,6 +158,25 @@ pub struct QueryHandle {
     tracker: Arc<Mutex<Option<QueryTracker>>>,
     /// Request context for tracking and metrics.
     request_context: Arc<RequestContext>,
+    /// `task_history` span covering the lifetime of this distributed query.
+    /// Created at submission and held in a slot shared by every clone so it
+    /// can be **taken** at finalization. The span moves into the spawned
+    /// finalize future via `.instrument(span)`; once that future ends the
+    /// span has no surviving clones and the OTel layer closes it, emitting
+    /// the `task_history` row.
+    ///
+    /// Storing the span behind an `Option` (rather than as a plain field)
+    /// is what keeps `execution_duration_ms` honest: if every clone of
+    /// `QueryHandle` retained its own clone of the span, the OTel span
+    /// would stay open until the *last* handle was dropped — which can be
+    /// long after the Ballista job finished — and the duration column
+    /// would include arbitrary post-completion handle lifetime. Taking
+    /// here means the span closes at finalization (success, failure, or
+    /// `Drop`-orphan), not at handle-drop.
+    ///
+    /// Mutex + `Option::take` also gives us idempotent finalization: only
+    /// the first call gets the span; later attempts see `None` and skip.
+    task_history_span: Arc<Mutex<Option<Span>>>,
 }
 
 impl std::fmt::Debug for QueryHandle {
@@ -188,6 +208,7 @@ impl QueryHandle {
         cache_key: Option<RawCacheKey>,
         tracker: Option<QueryTracker>,
         request_context: Arc<RequestContext>,
+        task_history_span: Span,
     ) -> Self {
         Self {
             ballista_job_id,
@@ -199,6 +220,7 @@ impl QueryHandle {
             cancel_token: CancellationToken::new(),
             tracker: Arc::new(Mutex::new(tracker)),
             request_context,
+            task_history_span: Arc::new(Mutex::new(Some(task_history_span))),
         }
     }
 
@@ -227,6 +249,7 @@ impl QueryHandle {
             cancel_token: CancellationToken::new(),
             tracker: Arc::new(Mutex::new(None)),
             request_context,
+            task_history_span: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -297,6 +320,14 @@ impl QueryHandle {
     ///
     /// Signals the cancellation token and requests cancellation from the Ballista scheduler.
     /// For cached results, this is a no-op since there's no job to cancel.
+    ///
+    /// Also finalizes the `task_history` row with `JobCancelled` error so
+    /// the recorded `error_message` reflects an explicit user cancel — not
+    /// the `Drop` guard's "client disconnected before completion" — when
+    /// callers `cancel()` and then drop the handle without ever draining
+    /// the result stream. `finish_tracker_with_error` is a no-op if some
+    /// other terminal path (e.g., `wait_for_complete` reacting to the
+    /// cancel token) raced ahead and already finalized.
     pub async fn cancel(&self) -> Result<()> {
         self.cancel_token.cancel();
 
@@ -308,6 +339,7 @@ impl QueryHandle {
                     message: format!("Failed to cancel job: {e}"),
                 })?;
         }
+        self.finish_tracker_with_error(&QueryHandleError::JobCancelled);
         Ok(())
     }
 
@@ -571,6 +603,12 @@ impl QueryHandle {
     }
 
     /// Finishes the query tracker with an error.
+    ///
+    /// Tracker `finish_with_error` emits `tracing::info!(target: "task_history",
+    /// ...)` events that attach to the *current* span. We enter
+    /// `task_history_span` first so the events land on the `sql_query` row for
+    /// this distributed job rather than whatever ambient span the polling
+    /// future happens to be running under.
     fn finish_tracker_with_error(&self, error: &QueryHandleError) {
         if let Some(tracker) = self.tracker.lock().take() {
             let error_code = match error {
@@ -581,15 +619,139 @@ impl QueryHandle {
                 | QueryHandleError::PartitionLocationError { .. }
                 | QueryHandleError::JobNotFound { .. } => ErrorCode::InternalError,
             };
-            tracker.finish_with_error(&self.request_context, error.to_string(), error_code);
+            self.spawn_finalize(tracker, Some((error.to_string(), error_code)), false);
         }
     }
 
     /// Finishes the query tracker successfully.
     fn finish_tracker_success(&self) {
         if let Some(tracker) = self.tracker.lock().take() {
-            tracker.finish(&self.request_context, &Arc::from(""));
+            self.spawn_finalize(tracker, None, false);
         }
+    }
+
+    /// Finalize the parent `sql_query` `task_history` row plus per-stage child
+    /// rows.
+    ///
+    /// **Span ownership**: the parent span is *taken* out of the shared
+    /// slot here, not cloned. The taken span moves into the spawned
+    /// finalize future via `.instrument(span)`; once that future ends and
+    /// any extra clones the future held drop, the OTel layer closes the
+    /// span. Because no surviving `QueryHandle` clone retains the span
+    /// after `spawn_finalize` runs, `execution_duration_ms` reflects the
+    /// query's runtime, not arbitrary post-completion handle lifetime.
+    /// `Option::take` also makes finalization idempotent.
+    ///
+    /// **Cancel-on-orphan**: `request_cancel = true` triggers
+    /// `scheduler.cancel_job(...)` from inside the spawned task before
+    /// recording the row. Set this from the `Drop` guard so a handle that
+    /// goes out of scope without the result stream being drained doesn't
+    /// leave the scheduler/executors running an unobserved job. Idempotent
+    /// w.r.t. the scheduler's own cancel handling.
+    ///
+    /// **No runtime fallback**: if `Drop` fires outside any tokio context,
+    /// finalize synchronously without stage detail — the parent row still
+    /// gets correct duration and error_message; stage children are skipped.
+    fn spawn_finalize(
+        &self,
+        tracker: QueryTracker,
+        error: Option<(String, ErrorCode)>,
+        request_cancel: bool,
+    ) {
+        // Take the span so the only surviving clones are inside the
+        // spawned future. When the future completes, those clones drop
+        // and the OTel span closes — capturing the *query* duration, not
+        // a handle-lifetime duration.
+        let Some(parent_span) = self.task_history_span.lock().take() else {
+            // Already finalized by an earlier path; nothing to do.
+            return;
+        };
+
+        let request_context = Arc::clone(&self.request_context);
+        let scheduler = match &self.state {
+            QueryHandleState::Running { scheduler } => Some(Arc::clone(scheduler)),
+            QueryHandleState::Cached { .. } => None,
+        };
+        let ballista_job_id = self.ballista_job_id.clone();
+
+        let Some(scheduler) = scheduler else {
+            // Cached path — nothing to walk. Synchronous finalize is fine
+            // because there's no async fetch to do. The span drops at
+            // end-of-scope here, closing the OTel span immediately.
+            parent_span.in_scope(|| match error {
+                Some((msg, code)) => tracker.finish_with_error(&request_context, msg, code),
+                None => tracker.finish(&request_context, &Arc::from("")),
+            });
+            return;
+        };
+
+        let job_id = self.ballista_job_id.clone();
+        let handle = match tokio::runtime::Handle::try_current() {
+            Ok(h) => h,
+            Err(_) => {
+                // No tokio runtime here (likely Drop on a non-runtime
+                // thread). Finalize the parent without stage detail or
+                // job cancellation rather than `block_on`'ing into a
+                // private API.
+                parent_span.in_scope(|| match error {
+                    Some((msg, code)) => tracker.finish_with_error(&request_context, msg, code),
+                    None => tracker.finish(&request_context, &Arc::from("")),
+                });
+                return;
+            }
+        };
+
+        // `.instrument(parent_span)` enters the span on every poll of
+        // the spawned future. Production sets the OTel subscriber as
+        // the *global* default (`bin/spiced/src/tracing.rs`), so the
+        // spawned task — even on a fresh tokio worker thread — picks
+        // it up automatically and child `ballista_stage` spans created
+        // inside attribute to the correct subscriber. Integration
+        // tests that rely on `set_default` (thread-local) must
+        // explicitly propagate the dispatcher through the test future
+        // (see `crates/runtime/tests/cluster/distributed_task_history.rs`).
+        let span_for_record = parent_span.clone();
+        let scheduler_for_cancel = Arc::clone(&scheduler);
+        let cancel_job_id = job_id.clone();
+        handle.spawn(
+            async move {
+                if request_cancel {
+                    // Best-effort: tell the scheduler to stop running this
+                    // job. The scheduler treats `cancel_job` as idempotent
+                    // so a concurrent path (e.g. `wait_for_complete`
+                    // reacting to `cancel_token`) cancelling first is OK.
+                    if let Err(e) =
+                        scheduler_for_cancel.cancel_job(cancel_job_id.clone()).await
+                    {
+                        tracing::warn!(
+                            target: "task_history",
+                            "Failed to cancel Ballista job {cancel_job_id} during orphaned-handle finalize: {e}"
+                        );
+                    }
+                }
+                let graph = scheduler
+                    .state
+                    .task_manager
+                    .get_job_execution_graph(&job_id)
+                    .await
+                    .ok()
+                    .flatten();
+                if let Some(graph) = graph.as_ref() {
+                    crate::datafusion::query::stage_history::record_stage_history(
+                        &span_for_record,
+                        &ballista_job_id,
+                        graph.as_ref(),
+                    );
+                }
+                match error {
+                    Some((msg, code)) => {
+                        tracker.finish_with_error(&request_context, msg, code)
+                    }
+                    None => tracker.finish(&request_context, &Arc::from("")),
+                }
+            }
+            .instrument(parent_span),
+        );
     }
 
     /// Waits for the job to complete and returns a stream of result batches.
@@ -660,6 +822,43 @@ impl QueryHandle {
         } else {
             Box::pin(stream)
         }
+    }
+}
+
+/// Finalizes an orphaned tracker when the last `QueryHandle` clone is dropped
+/// without the job having reached terminal state through the normal path
+/// (e.g., client disconnected before draining the result stream). Without
+/// this, the `task_history` row would have empty duration and no error,
+/// and the scheduler/executors would keep running an unobserved job.
+///
+/// The `Arc::strong_count == 1` check ensures only the *last* clone runs
+/// finalization — intermediate clones being dropped while other clones still
+/// hold the tracker must not finalize it. The `lock().take()` ensures
+/// finalization happens at most once even if a race were possible.
+///
+/// We trigger `cancel_token` synchronously so any in-flight
+/// `wait_for_complete` future bails out, *and* pass `request_cancel = true`
+/// to `spawn_finalize` so the spawned async task calls
+/// `scheduler.cancel_job(...)` directly — that covers the case where no
+/// `wait_for_complete` is running (e.g., the caller never started draining
+/// the result stream).
+impl Drop for QueryHandle {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.tracker) != 1 {
+            return;
+        }
+        let Some(tracker) = self.tracker.lock().take() else {
+            return;
+        };
+        self.cancel_token.cancel();
+        self.spawn_finalize(
+            tracker,
+            Some((
+                "client disconnected before completion".to_string(),
+                ErrorCode::QueryExecutionError,
+            )),
+            true,
+        );
     }
 }
 

--- a/crates/runtime/src/datafusion/query/stage_history.rs
+++ b/crates/runtime/src/datafusion/query/stage_history.rs
@@ -1,0 +1,245 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Decorates the parent `sql_query` `task_history` span and emits one child
+//! `ballista_stage` span per stage at distributed job completion.
+//!
+//! Run from `QueryHandle::finish_tracker_*` after the Ballista job reaches
+//! terminal state (success, failure, or cancellation). Walks the in-process
+//! `ExecutionGraph` and produces child rows via the existing OTel pipeline
+//! — child spans created inside `parent_span.in_scope(...)` inherit the
+//! parent's OTel context, so the exporter at
+//! `crate::task_history::otel_exporter` writes them with the correct
+//! `parent_span_id`.
+//!
+//! Tracing spans use wall-clock time, so a child span's
+//! `execution_duration_ms` reflects the brief window between creation and
+//! drop in this module, not the stage's actual run. The historical times
+//! are emitted as `stage_started_at` / `stage_ended_at` /
+//! `stage_duration_ms` labels — queries against stage rows should use
+//! those.
+
+use std::collections::HashMap;
+
+use ballista_scheduler::state::execution_graph::ExecutionGraph;
+use ballista_scheduler::state::execution_stage::{ExecutionStage, TaskInfo};
+use datafusion::common::format::ExplainFormat;
+use tracing::Span;
+
+/// Summary metrics extracted from a single stage's `TaskInfo`s.
+struct StageSummary {
+    partitions: usize,
+    attempt_num: usize,
+    task_count: usize,
+    executor_count: usize,
+    executor_histogram: String,
+    slowest_task_ms: u128,
+    slowest_task_executor: String,
+    total_executor_ms: u128,
+    stage_started_at: u128,
+    stage_ended_at: u128,
+    stage_duration_ms: u128,
+    error_message: Option<String>,
+}
+
+/// Decorate the parent `sql_query` span with job-wide summary labels and
+/// emit one child `ballista_stage` span per stage.
+///
+/// The parent span must be active (i.e., this function is called inside
+/// `parent_span.in_scope(...)`). Child spans created via `info_span!` will
+/// then inherit the OTel parent context automatically.
+pub(crate) fn record_stage_history(
+    parent_span: &Span,
+    ballista_job_id: &str,
+    graph: &dyn ExecutionGraph,
+) {
+    let stages = graph.stages();
+    let mut total_tasks: usize = 0;
+    let mut total_executor_ms: u128 = 0;
+    let mut all_executors: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // First pass: aggregate parent-level counters and prepare per-stage
+    // summaries so we can emit children once the parent labels are set.
+    let mut per_stage_summaries: Vec<(usize, StageSummary)> = Vec::with_capacity(stages.len());
+    let mut stage_ids: Vec<usize> = stages.keys().copied().collect();
+    stage_ids.sort_unstable();
+    for stage_id in stage_ids {
+        if let Some(stage) = stages.get(&stage_id) {
+            let summary = summarize_stage(stage);
+            total_tasks = total_tasks.saturating_add(summary.task_count);
+            total_executor_ms = total_executor_ms.saturating_add(summary.total_executor_ms);
+            for exec in executor_ids_in_stage(stage) {
+                all_executors.insert(exec);
+            }
+            per_stage_summaries.push((stage_id, summary));
+        }
+    }
+
+    parent_span.record("ballista_job_id", ballista_job_id);
+    parent_span.record("stage_count", stages.len() as u64);
+    parent_span.record("executor_count", all_executors.len() as u64);
+    parent_span.record("total_tasks", total_tasks as u64);
+    parent_span.record("total_executor_ms", total_executor_ms as u64);
+
+    for (stage_id, summary) in per_stage_summaries {
+        if let Some(stage) = stages.get(&stage_id) {
+            emit_stage_span(parent_span, stage_id, stage, &summary);
+        }
+    }
+}
+
+/// Create the child `ballista_stage` span and let it close to fire the
+/// `task_history` row write. Called inside the parent span's scope.
+fn emit_stage_span(
+    parent_span: &Span,
+    stage_id: usize,
+    stage: &ExecutionStage,
+    summary: &StageSummary,
+) {
+    // Render the stage plan in tree form via Ballista's per-variant
+    // `format_with` so the row's `input` matches what `EXPLAIN FORMAT TREE`
+    // would produce for the stage in isolation.
+    let plan_str = stage.format_with(&ExplainFormat::Tree);
+
+    parent_span.in_scope(|| {
+        let stage_span = tracing::info_span!(
+            target: "task_history",
+            "ballista_stage",
+            input = %plan_str,
+            stage_id = stage_id as u64,
+            stage_status = stage.variant_name(),
+            partitions = summary.partitions as u64,
+            attempt_num = summary.attempt_num as u64,
+            task_count = summary.task_count as u64,
+            executor_count = summary.executor_count as u64,
+            executor_histogram = %summary.executor_histogram,
+            slowest_task_ms = summary.slowest_task_ms as u64,
+            slowest_task_executor = %summary.slowest_task_executor,
+            total_executor_ms = summary.total_executor_ms as u64,
+            stage_started_at = summary.stage_started_at as u64,
+            stage_ended_at = summary.stage_ended_at as u64,
+            stage_duration_ms = summary.stage_duration_ms as u64,
+        );
+        if let Some(err) = summary.error_message.as_deref() {
+            tracing::error!(target: "task_history", parent: &stage_span, "{err}");
+        }
+        // stage_span drops here → OTel closes it → exporter writes the row.
+    });
+}
+
+/// Returns the set of executor ids that have run (or are running) any
+/// `TaskInfo` in the stage. Used to count distinct executors at the
+/// job level.
+fn executor_ids_in_stage(stage: &ExecutionStage) -> Vec<String> {
+    let mut ids = Vec::new();
+    for task_info in iter_task_infos(stage) {
+        if !task_info.executor_id.is_empty() {
+            ids.push(task_info.executor_id.clone());
+        }
+    }
+    ids
+}
+
+/// Iterate over the concrete `TaskInfo`s in a stage regardless of variant.
+/// Unresolved/Resolved stages yield no tasks (none have launched yet).
+fn iter_task_infos(stage: &ExecutionStage) -> Box<dyn Iterator<Item = &TaskInfo> + '_> {
+    match stage {
+        ExecutionStage::UnResolved(_) | ExecutionStage::Resolved(_) => Box::new(std::iter::empty()),
+        ExecutionStage::Running(s) => Box::new(s.task_infos.iter().filter_map(Option::as_ref)),
+        ExecutionStage::Successful(s) => Box::new(s.task_infos.iter()),
+        ExecutionStage::Failed(s) => Box::new(s.task_infos.iter().filter_map(Option::as_ref)),
+    }
+}
+
+/// Compute per-stage summary metrics from its `TaskInfo`s.
+fn summarize_stage(stage: &ExecutionStage) -> StageSummary {
+    let (partitions, attempt_num, error_message) = match stage {
+        ExecutionStage::UnResolved(s) => (0, s.stage_attempt_num, None),
+        ExecutionStage::Resolved(s) => (s.partitions, s.stage_attempt_num, None),
+        ExecutionStage::Running(s) => (s.partitions, s.stage_attempt_num, None),
+        ExecutionStage::Successful(s) => (s.partitions, s.stage_attempt_num, None),
+        ExecutionStage::Failed(s) => (
+            s.partitions,
+            s.stage_attempt_num,
+            Some(s.error_message.clone()),
+        ),
+    };
+
+    let mut task_count: usize = 0;
+    let mut total_executor_ms: u128 = 0;
+    let mut slowest_task_ms: u128 = 0;
+    let mut slowest_task_executor = String::new();
+    let mut stage_started_at: u128 = u128::MAX;
+    let mut stage_ended_at: u128 = 0;
+    let mut by_executor: HashMap<String, u64> = HashMap::new();
+
+    for task in iter_task_infos(stage) {
+        task_count = task_count.saturating_add(1);
+        let dur = task.end_exec_time.saturating_sub(task.start_exec_time);
+        total_executor_ms = total_executor_ms.saturating_add(dur);
+        if dur > slowest_task_ms {
+            slowest_task_ms = dur;
+            slowest_task_executor = task.executor_id.clone();
+        }
+        if task.launch_time != 0 && task.launch_time < stage_started_at {
+            stage_started_at = task.launch_time;
+        }
+        if task.finish_time > stage_ended_at {
+            stage_ended_at = task.finish_time;
+        }
+        *by_executor.entry(task.executor_id.clone()).or_insert(0) += 1;
+    }
+    if stage_started_at == u128::MAX {
+        stage_started_at = 0;
+    }
+    let stage_duration_ms = stage_ended_at.saturating_sub(stage_started_at);
+
+    let executor_count = by_executor.len();
+    let executor_histogram = format_executor_histogram(&by_executor);
+
+    StageSummary {
+        partitions,
+        attempt_num,
+        task_count,
+        executor_count,
+        executor_histogram,
+        slowest_task_ms,
+        slowest_task_executor,
+        total_executor_ms,
+        stage_started_at,
+        stage_ended_at,
+        stage_duration_ms,
+        error_message,
+    }
+}
+
+/// Format `{executor_id -> count}` as `"executor-a:120,executor-b:80"`
+/// sorted by executor id so the same shape always produces the same
+/// string (stable for snapshot tests).
+fn format_executor_histogram(by_executor: &HashMap<String, u64>) -> String {
+    let mut entries: Vec<(&String, &u64)> = by_executor.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    let mut s = String::new();
+    for (i, (exec, count)) in entries.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(exec);
+        s.push(':');
+        s.push_str(&count.to_string());
+    }
+    s
+}

--- a/crates/runtime/tests/cluster/distributed_task_history.rs
+++ b/crates/runtime/tests/cluster/distributed_task_history.rs
@@ -1,0 +1,505 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Integration tests for distributed-query observability in `task_history`.
+//!
+//! Verifies that a Ballista job submitted via `Query::submit_distributed`
+//! produces:
+//! - A single parent `sql_query` row with non-zero `execution_duration_ms`
+//!   and the expected summary labels (`distributed=true`,
+//!   `ballista_job_id`, `stage_count`, `executor_count`, `total_tasks`).
+//! - One or more child `ballista_stage` rows linked to the parent via
+//!   `parent_span_id`, each with a `stage_id` label and the stage's plan
+//!   in `input` (tree format).
+//! - On a failing query, `error_message` populated on the parent.
+//!
+//! ## Tracing-test note
+//!
+//! The shared helper `utils::init_tracing_with_task_history` uses
+//! `tracing::subscriber::set_default`, which is **thread-local**. In a
+//! `flavor = "multi_thread"` `tokio::test`, the spawned finalize future
+//! inside `QueryHandle::spawn_finalize` runs on a worker thread whose
+//! thread-local dispatcher is the (no-op) global default — so the OTel
+//! layer never sees the spans and no rows would be written.
+//!
+//! Production (`bin/spiced/src/tracing.rs`) avoids this by using
+//! `set_global_default`. We mirror that here in `init_global_task_history`
+//! — set the OTel subscriber as the *global* default exactly once per
+//! test binary, with the exporter pointed at a swappable `DataFusion`
+//! slot so each test can rebind it to its own scheduler runtime.
+//!
+//! ## Test serialization
+//!
+//! Because the global subscriber and `DF_SLOT` are process-wide, two tests
+//! in this module running concurrently can step on each other (one rebinds
+//! the slot to `None` while the other's export is still draining). Each
+//! test acquires `TEST_LOCK` for its whole body — including OTel flush
+//! and assertion queries — so the slot lifecycle never overlaps.
+
+use std::sync::{Arc, Mutex, Once, OnceLock};
+use tokio::sync::Mutex as AsyncMutex;
+
+use app::AppBuilder;
+use arrow::array::{AsArray, RecordBatch};
+use arrow::datatypes::Int64Type;
+use futures::TryStreamExt;
+use opentelemetry::InstrumentationScope;
+use opentelemetry::trace::TracerProvider;
+use opentelemetry_sdk::runtime::TokioCurrentThread;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
+use runtime::Runtime;
+use runtime::datafusion::DataFusion;
+use runtime::datafusion::query::QueryBuilder;
+use runtime::task_history::otel_exporter::TaskHistoryExporter;
+use spicepod::component::dataset::Dataset;
+use spicepod::component::runtime::{
+    TaskHistoryCapturedContext, TaskHistoryCapturedOutput, TaskHistoryCapturedPlan,
+};
+use std::time::Duration;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Layer;
+use tracing_subscriber::filter;
+use tracing_subscriber::fmt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::{configure_test_datafusion, utils::test_request_context};
+
+use super::harness::ClusterHarness;
+
+const NAMES_CSV: &str = include_str!("../acceleration/data/names.csv");
+
+/// Swappable target for the OTel task_history exporter.
+///
+/// We can't recreate the global tracing subscriber once it's installed
+/// (`set_global_default` is one-shot per process), but we *can* re-point
+/// where the exporter writes by swapping this slot before each test.
+type DataFusionSlot = Arc<Mutex<Option<Arc<DataFusion>>>>;
+
+static DF_SLOT: OnceLock<DataFusionSlot> = OnceLock::new();
+
+/// Serializes the two `tokio::test`s in this module so they don't race on
+/// `DF_SLOT`. Each test holds the lock for its whole body, including OTel
+/// flush and assertion queries.
+static TEST_LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
+
+fn test_lock() -> &'static AsyncMutex<()> {
+    TEST_LOCK.get_or_init(|| AsyncMutex::new(()))
+}
+
+/// Wraps a `TaskHistoryExporter` so its target `DataFusion` is read from a
+/// shared slot at export time rather than baked in at construction. Lets
+/// the global tracing subscriber outlive any single test's runtime.
+struct SwappableExporter {
+    slot: DataFusionSlot,
+}
+
+impl std::fmt::Debug for SwappableExporter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SwappableExporter").finish_non_exhaustive()
+    }
+}
+
+impl opentelemetry_sdk::trace::SpanExporter for SwappableExporter {
+    fn export(
+        &self,
+        batch: Vec<opentelemetry_sdk::trace::SpanData>,
+    ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send {
+        let df = self.slot.lock().expect("slot poisoned").clone();
+        async move {
+            let Some(df) = df else {
+                // No active test runtime bound; skip silently.
+                return Ok(());
+            };
+            // Build a fresh exporter pointed at the current runtime each
+            // batch. Cheap — TaskHistoryExporter is just a few Arcs.
+            // The scheduler runtime registers task_history in cluster
+            // mode, which requires every row to carry a non-null
+            // `node_id` — synthesize one for the test.
+            let exporter = TaskHistoryExporter::new(
+                df,
+                TaskHistoryCapturedOutput::Truncated,
+                TaskHistoryCapturedContext::Truncated,
+                None,
+                TaskHistoryCapturedPlan::None,
+                None,
+                Some(Arc::<str>::from("test-scheduler")),
+            );
+            opentelemetry_sdk::trace::SpanExporter::export(&exporter, batch).await
+        }
+    }
+}
+
+/// Install a process-wide tracing subscriber with the OTel task_history
+/// layer pointed at the shared `DF_SLOT`. Returns the provider so callers
+/// can `force_flush()`.
+fn init_global_task_history(rt: &Arc<Runtime>) -> SdkTracerProvider {
+    let slot = DF_SLOT.get_or_init(|| Arc::new(Mutex::new(None))).clone();
+    *slot.lock().expect("slot poisoned") = Some(rt.datafusion());
+
+    static PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+    static INIT_SUBSCRIBER: Once = Once::new();
+
+    let provider = PROVIDER
+        .get_or_init(|| {
+            let exporter = SwappableExporter { slot: slot.clone() };
+            let processor = BatchSpanProcessor::builder(exporter, TokioCurrentThread).build();
+            SdkTracerProvider::builder()
+                .with_span_processor(processor)
+                .build()
+        })
+        .clone();
+
+    INIT_SUBSCRIBER.call_once(|| {
+        let scope = InstrumentationScope::builder("task_history")
+            .with_version(env!("CARGO_PKG_VERSION"))
+            .build();
+        let tracer = provider.tracer_with_scope(scope);
+        let task_history_layer = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(filter::filter_fn(|metadata| {
+                metadata.target() == "task_history"
+            }));
+
+        let fmt_layer = fmt::layer()
+            .with_ansi(true)
+            .with_filter(EnvFilter::new("runtime=info,info"));
+
+        let _ = tracing_subscriber::registry()
+            .with(fmt_layer)
+            .with(task_history_layer)
+            .try_init();
+    });
+
+    provider
+}
+
+/// Submit a distributed query against the scheduler runtime and drain its
+/// result stream. Drops the handle so its `Drop` guard runs.
+async fn run_distributed(
+    harness: &ClusterHarness,
+    sql: &str,
+    job_name: &str,
+) -> Result<(), anyhow::Error> {
+    let handle = QueryBuilder::new(sql, harness.scheduler.datafusion())
+        .build()
+        .submit_distributed(job_name)
+        .await
+        .map_err(|e| anyhow::Error::msg(format!("submit_distributed failed: {e}")))?;
+    let stream = handle
+        .into_stream()
+        .await
+        .map_err(|e| anyhow::Error::msg(format!("into_stream failed: {e}")))?;
+    let _ = stream
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(|e| anyhow::Error::msg(format!("collect failed: {e}")))?;
+    drop(handle);
+    Ok(())
+}
+
+/// Poll `runtime.task_history` with the given count-query until it returns
+/// at least `min` rows or the deadline elapses. Returns the final count.
+///
+/// Used instead of a fixed sleep after `force_flush` — the OTel batch
+/// processor and the federated task_history table writer are both async,
+/// so a fixed delay would be both slow (over-waits the happy path) and
+/// flaky (under-waits under load). Polling proceeds as soon as the
+/// expected rows are visible and fails loudly with the last observed
+/// count on timeout.
+async fn wait_for_row_count(
+    harness: &ClusterHarness,
+    sql_count: &str,
+    min: i64,
+    timeout: Duration,
+) -> Result<i64, anyhow::Error> {
+    let deadline = std::time::Instant::now() + timeout;
+    let poll_interval = Duration::from_millis(100);
+    let mut last;
+    loop {
+        let rows = harness.query(sql_count).await?;
+        last = single_i64(&rows);
+        if last >= min {
+            return Ok(last);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow::Error::msg(format!(
+                "wait_for_row_count: expected ≥{min} rows for `{sql_count}` within {timeout:?}; last observed = {last}"
+            )));
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+/// Extract a single i64 from a single-column, single-row result batch.
+fn single_i64(rows: &[RecordBatch]) -> i64 {
+    assert_eq!(rows.len(), 1, "expected one batch, got {}", rows.len());
+    let batch = &rows[0];
+    assert_eq!(
+        batch.num_rows(),
+        1,
+        "expected one row, got {}",
+        batch.num_rows()
+    );
+    let col = batch.column(0).as_primitive::<Int64Type>();
+    col.value(0)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
+async fn test_distributed_query_records_parent_and_stage_rows() -> Result<(), anyhow::Error> {
+    // Serialize against other tests in this module — shared DF_SLOT +
+    // global subscriber would race otherwise.
+    let _serial = test_lock().lock().await;
+    test_request_context()
+        .scope(async {
+            let tempdir = tempfile::tempdir().expect("csv tempdir");
+            let csv_path = tempdir.path().join("names.csv");
+            tokio::fs::write(&csv_path, NAMES_CSV)
+                .await
+                .expect("write csv");
+
+            configure_test_datafusion();
+
+            let app = AppBuilder::new("test_distributed_task_history")
+                .with_dataset(Dataset::new(
+                    format!("file:{}", csv_path.display()).as_str(),
+                    "names",
+                ))
+                .build();
+
+            let harness = ClusterHarness::builder()
+                .scheduler(app)
+                .executors(1)
+                .start()
+                .await?;
+            harness.wait_for_executors(Duration::from_secs(15)).await?;
+
+            // Install the global OTel subscriber (or rebind the slot if
+            // another test already did). Must happen *after* the scheduler
+            // runtime is built so `runtime.task_history` exists.
+            let provider = init_global_task_history(&harness.scheduler);
+
+            // Sort forces a shuffle, producing multiple stages.
+            run_distributed(
+                &harness,
+                "SELECT id, name FROM names ORDER BY id LIMIT 5",
+                "th_test_success",
+            )
+            .await?;
+
+            let _ = provider.force_flush();
+
+            // Poll until the parent row + at least one child row land in
+            // task_history rather than guessing a sleep duration. Bounded
+            // by 10s with a clear failure message.
+            wait_for_row_count(
+                &harness,
+                "SELECT count(*)::bigint \
+                 FROM runtime.task_history \
+                 WHERE task = 'sql_query' \
+                 AND labels['distributed'] = 'true' \
+                 AND labels['job_id'] = 'th_test_success'",
+                1,
+                Duration::from_secs(10),
+            )
+            .await?;
+            wait_for_row_count(
+                &harness,
+                "SELECT count(*)::bigint \
+                 FROM runtime.task_history \
+                 WHERE task = 'ballista_stage' \
+                 AND parent_span_id IS NOT NULL",
+                1,
+                Duration::from_secs(10),
+            )
+            .await?;
+
+            // 1. ≥1 distributed parent sql_query row for our job.
+            let parent_count = single_i64(
+                &harness
+                    .query(
+                        "SELECT count(*)::bigint \
+                         FROM runtime.task_history \
+                         WHERE task = 'sql_query' \
+                         AND labels['distributed'] = 'true' \
+                         AND labels['job_id'] = 'th_test_success'",
+                    )
+                    .await?,
+            );
+            assert!(
+                parent_count >= 1,
+                "expected ≥1 distributed parent sql_query row, got {parent_count}"
+            );
+
+            // 2. Parent has non-zero duration and the summary labels.
+            let parent_metadata = single_i64(
+                &harness
+                    .query(
+                        "SELECT count(*)::bigint \
+                         FROM runtime.task_history \
+                         WHERE task = 'sql_query' \
+                         AND labels['job_id'] = 'th_test_success' \
+                         AND execution_duration_ms > 0 \
+                         AND labels['ballista_job_id'] IS NOT NULL \
+                         AND labels['stage_count'] IS NOT NULL \
+                         AND labels['executor_count'] IS NOT NULL \
+                         AND labels['total_tasks'] IS NOT NULL",
+                    )
+                    .await?,
+            );
+            assert!(
+                parent_metadata >= 1,
+                "expected parent row with nonzero duration and summary labels"
+            );
+
+            // 3. ≥1 ballista_stage child linked to the parent.
+            // Scope to *our* job — other tests in the same binary could in
+            // principle write task_history rows into this scheduler's
+            // table while DF_SLOT is bound, and unscoped predicates would
+            // count them. Joining via parent.span_id and filtering on the
+            // parent's job_id keeps the assertion narrow.
+            let stage_count = single_i64(
+                &harness
+                    .query(
+                        "SELECT count(*)::bigint \
+                         FROM runtime.task_history c \
+                         JOIN runtime.task_history p ON c.parent_span_id = p.span_id \
+                         WHERE c.task = 'ballista_stage' \
+                         AND c.labels['stage_id'] IS NOT NULL \
+                         AND p.task = 'sql_query' \
+                         AND p.labels['job_id'] = 'th_test_success'",
+                    )
+                    .await?,
+            );
+            assert!(
+                stage_count >= 1,
+                "expected ≥1 ballista_stage row with parent_span_id, got {stage_count}"
+            );
+
+            // (Previously asserted no orphan ballista_stage rows here.
+            // Once `parent.labels['job_id'] = 'th_test_success'` scopes
+            // children to our parent, that invariant is trivially true —
+            // children are *defined* by joining to our parent's span_id.
+            // The structural check is fully covered by the
+            // stage_count-equality assertion below.)
+
+            // 4. parent.labels['stage_count'] matches actual child row count.
+            let consistent = single_i64(
+                &harness
+                    .query(
+                        "WITH parent AS ( \
+                             SELECT span_id, CAST(labels['stage_count'] AS BIGINT) AS expected \
+                             FROM runtime.task_history \
+                             WHERE task = 'sql_query' \
+                             AND labels['job_id'] = 'th_test_success' \
+                             LIMIT 1 \
+                         ), \
+                         actual AS ( \
+                             SELECT count(*) AS got \
+                             FROM runtime.task_history c JOIN parent p \
+                                 ON c.parent_span_id = p.span_id \
+                             WHERE c.task = 'ballista_stage' \
+                         ) \
+                         SELECT CASE WHEN p.expected = a.got THEN 1 ELSE 0 END::bigint \
+                         FROM parent p, actual a",
+                    )
+                    .await?,
+            );
+            assert_eq!(
+                consistent, 1,
+                "parent stage_count label must equal actual child row count"
+            );
+
+            // Rebind the slot to None so subsequent tests don't write to a
+            // dropped DataFusion via this provider.
+            if let Some(slot) = DF_SLOT.get() {
+                *slot.lock().expect("slot poisoned") = None;
+            }
+            harness.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
+async fn test_distributed_query_records_error_on_failure() -> Result<(), anyhow::Error> {
+    let _serial = test_lock().lock().await;
+    test_request_context()
+        .scope(async {
+            let tempdir = tempfile::tempdir().expect("csv tempdir");
+            let csv_path = tempdir.path().join("names.csv");
+            tokio::fs::write(&csv_path, NAMES_CSV)
+                .await
+                .expect("write csv");
+
+            configure_test_datafusion();
+
+            let app = AppBuilder::new("test_distributed_task_history_error")
+                .with_dataset(Dataset::new(
+                    format!("file:{}", csv_path.display()).as_str(),
+                    "names",
+                ))
+                .build();
+
+            let harness = ClusterHarness::builder()
+                .scheduler(app)
+                .executors(1)
+                .start()
+                .await?;
+            harness.wait_for_executors(Duration::from_secs(15)).await?;
+
+            let provider = init_global_task_history(&harness.scheduler);
+
+            // Reference a column that doesn't exist — planning fails
+            // inside `submit_distributed_internal`, which still routes
+            // through the span path and should produce a parent row with
+            // `error_message`.
+            let handle_result = QueryBuilder::new(
+                "SELECT does_not_exist FROM names",
+                harness.scheduler.datafusion(),
+            )
+            .build()
+            .submit_distributed("th_test_failure")
+            .await;
+            assert!(
+                handle_result.is_err(),
+                "expected submit_distributed to fail for invalid column reference"
+            );
+
+            let _ = provider.force_flush();
+            wait_for_row_count(
+                &harness,
+                "SELECT count(*)::bigint \
+                 FROM runtime.task_history \
+                 WHERE task = 'sql_query' \
+                 AND labels['job_id'] = 'th_test_failure' \
+                 AND error_message IS NOT NULL",
+                1,
+                Duration::from_secs(10),
+            )
+            .await?;
+
+            if let Some(slot) = DF_SLOT.get() {
+                *slot.lock().expect("slot poisoned") = None;
+            }
+            harness.shutdown().await;
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/cluster/mod.rs
+++ b/crates/runtime/tests/cluster/mod.rs
@@ -17,6 +17,7 @@ limitations under the License.
 mod cancel_tasks;
 mod distributed_acceleration;
 mod distributed_cayenne_catalog;
+mod distributed_task_history;
 pub mod harness;
 mod in_memory_shuffle;
 mod job_store;


### PR DESCRIPTION
## Summary

Stacks on top of #10831. Bumps `spiceai/datafusion-ballista` to `ac3a3a1a` (the head of [spiceai/datafusion-ballista#39](https://github.com/spiceai/datafusion-ballista/pull/39)), so the next cluster bench run picks up both:

1. The distributed task-history changes in #10831 (the underlying PR).
2. A new operator-facing warning when a distributed query stops making progress.

## What changes in the scheduler logs

A healthy run emits **zero** new lines from this change at default `RUST_LOG=info`.

When a query gets stuck — partitions assigned but no progress, or an internal scheduler step that never returns — the scheduler now emits a block of warnings every 30 seconds while the condition holds, then goes silent the moment progress resumes:

```
WARN  Query 019E2-532-0E9-01782A has not made progress for 2m0s; 32 tasks pending.
WARN    Stage 4: 64 of 96 partitions complete, 32 not yet assigned to an executor.
WARN    3 executors alive.
WARN    The scheduler has been processing a 'TaskUpdating' step for 124s.
```

The primary line names the query, how long it has been stuck, and how many tasks are still pending. Subsequent lines appear only when their underlying check fires:

- per-stage breakdown when the snapshot read the job's state successfully
- "Tried to read this job's scheduler state but the read timed out" when the snapshot couldn't acquire a read lock within its 500ms budget
- "The scheduler has been processing a '...' step for N" when the scheduler's event loop has been inside a single handler longer than 30s

Together these tell an operator filing a bug *which* query is stuck and roughly *where* the wedge lives — without needing a second run with `RUST_LOG=debug`. The production wedge that motivated this is rare and high-impact: by the time anyone notices the cluster needs restarting, so any debug-level telemetry would no longer be in scope.

## What's in the bump

This commit just updates `Cargo.toml` / `Cargo.lock` to point at the ballista commit that adds the warning. See [spiceai/datafusion-ballista#39](https://github.com/spiceai/datafusion-ballista/pull/39) for the design and architecture diagram.

Also bumps `arc-swap` from `1.7` → `1.9` to match the vortex `spiceai-52` HEAD that ballista now tracks. Vortex bumps from `2ec7499c` to `e8869db2` on the `spiceai-52` branch as a transitive side effect (ballista tracks vortex by branch, not rev).

## Test plan

- [x] `cargo check -p runtime` — clean against the new ballista
- [ ] CI green
- [ ] End-to-end: deploy and run the production TPC-H bench. Expect either (a) zero new log lines if no stuck condition occurs, or (b) the warning block above if one does, identifying which query and which internal step are stuck.