### PR TITLE
Revert "fix(tests): stabilize flaky SQL search snapshots with score normalization (#10585)

### DIFF
--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -79,7 +79,7 @@ pub struct SearchTestCase {
     pub body: SearchTestType,
     pub should_fail: bool,
     pub skip: bool,
-    /// When true, score ordering uses rounding before tie-breaking.
+    /// When true, displayed scores use rounding instead of truncation.
     /// Use for tests with non-deterministic embeddings (e.g. model2vec/s3vectors)
     /// where raw scores can vary ±0.002 across CI runners.
     pub round_scores: bool,
@@ -281,14 +281,19 @@ async fn assert_search_result_primary_key_matches(
 fn assert_search_response_snapshot(test_name: &str, resp: Value, round_scores: bool) {
     match test_name {
         "multi_embedding_parent_child_basic" | "multi_embedding_parent_child_additional" => {
-            assert_search_response_scores_descending(test_name, &resp);
             insta::assert_json_snapshot!(
                 format!("{test_name}_response"),
                 normalize_search_response_json(resp, true, round_scores)
             );
         }
+        // S3 Vectors HTTP search results are non-deterministic: the backend may return
+        // different items with the same rounded score across runs, or scores can drift
+        // across a two-decimal rounding boundary. Use structural validation instead of
+        // exact snapshot comparison for these tests.
+        name if use_structural_search_response_validation(name) => {
+            assert_search_response_structure(name, resp, round_scores);
+        }
         _ => {
-            assert_search_response_scores_descending(test_name, &resp);
             insta::assert_snapshot!(
                 format!("{test_name}_response"),
                 normalize_search_response(resp, round_scores)
@@ -297,428 +302,127 @@ fn assert_search_response_snapshot(test_name: &str, resp: Value, round_scores: b
     }
 }
 
-fn assert_search_response_scores_descending(test_name: &str, resp: &Value) {
-    let results = resp
+fn use_structural_search_response_validation(test_name: &str) -> bool {
+    let is_s3_vectors_composite =
+        test_name.starts_with("s3vectors_composite") && !test_name.contains("with_where");
+    let is_s3_vectors_chunking = test_name.starts_with("s3vectors_chunking");
+
+    (is_s3_vectors_composite || is_s3_vectors_chunking) && !test_name.contains("vector_search_sql")
+}
+
+/// Validate the structure and invariants of a search response without asserting exact item content.
+/// Used for S3 Vectors HTTP search tests where the result set is non-deterministic.
+fn assert_search_response_structure(test_name: &str, resp: Value, round_scores: bool) {
+    let normalized = normalize_search_response_json(resp, true, round_scores);
+
+    let results = normalized
         .get("results")
-        .and_then(Value::as_array)
+        .and_then(|r| r.as_array())
         .unwrap_or_else(|| panic!("{test_name}: response should have a 'results' array"));
 
-    let mut previous_score = f64::MAX;
-    for (index, result) in results.iter().enumerate() {
-        let score = result
-            .get("_score")
-            .and_then(Value::as_f64)
-            .unwrap_or_else(|| panic!("{test_name}: result[{index}] missing numeric '_score'"));
+    assert_eq!(
+        results.len(),
+        4,
+        "{test_name}: expected 4 results, got {}",
+        results.len()
+    );
 
+    let expected_dataset = if test_name.contains("_view") {
+        "qs_view"
+    } else {
+        "qs"
+    };
+
+    let mut prev_score = f64::MAX;
+    for (i, result) in results.iter().enumerate() {
+        // Verify required fields exist
         assert!(
-            !score.is_nan(),
-            "{test_name}: result[{index}] score should not be NaN"
+            result.get("_score").is_some(),
+            "{test_name}: result[{i}] missing '_score'"
         );
         assert!(
-            score.is_finite() && score >= 0.0,
-            "{test_name}: result[{index}] score {score} should be finite and non-negative"
+            result.get("matches").is_some(),
+            "{test_name}: result[{i}] missing 'matches'"
         );
         assert!(
-            score <= previous_score,
-            "{test_name}: result[{index}] score {score} > previous {previous_score} (not descending)"
+            result.get("primary_key").is_some(),
+            "{test_name}: result[{i}] missing 'primary_key'"
         );
-        previous_score = score;
+
+        // Verify dataset name
+        let dataset = result.get("dataset").and_then(|d| d.as_str()).unwrap_or("");
+        assert_eq!(
+            dataset, expected_dataset,
+            "{test_name}: result[{i}] dataset should be '{expected_dataset}', got '{dataset}'"
+        );
+
+        // Verify scores are in descending order and within [0, 1]
+        let score: f64 = result
+            .get("_score")
+            .and_then(|s| s.as_str())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(-1.0);
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "{test_name}: result[{i}] score {score} not in [0, 1]"
+        );
+        assert!(
+            score <= prev_score,
+            "{test_name}: result[{i}] score {score} > previous {prev_score} (not descending)"
+        );
+        prev_score = score;
+
+        // Verify matches contain the 'answer' field
+        let matches = result.get("matches").and_then(|m| m.as_object());
+        assert!(
+            matches.is_some_and(|m| m.contains_key("answer")),
+            "{test_name}: result[{i}] matches should contain 'answer'"
+        );
+
+        // For additional_columns tests, verify extra fields are returned.
+        if test_name.contains("additional_columns") {
+            let data = result.get("data").and_then(|d| d.as_object());
+            let primary_key = result.get("primary_key").and_then(|p| p.as_object());
+            assert!(
+                data.is_some_and(|d| !d.is_empty()) || primary_key.is_some_and(|p| p.len() > 1),
+                "{test_name}: result[{i}] data or primary_key should contain requested additional columns"
+            );
+        }
     }
 }
 
 #[test]
-fn sql_response_normalization_stabilizes_clustered_2dp_scores_across_drift() {
-    // Both inputs are observed in CI for the same query against
-    // `s3vectors_chunking_view_vector_search_sql_filters` — they differ because
-    // the raw embedding scores drift by ±0.01 across runs, crossing the
-    // server-side `trunc(_score, 2)` boundary.
-    let pattern_a = json!([
-        {"id": 938, "answer": "a-938", "_score": 0.34},
-        {"id": 1015, "answer": "a-1015", "_score": 0.31},
-        {"id": 1035, "answer": "a-1035", "_score": 0.30},
-        {"id": 551, "answer": "a-551", "_score": 0.29}
-    ]);
-    let pattern_b = json!([
-        {"id": 938, "answer": "a-938", "_score": 0.34},
-        {"id": 1015, "answer": "a-1015", "_score": 0.30},
-        {"id": 551, "answer": "a-551", "_score": 0.29},
-        {"id": 1035, "answer": "a-1035", "_score": 0.29}
-    ]);
-
-    let normalized_a = normalize_sql_response_for_snapshot(pattern_a, true);
-    let normalized_b = normalize_sql_response_for_snapshot(pattern_b, true);
-
-    assert_eq!(
-        normalized_a, normalized_b,
-        "different score-drift patterns should normalize to the same value"
-    );
-
-    let expected = json!([
-        {"id": 551, "answer": "a-551", "_score": "[score]"},
-        {"id": 938, "answer": "a-938", "_score": "[score]"},
-        {"id": 1015, "answer": "a-1015", "_score": "[score]"},
-        {"id": 1035, "answer": "a-1035", "_score": "[score]"}
-    ]);
-    assert_eq!(normalized_a, expected);
-}
-
-#[test]
-fn sql_response_normalization_redacts_well_separated_2dp_scores_without_reordering() {
-    // s3vectors_chunking_view_vector_search_sql_basic shape — scores span
-    // 0.24, well above the 0.06 cluster threshold. The ordering should be
-    // returned unchanged, but score values should still be redacted.
-    let input = json!([
-        {"id": 612, "answer": "a-612", "_score": 0.8},
-        {"id": 349, "answer": "a-349", "_score": 0.79},
-        {"id": 948, "answer": "a-948", "_score": 0.56},
-        {"id": 1277, "answer": "a-1277", "_score": 0.56}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot(input, true);
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 612, "answer": "a-612", "_score": "[score]"},
-            {"id": 349, "answer": "a-349", "_score": "[score]"},
-            {"id": 948, "answer": "a-948", "_score": "[score]"},
-            {"id": 1277, "answer": "a-1277", "_score": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_redacts_higher_than_2dp_precision_without_reordering() {
-    let input = json!([
-        {"id": 468, "_score": 0.540},
-        {"id": 189, "_score": 0.539},
-        {"id": 1277, "_score": 0.539},
-        {"id": 948, "_score": 0.528}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot(input, true);
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 468, "_score": "[score]"},
-            {"id": 189, "_score": "[score]"},
-            {"id": 1277, "_score": "[score]"},
-            {"id": 948, "_score": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_redacts_scores_when_round_scores_disabled() {
-    let input = json!([
-        {"id": 1, "_score": 0.34},
-        {"id": 2, "_score": 0.30}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot(input, false);
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 1, "_score": "[score]"},
-            {"id": 2, "_score": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_redacts_trunc_3_columns_without_reordering() {
-    // Regression: a `trunc(_score, 3)` snapshot whose values all happen to end
-    // in `0` (e.g. `0.540, 0.530, 0.520, 0.510`) is numerically indistinguishable
-    // from a 2dp response. The explicit precision in the column name must keep us
-    // from reordering it, but the score values are still redacted for snapshots.
-    let input = json!([
-        {"id": 1, "trunc(vector_search()._score,Int64(3))": 0.540},
-        {"id": 2, "trunc(vector_search()._score,Int64(3))": 0.530},
-        {"id": 3, "trunc(vector_search()._score,Int64(3))": 0.520},
-        {"id": 4, "trunc(vector_search()._score,Int64(3))": 0.510}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot(input, true);
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 1, "trunc(vector_search()._score,Int64(3))": "[score]"},
-            {"id": 2, "trunc(vector_search()._score,Int64(3))": "[score]"},
-            {"id": 3, "trunc(vector_search()._score,Int64(3))": "[score]"},
-            {"id": 4, "trunc(vector_search()._score,Int64(3))": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_preserves_aliased_trunc_3_order() {
-    let input = json!([
-        {"id": 4, "_score": 0.540},
-        {"id": 3, "_score": 0.530},
-        {"id": 2, "_score": 0.520},
-        {"id": 1, "_score": 0.510}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot_with_sql(
-        input,
-        true,
-        Some(
-            "SELECT id, trunc(_score, 3) AS _score FROM vector_search(qs, 'second') ORDER BY _score DESC",
-        ),
-    );
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 4, "_score": "[score]"},
-            {"id": 3, "_score": "[score]"},
-            {"id": 2, "_score": "[score]"},
-            {"id": 1, "_score": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_stabilizes_exact_score_ties() {
-    let input = json!([
-        {"id": 495, "trunc(text_search()._score,Int64(3))": 6.331},
-        {"id": 494, "trunc(text_search()._score,Int64(3))": 6.331},
-        {"id": 499, "trunc(text_search()._score,Int64(3))": 6.192}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot_with_sql(
-        input,
-        false,
-        Some(
-            "SELECT id, trunc(_score, 3) FROM text_search(qs, 'angles', question) ORDER BY _score DESC",
-        ),
-    );
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 494, "trunc(text_search()._score,Int64(3))": "[score]"},
-            {"id": 495, "trunc(text_search()._score,Int64(3))": "[score]"},
-            {"id": 499, "trunc(text_search()._score,Int64(3))": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_respects_id_desc_tie_breaker() {
-    let input = json!([
-        {"id": 2, "_score": 0.34},
-        {"id": 4, "_score": 0.31},
-        {"id": 1, "_score": 0.30},
-        {"id": 3, "_score": 0.29}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot_with_sql(
-        input,
-        true,
-        Some(
-            "SELECT id, trunc(_score, 2) AS _score FROM vector_search(qs, 'second') ORDER BY _score DESC, id DESC",
-        ),
-    );
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 4, "_score": "[score]"},
-            {"id": 3, "_score": "[score]"},
-            {"id": 2, "_score": "[score]"},
-            {"id": 1, "_score": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_does_not_reorder_non_score_primary_ordering() {
-    let input = json!([
-        {"id": 2, "package_weight_kg": 4, "_score": 0.34},
-        {"id": 4, "package_weight_kg": 3, "_score": 0.31},
-        {"id": 1, "package_weight_kg": 2, "_score": 0.30},
-        {"id": 3, "package_weight_kg": 1, "_score": 0.29}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot_with_sql(
-        input,
-        true,
-        Some(
-            "SELECT id, package_weight_kg, trunc(_score, 2) AS _score FROM vector_search(qs, 'second') ORDER BY package_weight_kg DESC, _score DESC",
-        ),
-    );
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 2, "package_weight_kg": 4, "_score": "[score]"},
-            {"id": 4, "package_weight_kg": 3, "_score": "[score]"},
-            {"id": 1, "package_weight_kg": 2, "_score": "[score]"},
-            {"id": 3, "package_weight_kg": 1, "_score": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_redacts_round_score_columns() {
-    let input = json!([
-        {"id": 1, "round(vector_search().score,Int64(1))": 0.5},
-        {"id": 2, "round(vector_search().score,Int64(1))": 0.4}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot(input, true);
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 1, "round(vector_search().score,Int64(1))": "[score]"},
-            {"id": 2, "round(vector_search().score,Int64(1))": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_response_normalization_picks_primary_score_key_deterministically() {
-    // When a row carries multiple score-like columns (constructed manually here
-    // for the test), the function should always pick `_score` first regardless
-    // of JSON insertion order.
-    let input_a = json!([
-        {"id": 1, "_score": 0.34, "_fused_score": 0.34},
-        {"id": 2, "_score": 0.30, "_fused_score": 0.30},
-        {"id": 3, "_score": 0.29, "_fused_score": 0.29},
-        {"id": 4, "_score": 0.29, "_fused_score": 0.29}
-    ]);
-    let input_b = json!([
-        {"id": 1, "_fused_score": 0.34, "_score": 0.34},
-        {"id": 2, "_fused_score": 0.30, "_score": 0.30},
-        {"id": 3, "_fused_score": 0.29, "_score": 0.29},
-        {"id": 4, "_fused_score": 0.29, "_score": 0.29}
-    ]);
-    let a = normalize_sql_response_for_snapshot(input_a, true);
-    let b = normalize_sql_response_for_snapshot(input_b, true);
-
-    // Both should normalize identically; the field order inside each row will
-    // follow the original insertion order of that input, but the SET of fields
-    // and their values must match.
-    let extract_values = |v: &Value| -> Vec<(i64, String, String)> {
-        v.as_array()
-            .expect("normalized SQL response should be an array")
-            .iter()
-            .map(|row| {
-                let id = row
-                    .get("id")
-                    .and_then(Value::as_i64)
-                    .expect("normalized row should contain integer id");
-                let s = row
-                    .get("_score")
-                    .and_then(|x| x.as_str())
-                    .expect("normalized row should contain redacted _score")
-                    .to_string();
-                let f = row
-                    .get("_fused_score")
-                    .and_then(|x| x.as_str())
-                    .expect("normalized row should contain redacted _fused_score")
-                    .to_string();
-                (id, s, f)
-            })
-            .collect()
-    };
-    assert_eq!(extract_values(&a), extract_values(&b));
-}
-
-#[test]
-fn parse_trunc_precision_handles_int64_form() {
-    assert_eq!(parse_trunc_precision("trunc(x,Int64(2))"), Some(2));
-    assert_eq!(parse_trunc_precision("trunc(x,Int64(3))"), Some(3));
-    assert_eq!(
-        parse_trunc_precision("trunc(vector_search(qs, Utf8(\"a\"), col)._score,Int64(2))"),
-        Some(2)
-    );
-}
-
-#[test]
-fn parse_trunc_precision_handles_bare_integer_form() {
-    assert_eq!(parse_trunc_precision("trunc(x,2)"), Some(2));
-    assert_eq!(parse_trunc_precision("trunc(x, 3)"), Some(3));
-}
-
-#[test]
-fn parse_trunc_precision_returns_none_for_non_trunc_columns() {
-    assert_eq!(parse_trunc_precision("_score"), None);
-    assert_eq!(parse_trunc_precision("_fused_score"), None);
-    assert_eq!(parse_trunc_precision("id"), None);
-}
-
-#[test]
-fn sql_response_normalization_redacts_already_tight_2dp_clusters_without_reordering() {
-    // Range = 0.01 (here, 0.54 - 0.53 in f64 ≈ 0.010000000000000009). Scores
-    // are already so tight that 1-decimal rounding would collapse the cluster
-    // unnecessarily — preserve ordering while still redacting score values.
-    let input = json!([
-        {"id": 189, "_score": 0.54},
-        {"id": 468, "_score": 0.54},
-        {"id": 1277, "_score": 0.54},
-        {"id": 948, "_score": 0.53}
-    ]);
-    let normalized = normalize_sql_response_for_snapshot(input, true);
-    assert_eq!(
-        normalized,
-        json!([
-            {"id": 189, "_score": "[score]"},
-            {"id": 468, "_score": "[score]"},
-            {"id": 1277, "_score": "[score]"},
-            {"id": 948, "_score": "[score]"}
-        ])
-    );
-}
-
-#[test]
-fn sql_score_order_validation_catches_descending_order_regressions() {
-    let input = json!([
-        {"id": 1, "_score": 0.2},
-        {"id": 2, "_score": 0.3}
-    ]);
-    let err = ensure_sql_response_scores_descending(
-        "unordered_sql_scores",
-        "SELECT id, _score FROM vector_search(qs, 'second') ORDER BY _score DESC",
-        &input,
-    )
-    .expect_err("unordered score response should fail validation");
-
-    assert!(
-        err.to_string().contains("not descending"),
-        "unexpected error: {err}"
-    );
-}
-
-#[test]
-fn search_response_normalization_redacts_http_scores() {
-    let normalized = normalize_search_response_json(
+fn structural_search_response_accepts_additional_columns_in_data() {
+    assert_search_response_structure(
+        "s3vectors_chunking_additional_columns",
         json!({
             "duration_ms": 1,
             "results": [
-                {"_score": 6.331, "dataset": "qs", "matches": {"answer": ["a1"]}, "primary_key": {"id": 1}}
+                {"_score": 0.4, "data": {"question": "q1"}, "dataset": "qs", "matches": {"answer": ["a1"]}, "primary_key": {"id": 1}},
+                {"_score": 0.3, "data": {"question": "q2"}, "dataset": "qs", "matches": {"answer": ["a2"]}, "primary_key": {"id": 2}},
+                {"_score": 0.2, "data": {"question": "q3"}, "dataset": "qs", "matches": {"answer": ["a3"]}, "primary_key": {"id": 3}},
+                {"_score": 0.1, "data": {"question": "q4"}, "dataset": "qs", "matches": {"answer": ["a4"]}, "primary_key": {"id": 4}}
             ]
         }),
-        false,
-        false,
+        true,
     );
-
-    assert_eq!(normalized["results"][0]["_score"], json!("[score]"));
 }
 
 #[test]
-fn search_response_normalization_stabilizes_rounded_http_results_by_primary_key() {
-    let normalized = normalize_search_response_json(
+fn structural_search_response_accepts_additional_columns_in_primary_key() {
+    assert_search_response_structure(
+        "s3vectors_composite_additional_columns",
         json!({
             "duration_ms": 1,
             "results": [
-                {"_score": 0.80, "dataset": "qs", "matches": {"answer": ["a"]}, "primary_key": {"id": 2}},
-                {"_score": 0.79, "dataset": "qs", "matches": {"answer": ["b"]}, "primary_key": {"id": 1}}
+                {"_score": 0.4, "dataset": "qs", "matches": {"answer": ["a1"]}, "primary_key": {"id": 1, "question": "q1"}},
+                {"_score": 0.3, "dataset": "qs", "matches": {"answer": ["a2"]}, "primary_key": {"id": 2, "question": "q2"}},
+                {"_score": 0.2, "dataset": "qs", "matches": {"answer": ["a3"]}, "primary_key": {"id": 3, "question": "q3"}},
+                {"_score": 0.1, "dataset": "qs", "matches": {"answer": ["a4"]}, "primary_key": {"id": 4, "question": "q4"}}
             ]
         }),
-        false,
         true,
     );
-
-    let ids: Vec<i64> = normalized["results"]
-        .as_array()
-        .expect("normalized results should be an array")
-        .iter()
-        .map(|result| {
-            result["primary_key"]["id"]
-                .as_i64()
-                .expect("normalized result should contain primary key id")
-        })
-        .collect();
-
-    assert_eq!(ids, vec![1, 2]);
 }
 
 /// Normalizes vector similarity search response for consistent snapshot testing by replacing dynamic
@@ -732,63 +436,86 @@ fn normalize_search_response_json(
         *duration = json!("duration_ms_val");
     }
     if let Some(matches) = json.get_mut("results").and_then(|m| m.as_array_mut()) {
-        // Score ordering is validated before normalization. For snapshots whose
-        // scores are rounded/redacted, sort by stable row content so tiny score
-        // drift cannot reorder otherwise identical results across runners.
-        if round_scores {
-            matches.sort_by(|a, b| {
-                search_result_snapshot_key(a, sort_ties_by_matches)
-                    .cmp(&search_result_snapshot_key(b, sort_ties_by_matches))
-            });
-        } else {
-            matches.sort_by(|a, b| {
-                let Some(Value::Number(num_a)) = a.get("_score") else {
-                    return Ordering::Greater;
-                };
-                let Some(score_a) = num_a.as_f64() else {
-                    return Ordering::Greater;
-                };
-                let Some(Value::Number(num_b)) = b.get("_score") else {
-                    return Ordering::Less;
-                };
-                let Some(score_b) = num_b.as_f64() else {
-                    return Ordering::Less;
-                };
+        // To avoid inconsistent snapshots when scores are equal (common when using RRF)
+        // or near truncation boundaries (model2vec scores vary ±0.01 across CI runners),
+        // we round scores before comparing and also order based on primary key.
+        matches.sort_by(|a, b| {
+            let Some(Value::Number(num_a)) = a.get("_score") else {
+                return Ordering::Greater;
+            };
+            let Some(score_a) = num_a.as_f64() else {
+                return Ordering::Greater;
+            };
+            let Some(Value::Number(num_b)) = b.get("_score") else {
+                return Ordering::Less;
+            };
+            let Some(score_b) = num_b.as_f64() else {
+                return Ordering::Less;
+            };
 
-                // Opposite because we want to order descendingly
-                if score_a > score_b {
-                    return Ordering::Less;
-                } else if score_a < score_b {
-                    return Ordering::Greater;
+            // When round_scores is true, round to 2 decimal places before comparing
+            // to avoid flaky ordering from minor floating-point variance across CI
+            // runners (model2vec/s3vectors). Otherwise use raw float comparison.
+            let cmp_a = if round_scores {
+                (100.0 * score_a).round() / 100.0
+            } else {
+                score_a
+            };
+            let cmp_b = if round_scores {
+                (100.0 * score_b).round() / 100.0
+            } else {
+                score_b
+            };
+
+            // Opposite because we want to order descendingly
+            if cmp_a > cmp_b {
+                return Ordering::Less;
+            } else if cmp_a < cmp_b {
+                return Ordering::Greater;
+            }
+
+            if sort_ties_by_matches {
+                let matches_a = a
+                    .get("matches")
+                    .map(|value| serde_json::to_string(value).unwrap_or_default())
+                    .unwrap_or_default();
+                let matches_b = b
+                    .get("matches")
+                    .map(|value| serde_json::to_string(value).unwrap_or_default())
+                    .unwrap_or_default();
+                let matches_cmp = matches_a.cmp(&matches_b);
+                if matches_cmp != Ordering::Equal {
+                    return matches_cmp;
                 }
+            }
 
-                if sort_ties_by_matches {
-                    let matches_a = a.get("matches").map(json_tiebreak_key).unwrap_or_default();
-                    let matches_b = b.get("matches").map(json_tiebreak_key).unwrap_or_default();
-                    let matches_cmp = matches_a.cmp(&matches_b);
-                    if matches_cmp != Ordering::Equal {
-                        return matches_cmp;
-                    }
-                }
-
-                let Some(Value::Object(a_pks)) = a.get("primary_key") else {
-                    return Ordering::Equal;
-                };
-                let Some(Value::Object(b_pks)) = b.get("primary_key") else {
-                    return Ordering::Equal;
-                };
-                let primary_key_a = json_tiebreak_key(&Value::Object(a_pks.clone()));
-                let primary_key_b = json_tiebreak_key(&Value::Object(b_pks.clone()));
-                primary_key_b.cmp(&primary_key_a)
-            });
-        }
+            let Some(Value::Object(a_pks)) = a.get("primary_key") else {
+                return Ordering::Equal;
+            };
+            let Some(Value::Object(b_pks)) = b.get("primary_key") else {
+                return Ordering::Equal;
+            };
+            format!("{b_pks:?}").cmp(&format!("{a_pks:?}"))
+        });
 
         for m in matches {
             if let Some(obj) = m.as_object_mut()
                 && let Some(Value::Number(n)) = obj.get("_score")
-                && n.as_f64().is_some()
+                && let Some(score) = n.as_f64()
             {
-                obj.insert("_score".to_string(), Value::String("[score]".to_string()));
+                // Use rounding for non-deterministic embeddings (model2vec/s3vectors/OpenAI)
+                // to stabilize scores that vary ±0.01 across CI runs.
+                // Use truncation for deterministic embeddings (HF) to preserve
+                // exact snapshot values.
+                let display_score = if round_scores {
+                    (100.0 * score).round() / 100.0
+                } else {
+                    (100.0 * score).trunc() / 100.0
+                };
+                obj.insert(
+                    "_score".to_string(),
+                    Value::String(format!("{display_score:.2}")),
+                );
             }
         }
     }
@@ -798,343 +525,9 @@ fn normalize_search_response_json(
     json
 }
 
-fn json_tiebreak_key(value: &Value) -> String {
-    let mut normalized = value.clone();
-    sort_json_keys(&mut normalized);
-    serde_json::to_string(&normalized).expect("JSON tiebreak key serialization should succeed")
-}
-
-fn search_result_snapshot_key(result: &Value, sort_ties_by_matches: bool) -> String {
-    let mut parts = Vec::new();
-    if sort_ties_by_matches {
-        parts.push(
-            result
-                .get("matches")
-                .map(json_tiebreak_key)
-                .unwrap_or_default(),
-        );
-    }
-    parts.push(
-        result
-            .get("primary_key")
-            .map(json_tiebreak_key)
-            .unwrap_or_default(),
-    );
-    parts.push(
-        result
-            .get("matches")
-            .map(json_tiebreak_key)
-            .unwrap_or_default(),
-    );
-    parts.join("\u{1f}")
-}
-
 fn normalize_search_response(json: Value, round_scores: bool) -> String {
     serde_json::to_string_pretty(&normalize_search_response_json(json, false, round_scores))
-        .expect("search response snapshot serialization should succeed")
-}
-
-/// Normalize a SQL search response for snapshot comparison when scores are
-/// non-deterministic.
-///
-/// Redacts score-like columns before snapshotting. When `round_scores` is `true`
-/// and the response contains clustered 2-decimal precision scores, re-sorts rows
-/// by 1-decimal rounded score (descending) then by `id` (ascending). This absorbs
-/// the ±0.01 jitter that crosses `trunc` boundaries across CI runs with
-/// non-deterministic embeddings (`model2vec` / `s3vectors` / `OpenAI`).
-///
-/// Returns the input unchanged when the response has no score-like column.
-fn normalize_sql_response_for_snapshot(value: Value, round_scores: bool) -> Value {
-    normalize_sql_response_for_snapshot_with_sql(value, round_scores, None)
-}
-
-fn normalize_sql_response_for_snapshot_with_sql(
-    value: Value,
-    round_scores: bool,
-    sql: Option<&str>,
-) -> Value {
-    let Value::Array(mut rows) = value else {
-        return value;
-    };
-    if rows.is_empty() {
-        return Value::Array(rows);
-    }
-
-    let Some((primary_score_key, score_keys)) = sql_score_keys(&rows) else {
-        return Value::Array(rows);
-    };
-
-    let scores: Vec<f64> = rows
-        .iter()
-        .filter_map(|row| row.get(&primary_score_key).and_then(Value::as_f64))
-        .collect();
-    if scores.is_empty() {
-        return Value::Array(rows);
-    }
-
-    let should_stabilize_score_order =
-        round_scores && should_stabilize_sql_score_order(&primary_score_key, &scores, sql);
-    let should_stabilize_exact_ties = has_duplicate_scores(&scores);
-
-    if let Some(tie_breaker) = sql_score_tie_breaker(sql)
-        && (should_stabilize_score_order || should_stabilize_exact_ties)
-    {
-        rows.sort_by(|a, b| {
-            let score_a = a
-                .get(&primary_score_key)
-                .and_then(Value::as_f64)
-                .map_or(0.0, |score| {
-                    if should_stabilize_score_order {
-                        round_to_one_decimal(score)
-                    } else {
-                        score
-                    }
-                });
-            let score_b = b
-                .get(&primary_score_key)
-                .and_then(Value::as_f64)
-                .map_or(0.0, |score| {
-                    if should_stabilize_score_order {
-                        round_to_one_decimal(score)
-                    } else {
-                        score
-                    }
-                });
-            match score_b.partial_cmp(&score_a).unwrap_or(Ordering::Equal) {
-                Ordering::Equal => {
-                    let id_a = a.get("id").and_then(Value::as_i64).unwrap_or(i64::MAX);
-                    let id_b = b.get("id").and_then(Value::as_i64).unwrap_or(i64::MAX);
-                    match tie_breaker {
-                        SqlTieBreaker::Asc => id_a.cmp(&id_b),
-                        SqlTieBreaker::Desc => id_b.cmp(&id_a),
-                    }
-                }
-                order => order,
-            }
-        });
-    }
-
-    for row in &mut rows {
-        let Some(obj) = row.as_object_mut() else {
-            continue;
-        };
-        for k in &score_keys {
-            if obj.get(k).and_then(Value::as_f64).is_some() {
-                obj.insert(k.clone(), Value::String("[score]".to_string()));
-            }
-        }
-    }
-
-    Value::Array(rows)
-}
-
-fn has_duplicate_scores(scores: &[f64]) -> bool {
-    scores.iter().enumerate().any(|(index, score)| {
-        scores
-            .iter()
-            .skip(index + 1)
-            .any(|other_score| score.total_cmp(other_score) == Ordering::Equal)
-    })
-}
-
-fn ensure_sql_response_scores_descending(
-    test_name: &str,
-    sql: &str,
-    value: &Value,
-) -> Result<(), anyhow::Error> {
-    if !sql_orders_by_score_desc(sql) {
-        return Ok(());
-    }
-
-    let Some(rows) = value.as_array() else {
-        return Ok(());
-    };
-    let Some((primary_score_key, _)) = sql_score_keys(rows) else {
-        return Ok(());
-    };
-
-    let mut previous_score = f64::MAX;
-    for (index, row) in rows.iter().enumerate() {
-        let score = row
-            .get(&primary_score_key)
-            .and_then(Value::as_f64)
-            .with_context(|| {
-                format!(
-                    "{test_name}: result[{index}] missing numeric '{primary_score_key}' for ORDER BY score validation"
-                )
-            })?;
-        anyhow::ensure!(
-            !score.is_nan(),
-            "{test_name}: result[{index}] score should not be NaN"
-        );
-        anyhow::ensure!(
-            score <= previous_score,
-            "{test_name}: result[{index}] score {score} > previous {previous_score} (not descending)"
-        );
-        previous_score = score;
-    }
-
-    Ok(())
-}
-
-fn sql_orders_by_score_desc(sql: &str) -> bool {
-    sql_order_by_terms(sql)
-        .first()
-        .is_some_and(|term| order_term_is_score_desc(term))
-}
-
-#[derive(Clone, Copy)]
-enum SqlTieBreaker {
-    Asc,
-    Desc,
-}
-
-fn sql_score_tie_breaker(sql: Option<&str>) -> Option<SqlTieBreaker> {
-    let Some(sql) = sql else {
-        return Some(SqlTieBreaker::Asc);
-    };
-
-    let terms = sql_order_by_terms(sql);
-    let Some(first_term) = terms.first() else {
-        return Some(SqlTieBreaker::Asc);
-    };
-    if !order_term_is_score_desc(first_term) {
-        return None;
-    }
-
-    match terms.get(1).map(String::as_str) {
-        Some(term) if order_term_is_id(term) && term.contains("desc") => Some(SqlTieBreaker::Desc),
-        Some(term) if order_term_is_id(term) => Some(SqlTieBreaker::Asc),
-        Some(_) => None,
-        None => Some(SqlTieBreaker::Asc),
-    }
-}
-
-fn sql_order_by_terms(sql: &str) -> Vec<String> {
-    let normalized = sql.to_ascii_lowercase();
-    let Some((_, order_by)) = normalized.split_once("order by") else {
-        return Vec::new();
-    };
-    let order_by = order_by
-        .split_once(" limit ")
-        .map_or(order_by, |(order_by, _)| order_by);
-    order_by
-        .trim_end_matches(';')
-        .split(',')
-        .map(str::trim)
-        .filter(|term| !term.is_empty())
-        .map(ToString::to_string)
-        .collect()
-}
-
-fn order_term_is_score_desc(term: &str) -> bool {
-    (term.contains("_score") || term.contains("_fused_score")) && term.contains("desc")
-}
-
-fn order_term_is_id(term: &str) -> bool {
-    let term = term.trim_start_matches('(').trim();
-    term == "id" || term.starts_with("id ") || term == "\"id\"" || term.starts_with("\"id\" ")
-}
-
-fn sql_score_keys(rows: &[Value]) -> Option<(String, Vec<String>)> {
-    let mut score_keys: Vec<String> = rows
-        .first()
-        .and_then(Value::as_object)
-        .map(|obj| {
-            obj.keys()
-                .filter(|k| {
-                    let s = k.as_str();
-                    s == "_score"
-                        || s == "_fused_score"
-                        || ((s.starts_with("trunc(") || s.starts_with("round("))
-                            && s.contains("score"))
-                })
-                .cloned()
-                .collect()
-        })
-        .unwrap_or_default();
-
-    score_keys.sort_by(|a, b| score_key_priority(a).cmp(&score_key_priority(b)));
-    let primary_score_key = score_keys.first().cloned()?;
-    Some((primary_score_key, score_keys))
-}
-
-fn should_stabilize_sql_score_order(
-    primary_score_key: &str,
-    scores: &[f64],
-    sql: Option<&str>,
-) -> bool {
-    if let Some(precision) = sql
-        .and_then(|sql| aliased_sql_trunc_precision(sql, primary_score_key))
-        .or_else(|| parse_trunc_precision(primary_score_key))
-        && precision != 2
-    {
-        return false;
-    }
-
-    let is_2dp_precision = scores.iter().all(|&score| {
-        let scaled = score * 100.0;
-        (scaled - scaled.round()).abs() < 1e-6
-    });
-    if !is_2dp_precision {
-        return false;
-    }
-
-    let max = scores.iter().copied().fold(f64::MIN, f64::max);
-    let min = scores.iter().copied().fold(f64::MAX, f64::min);
-    let range = max - min;
-
-    (0.011..=0.06).contains(&range)
-}
-
-fn aliased_sql_trunc_precision(sql: &str, primary_score_key: &str) -> Option<usize> {
-    let compact_sql: String = sql
-        .chars()
-        .filter(|c| !c.is_ascii_whitespace())
-        .flat_map(char::to_lowercase)
-        .collect();
-    let unquoted_alias = format!("as{primary_score_key}");
-    let quoted_alias = format!("as\"{primary_score_key}\"");
-
-    for precision in 0..=9 {
-        let bare_precision = format!("trunc({primary_score_key},{precision})");
-        let int64_precision = format!("trunc({primary_score_key},int64({precision}))");
-        if [bare_precision, int64_precision].iter().any(|trunc_expr| {
-            compact_sql.contains(&format!("{trunc_expr}{unquoted_alias}"))
-                || compact_sql.contains(&format!("{trunc_expr}{quoted_alias}"))
-        }) {
-            return Some(precision);
-        }
-    }
-
-    None
-}
-
-fn round_to_one_decimal(score: f64) -> f64 {
-    (score * 10.0).round() / 10.0
-}
-
-fn score_key_priority(key: &str) -> (u8, &str) {
-    let bucket = match key {
-        "_score" => 0,
-        "_fused_score" => 1,
-        _ => 2,
-    };
-    (bucket, key)
-}
-
-/// Parse the precision argument out of a `DataFusion` `trunc(<expr>, Int64(N))`
-/// or `trunc(<expr>, N)` column name. Returns `None` for any other column
-/// shape (including aliased columns like `_score`).
-fn parse_trunc_precision(col_name: &str) -> Option<usize> {
-    let inner = col_name.strip_prefix("trunc(")?.strip_suffix(')')?;
-    let comma = inner.rfind(',')?;
-    let arg = inner[comma + 1..].trim();
-    let n_str = arg
-        .strip_prefix("Int64(")
-        .and_then(|s| s.strip_suffix(')'))
-        .unwrap_or(arg);
-    n_str.trim().parse().ok()
+        .unwrap_or_default()
 }
 
 fn quote_sql_identifier(identifier: &str) -> String {
@@ -1280,7 +673,7 @@ pub(crate) async fn run_search(
 }
 
 // if `explain_sql`, for any [`SearchTestCase`] that is [`SearchTestType::Sql`], a snapshot will be taken of the associated explain query.
-// if `round_scores`, HTTP search response score ordering uses rounding before tie-breaking.
+// if `round_scores`, HTTP search response scores use rounding instead of truncation for display.
 // Use for tests with non-deterministic embeddings (e.g. model2vec/s3vectors).
 pub(crate) async fn run_search_w_explain(
     app: App,
@@ -1337,14 +730,7 @@ pub(crate) async fn run_search_w_explain(
                             continue;
                         }
 
-                        let resp = resp?;
-                        ensure_sql_response_scores_descending(&test_name, &sql, &resp)?;
-                        let resp = normalize_sql_response_for_snapshot_with_sql(
-                            resp,
-                            ts.round_scores,
-                            Some(&sql),
-                        );
-                        insta::assert_json_snapshot!(test_name.clone(), resp);
+                        insta::assert_json_snapshot!(test_name.clone(), resp?);
 
                         if explain_sql {
                             let c: Vec<arrow::record_batch::RecordBatch> = client

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__additional_columns_metadata_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__additional_columns_metadata_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -20,7 +20,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.94"
     },
     {
       "data": {
@@ -36,7 +36,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 1316
       },
-      "_score": "[score]"
+      "_score": "0.92"
     },
     {
       "data": {
@@ -52,7 +52,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 590
       },
-      "_score": "[score]"
+      "_score": "0.91"
     },
     {
       "data": {
@@ -68,7 +68,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.91"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__additional_columns_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -19,7 +19,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.89"
     },
     {
       "data": {
@@ -34,7 +34,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 1316
       },
-      "_score": "[score]"
+      "_score": "0.84"
     },
     {
       "data": {
@@ -49,7 +49,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 590
       },
-      "_score": "[score]"
+      "_score": "0.83"
     },
     {
       "data": {
@@ -64,7 +64,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.83"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_additional_columns_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -19,7 +19,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.89"
     },
     {
       "data": {
@@ -34,7 +34,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 1316
       },
-      "_score": "[score]"
+      "_score": "0.84"
     },
     {
       "data": {
@@ -49,7 +49,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 590
       },
-      "_score": "[score]"
+      "_score": "0.83"
     },
     {
       "data": {
@@ -64,7 +64,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.83"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_basic_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.89"
     },
     {
       "dataset": "qs",
@@ -28,7 +28,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 1316
       },
-      "_score": "[score]"
+      "_score": "0.84"
     },
     {
       "dataset": "qs",
@@ -40,7 +40,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 590
       },
-      "_score": "[score]"
+      "_score": "0.83"
     },
     {
       "dataset": "qs",
@@ -52,7 +52,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.83"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_vector_search_sql_filters.snap
@@ -7,21 +7,21 @@ snapshot_kind: text
   {
     "id": 863,
     "answer": "Choices create costs and benefits.",
-    "_score": "[score]"
+    "_score": "0.87"
   },
   {
     "id": 6,
     "answer": "<refined solution>  \n\n*(Repeated for each question-answer pair above.)",
-    "_score": "[score]"
+    "_score": "0.82"
   },
   {
     "id": 438,
     "answer": "The Cat does not need to drink, as it obtains sufficient water from its prey.",
-    "_score": "[score]"
+    "_score": "0.80"
   },
   {
     "id": 1041,
     "answer": "A common thermometer operates on the principle that matter usually expands when it absorbs heat energy.",
-    "_score": "[score]"
+    "_score": "0.77"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_vector_search_sql_projection.snap
@@ -9,27 +9,27 @@ snapshot_kind: text
     "answer": "Choices create costs and benefits.",
     "question": "What is created by making a choice?",
     "subject": "economics",
-    "_score": "[score]"
+    "_score": "0.89"
   },
   {
     "id": 1316,
     "answer": "\\(\\boxed{2a + 4b}\\)",
     "question": "Write down in simplest form \\( 5a - 2b - 3a + 6b \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": "0.84"
   },
   {
     "id": 590,
     "answer": "\\(\\boxed{x = A + E}\\)",
     "question": "Make \\( x \\) the subject of the formula \\( x - A = E \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": "0.83"
   },
   {
     "id": 6,
     "answer": "<refined solution>  \n\n*(Repeated for each question-answer pair above.)",
     "question": "<refined question>",
     "subject": "medicine",
-    "_score": "[score]"
+    "_score": "0.83"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__basic_with_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.87"
     },
     {
       "dataset": "qs",
@@ -28,7 +28,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.82"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_all_datasets_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_all_datasets_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "dataset": "spice.public.catalog_page_with_chunking",
       "matches": {
         "cp_description": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "dataset": "spice.public.catalog_page_with_chunking_no_pk",
       "matches": {
         "cp_description": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.89",
       "data": {
         "i_color": "yellow",
         "i_item_id": "AAAAAAAAKAAAAAAA"
@@ -22,7 +22,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.84",
       "data": {
         "i_color": "wheat",
         "i_item_id": "AAAAAAAAIAAAAAAA"

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_no_pk_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_no_pk_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "dataset": "catalog_page_with_chunking_no_pk",
       "matches": {
         "cp_description": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "dataset": "catalog_page_with_chunking",
       "matches": {
         "cp_description": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_column_no_pk2_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_column_no_pk2_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "data": {
         "cp_catalog_page_sk": 1,
         "cp_department": "DEPARTMENT",

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_column_no_pk_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_column_no_pk_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "data": {
         "cp_department": "DEPARTMENT"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns2_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns2_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -20,7 +20,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.94"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_and_where_no_pk_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_and_where_no_pk_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "data": {
         "cp_department": "DEPARTMENT"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_and_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_and_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "data": {
         "cp_department": "DEPARTMENT"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "data": {
         "cp_department": "DEPARTMENT"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_search_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_search_additional_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -20,7 +20,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.03"
     },
     {
       "data": {
@@ -35,7 +35,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 15
       },
-      "_score": "[score]"
+      "_score": "0.01"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_search_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_search_basic_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -17,7 +17,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.03"
     },
     {
       "dataset": "hybrid_column_search",
@@ -29,7 +29,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 15
       },
-      "_score": "[score]"
+      "_score": "0.01"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_additional_columns_response.snap
@@ -6,7 +6,7 @@ expression: "normalize_search_response(resp, round_scores)"
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "In which of the following compounds, cations are present in tetrahedral voids?  \na. ZnS  \nb. SrF₂  \nc. NaBr  \nd. Na₂O"
       },
@@ -21,7 +21,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?"
       },
@@ -36,7 +36,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$"
       },
@@ -51,7 +51,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "How many chirality centers does cholesterol have?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_basic_response.snap
@@ -6,7 +6,7 @@ expression: "normalize_search_response(resp, round_scores)"
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.78",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.75",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.74",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.73",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": 0.02
   },
   {
     "id": 772,
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": 0.017
   },
   {
     "id": 361,
     "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": 0.016
   },
   {
     "id": 462,
     "question": "How many groups of 2 are in 14?",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": 0.016
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_explicit_join.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_explicit_join.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": 0.02
   },
   {
     "id": 772,
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": 0.017
   },
   {
     "id": 361,
     "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": 0.016
   },
   {
     "id": 462,
     "question": "How many groups of 2 are in 14?",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": 0.016
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_text_search.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_text_search.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_vector_search.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_vector_search.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 361,
     "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
-    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": 0.785
   },
   {
     "id": 462,
     "question": "How many groups of 2 are in 14?",
-    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": 0.775
   },
   {
     "id": 464,
     "question": "How many groups of 5 are in 25?",
-    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": 0.762
   },
   {
     "id": 463,
     "question": "How many groups of 3 are in 18?",
-    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": 0.759
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_rrf_duckdb_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_rrf_duckdb_basic.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
-    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": 0.02
   },
   {
     "id": 772,
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
-    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": 0.017
   },
   {
     "id": 361,
     "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
-    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": 0.016
   },
   {
     "id": 462,
     "question": "How many groups of 2 are in 14?",
-    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")))._fused_score,Int64(3))": 0.016
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_rrf_duckdb_explicit_join.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_rrf_duckdb_explicit_join.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
-    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": 0.02
   },
   {
     "id": 772,
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
-    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": 0.017
   },
   {
     "id": 361,
     "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
-    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": 0.016
   },
   {
     "id": 462,
     "question": "How many groups of 2 are in 14?",
-    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": "[score]"
+    "trunc(rrf(text_search(qs, Utf8(\"second\")), vector_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} })._fused_score,Int64(3))": 0.016
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_additional_columns_response.snap
@@ -6,7 +6,7 @@ expression: "normalize_search_response(resp, round_scores)"
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "In which of the following compounds, cations are present in tetrahedral voids?  \na. ZnS  \nb. SrF₂  \nc. NaBr  \nd. Na₂O"
       },
@@ -21,7 +21,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants."
       },
@@ -36,7 +36,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "How many chirality centers does cholesterol have?"
       },
@@ -51,7 +51,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "What is the area of a parallelogram with a base of 8 units and a height of 9 units?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_basic_response.snap
@@ -6,7 +6,7 @@ expression: "normalize_search_response(resp, round_scores)"
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -19,7 +19,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -31,7 +31,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -43,7 +43,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_sql_text_search.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_sql_text_search.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 361,
     "answer": "The number of ways is \\( 18 \\times 17 \\times 16 = \\boxed{4896} \\).",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 5.065
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_sql_vector_search.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_sql_vector_search.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 361,
     "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
-    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": 0.785
   },
   {
     "id": 462,
     "question": "How many groups of 2 are in 14?",
-    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": 0.775
   },
   {
     "id": 464,
     "question": "How many groups of 5 are in 25?",
-    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": 0.762
   },
   {
     "id": 463,
     "question": "How many groups of 3 are in 18?",
-    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(vector_search(qs, Utf8(\"second\"))._score,Int64(3))": 0.759
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.66",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.66",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.65",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.64",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_additional_columns_response.snap
@@ -6,7 +6,7 @@ expression: "normalize_search_response(resp, round_scores)"
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words."
       },
@@ -21,7 +21,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "In which of the following compounds, cations are present in tetrahedral voids?  \na. ZnS  \nb. SrF₂  \nc. NaBr  \nd. Na₂O"
       },
@@ -36,7 +36,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "How many chirality centers does cholesterol have?"
       },
@@ -51,7 +51,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\)."
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_additional_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 8
       },
-      "_score": "[score]"
+      "_score": "0.01"
     },
     {
       "data": {
@@ -33,7 +33,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 2
       },
-      "_score": "[score]"
+      "_score": "0.01"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_basic_response.snap
@@ -6,7 +6,7 @@ expression: "normalize_search_response(resp, round_scores)"
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_additional_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -19,7 +19,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.94"
     },
     {
       "data": {
@@ -34,7 +34,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 15
       },
-      "_score": "[score]"
+      "_score": "0.94"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_basic_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 2
       },
-      "_score": "[score]"
+      "_score": "0.01"
     },
     {
       "dataset": "multi_column_hybrid_search",
@@ -31,7 +31,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.03"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 15
       },
-      "_score": "[score]"
+      "_score": "0.93"
     },
     {
       "dataset": "multi_column_hybrid_search",
@@ -28,7 +28,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 3
       },
-      "_score": "[score]"
+      "_score": "0.93"
     },
     {
       "dataset": "multi_column_hybrid_search",
@@ -40,7 +40,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.94"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_question_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_question_vector_search_sql_filters.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 938,
     "answer": "The presence of fibrinolysin in the reagents can partially or totally dissolve the clot, leading to erroneous results.",
-    "_score": "[score]"
+    "_score": 0.668
   },
   {
     "id": 1279,
     "answer": "$\\boxed{\\text{Pyruvate}}$ is not an intermediate of the TCA cycle. It is converted to acetyl-CoA, which then enters the cycle.",
-    "_score": "[score]"
+    "_score": 0.667
   },
   {
     "id": 1289,
     "answer": "$\\boxed{\\text{(a) pressure}}$ (Intensive properties, like pressure, do not depend on the size or mass of the system.)",
-    "_score": "[score]"
+    "_score": 0.654
   },
   {
     "id": 446,
     "answer": "Infection is acquired by ingestion of the spores, which transmit the sporoplasm through the tubules into enterocytes.",
-    "_score": "[score]"
+    "_score": 0.647
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_question_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_question_vector_search_sql_vectors.snap
@@ -1,30 +1,30 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 361,
     "answer": "The number of ways is \\( 18 \\times 17 \\times 16 = \\boxed{4896} \\).",
     "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
-    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": "[score]"
+    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": 0.8
   },
   {
     "id": 462,
     "answer": "To find how many groups of 2 are in 14, divide 14 by 2:  \n\\[ 14 \\div 2 = 7 \\]  \nThus, there are $\\boxed{7}$ groups of 2 in 14.",
     "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
-    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": "[score]"
-  },
-  {
-    "id": 463,
-    "answer": "To find how many groups of 3 are in 18, divide 18 by 3.  \n\\[ 18 \\div 3 = 6 \\]  \nThus, there are $\\boxed{6}$ groups of 3 in 18.",
-    "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
-    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": "[score]"
+    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": 0.8
   },
   {
     "id": 464,
     "answer": "To find how many groups of 5 are in 25, divide 25 by 5:  \n\\[ 25 \\div 5 = 5 \\]  \nSo, there are $\\boxed{5}$ groups of 5 in 25.",
     "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
-    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": "[score]"
+    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": 0.8
+  },
+  {
+    "id": 463,
+    "answer": "To find how many groups of 3 are in 18, divide 18 by 3.  \n\\[ 18 \\div 3 = 6 \\]  \nThus, there are $\\boxed{6}$ groups of 3 in 18.",
+    "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
+    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": 0.8
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_additional_columns_response.snap
@@ -6,7 +6,7 @@ expression: "normalize_search_response(resp, round_scores)"
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Simplify the expression according to the order of operations.\na) $-|-9|$  \nb) $-(-9)$  \nc) $2-(-6)$  \nd) $2-|-6|$"
       },
@@ -21,7 +21,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "In which of the following compounds, cations are present in tetrahedral voids?  \na. ZnS  \nb. SrF₂  \nc. NaBr  \nd. Na₂O"
       },
@@ -36,7 +36,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "How many chirality centers does cholesterol have?"
       },
@@ -51,7 +51,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Evaluate the function \\( h(x) = -3x - 4 \\) at the given values:\na. \\( h(7) \\)\nb. \\( h(-4) \\)"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Simplify the expression according to the order of operations.\na) $-|-9|$  \nb) $-(-9)$  \nc) $2-(-6)$  \nd) $2-|-6|$"
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "In which of the following compounds, cations are present in tetrahedral voids?  \na. ZnS  \nb. SrF₂  \nc. NaBr  \nd. Na₂O"
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "How many chirality centers does cholesterol have?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Evaluate the function \\( h(x) = -3x - 4 \\) at the given values:\na. \\( h(7) \\)\nb. \\( h(-4) \\)"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "serde_json::to_string_pretty(&normalize_search_response_json(resp, true))\n    .expect(\"search response snapshot serialization should succeed\")"
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,19 @@ expression: "serde_json::to_string_pretty(&normalize_search_response_json(resp, 
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
+      "dataset": "qs",
+      "matches": {
+        "question": [
+          "\\((-6) \\div (-2)\\)"
+        ]
+      },
+      "primary_key": {
+        "id": 1324
+      }
+    },
+    {
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +42,7 @@ expression: "serde_json::to_string_pretty(&normalize_search_response_json(resp, 
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -39,18 +51,6 @@ expression: "serde_json::to_string_pretty(&normalize_search_response_json(resp, 
       },
       "primary_key": {
         "id": 1323
-      }
-    },
-    {
-      "_score": "[score]",
-      "dataset": "qs",
-      "matches": {
-        "question": [
-          "\\((-6) \\div (-2)\\)"
-        ]
-      },
-      "primary_key": {
-        "id": 1324
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -33,7 +33,19 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
+        ]
+      },
+      "primary_key": {
+        "id": 1277
+      }
+    },
+    {
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
-  },
-  {
-    "id": 821,
-    "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.64
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.62
+  },
+  {
+    "id": 821,
+    "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
+    "_score": 0.62
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.6
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
-  },
-  {
-    "id": 948,
-    "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "What is the fifth root of 32?",
-    "subject": "math",
-    "_score": "[score]"
+    "_score": 0.77
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.77
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 948,
+    "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.77
+  },
+  {
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "subject": "math",
+    "_score": 0.77
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.77
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.77
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.77
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.77
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_answer_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_basic_response.snap
@@ -6,7 +6,7 @@ expression: "normalize_search_response(resp, round_scores)"
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_question_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_question_vector_search_sql_filters.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 938,
     "answer": "The presence of fibrinolysin in the reagents can partially or totally dissolve the clot, leading to erroneous results.",
-    "_score": "[score]"
+    "_score": 0.668
   },
   {
     "id": 1279,
     "answer": "$\\boxed{\\text{Pyruvate}}$ is not an intermediate of the TCA cycle. It is converted to acetyl-CoA, which then enters the cycle.",
-    "_score": "[score]"
+    "_score": 0.667
   },
   {
     "id": 1289,
     "answer": "$\\boxed{\\text{(a) pressure}}$ (Intensive properties, like pressure, do not depend on the size or mass of the system.)",
-    "_score": "[score]"
+    "_score": 0.654
   },
   {
     "id": 446,
     "answer": "Infection is acquired by ingestion of the spores, which transmit the sporoplasm through the tubules into enterocytes.",
-    "_score": "[score]"
+    "_score": 0.647
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_question_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_question_vector_search_sql_vectors.snap
@@ -1,30 +1,30 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 361,
     "answer": "The number of ways is \\( 18 \\times 17 \\times 16 = \\boxed{4896} \\).",
     "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
-    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": "[score]"
+    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": 0.8
   },
   {
     "id": 462,
     "answer": "To find how many groups of 2 are in 14, divide 14 by 2:  \n\\[ 14 \\div 2 = 7 \\]  \nThus, there are $\\boxed{7}$ groups of 2 in 14.",
     "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
-    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": "[score]"
-  },
-  {
-    "id": 463,
-    "answer": "To find how many groups of 3 are in 18, divide 18 by 3.  \n\\[ 18 \\div 3 = 6 \\]  \nThus, there are $\\boxed{6}$ groups of 3 in 18.",
-    "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
-    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": "[score]"
+    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": 0.8
   },
   {
     "id": 464,
     "answer": "To find how many groups of 5 are in 25, divide 25 by 5:  \n\\[ 25 \\div 5 = 5 \\]  \nSo, there are $\\boxed{5}$ groups of 5 in 25.",
     "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
-    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": "[score]"
+    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": 0.8
+  },
+  {
+    "id": 463,
+    "answer": "To find how many groups of 3 are in 18, divide 18 by 3.  \n\\[ 18 \\div 3 = 6 \\]  \nThus, there are $\\boxed{6}$ groups of 3 in 18.",
+    "array_length(vector_search(qs, Utf8(\"second\"), question).question_embedding)": 64,
+    "round(vector_search(qs, Utf8(\"second\"), question)._score,Int64(1))": 0.8
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 7
       },
-      "_score": "[score]"
+      "_score": "0.03"
     },
     {
       "dataset": "multi_column_search",
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 3
       },
-      "_score": "[score]"
+      "_score": "0.01"
     },
     {
       "dataset": "multi_column_search",
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 5
       },
-      "_score": "[score]"
+      "_score": "0.01"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_models_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_models_additional_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -22,7 +22,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.03"
     },
     {
       "data": {
@@ -40,7 +40,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 2
       },
-      "_score": "[score]"
+      "_score": "0.03"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_models_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_models_basic_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -19,7 +19,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.03"
     },
     {
       "dataset": "multi_embedding_models",
@@ -34,7 +34,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 2
       },
-      "_score": "[score]"
+      "_score": "0.03"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_models_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_models_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -19,7 +19,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 2
       },
-      "_score": "[score]"
+      "_score": "0.03"
     },
     {
       "dataset": "multi_embedding_models",
@@ -34,7 +34,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 6
       },
-      "_score": "[score]"
+      "_score": "0.03"
     },
     {
       "dataset": "multi_embedding_models",
@@ -49,7 +49,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 8
       },
-      "_score": "[score]"
+      "_score": "0.03"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_additional_response.snap
@@ -2,30 +2,6 @@
 source: crates/runtime/tests/models/search.rs
 expression: "normalize_search_response_json(resp, true, round_scores)"
 ---
-{
-  "duration_ms": "duration_ms_val",
-  "results": [
-    {
-      "_score": "[score]",
-      "data": {
-        "cp_catalog_number": 1
-      },
-      "dataset": "multiple_columns",
-      "matches": {
-        "cp_department": [
-          "DEPARTMENT"
-        ],
-        "cp_description": [
-          "In general basic characters welcome. Clearly lively friends conv"
-        ]
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 1
-      }
-    },
-    {
-      "_score": "[score]",
-      "data": {
         "cp_catalog_number": 1
       },
       "dataset": "multiple_columns",
@@ -38,7 +14,15 @@ expression: "normalize_search_response_json(resp, true, round_scores)"
         ]
       },
       "primary_key": {
-        "cp_catalog_page_sk": 11
+        "cp_department": [
+          "DEPARTMENT"
+        ],
+        "cp_description": [
+          "In general basic characters welcome. Clearly lively friends conv"
+        ]
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_basic_response.snap
@@ -2,11 +2,19 @@
 source: crates/runtime/tests/models/search.rs
 expression: "normalize_search_response_json(resp, true, round_scores)"
 ---
-{
-  "duration_ms": "duration_ms_val",
-  "results": [
+        "cp_department": [
+          "DEPARTMENT"
+        ],
+        "cp_description": [
+          "Programmes receive just likely, key homes. Relevant,"
+        ]
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 11
+      }
+    },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "multiple_columns",
       "matches": {
         "cp_department": [
@@ -18,21 +26,6 @@ expression: "normalize_search_response_json(resp, true, round_scores)"
       },
       "primary_key": {
         "cp_catalog_page_sk": 1
-      }
-    },
-    {
-      "_score": "[score]",
-      "dataset": "multiple_columns",
-      "matches": {
-        "cp_department": [
-          "DEPARTMENT"
-        ],
-        "cp_description": [
-          "Programmes receive just likely, key homes. Relevant,"
-        ]
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 11
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "multiple_columns",
       "matches": {
         "cp_department": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embeddings_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embeddings_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.60",
       "data": {
         "question": "What is the `car` of the list `l` where `l` is `((a b c) x y z)`?"
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.57",
       "data": {
         "question": "Simplify the expression according to the order of operations.\na) $-|-9|$  \nb) $-(-9)$  \nc) $2-(-6)$  \nd) $2-|-6|$"
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "Evaluate the function \\( h(x) = -3x - 4 \\) at the given values:\na. \\( h(7) \\)\nb. \\( h(-4) \\)"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.55",
       "data": {
         "question": "Evaluate the function \\( G(x) = x - 1 \\) at the following values of \\( x \\):\na. \\( x = 3 \\)\nb. \\( x = -5 \\)\nc. \\( x = 0 \\)"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embeddings_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embeddings_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.60",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.57",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.55",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embeddings_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embeddings_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.63",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.63",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.62",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.62",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?"
       },
@@ -21,7 +21,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants."
       },
@@ -36,7 +36,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_additional_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -19,7 +19,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "8.12"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_fused_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_fused_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -23,7 +23,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.03"
     },
     {
       "data": {
@@ -39,7 +39,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 2
       },
-      "_score": "[score]"
+      "_score": "0.01"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "5.06",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_basic_answer.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_basic_answer.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
-    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
-    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_basic_question.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_basic_question.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
-    "id": 494,
-    "question": "If \\( b^\\circ \\) and \\( 30^\\circ \\) are vertical angles, what is the value of \\( b \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
-  },
-  {
     "id": 495,
     "question": "If \\( b^\\circ \\) and \\( 50^\\circ \\) are vertical angles, what is the value of \\( b \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.934
+  },
+  {
+    "id": 494,
+    "question": "If \\( b^\\circ \\) and \\( 30^\\circ \\) are vertical angles, what is the value of \\( b \\)?",
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.934
   },
   {
     "id": 499,
     "question": "If \\( m \\) and \\( n \\) are two angles that lie on a straight line, what is the value of \\( m + n \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.245
   },
   {
     "id": 1175,
     "question": "What is the sum of the angles \\( a + b + c + d + e + f + g + h \\) around a point in the diagram?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.129
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_filters.snap
@@ -6,6 +6,6 @@ expression: resp?
   {
     "id": 890,
     "answer": "Relative or \"stress\" polycythaemia, which is secondary to a depletion in the plasma volume.",
-    "_score": "[score]"
+    "_score": 7.522
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_projection.snap
@@ -8,13 +8,13 @@ expression: resp?
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "8.12"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "7.52",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.60",
       "data": {
         "question": "What is the `car` of the list `l` where `l` is `((a b c) x y z)`?"
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.57",
       "data": {
         "question": "Simplify the expression according to the order of operations.\na) $-|-9|$  \nb) $-(-9)$  \nc) $2-(-6)$  \nd) $2-|-6|$"
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "Evaluate the function \\( h(x) = -3x - 4 \\) at the given values:\na. \\( h(7) \\)\nb. \\( h(-4) \\)"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.55",
       "data": {
         "question": "Evaluate the function \\( G(x) = x - 1 \\) at the following values of \\( x \\):\na. \\( x = 3 \\)\nb. \\( x = -5 \\)\nc. \\( x = 0 \\)"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_all_datasets_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_all_datasets_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "i_item_sk": 19
       },
-      "_score": "[score]"
+      "_score": "0.76"
     },
     {
       "dataset": "spice.public.item",
@@ -28,7 +28,7 @@ snapshot_kind: text
       "primary_key": {
         "i_item_sk": 7
       },
-      "_score": "[score]"
+      "_score": "0.74"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.60",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.57",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.55",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_casing_chunking_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_casing_chunking_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.78",
       "dataset": "clickbench_chunking",
       "matches": {
         "Referer": [
@@ -15,7 +15,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.78",
       "dataset": "clickbench_chunking",
       "matches": {
         "Referer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_casing_no_chunking_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_casing_no_chunking_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.78",
       "dataset": "clickbench_no_chunking",
       "matches": {
         "Referer": [
@@ -15,7 +15,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.78",
       "dataset": "clickbench_no_chunking",
       "matches": {
         "Referer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_chunking_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_chunking_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.68"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__openai_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.63",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.63",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.62",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.62",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__post_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__post_cache_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
@@ -15,7 +15,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.94"
     },
     {
       "dataset": "spice.public.cached_search_bypass",
@@ -27,7 +27,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 15
       },
-      "_score": "[score]"
+      "_score": "0.93"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__pre_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__pre_cache_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
@@ -15,7 +15,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "_score": "[score]"
+      "_score": "0.94"
     },
     {
       "dataset": "spice.public.cached_search_bypass",
@@ -27,7 +27,7 @@ expression: normalize_search_response(resp)
       "primary_key": {
         "cp_catalog_page_sk": 15
       },
-      "_score": "[score]"
+      "_score": "0.93"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__rrf_recency_unboosting_disjoint_regression.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__rrf_recency_unboosting_disjoint_regression.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/runtime/tests/models/search.rs
 description: "SELECT id, content, picked_at FROM rrf(vector_search(left_fruit, 'red crispy', content), vector_search(right_fruit, 'red crispy', content), join_key => 'id', k => 0, time_column => 'picked_at', decay_constant => 0.25) ORDER BY _fused_score DESC, id ASC LIMIT 3"
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, true)"
 snapshot_kind: text
 ---
 [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_additional_columns_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -20,7 +20,7 @@ snapshot_kind: text
         "id": 863,
         "question": "What is created by making a choice?"
       },
-      "_score": "[score]"
+      "_score": "0.89"
     },
     {
       "data": {
@@ -36,7 +36,7 @@ snapshot_kind: text
         "id": 1316,
         "question": "Write down in simplest form \\( 5a - 2b - 3a + 6b \\)."
       },
-      "_score": "[score]"
+      "_score": "0.84"
     },
     {
       "data": {
@@ -52,7 +52,7 @@ snapshot_kind: text
         "id": 590,
         "question": "Make \\( x \\) the subject of the formula \\( x - A = E \\)."
       },
-      "_score": "[score]"
+      "_score": "0.83"
     },
     {
       "data": {
@@ -68,7 +68,7 @@ snapshot_kind: text
         "id": 6,
         "question": "<refined question>"
       },
-      "_score": "[score]"
+      "_score": "0.83"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_basic_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -17,7 +17,7 @@ snapshot_kind: text
         "id": 863,
         "question": "What is created by making a choice?"
       },
-      "_score": "[score]"
+      "_score": "0.89"
     },
     {
       "dataset": "qs",
@@ -30,7 +30,7 @@ snapshot_kind: text
         "id": 1316,
         "question": "Write down in simplest form \\( 5a - 2b - 3a + 6b \\)."
       },
-      "_score": "[score]"
+      "_score": "0.84"
     },
     {
       "dataset": "qs",
@@ -43,7 +43,7 @@ snapshot_kind: text
         "id": 590,
         "question": "Make \\( x \\) the subject of the formula \\( x - A = E \\)."
       },
-      "_score": "[score]"
+      "_score": "0.83"
     },
     {
       "dataset": "qs",
@@ -56,7 +56,7 @@ snapshot_kind: text
         "id": 6,
         "question": "<refined question>"
       },
-      "_score": "[score]"
+      "_score": "0.83"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "question": "What is the possible action of pedunculagin and alchemillin, chemical components of lady's mantle?",
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.286
   },
   {
     "question": "What is the definition of a partial relation?",
     "answer": "A relation is partial if there is an element in the domain that is not related to any element in the co-domain.",
-    "_score": "[score]"
+    "_score": 0.283
   },
   {
     "question": "What causes dermatomycosis, and what are some examples of this condition?",
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.247
   },
   {
     "question": "How long of a follow-up is required after spinal cord (SC) ependymoma resection?",
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.235
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_view_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_view_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "question": "What is the possible action of pedunculagin and alchemillin, chemical components of lady's mantle?",
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.286
   },
   {
     "question": "What is the definition of a partial relation?",
     "answer": "A relation is partial if there is an element in the domain that is not related to any element in the co-domain.",
-    "_score": "[score]"
+    "_score": 0.283
   },
   {
     "question": "What causes dermatomycosis, and what are some examples of this condition?",
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.247
   },
   {
     "question": "How long of a follow-up is required after spinal cord (SC) ependymoma resection?",
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.235
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_composite_with_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -17,7 +17,7 @@ snapshot_kind: text
         "id": 863,
         "question": "What is created by making a choice?"
       },
-      "_score": "[score]"
+      "_score": "0.87"
     },
     {
       "dataset": "qs",
@@ -30,7 +30,7 @@ snapshot_kind: text
         "id": 6,
         "question": "<refined question>"
       },
-      "_score": "[score]"
+      "_score": "0.82"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_additional_columns_metadata_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_additional_columns_metadata_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "reference_answer": "7",
         "source": "textbook_reasoning"
@@ -22,7 +22,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "reference_answer": "-16",
         "source": "textbook_reasoning"
@@ -38,7 +38,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "reference_answer": "2",
         "source": "textbook_reasoning"
@@ -54,7 +54,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "data": {
         "reference_answer": "2",
         "source": "textbook_reasoning"

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_basic_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.89"
     },
     {
       "dataset": "qs",
@@ -28,7 +28,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 1316
       },
-      "_score": "[score]"
+      "_score": "0.84"
     },
     {
       "dataset": "qs",
@@ -40,7 +40,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 590
       },
-      "_score": "[score]"
+      "_score": "0.83"
     },
     {
       "dataset": "qs",
@@ -52,7 +52,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.83"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_vector_search_sql_filters.snap
@@ -7,21 +7,21 @@ snapshot_kind: text
   {
     "id": 863,
     "answer": "Choices create costs and benefits.",
-    "_score": "[score]"
+    "_score": "0.87"
   },
   {
     "id": 1316,
     "answer": "\\(\\boxed{2a + 4b}\\)",
-    "_score": "[score]"
+    "_score": "0.83"
   },
   {
     "id": 590,
     "answer": "\\(\\boxed{x = A + E}\\)",
-    "_score": "[score]"
+    "_score": "0.82"
   },
   {
     "id": 6,
     "answer": "<refined solution>  \n\n*(Repeated for each question-answer pair above.)",
-    "_score": "[score]"
+    "_score": "0.82"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_vector_search_sql_filters_metadata.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_vector_search_sql_filters_metadata.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.286
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.247
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.235
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.205
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_vector_search_sql_projection.snap
@@ -9,27 +9,27 @@ snapshot_kind: text
     "answer": "Choices create costs and benefits.",
     "reference_answer": "Choices create costs and benefits.",
     "source": "textbook_reasoning",
-    "_score": "[score]"
+    "_score": "0.89"
   },
   {
     "id": 1316,
     "answer": "\\(\\boxed{2a + 4b}\\)",
     "reference_answer": "2a + 4b",
     "source": "textbook_reasoning",
-    "_score": "[score]"
+    "_score": "0.84"
   },
   {
     "id": 590,
     "answer": "\\(\\boxed{x = A + E}\\)",
     "reference_answer": "x = A + E",
     "source": "textbook_reasoning",
-    "_score": "[score]"
+    "_score": "0.83"
   },
   {
     "id": 6,
     "answer": "<refined solution>  \n\n*(Repeated for each question-answer pair above.)",
     "reference_answer": "78.54 cm²\n\nPlease provide the actual question and detailed answer you need me to work with.",
     "source": "textbook_reasoning",
-    "_score": "[score]"
+    "_score": "0.83"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_vector_search_sql_projection_metadata.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_vector_search_sql_projection_metadata.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
-    "subject": "math",
-    "_score": "[score]"
-  },
-  {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.539
+  },
+  {
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "subject": "math",
+    "_score": 0.539
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.528
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_view_additional_columns_metadata_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_view_additional_columns_metadata_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "reference_answer": "7",
         "source": "textbook_reasoning"
@@ -22,7 +22,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "reference_answer": "-16",
         "source": "textbook_reasoning"
@@ -38,7 +38,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "reference_answer": "2",
         "source": "textbook_reasoning"
@@ -54,7 +54,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "data": {
         "reference_answer": "2",
         "source": "textbook_reasoning"

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_view_vector_search_sql_filters_metadata.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_view_vector_search_sql_filters_metadata.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.286
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.247
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.235
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.205
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_view_vector_search_sql_projection_metadata.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_view_vector_search_sql_projection_metadata.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
-    "subject": "math",
-    "_score": "[score]"
-  },
-  {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.539
+  },
+  {
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "subject": "math",
+    "_score": 0.539
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.528
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_view_with_where_metadata_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_view_with_where_metadata_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_with_where_metadata_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_with_where_metadata_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vector_metadata_with_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.87"
     },
     {
       "dataset": "qs",
@@ -28,7 +28,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 1316
       },
-      "_score": "[score]"
+      "_score": "0.83"
     },
     {
       "dataset": "qs",
@@ -40,7 +40,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 590
       },
-      "_score": "[score]"
+      "_score": "0.82"
     },
     {
       "dataset": "qs",
@@ -52,7 +52,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.82"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "How many multiples of 4 are there between 1 and 30? List them and count the total."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "data": {
         "question": "What is the fifth root of 32?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_basic_response.snap
@@ -1,24 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
-        ]
-      },
-      "primary_key": {
-        "id": 1277
-      }
-    },
-    {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +30,19 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
+        ]
+      },
+      "primary_key": {
+        "id": 1277
+      }
+    },
+    {
+      "_score": "0.53",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.49",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.29
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.25
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.23
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.2
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "How many multiples of 4 are there between 1 and 30? List them and count the total."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "data": {
         "question": "What is the fifth root of 32?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.49",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.29
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.25
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.23
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.2
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_basic_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.80",
       "data": {
         "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.79",
       "data": {
         "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "What is the fifth root of 32?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.80",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.79",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.52",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.80",
       "data": {
         "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.79",
       "data": {
         "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "What is the fifth root of 32?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.80",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.79",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.52",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_vector_search_sql_filters.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
-    "id": 551,
-    "answer": "No. Late recurrences can occur beyond 10 years, so patients require lifelong follow-up. $\\boxed{\\text{No}}$",
-    "_score": "[score]"
-  },
-  {
     "id": 938,
     "answer": "The presence of fibrinolysin in the reagents can partially or totally dissolve the clot, leading to erroneous results.",
-    "_score": "[score]"
+    "_score": 0.34
   },
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.3
+  },
+  {
+    "id": 551,
+    "answer": "No. Late recurrences can occur beyond 10 years, so patients require lifelong follow-up. $\\boxed{\\text{No}}$",
+    "_score": 0.29
   },
   {
     "id": 1035,
     "answer": "The primary effect of α₁-adrenergic blockers is to decrease systemic vascular resistance (SVR) by causing vasodilation.",
-    "_score": "[score]"
+    "_score": 0.29
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_vector_search_sql_projection.snap
@@ -8,27 +8,27 @@ expression: resp?
     "answer": "1. Perform the division: \\(4 \\div 10 = 0.4\\).  \n2. The decimal \\(0.4\\) is expressed in words as \\(\\boxed{\\text{four tenths}}\\).",
     "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.8
   },
   {
     "id": 349,
     "answer": "The missing factor is \\(\\boxed{2}\\).  \n\n(Explanation: Since \\( 21 \\times 2 = 42 \\), the missing factor is 2.)",
     "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\).",
     "subject": "math",
-    "_score": "[score]"
-  },
-  {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
-    "subject": "math",
-    "_score": "[score]"
+    "_score": 0.79
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.56
+  },
+  {
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "subject": "math",
+    "_score": 0.56
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 612,
     "answer": "1. Perform the division: \\(4 \\div 10 = 0.4\\).  \n2. The decimal \\(0.4\\) is expressed in words as \\(\\boxed{\\text{four tenths}}\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.8
   },
   {
     "id": 349,
     "answer": "The missing factor is \\(\\boxed{2}\\).  \n\n(Explanation: Since \\( 21 \\times 2 = 42 \\), the missing factor is 2.)",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.79
   },
   {
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.56
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.56
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.80",
       "data": {
         "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.79",
       "data": {
         "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "What is the fifth root of 32?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.80",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.79",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_vector_search_sql_filters.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
-    "id": 551,
-    "answer": "No. Late recurrences can occur beyond 10 years, so patients require lifelong follow-up. $\\boxed{\\text{No}}$",
-    "_score": "[score]"
-  },
-  {
     "id": 938,
     "answer": "The presence of fibrinolysin in the reagents can partially or totally dissolve the clot, leading to erroneous results.",
-    "_score": "[score]"
+    "_score": 0.34
   },
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.3
+  },
+  {
+    "id": 551,
+    "answer": "No. Late recurrences can occur beyond 10 years, so patients require lifelong follow-up. $\\boxed{\\text{No}}$",
+    "_score": 0.29
   },
   {
     "id": 1035,
     "answer": "The primary effect of α₁-adrenergic blockers is to decrease systemic vascular resistance (SVR) by causing vasodilation.",
-    "_score": "[score]"
+    "_score": 0.29
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_vector_search_sql_projection.snap
@@ -8,27 +8,27 @@ expression: resp?
     "answer": "1. Perform the division: \\(4 \\div 10 = 0.4\\).  \n2. The decimal \\(0.4\\) is expressed in words as \\(\\boxed{\\text{four tenths}}\\).",
     "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.8
   },
   {
     "id": 349,
     "answer": "The missing factor is \\(\\boxed{2}\\).  \n\n(Explanation: Since \\( 21 \\times 2 = 42 \\), the missing factor is 2.)",
     "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\).",
     "subject": "math",
-    "_score": "[score]"
-  },
-  {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
-    "subject": "math",
-    "_score": "[score]"
+    "_score": 0.79
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.56
+  },
+  {
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "subject": "math",
+    "_score": 0.56
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 612,
     "answer": "1. Perform the division: \\(4 \\div 10 = 0.4\\).  \n2. The decimal \\(0.4\\) is expressed in words as \\(\\boxed{\\text{four tenths}}\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.8
   },
   {
     "id": 349,
     "answer": "The missing factor is \\(\\boxed{2}\\).  \n\n(Explanation: Since \\( 21 \\times 2 = 42 \\), the missing factor is 2.)",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.79
   },
   {
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.56
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.56
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.34",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.30",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_metadata_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.34",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.30",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_vector_search_sql_filters.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
-    "id": 551,
-    "answer": "No. Late recurrences can occur beyond 10 years, so patients require lifelong follow-up. $\\boxed{\\text{No}}$",
-    "_score": "[score]"
-  },
-  {
     "id": 938,
     "answer": "The presence of fibrinolysin in the reagents can partially or totally dissolve the clot, leading to erroneous results.",
-    "_score": "[score]"
+    "_score": 0.34
   },
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.3
+  },
+  {
+    "id": 551,
+    "answer": "No. Late recurrences can occur beyond 10 years, so patients require lifelong follow-up. $\\boxed{\\text{No}}$",
+    "_score": 0.29
   },
   {
     "id": 1035,
     "answer": "The primary effect of α₁-adrenergic blockers is to decrease systemic vascular resistance (SVR) by causing vasodilation.",
-    "_score": "[score]"
+    "_score": 0.29
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_vector_search_sql_projection.snap
@@ -8,27 +8,27 @@ expression: resp?
     "answer": "1. Perform the division: \\(4 \\div 10 = 0.4\\).  \n2. The decimal \\(0.4\\) is expressed in words as \\(\\boxed{\\text{four tenths}}\\).",
     "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.8
   },
   {
     "id": 349,
     "answer": "The missing factor is \\(\\boxed{2}\\).  \n\n(Explanation: Since \\( 21 \\times 2 = 42 \\), the missing factor is 2.)",
     "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\).",
     "subject": "math",
-    "_score": "[score]"
-  },
-  {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
-    "subject": "math",
-    "_score": "[score]"
+    "_score": 0.79
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.56
+  },
+  {
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "subject": "math",
+    "_score": 0.56
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 612,
     "answer": "1. Perform the division: \\(4 \\div 10 = 0.4\\).  \n2. The decimal \\(0.4\\) is expressed in words as \\(\\boxed{\\text{four tenths}}\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.8
   },
   {
     "id": 349,
     "answer": "The missing factor is \\(\\boxed{2}\\).  \n\n(Explanation: Since \\( 21 \\times 2 = 42 \\), the missing factor is 2.)",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.79
   },
   {
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.56
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.56
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.80",
       "data": {
         "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.79",
       "data": {
         "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "What is the fifth root of 32?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.80",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.79",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.56",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.52",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_vector_search_sql_filters.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
-    "id": 551,
-    "answer": "No. Late recurrences can occur beyond 10 years, so patients require lifelong follow-up. $\\boxed{\\text{No}}$",
-    "_score": "[score]"
-  },
-  {
     "id": 938,
     "answer": "The presence of fibrinolysin in the reagents can partially or totally dissolve the clot, leading to erroneous results.",
-    "_score": "[score]"
+    "_score": 0.34
   },
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.31
   },
   {
     "id": 1035,
     "answer": "The primary effect of α₁-adrenergic blockers is to decrease systemic vascular resistance (SVR) by causing vasodilation.",
-    "_score": "[score]"
+    "_score": 0.3
+  },
+  {
+    "id": 551,
+    "answer": "No. Late recurrences can occur beyond 10 years, so patients require lifelong follow-up. $\\boxed{\\text{No}}$",
+    "_score": 0.29
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_vector_search_sql_projection.snap
@@ -8,27 +8,27 @@ expression: resp?
     "answer": "1. Perform the division: \\(4 \\div 10 = 0.4\\).  \n2. The decimal \\(0.4\\) is expressed in words as \\(\\boxed{\\text{four tenths}}\\).",
     "question": "Perform the division \\(4 \\div 10\\) and express the resulting decimal in words.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.8
   },
   {
     "id": 349,
     "answer": "The missing factor is \\(\\boxed{2}\\).  \n\n(Explanation: Since \\( 21 \\times 2 = 42 \\), the missing factor is 2.)",
     "question": "Find the missing factor in the equation: \\( 42 = 21 \\times \\,? \\).",
     "subject": "math",
-    "_score": "[score]"
-  },
-  {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
-    "subject": "math",
-    "_score": "[score]"
+    "_score": 0.79
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.56
+  },
+  {
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "subject": "math",
+    "_score": 0.56
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 612,
     "answer": "1. Perform the division: \\(4 \\div 10 = 0.4\\).  \n2. The decimal \\(0.4\\) is expressed in words as \\(\\boxed{\\text{four tenths}}\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.8
   },
   {
     "id": 349,
     "answer": "The missing factor is \\(\\boxed{2}\\).  \n\n(Explanation: Since \\( 21 \\times 2 = 42 \\), the missing factor is 2.)",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.79
   },
   {
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.56
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.56
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "serde_json::to_string_pretty(&normalize_search_response_json(resp, true))\n    .expect(\"search response snapshot serialization should succeed\")"
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.34",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: "serde_json::to_string_pretty(&normalize_search_response_json(resp, 
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.31",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,19 +30,7 @@ expression: "serde_json::to_string_pretty(&normalize_search_response_json(resp, 
       }
     },
     {
-      "_score": "[score]",
-      "dataset": "qs_view",
-      "matches": {
-        "answer": [
-          " Late recurrences can occur beyond 10 years, so patients requir"
-        ]
-      },
-      "primary_key": {
-        "id": 551
-      }
-    },
-    {
-      "_score": "[score]",
+      "_score": "0.30",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -51,6 +39,18 @@ expression: "serde_json::to_string_pretty(&normalize_search_response_json(resp, 
       },
       "primary_key": {
         "id": 1035
+      }
+    },
+    {
+      "_score": "0.29",
+      "dataset": "qs_view",
+      "matches": {
+        "answer": [
+          " Late recurrences can occur beyond 10 years, so patients requir"
+        ]
+      },
+      "primary_key": {
+        "id": 551
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_chunking_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.34",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.30",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.29
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.25
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.23
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.2
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_view_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_view_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.29
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.25
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.23
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.2
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_view_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_view_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_view_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_view_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -19,7 +19,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -32,7 +32,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -45,7 +45,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_composite_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -19,7 +19,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -32,7 +32,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -45,7 +45,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_additional_columns2_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_additional_columns2_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "answer": "The number of ways is \\( 18 \\times 17 \\times 16 = \\boxed{4896} \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "question": "How many multiples of 4 are there between 1 and 30? List them and count the total."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_view_additional_columns2_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_view_additional_columns2_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "answer": "The number of ways is \\( 18 \\times 17 \\times 16 = \\boxed{4896} \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_view_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_view_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "question": "How many multiples of 4 are there between 1 and 30? List them and count the total."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_view_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_view_basic_response.snap
@@ -1,16 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
-      "dataset": "qs_view",
-      "matches": {
-        "answer": [
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -22,7 +18,19 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
+      "dataset": "qs_view",
+      "matches": {
+        "question": [
+          "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants."
+        ]
+      },
+      "primary_key": {
+        "id": 361
+      }
+    },
+    {
+      "_score": "0.02",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -34,15 +42,15 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs_view",
       "matches": {
-        "question": [
-          "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants."
+        "answer": [
+          "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
         ]
       },
       "primary_key": {
-        "id": 361
+        "id": 1277
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_hybrid_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "How many multiples of 4 are there between 1 and 30? List them and count the total."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "data": {
         "question": "What is the fifth root of 32?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_basic_response.snap
@@ -1,24 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
-        ]
-      },
-      "primary_key": {
-        "id": 1277
-      }
-    },
-    {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +30,19 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
+        ]
+      },
+      "primary_key": {
+        "id": 1277
+      }
+    },
+    {
+      "_score": "0.53",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.49",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.29
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.25
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.23
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.2
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "How many multiples of 4 are there between 1 and 30? List them and count the total."
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
       },
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "data": {
         "question": "What is the fifth root of 32?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.53",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.54",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.51",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.49",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.29
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.25
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.23
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.2
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_metadata_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.29",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.25",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -30,7 +30,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.23",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.20",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_additional_columns2_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_additional_columns2_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
       },
@@ -24,7 +24,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples."
       },
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]"
       },
@@ -60,7 +60,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "question": "What is the fifth root of 32?"
       },
@@ -24,7 +24,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "question": "How many multiples of 4 are there between 1 and 30? List them and count the total."
       },
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
       },
@@ -60,7 +60,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_basic_response.snap
@@ -1,42 +1,27 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
-          "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
+          "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
         ],
         "question": [
-          "Which base number, when raised to the fifth power, equals thirty-two?"
+          "What is the fifth root of 32?"
         ]
       },
       "primary_key": {
-        "id": 1277
+        "id": 948
       }
     },
     {
-      "_score": "[score]",
-      "dataset": "qs",
-      "matches": {
-        "answer": [
-          "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]"
-        ],
-        "question": [
-          "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
-        ]
-      },
-      "primary_key": {
-        "id": 189
-      }
-    },
-    {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -51,18 +36,33 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
-          "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
+          "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]"
         ],
         "question": [
-          "What is the fifth root of 32?"
+          "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
         ]
       },
       "primary_key": {
-        "id": 948
+        "id": 189
+      }
+    },
+    {
+      "_score": "0.03",
+      "dataset": "qs",
+      "matches": {
+        "answer": [
+          "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
+        ],
+        "question": [
+          "Which base number, when raised to the fifth power, equals thirty-two?"
+        ]
+      },
+      "primary_key": {
+        "id": 1277
       }
     }
   ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -48,7 +48,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
+    "_score": 0.29
   },
   {
     "id": 821,
     "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.25
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.24
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.2
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_additional_columns2_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_additional_columns2_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
       },
@@ -24,7 +24,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples."
       },
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]"
       },
@@ -60,7 +60,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\)."
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "question": "What is the fifth root of 32?"
       },
@@ -24,7 +24,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "question": "How many multiples of 4 are there between 1 and 30? List them and count the total."
       },
@@ -42,7 +42,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\)."
       },
@@ -60,7 +60,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "data": {
         "question": "Which base number, when raised to the fifth power, equals thirty-two?"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_keywords_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -48,7 +48,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.02",
       "dataset": "qs_view",
       "matches": {
         "question": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_vector_search_sql_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_vector_search_sql_filters.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 1015,
     "answer": "Pedunculagin and alchemillin have astringent and wound-healing properties, possibly due to their high tannin content.",
-    "_score": "[score]"
-  },
-  {
-    "id": 821,
-    "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
-    "_score": "[score]"
+    "_score": 0.28
   },
   {
     "id": 449,
     "answer": "More than 10 years of follow-up is required, as late recurrences (beyond 12 years) have been reported in 5%–10% of patients.",
-    "_score": "[score]"
+    "_score": 0.24
+  },
+  {
+    "id": 821,
+    "answer": "Dermatomycosis is caused by fungal infections, specifically various forms of *tinea*, such as athlete's foot (*tinea pedis*).",
+    "_score": 0.24
   },
   {
     "id": 1193,
     "answer": "The body profile of Menidae is very deep and resembles a flat disc, due to the strongly curved ventral contour.",
-    "_score": "[score]"
+    "_score": 0.2
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_vector_search_sql_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_vector_search_sql_projection.snap
@@ -4,31 +4,31 @@ expression: resp?
 ---
 [
   {
-    "id": 1277,
-    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
-    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
+    "id": 189,
+    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
+    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "question": "How many multiples of 4 are there between 1 and 30? List them and count the total.",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
-    "id": 189,
-    "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
-    "question": "Evaluate the expression \\( 2 - 2x^2 \\), where \\( x = -3 \\).",
+    "id": 1277,
+    "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
+    "question": "Which base number, when raised to the fifth power, equals thirty-two?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "question": "What is the fifth root of 32?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_vector_search_sql_vectors.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_vector_search_sql_vectors.snap
@@ -7,24 +7,24 @@ expression: resp?
     "id": 1277,
     "answer": "The base number is \\(\\boxed{2}\\), because \\(2^5 = 2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 468,
     "answer": "The multiples of 4 between 1 and 30 are 4, 8, 12, 16, 20, 24, and 28. Counting these, there are $\\boxed{7}$ multiples.",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 189,
     "answer": "\\[\n2 - 2(-3)^2 = 2 - 2(9) = 2 - 18 = \\boxed{-16}\n\\]",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.54
   },
   {
     "id": 948,
     "answer": "The fifth root of 32 is \\(\\boxed{2}\\), because \\(2 \\times 2 \\times 2 \\times 2 \\times 2 = 32\\).",
     "array_length(vector_search(qs_view, Utf8(\"second\"), answer).answer_embedding)": 64,
-    "_score": "[score]"
+    "_score": 0.53
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs_view",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__s3vectors_multiple_embeddings_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: "normalize_search_response(resp, round_scores)"
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -36,7 +36,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -51,7 +51,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.03",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_sql_where_rowid_is_search_column_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_sql_where_rowid_is_search_column_basic.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_sql_where_rowid_is_search_column_composite_pk_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_sql_where_rowid_is_search_column_composite_pk_basic.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_where_rowid_is_search_column_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_where_rowid_is_search_column_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "6.33",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "6.19",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_where_rowid_is_search_column_composite_pk_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_where_rowid_is_search_column_composite_pk_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "6.33",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -19,7 +19,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "6.19",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_where_rowid_is_search_column_multi_column_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__test_text_search_where_rowid_is_search_column_multi_column_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "6.33",
       "data": {
         "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?"
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "6.19",
       "data": {
         "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "6.33",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "6.19",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_basic_without_defined_dataset_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_basic_without_defined_dataset_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "6.33",
       "dataset": "spice.public.qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "6.19",
       "dataset": "spice.public.qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_keywords_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_keywords_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?"
       },
@@ -21,7 +21,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants."
       },
@@ -36,7 +36,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "data": {
         "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "question": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.01",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_answer.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_answer.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
-    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
-    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_answer_w_question.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_answer_w_question.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
-    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": 6.331
   },
   {
     "id": 772,
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
-    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"), answer)._score,Int64(3))": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_question.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_question.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 494,
     "question": "If \\( b^\\circ \\) and \\( 30^\\circ \\) are vertical angles, what is the value of \\( b \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.934
   },
   {
     "id": 495,
     "question": "If \\( b^\\circ \\) and \\( 50^\\circ \\) are vertical angles, what is the value of \\( b \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.934
   },
   {
     "id": 499,
     "question": "If \\( m \\) and \\( n \\) are two angles that lie on a straight line, what is the value of \\( m + n \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.245
   },
   {
     "id": 1175,
     "question": "What is the sum of the angles \\( a + b + c + d + e + f + g + h \\) around a point in the diagram?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.129
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_subject_filter.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_subject_filter.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 494,
     "question": "If \\( b^\\circ \\) and \\( 30^\\circ \\) are vertical angles, what is the value of \\( b \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.934
   },
   {
     "id": 495,
     "question": "If \\( b^\\circ \\) and \\( 50^\\circ \\) are vertical angles, what is the value of \\( b \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.934
   },
   {
     "id": 499,
     "question": "If \\( m \\) and \\( n \\) are two angles that lie on a straight line, what is the value of \\( m + n \\)?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.245
   },
   {
     "id": 1175,
     "question": "What is the sum of the angles \\( a + b + c + d + e + f + g + h \\) around a point in the diagram?",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.129
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_subject_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_sql_text_search_subject_projection.snap
@@ -1,26 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 494,
     "subject": "math",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.934
   },
   {
     "id": 495,
     "subject": "math",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.934
   },
   {
     "id": 499,
     "subject": "math",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.245
   },
   {
     "id": 1175,
     "subject": "math",
-    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"angles\"), question)._score,Int64(3))": 4.129
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_metadata_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "7.52",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_basic.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_filters.snap
@@ -6,6 +6,6 @@ expression: resp?
   {
     "id": 890,
     "answer": "Relative or \"stress\" polycythaemia, which is secondary to a depletion in the plasma volume.",
-    "_score": "[score]"
+    "_score": 7.522
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_projection.snap
@@ -8,13 +8,13 @@ expression: resp?
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_additional_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_additional_columns_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "6.33",
       "data": {
         "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?"
       },
@@ -21,7 +21,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "6.19",
       "data": {
         "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_basic_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "6.33",
       "dataset": "qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "6.19",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_basic_without_defined_dataset_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_basic_without_defined_dataset_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "6.33",
       "dataset": "spice.public.qs",
       "matches": {
         "answer": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "6.19",
       "dataset": "spice.public.qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_basic.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
+expression: resp?
 ---
 [
   {
     "id": 525,
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
-    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": "[score]"
+    "trunc(text_search(qs, Utf8(\"second\"))._score,Int64(3))": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_filters.snap
@@ -6,6 +6,6 @@ expression: resp?
   {
     "id": 890,
     "answer": "Relative or \"stress\" polycythaemia, which is secondary to a depletion in the plasma volume.",
-    "_score": "[score]"
+    "_score": 7.522
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_sql_text_search_projection.snap
@@ -8,13 +8,13 @@ expression: resp?
     "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]",
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 6.331
   },
   {
     "id": 772,
     "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\).",
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
     "subject": "math",
-    "_score": "[score]"
+    "_score": 6.192
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_view_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "7.52",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_with_extra_columns_and_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_with_extra_columns_and_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -20,7 +20,7 @@ snapshot_kind: text
       "primary_key": {
         "i_item_sk": 19
       },
-      "_score": "[score]"
+      "_score": "4.28"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_with_where_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "7.52",
       "dataset": "qs",
       "matches": {
         "answer": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__topk_with_fetch_2_from_parameter_ignores_other_limit_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__topk_with_fetch_2_from_parameter_ignores_other_limit_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(result.clone())
+expression: "normalize_search_response(result.clone(), false)"
 ---
 [
   {

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__topk_with_fetch_3_from_parameter_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__topk_with_fetch_3_from_parameter_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(result.clone())
+expression: "normalize_search_response(result.clone(), false)"
 ---
 [
   {

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__topk_with_fetch_4_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__topk_with_fetch_4_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(result.clone())
+expression: "normalize_search_response(result.clone(), false)"
 ---
 [
   {

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_bypass_post_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_bypass_post_cache_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.61",
       "dataset": "spice.public.cached_search_bypass",
       "matches": {
         "cp_description": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.59",
       "dataset": "spice.public.cached_search_bypass",
       "matches": {
         "cp_description": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_bypass_pre_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_bypass_pre_cache_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.61",
       "dataset": "spice.public.cached_search_bypass",
       "matches": {
         "cp_description": [
@@ -18,7 +18,7 @@ expression: normalize_search_response(resp)
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.59",
       "dataset": "spice.public.cached_search_bypass",
       "matches": {
         "cp_description": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_post_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_post_cache_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.93",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.93",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.92",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -54,7 +54,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.91",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -66,7 +66,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.91",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -78,7 +78,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.91",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -90,7 +90,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.90",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -102,7 +102,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.90",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -114,7 +114,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.90",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -126,7 +126,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.89",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -138,7 +138,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.89",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -150,7 +150,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.89",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -162,7 +162,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.88",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -174,7 +174,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.87",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -186,7 +186,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.87",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -198,7 +198,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.86",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -210,7 +210,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.84",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -222,7 +222,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.82",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_pre_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_pre_cache_response.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: "normalize_search_response(resp, round_scores)"
+expression: normalize_search_response(resp, round_scores)
 ---
 {
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "_score": "[score]",
+      "_score": "0.94",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -18,7 +18,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.93",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -30,7 +30,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.93",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -42,7 +42,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.92",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -54,7 +54,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.91",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -66,7 +66,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.91",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -78,7 +78,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.91",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -90,7 +90,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.90",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -102,7 +102,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.90",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -114,7 +114,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.90",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -126,7 +126,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.89",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -138,7 +138,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.89",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -150,7 +150,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.89",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -162,7 +162,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.88",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -174,7 +174,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.87",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -186,7 +186,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.87",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -198,7 +198,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.86",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -210,7 +210,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.84",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [
@@ -222,7 +222,7 @@ expression: "normalize_search_response(resp, round_scores)"
       }
     },
     {
-      "_score": "[score]",
+      "_score": "0.82",
       "dataset": "spice.public.cached_search",
       "matches": {
         "cp_description": [

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__with_where_metadata_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__with_where_metadata_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.93"
     },
     {
       "dataset": "qs",
@@ -28,7 +28,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.90"
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__with_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__with_where_response.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: normalize_search_response(resp)
+expression: normalize_search_response(resp, round_scores)
 snapshot_kind: text
 ---
 {
@@ -16,7 +16,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 863
       },
-      "_score": "[score]"
+      "_score": "0.93"
     },
     {
       "dataset": "qs",
@@ -28,7 +28,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 1316
       },
-      "_score": "[score]"
+      "_score": "0.91"
     },
     {
       "dataset": "qs",
@@ -40,7 +40,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 590
       },
-      "_score": "[score]"
+      "_score": "0.91"
     },
     {
       "dataset": "qs",
@@ -52,7 +52,7 @@ snapshot_kind: text
       "primary_key": {
         "id": 6
       },
-      "_score": "[score]"
+      "_score": "0.90"
     }
   ]
 }


### PR DESCRIPTION
This reverts commit efc8d00164b7e94d248b50892be14aebfc7b2b9f, PR #10585

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->