### PR TITLE
fix(search): preserve column casing in /v1/search primary key plumbing (fixes #10631)

### DIFF
--- a/crates/runtime/src/search/search_engine.rs
+++ b/crates/runtime/src/search/search_engine.rs
@@ -383,7 +383,7 @@ impl SearchEngine {
                         &tbl,
                         get_filter_for_table(&self.df, &tbl, where_cond.as_ref()).await?,
                         table_cols,
-                        primary_keys.iter().map(|pk| Column::from_qualified_name(pk.clone()) ).collect::<Vec<Column>>(),
+                        primary_keys.iter().map(|pk| Column::from_name(pk.clone()) ).collect::<Vec<Column>>(),
                         keywords,
                         *limit
                     ).await.context(SearchPipelineSnafu)?;

--- a/crates/search/src/aggregation/reciprocal_rank.rs
+++ b/crates/search/src/aggregation/reciprocal_rank.rs
@@ -263,7 +263,7 @@ fn additional_columns_of_schema(schema: &SchemaRef, primary_key: &[Column]) -> V
         .iter()
         .filter_map(|f| {
             let name = f.name();
-            let col = Column::from_qualified_name(f.name());
+            let col = Column::from_name(f.name());
             if [SEARCH_SCORE_COLUMN_NAME, SEARCH_VALUE_COLUMN_NAME].contains(&name.as_str())
                 || primary_key.contains(&col)
             {
@@ -531,6 +531,34 @@ mod tests {
         assert_eq!(
             additional_columns_of_schema(&schema, primary_keys.as_slice()),
             vec![Column::from_name("additional")]
+        );
+    }
+
+    /// Regression test for #10631: mixed-case column names (e.g. `LocationID`) must
+    /// retain their original casing through `additional_columns_of_schema`. Using
+    /// `Column::from_qualified_name` here would lowercase the identifier and cause
+    /// downstream plan resolution to fail with `No field named locationid` against
+    /// a schema that registered the field as `"LocationID"`.
+    #[test]
+    fn test_additional_columns_of_schema_preserves_mixed_case() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(SEARCH_SCORE_COLUMN_NAME, DataType::Int8, false),
+            Field::new(SEARCH_VALUE_COLUMN_NAME, DataType::Int8, false),
+            Field::new("LocationID", DataType::Utf8, false),
+            Field::new("Borough", DataType::Utf8, false),
+            Field::new("service_zone", DataType::Utf8, false),
+        ]));
+        let primary_keys = vec![Column::from_name("LocationID")];
+        let additional = additional_columns_of_schema(&schema, primary_keys.as_slice());
+        let names: Vec<String> = additional.iter().map(|c| c.name.clone()).collect();
+        assert_eq!(
+            names,
+            vec!["Borough".to_string(), "service_zone".to_string()]
+        );
+        // Make sure no column got lowercased on its way through.
+        assert!(
+            !names.iter().any(|n| n == "borough"),
+            "expected Borough to retain mixed case, got {names:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes #10631

`POST /v1/search` was failing with HTTP 500 (`Schema error: No field named locationid`) on datasets whose primary key column used mixed-case (e.g. `LocationID`). The schema registered the field with its original case, but the search pipeline emitted a lowercased reference, so DataFusion's projection lookup failed.

**Root cause.** Two call sites constructed `Column` structs from primary-key strings via `Column::from_qualified_name(...)`, which calls `parse_identifiers_normalized()` and lowercases any unquoted identifier before the plan is built. Case-handling was previously added in an earlier PR but was removed during the LogicalPlanBuilder refactor, which replaced the SQL-string + `quote_identifier` flow with direct `Column::from_qualified_name(...)` calls.

## Changes
- `crates/runtime/src/search/search_engine.rs`: build the per-table primary-key `Column` list with `Column::from_name(...)` (no normalization) instead of `Column::from_qualified_name(...)` (lowercases).
- `crates/search/src/aggregation/reciprocal_rank.rs`: same swap inside `additional_columns_of_schema`, which had the same lowercasing bug for non-primary-key columns.
- This brings the search/RRF pipeline in line with `candidate/vector.rs` and `index/vector_table.rs`, which already use `Column::from_name`.

## Test plan
- [x] Added regression test `test_additional_columns_of_schema_preserves_mixed_case` exercising a schema with `LocationID`, `Borough`, `service_zone` and asserting the columns round-trip with original casing.
- [x] `make lint` passes (workspace-wide formatting and clippy gate).
- [x] `make test` passes.

## Checklist
- [x] Root cause identified and fixed
- [x] Regression test added
- [x] Edge cases covered (mixed-case primary key + mixed-case additional columns + lowercase column unchanged)
- [x] No snapshot deletions
- [x] Lint clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->