### PR TITLE
Align HTAP CH-benCH queries with BenchBase/HeatWave oracle implementions

### DIFF
--- a/crates/test-framework/src/queries/chbench/q1.sql
+++ b/crates/test-framework/src/queries/chbench/q1.sql
@@ -1,15 +1,11 @@
-select
+SELECT
     ol_number,
     sum(ol_quantity) as sum_qty,
     sum(ol_amount) as sum_amount,
     avg(ol_quantity) as avg_qty,
     avg(ol_amount) as avg_amount,
     count(*) as count_order
-from
-    order_line
-where
-    ol_delivery_d > '2007-01-02 00:00:00.000000'
-group by
-    ol_number
-order by
-    ol_number;
+FROM order_line
+WHERE ol_delivery_d > '2007-01-02 00:00:00.000000'
+GROUP BY ol_number
+ORDER BY ol_number;

--- a/crates/test-framework/src/queries/chbench/q10.sql
+++ b/crates/test-framework/src/queries/chbench/q10.sql
@@ -1,18 +1,23 @@
-select
-    c_id, c_last, sum(ol_amount) as revenue, c_city, c_phone, n_name
-from
+SELECT
+    c_id,
+    c_last,
+    sum(ol_amount) AS revenue,
+    c_city,
+    c_phone,
+    n_name
+FROM
     customer, orders, order_line, nation
-where
+WHERE
     c_id = o_c_id
-    and c_w_id = o_w_id
-    and c_d_id = o_d_id
-    and ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_o_id = o_id
-    and o_entry_d >= '2007-01-02 00:00:00.000000'
-    and o_entry_d <= ol_delivery_d
-    and n_nationkey = ascii(substr(c_state,1,1)) - 65
-group by
+    AND c_w_id = o_w_id
+    AND c_d_id = o_d_id
+    AND ol_w_id = o_w_id
+    AND ol_d_id = o_d_id
+    AND ol_o_id = o_id
+    AND o_entry_d >= '2007-01-02 00:00:00.000000'
+    AND o_entry_d <= ol_delivery_d
+    AND n_nationkey = ascii(substr(c_state,1,1)) - 65
+GROUP BY
     c_id, c_last, c_city, c_phone, n_name
-order by
-    revenue desc;
+ORDER BY
+    revenue DESC;

--- a/crates/test-framework/src/queries/chbench/q11.sql
+++ b/crates/test-framework/src/queries/chbench/q11.sql
@@ -1,19 +1,19 @@
-select
-    s_i_id, sum(s_order_cnt) as ordercount
-from
+SELECT
+    s_i_id, sum(s_order_cnt) AS ordercount
+FROM
     stock, supplier, nation
-where
-    mod((s_w_id * s_i_id),10000) = s_suppkey
-    and s_nationkey = n_nationkey
-    and n_name = 'CHINA'
-group by
+WHERE
+    mod((s_w_id * s_i_id),10000) = su_suppkey
+    AND su_nationkey = n_nationkey
+    AND n_name = 'CHINA'
+GROUP BY
     s_i_id
-having
+HAVING
     sum(s_order_cnt) >
-    (select sum(s_order_cnt) * .005
-     from stock, supplier, nation
-     where mod((s_w_id * s_i_id),10000) = s_suppkey
-       and s_nationkey = n_nationkey
-       and n_name = 'CHINA')
-order by
-    ordercount desc;
+    (SELECT sum(s_order_cnt) * .005
+     FROM stock, supplier, nation
+     WHERE mod((s_w_id * s_i_id),10000) = su_suppkey
+       AND su_nationkey = n_nationkey
+       AND n_name = 'CHINA')
+ORDER BY
+    ordercount DESC;

--- a/crates/test-framework/src/queries/chbench/q12.sql
+++ b/crates/test-framework/src/queries/chbench/q12.sql
@@ -1,16 +1,16 @@
-select
+SELECT
     o_ol_cnt,
-    sum(case when o_carrier_id = 1 or o_carrier_id = 2 then 1 else 0 end) as high_line_count,
-    sum(case when o_carrier_id <> 1 and o_carrier_id <> 2 then 1 else 0 end) as low_line_count
-from
+    sum(CASE WHEN o_carrier_id = 1 OR o_carrier_id = 2 THEN 1 ELSE 0 END) AS high_line_count,
+    sum(CASE WHEN o_carrier_id <> 1 AND o_carrier_id <> 2 THEN 1 ELSE 0 END) AS low_line_count
+FROM
     orders, order_line
-where
+WHERE
     ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_o_id = o_id
