### PR TITLE
fix: Disable Cayenne HashJoin rewriter optimizer

### DIFF
--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -814,23 +814,10 @@ pub(crate) fn default_extension_planners(
 #[cfg(test)]
 mod tests {
     #[cfg(not(windows))]
-    use arrow::{
-        array::{ArrayRef, Int32Array},
-        datatypes::{DataType, Field, Schema},
-        record_batch::RecordBatch,
-    };
-    #[cfg(not(windows))]
-    use cayenne::provider::CayenneAccelerationExec;
+    use arrow::datatypes::{DataType, Field, Schema};
     #[cfg(not(windows))]
     use datafusion::catalog::MemTable;
     use datafusion::optimizer::Analyzer;
-    #[cfg(not(windows))]
-    use datafusion::{
-        common::{JoinType, NullEquality},
-        datasource::memory::MemorySourceConfig,
-        physical_expr::expressions::col,
-        physical_plan::{ExecutionPlan, displayable, joins::HashJoinExec, joins::PartitionMode},
-    };
 
     use super::{
         DEFAULT_MAXIMUM_SHARED_INLIST_MEMORY_BYTES, DataFusionBuilder,
@@ -1160,9 +1147,8 @@ mod tests {
         });
     }
 
-    /// Cayenne rewrites `HashJoinExec` to use a custom accumulator type, so it
-    /// must run after `DataFusion`'s built-in physical optimizer rules that
-    /// downcast to the default `HashJoinExec` type.
+    /// Cayenne physical optimizer rules must run after `DataFusion`'s built-in
+    /// physical optimizer rules.
     #[test]
     #[cfg(not(windows))]
     fn test_built_datafusion_registers_cayenne_rules_after_datafusion_rules() {
@@ -1205,76 +1191,6 @@ mod tests {
         assert!(
             cayenne_filter_sharing_position < cayenne_anti_sort_merge_position,
             "CayenneDynamicFilterSharing must run before CayenneAntiJoinSortMergeRewriter so anti joins can still receive shared scan filters"
-        );
-    }
-
-    #[cfg(not(windows))]
-    fn memory_exec(column_name: &str) -> Arc<dyn ExecutionPlan> {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            column_name,
-            DataType::Int32,
-            false,
-        )]));
-        let values: ArrayRef = Arc::new(Int32Array::from(vec![1]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![values])
-            .expect("memory exec batch should be valid");
-        MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None)
-            .expect("memory exec should be valid")
-    }
-
-    #[cfg(not(windows))]
-    fn cayenne_backed_join() -> Arc<dyn ExecutionPlan> {
-        let left = memory_exec("left_id");
-        let right: Arc<dyn ExecutionPlan> =
-            Arc::new(CayenneAccelerationExec::new(memory_exec("right_id")));
-
-        Arc::new(
-            HashJoinExec::try_new(
-                Arc::clone(&left),
-                Arc::clone(&right),
-                vec![(
-                    col("left_id", &left.schema()).expect("left join key should exist"),
-                    col("right_id", &right.schema()).expect("right join key should exist"),
-                )],
-                None,
-                &JoinType::Inner,
-                None,
-                PartitionMode::Partitioned,
-                NullEquality::NullEqualsNothing,
-            )
-            .expect("hash join should be valid"),
-        )
-    }
-
-    #[test]
-    #[cfg(not(windows))]
-    fn test_built_datafusion_applies_cayenne_join_rewriter_to_physical_plan() {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("tokio runtime");
-        let handle = rt.handle().clone();
-
-        let df = DataFusionBuilder::new(
-            status::RuntimeStatus::new(),
-            Arc::new(AcceleratorEngineRegistry::default()),
-            handle,
-        )
-        .build();
-
-        let state = df.ctx.state();
-        let mut plan = cayenne_backed_join();
-        for optimizer in state.physical_optimizers() {
-            plan = optimizer
-                .optimize(plan, state.config_options())
-                .expect("physical optimizer should succeed");
-        }
-
-        let plan = displayable(plan.as_ref()).indent(true).to_string();
-
-        assert!(
-            plan.contains("accumulator=ExactLeftAccumulator"),
-            "Runtime physical optimizer stack should rewrite Cayenne-backed joins: {plan}"
         );
     }
 }

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -32,9 +32,7 @@ use cache::Caching;
 #[cfg(not(windows))]
 use cayenne::logical_optimizer::CayennePropagateFilterAcrossEquiJoinKeys;
 #[cfg(not(windows))]
