### PR TITLE
feat(benchmarks): add Cayenne vs DuckDB performance comparison suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3415,6 +3415,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "datafusion-table-providers",
+ "duckdb",
  "flatbuffers",
  "futures",
  "hash-index",

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -73,6 +73,7 @@ partition-table-provider = ["dep:runtime-table-partition"]
 criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 datafusion-federation.workspace = true
 datafusion-functions = { workspace = true }
+duckdb = { workspace = true, features = ["bundled"] }
 insta = { workspace = true, features = ["json"] }
 paste.workspace = true
 rstest = "0.26.1"
@@ -101,3 +102,19 @@ name = "mutation_writer"
 [[bench]]
 harness = false
 name = "listing_fence_overhead"
+
+[[bench]]
+harness = false
+name = "vs_duckdb_ingest"
+
+[[bench]]
+harness = false
+name = "vs_duckdb_scan"
+
+[[bench]]
+harness = false
+name = "vs_duckdb_pk_lookup"
+
+[[bench]]
+harness = false
+name = "vs_duckdb_delete"

--- a/crates/cayenne/benches/vs_duckdb_delete.rs
+++ b/crates/cayenne/benches/vs_duckdb_delete.rs
@@ -1,0 +1,176 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Delete + re-scan throughput: Cayenne vs DuckDB.
+//!
+//! Cayenne's deletion-vector path is one of its biggest architectural
+//! wins over DuckDB — DuckDB rewrites the affected blocks; Cayenne
+//! writes an Arrow IPC deletion vector and applies it transparently at
+//! read time. This bench measures the delta on the two halves of that
+//! tradeoff:
+//!
+//! 1. `delete`            — wall time to execute a `DELETE FROM t WHERE …`
+//!                          touching ~10% of rows.
+//! 2. `scan_after_delete` — full-table `SELECT SUM(value) FROM t` immediately
+//!                          after the delete, exercising the read-time
+//!                          deletion-vector filter on Cayenne and DuckDB's
+//!                          rewritten blocks.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arrow::array::UInt64Array;
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use datafusion::datasource::TableProvider;
+use datafusion::prelude::SessionContext;
+use datafusion_expr::{col, lit};
+use tokio::runtime::Runtime;
+
+use common::{
+    CayenneFixture, DuckDbFixture, cayenne_insert, cayenne_query, duckdb_insert_parquet,
+    duckdb_query_scalar, make_batch, schema, setup_cayenne_pk, setup_duckdb_pk, write_parquet,
+};
+
+const TABLE_SIZES: &[usize] = &[16_384, 131_072, 1_048_576];
+
+async fn cayenne_delete_range(fixture: &CayenneFixture, lo: i64, hi: i64) -> u64 {
+    let ctx = SessionContext::new();
+    let filter = col("id").gt_eq(lit(lo)).and(col("id").lt_eq(lit(hi)));
+    let plan = fixture
+        .table
+        .delete_from(&ctx.state(), vec![filter])
+        .await
+        .expect("cayenne delete plan");
+    let results = datafusion_physical_plan::collect(plan, ctx.task_ctx())
+        .await
+        .expect("cayenne delete collect");
+    results
+        .first()
+        .and_then(|b| b.column(0).as_any().downcast_ref::<UInt64Array>())
+        .and_then(|a| a.values().first())
+        .copied()
+        .unwrap_or(0)
+}
+
+fn duckdb_delete_range(fixture: &DuckDbFixture, table: &str, lo: i64, hi: i64) {
+    fixture
+        .conn
+        .execute_batch(&format!(
+            "DELETE FROM {table} WHERE id BETWEEN {lo} AND {hi};"
+        ))
+        .expect("duckdb delete");
+}
+
+async fn load_cayenne(rows: usize) -> CayenneFixture {
+    let fixture = setup_cayenne_pk("del_bench").await;
+    let batch = make_batch(schema(), 0, rows);
+    let _ = cayenne_insert(&fixture.table, batch).await;
+    fixture
+}
+
+fn load_duckdb(rows: usize, parquet_path: &std::path::Path) -> DuckDbFixture {
+    let fixture = setup_duckdb_pk("del_bench");
+    let _ = rows;
+    duckdb_insert_parquet(&fixture.conn, "del_bench", parquet_path);
+    fixture
+}
+
+fn bench_delete(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_delete");
+    group.sample_size(10);
+
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+
+    for &rows in TABLE_SIZES {
+        group.throughput(Throughput::Elements(rows as u64));
+
+        let parquet_path = parquet_dir.path().join(format!("rows_{rows}.parquet"));
+        let batch = make_batch(schema(), 0, rows);
+        write_parquet(&batch, &parquet_path);
+
+        // Delete the middle ~10% of rows; both engines see the same range.
+        let lo = (rows as i64) * 45 / 100;
+        let hi = (rows as i64) * 55 / 100;
+
+        // --- delete (timed; setup is re-run per iteration to keep state clean) ---
+        group.bench_with_input(BenchmarkId::new("cayenne/delete", rows), &rows, |b, &_| {
+            b.iter_batched(
+                || rt.block_on(load_cayenne(rows)),
+                |fixture| {
+                    rt.block_on(async {
+                        let deleted = cayenne_delete_range(&fixture, lo, hi).await;
+                        black_box((fixture, deleted));
+                    });
+                },
+                BatchSize::PerIteration,
+            );
+        });
+        let path = parquet_path.clone();
+        group.bench_with_input(BenchmarkId::new("duckdb/delete", rows), &rows, |b, &_| {
+            b.iter_batched(
+                || load_duckdb(rows, &path),
+                |fixture| {
+                    duckdb_delete_range(&fixture, "del_bench", lo, hi);
+                    black_box(fixture);
+                },
+                BatchSize::PerIteration,
+            );
+        });
+
+        // --- scan_after_delete (load + delete once outside the timed region,
+        //     then query many times to measure read-time filtering cost) ---
+        let cayenne_fixture = Arc::new(rt.block_on(async {
+            let fixture = load_cayenne(rows).await;
+            let _ = cayenne_delete_range(&fixture, lo, hi).await;
+            fixture
+        }));
+        let duckdb_fixture = Arc::new({
+            let fixture = load_duckdb(rows, &parquet_path);
+            duckdb_delete_range(&fixture, "del_bench", lo, hi);
+            fixture
+        });
+
+        let cf = Arc::clone(&cayenne_fixture);
+        group.bench_with_input(
+            BenchmarkId::new("cayenne/scan_after_delete", rows),
+            &rows,
+            |b, &_| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches =
+                            cayenne_query(&cf.table, "SELECT SUM(value) FROM t").await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let df = Arc::clone(&duckdb_fixture);
+        group.bench_with_input(
+            BenchmarkId::new("duckdb/scan_after_delete", rows),
+            &rows,
+            |b, &_| {
+                b.iter(|| {
+                    let v = duckdb_query_scalar(&df.conn, "SELECT SUM(value) FROM del_bench");
+                    black_box(v);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_delete);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_delete.rs
+++ b/crates/cayenne/benches/vs_duckdb_delete.rs
@@ -79,9 +79,8 @@ async fn load_cayenne(rows: usize) -> CayenneFixture {
     fixture
 }
 
-fn load_duckdb(rows: usize, parquet_path: &std::path::Path) -> DuckDbFixture {
+fn load_duckdb(parquet_path: &std::path::Path) -> DuckDbFixture {
     let fixture = setup_duckdb_pk("del_bench");
-    let _ = rows;
     duckdb_insert_parquet(&fixture.conn, "del_bench", parquet_path);
     fixture
 }
@@ -120,7 +119,7 @@ fn bench_delete(c: &mut Criterion) {
         let path = parquet_path.clone();
         group.bench_with_input(BenchmarkId::new("duckdb/delete", rows), &rows, |b, &_| {
             b.iter_batched(
-                || load_duckdb(rows, &path),
+                || load_duckdb(&path),
                 |fixture| {
                     duckdb_delete_range(&fixture, "del_bench", lo, hi);
                     black_box(fixture);
@@ -137,7 +136,7 @@ fn bench_delete(c: &mut Criterion) {
             fixture
         }));
         let duckdb_fixture = Arc::new({
-            let fixture = load_duckdb(rows, &parquet_path);
+            let fixture = load_duckdb(&parquet_path);
             duckdb_delete_range(&fixture, "del_bench", lo, hi);
             fixture
         });

--- a/crates/cayenne/benches/vs_duckdb_helpers/common.rs
+++ b/crates/cayenne/benches/vs_duckdb_helpers/common.rs
@@ -1,0 +1,254 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Shared helpers for the Cayenne-vs-DuckDB micro-benchmarks.
+//!
+//! Each `vs_duckdb_*` bench compares Cayenne and DuckDB on the same Arrow
+//! input, doing identical logical work. Helpers in this module own the
+//! pieces that are identical across benches — schema, fixture generation,
+//! parquet materialization, and the canonical Cayenne / DuckDB setup paths.
+//!
+//! Included via `#[path = "vs_duckdb_common.rs"] mod common;` from each
+//! bench file — keeps Cayenne's bench layout (one file per bench, no
+//! shared crate) intact while avoiding code duplication.
+
+#![allow(dead_code)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use cayenne::metadata::CreateTableOptions;
+use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::parquet::file::properties::WriterProperties;
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+use duckdb::Connection;
+use tempfile::TempDir;
+
+/// Canonical schema for the comparison benches.
+///
+/// Three columns chosen to mirror the shape of a TPC-H `customer` / `orders`
+/// row that's been keyed on a single int64 primary key:
+/// - `id`: int64 PK (dense, monotonic)
+/// - `name`: utf8 (variable-width, low cardinality on repeat)
+/// - `value`: int64 (numeric payload)
+pub fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]))
+}
+
+/// Build a deterministic batch of `rows` rows starting at `start_id`.
+pub fn make_batch(schema: Arc<Schema>, start_id: i64, rows: usize) -> RecordBatch {
+    let ids: Vec<i64> = (0..rows as i64).map(|i| start_id + i).collect();
+    let names: Vec<String> = ids.iter().map(|id| format!("name_{id}")).collect();
+    let values: Vec<i64> = ids.iter().map(|id| id * 100).collect();
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(Int64Array::from(values)),
+        ],
+    )
+    .expect("batch")
+}
+
+/// Write a single record batch to a parquet file so both engines can ingest
+/// from the same on-disk source — the realistic Spice ingestion path.
+pub fn write_parquet(batch: &RecordBatch, path: &Path) {
+    let file = std::fs::File::create(path).expect("create parquet");
+    let props = WriterProperties::builder().build();
+    let mut writer =
+        ArrowWriter::try_new(file, batch.schema(), Some(props)).expect("arrow writer");
+    writer.write(batch).expect("write");
+    writer.close().expect("close");
+}
+
+/// A clean Cayenne table backed by a fresh SQLite metastore + temp data dir.
+pub struct CayenneFixture {
+    pub _temp_dir: TempDir,
+    pub table: Arc<CayenneTableProvider>,
+    pub catalog: Arc<dyn MetadataCatalog>,
+}
+
+pub async fn setup_cayenne(table_name: &str) -> CayenneFixture {
+    setup_cayenne_with_pk(table_name, vec![], None).await
+}
+
+pub async fn setup_cayenne_pk(table_name: &str) -> CayenneFixture {
+    setup_cayenne_with_pk(
+        table_name,
+        vec!["id".to_string()],
+        Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "id".to_string(),
+        ]))),
+    )
+    .await
+}
+
+async fn setup_cayenne_with_pk(
+    table_name: &str,
+    primary_key: Vec<String>,
+    on_conflict: Option<OnConflict>,
+) -> CayenneFixture {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let data_path = temp_dir.path().join("data");
+    tokio::fs::create_dir_all(&data_path)
+        .await
+        .expect("data dir");
+    let db_path = temp_dir.path().join("catalog.db");
+    let catalog = Arc::new(
+        CayenneCatalog::new(format!("sqlite://{}", db_path.to_string_lossy())).expect("catalog"),
+    );
+    catalog.init().await.expect("catalog init");
+
+    let table = Arc::new(
+        CayenneTableProvider::create_table(
+            Arc::clone(&catalog) as Arc<dyn MetadataCatalog>,
+            CreateTableOptions {
+                table_name: table_name.to_string(),
+                schema: schema(),
+                primary_key,
+                on_conflict,
+                base_path: data_path.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config: cayenne::metadata::VortexConfig::default(),
+            },
+            Arc::new(RuntimeEnv::default()),
+        )
+        .await
+        .expect("cayenne create_table"),
+    );
+
+    CayenneFixture {
+        _temp_dir: temp_dir,
+        table,
+        catalog: Arc::clone(&catalog) as Arc<dyn MetadataCatalog>,
+    }
+}
+
+/// A clean DuckDB file-mode database with the same schema.
+///
+/// File-backed (not in-memory) for parity with Cayenne, which only supports
+/// `mode: file`. Comparing Cayenne-file vs DuckDB-memory would not be fair
+/// (see `tools/testoperator/dispatch/perf-cayenne-vs-duckdb/README.md`).
+pub struct DuckDbFixture {
+    pub _temp_dir: TempDir,
+    pub conn: Connection,
+}
+
+pub fn setup_duckdb(table_name: &str) -> DuckDbFixture {
+    setup_duckdb_with_pk(table_name, false)
+}
+
+pub fn setup_duckdb_pk(table_name: &str) -> DuckDbFixture {
+    setup_duckdb_with_pk(table_name, true)
+}
+
+fn setup_duckdb_with_pk(table_name: &str, with_pk: bool) -> DuckDbFixture {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let db_path = temp_dir.path().join("duck.db");
+    let conn = Connection::open(&db_path).expect("duckdb open");
+    let pk_clause = if with_pk { " PRIMARY KEY" } else { "" };
+    conn.execute_batch(&format!(
+        "CREATE TABLE {table_name} (id BIGINT{pk_clause}, name VARCHAR NOT NULL, value BIGINT NOT NULL);"
+    ))
+    .expect("duckdb create table");
+    DuckDbFixture {
+        _temp_dir: temp_dir,
+        conn,
+    }
+}
+
+/// Bulk-insert via DuckDB's native parquet loader. This is DuckDB's
+/// fastest ingestion path and the apples-to-apples comparison for
+/// Cayenne's parquet-source insert path.
+pub fn duckdb_insert_parquet(conn: &Connection, table_name: &str, parquet_path: &Path) {
+    conn.execute_batch(&format!(
+        "INSERT INTO {table_name} SELECT * FROM read_parquet('{}');",
+        parquet_path.display()
+    ))
+    .expect("duckdb insert parquet");
+}
+
+/// Insert an Arrow batch through Cayenne via the DataFusion `insert_into` API.
+/// Mirrors how spiced loads accelerator data in production.
+pub async fn cayenne_insert(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> u64 {
+    use datafusion::datasource::TableProvider;
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::prelude::SessionContext;
+    use datafusion_expr::dml::InsertOp;
+
+    let ctx = SessionContext::new();
+    let schema = Arc::clone(batch.schema_ref());
+    let input_exec =
+        MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).expect("memory exec");
+    let insert_plan = table
+        .insert_into(&ctx.state(), input_exec, InsertOp::Append)
+        .await
+        .expect("cayenne insert plan");
+    let results = datafusion_physical_plan::collect(insert_plan, ctx.task_ctx())
+        .await
+        .expect("cayenne insert collect");
+    results
+        .first()
+        .and_then(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .map_or(0, |rows| rows.value(0))
+}
+
+/// Run a SQL query through Cayenne and return the collected batches.
+pub async fn cayenne_query(
+    table: &Arc<CayenneTableProvider>,
+    sql: &str,
+) -> Vec<RecordBatch> {
+    use datafusion::datasource::TableProvider;
+    use datafusion::prelude::SessionContext;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("t", Arc::clone(table) as Arc<dyn TableProvider>)
+        .expect("register table");
+    let df = ctx.sql(sql).await.expect("cayenne sql");
+    df.collect().await.expect("cayenne collect")
+}
+
+/// Run a SQL query through DuckDB and return the number of rows in the
+/// result. Discarding the row content keeps the bench focused on engine
+/// work, not on Rust-side decoding.
+pub fn duckdb_query_count(conn: &Connection, sql: &str) -> i64 {
+    let mut stmt = conn.prepare(sql).expect("duckdb prepare");
+    let mut rows = stmt.query([]).expect("duckdb query");
+    let mut count: i64 = 0;
+    while let Some(_row) = rows.next().expect("duckdb row") {
+        count += 1;
+    }
+    count
+}
+
+/// Run a SQL aggregate query that returns a single scalar i64.
+pub fn duckdb_query_scalar(conn: &Connection, sql: &str) -> i64 {
+    let mut stmt = conn.prepare(sql).expect("duckdb prepare");
+    stmt.query_row([], |row| row.get::<_, i64>(0))
+        .expect("duckdb query_row")
+}

--- a/crates/cayenne/benches/vs_duckdb_helpers/common.rs
+++ b/crates/cayenne/benches/vs_duckdb_helpers/common.rs
@@ -13,9 +13,10 @@
 //! pieces that are identical across benches — schema, fixture generation,
 //! parquet materialization, and the canonical Cayenne / DuckDB setup paths.
 //!
-//! Included via `#[path = "vs_duckdb_common.rs"] mod common;` from each
-//! bench file — keeps Cayenne's bench layout (one file per bench, no
-//! shared crate) intact while avoiding code duplication.
+//! Included via `#[path = "vs_duckdb_helpers/common.rs"] mod common;`
+//! from each bench file. Placing the helper inside a subdirectory keeps
+//! Cargo's bench auto-discovery from picking it up as a standalone target,
+//! so no `autobenches = false` is required on the cayenne crate.
 
 #![allow(dead_code)]
 #![allow(clippy::expect_used)]
@@ -200,6 +201,48 @@ pub async fn cayenne_insert(table: &Arc<CayenneTableProvider>, batch: RecordBatc
     let schema = Arc::clone(batch.schema_ref());
     let input_exec =
         MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).expect("memory exec");
+    let insert_plan = table
+        .insert_into(&ctx.state(), input_exec, InsertOp::Append)
+        .await
+        .expect("cayenne insert plan");
+    let results = datafusion_physical_plan::collect(insert_plan, ctx.task_ctx())
+        .await
+        .expect("cayenne insert collect");
+    results
+        .first()
+        .and_then(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .map_or(0, |rows| rows.value(0))
+}
+
+/// Insert from a parquet file through Cayenne via DataFusion's parquet
+/// reader. Mirrors spiced's `file:` connector → accelerator ingestion path
+/// and gives parity with `duckdb_insert_parquet` (both engines now consume
+/// the same on-disk parquet, including the decode work).
+pub async fn cayenne_insert_from_parquet(
+    table: &Arc<CayenneTableProvider>,
+    parquet_path: &Path,
+) -> u64 {
+    use datafusion::datasource::TableProvider;
+    use datafusion::prelude::{ParquetReadOptions, SessionContext};
+    use datafusion_expr::dml::InsertOp;
+
+    let ctx = SessionContext::new();
+    let df = ctx
+        .read_parquet(
+            parquet_path.to_string_lossy().as_ref(),
+            ParquetReadOptions::default(),
+        )
+        .await
+        .expect("cayenne read_parquet");
+    let input_exec = df
+        .create_physical_plan()
+        .await
+        .expect("cayenne physical plan");
     let insert_plan = table
         .insert_into(&ctx.state(), input_exec, InsertOp::Append)
         .await

--- a/crates/cayenne/benches/vs_duckdb_ingest.rs
+++ b/crates/cayenne/benches/vs_duckdb_ingest.rs
@@ -8,9 +8,12 @@
 
 //! Ingest throughput: Cayenne vs DuckDB.
 //!
-//! For each row count, two benches run on the same generated Arrow batch:
-//! * `cayenne` — insert via `CayenneTableProvider::insert_into`
-//! * `duckdb`  — insert via `INSERT INTO ... SELECT * FROM read_parquet(...)`,
+//! Both engines load from the same pre-materialized parquet file
+//! (written once outside the timed region) so the measurement is
+//! apples-to-apples — both pay parquet decode cost on top of the
+//! engine's write path:
+//! * `cayenne` — `ctx.read_parquet(...)` → `CayenneTableProvider::insert_into`
+//! * `duckdb`  — `INSERT INTO ... SELECT * FROM read_parquet(...)`,
 //!               DuckDB's recommended bulk-ingestion path
 //!
 //! Both engines materialize to local disk (Cayenne to a temp directory,
@@ -18,11 +21,6 @@
 //! file-mode — see `tools/testoperator/dispatch/perf-cayenne-vs-duckdb/README.md`
 //! for why that's the only fair pairing (Cayenne does not support
 //! in-memory mode).
-//!
-//! The DuckDB path includes the parquet read cost. Cayenne reads the
-//! same parquet via DataFusion's ListingTable in a real spiced
-//! ingestion, so the comparison is end-to-end ingestion, not raw
-//! writer throughput.
 
 #![allow(clippy::expect_used)]
 #![allow(clippy::cast_possible_wrap)]
@@ -37,8 +35,8 @@ use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, 
 use tokio::runtime::Runtime;
 
 use common::{
-    cayenne_insert, duckdb_insert_parquet, make_batch, schema, setup_cayenne, setup_duckdb,
-    write_parquet,
+    cayenne_insert_from_parquet, duckdb_insert_parquet, make_batch, schema, setup_cayenne,
+    setup_duckdb, write_parquet,
 };
 
 const ROW_COUNTS: &[usize] = &[1_024, 16_384, 131_072];
@@ -57,13 +55,14 @@ fn bench_bulk_ingest(c: &mut Criterion) {
         let batch = make_batch(schema(), 0, rows);
         write_parquet(&batch, &parquet_path);
 
+        let path = parquet_path.clone();
         group.bench_with_input(BenchmarkId::new("cayenne", rows), &rows, |b, &_rows| {
             b.iter_batched(
                 || rt.block_on(setup_cayenne("ingest_bench")),
                 |fixture| {
                     rt.block_on(async {
-                        let batch = make_batch(schema(), 0, rows);
-                        let written = cayenne_insert(&fixture.table, batch).await;
+                        let written =
+                            cayenne_insert_from_parquet(&fixture.table, &path).await;
                         black_box((fixture, written));
                     });
                 },
@@ -71,11 +70,12 @@ fn bench_bulk_ingest(c: &mut Criterion) {
             );
         });
 
+        let path = parquet_path.clone();
         group.bench_with_input(BenchmarkId::new("duckdb", rows), &rows, |b, &_rows| {
             b.iter_batched(
                 || setup_duckdb("ingest_bench"),
                 |fixture| {
-                    duckdb_insert_parquet(&fixture.conn, "ingest_bench", &parquet_path);
+                    duckdb_insert_parquet(&fixture.conn, "ingest_bench", &path);
                     black_box(fixture);
                 },
                 BatchSize::PerIteration,
@@ -113,18 +113,15 @@ fn bench_incremental_append(c: &mut Criterion) {
     }
     let parquet_paths = Arc::new(parquet_paths);
 
+    let cayenne_paths = Arc::clone(&parquet_paths);
     group.bench_function("cayenne", |b| {
+        let paths = Arc::clone(&cayenne_paths);
         b.iter_batched(
             || rt.block_on(setup_cayenne("incr_bench")),
             |fixture| {
                 rt.block_on(async {
-                    for i in 0..batches_count {
-                        let batch = make_batch(
-                            schema(),
-                            (i * per_batch_rows) as i64,
-                            per_batch_rows,
-                        );
-                        let _ = cayenne_insert(&fixture.table, batch).await;
+                    for path in paths.iter() {
+                        let _ = cayenne_insert_from_parquet(&fixture.table, path).await;
                     }
                     black_box(fixture);
                 });

--- a/crates/cayenne/benches/vs_duckdb_ingest.rs
+++ b/crates/cayenne/benches/vs_duckdb_ingest.rs
@@ -1,0 +1,154 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Ingest throughput: Cayenne vs DuckDB.
+//!
+//! For each row count, two benches run on the same generated Arrow batch:
+//! * `cayenne` — insert via `CayenneTableProvider::insert_into`
+//! * `duckdb`  — insert via `INSERT INTO ... SELECT * FROM read_parquet(...)`,
+//!               DuckDB's recommended bulk-ingestion path
+//!
+//! Both engines materialize to local disk (Cayenne to a temp directory,
+//! DuckDB to a temp `.duckdb` file) so the comparison is file-mode vs
+//! file-mode — see `tools/testoperator/dispatch/perf-cayenne-vs-duckdb/README.md`
+//! for why that's the only fair pairing (Cayenne does not support
+//! in-memory mode).
+//!
+//! The DuckDB path includes the parquet read cost. Cayenne reads the
+//! same parquet via DataFusion's ListingTable in a real spiced
+//! ingestion, so the comparison is end-to-end ingestion, not raw
+//! writer throughput.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use common::{
+    cayenne_insert, duckdb_insert_parquet, make_batch, schema, setup_cayenne, setup_duckdb,
+    write_parquet,
+};
+
+const ROW_COUNTS: &[usize] = &[1_024, 16_384, 131_072];
+
+fn bench_bulk_ingest(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_bulk_ingest");
+    group.sample_size(10);
+
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+
+    for &rows in ROW_COUNTS {
+        group.throughput(Throughput::Elements(rows as u64));
+
+        let parquet_path = parquet_dir.path().join(format!("rows_{rows}.parquet"));
+        let batch = make_batch(schema(), 0, rows);
+        write_parquet(&batch, &parquet_path);
+
+        group.bench_with_input(BenchmarkId::new("cayenne", rows), &rows, |b, &_rows| {
+            b.iter_batched(
+                || rt.block_on(setup_cayenne("ingest_bench")),
+                |fixture| {
+                    rt.block_on(async {
+                        let batch = make_batch(schema(), 0, rows);
+                        let written = cayenne_insert(&fixture.table, batch).await;
+                        black_box((fixture, written));
+                    });
+                },
+                BatchSize::PerIteration,
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("duckdb", rows), &rows, |b, &_rows| {
+            b.iter_batched(
+                || setup_duckdb("ingest_bench"),
+                |fixture| {
+                    duckdb_insert_parquet(&fixture.conn, "ingest_bench", &parquet_path);
+                    black_box(fixture);
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_incremental_append(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_incremental_append");
+    group.sample_size(10);
+
+    // Each batch appended on top of an existing table — simulates the
+    // streaming ingestion path where many small batches arrive over time.
+    let per_batch_rows: usize = 4_096;
+    let batches_count: usize = 16;
+    group.throughput(Throughput::Elements(
+        (per_batch_rows * batches_count) as u64,
+    ));
+
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+    let mut parquet_paths = Vec::with_capacity(batches_count);
+    for i in 0..batches_count {
+        let batch = make_batch(
+            schema(),
+            (i * per_batch_rows) as i64,
+            per_batch_rows,
+        );
+        let path = parquet_dir.path().join(format!("batch_{i}.parquet"));
+        write_parquet(&batch, &path);
+        parquet_paths.push(path);
+    }
+    let parquet_paths = Arc::new(parquet_paths);
+
+    group.bench_function("cayenne", |b| {
+        b.iter_batched(
+            || rt.block_on(setup_cayenne("incr_bench")),
+            |fixture| {
+                rt.block_on(async {
+                    for i in 0..batches_count {
+                        let batch = make_batch(
+                            schema(),
+                            (i * per_batch_rows) as i64,
+                            per_batch_rows,
+                        );
+                        let _ = cayenne_insert(&fixture.table, batch).await;
+                    }
+                    black_box(fixture);
+                });
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("duckdb", |b| {
+        let paths = Arc::clone(&parquet_paths);
+        b.iter_batched(
+            || setup_duckdb("incr_bench"),
+            |fixture| {
+                for path in paths.iter() {
+                    duckdb_insert_parquet(&fixture.conn, "incr_bench", path);
+                }
+                black_box(fixture);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_bulk_ingest, bench_incremental_append);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_pk_lookup.rs
+++ b/crates/cayenne/benches/vs_duckdb_pk_lookup.rs
@@ -1,0 +1,180 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! PK equality lookups: Cayenne vs DuckDB.
+//!
+//! Models the "interactive query" workload — many small queries that
+//! resolve a single row by primary key. The PK is `id BIGINT` for both
+//! engines (DuckDB declares it as `PRIMARY KEY`, Cayenne tracks it via
+//! its `primary_key` table option which routes through the Int64Pk
+//! deletion strategy).
+//!
+//! Three lookup patterns:
+//! * `single_pk`     — `WHERE id = ?`. Tight loop, measures per-lookup latency.
+//! * `pk_in_list`    — `WHERE id IN (?, ?, ?, ..., ?)`. Batch of 32 keys.
+//! * `pk_range`      — `WHERE id BETWEEN ? AND ?`. Range scan of 32 keys.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use common::{
+    CayenneFixture, DuckDbFixture, cayenne_insert, cayenne_query, duckdb_insert_parquet,
+    duckdb_query_scalar, make_batch, schema, setup_cayenne_pk, setup_duckdb_pk, write_parquet,
+};
+
+const TABLE_SIZES: &[usize] = &[16_384, 131_072, 1_048_576];
+const BATCH_KEYS: usize = 32;
+
+async fn load_cayenne(rows: usize) -> CayenneFixture {
+    let fixture = setup_cayenne_pk("pk_bench").await;
+    let batch = make_batch(schema(), 0, rows);
+    let _ = cayenne_insert(&fixture.table, batch).await;
+    fixture
+}
+
+fn load_duckdb(rows: usize, parquet_path: &std::path::Path) -> DuckDbFixture {
+    let fixture = setup_duckdb_pk("pk_bench");
+    let _ = rows;
+    duckdb_insert_parquet(&fixture.conn, "pk_bench", parquet_path);
+    fixture
+}
+
+fn bench_pk_lookup(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_pk_lookup");
+    group.sample_size(20);
+
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+
+    for &rows in TABLE_SIZES {
+        let parquet_path = parquet_dir.path().join(format!("rows_{rows}.parquet"));
+        let batch = make_batch(schema(), 0, rows);
+        write_parquet(&batch, &parquet_path);
+
+        let cayenne_fixture = Arc::new(rt.block_on(load_cayenne(rows)));
+        let duckdb_fixture = Arc::new(load_duckdb(rows, &parquet_path));
+
+        // Pick a stable key in the middle so neither engine's caching is
+        // accidentally over-counted at edges.
+        let target_id = (rows / 2) as i64;
+        let target_lo = target_id - (BATCH_KEYS as i64) / 2;
+        let target_hi = target_id + (BATCH_KEYS as i64) / 2;
+
+        // --- single PK lookup ---
+        let cayenne_sql = format!("SELECT value FROM t WHERE id = {target_id}");
+        let duckdb_sql = format!("SELECT value FROM pk_bench WHERE id = {target_id}");
+        let cf = Arc::clone(&cayenne_fixture);
+        let s = cayenne_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("cayenne/single_pk", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query(&cf.table, &s).await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let df = Arc::clone(&duckdb_fixture);
+        let s = duckdb_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("duckdb/single_pk", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    let v = duckdb_query_scalar(&df.conn, &s);
+                    black_box(v);
+                });
+            },
+        );
+
+        // --- IN-list lookup ---
+        let ids: Vec<String> = (target_lo..target_hi).map(|i| i.to_string()).collect();
+        let in_list = ids.join(",");
+        let cayenne_sql = format!("SELECT SUM(value) FROM t WHERE id IN ({in_list})");
+        let duckdb_sql = format!("SELECT SUM(value) FROM pk_bench WHERE id IN ({in_list})");
+
+        let cf = Arc::clone(&cayenne_fixture);
+        let s = cayenne_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("cayenne/pk_in_list", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query(&cf.table, &s).await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let df = Arc::clone(&duckdb_fixture);
+        let s = duckdb_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("duckdb/pk_in_list", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    let v = duckdb_query_scalar(&df.conn, &s);
+                    black_box(v);
+                });
+            },
+        );
+
+        // --- PK range scan ---
+        let cayenne_sql = format!(
+            "SELECT SUM(value) FROM t WHERE id BETWEEN {target_lo} AND {target_hi}"
+        );
+        let duckdb_sql = format!(
+            "SELECT SUM(value) FROM pk_bench WHERE id BETWEEN {target_lo} AND {target_hi}"
+        );
+
+        let cf = Arc::clone(&cayenne_fixture);
+        let s = cayenne_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("cayenne/pk_range", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query(&cf.table, &s).await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let df = Arc::clone(&duckdb_fixture);
+        let s = duckdb_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("duckdb/pk_range", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    let v = duckdb_query_scalar(&df.conn, &s);
+                    black_box(v);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_pk_lookup);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_pk_lookup.rs
+++ b/crates/cayenne/benches/vs_duckdb_pk_lookup.rs
@@ -46,9 +46,8 @@ async fn load_cayenne(rows: usize) -> CayenneFixture {
     fixture
 }
 
-fn load_duckdb(rows: usize, parquet_path: &std::path::Path) -> DuckDbFixture {
+fn load_duckdb(parquet_path: &std::path::Path) -> DuckDbFixture {
     let fixture = setup_duckdb_pk("pk_bench");
-    let _ = rows;
     duckdb_insert_parquet(&fixture.conn, "pk_bench", parquet_path);
     fixture
 }
@@ -66,7 +65,7 @@ fn bench_pk_lookup(c: &mut Criterion) {
         write_parquet(&batch, &parquet_path);
 
         let cayenne_fixture = Arc::new(rt.block_on(load_cayenne(rows)));
-        let duckdb_fixture = Arc::new(load_duckdb(rows, &parquet_path));
+        let duckdb_fixture = Arc::new(load_duckdb(&parquet_path));
 
         // Pick a stable key in the middle so neither engine's caching is
         // accidentally over-counted at edges.

--- a/crates/cayenne/benches/vs_duckdb_scan.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan.rs
@@ -44,9 +44,8 @@ async fn load_cayenne(rows: usize) -> CayenneFixture {
     fixture
 }
 
-fn load_duckdb(rows: usize, parquet_path: &std::path::Path) -> DuckDbFixture {
+fn load_duckdb(parquet_path: &std::path::Path) -> DuckDbFixture {
     let fixture = setup_duckdb("scan_bench");
-    let _ = rows;
     duckdb_insert_parquet(&fixture.conn, "scan_bench", parquet_path);
     fixture
 }
@@ -67,7 +66,7 @@ fn bench_scan(c: &mut Criterion) {
 
         // Load once, query many times — match the steady-state read pattern.
         let cayenne_fixture = Arc::new(rt.block_on(load_cayenne(rows)));
-        let duckdb_fixture = Arc::new(load_duckdb(rows, &parquet_path));
+        let duckdb_fixture = Arc::new(load_duckdb(&parquet_path));
 
         // --- count_star ---
         let cf = Arc::clone(&cayenne_fixture);

--- a/crates/cayenne/benches/vs_duckdb_scan.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan.rs
@@ -1,0 +1,163 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Scan + aggregate throughput: Cayenne vs DuckDB.
+//!
+//! Each table is loaded once with a deterministic dataset (outside the
+//! timed region) and then exercised with three representative read
+//! shapes:
+//! * `count_star`  — `SELECT COUNT(*) FROM t`. Pure cardinality.
+//! * `sum_value`   — `SELECT SUM(value) FROM t`. Numeric column scan +
+//!                    aggregate; exercises decompression and SIMD paths.
+//! * `filter_sum`  — `SELECT SUM(value) FROM t WHERE id BETWEEN ? AND ?`.
+//!                    Exercises filter pushdown and predicate evaluation
+//!                    in both engines.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use common::{
+    CayenneFixture, DuckDbFixture, cayenne_insert, cayenne_query, duckdb_insert_parquet,
+    duckdb_query_scalar, make_batch, schema, setup_cayenne, setup_duckdb, write_parquet,
+};
+
+const ROW_COUNTS: &[usize] = &[16_384, 131_072, 1_048_576];
+
+async fn load_cayenne(rows: usize) -> CayenneFixture {
+    let fixture = setup_cayenne("scan_bench").await;
+    let batch = make_batch(schema(), 0, rows);
+    let _ = cayenne_insert(&fixture.table, batch).await;
+    fixture
+}
+
+fn load_duckdb(rows: usize, parquet_path: &std::path::Path) -> DuckDbFixture {
+    let fixture = setup_duckdb("scan_bench");
+    let _ = rows;
+    duckdb_insert_parquet(&fixture.conn, "scan_bench", parquet_path);
+    fixture
+}
+
+fn bench_scan(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_scan");
+    group.sample_size(10);
+
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+
+    for &rows in ROW_COUNTS {
+        group.throughput(Throughput::Elements(rows as u64));
+
+        let parquet_path = parquet_dir.path().join(format!("rows_{rows}.parquet"));
+        let batch = make_batch(schema(), 0, rows);
+        write_parquet(&batch, &parquet_path);
+
+        // Load once, query many times — match the steady-state read pattern.
+        let cayenne_fixture = Arc::new(rt.block_on(load_cayenne(rows)));
+        let duckdb_fixture = Arc::new(load_duckdb(rows, &parquet_path));
+
+        // --- count_star ---
+        let cf = Arc::clone(&cayenne_fixture);
+        group.bench_with_input(
+            BenchmarkId::new("cayenne/count_star", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query(&cf.table, "SELECT COUNT(*) FROM t").await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let df = Arc::clone(&duckdb_fixture);
+        group.bench_with_input(
+            BenchmarkId::new("duckdb/count_star", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    let v = duckdb_query_scalar(&df.conn, "SELECT COUNT(*) FROM scan_bench");
+                    black_box(v);
+                });
+            },
+        );
+
+        // --- sum_value ---
+        let cf = Arc::clone(&cayenne_fixture);
+        group.bench_with_input(
+            BenchmarkId::new("cayenne/sum_value", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query(&cf.table, "SELECT SUM(value) FROM t").await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let df = Arc::clone(&duckdb_fixture);
+        group.bench_with_input(
+            BenchmarkId::new("duckdb/sum_value", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    let v = duckdb_query_scalar(&df.conn, "SELECT SUM(value) FROM scan_bench");
+                    black_box(v);
+                });
+            },
+        );
+
+        // --- filter_sum (selects ~10% of rows in the middle of the range) ---
+        let lo = (rows as i64) * 45 / 100;
+        let hi = (rows as i64) * 55 / 100;
+        let cayenne_sql = format!("SELECT SUM(value) FROM t WHERE id BETWEEN {lo} AND {hi}");
+        let duckdb_sql =
+            format!("SELECT SUM(value) FROM scan_bench WHERE id BETWEEN {lo} AND {hi}");
+
+        let cf = Arc::clone(&cayenne_fixture);
+        let cayenne_sql_owned = cayenne_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("cayenne/filter_sum", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query(&cf.table, &cayenne_sql_owned).await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let df = Arc::clone(&duckdb_fixture);
+        let duckdb_sql_owned = duckdb_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("duckdb/filter_sum", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    let v = duckdb_query_scalar(&df.conn, &duckdb_sql_owned);
+                    black_box(v);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan);
+criterion_main!(benches);

--- a/docs/dev/cayenne_vs_duckdb_benchmarks.md
+++ b/docs/dev/cayenne_vs_duckdb_benchmarks.md
@@ -108,5 +108,6 @@ layer-2 micro-bench that targets that path.
    entry to `pairs.yaml`, and document any unavoidable asymmetry.
 3. **Micro-bench**: add `crates/cayenne/benches/vs_duckdb_<dimension>.rs`,
    register it in `crates/cayenne/Cargo.toml`'s `[[bench]]` section, and
-   reuse `vs_duckdb_common.rs` helpers where possible.
+   reuse the helpers in `crates/cayenne/benches/vs_duckdb_helpers/common.rs`
+   where possible.
 4. Update this page with the new entry.

--- a/docs/dev/cayenne_vs_duckdb_benchmarks.md
+++ b/docs/dev/cayenne_vs_duckdb_benchmarks.md
@@ -1,0 +1,112 @@
+# Cayenne vs DuckDB benchmarks
+
+This page documents the head-to-head performance comparison between the
+Cayenne and DuckDB accelerators. The goal is to make it easy to confirm
+Cayenne wins on every dimension that matters — ingestion, query, mutation,
+retention, throughput — and to catch regressions early.
+
+The comparison has two layers:
+
+| Layer | What it measures | Where it lives | How to run |
+|---|---|---|---|
+| End-to-end spicepod benchmarks | Real spiced ingesting from real sources, queries via Flight | `tools/testoperator/dispatch/perf-cayenne-vs-duckdb/pairs.yaml` references existing yamls under `test/spicepods/` | `testoperator run bench` / `throughput` / `load` / `append` on each side of a pair |
+| In-process micro-benchmarks | Direct `CayenneTableProvider` vs `duckdb::Connection` on identical Arrow input | `crates/cayenne/benches/vs_duckdb_*.rs` | `cargo bench -p cayenne --bench vs_duckdb_ingest` (or the other three) |
+
+## Layer 1 — Spicepod matrix
+
+`tools/testoperator/dispatch/perf-cayenne-vs-duckdb/pairs.yaml` lists every
+paired (cayenne, duckdb) spicepod plus the workload they should be
+compared on. The manifest references existing yamls under
+`test/spicepods/` rather than duplicating them, so the comparison always
+runs against the same pods that drive the dedicated benchmark workflows.
+
+To compare a single pair locally:
+
+```sh
+# Cayenne side
+cargo run -p testoperator -- run bench \
+  -p test/spicepods/tpch/sf1/accelerated/file\[parquet\]-cayenne\[file\].yaml \
+  -s spiced -d ./.data --query-set tpch --validate
+
+# DuckDB side
+cargo run -p testoperator -- run bench \
+  -p test/spicepods/tpch/sf1/accelerated/file\[parquet\]-duckdb\[file\].yaml \
+  -s spiced -d ./.data --query-set tpch --validate
+```
+
+Then diff the query durations. A first-class `testoperator compare`
+subcommand that ingests `pairs.yaml` and produces a side-by-side report is
+planned — see the manifest's README for the input format.
+
+### Fair-comparison rules
+
+Two pods are a valid pair only if they differ in the accelerator engine
+(and accelerator-specific tuning) and nothing else. Specifically:
+
+- `mode: file` on both sides. Cayenne does not support memory mode, so a
+  `cayenne[file]` vs `duckdb[memory]` pair is rejected.
+- Identical source connector, schema, primary key, partition column,
+  retention policy, refresh policy, and `on_conflict` semantics.
+- The same query overrides on both runs (or none).
+
+When something must differ — e.g. one engine supports a feature the other
+doesn't — the pair carries a `notes:` explanation and `must_beat: false`.
+See `tools/testoperator/dispatch/perf-cayenne-vs-duckdb/README.md` for
+the full rule set.
+
+## Layer 2 — In-process micro-benchmarks
+
+The `vs_duckdb_*` benches in `crates/cayenne/benches/` exercise the
+accelerator-internal write/read paths directly, with no spiced and no
+Flight. They run identical work against `CayenneTableProvider` and a
+file-backed `duckdb::Connection`.
+
+| Bench | What it measures |
+|---|---|
+| `vs_duckdb_ingest` | Bulk load from parquet and incremental append of N batches |
+| `vs_duckdb_scan` | `COUNT(*)`, full-column `SUM`, range-filtered `SUM` |
+| `vs_duckdb_pk_lookup` | `WHERE id = ?`, `WHERE id IN (...)`, `WHERE id BETWEEN ? AND ?` |
+| `vs_duckdb_delete` | DELETE of ~10% of rows, then scan exercising the deletion-vector filter |
+
+Each bench groups Cayenne and DuckDB measurements together so criterion's
+HTML report shows them on the same chart. To run all four:
+
+```sh
+cargo bench -p cayenne --bench vs_duckdb_ingest
+cargo bench -p cayenne --bench vs_duckdb_scan
+cargo bench -p cayenne --bench vs_duckdb_pk_lookup
+cargo bench -p cayenne --bench vs_duckdb_delete
+```
+
+Shared fixtures (schema, batch generation, parquet materialization,
+Cayenne/DuckDB setup helpers) live in `vs_duckdb_helpers/common.rs` and
+are included via `#[path = "vs_duckdb_helpers/common.rs"] mod common;`
+from each bench file. The subdirectory keeps Cargo's bench
+auto-discovery from picking up the helper as a standalone target.
+
+### What's measured, what's not
+
+The micro-benches isolate the engine's hot path. They explicitly do not
+measure:
+
+- Flight serialization or DataFusion plan construction overhead — those
+  are covered by the layer-1 spicepod benchmarks.
+- Concurrency or throughput under load — covered by `testoperator run
+  throughput` against the same pods.
+- Resource consumption (peak RSS, disk usage) — covered by spiced's OTLP
+  metrics during layer-1 runs.
+
+For end-to-end "is Cayenne winning?" answers, run the layer-1 pairs.
+For "why is Cayenne winning/losing on path X?" investigations, run the
+layer-2 micro-bench that targets that path.
+
+## Adding a new dimension
+
+1. If the new dimension is a workload, decide whether it's better served
+   by a spicepod pair (more realistic) or a micro-bench (more isolated).
+2. **Spicepod pair**: add the yamls under `test/spicepods/`, append an
+   entry to `pairs.yaml`, and document any unavoidable asymmetry.
+3. **Micro-bench**: add `crates/cayenne/benches/vs_duckdb_<dimension>.rs`,
+   register it in `crates/cayenne/Cargo.toml`'s `[[bench]]` section, and
+   reuse `vs_duckdb_common.rs` helpers where possible.
+4. Update this page with the new entry.

--- a/tools/testoperator/dispatch/perf-cayenne-vs-duckdb/README.md
+++ b/tools/testoperator/dispatch/perf-cayenne-vs-duckdb/README.md
@@ -1,0 +1,82 @@
+# Cayenne vs DuckDB performance matrix
+
+This directory pairs every Cayenne spicepod with its DuckDB counterpart so the
+two accelerators can be compared head-to-head across query, throughput, load,
+ingest, and write-heavy workloads.
+
+It is **not** a new set of spicepods — every yaml referenced from
+`pairs.yaml` already lives under `test/spicepods/`. The manifest is the single
+source of truth for "which Cayenne pod should I compare against which DuckDB
+pod, on which workload, at which scale."
+
+## Running a single pair locally
+
+```sh
+# Bench (single query stream, all 22 TPC-H queries):
+testoperator run bench \
+  -p test/spicepods/tpch/sf1/accelerated/file[parquet]-cayenne[file].yaml \
+  -s spiced -d ./.data --query-set tpch --validate
+
+testoperator run bench \
+  -p test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file].yaml \
+  -s spiced -d ./.data --query-set tpch --validate
+```
+
+Run both and diff the resulting query durations. A first-class
+`testoperator compare` subcommand that does this in one shot is planned —
+this manifest is its input format.
+
+## Adding a new pair
+
+1. Confirm both yamls exist under `test/spicepods/`.
+2. Open both and confirm they differ **only** in:
+   - `engine: cayenne` vs `engine: duckdb`
+   - Accelerator-tuning fields (`vortex_config`, DuckDB `params`, etc.)
+   Everything else (source, schema, primary key, partition column, refresh
+   policy, retention policy, on_conflict behavior) must match.
+3. If you must change something else (e.g. Cayenne supports a feature DuckDB
+   doesn't), document it in the entry's `notes:` field and set
+   `must_beat: false`.
+4. Append the entry to `pairs.yaml`. Keep entries grouped by workload, then
+   `query_set`, then `scale_factor`.
+
+## Fair-comparison rules
+
+These rules keep the matrix honest and reproducible.
+
+### Allowed to differ
+- Accelerator engine and its tuning (`vortex_config`, file size targets,
+  DuckDB `params.memory_limit`, etc.). Defaults vs. tuned should be tracked
+  in separate entries (`-2gib`, `-4gib` variants already follow this pattern).
+- Mode-specific tuning, *only when both engines support that mode at the
+  configured target* (e.g. partitioning).
+
+### Must be identical
+- Source connector (`from:`), source data, schema, refresh policy.
+- Primary key and `on_conflict` semantics.
+- Partition column. (If only one engine supports a partition scheme, do
+  not include the asymmetric pair without `must_beat: false`.)
+- Retention period or retention SQL.
+- Refresh check interval.
+
+### Refused asymmetries
+- `engine: cayenne` only supports `mode: file`. A pair that pits
+  `cayenne[file]` against `duckdb[memory]` is **not** fair and will be
+  rejected by `testoperator compare` unless `--allow-asymmetric` is set.
+- A pair that uses different query overrides (`--query-overrides`) on each
+  side is asymmetric. Use the same overrides (or none) on both runs.
+
+### What counts as "winning"
+For a `must_beat: true` pair, Cayenne is expected to be **strictly faster**
+on at least the configured `success_metric` (default: median query
+duration). A regression on any individual query is reported but does not
+fail the run unless it's the success_metric.
+
+## Why a manifest instead of paired yamls?
+
+The existing `test/spicepods/` tree is already exhaustive. Duplicating it
+would double maintenance: every time someone tunes the Cayenne pod for
+SF10 they'd have to remember to update a mirror under
+`perf-cayenne-vs-duckdb/`. The manifest references the originals so the
+comparison always uses the same configuration that runs in dedicated
+benchmark workflows.

--- a/tools/testoperator/dispatch/perf-cayenne-vs-duckdb/README.md
+++ b/tools/testoperator/dispatch/perf-cayenne-vs-duckdb/README.md
@@ -12,13 +12,15 @@ pod, on which workload, at which scale."
 ## Running a single pair locally
 
 ```sh
-# Bench (single query stream, all 22 TPC-H queries):
+# Bench (single query stream, all 22 TPC-H queries).
+# Spicepod paths are quoted because they contain `[` and `]`, which
+# zsh and some other shells interpret as glob characters.
 testoperator run bench \
-  -p test/spicepods/tpch/sf1/accelerated/file[parquet]-cayenne[file].yaml \
+  -p 'test/spicepods/tpch/sf1/accelerated/file[parquet]-cayenne[file].yaml' \
   -s spiced -d ./.data --query-set tpch --validate
 
 testoperator run bench \
-  -p test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file].yaml \
+  -p 'test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file].yaml' \
   -s spiced -d ./.data --query-set tpch --validate
 ```
 

--- a/tools/testoperator/dispatch/perf-cayenne-vs-duckdb/pairs.yaml
+++ b/tools/testoperator/dispatch/perf-cayenne-vs-duckdb/pairs.yaml
@@ -114,14 +114,15 @@ pairs:
     must_beat: true
     runner_type: spiceai-dev-large-runners
 
-  - id: throughput-tpch-sf10-file
+  - id: throughput-tpch-sf10-s3
     workload: throughput
     query_set: tpch
     scale_factor: 10
-    cayenne: tpch/sf10/accelerated/file[parquet]-cayenne[file].yaml
-    duckdb: tpch/sf10/accelerated/file[parquet]-duckdb[file].yaml
+    cayenne: tpch/sf10/accelerated/s3[parquet]-cayenne[file].yaml
+    duckdb: tpch/sf10/accelerated/s3[parquet]-duckdb[file].yaml
     must_beat: true
     runner_type: spiceai-dev-large-runners
+    notes: SF10 file-mode pair is omitted because no DuckDB file-mode SF10 pod exists today.
 
   # ===========================================================================
   # Load tests (long-running, read-only, observe drift over time)

--- a/tools/testoperator/dispatch/perf-cayenne-vs-duckdb/pairs.yaml
+++ b/tools/testoperator/dispatch/perf-cayenne-vs-duckdb/pairs.yaml
@@ -1,0 +1,180 @@
+# Cayenne vs DuckDB performance comparison matrix.
+#
+# Each entry pairs a Cayenne spicepod with a DuckDB spicepod that differ ONLY in
+# the acceleration engine (and accelerator-specific tuning). All other inputs —
+# source data, refresh mode, primary key, partition column, retention policy —
+# must be identical so any performance delta can be attributed to the
+# accelerator alone.
+#
+# Schema:
+#   pairs:
+#     - id:              unique identifier for the pair
+#       workload:        bench | throughput | load | ingest | mutation | point-lookup | append
+#       query_set:       tpch | tpcds | clickbench | chbench (omit for non-query workloads)
+#       scale_factor:    1 | 5 | 10 | 100 | 1000
+#       cayenne:         spicepod path relative to test/spicepods/
+#       duckdb:          spicepod path relative to test/spicepods/
+#       must_beat:       true if Cayenne is expected to beat DuckDB on this workload
+#                        (used by `testoperator compare` to set non-zero exit code on regression)
+#       runner_type:     spiceai-dev-runners | spiceai-dev-large-runners
+#       duration_secs:   load/throughput test duration (omit for bench)
+#       notes:           free-text explanation of trade-offs or known asymmetries
+#
+# Adding a new pair:
+#   1. Confirm both yamls already exist under test/spicepods/.
+#   2. Read both files and confirm only the engine and accelerator-specific
+#      fields differ. Document any unavoidable asymmetry in `notes`.
+#   3. Append the entry below. Keep pairs grouped by workload, then by
+#      query_set, then by scale_factor.
+
+version: v1
+spicepod_root: ../../../../test/spicepods
+
+pairs:
+  # ===========================================================================
+  # Query benchmarks (read-only, single query stream)
+  # ===========================================================================
+  - id: bench-tpch-sf1-file
+    workload: bench
+    query_set: tpch
+    scale_factor: 1
+    cayenne: tpch/sf1/accelerated/file[parquet]-cayenne[file].yaml
+    duckdb: tpch/sf1/accelerated/file[parquet]-duckdb[file].yaml
+    must_beat: true
+    runner_type: spiceai-dev-runners
+
+  # sf10 file: no DuckDB sf10 file-mode pod exists today (only s3 at sf10);
+  # add a `file[parquet]-duckdb[file].yaml` under test/spicepods/tpch/sf10/
+  # mirroring the SF1 layout to enable this pair.
+
+  - id: bench-tpch-sf1-s3-partitioned
+    workload: bench
+    query_set: tpch
+    scale_factor: 1
+    cayenne: tpch/sf1/accelerated/s3[parquet]-cayenne[file]-partitioned.yaml
+    duckdb: tpch/sf1/accelerated/s3[parquet]-duckdb[file]-partitioned.yaml
+    must_beat: true
+    runner_type: spiceai-dev-runners
+    notes: Both pods use the same partition column; differences should be accelerator-only.
+
+  - id: bench-tpch-sf10-s3
+    workload: bench
+    query_set: tpch
+    scale_factor: 10
+    cayenne: tpch/sf10/accelerated/s3[parquet]-cayenne[file].yaml
+    duckdb: tpch/sf10/accelerated/s3[parquet]-duckdb[file].yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+
+  - id: bench-tpch-sf100-s3
+    workload: bench
+    query_set: tpch
+    scale_factor: 100
+    cayenne: tpch/sf100/accelerated/s3[parquet]-cayenne[file].yaml
+    duckdb: tpch/sf100/accelerated/s3[parquet]-duckdb[file].yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+
+  - id: bench-tpcds-sf1-file
+    workload: bench
+    query_set: tpcds
+    scale_factor: 1
+    cayenne: tpcds/sf1/accelerated/file[parquet]-cayenne[file].yaml
+    duckdb: tpcds/sf1/accelerated/file[parquet]-duckdb[file].yaml
+    must_beat: true
+    runner_type: spiceai-dev-runners
+
+  - id: bench-tpcds-sf1-s3
+    workload: bench
+    query_set: tpcds
+    scale_factor: 1
+    cayenne: tpcds/sf1/accelerated/s3[parquet]-cayenne[file].yaml
+    duckdb: tpcds/sf1/accelerated/s3[parquet]-duckdb[file].yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+
+  - id: bench-clickbench-sf1-s3
+    workload: bench
+    query_set: clickbench
+    scale_factor: 1
+    cayenne: clickbench/sf1/accelerated/s3[parquet]-cayenne[file].yaml
+    duckdb: clickbench/sf1/accelerated/s3[parquet]-duckdb[file].yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+
+  # ===========================================================================
+  # Throughput benchmarks (read-only, many concurrent query streams)
+  # ===========================================================================
+  - id: throughput-tpch-sf1-file
+    workload: throughput
+    query_set: tpch
+    scale_factor: 1
+    cayenne: tpch/sf1/accelerated/file[parquet]-cayenne[file].yaml
+    duckdb: tpch/sf1/accelerated/file[parquet]-duckdb[file].yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+
+  - id: throughput-tpch-sf10-file
+    workload: throughput
+    query_set: tpch
+    scale_factor: 10
+    cayenne: tpch/sf10/accelerated/file[parquet]-cayenne[file].yaml
+    duckdb: tpch/sf10/accelerated/file[parquet]-duckdb[file].yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+
+  # ===========================================================================
+  # Load tests (long-running, read-only, observe drift over time)
+  # ===========================================================================
+  - id: load-tpch-sf1-file
+    workload: load
+    query_set: tpch
+    scale_factor: 1
+    cayenne: tpch/sf1/accelerated/file[parquet]-cayenne[file].yaml
+    duckdb: tpch/sf1/accelerated/file[parquet]-duckdb[file].yaml
+    must_beat: false
+    runner_type: spiceai-dev-large-runners
+    duration_secs: 28800
+    notes: 8-hour load. Measures drift, leak resistance, and long-tail latency.
+
+  # ===========================================================================
+  # Append + upsert workloads (write-heavy with concurrent reads)
+  # ===========================================================================
+  - id: append-tpch-sf1
+    workload: append
+    query_set: tpch
+    scale_factor: 1
+    cayenne: tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append.yaml
+    duckdb: tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append.yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+
+  - id: append-tpch-sf1-upsert
+    workload: append
+    query_set: tpch
+    scale_factor: 1
+    cayenne: tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_upsert.yaml
+    duckdb: tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_upsert.yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+    notes: Stresses primary-key conflict resolution (deletion-vector vs row-rewrite paths).
+
+  - id: append-tpch-sf1-retention-period
+    workload: append
+    query_set: tpch
+    scale_factor: 1
+    cayenne: tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_period.yaml
+    duckdb: tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_period.yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+    notes: Time-based retention. Exercises Cayenne's retention-filter pushdown.
+
+  - id: append-tpch-sf1-retention-sql
+    workload: append
+    query_set: tpch
+    scale_factor: 1
+    cayenne: tpch/sf1/accelerated/append/file[parquet]-cayenne[file]-append_retention_sql.yaml
+    duckdb: tpch/sf1/accelerated/append/file[parquet]-duckdb[file]-append_retention_sql.yaml
+    must_beat: true
+    runner_type: spiceai-dev-large-runners
+    notes: SQL-based retention.


### PR DESCRIPTION
## Summary

Adds a two-layer head-to-head comparison so wins and regressions against DuckDB are visible across ingestion, scan, point-lookup, and delete paths.

- **Layer 1 — spicepod matrix**: `tools/testoperator/dispatch/perf-cayenne-vs-duckdb/pairs.yaml` lists every paired (cayenne, duckdb) spicepod plus workload, scale factor, and runner. The manifest references existing yamls under `test/spicepods/` rather than duplicating them. Fair-comparison rules (mode parity, schema parity, allowed asymmetries) are documented in the accompanying README.
- **Layer 2 — in-process micro-benches** in `crates/cayenne/benches/`:
  - `vs_duckdb_ingest`: bulk parquet load + incremental append
  - `vs_duckdb_scan`: `COUNT(*)`, full-column `SUM`, range-filtered `SUM`
  - `vs_duckdb_pk_lookup`: single-PK, IN-list, PK range
  - `vs_duckdb_delete`: bulk DELETE + scan-after-delete (exercises the deletion-vector path on Cayenne vs DuckDB's block rewrite)

Shared fixtures (schema, batch generation, parquet materialization, Cayenne/DuckDB setup helpers) live in `crates/cayenne/benches/vs_duckdb_helpers/common.rs` and are included via `#[path]` from each bench file. Placing the helper inside a subdirectory keeps Cargo's bench auto-discovery from treating it as a standalone target — no `autobenches = false` needed.

DuckDB ingestion uses the native parquet loader (`INSERT … SELECT * FROM read_parquet(…)`) so both engines load from the same on-disk source — the realistic spiced-equivalent ingestion path. Both engines run in file mode for parity, since Cayenne does not support in-memory mode.

`docs/dev/cayenne_vs_duckdb_benchmarks.md` explains how to run, what each layer measures, and how to add a new dimension.

## Branch note

This change was originally intended to land on `lukim/q21` (PR #10840). The remote git proxy refused pushes to that branch from this session's credentials (`HTTP 403`, persistent across the configured backoff retries), so it's parked here as a clean single-commit branch on `trunk` that can be cherry-picked.

## Test plan

- [ ] `cargo check -p cayenne --benches` — verifies the four `vs_duckdb_*` files compile alongside the existing benches.
- [ ] `cargo bench -p cayenne --bench vs_duckdb_ingest -- --quick` — sanity-check that ingest measurements collect on both engines.
- [ ] Repeat for `vs_duckdb_scan`, `vs_duckdb_pk_lookup`, `vs_duckdb_delete`.
- [ ] Spot-check one Layer-1 pair, e.g. `testoperator run bench -p test/spicepods/tpch/sf1/accelerated/file[parquet]-cayenne[file].yaml --query-set tpch --validate` then the same with the DuckDB pod.
- [ ] Verify all spicepod paths referenced in `pairs.yaml` resolve under `test/spicepods/`.

https://claude.ai/code/session_01JzU8fFkP2DHQCSaCx1GU16

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzU8fFkP2DHQCSaCx1GU16)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->