-    and o_entry_d <= ol_delivery_d
-    and ol_delivery_d < '2030-01-01 00:00:00.000000'
-group by
+    AND ol_d_id = o_d_id
+    AND ol_o_id = o_id
+    AND o_entry_d <= ol_delivery_d
+    AND ol_delivery_d < '2030-01-01 00:00:00.000000'
+GROUP BY
     o_ol_cnt
-order by
+ORDER BY
     o_ol_cnt;

--- a/crates/test-framework/src/queries/chbench/q13.sql
+++ b/crates/test-framework/src/queries/chbench/q13.sql
@@ -1,14 +1,14 @@
-select
-    c_count, count(*) as custdist
-from
-    (select c_id, count(o_id) as c_count
-     from customer left outer join orders on (
+SELECT
+    c_count, count(*) AS custdist
+FROM
+    (SELECT c_id, count(o_id) AS c_count
+     FROM customer LEFT OUTER JOIN orders ON (
          c_w_id = o_w_id
-         and c_d_id = o_d_id
-         and c_id = o_c_id
-         and o_carrier_id > 8)
-     group by c_id) as c_orders
-group by
+         AND c_d_id = o_d_id
+         AND c_id = o_c_id
+         AND o_carrier_id > 8)
+     GROUP BY c_id) AS c_orders
+GROUP BY
     c_count
-order by
-    custdist desc, c_count desc;
+ORDER BY
+    custdist DESC, c_count DESC;

--- a/crates/test-framework/src/queries/chbench/q14.sql
+++ b/crates/test-framework/src/queries/chbench/q14.sql
@@ -1,8 +1,8 @@
-select
-    100.00 * sum(case when i_data like 'PR%' then ol_amount else 0 end) / (1+sum(ol_amount)) as promo_revenue
-from
+SELECT
+    100.00 * sum(CASE WHEN i_data LIKE 'PR%' THEN ol_amount ELSE 0 END) / (1+sum(ol_amount)) AS promo_revenue
+FROM
     order_line, item
-where
+WHERE
     ol_i_id = i_id
-    and ol_delivery_d >= '2007-01-02 00:00:00.000000'
-    and ol_delivery_d < '2030-01-02 00:00:00.000000';
+    AND ol_delivery_d >= '2007-01-02 00:00:00.000000'
+    AND ol_delivery_d < '2030-01-02 00:00:00.000000';

--- a/crates/test-framework/src/queries/chbench/q15.sql
+++ b/crates/test-framework/src/queries/chbench/q15.sql
@@ -1,0 +1,22 @@
+WITH revenue0 (supplier_no, total_revenue) AS (
+    SELECT
+        mod((s_w_id * s_i_id), 10000) AS supplier_no,
+        sum(ol_amount) AS total_revenue
+    FROM
+        order_line, stock
+    WHERE
+        ol_i_id = s_i_id
+        AND ol_supply_w_id = s_w_id
+        AND ol_delivery_d >= '2007-01-02 00:00:00.000000'
+    GROUP BY
+        supplier_no
+)
+SELECT
+    su_suppkey, su_name, su_address, su_phone, total_revenue
+FROM
+    supplier, revenue0
+WHERE
+    su_suppkey = supplier_no
+    AND total_revenue = (SELECT max(total_revenue) FROM revenue0)
+ORDER BY
+    su_suppkey;

--- a/crates/test-framework/src/queries/chbench/q16.sql
+++ b/crates/test-framework/src/queries/chbench/q16.sql
@@ -1,18 +1,18 @@
-select
+SELECT
     i_name,
-    substr(i_data, 1, 3) as brand,
+    substr(i_data, 1, 3) AS brand,
     i_price,
-    count(distinct (mod((s_w_id * s_i_id),10000))) as supplier_cnt
-from
+    count(DISTINCT (mod((s_w_id * s_i_id),10000))) AS supplier_cnt
+FROM
     stock, item
-where
+WHERE
     i_id = s_i_id
-    and i_data not like 'zz%'
-    and (mod((s_w_id * s_i_id),10000) not in
-         (select s_suppkey
-          from supplier
-          where s_comment like '%bad%'))
-group by
+    AND i_data NOT LIKE 'zz%'
+    AND (mod((s_w_id * s_i_id),10000) NOT IN
+         (SELECT su_suppkey
+          FROM supplier
+          WHERE su_comment LIKE '%bad%'))
+GROUP BY
     i_name, substr(i_data, 1, 3), i_price
-order by
-    supplier_cnt desc;
+ORDER BY
+    supplier_cnt DESC;

