### PR TITLE
feat(observability): propagate request trace context across distributed query boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5392,6 +5392,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.24",
  "runtime-rate-control",
+ "runtime-request-context",
  "rusqlite",
  "s3_vectors",
  "s3_vectors_metadata_filter",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -88,6 +88,7 @@ rdkafka = { workspace = true, features = ["ssl-vendored"], optional = true }
 regex.workspace = true
 reqwest.workspace = true
 runtime-rate-control = { path = "../runtime-rate-control" }
+runtime-request-context = { path = "../runtime-request-context" }
 rusqlite = { workspace = true, optional = true }
 elasticsearch = { path = "../elasticsearch", optional = true }
 s3_vectors = { path = "../s3_vectors", optional = true }

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -57,10 +57,21 @@ use datafusion::{
     },
     sql::TableReference,
 };
+use runtime_request_context::RequestContext;
 use tonic::codegen::Bytes;
 use tonic::transport::{Channel, channel};
 
 use crate::Read;
+
+/// Build a W3C `traceparent` header value (`00-{trace_id}-{span_id}-01`)
+/// from the typed `Arc<RequestContext>` extension on the
+/// [`TaskContext`]'s session config, if one is present. The fixed `01`
+/// trace flag marks the trace as sampled.
+fn trace_parent_from_task_context(context: &TaskContext) -> Option<String> {
+    let request_context = context.session_config().get_extension::<RequestContext>()?;
+    let tp = request_context.trace_parent().as_ref()?;
+    Some(format!("00-{}-{}-01", tp.trace_id, tp.span_id))
+}
 
 pub mod federation;
 
@@ -432,6 +443,12 @@ pub struct FlightSqlExec {
     properties: PlanProperties,
     cookie_store: Arc<CookieStore>,
     metrics: ExecutionPlanMetricsSet,
+    /// Optional W3C `traceparent` value (e.g. `00-{trace_id}-{span_id}-01`)
+    /// to attach as a gRPC metadata header on outgoing `execute()` and
+    /// `do_get()` calls. When `None`, `execute()` falls back to reading
+    /// the typed `Arc<RequestContext>` extension from the `TaskContext`
+    /// session config and constructs a header from its `trace_parent()`.
+    trace_parent: Option<String>,
 }
 
 impl FlightSqlExec {
@@ -460,7 +477,25 @@ impl FlightSqlExec {
             ),
             cookie_store,
             metrics: ExecutionPlanMetricsSet::new(),
+            trace_parent: None,
         })
+    }
+
+    /// Set an explicit W3C `traceparent` header value to forward on each
+    /// outgoing FlightSQL call. Useful when the plan-creation path has
+    /// access to an `Arc<RequestContext>` but the executor-side
+    /// `TaskContext` will not (e.g. when this `ExecutionPlan` is shipped
+    /// to a remote executor via Ballista codecs).
+    #[must_use]
+    pub fn with_trace_parent(mut self, trace_parent: Option<String>) -> Self {
+        self.trace_parent = trace_parent;
+        self
+    }
+
+    /// Returns the currently configured W3C `traceparent` value, if any.
+    #[must_use]
+    pub fn trace_parent(&self) -> Option<&str> {
+        self.trace_parent.as_deref()
     }
 
     /// Returns a reference to the underlying `FlightSqlClient`.
@@ -655,6 +690,7 @@ impl ExecutionPlan for FlightSqlExec {
             ),
             cookie_store: Arc::clone(&self.cookie_store),
             metrics: ExecutionPlanMetricsSet::new(),
