### PR TITLE
refactor: leverage DataFusion TreeNode and split_binary utilities

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task/deletion.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/deletion.rs
@@ -228,6 +228,7 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use datafusion::common::ScalarValue;
     use datafusion::logical_expr::Operator;
+    use datafusion::logical_expr::utils::split_binary;
     use std::sync::Arc;
 
     fn make_single_row_batch(pk: i64, sk: &str) -> RecordBatch {
@@ -511,28 +512,12 @@ mod tests {
         assert!(pairs.contains(&(2, "b".to_string())));
     }
 
-    /// Recursively collects all leaf conditions from an OR tree
     fn collect_or_conditions(expr: &Expr) -> Vec<&Expr> {
-        match expr {
-            Expr::BinaryExpr(binary) if binary.op == Operator::Or => {
-                let mut conditions = collect_or_conditions(&binary.left);
-                conditions.extend(collect_or_conditions(&binary.right));
-                conditions
-            }
-            _ => vec![expr],
-        }
+        split_binary(expr, Operator::Or)
     }
 
-    /// Recursively collects all leaf conditions from an AND tree
     fn collect_and_conditions(expr: &Expr) -> Vec<&Expr> {
-        match expr {
-            Expr::BinaryExpr(binary) if binary.op == Operator::And => {
-                let mut conditions = collect_and_conditions(&binary.left);
-                conditions.extend(collect_and_conditions(&binary.right));
-                conditions
-            }
-            _ => vec![expr],
-        }
+        split_binary(expr, Operator::And)
     }
 
     /// Checks if expression is `column_name = <something>`

--- a/crates/s3_vectors_metadata_filter/src/datafusion.rs
+++ b/crates/s3_vectors_metadata_filter/src/datafusion.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use crate::error::{InvalidFilterSnafu, InvalidValueTypeSnafu, Result};
 use crate::filter::{FieldOperation, FilterExpression, LogicalOperation, MetadataFilter, Operator};
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::{Expr, Operator as DFOperator, binary_expr, col, lit};
 use datafusion::prelude::{and, or};
@@ -35,12 +36,38 @@ pub fn convert_to_datafusion_expr(filter: &MetadataFilter) -> Result<Expr> {
 /// Checks that an arbitrary [`Expr`] can be successfully converted to a [`MetadataFilter`] and that all columns referenced are within `columns`.
 #[must_use]
 pub fn supports_filter_expr(columns: &[String], filter: &Expr) -> bool {
-    match filter {
-        Expr::BinaryExpr(binary) => supports_binary_expr(columns, binary),
-        Expr::IsNull(expr) | Expr::IsNotNull(expr) => supports_column_ref(columns, expr),
-        Expr::InList(in_list) => supports_in_list(columns, in_list),
-        _ => false, // Unsupported expression type
-    }
+    let mut supported = true;
+    let _ = filter.apply(|e| {
+        let leaf_ok = match e {
+            Expr::BinaryExpr(binary) => match binary.op {
+                DFOperator::And | DFOperator::Or => {
+                    // Recurse into children to validate sub-expressions.
+                    return Ok(TreeNodeRecursion::Continue);
+                }
+                DFOperator::Eq
+                | DFOperator::NotEq
+                | DFOperator::Lt
+                | DFOperator::LtEq
+                | DFOperator::Gt
+                | DFOperator::GtEq => {
+                    supports_column_ref(columns, &binary.left) && is_literal(&binary.right)
+                }
+                _ => false,
+            },
+            Expr::IsNull(inner) | Expr::IsNotNull(inner) => supports_column_ref(columns, inner),
+            Expr::InList(in_list) => supports_in_list(columns, in_list),
+            _ => false,
+        };
+
+        if leaf_ok {
+            // Comparison/IS NULL/IN-list leaves are fully validated; skip their children.
+            Ok(TreeNodeRecursion::Jump)
+        } else {
+            supported = false;
+            Ok(TreeNodeRecursion::Stop)
+        }
+    });
+    supported
 }
 
 /// Converts `DataFusion` Expr filters to S3 Vectors API filter format.
@@ -83,29 +110,6 @@ pub fn convert_datafusion_filters_to_s3_vectors(
         Ok(Some(MetadataFilter::Complex(FilterExpression::Logical(
             logical_op,
         ))))
-    }
-}
-
-/// Checks if a binary expression is supported
-fn supports_binary_expr(columns: &[String], binary: &datafusion::logical_expr::BinaryExpr) -> bool {
-    use datafusion::logical_expr::Operator;
-
-    match binary.op {
-        Operator::And | Operator::Or => {
-            // Logical operators - check both sides
-            supports_filter_expr(columns, &binary.left)
-                && supports_filter_expr(columns, &binary.right)
-        }
-        Operator::Eq
-        | Operator::NotEq
-        | Operator::Lt
-        | Operator::LtEq
-        | Operator::Gt
-        | Operator::GtEq => {
-            // Comparison operators - check left is column and right is literal
-            supports_column_ref(columns, &binary.left) && is_literal(&binary.right)
-        }
-        _ => false, // Unsupported operator
     }
 }
 


### PR DESCRIPTION
## Summary

Replace hand-rolled `BinaryExpr` recursion with existing DataFusion utilities in two spots surfaced by an audit of `Expr` traversal in the codebase.

- **`s3_vectors_metadata_filter`** (production): Collapse `supports_filter_expr` + its private `supports_binary_expr` helper into a single `Expr::apply` walk. The traversal recurses into `AND`/`OR` children (`TreeNodeRecursion::Continue`), treats validated comparison / `IS NULL` / `InList` nodes as leaves (`Jump`), and short-circuits on unsupported nodes (`Stop`). Adding a new top-level expression type is now a single match arm.

- **`accelerated_table` deletion tests**: Replace the hand-rolled recursive `collect_or_conditions` / `collect_and_conditions` helpers with a direct call to `datafusion::logical_expr::utils::split_binary`, which does exactly the same flattening and additionally handles `Expr::Alias` transparently.

Net diff: +36 / -47.

## Test plan

- [x] `cargo test -p s3_vectors_metadata_filter --lib` — 11/11 pass, including `test_valid_datafusion_expressions` which exercises every branch of `supports_filter_expr` (AND/OR, all six comparison ops, IS NULL / IS NOT NULL, InList, and nested combinations).
- [x] `cargo clippy -p s3_vectors_metadata_filter --no-deps -- -D warnings` — clean.
- [x] `cargo check -p runtime --lib` — clean (pre-existing warnings only).
- [ ] CI to validate `runtime` test build (couldn't build locally — out of disk in remote env).

## Follow-ups (out of scope)

- `runtime/src/datafusion/refresh_sql.rs:347` also reimplements `split_conjunction` and could call into the upstream utility.
- `datafusion-optimizer-rules/src/physical_plan/duckdb/intermediate_index_cte.rs:72` mimics `split_conjunction` for SQL AST (different `Expr` type — not directly replaceable, but worth noting).

---
_Generated by [Claude Code](https://claude.ai/code/session_015BiBjsLAmSD5cqXnqSkZgG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->