### PR TITLE
Fix clippy lint failures

### DIFF
--- a/crates/cayenne/src/logical_optimizer.rs
+++ b/crates/cayenne/src/logical_optimizer.rs
@@ -1458,7 +1458,7 @@ mod tests {
         // Cycle prevention: running the rule a second time must be a no-op
         // (the unified Display-keyed cycle guard tracks the InSubquery target
         // expression, not just column targets).
-        let (_, changed2) = apply_rule_to_all_joins(&r, transformed_plan.clone(), &cfg)?;
+        let (_, changed2) = apply_rule_to_all_joins(&r, transformed_plan, &cfg)?;
         assert!(
             !changed2,
             "second pass must not re-propagate (cycle guard) on expression target"

--- a/crates/cayenne/tests/cross_partition_overwrite_test.rs
+++ b/crates/cayenne/tests/cross_partition_overwrite_test.rs
@@ -29,28 +29,28 @@ You may obtain a copy of the License at
 //! crash-recovery infrastructure now perform the required parent-directory
 //! sync after `create_dir_all` (snapshot directories via
 //! `ensure_snapshot_dir_exists` (including initial table creation before
-//! metastore INSERT), the _partitioned_wal/ coordination directory via the
+//! metastore INSERT), the `_partitioned_wal/` coordination directory via the
 //! helper in `PartitionedWal::write_to`, `deletions/` subdirectories under
-//! snapshots via DeletionVectorWriter, and partition value subdirectories
-//! via CayennePartitionCreator before `add_partition`).
+//! snapshots via `DeletionVectorWriter`, and partition value subdirectories
+//! via `CayennePartitionCreator` before `add_partition`).
 //! The catalog DB directory creation in `CayenneCatalog::init` also
 //! receives a best-effort parent sync for completeness of the system
 //! initialization path.
 //! Combined with the per-partition staging WAL, deletion vector file
-//! sync_all, and directory syncs in the delete sinks, a successful
+//! `sync_all`, and directory syncs in the delete sinks, a successful
 //! cross-partition operation (append or overwrite, including any
 //! concurrent or pending deletions or new partitions) leaves a fully
 //! durable set of coordination records and data files on local FS.
 //! The existing fault-injection and restart tests in this file, together
 //! with the per-partition durability tests (deletion vector restart,
-//! staged-append restart, acid_compliance, data_inlining, catalog
-//! concurrency with partitions, and shared_metastore_concurrency_test
+//! staged-append restart, `acid_compliance`, `data_inlining`, catalog
+//! concurrency with partitions, and `shared_metastore_concurrency_test`
 //! which exercises fresh catalog DB directory creation in both
-//! CayenneCatalog::init and the SQLite/Turso metastore backends with
+//! `CayenneCatalog::init` and the SQLite/Turso metastore backends with
 //! best-effort parent sync + warning),
 //! provide comprehensive regression coverage for this property,
 //! including the edge cases of the very first cross-partition write on a
-//! brand-new table (first creation of the _partitioned_wal/ directory),
+//! brand-new table (first creation of the `_partitioned_wal/` directory),
 //! the first deletion vector written to a snapshot, the first discovery
 //! of a new partition value, and first-time catalog initialization on a
 //! brand-new data directory (including defense-in-depth in the

--- a/crates/data_components/src/elasticsearch/query_table.rs
+++ b/crates/data_components/src/elasticsearch/query_table.rs
@@ -975,8 +975,8 @@ mod tests {
     // ── UInt64 (ES `unsigned_long`) ────────────────────────────────────────────
 
     /// schema.rs maps ES `unsigned_long` to Arrow `UInt64`. Without a dedicated
-    /// decoder arm, the schema would say UInt64 while the decoder fell into
-    /// the JSON-string fallback, blowing up at RecordBatch construction with a
+    /// decoder arm, the schema would say `UInt64` while the decoder fell into
+    /// the JSON-string fallback, blowing up at `RecordBatch` construction with a
     /// schema/data type mismatch.
     #[test]
     fn test_unsigned_long_decodes_to_uint64() {

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -1085,7 +1085,7 @@ mod tests {
 
     /// Regression test for the post-decorrelation re-propagation bug
     /// (`cayenne::logical_optimizer`): after the rule wraps a Filter with
-    /// `InSubquery` and DataFusion decorrelates it to `LeftSemi`, the
+    /// `InSubquery` and `DataFusion` decorrelates it to `LeftSemi`, the
     /// optimizer iterates the rule pipeline to fixed point. Without the
     /// cycle-detection fix in `analyze_logical_side`, the rule would re-fire
     /// each pass and stack one redundant `LeftSemi` per iteration up to


### PR DESCRIPTION
## Summary
- Add backticks to doc comments flagged by clippy::doc_markdown.
- Remove a redundant clone in the Cayenne logical optimizer test.

## Testing
- make lint-rust

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->