--- a/crates/test-framework/src/queries/chbench/q17.sql
+++ b/crates/test-framework/src/queries/chbench/q17.sql
@@ -1,12 +1,12 @@
-select
-    sum(ol_amount) / 2.0 as avg_yearly
-from
+SELECT
+    sum(ol_amount) / 2.0 AS avg_yearly
+FROM
     order_line,
-    (select   i_id, avg(ol_quantity) as a
-     from     item, order_line
-     where    i_data like '%b'
-       and ol_i_id = i_id
-     group by i_id) t
-where
+    (SELECT   i_id, avg(ol_quantity) AS a
+     FROM     item, order_line
+     WHERE    i_data LIKE '%b'
+       AND ol_i_id = i_id
+     GROUP BY i_id) t
+WHERE
     ol_i_id = t.i_id
-    and ol_quantity < t.a;
+    AND ol_quantity < t.a;

--- a/crates/test-framework/src/queries/chbench/q18.sql
+++ b/crates/test-framework/src/queries/chbench/q18.sql
@@ -1,17 +1,22 @@
-select
-    c_last, c_id, o_id, o_entry_d, o_ol_cnt, sum(ol_amount)
-from
+SELECT
+    c_last,
+    c_id,
+    o_id,
+    o_entry_d,
+    o_ol_cnt,
+    sum(ol_amount) AS amount_sum
+FROM
     customer, orders, order_line
-where
+WHERE
     c_id = o_c_id
-    and c_w_id = o_w_id
-    and c_d_id = o_d_id
-    and ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_o_id = o_id
-group by
+    AND c_w_id = o_w_id
+    AND c_d_id = o_d_id
+    AND ol_w_id = o_w_id
+    AND ol_d_id = o_d_id
+    AND ol_o_id = o_id
+GROUP BY
     o_id, o_w_id, o_d_id, c_id, c_last, o_entry_d, o_ol_cnt
-having
+HAVING
     sum(ol_amount) > 200
-order by
-    sum(ol_amount) desc, o_entry_d;
+ORDER BY
+    amount_sum DESC, o_entry_d;

--- a/crates/test-framework/src/queries/chbench/q19.sql
+++ b/crates/test-framework/src/queries/chbench/q19.sql
@@ -1,27 +1,28 @@
-select
-    sum(ol_amount) as revenue
-from
-    order_line, item
-where
+SELECT
+    sum(ol_amount) AS revenue
+FROM
+    order_line,
+    item
+WHERE
     (
         ol_i_id = i_id
-        and i_data like '%a'
-        and ol_quantity >= 1
-        and ol_quantity <= 10
-        and i_price between 1 and 400000
-        and ol_w_id in (1,2,3)
-    ) or (
+        AND i_data LIKE '%a'
+        AND ol_quantity >= 1
+        AND ol_quantity <= 10
+        AND i_price BETWEEN 1 AND 400000
+        AND ol_w_id IN (1,2,3)
+    ) OR (
         ol_i_id = i_id
-        and i_data like '%b'
-        and ol_quantity >= 1
-        and ol_quantity <= 10
-        and i_price between 1 and 400000
-        and ol_w_id in (1,2,4)
-    ) or (
+        AND i_data LIKE '%b'
+        AND ol_quantity >= 1
+        AND ol_quantity <= 10
+        AND i_price BETWEEN 1 AND 400000
+        AND ol_w_id IN (1,2,4)
+    ) OR (
         ol_i_id = i_id
-        and i_data like '%c'
-        and ol_quantity >= 1
-        and ol_quantity <= 10
-        and i_price between 1 and 400000
-        and ol_w_id in (1,5,3)
+        AND i_data LIKE '%c'
+        AND ol_quantity >= 1
+        AND ol_quantity <= 10
+        AND i_price BETWEEN 1 AND 400000
+        AND ol_w_id IN (1,5,3)
     );