+            trace_parent: self.trace_parent.clone(),
         };
 
         Ok(SortOrderPushdownResult::Exact {
@@ -665,7 +701,7 @@ impl ExecutionPlan for FlightSqlExec {
     fn execute(
         &self,
         partition: usize,
-        _context: Arc<TaskContext>,
+        context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let sql = self.sql().map_err(to_execution_error)?;
         let target_schema = self.schema();
@@ -676,7 +712,16 @@ impl ExecutionPlan for FlightSqlExec {
 
         let baseline = datafusion::common::instant::Instant::now();
 
-        let inner = query_to_stream(self.client.clone(), sql, Arc::clone(&self.cookie_store)).map(
+        let mut client = self.client.clone();
+        let trace_parent = self
+            .trace_parent
+            .clone()
+            .or_else(|| trace_parent_from_task_context(&context));
+        if let Some(value) = trace_parent {
+            client.set_header("traceparent", value);
+        }
+
+        let inner = query_to_stream(client, sql, Arc::clone(&self.cookie_store)).map(
             move |result| result.and_then(|batch| coerce_batch_to_schema(&batch, &target_schema)),
         );
 
@@ -727,6 +772,7 @@ impl ExecutionPlan for FlightSqlExec {
             properties: self.properties.clone(),
             cookie_store: Arc::clone(&self.cookie_store),
             metrics: ExecutionPlanMetricsSet::new(),
+            trace_parent: self.trace_parent.clone(),
         };
 
         Some(Arc::new(new_plan))

--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/exec.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/exec.rs
@@ -153,6 +153,11 @@ pub struct PartialAggregationFlightSqlExec {
     cookie_store: Arc<CookieStore>,
     /// Cached plan properties.
     properties: PlanProperties,
+    /// Optional W3C `traceparent` value inherited from the source
+    /// `FlightSqlExec`. Forwarded as a gRPC metadata header on each
+    /// outgoing call so executor-side spans chain back to the originating
+    /// request.
+    trace_parent: Option<String>,
 }
 
 impl PartialAggregationFlightSqlExec {
@@ -181,6 +186,7 @@ impl PartialAggregationFlightSqlExec {
             client: source.client().clone(),
             cookie_store: Arc::clone(source.cookie_store()),
             properties,
+            trace_parent: source.trace_parent().map(str::to_string),
         }
     }
 
@@ -261,14 +267,15 @@ impl ExecutionPlan for PartialAggregationFlightSqlExec {
         let target_schema = self.schema();
         let column_mapping = query.column_mapping;
 
-        let stream = query_to_stream(
-            self.client.clone(),
-            query.sql,
-            Arc::clone(&self.cookie_store),
-        )
-        .map(move |result: std::result::Result<_, DataFusionError>| {
-            result.and_then(|batch| remap_batch(&batch, &column_mapping, &target_schema))
-        });
+        let mut client = self.client.clone();
+        if let Some(value) = self.trace_parent.clone() {
+            client.set_header("traceparent", value);
+        }
+
+        let stream = query_to_stream(client, query.sql, Arc::clone(&self.cookie_store))
+            .map(move |result: std::result::Result<_, DataFusionError>| {
+                result.and_then(|batch| remap_batch(&batch, &column_mapping, &target_schema))
+            });
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),

--- a/crates/runtime-datafusion/src/config/mod.rs
+++ b/crates/runtime-datafusion/src/config/mod.rs
@@ -1,1 +1,2 @@
 pub mod cluster_config;
+pub mod request_context_config;

--- a/crates/runtime-datafusion/src/config/request_context_config.rs
+++ b/crates/runtime-datafusion/src/config/request_context_config.rs
@@ -1,0 +1,188 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `ConfigExtension` that carries `RequestContext` trace fields through
+//! transport boundaries that round-trip a DataFusion `SessionConfig` as
+//! opaque key/value pairs — primarily the Ballista `TaskDefinition` props
+//! used to ship per-job session config to executors.
+//!
+//! The receiver reconstructs an `Arc<RequestContext>` via
+//! [`SpiceRequestContextConfig::to_request_context`] so executor-side exec
+//! nodes (`BytesProcessedExec` and similar) attribute metrics and any
+//! emitted task-history rows to the originating request.
+//!
+//! The propagated `span_id` is the sender's *current* span; on the receiver
+//! it becomes the parent of any new spans created from the reconstructed
+//! context (standard W3C trace-context semantics).
+
+use datafusion::common::extensions_options;
+use datafusion::config::ConfigExtension;
+use opentelemetry::trace::{SpanId, TraceId};
+use runtime_request_context::{Protocol, RequestContext, RequestContextBuilder, TraceParent};
+use std::sync::Arc;
+
+extensions_options! {
+    /// Trace fields propagated from a scheduler (or any upstream sender) to
+    /// downstream executors via a `SessionConfig` round-trip.
+    pub struct SpiceRequestContextConfig {
+        /// Source request protocol, encoded as `Protocol as u8`. `None` if
+        /// unset (executor falls back to `Protocol::Internal`).
+        pub protocol: Option<u8>, default = None
+        /// W3C trace id (32 lowercase hex chars). `None` if the upstream
+        /// request had no trace context.
+        pub trace_id: Option<String>, default = None
+        /// W3C span id of the *current* span on the sender (16 lowercase
+        /// hex chars). On the receiver this is the parent of any new spans
+        /// created from the reconstructed `RequestContext`.
+        pub span_id: Option<String>, default = None
+    }
+}
+
+impl ConfigExtension for SpiceRequestContextConfig {
+    const PREFIX: &'static str = "spice_ctx";
+}
+
+impl SpiceRequestContextConfig {
+    /// Populate from a `RequestContext` for shipping over a transport.
+    ///
+    /// The `span_id` in the resulting config is the request's current span
+    /// (i.e. `request.trace_parent().span_id`), which becomes the parent of
+    /// any spans created from the reconstructed context on the receiver.
+    #[must_use]
+    pub fn from_request_context(request: &RequestContext) -> Self {
+        let protocol = request.protocol();
+        let (trace_id, span_id) = match request.trace_parent() {
+            Some(tp) => (Some(tp.trace_id.to_string()), Some(tp.span_id.to_string())),
+            None => (None, None),
+        };
+        Self {
+            protocol: Some(protocol as u8),
+            trace_id,
+            span_id,
+        }
+    }
+
+    /// Build a fresh `RequestContext` from the propagated fields.
+    ///
+    /// `protocol` defaults to [`Protocol::Internal`] when missing or
+    /// invalid. `trace_id` / `span_id` populate the `TraceParent` only if
+    /// both parse as valid W3C ids.
+    #[must_use]
+    pub fn to_request_context(&self) -> Arc<RequestContext> {
+        let protocol = self
+            .protocol
+            .map(Protocol::from)
+            .filter(|p| !matches!(p, Protocol::Invalid))
+            .unwrap_or(Protocol::Internal);
+
+        let mut builder = RequestContextBuilder::new(protocol);
+
+        if let (Some(trace_id_str), Some(span_id_str)) =
+            (self.trace_id.as_deref(), self.span_id.as_deref())
+            && let (Ok(trace_id), Ok(span_id)) = (
+                TraceId::from_hex(trace_id_str),
+                SpanId::from_hex(span_id_str),
+            )
+        {
+            builder = builder.with_trace_parent(Some(TraceParent { trace_id, span_id }));
+        }
+
+        Arc::new(builder.build())
+    }
+
+    /// Returns `true` if any field carries a value — useful to decide
+    /// whether the receiver should prefer this extension over a fallback.
+    #[must_use]
+    pub fn is_populated(&self) -> bool {
+        self.protocol.is_some() || self.trace_id.is_some() || self.span_id.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_to_request_context_roundtrip_with_trace_parent() {
+        let trace_id = TraceId::from_hex("0123456789abcdef0123456789abcdef").expect("trace id");
+        let span_id = SpanId::from_hex("0123456789abcdef").expect("span id");
+        let original = Arc::new(
+            RequestContextBuilder::new(Protocol::FlightSQL)
+                .with_trace_parent(Some(TraceParent { trace_id, span_id }))
+                .build(),
+        );
+
+        let cfg = SpiceRequestContextConfig::from_request_context(&original);
+        assert_eq!(cfg.protocol, Some(Protocol::FlightSQL as u8));
+        assert_eq!(
+            cfg.trace_id.as_deref(),
+            Some("0123456789abcdef0123456789abcdef")
+        );
+        assert_eq!(cfg.span_id.as_deref(), Some("0123456789abcdef"));
+
+        let rebuilt = cfg.to_request_context();
+        assert!(matches!(rebuilt.protocol(), Protocol::FlightSQL));
+        let tp = rebuilt
+            .trace_parent()
+            .as_ref()
+            .expect("trace parent should be present");
+        assert_eq!(tp.trace_id, trace_id);
+        assert_eq!(tp.span_id, span_id);
+    }
+
+    #[test]
+    fn to_request_context_without_trace_fields_defaults_to_internal() {
+        let cfg = SpiceRequestContextConfig::default();
+        assert!(!cfg.is_populated());
+
+        let ctx = cfg.to_request_context();
+        assert!(matches!(ctx.protocol(), Protocol::Internal));
+        assert!(ctx.trace_parent().is_none());
+    }
+
+    #[test]
+    fn to_request_context_with_invalid_trace_id_drops_trace_parent() {
+        let cfg = SpiceRequestContextConfig {
+            protocol: Some(Protocol::Http as u8),
+            trace_id: Some("not-hex".to_string()),
+            span_id: Some("0123456789abcdef".to_string()),
+        };
+        let ctx = cfg.to_request_context();
+        assert!(matches!(ctx.protocol(), Protocol::Http));
+        assert!(ctx.trace_parent().is_none());
+    }
+
+    #[test]
+    fn entries_use_prefix() {
+        use datafusion::config::ExtensionOptions;
+
+        let cfg = SpiceRequestContextConfig::from_request_context(&Arc::new(
+            RequestContextBuilder::new(Protocol::FlightSQL)
+                .with_trace_parent(Some(TraceParent {
+                    trace_id: TraceId::from_hex("0123456789abcdef0123456789abcdef")
+                        .expect("trace id"),
+                    span_id: SpanId::from_hex("0123456789abcdef").expect("span id"),
+                }))
+                .build(),
+        ));
+
+        let entries = cfg.entries();
+        let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
+        assert!(keys.contains(&"protocol"));
+        assert!(keys.contains(&"trace_id"));
+        assert!(keys.contains(&"span_id"));
+    }
+}

--- a/crates/runtime-datafusion/src/extension/bytes_processed.rs
+++ b/crates/runtime-datafusion/src/extension/bytes_processed.rs
@@ -46,8 +46,9 @@ use datafusion::{
     },
 };
 use futures::{Stream, StreamExt};
+use crate::extension::request_context::resolve_request_context;
 use opentelemetry::KeyValue;
-use runtime_request_context::{Protocol, RequestContext, RequestContextBuilder};
+use runtime_request_context::RequestContext;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{any::Any, sync::Arc};
@@ -299,13 +300,9 @@ impl ExecutionPlan for BytesProcessedExec {
         let stream = self.input_exec.execute(partition, Arc::clone(&context))?;
         let schema = stream.schema();
 
-        let request_context = if let Some(request_context) =
-            context.session_config().get_extension::<RequestContext>()
-        {
-            request_context
-        } else if self.fallback_to_new_context {
-            Arc::new(RequestContextBuilder::new(Protocol::Internal).build())
-        } else {
+        let Some(request_context) =
+            resolve_request_context(&context, self.fallback_to_new_context)
+        else {
             // This should never happen if all queries are run through the query builder, so if it does its a bug we need to catch in development.
             panic!(
                 "The request context was not provided to BytesProcessedExec, report a bug at https://github.com/spiceai/spiceai/issues"
@@ -420,7 +417,10 @@ mod tests {
     use datafusion::prelude::{SessionConfig, SessionContext};
     use std::sync::{Arc, Mutex};
 
+    use crate::config::request_context_config::SpiceRequestContextConfig;
     use crate::extension::bytes_processed::{BytesEmittedCallback, BytesProcessedExec};
+    use opentelemetry::trace::{SpanId, TraceId};
+    use runtime_request_context::{Protocol, RequestContextBuilder, TraceParent};
 
     fn make_test_table() -> Result<Arc<dyn TableProvider>> {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
@@ -608,6 +608,66 @@ mod tests {
             after_total > 0,
             "Expected non-zero bytes tracked after repartitioning"
         );
+
+        Ok(())
+    }
+
+    /// Verifies the executor-side propagation path that this issue
+    /// enables: when no typed `Arc<RequestContext>` is present on the
+    /// session config (the case after Ballista round-trips the config to
+    /// an executor), `BytesProcessedExec` reconstructs the request
+    /// context from the `SpiceRequestContextConfig` option extension and
+    /// emits metric dimensions tagged with the originating protocol.
+    #[tokio::test]
+    async fn test_uses_config_extension_when_typed_request_context_missing() -> Result<()> {
+        let trace_id = TraceId::from_hex("0123456789abcdef0123456789abcdef").expect("trace id");
+        let span_id = SpanId::from_hex("0123456789abcdef").expect("span id");
+
+        let cfg_ext = SpiceRequestContextConfig::from_request_context(&Arc::new(
+            RequestContextBuilder::new(Protocol::FlightSQL)
+                .with_trace_parent(Some(TraceParent { trace_id, span_id }))
+                .build(),
+        ));
+
+        let session_config = SessionConfig::new()
+            .with_target_partitions(1)
+            .with_option_extension(cfg_ext);
+        let ctx = SessionContext::new_with_config(session_config);
+        let test_table = make_test_table()?;
+
+        let data_source_exec = test_table.scan(&ctx.state(), None, &[], None).await?;
+
+        // `fallback_to_new_context` is intentionally left off here: the
+        // exec must resolve via the config extension, not the fallback.
+        let exec = Arc::new(BytesProcessedExec::new(
+            data_source_exec,
+            Arc::new(Box::new(|_, _| {})),
+        )) as Arc<dyn ExecutionPlan>;
+
+        let observed_protocol = Arc::new(Mutex::new(None::<String>));
+        let observed_clone = Arc::clone(&observed_protocol);
+        let capture_protocol: Arc<BytesEmittedCallback> = Arc::new(Box::new(move |_, dims| {
+            let protocol = dims
+                .iter()
+                .find(|kv| kv.key.as_str() == "protocol")
+                .map(|kv| kv.value.as_str().to_string());
+            *observed_clone
+                .lock()
+                .expect("observed protocol mutex should not be poisoned") = protocol;
+        }));
+
+        let capturing_exec = Arc::new(BytesProcessedExec::new(
+            exec,
+            Arc::clone(&capture_protocol),
+        )) as Arc<dyn ExecutionPlan>;
+
+        let _ = collect(capturing_exec, ctx.task_ctx()).await?;
+
+        let observed = observed_protocol
+            .lock()
+            .expect("observed protocol mutex should not be poisoned")
+            .clone();
+        assert_eq!(observed.as_deref(), Some("flightsql"));
 
         Ok(())
     }

--- a/crates/runtime-datafusion/src/extension/mod.rs
+++ b/crates/runtime-datafusion/src/extension/mod.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 
 pub mod bytes_processed;
 pub mod data_source_tree_display;
+pub mod request_context;
 
 /// [`ExtensionPlanQueryPlanner`] implements [`QueryPlanner`] with a set of [`ExtensionPlanner`].
 ///

--- a/crates/runtime-datafusion/src/extension/request_context.rs
+++ b/crates/runtime-datafusion/src/extension/request_context.rs
@@ -1,0 +1,146 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Shared resolution for an `Arc<RequestContext>` from a DataFusion
+//! [`TaskContext`].
+//!
+//! Establishes a canonical lookup order for any Spice exec node that needs
+//! the originating request's context on an executor:
+//!
+//! 1. A typed extension on the [`SessionConfig`] (set on the
+//!    scheduler-side in-process via
+//!    `SessionConfig::with_extension::<RequestContext>`).
+//! 2. The [`SpiceRequestContextConfig`] `ConfigExtension`, populated when
+//!    the per-job `SessionConfig` round-trips over a transport (Ballista
+//!    `TaskDefinition` props).
+//! 3. A fresh `Protocol::Internal` context — only when the caller opts in
+//!    via `fallback_to_internal = true`. Otherwise returns `None`.
+//!
+//! Source 1 is preferred so single-process queries continue to see the
+//! exact same `Arc<RequestContext>` (including extensions and
+//! cancellation token) that was installed by the query builder. Only when
+//! crossing a transport boundary do we reconstruct a fresh
+//! `RequestContext` from the config extension.
+
+use crate::config::request_context_config::SpiceRequestContextConfig;
+use datafusion::execution::TaskContext;
+use runtime_request_context::{Protocol, RequestContext, RequestContextBuilder};
+use std::sync::Arc;
+
+/// Resolve an `Arc<RequestContext>` for executor-side telemetry.
+///
+/// Returns `None` if no context is available and `fallback_to_internal`
+/// is `false` — callers can treat that as a missing-context bug to panic
+/// on, matching the prior `BytesProcessedExec` behavior.
+#[must_use]
+pub fn resolve_request_context(
+    context: &TaskContext,
+    fallback_to_internal: bool,
+) -> Option<Arc<RequestContext>> {
+    if let Some(request_context) = context.session_config().get_extension::<RequestContext>() {
+        return Some(request_context);
+    }
+
+    let config_ext = context
+        .session_config()
+        .options()
+        .extensions
+        .get::<SpiceRequestContextConfig>();
+    if let Some(ext) = config_ext
+        && ext.is_populated()
+    {
+        return Some(ext.to_request_context());
+    }
+
+    if fallback_to_internal {
+        return Some(Arc::new(
+            RequestContextBuilder::new(Protocol::Internal).build(),
+        ));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionConfig;
+    use opentelemetry::trace::{SpanId, TraceId};
+    use runtime_request_context::TraceParent;
+
+    fn task_context(config: SessionConfig) -> TaskContext {
+        TaskContext::default().with_session_config(config)
+    }
+
+    #[test]
+    fn prefers_typed_extension_over_config_extension() {
+        let typed = Arc::new(
+            RequestContextBuilder::new(Protocol::FlightSQL)
+                .with_trace_parent(Some(TraceParent {
+                    trace_id: TraceId::from_hex("00000000000000000000000000000001").unwrap(),
+                    span_id: SpanId::from_hex("0000000000000001").unwrap(),
+                }))
+                .build(),
+        );
+
+        let config_ext = SpiceRequestContextConfig {
+            protocol: Some(Protocol::Http as u8),
+            trace_id: Some("00000000000000000000000000000002".to_string()),
+            span_id: Some("0000000000000002".to_string()),
+        };
+
+        let config = SessionConfig::new()
+            .with_extension(Arc::clone(&typed))
+            .with_option_extension(config_ext);
+
+        let resolved = resolve_request_context(&task_context(config), false).unwrap();
+        assert!(matches!(resolved.protocol(), Protocol::FlightSQL));
+        // Same Arc — typed extension wins.
+        assert!(Arc::ptr_eq(&resolved, &typed));
+    }
+
+    #[test]
+    fn falls_back_to_config_extension_when_typed_missing() {
+        let config_ext = SpiceRequestContextConfig {
+            protocol: Some(Protocol::Http as u8),
+            trace_id: Some("0123456789abcdef0123456789abcdef".to_string()),
+            span_id: Some("0123456789abcdef".to_string()),
+        };
+        let config = SessionConfig::new().with_option_extension(config_ext);
+
+        let resolved = resolve_request_context(&task_context(config), false).unwrap();
+        assert!(matches!(resolved.protocol(), Protocol::Http));
+        let tp = resolved.trace_parent().as_ref().unwrap();
+        assert_eq!(
+            tp.trace_id,
+            TraceId::from_hex("0123456789abcdef0123456789abcdef").unwrap()
+        );
+        assert_eq!(tp.span_id, SpanId::from_hex("0123456789abcdef").unwrap());
+    }
+
+    #[test]
+    fn returns_none_when_unpopulated_and_no_fallback() {
+        let config = SessionConfig::new().with_option_extension(SpiceRequestContextConfig::default());
+        assert!(resolve_request_context(&task_context(config), false).is_none());
+    }
+
+    #[test]
+    fn returns_internal_when_fallback_requested() {
+        let config = SessionConfig::new();
+        let resolved = resolve_request_context(&task_context(config), true).unwrap();
+        assert!(matches!(resolved.protocol(), Protocol::Internal));
+    }
+}

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -57,6 +57,7 @@ use datafusion_expr::Expr;
 use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
 use futures::future::try_join_all;
 use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
+use runtime_datafusion::config::request_context_config::SpiceRequestContextConfig;
 use runtime_object_store::registry::default_runtime_env;
 use runtime_proto::cluster_service_client::ClusterServiceClient;
 use runtime_proto::{
@@ -1281,6 +1282,7 @@ pub async fn initialize_cluster_executor(
     let config_producer: ConfigProducer = Arc::new(move || {
         let mut config = SessionConfig::new_with_ballista()
             .with_option_extension(SpiceClusterConfig::default())
+            .with_option_extension(SpiceRequestContextConfig::default())
             .with_ballista_use_tls(tls_enabled)
             // Use 100MB max message size to match other gRPC configurations in the codebase.
             // The default Ballista config is 16MB which is too small for shuffle operations
@@ -1744,7 +1746,7 @@ async fn create_scheduler_server(
     // Uses the dynamic total_executor_slots to set target_partitions
     let slots_for_session = Arc::clone(&total_executor_slots);
     let session_builder: ballista_scheduler::scheduler_server::SessionBuilder =
-        Arc::new(move |_cfg| {
+        Arc::new(move |incoming_cfg| {
             // Get dynamic target_partitions based on cluster capacity
             let total_slots = slots_for_session.load(Ordering::Relaxed);
             let target_partitions = if total_slots > 0 { total_slots } else { 16 };
@@ -1755,10 +1757,24 @@ async fn create_scheduler_server(
                 "Cluster session_builder: setting target_partitions based on cluster capacity"
             );
 
+            // Inherit any `SpiceRequestContextConfig` set on the incoming
+            // per-job session config (populated by
+            // `Query::submit_distributed_internal`). The session builder
+            // otherwise rebuilds the session config from
+            // `current_context.copied_config()`, which is a shared
+            // background context with no request-specific trace ids.
+            let incoming_request_context = incoming_cfg
+                .options()
+                .extensions
+                .get::<SpiceRequestContextConfig>()
+                .cloned()
+                .unwrap_or_default();
+
             let mut cfg = current_context
                 .copied_config()
                 .with_target_partitions(target_partitions)
                 .with_option_extension(SpiceClusterConfig::default())
+                .with_option_extension(incoming_request_context)
                 .with_ballista_shuffle_format(ballista_shuffle_format)
                 .with_ballista_shuffle_memory_mode(shuffle_memory_mode);
 
@@ -1809,6 +1825,7 @@ async fn create_scheduler_server(
         SessionConfig::new_with_ballista()
             .with_target_partitions(target_partitions)
             .with_option_extension(SpiceClusterConfig::default())
+            .with_option_extension(SpiceRequestContextConfig::default())
             .with_ballista_shuffle_format(ballista_shuffle_format)
             .with_ballista_shuffle_memory_mode(shuffle_memory_mode)
     });

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -90,6 +90,7 @@ use crate::datafusion::{
 use managed_runtime::ManagedRuntimeError;
 use opentelemetry::KeyValue;
 use runtime_datafusion::allowlist::ResolvedTableAwareAllowlist;
+use runtime_datafusion::config::request_context_config::SpiceRequestContextConfig;
 use runtime_request_context::{AsyncMarker, RequestContext};
 use tokio::runtime::Handle;
 
@@ -350,8 +351,15 @@ impl Query {
         let scheduler = Self::get_scheduler_server(&self.df)?;
         let tracker = self.tracker;
 
-        // Create session for this job
-        let session_config = datafusion::prelude::SessionConfig::new_with_ballista();
+        // Create session for this job. The
+        // `SpiceRequestContextConfig` extension propagates the originating
+        // request's trace ids to executors through Ballista's
+        // `TaskDefinition` props; the scheduler-side session builder reads
+        // it back out and re-injects it on the built session config.
+        let session_config = datafusion::prelude::SessionConfig::new_with_ballista()
+            .with_option_extension(SpiceRequestContextConfig::from_request_context(
+                &request_context,
+            ));
         let session_ctx = scheduler
             .state
             .session_manager


### PR DESCRIPTION
## Summary

Issue #10202. Distributed query executors no longer create a fresh internal request context — they inherit the originating request's protocol and W3C trace ids so executor-side metrics, telemetry dimensions, and any future executor-side task_history rows correlate end-to-end with the scheduler.

Stacked on top of #10831.

## What changed

- **New `SpiceRequestContextConfig` (`spice_ctx` prefix)** in `crates/runtime-datafusion/src/config/`. Carries `protocol`, `trace_id`, `span_id` through DataFusion's `ConfigExtension` mechanism — round-tripped opaquely by Ballista as `TaskDefinition` config props with **zero fork changes**.
- **Registration at all 3 sites** in `runtime/src/cluster/mod.rs` (executor config_producer, scheduler session_builder, scheduler config_producer). The session_builder previously ignored its `_cfg` argument; it now reads `SpiceRequestContextConfig` off the incoming per-job session config and re-injects it on the built session config.
- **Scheduler-side injection** in `Query::submit_distributed_internal` — populates the extension from the current `RequestContext` before `create_or_update_session`.
- **`resolve_request_context(TaskContext)` shared helper** establishes the canonical lookup order: typed `Arc<RequestContext>` extension → config extension → `Protocol::Internal` fallback (or `None`). `BytesProcessedExec::execute` switched to use it; the original panic-on-missing behavior is preserved when `fallback_to_new_context` is off.
- **FlightSQL traceparent forwarding.** `FlightSqlExec` gains an optional `trace_parent: Option<String>` field + `with_trace_parent` builder. `execute()` sets it as a `traceparent` gRPC metadata header (`FlightSqlServiceClient::set_header`), falling back to formatting from the typed `RequestContext` extension on the `TaskContext` session config when not preset. `PartialAggregationFlightSqlExec` inherits and forwards on its own `execute()`.

## Design notes

- **W3C span semantics preserved.** The propagated `span_id` is the *sender's current span*; on the receiver it becomes the parent of any new spans created from the reconstructed context. The existing `parent_span_id` chain in `task_history` extends naturally one level per executor hop, so the UI tree view keeps rendering.
- **Two transports, one shape.** Ballista propagates via `SpiceRequestContextConfig` round-tripped in `SessionConfig`; FlightSQL propagates via the W3C `traceparent` gRPC header on the outgoing call. On the executor side both paths converge through `resolve_request_context(TaskContext)`.
- **No new proto messages.** No Ballista fork changes. No per-node context embedding on plan trees.

## Out of scope

- `authorization` header propagation.
- Setting the ambient task-local `RequestContext` on Ballista executors (would require a small fork change; can be added later if UDFs/embeddings need it).

## Tests

- **Config extension** (`request_context_config.rs`): roundtrip with trace parent, default → Internal, invalid hex drops trace parent, entries use prefix. (4 tests)
- **Resolver** (`request_context.rs`): typed extension wins over config extension, falls back to config extension, returns `None` without fallback, returns Internal when fallback requested. (4 tests)
- **`BytesProcessedExec` integration** (`bytes_processed.rs`): emitted metric dimensions carry `protocol=flightsql` when only the config extension is present (asserts the executor-side propagation path end-to-end through `execute()`). (1 test)

## Verified

- `cargo check -p runtime-datafusion -p data_components -p datafusion-optimizer-rules -p runtime` — clean.
- `cargo test -p runtime-datafusion --lib request_context` — 9/9 pass.
- `cargo test -p data_components --lib` — 452/452 pass.
- `cargo test -p runtime --test integration --no-run` — compiles clean.

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->