### PR TITLE
feat(cli): add `spice feedback` command to open community Slack

### DIFF
--- a/bin/spice/src/commands/feedback.rs
+++ b/bin/spice/src/commands/feedback.rs
@@ -1,0 +1,46 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Feedback command - opens the Spice.ai community Slack in the user's browser.
+
+use crate::error::Result;
+use clap::Args;
+
+const FEEDBACK_URL: &str = "https://spice.ai/slack";
+
+/// Arguments for the feedback command.
+#[derive(Args, Debug)]
+#[command(
+    about = "Open the Spice.ai community Slack to share feedback",
+    long_about = r#"Open the Spice.ai community Slack to share feedback
+
+Examples:
+  spice feedback
+
+See more at: https://spiceai.org/docs/"#
+)]
+pub struct FeedbackArgs {}
+
+/// Execute the feedback command.
+pub fn execute(_args: &FeedbackArgs) -> Result<()> {
+    println!("Opening Spice.ai community Slack in your default browser:");
+    println!("\n  {FEEDBACK_URL}\n");
+    println!("If the browser does not open, visit the URL above manually.");
+
+    let _ = open::that(FEEDBACK_URL);
+
+    Ok(())
+}

--- a/bin/spice/src/commands/mod.rs
+++ b/bin/spice/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod completions;
 pub mod connect;
 pub mod dataset;
 pub mod datasets;
+pub mod feedback;
 pub mod init;
 pub mod install;
 pub mod login;

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -20,8 +20,8 @@ use clap::{CommandFactory, Parser, Subcommand};
 use spice::commands::acceleration::{AccelerationArgs, SnapshotArgs, SnapshotsArgs};
 use spice::commands::{
     acceleration, add, catalogs, chat, cloud, cluster, completions, connect, dataset, datasets,
-    init, install, login, models, nsql, pods, query, refresh, run, search, sql, status, trace,
-    upgrade, validate, version, workers,
+    feedback, init, install, login, models, nsql, pods, query, refresh, run, search, sql, status,
+    trace, upgrade, validate, version, workers,
 };
 use spice::{Result, RuntimeContext};
 use tracing_subscriber::EnvFilter;
@@ -138,6 +138,9 @@ enum Commands {
 
     /// Validate a spicepod.yaml without starting the runtime
     Validate(validate::ValidateArgs),
+
+    /// Open the Spice.ai community Slack to share feedback
+    Feedback(feedback::FeedbackArgs),
 }
 
 fn main() {
@@ -379,6 +382,9 @@ fn run_cli(cli: Cli) -> Result<()> {
             let rt = tokio::runtime::Runtime::new()
                 .map_err(|e| spice::error::Error::RuntimeExecution { source: e })?;
             rt.block_on(validate::execute(&args))?;
+        }
+        Commands::Feedback(args) => {
+            feedback::execute(&args)?;
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a new `spice feedback` subcommand that opens https://spice.ai/slack in the user's default browser to share feedback with the community.
- Prints the URL alongside opening it as a fallback for headless environments where a browser cannot be launched.

## Test plan

- [x] `cargo build -p spice --bin spice` succeeds
- [x] `spice feedback --help` shows the new command help text
- [x] `spice feedback` prints the Slack URL and attempts to launch the browser
- [x] `spice --help` lists `feedback` alongside the other subcommands

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQTmyVhAZkJML9TuisqAdA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->