--- a/crates/test-framework/src/queries/chbench/q2.sql
+++ b/crates/test-framework/src/queries/chbench/q2.sql
@@ -1,23 +1,40 @@
-select
-    s_suppkey, s_name, n_name, i_id, i_name, s_address, s_phone, s_comment
-from
-    item, supplier, stock, nation, region,
-    (select s_i_id as m_i_id,
-            min(s_quantity) as m_s_quantity
-     from   stock, supplier, nation, region
-     where  mod((s_w_id*s_i_id),10000)=s_suppkey
-       and s_nationkey=n_nationkey
-       and n_regionkey=r_regionkey
-       and r_name like 'EUROP%'
-     group by s_i_id) m
-where
-    i_id = s_i_id
-    and mod((s_w_id * s_i_id), 10000) = s_suppkey
-    and s_nationkey = n_nationkey
-    and n_regionkey = r_regionkey
-    and i_data like '%b'
-    and r_name like 'EUROP%'
-    and i_id=m_i_id
-    and s_quantity = m_s_quantity
-order by
-    n_name, s_name, i_id;
+SELECT
+    su_suppkey,
+    su_name,
+    n_name,
+    i_id,
+    i_name,
+    su_address,
+    su_phone,
+    su_comment
+FROM
+    item,
+    supplier,
+    stock,
+    nation,
+    region,
+    (SELECT
+         s_i_id AS m_i_id,
+         min(s_quantity) as m_s_quantity
+     FROM
+         stock,
+         supplier,
+         nation,
+         region
+     WHERE mod((s_w_id*s_i_id),10000)=su_suppkey
+       AND su_nationkey=n_nationkey
+       AND n_regionkey=r_regionkey
+       AND r_name LIKE 'EUROP%'
+     GROUP BY s_i_id) m
+WHERE i_id = s_i_id
+  AND mod((s_w_id * s_i_id), 10000) = su_suppkey
+  AND su_nationkey = n_nationkey
+  AND n_regionkey = r_regionkey
+  AND i_data LIKE '%b'
+  AND r_name LIKE 'EUROP%'
+  AND i_id = m_i_id
+  AND s_quantity = m_s_quantity
+ORDER BY
+    n_name,
+    su_name,
+    i_id;

--- a/crates/test-framework/src/queries/chbench/q20.sql
+++ b/crates/test-framework/src/queries/chbench/q20.sql
@@ -1,20 +1,20 @@
-select
-    s_name, s_address
-from
-    supplier, nation
-where
-    s_suppkey in
-    (select  mod(s_i_id * s_w_id, 10000)
-     from     stock, order_line
-     where    s_i_id in
-              (select i_id
-               from item
-               where i_data like 'co%')
-       and ol_i_id=s_i_id
-       and ol_delivery_d > '2010-05-23 12:00:00'
-     group by s_i_id, s_w_id, s_quantity
-     having   2*s_quantity > sum(ol_quantity))
-    and s_nationkey = n_nationkey
-    and n_name = 'CHINA'
-order by
-    s_name;
+SELECT
+    su_name,
+    su_address
+FROM
+    supplier,
+    nation
+WHERE
+    su_suppkey IN
+    (SELECT mod(s_i_id * s_w_id, 10000)
+     FROM stock
+     INNER JOIN item ON i_id = s_i_id
+     INNER JOIN order_line ON ol_i_id = s_i_id
+     WHERE ol_delivery_d > '2010-05-23 12:00:00'
+       AND i_data LIKE 'co%'
+     GROUP BY s_i_id, s_w_id, s_quantity
+     HAVING 2*s_quantity > sum(ol_quantity))
+    AND su_nationkey = n_nationkey
+    AND n_name = 'CHINA'
+ORDER BY
+    su_name;

--- a/crates/test-framework/src/queries/chbench/q21.sql
+++ b/crates/test-framework/src/queries/chbench/q21.sql
@@ -1,24 +1,28 @@
-select
-    s_name, count(*) as numwait
-from
-    supplier, order_line l1, orders, stock, nation
-where
+SELECT
+    su_name, count(*) AS numwait
+FROM
+    supplier,
+    order_line l1,
+    orders,
+    stock,
+    nation
+WHERE
     ol_o_id = o_id
-    and ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_w_id = s_w_id
-    and ol_i_id = s_i_id
-    and mod((s_w_id * s_i_id),10000) = s_suppkey
-    and l1.ol_delivery_d > o_entry_d
-    and not exists (select *
-                    from order_line l2
-                    where l2.ol_o_id = l1.ol_o_id
-                      and l2.ol_w_id = l1.ol_w_id
-                      and l2.ol_d_id = l1.ol_d_id
-                      and l2.ol_delivery_d > l1.ol_delivery_d)
-    and s_nationkey = n_nationkey
-    and n_name = 'CHINA'
-group by
-    s_name
-order by
-    numwait desc, s_name;
+    AND ol_w_id = o_w_id
+    AND ol_d_id = o_d_id
+    AND ol_w_id = s_w_id
+    AND ol_i_id = s_i_id
+    AND mod((s_w_id * s_i_id),10000) = su_suppkey
+    AND l1.ol_delivery_d > o_entry_d
+    AND NOT EXISTS (SELECT *
+                    FROM order_line l2
+                    WHERE l2.ol_o_id = l1.ol_o_id
+                      AND l2.ol_w_id = l1.ol_w_id
+                      AND l2.ol_d_id = l1.ol_d_id
+                      AND l2.ol_delivery_d > l1.ol_delivery_d)
+    AND su_nationkey = n_nationkey
+    AND n_name = 'CHINA'
+GROUP BY
+    su_name
+ORDER BY
+    numwait DESC, su_name;

