### PR TITLE
Add stale pull request workflow

### DIFF
--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -1,0 +1,58 @@
+name: Stale Pull Requests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '37 2 * * *'
+
+jobs:
+  stale:
+    name: Mark and close stale pull requests
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Ensure stale label exists
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const label = 'stale';
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'ededed',
+                description: 'Pull requests with no recent activity',
+              });
+            }
+
+      - name: Mark and close stale pull requests
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          stale-pr-label: stale
+          stale-pr-message: |
+            This pull request has been inactive for 7 days and has been marked stale. It will be closed in 7 days if there is no further activity.
+          close-pr-message: |
+            This pull request was closed because it was stale for 7 days without further activity. Reopen it or open a new pull request when you are ready to continue.
+          exempt-pr-labels: wip,nomerge
+          exempt-draft-pr: true
+          operations-per-run: 100


### PR DESCRIPTION
Adds scheduled stale automation for pull requests using `actions/stale`.

Summary:
- Marks inactive pull requests stale after 7 days and closes them after 7 stale days.
- Disables issue staleness explicitly.
- Ensures the `stale` label exists before running the action.
- Exempts draft PRs and PRs labeled `wip` or `nomerge`.

Validation:
- Parsed `.github/workflows/stale_prs.yml` with Python/PyYAML.
- VS Code diagnostics reported no errors for the workflow file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->