### PR TITLE
Revert "Temporary disable HTTP dynamic request header tests"

### DIFF
--- a/crates/runtime/tests/http/mod.rs
+++ b/crates/runtime/tests/http/mod.rs
@@ -682,7 +682,6 @@ async fn test_http_dynamic_request_headers() -> Result<(), String> {
 /// `DataFusion` plans the subquery as a `HashJoinExec` (semi-join) over
 /// `HttpExec`, which the optimizer rewrites into `HttpWithDeferredParamsExec`.
 #[tokio::test]
-#[ignore = "https://github.com/spiceai/spiceai/issues/10861"]
 async fn test_http_dynamic_request_headers_from_subquery() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     register_test_connectors().await;
@@ -1432,7 +1431,6 @@ async fn test_http_oauth2_rejects_partial_configuration() -> Result<(), String> 
 ///   3. A query that builds JSON headers from the CSV rows and uses
 ///      `IN (SELECT ...)` to drive dynamic HTTP requests across multiple pages
 #[tokio::test]
-#[ignore = "https://github.com/spiceai/spiceai/issues/10861"]
 async fn test_http_dynamic_request_headers_from_subquery_with_pagination() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     register_test_connectors().await;


### PR DESCRIPTION
Reverts spiceai/spiceai#10862

Fixed by 
- https://github.com/spiceai/spiceai/pull/10863

Closes https://github.com/spiceai/spiceai/issues/10861

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->