--- a/crates/test-framework/src/queries/chbench/q22.sql
+++ b/crates/test-framework/src/queries/chbench/q22.sql
@@ -1,19 +1,19 @@
-select
-    substr(c_state,1,1) as country,
-    count(*) as numcust,
-    sum(c_balance) as totacctbal
-from
+SELECT
+    substr(c_state,1,1) AS country,
+    count(*) AS numcust,
+    sum(c_balance) AS totacctbal
+FROM
     customer
-where
-    substr(c_phone,1,1) in ('1','2','3','4','5','6','7')
-    and c_balance > (select avg(c_balance) from customer
-                     where c_balance > 0.00
-                       and substr(c_phone,1,1) in ('1','2','3','4','5','6','7'))
-    and not exists (select * from orders
-                    where o_c_id = c_id
-                      and o_w_id = c_w_id
-                      and o_d_id = c_d_id)
-group by
+WHERE
+    substr(c_phone,1,1) IN ('1','2','3','4','5','6','7')
+    AND c_balance > (SELECT avg(c_balance) FROM customer
+                     WHERE c_balance > 0.00
+                       AND substr(c_phone,1,1) IN ('1','2','3','4','5','6','7'))
+    AND NOT EXISTS (SELECT * FROM orders
+                    WHERE o_c_id = c_id
+                      AND o_w_id = c_w_id
+                      AND o_d_id = c_d_id)
+GROUP BY
     substr(c_state,1,1)
-order by
+ORDER BY
     country;

--- a/crates/test-framework/src/queries/chbench/q3.sql
+++ b/crates/test-framework/src/queries/chbench/q3.sql
@@ -1,21 +1,30 @@
-select
-    ol_o_id, ol_w_id, ol_d_id,
-    sum(ol_amount) as revenue, o_entry_d
-from
-    customer, new_order, orders, order_line
-where
-    c_state like 'A%'
-    and c_id = o_c_id
-    and c_w_id = o_w_id
-    and c_d_id = o_d_id
-    and no_w_id = o_w_id
-    and no_d_id = o_d_id
-    and no_o_id = o_id
-    and ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_o_id = o_id
-    and o_entry_d > '2007-01-02 00:00:00.000000'
-group by
-    ol_o_id, ol_w_id, ol_d_id, o_entry_d
-order by
-    revenue desc, o_entry_d;
+SELECT
+    ol_o_id,
+    ol_w_id,
+    ol_d_id,
+    sum(ol_amount) AS revenue,
+    o_entry_d
+FROM
+    customer,
+    new_order,
+    orders,
+    order_line
+WHERE c_state LIKE 'A%'
+  AND c_id = o_c_id
+  AND c_w_id = o_w_id
+  AND c_d_id = o_d_id
+  AND no_w_id = o_w_id
+  AND no_d_id = o_d_id
+  AND no_o_id = o_id
+  AND ol_w_id = o_w_id
+  AND ol_d_id = o_d_id
+  AND ol_o_id = o_id
+  AND o_entry_d > '2007-01-02 00:00:00.000000'
+GROUP BY
+    ol_o_id,
+    ol_w_id,
+    ol_d_id,
+    o_entry_d
+ORDER BY
+    revenue DESC,
+    o_entry_d;

--- a/crates/test-framework/src/queries/chbench/q4.sql
+++ b/crates/test-framework/src/queries/chbench/q4.sql
@@ -1,17 +1,13 @@
-select
-    o_ol_cnt, count(*) as order_count
-from
+SELECT
+    o_ol_cnt,
+    count(*) as order_count
+FROM
     orders
-where
-    o_entry_d >= '2007-01-02 00:00:00.000000'
-    and o_entry_d < '2032-01-02 00:00:00.000000'
-    and exists (select *
-                from order_line
-                where o_id = ol_o_id
-                  and o_w_id = ol_w_id
-                  and o_d_id = ol_d_id
-                  and ol_delivery_d >= o_entry_d)
-group by
-    o_ol_cnt
-order by
-    o_ol_cnt;
+WHERE exists (SELECT *
+              FROM order_line
+              WHERE o_id = ol_o_id
+                AND o_w_id = ol_w_id
+                AND o_d_id = ol_d_id
+                AND ol_delivery_d >= o_entry_d)
+GROUP BY o_ol_cnt
+ORDER BY o_ol_cnt;