-use cayenne::optimizer_rules::{
-    CayenneAntiJoinSortMergeRewriter, CayenneDynamicFilterSharing, CayenneJoinRewriter,
-};
+use cayenne::optimizer_rules::{CayenneAntiJoinSortMergeRewriter, CayenneDynamicFilterSharing};
 #[cfg(not(windows))]
 use datafusion::optimizer::{Optimizer, OptimizerRule};
 use datafusion::{
@@ -392,8 +390,7 @@ impl DataFusionBuilder {
             state = with_cayenne_logical_optimizer(state);
             state = state
                 .with_physical_optimizer_rule(Arc::new(CayenneDynamicFilterSharing::new()))
-                .with_physical_optimizer_rule(Arc::new(CayenneAntiJoinSortMergeRewriter::new()))
-                .with_physical_optimizer_rule(Arc::new(CayenneJoinRewriter::new()));
+                .with_physical_optimizer_rule(Arc::new(CayenneAntiJoinSortMergeRewriter::new()));
         }
         #[cfg(windows)]
         {
@@ -1168,7 +1165,7 @@ mod tests {
     /// downcast to the default `HashJoinExec` type.
     #[test]
     #[cfg(not(windows))]
-    fn test_built_datafusion_registers_cayenne_join_rewriter_after_datafusion_rules() {
+    fn test_built_datafusion_registers_cayenne_rules_after_datafusion_rules() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -1192,10 +1189,6 @@ mod tests {
             .iter()
             .position(|name| *name == "SanityCheckPlan")
             .expect("DataFusion sanity check rule should be registered");
-        let cayenne_rewriter_position = rule_names
-            .iter()
-            .position(|name| *name == "CayenneJoinRewriter")
-            .expect("Cayenne join rewriter should be registered");
         let cayenne_filter_sharing_position = rule_names
             .iter()
             .position(|name| *name == "CayenneDynamicFilterSharing")
@@ -1206,24 +1199,12 @@ mod tests {
             .expect("Cayenne anti join sort-merge rewriter should be registered");
 
         assert!(
-            sanity_check_position < cayenne_rewriter_position,
-            "CayenneJoinRewriter must run after DataFusion's built-in physical optimizer rules"
-        );
-        assert!(
             sanity_check_position < cayenne_filter_sharing_position,
             "CayenneDynamicFilterSharing must run after DataFusion's built-in physical optimizer rules"
         );
         assert!(
-            cayenne_filter_sharing_position < cayenne_rewriter_position,
-            "CayenneDynamicFilterSharing must run before CayenneJoinRewriter so it can inspect DataFusion's default HashJoinExec nodes"
-        );
-        assert!(
             cayenne_filter_sharing_position < cayenne_anti_sort_merge_position,
             "CayenneDynamicFilterSharing must run before CayenneAntiJoinSortMergeRewriter so anti joins can still receive shared scan filters"
-        );
-        assert!(
-            cayenne_anti_sort_merge_position < cayenne_rewriter_position,
-            "CayenneAntiJoinSortMergeRewriter must run before CayenneJoinRewriter so anti joins are not recreated with the hash-join accumulator"
         );
     }
 


### PR DESCRIPTION
## 📝 Summary

This rule has been added and disabled before due to performance regressions, this PR disable it again due to similar reason:

Added in #8316 (2025-12-01)
Disabled in #8439 (2025-12-08) — performance regression
Re-enabled in #10818 (2026-05-14)
Disable again in this PR — similar performance regression


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->