### PR TITLE
Authorization header + Bump async-openai + `responses_adapter` fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "async-openai"
 version = "0.32.0"
-source = "git+https://github.com/spiceai/async-openai?rev=8dbb88bcd14b70dfd92ddd02aeb9f31112c7b63b#8dbb88bcd14b70dfd92ddd02aeb9f31112c7b63b"
+source = "git+https://github.com/spiceai/async-openai?rev=98e0c53be444e2427177cc77554d70813913d775#98e0c53be444e2427177cc77554d70813913d775"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "async-openai-macros"
 version = "0.1.1"
-source = "git+https://github.com/spiceai/async-openai?rev=8dbb88bcd14b70dfd92ddd02aeb9f31112c7b63b#8dbb88bcd14b70dfd92ddd02aeb9f31112c7b63b"
+source = "git+https://github.com/spiceai/async-openai?rev=98e0c53be444e2427177cc77554d70813913d775#98e0c53be444e2427177cc77554d70813913d775"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ arrow-json = "57.0.0"
 arrow-odbc = { git = "https://github.com/pacman82/arrow-odbc", rev = "7316b13" }
 arrow-row = "57.0.0"
 arrow-schema = "57.0.0"
-async-openai = { git = "https://github.com/spiceai/async-openai", rev = "8dbb88bcd14b70dfd92ddd02aeb9f31112c7b63b", features = [
+async-openai = { git = "https://github.com/spiceai/async-openai", rev = "98e0c53be444e2427177cc77554d70813913d775", features = [
     "byot",
     "embedding",
     "chat-completion",

--- a/crates/llms/src/openai/responses_adapter.rs
+++ b/crates/llms/src/openai/responses_adapter.rs
@@ -258,10 +258,10 @@ fn input_item_from_chat_tool_call(
     match tool_call {
         ChatCompletionMessageToolCalls::Function(function_call) => {
             Ok(InputItem::Item(Item::FunctionCall(FunctionToolCall {
-                call_id: function_call.id.clone(),
+                call_id: function_call.id,
                 name: function_call.function.name,
                 arguments: function_call.function.arguments,
-                id: Some(function_call.id),
+                id: None,
                 status: Some(OutputStatus::Completed),
             })))
         }
@@ -1057,12 +1057,111 @@ mod tests {
             panic!("chat messages should map to response input items");
         };
 
-        assert!(matches!(items[0], InputItem::Item(Item::FunctionCall(_))));
-        assert!(matches!(
-            items[1],
-            InputItem::Item(Item::FunctionCallOutput(_))
-        ));
+        let InputItem::Item(Item::FunctionCall(ref fc)) = items[0] else {
+            panic!("first item should be a FunctionCall");
+        };
+        // id must be None: the Chat Completions tool call ID (e.g. 53-char fc_-prefixed string)
+        // exceeds OpenAI's item id length constraint and is rejected if forwarded as the item id.
+        // call_id is sufficient to link the call to its output.
+        assert_eq!(
+            fc.id, None,
+            "FunctionToolCall item id must be None when converting from Chat Completions history"
+        );
+        assert_eq!(fc.call_id, "call_123");
+
+        let InputItem::Item(Item::FunctionCallOutput(ref fco)) = items[1] else {
+            panic!("second item should be a FunctionCallOutput");
+        };
+        assert_eq!(fco.id, None);
+        assert_eq!(fco.call_id, "call_123");
+
         assert!(matches!(items[2], InputItem::EasyMessage(_)));
+    }
+
+    #[test]
+    #[expect(deprecated)]
+    fn multiple_tool_calls_in_one_turn_all_get_id_none() {
+        let req = CreateChatCompletionRequest {
+            model: "public-model".to_string(),
+            messages: vec![ChatCompletionRequestMessage::Assistant(
+                ChatCompletionRequestAssistantMessage {
+                    content: None,
+                    refusal: None,
+                    name: None,
+                    audio: None,
+                    tool_calls: Some(vec![
+                        ChatCompletionMessageToolCalls::Function(ChatCompletionMessageToolCall {
+                            id: "fc_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                                .to_string(),
+                            function: FunctionCall {
+                                name: "tool_a".to_string(),
+                                arguments: "{}".to_string(),
+                            },
+                        }),
+                        ChatCompletionMessageToolCalls::Function(ChatCompletionMessageToolCall {
+                            id: "fc_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                                .to_string(),
+                            function: FunctionCall {
+                                name: "tool_b".to_string(),
+                                arguments: "{}".to_string(),
+                            },
+                        }),
+                    ]),
+                    function_call: None,
+                },
+            )],
+            ..Default::default()
+        };
+
+        let response_req = responses_request_from_chat_completion_request(req, "backend-model")
+            .expect("request should map to Responses API");
+        let InputParam::Items(items) = response_req.input else {
+            panic!("chat messages should map to response input items");
+        };
+
+        assert_eq!(items.len(), 2);
+        for item in &items {
+            let InputItem::Item(Item::FunctionCall(fc)) = item else {
+                panic!("expected FunctionCall item");
+            };
+            assert_eq!(fc.id, None, "every tool call item must have id: None");
+        }
+        let InputItem::Item(Item::FunctionCall(ref fc_a)) = items[0] else {
+            unreachable!()
+        };
+        let InputItem::Item(Item::FunctionCall(ref fc_b)) = items[1] else {
+            unreachable!()
+        };
+        assert_eq!(
+            fc_a.call_id,
+            "fc_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(
+            fc_b.call_id,
+            "fc_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+    }
+
+    #[test]
+    fn tool_call_history_id_not_forwarded_as_item_id() {
+        // Regression: OpenAI Responses API rejects item ids that exceed ~40 chars or use the
+        // fc_-prefixed format from Chat Completions. Setting id: None avoids the rejection.
+        let long_id = "fc_0bfce048f8124bc5006a068df33b348195ab7d85a4ab36380d".to_string();
+
+        let tool_call = ChatCompletionMessageToolCalls::Function(ChatCompletionMessageToolCall {
+            id: long_id.clone(),
+            function: FunctionCall {
+                name: "lookup".to_string(),
+                arguments: "{}".to_string(),
+            },
+        });
+
+        let item = input_item_from_chat_tool_call(tool_call).expect("should convert");
+        let InputItem::Item(Item::FunctionCall(fc)) = item else {
+            panic!("expected FunctionCall item");
+        };
+        assert_eq!(fc.id, None);
+        assert_eq!(fc.call_id, long_id);
     }
 
     #[tokio::test]

--- a/crates/runtime-auth/src/api_key/mod.rs
+++ b/crates/runtime-auth/src/api_key/mod.rs
@@ -88,7 +88,7 @@ impl ApiKeyAuth {
 }
 
 impl HttpAuth for ApiKeyAuth {
-    /// Checks the `X-API-Key` header for a valid API key
+    /// Checks the `X-API-Key` header or `Authorization: Bearer` header for a valid API key
     fn http_verify(&self, request: &http::request::Parts) -> Result<AuthVerdict, Error> {
         let api_key = request
             .headers
@@ -96,11 +96,26 @@ impl HttpAuth for ApiKeyAuth {
             .and_then(|value| value.to_str().ok())
             .unwrap_or_default();
 
-        if api_key.is_empty() {
+        if !api_key.is_empty() {
+            return match self.lookup(api_key) {
+                Some(api_key) => Ok(AuthVerdict::Allow(Arc::new(api_key))),
+                None => Ok(AuthVerdict::Deny),
+            };
+        }
+
+        let bearer = request
+            .headers
+            .get("Authorization")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.split_once(' '))
+            .and_then(|(scheme, token)| scheme.eq_ignore_ascii_case("Bearer").then_some(token))
+            .unwrap_or_default();
+
+        if bearer.is_empty() {
             return Ok(AuthVerdict::Deny);
         }
 
-        match self.lookup(api_key) {
+        match self.lookup(bearer) {
             Some(api_key) => Ok(AuthVerdict::Allow(Arc::new(api_key))),
             None => Ok(AuthVerdict::Deny),
         }
@@ -238,6 +253,61 @@ mod tests {
             assert_eq!(comparison_count, 3);
             assert_eq!(matched.is_some(), presented != "missing");
         }
+    }
+
+    fn create_bearer_request_parts(authorization: &str) -> http::request::Parts {
+        let request = Builder::new()
+            .uri("https://example.com")
+            .header("Authorization", authorization)
+            .body(())
+            .expect("Failed to build request");
+        request.into_parts().0
+    }
+
+    #[test]
+    fn test_valid_bearer_token() {
+        let auth = ApiKeyAuth::new(vec![ApiKey::parse_str("valid-key")]);
+        let parts = create_bearer_request_parts("Bearer valid-key");
+        assert!(matches!(auth.http_verify(&parts), Ok(AuthVerdict::Allow(_))));
+    }
+
+    #[test]
+    fn test_invalid_bearer_token() {
+        let auth = ApiKeyAuth::new(vec![ApiKey::parse_str("valid-key")]);
+        let parts = create_bearer_request_parts("Bearer wrong-key");
+        assert!(matches!(auth.http_verify(&parts), Ok(AuthVerdict::Deny)));
+    }
+
+    #[test]
+    fn test_bearer_scheme_case_insensitive() {
+        let auth = ApiKeyAuth::new(vec![ApiKey::parse_str("valid-key")]);
+        for header in ["bearer valid-key", "BEARER valid-key", "BeArEr valid-key"] {
+            let parts = create_bearer_request_parts(header);
+            assert!(
+                matches!(auth.http_verify(&parts), Ok(AuthVerdict::Allow(_))),
+                "scheme casing '{header}' should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_auth_scheme_denied() {
+        let auth = ApiKeyAuth::new(vec![ApiKey::parse_str("valid-key")]);
+        let parts = create_bearer_request_parts("Basic valid-key");
+        assert!(matches!(auth.http_verify(&parts), Ok(AuthVerdict::Deny)));
+    }
+
+    #[test]
+    fn test_x_api_key_takes_precedence_over_bearer() {
+        let auth = ApiKeyAuth::new(vec![ApiKey::parse_str("valid-key")]);
+        let request = Builder::new()
+            .uri("https://example.com")
+            .header("X-API-Key", "valid-key")
+            .header("Authorization", "Bearer wrong-key")
+            .body(())
+            .expect("Failed to build request");
+        let parts = request.into_parts().0;
+        assert!(matches!(auth.http_verify(&parts), Ok(AuthVerdict::Allow(_))));
     }
 
     #[test]

--- a/crates/runtime-auth/src/api_key/mod.rs
+++ b/crates/runtime-auth/src/api_key/mod.rs
@@ -268,7 +268,10 @@ mod tests {
     fn test_valid_bearer_token() {
         let auth = ApiKeyAuth::new(vec![ApiKey::parse_str("valid-key")]);
         let parts = create_bearer_request_parts("Bearer valid-key");
-        assert!(matches!(auth.http_verify(&parts), Ok(AuthVerdict::Allow(_))));
+        assert!(matches!(
+            auth.http_verify(&parts),
+            Ok(AuthVerdict::Allow(_))
+        ));
     }
 
     #[test]
@@ -307,7 +310,10 @@ mod tests {
             .body(())
             .expect("Failed to build request");
         let parts = request.into_parts().0;
-        assert!(matches!(auth.http_verify(&parts), Ok(AuthVerdict::Allow(_))));
+        assert!(matches!(
+            auth.http_verify(&parts),
+            Ok(AuthVerdict::Allow(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 📝 Summary

1. Add support for `Authorization: Bearer` to spice runtime (currently only `x-api-key` is supported)
2. Bump `async-openai` to include https://github.com/spiceai/async-openai/pull/35
3. Fix for `responses_adapter`: do not populate `FunctionToolCall.id` - let OpenAI-compatible server populate it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->