--- a/crates/test-framework/src/queries/chbench/q5.sql
+++ b/crates/test-framework/src/queries/chbench/q5.sql
@@ -1,22 +1,28 @@
-select
+SELECT
     n_name,
-    sum(ol_amount) as revenue
-from
-    customer, orders, order_line, stock, supplier, nation, region
-where
+    sum(ol_amount) AS revenue
+FROM
+    customer, 
+    orders,
+    order_line,
+    stock,
+    supplier,
+    nation,
+    region
+WHERE
     c_id = o_c_id
-    and c_w_id = o_w_id
-    and c_d_id = o_d_id
-    and ol_o_id = o_id
-    and ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_w_id = s_w_id
-    and ol_i_id = s_i_id
-    and mod((s_w_id * s_i_id),10000) = s_suppkey
-    and ascii(substr(c_state,1,1)) - 65 = s_nationkey
-    and s_nationkey = n_nationkey
-    and n_regionkey = r_regionkey
-    and r_name = 'EUROPE'
-    and o_entry_d >= '2007-01-02 00:00:00.000000'
-group by
-    n_name;
+    AND c_w_id = o_w_id
+    AND c_d_id = o_d_id
+    AND ol_o_id = o_id
+    AND ol_w_id = o_w_id
+    AND ol_d_id = o_d_id
+    AND ol_w_id = s_w_id
+    AND ol_i_id = s_i_id
+    AND mod((s_w_id * s_i_id),10000) = su_suppkey
+    AND ascii(substr(c_state,1,1)) - 65 = su_nationkey
+    AND su_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'EUROPE'
+    AND o_entry_d >= '2007-01-02 00:00:00.000000'
+GROUP BY n_name
+ORDER BY revenue DESC;

--- a/crates/test-framework/src/queries/chbench/q6.sql
+++ b/crates/test-framework/src/queries/chbench/q6.sql
@@ -1,8 +1,8 @@
-select
-    sum(ol_amount) as revenue
-from
+SELECT
+    sum(ol_amount) AS revenue
+FROM
     order_line
-where
+WHERE
     ol_delivery_d >= '1997-01-01 00:00:00'
-    and ol_delivery_d < '2030-01-01 00:00:00'
-    and ol_quantity between 1 and 100000;
+    AND ol_delivery_d < '2030-01-01 00:00:00'
+    AND ol_quantity BETWEEN 1 AND 100000;

--- a/crates/test-framework/src/queries/chbench/q7.sql
+++ b/crates/test-framework/src/queries/chbench/q7.sql
@@ -1,29 +1,28 @@
-select
-    s_nationkey as supp_nation,
-    substr(c_state,1,1) as cust_nation,
-    extract(year from o_entry_d) as l_year,
-    sum(ol_amount) as revenue
-from
+SELECT
+    su_nationkey AS supp_nation,
+    substr(c_state,1,1) AS cust_nation,
+    extract(year FROM o_entry_d) AS l_year,
+    sum(ol_amount) AS revenue
+FROM
     supplier, stock, order_line, orders, customer, nation n1, nation n2
-where
+WHERE
     ol_supply_w_id = s_w_id
