### PR TITLE
deps(ballista): bump to 47e2b494 to fix S3 shuffle reads under cluster mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=c25e25b9e88c50404e230c698a35cbde2fdd30ae#c25e25b9e88c50404e230c698a35cbde2fdd30ae"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=47e2b4946762c834d4a11532a25cc99c9e8a0b9d#47e2b4946762c834d4a11532a25cc99c9e8a0b9d"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2362,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=c25e25b9e88c50404e230c698a35cbde2fdd30ae#c25e25b9e88c50404e230c698a35cbde2fdd30ae"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=47e2b4946762c834d4a11532a25cc99c9e8a0b9d#47e2b4946762c834d4a11532a25cc99c9e8a0b9d"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2395,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=c25e25b9e88c50404e230c698a35cbde2fdd30ae#c25e25b9e88c50404e230c698a35cbde2fdd30ae"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=47e2b4946762c834d4a11532a25cc99c9e8a0b9d#47e2b4946762c834d4a11532a25cc99c9e8a0b9d"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,9 +426,9 @@ datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev 
 
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b798c391b6566c172d44361f8acc8472c958ca75" } # spiceai-52
 
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "c25e25b9e88c50404e230c698a35cbde2fdd30ae" }      # spiceai-52.5
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "c25e25b9e88c50404e230c698a35cbde2fdd30ae" } # spiceai-52.5
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "c25e25b9e88c50404e230c698a35cbde2fdd30ae" } # spiceai-52.5
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "47e2b4946762c834d4a11532a25cc99c9e8a0b9d" }      # spiceai-52.5
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "47e2b4946762c834d4a11532a25cc99c9e8a0b9d" } # spiceai-52.5
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "47e2b4946762c834d4a11532a25cc99c9e8a0b9d" } # spiceai-52.5
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 


### PR DESCRIPTION
## Summary

Pulls in spiceai/datafusion-ballista#41 (commit `47e2b494`).

The shuffle reader was looking up the S3 object store via `RuntimeEnv::object_store(...)`. In our embedded deployment that registry only holds the *dataset* object stores — the shuffle bucket isn't registered there, so the lookup returned a default unauthenticated S3 client and reads landed with a 403 AccessDenied, even though the writer had successfully uploaded the partition (the writer builds its own client via `AmazonS3Builder::from_env()`).

After this bump, the reader also builds its client from the executor pod's env vars, matching the writer. Async queries that set `runtime.params.shuffle_location: s3://...` complete end-to-end.

A proper architectural follow-up — register the shuffle storage on `RuntimeEnv` at executor startup using the host runtime's secret store (the same pattern `executor_bind_object_stores` uses for datasets) — is tracked separately. That removes the env-var dependency entirely and the per-fetch client construction.

## Test plan

- [x] `cargo check -p runtime` compiles clean with the bumped Cargo.lock
- [ ] Re-deploy a clustered app with `shuffle_location: s3://...` and run ClickBench (the workload that originally hit the 403)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->