-    and ol_i_id = s_i_id
-    and mod((s_w_id * s_i_id), 10000) = s_suppkey
-    and ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_o_id = o_id
-    and c_id = o_c_id
-    and c_w_id = o_w_id
-    and c_d_id = o_d_id
-    and s_nationkey = n1.n_nationkey
-    and ascii(substr(c_state,1,1)) - 65 = n2.n_nationkey
-    and (
-        (n1.n_name = 'JAPAN' and n2.n_name = 'CHINA')
-        or
-        (n1.n_name = 'CHINA' and n2.n_name = 'JAPAN')
+    AND ol_i_id = s_i_id
+    AND mod((s_w_id * s_i_id), 10000) = su_suppkey
+    AND ol_w_id = o_w_id
+    AND ol_d_id = o_d_id
+    AND ol_o_id = o_id
+    AND c_id = o_c_id
+    AND c_w_id = o_w_id
+    AND c_d_id = o_d_id
+    AND su_nationkey = n1.n_nationkey
+    AND ascii(substr(c_state,1,1)) - 65 = n2.n_nationkey
+    AND (
+        (n1.n_name = 'JAPAN' AND n2.n_name = 'CHINA')
+        OR
+        (n1.n_name = 'CHINA' AND n2.n_name = 'JAPAN')
     )
-    and ol_delivery_d between '2007-01-02 00:00:00.000000' and '2032-01-02 00:00:00.000000'
-group by
-    s_nationkey, substr(c_state,1,1), extract(year from o_entry_d)
-order by
-    s_nationkey, cust_nation, l_year;
+GROUP BY
+    su_nationkey, cust_nation, l_year
+ORDER BY
+    su_nationkey, cust_nation, l_year;

--- a/crates/test-framework/src/queries/chbench/q8.sql
+++ b/crates/test-framework/src/queries/chbench/q8.sql
@@ -1,27 +1,27 @@
-select
-    extract(year from o_entry_d) as l_year,
-    sum(case when n2.n_name = 'INDIA' then ol_amount else 0 end) / sum(ol_amount) as mkt_share
-from
+SELECT
+    extract(year FROM o_entry_d) AS l_year,
+    sum(CASE WHEN n2.n_name = 'INDIA' THEN ol_amount ELSE 0 END) / sum(ol_amount) AS mkt_share
+FROM
     item, supplier, stock, order_line, orders, customer, nation n1, nation n2, region
-where
+WHERE
     i_id = s_i_id
-    and ol_i_id = s_i_id
-    and ol_supply_w_id = s_w_id
-    and mod((s_w_id * s_i_id),10000) = s_suppkey
-    and ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_o_id = o_id
-    and c_id = o_c_id
-    and c_w_id = o_w_id
-    and c_d_id = o_d_id
-    and n1.n_nationkey = ascii(substr(c_state,1,1)) - 65
-    and n1.n_regionkey = r_regionkey
-    and ol_i_id < 1000
-    and r_name = 'ASIA'
-    and s_nationkey = n2.n_nationkey
-    and o_entry_d between '2007-01-02 00:00:00.000000' and '2032-01-02 00:00:00.000000'
-    and i_id = ol_i_id
-group by
-    extract(year from o_entry_d)
-order by
+    AND ol_i_id = s_i_id
+    AND ol_supply_w_id = s_w_id
+    AND mod((s_w_id * s_i_id),10000) = su_suppkey
+    AND ol_w_id = o_w_id
+    AND ol_d_id = o_d_id
+    AND ol_o_id = o_id
+    AND c_id = o_c_id
+    AND c_w_id = o_w_id
+    AND c_d_id = o_d_id
+    AND n1.n_nationkey = ascii(substr(c_state,1,1)) - 65
+    AND n1.n_regionkey = r_regionkey
+    AND ol_i_id < 1000
+    AND r_name = 'ASIA'
+    AND su_nationkey = n2.n_nationkey
+    AND i_data LIKE '%b'
+    AND i_id = ol_i_id
+GROUP BY
+    l_year
+ORDER BY
     l_year;

--- a/crates/test-framework/src/queries/chbench/q9.sql
+++ b/crates/test-framework/src/queries/chbench/q9.sql
@@ -1,18 +1,19 @@
-select
-    n_name, extract(year from o_entry_d) as l_year, sum(ol_amount) as sum_profit
-from
+SELECT
+    n_name, extract(year FROM o_entry_d) AS l_year,
+    sum(ol_amount) AS sum_profit
+FROM
     item, stock, supplier, order_line, orders, nation
-where
+WHERE
     ol_i_id = s_i_id
-    and ol_supply_w_id = s_w_id
-    and mod((s_w_id * s_i_id), 10000) = s_suppkey
-    and ol_w_id = o_w_id
-    and ol_d_id = o_d_id
-    and ol_o_id = o_id
-    and ol_i_id = i_id
-    and s_nationkey = n_nationkey
-    and i_data like '%BB'
-group by
-    n_name, extract(year from o_entry_d)
-order by
-    n_name, l_year desc;
+    AND ol_supply_w_id = s_w_id
+    AND mod((s_w_id * s_i_id), 10000) = su_suppkey
+    AND ol_w_id = o_w_id
+    AND ol_d_id = o_d_id
+    AND ol_o_id = o_id
+    AND ol_i_id = i_id
+    AND su_nationkey = n_nationkey
+    AND i_data LIKE '%BB'
+GROUP BY
+    n_name, l_year
+ORDER BY
+    n_name, l_year DESC;

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -596,6 +596,7 @@ impl QuerySet {
                     "chbench_q12",
                     "chbench_q13",
                     "chbench_q14",
+                    "chbench_q15",
                     "chbench_q16",
                     "chbench_q17",
                     "chbench_q18",
@@ -1215,9 +1216,8 @@ pub fn get_clickbench_test_queries(overrides: Option<QueryOverrides>) -> Vec<Que
 #[must_use]
 pub fn get_chbench_test_queries(overrides: Option<QueryOverrides>) -> Vec<Query> {
     let queries = generate_chbench_queries!(
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 22
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22
     );
-    // q15 excluded: requires a `revenue1` view
 
     match overrides {
         // No engine-specific overrides yet

--- a/test/spicepods/chbench/sf1/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-arrow.yaml
@@ -130,6 +130,6 @@ datasets:
       pg_replication_slot: spice_supplier
     acceleration:
       <<: *arrow_accel
-      primary_key: s_suppkey
+      primary_key: su_suppkey
       on_conflict:
-        s_suppkey: upsert
+        su_suppkey: upsert

--- a/test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
@@ -168,9 +168,9 @@ datasets:
       pg_replication_slot: spice_supplier
     acceleration:
       <<: *cayenne_accel
-      primary_key: s_suppkey
+      primary_key: su_suppkey
       on_conflict:
-        s_suppkey: upsert
+        su_suppkey: upsert
       params:
         cayenne_write_concurrency: "4"
         cayenne_upload_concurrency: "4"

--- a/test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-cayenne[file].yaml
@@ -131,6 +131,6 @@ datasets:
       pg_replication_slot: spice_supplier
     acceleration:
       <<: *cayenne_accel
-      primary_key: s_suppkey
+      primary_key: su_suppkey
       on_conflict:
-        s_suppkey: upsert
+        su_suppkey: upsert

--- a/test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/sf1/accelerated/postgres-duckdb[file].yaml
@@ -131,6 +131,6 @@ datasets:
       pg_replication_slot: spice_supplier
     acceleration:
       <<: *duckdb_accel
-      primary_key: s_suppkey
+      primary_key: su_suppkey
       on_conflict:
-        s_suppkey: upsert
+        su_suppkey: upsert

--- a/tools/chbench-driver/src/loader.rs
+++ b/tools/chbench-driver/src/loader.rs
@@ -590,7 +590,7 @@ async fn load_supplier(client: &Client, rng: &mut impl Rng) -> Result<()> {
     const SUPPLIER_COUNT: i64 = 10_000;
     println!("  loading supplier ({SUPPLIER_COUNT} rows)");
     let mut sink = BatchSink::new(
-        "INSERT INTO supplier (s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment) VALUES",
+        "INSERT INTO supplier (su_suppkey, su_name, su_address, su_nationkey, su_phone, su_acctbal, su_comment) VALUES",
     );
     let mut row = String::new();
 

--- a/tools/chbench-driver/src/schema.rs
+++ b/tools/chbench-driver/src/schema.rs
@@ -286,14 +286,14 @@ pub async fn create_tables(client: &Client) -> Result<()> {
         (
             "supplier",
             "CREATE TABLE IF NOT EXISTS supplier (
-                s_suppkey BIGINT NOT NULL,
-                s_name CHAR(25) NOT NULL,
-                s_address VARCHAR(40) NOT NULL,
-                s_nationkey BIGINT NOT NULL,
-                s_phone CHAR(15) NOT NULL,
-                s_acctbal DOUBLE PRECISION NOT NULL,
-                s_comment VARCHAR(101) NOT NULL,
-                PRIMARY KEY (s_suppkey)
+                su_suppkey BIGINT NOT NULL,
+                su_name CHAR(25) NOT NULL,
+                su_address VARCHAR(40) NOT NULL,
+                su_nationkey BIGINT NOT NULL,
+                su_phone CHAR(15) NOT NULL,
+                su_acctbal DOUBLE PRECISION NOT NULL,
+                su_comment VARCHAR(101) NOT NULL,
+                PRIMARY KEY (su_suppkey)
             )",
         ),
     ];


### PR DESCRIPTION
## 📝 Summary

Aligns Spice CH-benCH query files with the canonical BenchBase (cmu-db/benchbase) and Oracle HeatWave implementations:

- Rename supplier columns from `s_*` to `su_*` across all queries, spicepod configs, schema DDL, and loader
- Remove no-op date filters from Q4 (`o_entry_d`) and Q7 (`ol_delivery_d`) that aren't in BenchBase/HeatWave
- Restructure Q20 subquery to use `INNER JOIN` matching BenchBase/HeatWave style
- Use column aliases in Q7 `GROUP BY` instead of repeating expressions
- Uppercase all SQL keywords for consistency
- Update chbench spicepod configs: `primary_key` and `on_conflict` use `su_suppkey`
- Update chbench-driver `schema.rs` and `loader.rs` to generate `su_*` supplier columns


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->