### PR TITLE
Tune accelerators by storage profile

### DIFF
--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -106,6 +106,37 @@ impl Display for Mode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StorageProfile {
+    #[default]
+    Auto,
+    LocalSsd,
+    Ebs,
+    Tmpfs,
+}
+
+impl From<spicepod_acceleration::StorageProfile> for StorageProfile {
+    fn from(storage: spicepod_acceleration::StorageProfile) -> Self {
+        match storage {
+            spicepod_acceleration::StorageProfile::Auto => StorageProfile::Auto,
+            spicepod_acceleration::StorageProfile::LocalSsd => StorageProfile::LocalSsd,
+            spicepod_acceleration::StorageProfile::Ebs => StorageProfile::Ebs,
+            spicepod_acceleration::StorageProfile::Tmpfs => StorageProfile::Tmpfs,
+        }
+    }
+}
+
+impl Display for StorageProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StorageProfile::Auto => write!(f, "auto"),
+            StorageProfile::LocalSsd => write!(f, "local_ssd"),
+            StorageProfile::Ebs => write!(f, "ebs"),
+            StorageProfile::Tmpfs => write!(f, "tmpfs"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum RefreshOnStartup {
     /// Always start a new refresh when Spice starts.
@@ -321,6 +352,8 @@ pub struct Acceleration {
 
     pub write_mode: spicepod_acceleration::WriteMode,
 
+    pub storage_profile: StorageProfile,
+
     pub disable_federation: bool,
 
     pub partition_by: Vec<PartitionedBy>,
@@ -524,6 +557,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             primary_key,
             on_conflict,
             write_mode: acceleration.write_mode,
+            storage_profile: StorageProfile::from(acceleration.storage_profile),
             partition_by: acceleration.partition_by,
             snapshot_behavior: SnapshotBehavior::disabled(),
             snapshots_trigger: acceleration.snapshots_trigger,
@@ -567,6 +601,7 @@ impl Default for Acceleration {
             primary_key: None,
             on_conflict: HashMap::default(),
             write_mode: spicepod_acceleration::WriteMode::default(),
+            storage_profile: StorageProfile::default(),
             disable_federation: false,
             refresh_on_startup: RefreshOnStartup::default(),
             partition_by: vec![],
@@ -754,5 +789,16 @@ mod tests {
         let parsed = Acceleration::try_from(acceleration).expect("acceleration should parse");
         assert!(!parsed.params.contains_key("hash_index"));
         assert!(!parsed.is_hash_index_enabled());
+    }
+
+    #[test]
+    fn test_storage_profile_is_parsed_from_spicepod_acceleration() {
+        let acceleration = spicepod_acceleration::Acceleration {
+            storage_profile: spicepod_acceleration::StorageProfile::Ebs,
+            ..Default::default()
+        };
+
+        let parsed = Acceleration::try_from(acceleration).expect("acceleration should parse");
+        assert_eq!(parsed.storage_profile, StorageProfile::Ebs);
     }
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -54,6 +54,7 @@ use super::{
 };
 use crate::component::dataset::acceleration::{Acceleration, Engine, Mode};
 use crate::dataaccelerator::cayenne::s3::{S3_PARAMETERS, S3_PARAMS_LEN};
+use crate::dataaccelerator::storage::{ResolvedAccelerationStorage, resolve_acceleration_storage};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
 use crate::parameters::ParameterSpec;
 use crate::register_data_accelerator;
@@ -408,6 +409,52 @@ impl CayenneAccelerator {
         source: &dyn AccelerationSource,
     ) -> cayenne::metadata::VortexConfig {
         let mut config = cayenne::metadata::VortexConfig::default();
+
+        // Storage-aware default for target Vortex file size on local disk.
+        // Smaller files reduce write amplification on EBS-class network
+        // storage; larger files improve scan throughput on tmpfs / RAM-backed
+        // mounts. Skip for S3 (cayenne_file_path/s3:// or s3_zone_ids) where
+        // we always use the engine default; the network-attached object
+        // store doesn't benefit from local mount classification.
+        if let Some(acceleration) = source.acceleration() {
+            let is_s3 = acceleration
+                .params
+                .get("cayenne_s3_zone_ids")
+                .is_some_and(|v| !v.trim().is_empty())
+                || acceleration
+                    .params
+                    .get("cayenne_file_path")
+                    .is_some_and(|p| p.starts_with("s3://"));
+            let user_set_file_size = acceleration
+                .params
+                .contains_key("cayenne_target_file_size_mb");
+
+            if !is_s3 && !user_set_file_size {
+                if let Ok(data_dir) = CayenneAccelerator::new().cayenne_data_dir(source) {
+                    let storage = resolve_acceleration_storage(
+                        acceleration.storage_profile,
+                        std::path::Path::new(&data_dir),
+                    );
+                    let storage_default = match storage {
+                        ResolvedAccelerationStorage::Ebs => Some(256_usize),
+                        ResolvedAccelerationStorage::Tmpfs => Some(64_usize),
+                        ResolvedAccelerationStorage::LocalSsd
+                        | ResolvedAccelerationStorage::Unknown => None,
+                    };
+                    if let Some(size_mb) = storage_default {
+                        tracing::debug!(
+                            target: "spiced::acceleration::cayenne",
+                            table = %table_name,
+                            configured = %acceleration.storage_profile,
+                            resolved = ?storage,
+                            target_file_size_mb = size_mb,
+                            "Applying storage-aware default cayenne_target_file_size_mb"
+                        );
+                        config.target_vortex_file_size_mb = size_mb;
+                    }
+                }
+            }
+        }
 
         if let Some(acceleration) = source.acceleration() {
             // Parse cache options - use VortexConfig defaults if not specified

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -431,28 +431,29 @@ impl CayenneAccelerator {
                 .params
                 .contains_key("cayenne_target_file_size_mb");
 
-            if !is_s3 && !user_set_file_size {
-                if let Ok(data_dir) = CayenneAccelerator::new().cayenne_data_dir(source) {
-                    let storage =
-                        resolve_acceleration_storage_async(acceleration.storage_profile, &data_dir)
-                            .await;
-                    let storage_default = match storage {
-                        ResolvedAccelerationStorage::Ebs => Some(256_usize),
-                        ResolvedAccelerationStorage::Tmpfs => Some(64_usize),
-                        ResolvedAccelerationStorage::LocalSsd
-                        | ResolvedAccelerationStorage::Unknown => None,
-                    };
-                    if let Some(size_mb) = storage_default {
-                        tracing::debug!(
-                            target: "spiced::acceleration::cayenne",
-                            table = %table_name,
-                            configured = %acceleration.storage_profile,
-                            resolved = ?storage,
-                            target_file_size_mb = size_mb,
-                            "Applying storage-aware default cayenne_target_file_size_mb"
-                        );
-                        config.target_vortex_file_size_mb = size_mb;
-                    }
+            if !is_s3
+                && !user_set_file_size
+                && let Ok(data_dir) = CayenneAccelerator::new().cayenne_data_dir(source)
+            {
+                let storage =
+                    resolve_acceleration_storage_async(acceleration.storage_profile, &data_dir)
+                        .await;
+                let storage_default = match storage {
+                    ResolvedAccelerationStorage::Ebs => Some(256_usize),
+                    ResolvedAccelerationStorage::Tmpfs => Some(64_usize),
+                    ResolvedAccelerationStorage::LocalSsd
+                    | ResolvedAccelerationStorage::Unknown => None,
+                };
+                if let Some(size_mb) = storage_default {
+                    tracing::debug!(
+                        target: "spiced::acceleration::cayenne",
+                        table = %table_name,
+                        configured = %acceleration.storage_profile,
+                        resolved = ?storage,
+                        target_file_size_mb = size_mb,
+                        "Applying storage-aware default cayenne_target_file_size_mb"
+                    );
+                    config.target_vortex_file_size_mb = size_mb;
                 }
             }
         }

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -54,7 +54,9 @@ use super::{
 };
 use crate::component::dataset::acceleration::{Acceleration, Engine, Mode};
 use crate::dataaccelerator::cayenne::s3::{S3_PARAMETERS, S3_PARAMS_LEN};
-use crate::dataaccelerator::storage::{ResolvedAccelerationStorage, resolve_acceleration_storage};
+use crate::dataaccelerator::storage::{
+    ResolvedAccelerationStorage, resolve_acceleration_storage_async,
+};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
 use crate::parameters::ParameterSpec;
 use crate::register_data_accelerator;
@@ -404,7 +406,7 @@ impl CayenneAccelerator {
     /// Parse Vortex encoding configuration from acceleration parameters.
     /// This allows fine-grained control over which SIMD-optimized encodings to use.
     ///
-    fn get_vortex_config(
+    async fn get_vortex_config(
         table_name: &str,
         source: &dyn AccelerationSource,
     ) -> cayenne::metadata::VortexConfig {
@@ -431,10 +433,9 @@ impl CayenneAccelerator {
 
             if !is_s3 && !user_set_file_size {
                 if let Ok(data_dir) = CayenneAccelerator::new().cayenne_data_dir(source) {
-                    let storage = resolve_acceleration_storage(
-                        acceleration.storage_profile,
-                        std::path::Path::new(&data_dir),
-                    );
+                    let storage =
+                        resolve_acceleration_storage_async(acceleration.storage_profile, &data_dir)
+                            .await;
                     let storage_default = match storage {
                         ResolvedAccelerationStorage::Ebs => Some(256_usize),
                         ResolvedAccelerationStorage::Tmpfs => Some(64_usize),
@@ -793,7 +794,7 @@ impl CayenneAccelerator {
 
         // Check if using S3 Express One Zone storage
         let is_s3_express = s3::is_s3_express_data_path(source);
-        let vortex_config = Self::get_vortex_config(table_name, source);
+        let vortex_config = Self::get_vortex_config(table_name, source).await;
 
         // Build S3 object store if using S3 Express One Zone storage
         let object_store =
@@ -1530,7 +1531,7 @@ impl DataAccelerator for CayenneAccelerator {
             // Create partition creator
             let unsupported_type_action = Self::get_unsupported_type_action(source);
             let is_s3_express = s3::is_s3_express_data_path(source);
-            let vortex_config = Self::get_vortex_config(&table_name, source);
+            let vortex_config = Self::get_vortex_config(&table_name, source).await;
 
             // Log S3 Express configuration for partitioned tables
             if is_s3_express {
@@ -2499,8 +2500,8 @@ mod tests {
             ..Default::default()
         });
 
-        let hot = CayenneAccelerator::get_vortex_config("hot", &hot_dataset);
-        let quiet = CayenneAccelerator::get_vortex_config("quiet", &quiet_dataset);
+        let hot = CayenneAccelerator::get_vortex_config("hot", &hot_dataset).await;
+        let quiet = CayenneAccelerator::get_vortex_config("quiet", &quiet_dataset).await;
 
         assert_eq!(hot.write_concurrency, Some(16));
         assert_eq!(quiet.write_concurrency, Some(2));
@@ -2549,7 +2550,7 @@ mod tests {
             ..Default::default()
         });
 
-        let config = CayenneAccelerator::get_vortex_config("cdc_hot", &dataset);
+        let config = CayenneAccelerator::get_vortex_config("cdc_hot", &dataset).await;
 
         assert_eq!(config.inline_max_rows, 0);
         assert_eq!(config.inline_max_bytes, 262_144);

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -20,13 +20,14 @@ use crate::{
     component::{
         dataset::{
             Dataset,
-            acceleration::{Acceleration, Engine, Mode, RefreshMode},
+            acceleration::{Acceleration, Engine, Mode, RefreshMode, StorageProfile},
         },
         view::View,
     },
     dataaccelerator::{
         FilePathError,
         snapshots::{download_snapshot_if_needed, snapshot_before_recreate},
+        storage::{ResolvedAccelerationStorage, resolve_acceleration_storage_async},
     },
     datafusion::{
         dialect::new_duckdb_dialect,
@@ -80,6 +81,7 @@ use std::{
 pub(crate) mod settings;
 
 pub(crate) const DEFAULT_MIN_IDLE_CONNECTIONS: u32 = 10;
+pub(crate) const DEFAULT_EBS_MIN_IDLE_CONNECTIONS: u32 = 4;
 pub(crate) const SPICE_ACCELERATOR_METADATA_KEY: &str = "spice.accelerator";
 pub(crate) const SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY: &str =
     "spice.optimizer.duckdb_aggregate_pushdown";
@@ -166,11 +168,24 @@ impl DuckDBAccelerator {
                     &source.app(),
                     source.runtime(),
                 );
-                let max_size = Self::get_pool_max_size(num_accelerating_datasets, acceleration);
-                let pool_builder = DuckDbConnectionPoolBuilder::file(&duckdb_file)
+                let storage =
+                    resolve_acceleration_storage_async(acceleration.storage_profile, &duckdb_file)
+                        .await;
+                tracing::debug!(
+                    dataset = %source.name(),
+                    storage = %storage,
+                    "Resolved DuckDB acceleration storage profile"
+                );
+                let max_size =
+                    Self::get_pool_max_size(num_accelerating_datasets, acceleration, storage);
+                let min_idle = Self::get_pool_min_idle(storage, max_size);
+                let mut pool_builder = DuckDbConnectionPoolBuilder::file(&duckdb_file)
                     .with_max_size(Some(max_size))
-                    .with_min_idle(Some(DEFAULT_MIN_IDLE_CONNECTIONS))
+                    .with_min_idle(Some(min_idle))
                     .with_connection_setup_query("PRAGMA enable_checkpoint_on_shutdown");
+                for pragma in Self::storage_setup_queries(storage) {
+                    pool_builder = pool_builder.with_connection_setup_query(*pragma);
+                }
                 self.duckdb_factory
                     .get_or_init_instance_with_builder(pool_builder)
                     .await
@@ -180,10 +195,16 @@ impl DuckDBAccelerator {
             (_, Mode::Memory) => {
                 let num_accelerating_datasets =
                     self.get_num_accelerating_datasets(None, &source.app(), source.runtime());
-                let max_size = Self::get_pool_max_size(num_accelerating_datasets, acceleration);
+                let max_size = Self::get_pool_max_size(
+                    num_accelerating_datasets,
+                    acceleration,
+                    ResolvedAccelerationStorage::Unknown,
+                );
+                let min_idle =
+                    Self::get_pool_min_idle(ResolvedAccelerationStorage::Unknown, max_size);
                 let pool_builder = DuckDbConnectionPoolBuilder::memory()
                     .with_max_size(Some(max_size))
-                    .with_min_idle(Some(DEFAULT_MIN_IDLE_CONNECTIONS))
+                    .with_min_idle(Some(min_idle))
                     .with_connection_setup_query("PRAGMA enable_checkpoint_on_shutdown");
                 self.duckdb_factory
                     .get_or_init_instance_with_builder(pool_builder)
@@ -238,14 +259,58 @@ impl DuckDBAccelerator {
         instance_usage
     }
 
-    fn get_pool_max_size(num_accelerating_datasets: u32, acceleration: &Acceleration) -> u32 {
+    pub(crate) fn default_connection_pool_size(storage: ResolvedAccelerationStorage) -> u32 {
+        match storage {
+            ResolvedAccelerationStorage::Ebs => DEFAULT_EBS_MIN_IDLE_CONNECTIONS,
+            ResolvedAccelerationStorage::LocalSsd
+            | ResolvedAccelerationStorage::Tmpfs
+            | ResolvedAccelerationStorage::Unknown => DEFAULT_MIN_IDLE_CONNECTIONS,
+        }
+    }
+
+    pub(crate) fn get_pool_min_idle(storage: ResolvedAccelerationStorage, max_size: u32) -> u32 {
+        Self::default_connection_pool_size(storage).min(max_size)
+    }
+
+    /// Storage-profile-specific DuckDB pragmas applied to every connection in
+    /// the pool. These tune DuckDB's I/O behavior to match the underlying
+    /// medium's latency and durability profile.
+    pub(crate) fn storage_setup_queries(
+        storage: ResolvedAccelerationStorage,
+    ) -> &'static [&'static str] {
+        match storage {
+            // Network-attached block storage (e.g. EBS, Azure Managed Disks)
+            // pays per-IO latency on every flush. Raise the checkpoint
+            // threshold so WAL flushes are larger and less frequent, which
+            // reduces write amplification on the slow link.
+            ResolvedAccelerationStorage::Ebs => &["PRAGMA checkpoint_threshold='256MiB'"],
+            // tmpfs/ramfs is volatile and effectively free to write, but
+            // checkpointing still copies pages around. Push the threshold up
+            // so steady-state workloads don't pay checkpoint cost on tiny
+            // amounts of dirty data.
+            ResolvedAccelerationStorage::Tmpfs => &["PRAGMA checkpoint_threshold='1GiB'"],
+            // Local SSD/NVMe handles small frequent flushes well; keep
+            // DuckDB defaults.
+            ResolvedAccelerationStorage::LocalSsd | ResolvedAccelerationStorage::Unknown => &[],
+        }
+    }
+
+    fn get_pool_max_size(
+        num_accelerating_datasets: u32,
+        acceleration: &Acceleration,
+        storage: ResolvedAccelerationStorage,
+    ) -> u32 {
         let pool_size_param = acceleration
             .params
             .get("connection_pool_size")
             .and_then(|size_str| size_str.parse::<u32>().ok());
 
-        pool_size_param
-            .unwrap_or_else(|| max(DEFAULT_MIN_IDLE_CONNECTIONS, num_accelerating_datasets))
+        pool_size_param.unwrap_or_else(|| {
+            max(
+                Self::default_connection_pool_size(storage),
+                num_accelerating_datasets,
+            )
+        })
     }
 }
 
@@ -2105,5 +2170,34 @@ mod tests {
         underlying
             .execute(&format!("DROP TABLE IF EXISTS \"{table_name}\""), [])
             .expect("drop of non-existent table should succeed");
+    }
+
+    #[test]
+    fn storage_profile_drives_setup_pragmas() {
+        use crate::dataaccelerator::storage::ResolvedAccelerationStorage;
+
+        // EBS bumps the checkpoint threshold to amortize remote-disk writes.
+        let ebs = DuckDBAccelerator::storage_setup_queries(ResolvedAccelerationStorage::Ebs);
+        assert!(
+            ebs.iter().any(|q| q.contains("checkpoint_threshold")),
+            "EBS profile should tune checkpoint_threshold, got {ebs:?}"
+        );
+
+        // Tmpfs also raises checkpoint threshold (volatile, RAM-backed).
+        let tmpfs = DuckDBAccelerator::storage_setup_queries(ResolvedAccelerationStorage::Tmpfs);
+        assert!(
+            tmpfs.iter().any(|q| q.contains("checkpoint_threshold")),
+            "Tmpfs profile should tune checkpoint_threshold, got {tmpfs:?}"
+        );
+
+        // Local SSD and Unknown keep DuckDB defaults.
+        assert!(
+            DuckDBAccelerator::storage_setup_queries(ResolvedAccelerationStorage::LocalSsd)
+                .is_empty()
+        );
+        assert!(
+            DuckDBAccelerator::storage_setup_queries(ResolvedAccelerationStorage::Unknown)
+                .is_empty()
+        );
     }
 }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -272,8 +272,8 @@ impl DuckDBAccelerator {
         Self::default_connection_pool_size(storage).min(max_size)
     }
 
-    /// Storage-profile-specific DuckDB pragmas applied to every connection in
-    /// the pool. These tune DuckDB's I/O behavior to match the underlying
+    /// Storage-profile-specific `DuckDB` pragmas applied to every connection in
+    /// the pool. These tune `DuckDB`'s I/O behavior to match the underlying
     /// medium's latency and durability profile.
     pub(crate) fn storage_setup_queries(
         storage: ResolvedAccelerationStorage,

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -20,7 +20,7 @@ use crate::{
     component::{
         dataset::{
             Dataset,
-            acceleration::{Acceleration, Engine, Mode, RefreshMode, StorageProfile},
+            acceleration::{Acceleration, Engine, Mode, RefreshMode},
         },
         view::View,
     },
@@ -80,8 +80,8 @@ use std::{
 
 pub(crate) mod settings;
 
-pub(crate) const DEFAULT_MIN_IDLE_CONNECTIONS: u32 = 10;
-pub(crate) const DEFAULT_EBS_MIN_IDLE_CONNECTIONS: u32 = 4;
+pub(crate) const DEFAULT_CONNECTION_POOL_SIZE: u32 = 10;
+pub(crate) const DEFAULT_EBS_CONNECTION_POOL_SIZE: u32 = 4;
 pub(crate) const SPICE_ACCELERATOR_METADATA_KEY: &str = "spice.accelerator";
 pub(crate) const SPICE_OPT_DUCKDB_AGG_PUSHDOWN_KEY: &str =
     "spice.optimizer.duckdb_aggregate_pushdown";
@@ -261,10 +261,10 @@ impl DuckDBAccelerator {
 
     pub(crate) fn default_connection_pool_size(storage: ResolvedAccelerationStorage) -> u32 {
         match storage {
-            ResolvedAccelerationStorage::Ebs => DEFAULT_EBS_MIN_IDLE_CONNECTIONS,
+            ResolvedAccelerationStorage::Ebs => DEFAULT_EBS_CONNECTION_POOL_SIZE,
             ResolvedAccelerationStorage::LocalSsd
             | ResolvedAccelerationStorage::Tmpfs
-            | ResolvedAccelerationStorage::Unknown => DEFAULT_MIN_IDLE_CONNECTIONS,
+            | ResolvedAccelerationStorage::Unknown => DEFAULT_CONNECTION_POOL_SIZE,
         }
     }
 

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -58,6 +58,7 @@ pub mod turso;
 
 pub(crate) mod snapshots;
 pub mod spice_sys;
+pub(crate) mod storage;
 pub mod swappable;
 pub mod upsert_dedup;
 

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -58,7 +58,7 @@ use super::{
 };
 use crate::{
     component::dataset::acceleration::{Engine, Mode},
-    dataaccelerator::FilePathError,
+    dataaccelerator::{FilePathError, storage::resolve_acceleration_storage_async},
     datafusion::{dialect::new_duckdb_dialect, udf::deny_spice_functions_for_duckdb},
     parameters::ParameterSpec,
     register_data_accelerator, spice_data_base_path,
@@ -194,8 +194,14 @@ impl PartitionedDuckDBAccelerator {
             .join("checkpoint.db")
             .display()
             .to_string();
+        let storage = match source.acceleration() {
+            Some(acceleration) => {
+                resolve_acceleration_storage_async(acceleration.storage_profile, &duckdb_path).await
+            }
+            None => super::storage::ResolvedAccelerationStorage::Unknown,
+        };
 
-        get_pool(&self.duckdb_factory, &duckdb_path)
+        get_pool(&self.duckdb_factory, &duckdb_path, storage)
             .await
             .context(FailedToCreateCheckpointingPoolSnafu)
     }
@@ -447,9 +453,13 @@ impl PartitionCreator for DuckDBPartitionCreator {
                 .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
             let duckdb_path = path.display().to_string();
-            get_pool(&self.duckdb_factory, &duckdb_path)
-                .await
-                .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
+            get_pool(
+                &self.duckdb_factory,
+                &duckdb_path,
+                super::storage::ResolvedAccelerationStorage::Unknown,
+            )
+            .await
+            .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
             let table_provider = create_table_provider(&self.duckdb_factory, &cmd, None)
                 .await
@@ -498,10 +508,16 @@ fn create_factory() -> DuckDBTableProviderFactory {
 async fn get_pool(
     duckdb_factory: &DuckDBTableProviderFactory,
     duckdb_path: &str,
+    storage: super::storage::ResolvedAccelerationStorage,
 ) -> Result<Arc<DuckDbConnectionPool>, datafusion_table_providers::duckdb::Error> {
-    let pool_builder = DuckDbConnectionPoolBuilder::file(duckdb_path)
-        .with_max_size(Some(10))
-        .with_min_idle(Some(10));
+    let max_size = DuckDBAccelerator::default_connection_pool_size(storage);
+    let min_idle = DuckDBAccelerator::get_pool_min_idle(storage, max_size);
+    let mut pool_builder = DuckDbConnectionPoolBuilder::file(duckdb_path)
+        .with_max_size(Some(max_size))
+        .with_min_idle(Some(min_idle));
+    for pragma in DuckDBAccelerator::storage_setup_queries(storage) {
+        pool_builder = pool_builder.with_connection_setup_query(*pragma);
+    }
     Ok(Arc::new(
         duckdb_factory
             .get_or_init_instance_with_builder(pool_builder)

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -64,6 +64,7 @@ use crate::{
         partitioned_duckdb::{
             ExpectedAccelerationSourceSnafu, FailedToCreateConnectionPoolSnafu, FileModeOnlySnafu,
         },
+        storage::{ResolvedAccelerationStorage, resolve_acceleration_storage_async},
     },
     datafusion::{dialect::new_duckdb_dialect, udf::deny_spice_functions_for_duckdb},
     make_spice_data_directory,
@@ -98,12 +99,18 @@ impl TablesModePartitionedDuckDBAccelerator {
             .file_path(source)
             .map_err(|e| super::Error::AccelerationInitializationFailed { source: e.into() })?;
 
-        let pool_size = source
-            .acceleration()
+        let acceleration = source.acceleration();
+        let pool_size = acceleration
             .and_then(|accel| accel.params.get("connection_pool_size"))
             .and_then(|size_str| size_str.parse::<u32>().ok());
+        let storage = match acceleration {
+            Some(acceleration) => {
+                resolve_acceleration_storage_async(acceleration.storage_profile, &duckdb_path).await
+            }
+            None => ResolvedAccelerationStorage::Unknown,
+        };
 
-        get_pool(&self.duckdb_factory, &duckdb_path, pool_size)
+        get_pool(&self.duckdb_factory, &duckdb_path, pool_size, storage)
             .await
             .context(FailedToCreateConnectionPoolSnafu)
     }
@@ -461,12 +468,17 @@ async fn get_pool(
     duckdb_factory: &DuckDBTableProviderFactory,
     duckdb_path: &str,
     connection_pool_size: Option<u32>,
+    storage: ResolvedAccelerationStorage,
 ) -> Result<Arc<DuckDbConnectionPool>, datafusion_table_providers::duckdb::Error> {
-    let pool_builder = DuckDbConnectionPoolBuilder::file(duckdb_path)
-        .with_max_size(Some(connection_pool_size.unwrap_or(10)))
-        .with_min_idle(Some(
-            crate::dataaccelerator::duckdb::DEFAULT_MIN_IDLE_CONNECTIONS,
-        ));
+    let max_size = connection_pool_size
+        .unwrap_or_else(|| DuckDBAccelerator::default_connection_pool_size(storage));
+    let min_idle = DuckDBAccelerator::get_pool_min_idle(storage, max_size);
+    let mut pool_builder = DuckDbConnectionPoolBuilder::file(duckdb_path)
+        .with_max_size(Some(max_size))
+        .with_min_idle(Some(min_idle));
+    for pragma in DuckDBAccelerator::storage_setup_queries(storage) {
+        pool_builder = pool_builder.with_connection_setup_query(*pragma);
+    }
     Ok(Arc::new(
         duckdb_factory
             .get_or_init_instance_with_builder(pool_builder)

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -21,6 +21,7 @@ use crate::{
     dataaccelerator::{
         FilePathError,
         snapshots::{download_snapshot_if_needed, snapshot_before_recreate},
+        storage::{ResolvedAccelerationStorage, resolve_acceleration_storage_async},
     },
     datafusion::udf::deny_spice_specific_functions,
     make_spice_data_directory,
@@ -162,6 +163,45 @@ impl SqliteAccelerator {
         Ok(Duration::from_millis(5000))
     }
 
+    /// Returns the effective busy_timeout, applying storage-profile defaults
+    /// when the user did not explicitly set `busy_timeout`.
+    ///
+    /// For network-attached storage (`Ebs`), fsync latency spikes are more
+    /// likely, so we default to a longer timeout to reduce spurious
+    /// `SQLITE_BUSY` errors.
+    fn effective_busy_timeout(
+        &self,
+        source: &dyn AccelerationSource,
+        storage: ResolvedAccelerationStorage,
+    ) -> Result<Duration> {
+        let user_set = source
+            .acceleration()
+            .is_some_and(|a| a.params.contains_key("busy_timeout"));
+        if user_set {
+            return self.sqlite_busy_timeout(source);
+        }
+        Ok(match storage {
+            ResolvedAccelerationStorage::Ebs => Duration::from_millis(15_000),
+            _ => Duration::from_millis(5_000),
+        })
+    }
+
+    /// Returns extra PRAGMA statements to apply post-init based on storage
+    /// profile. These are durability-preserving (cache size + memory mapping)
+    /// and never weaken `synchronous` or `journal_mode`.
+    fn storage_setup_pragmas(storage: ResolvedAccelerationStorage) -> &'static [&'static str] {
+        match storage {
+            // Larger page cache to absorb network latency on EBS-class storage.
+            // `cache_size` in negative form is KiB; -200000 => ~200 MiB.
+            ResolvedAccelerationStorage::Ebs => {
+                &["PRAGMA cache_size=-200000", "PRAGMA mmap_size=268435456"]
+            }
+            ResolvedAccelerationStorage::Tmpfs
+            | ResolvedAccelerationStorage::LocalSsd
+            | ResolvedAccelerationStorage::Unknown => &[],
+        }
+    }
+
     /// Returns an existing `SQLite` connection pool for the given dataset, or creates a new one if it doesn't exist.
     pub async fn get_shared_pool(
         &self,
@@ -179,18 +219,66 @@ impl SqliteAccelerator {
             }
             Mode::Memory => datafusion_table_providers::sql::db_connection_pool::Mode::Memory,
         };
+
+        let storage = if matches!(
+            acceleration.mode,
+            Mode::File | Mode::FileCreate | Mode::FileUpdate
+        ) {
+            let resolved =
+                resolve_acceleration_storage_async(acceleration.storage_profile, &sqlite_file)
+                    .await;
+            tracing::debug!(
+                "SQLite accelerator for {dataset} using storage profile {resolved} (file: {file})",
+                dataset = source.name(),
+                file = sqlite_file
+            );
+            resolved
+        } else {
+            ResolvedAccelerationStorage::Unknown
+        };
+
         let file_path: Arc<str> = sqlite_file.into();
-        let busy_timeout = self.sqlite_busy_timeout(source)?;
+        let busy_timeout = self.effective_busy_timeout(source, storage)?;
 
         let pool = self
             .sqlite_factory
-            .get_or_init_instance(file_path, mode, busy_timeout)
+            .get_or_init_instance(Arc::clone(&file_path), mode, busy_timeout)
             .await
             .boxed()
             .context(AccelerationCreationFailedSnafu)?;
 
+        // Apply storage-profile pragmas after the pool's own `setup()` so they
+        // override the engine-default cache/mmap sizes.
+        let pragmas = Self::storage_setup_pragmas(storage);
+        if !pragmas.is_empty() {
+            apply_sqlite_pragmas(&pool, pragmas)
+                .await
+                .map_err(|source| Error::AccelerationCreationFailed { source })?;
+        }
+
         Ok(pool)
     }
+}
+
+/// Execute a sequence of PRAGMA statements against the shared SQLite
+/// connection backing the pool. Failures are logged and propagated so that
+/// pool creation surfaces misconfiguration rather than silently dropping the
+/// pragma.
+async fn apply_sqlite_pragmas(
+    pool: &SqliteConnectionPool,
+    pragmas: &[&'static str],
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use datafusion_table_providers::sql::db_connection_pool::DbConnectionPool;
+    let conn = pool.connect().await?;
+    let async_conn =
+        conn.as_async()
+            .ok_or_else(|| -> Box<dyn std::error::Error + Send + Sync> {
+                "SQLite connection does not expose async interface".into()
+            })?;
+    for pragma in pragmas {
+        async_conn.execute(pragma, &[]).await?;
+    }
+    Ok(())
 }
 
 const PARAMETERS: &[ParameterSpec] = &[

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -163,7 +163,7 @@ impl SqliteAccelerator {
         Ok(Duration::from_millis(5000))
     }
 
-    /// Returns the effective busy_timeout, applying storage-profile defaults
+    /// Returns the effective `busy_timeout`, applying storage-profile defaults
     /// when the user did not explicitly set `busy_timeout`.
     ///
     /// For network-attached storage (`Ebs`), fsync latency spikes are more
@@ -260,7 +260,7 @@ impl SqliteAccelerator {
     }
 }
 
-/// Execute a sequence of PRAGMA statements against the shared SQLite
+/// Execute a sequence of PRAGMA statements against the shared `SQLite`
 /// connection backing the pool. Failures are logged and propagated so that
 /// pool creation surfaces misconfiguration rather than silently dropping the
 /// pragma.

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -270,11 +270,9 @@ async fn apply_sqlite_pragmas(
 ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use datafusion_table_providers::sql::db_connection_pool::DbConnectionPool;
     let conn = pool.connect().await?;
-    let async_conn =
-        conn.as_async()
-            .ok_or_else(|| -> Box<dyn std::error::Error + Send + Sync> {
-                "SQLite connection does not expose async interface".into()
-            })?;
+    let Some(async_conn) = conn.as_async() else {
+        unreachable!("SqliteConnectionPool only returns async-capable SQLite connections");
+    };
     for pragma in pragmas {
         if let Err(err) = async_conn.execute(pragma, &[]).await {
             tracing::warn!(

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -276,7 +276,14 @@ async fn apply_sqlite_pragmas(
                 "SQLite connection does not expose async interface".into()
             })?;
     for pragma in pragmas {
-        async_conn.execute(pragma, &[]).await?;
+        if let Err(err) = async_conn.execute(pragma, &[]).await {
+            tracing::warn!(
+                pragma,
+                error = %err,
+                "Failed to apply SQLite storage-profile pragma"
+            );
+            return Err(err);
+        }
     }
     Ok(())
 }

--- a/crates/runtime/src/dataaccelerator/storage.rs
+++ b/crates/runtime/src/dataaccelerator/storage.rs
@@ -1,0 +1,417 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{fmt::Display, path::Path};
+
+use crate::component::dataset::acceleration::StorageProfile;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolvedAccelerationStorage {
+    LocalSsd,
+    Ebs,
+    Tmpfs,
+    Unknown,
+}
+
+impl Display for ResolvedAccelerationStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LocalSsd => write!(f, "local_ssd"),
+            Self::Ebs => write!(f, "ebs"),
+            Self::Tmpfs => write!(f, "tmpfs"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+#[must_use]
+pub(crate) fn resolve_acceleration_storage(
+    configured_storage: StorageProfile,
+    path: &Path,
+) -> ResolvedAccelerationStorage {
+    match configured_storage {
+        StorageProfile::Auto => detect_path_storage(path),
+        StorageProfile::LocalSsd => ResolvedAccelerationStorage::LocalSsd,
+        StorageProfile::Ebs => ResolvedAccelerationStorage::Ebs,
+        StorageProfile::Tmpfs => ResolvedAccelerationStorage::Tmpfs,
+    }
+}
+
+/// Resolve the storage profile from a path, off the async runtime when the
+/// profile is `Auto` (which performs blocking `/proc` and `/sys` reads on
+/// Linux). Explicit profiles short-circuit synchronously.
+pub(crate) async fn resolve_acceleration_storage_async(
+    configured_storage: StorageProfile,
+    path: &str,
+) -> ResolvedAccelerationStorage {
+    if configured_storage != StorageProfile::Auto {
+        return resolve_acceleration_storage(configured_storage, Path::new(path));
+    }
+
+    let path = std::path::PathBuf::from(path);
+    match tokio::task::spawn_blocking(move || {
+        resolve_acceleration_storage(configured_storage, &path)
+    })
+    .await
+    {
+        Ok(storage) => storage,
+        Err(err) => {
+            tracing::debug!("Failed to detect acceleration storage profile: {err}");
+            ResolvedAccelerationStorage::Unknown
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn detect_path_storage(_path: &Path) -> ResolvedAccelerationStorage {
+    ResolvedAccelerationStorage::Unknown
+}
+
+#[cfg(target_os = "linux")]
+fn detect_path_storage(path: &Path) -> ResolvedAccelerationStorage {
+    use std::{collections::HashSet, fs, path::PathBuf};
+
+    let detection_path = normalize_detection_path(path);
+    let Ok(mountinfo) = fs::read_to_string("/proc/self/mountinfo") else {
+        return ResolvedAccelerationStorage::Unknown;
+    };
+
+    let Some(mount) = find_longest_matching_mount(&detection_path, &mountinfo) else {
+        return ResolvedAccelerationStorage::Unknown;
+    };
+
+    if is_in_memory_fstype(&mount.fstype) {
+        return ResolvedAccelerationStorage::Tmpfs;
+    }
+
+    let dev_block_path = PathBuf::from("/sys/dev/block").join(&mount.major_minor);
+    let mut visited = HashSet::new();
+    let devices = collect_block_devices(&dev_block_path, &mut visited);
+
+    classify_block_devices(&devices)
+}
+
+#[cfg(target_os = "linux")]
+fn is_in_memory_fstype(fstype: &str) -> bool {
+    matches!(fstype, "tmpfs" | "ramfs")
+}
+
+#[cfg(target_os = "linux")]
+fn normalize_detection_path(path: &Path) -> std::path::PathBuf {
+    let absolute_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+    };
+
+    let existing_path = if absolute_path.exists() {
+        absolute_path.as_path()
+    } else {
+        absolute_path
+            .ancestors()
+            .find(|ancestor| ancestor.exists())
+            .unwrap_or(absolute_path.as_path())
+    };
+
+    existing_path
+        .canonicalize()
+        .unwrap_or_else(|_| absolute_path.clone())
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MountInfo {
+    major_minor: String,
+    mount_point: std::path::PathBuf,
+    fstype: String,
+}
+
+#[cfg(target_os = "linux")]
+fn find_longest_matching_mount(path: &Path, mountinfo: &str) -> Option<MountInfo> {
+    mountinfo
+        .lines()
+        .filter_map(parse_mountinfo_line)
+        .filter(|mount| path.starts_with(&mount.mount_point))
+        .max_by_key(|mount| mount.mount_point.components().count())
+}
+
+#[cfg(target_os = "linux")]
+fn parse_mountinfo_line(line: &str) -> Option<MountInfo> {
+    // mountinfo format:
+    // mount_id parent_id major:minor root mount_point mount_options optional - fstype source super_options
+    let (before_sep, after_sep) = line.split_once(" - ")?;
+    let before_fields: Vec<&str> = before_sep.split(' ').collect();
+    let major_minor = before_fields.get(2)?;
+    let mount_point = before_fields.get(4)?;
+
+    let after_fields: Vec<&str> = after_sep.split(' ').collect();
+    let fstype = after_fields.first()?;
+
+    Some(MountInfo {
+        major_minor: (*major_minor).to_string(),
+        mount_point: std::path::PathBuf::from(unescape_mountinfo_path(mount_point)),
+        fstype: (*fstype).to_string(),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn unescape_mountinfo_path(path: &str) -> String {
+    let bytes = path.as_bytes();
+    let mut output = String::with_capacity(path.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\'
+            && index + 3 < bytes.len()
+            && bytes[index + 1].is_ascii_digit()
+            && bytes[index + 2].is_ascii_digit()
+            && bytes[index + 3].is_ascii_digit()
+        {
+            let value = (bytes[index + 1] - b'0') * 64
+                + (bytes[index + 2] - b'0') * 8
+                + (bytes[index + 3] - b'0');
+            output.push(char::from(value));
+            index += 4;
+        } else {
+            output.push(char::from(bytes[index]));
+            index += 1;
+        }
+    }
+
+    output
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BlockDevice {
+    name: String,
+    model: Option<String>,
+    vendor: Option<String>,
+    rotational: Option<bool>,
+}
+
+#[cfg(target_os = "linux")]
+fn collect_block_devices(
+    dev_block_path: &Path,
+    visited: &mut std::collections::HashSet<std::path::PathBuf>,
+) -> Vec<BlockDevice> {
+    let canonical_path = dev_block_path
+        .canonicalize()
+        .unwrap_or_else(|_| dev_block_path.to_path_buf());
+    if !visited.insert(canonical_path.clone()) {
+        return Vec::new();
+    }
+
+    let mut devices = block_device_name_from_sys_path(&canonical_path)
+        .map(|name| vec![read_block_device(&name)])
+        .unwrap_or_default();
+
+    if let Ok(entries) = std::fs::read_dir(dev_block_path.join("slaves")) {
+        for entry in entries.filter_map(Result::ok) {
+            devices.extend(collect_block_devices(&entry.path(), visited));
+        }
+    }
+
+    devices
+}
+
+#[cfg(target_os = "linux")]
+fn block_device_name_from_sys_path(path: &Path) -> Option<String> {
+    let mut block_component_seen = false;
+    for component in path.components() {
+        let component = component.as_os_str().to_string_lossy();
+        if block_component_seen {
+            return Some(component.into_owned());
+        }
+        if component == "block" {
+            block_component_seen = true;
+        }
+    }
+
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+}
+
+#[cfg(target_os = "linux")]
+fn read_block_device(name: &str) -> BlockDevice {
+    let sys_block_path = std::path::PathBuf::from("/sys/block").join(name);
+    BlockDevice {
+        name: name.to_ascii_lowercase(),
+        model: read_trimmed_lowercase(&sys_block_path.join("device/model")),
+        vendor: read_trimmed_lowercase(&sys_block_path.join("device/vendor")),
+        rotational: read_trimmed_lowercase(&sys_block_path.join("queue/rotational")).and_then(
+            |rotational| match rotational.as_str() {
+                "0" => Some(false),
+                "1" => Some(true),
+                _ => None,
+            },
+        ),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_trimmed_lowercase(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|contents| contents.trim().to_ascii_lowercase())
+        .filter(|contents| !contents.is_empty())
+}
+
+#[cfg(target_os = "linux")]
+fn classify_block_devices(devices: &[BlockDevice]) -> ResolvedAccelerationStorage {
+    let mut non_rotational_storage_found = false;
+
+    for device in devices {
+        let description = format!(
+            "{} {} {}",
+            device.name,
+            device.model.as_deref().unwrap_or_default(),
+            device.vendor.as_deref().unwrap_or_default()
+        );
+
+        if description.contains("amazon elastic block store")
+            || description.contains("amazon ebs")
+            || description.contains("elastic block store")
+        {
+            return ResolvedAccelerationStorage::Ebs;
+        }
+
+        // Azure Managed Disks (Premium SSD, Standard SSD, Standard HDD, Ultra
+        // Disk) attach to Linux VMs as Hyper-V virtual SCSI disks reporting
+        // vendor "Msft" and model "Virtual Disk". Treat them like EBS for
+        // pool sizing because they share the same network-attached latency
+        // characteristics.
+        if description.contains("msft virtual disk")
+            || description.contains("microsoft virtual disk")
+            || description.contains("azure managed disk")
+        {
+            return ResolvedAccelerationStorage::Ebs;
+        }
+
+        if description.contains("amazon ec2 nvme instance storage") {
+            return ResolvedAccelerationStorage::LocalSsd;
+        }
+
+        if device.name.starts_with("nvme") || device.rotational == Some(false) {
+            non_rotational_storage_found = true;
+        }
+    }
+
+    if non_rotational_storage_found {
+        ResolvedAccelerationStorage::LocalSsd
+    } else {
+        ResolvedAccelerationStorage::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn unescapes_mountinfo_paths() {
+        assert_eq!(
+            unescape_mountinfo_path("/mnt/local\\040ssd"),
+            "/mnt/local ssd"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn finds_longest_matching_mount() {
+        let mountinfo = "1 0 8:1 / / rw - ext4 /dev/sda1 rw\n2 1 259:0 / /mnt/local\\040ssd rw - ext4 /dev/nvme0n1 rw";
+        let mount = find_longest_matching_mount(Path::new("/mnt/local ssd/table.db"), mountinfo)
+            .expect("mount should resolve");
+        assert_eq!(mount.major_minor, "259:0");
+        assert_eq!(mount.fstype, "ext4");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detects_tmpfs_fstype() {
+        let mountinfo =
+            "1 0 8:1 / / rw - ext4 /dev/sda1 rw\n2 1 0:42 / /mnt/ram rw - tmpfs tmpfs rw,size=8G";
+        let mount = find_longest_matching_mount(Path::new("/mnt/ram/cache.db"), mountinfo)
+            .expect("mount should resolve");
+        assert_eq!(mount.fstype, "tmpfs");
+        assert!(is_in_memory_fstype(&mount.fstype));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn classifies_amazon_ebs_before_nvme() {
+        let devices = vec![BlockDevice {
+            name: "nvme1n1".to_string(),
+            model: Some("amazon elastic block store".to_string()),
+            vendor: Some("amazon ec2".to_string()),
+            rotational: Some(false),
+        }];
+
+        assert_eq!(
+            classify_block_devices(&devices),
+            ResolvedAccelerationStorage::Ebs
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn classifies_instance_store_as_local_ssd() {
+        let devices = vec![BlockDevice {
+            name: "nvme0n1".to_string(),
+            model: Some("amazon ec2 nvme instance storage".to_string()),
+            vendor: Some("amazon ec2".to_string()),
+            rotational: Some(false),
+        }];
+
+        assert_eq!(
+            classify_block_devices(&devices),
+            ResolvedAccelerationStorage::LocalSsd
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn classifies_azure_managed_disk_as_ebs() {
+        let devices = vec![BlockDevice {
+            name: "sda".to_string(),
+            model: Some("virtual disk".to_string()),
+            vendor: Some("msft".to_string()),
+            rotational: Some(false),
+        }];
+
+        assert_eq!(
+            classify_block_devices(&devices),
+            ResolvedAccelerationStorage::Ebs
+        );
+    }
+
+    #[test]
+    fn honors_configured_storage_override() {
+        assert_eq!(
+            resolve_acceleration_storage(StorageProfile::Ebs, Path::new("/does/not/matter")),
+            ResolvedAccelerationStorage::Ebs
+        );
+        assert_eq!(
+            resolve_acceleration_storage(StorageProfile::LocalSsd, Path::new("/does/not/matter")),
+            ResolvedAccelerationStorage::LocalSsd
+        );
+        assert_eq!(
+            resolve_acceleration_storage(StorageProfile::Tmpfs, Path::new("/does/not/matter")),
+            ResolvedAccelerationStorage::Tmpfs
+        );
+    }
+}

--- a/crates/runtime/src/dataaccelerator/turso.rs
+++ b/crates/runtime/src/dataaccelerator/turso.rs
@@ -59,6 +59,7 @@ use crate::{
     dataaccelerator::{
         FilePathError,
         snapshots::{download_snapshot_if_needed, snapshot_before_recreate},
+        storage::{ResolvedAccelerationStorage, resolve_acceleration_storage_async},
     },
     datafusion::udf::deny_spice_specific_functions,
     make_spice_data_directory,
@@ -324,22 +325,80 @@ impl TursoAccelerator {
 
         let mut pools = self.pools.lock().await;
         if let Some(pool) = pools.get(&turso_file) {
-            Ok(Arc::clone(pool))
-        } else {
-            let pool = Arc::new(
-                TursoConnectionPool::new_with_timestamp_format(&turso_file, timestamp_format)
-                    .await
-                    .map_err(|e| match e {
-                        data_components::turso::Error::TursoDatabaseError { source } => {
-                            Error::TursoDatabaseError { source }
-                        }
-                        _ => Error::AccelerationCreationFailed {
-                            source: Box::new(e),
-                        },
-                    })?,
+            return Ok(Arc::clone(pool));
+        }
+
+        // Resolve storage profile so we can tune per-storage pragmas. Skip
+        // detection for in-memory databases; they have no on-disk footprint.
+        let storage = if source.is_file_accelerated() {
+            let configured = source
+                .acceleration()
+                .map(|a| a.storage_profile)
+                .unwrap_or_default();
+            let resolved = resolve_acceleration_storage_async(configured, &turso_file).await;
+            tracing::debug!(
+                target: "spiced::acceleration::turso",
+                configured = %configured,
+                resolved = ?resolved,
+                file = %turso_file,
+                "Resolved acceleration storage profile for Turso pool"
             );
-            pools.insert(turso_file, Arc::clone(&pool));
-            Ok(pool)
+            resolved
+        } else {
+            ResolvedAccelerationStorage::Unknown
+        };
+
+        let pool = Arc::new(
+            TursoConnectionPool::new_with_timestamp_format(&turso_file, timestamp_format)
+                .await
+                .map_err(|e| match e {
+                    data_components::turso::Error::TursoDatabaseError { source } => {
+                        Error::TursoDatabaseError { source }
+                    }
+                    _ => Error::AccelerationCreationFailed {
+                        source: Box::new(e),
+                    },
+                })?,
+        );
+
+        // Apply storage-aware pragmas after the pool's own MVCC initialization.
+        let pragmas = Self::storage_setup_pragmas(storage);
+        if !pragmas.is_empty() {
+            let conn = pool.connect().await.map_err(|e| match e {
+                data_components::turso::Error::TursoDatabaseError { source } => {
+                    Error::TursoDatabaseError { source }
+                }
+                _ => Error::AccelerationCreationFailed {
+                    source: Box::new(e),
+                },
+            })?;
+            for (name, value) in pragmas {
+                conn.pragma_update(name, value)
+                    .await
+                    .context(TursoDatabaseSnafu)?;
+            }
+        }
+
+        pools.insert(turso_file, Arc::clone(&pool));
+        Ok(pool)
+    }
+
+    /// Per-storage SQLite/Turso pragma overrides applied after pool creation.
+    ///
+    /// On EBS-class network-attached storage we bump the page cache and enable
+    /// mmap to absorb random I/O latency. Local SSD, tmpfs, and unknown
+    /// storage keep the engine defaults.
+    fn storage_setup_pragmas(
+        storage: ResolvedAccelerationStorage,
+    ) -> &'static [(&'static str, &'static str)] {
+        match storage {
+            // 200_000 KiB is about a 200 MiB page cache, plus a 256 MiB mmap window.
+            ResolvedAccelerationStorage::Ebs => {
+                &[("cache_size", "-200000"), ("mmap_size", "268435456")]
+            }
+            ResolvedAccelerationStorage::LocalSsd
+            | ResolvedAccelerationStorage::Tmpfs
+            | ResolvedAccelerationStorage::Unknown => &[],
         }
     }
 }

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -369,7 +369,7 @@ pub struct Acceleration {
 
     /// Storage profile for file-backed acceleration. `auto` detects the
     /// profile from the resolved acceleration path; use `local_ssd`/`ssd`/`nvme`
-    /// or `ebs` to override detection.
+    /// `ebs`, or `tmpfs`/`ram`/`ramdisk`/`ramfs`/`memory` to override detection.
     #[serde(default, skip_serializing_if = "is_default_storage_profile")]
     pub storage_profile: StorageProfile,
 
@@ -618,7 +618,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_all_storage_modes() {
+    fn test_deserialize_all_storage_profiles() {
         for (yaml_value, expected) in [
             ("auto", StorageProfile::Auto),
             ("local_ssd", StorageProfile::LocalSsd),

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -90,6 +90,38 @@ impl Display for Mode {
     }
 }
 
+/// Storage profile for file-backed accelerations.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum StorageProfile {
+    /// Detect the storage profile from the acceleration path.
+    #[default]
+    Auto,
+    /// Local SSD/NVMe-backed storage, such as EC2 instance store or Azure
+    /// temporary/NVMe local storage.
+    #[serde(alias = "ssd", alias = "nvme")]
+    LocalSsd,
+    /// Network-attached block storage, such as Amazon EBS or Azure Managed
+    /// Disks.
+    #[serde(alias = "azure_disk", alias = "managed_disk", alias = "network_disk")]
+    Ebs,
+    /// In-memory storage, such as a tmpfs or ramfs mount.
+    #[serde(alias = "ram", alias = "ramdisk", alias = "ramfs", alias = "memory")]
+    Tmpfs,
+}
+
+impl Display for StorageProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StorageProfile::Auto => write!(f, "auto"),
+            StorageProfile::LocalSsd => write!(f, "local_ssd"),
+            StorageProfile::Ebs => write!(f, "ebs"),
+            StorageProfile::Tmpfs => write!(f, "tmpfs"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "lowercase")]
@@ -335,6 +367,12 @@ pub struct Acceleration {
     #[serde(default, skip_serializing_if = "is_default_write_mode")]
     pub write_mode: WriteMode,
 
+    /// Storage profile for file-backed acceleration. `auto` detects the
+    /// profile from the resolved acceleration path; use `local_ssd`/`ssd`/`nvme`
+    /// or `ebs` to override detection.
+    #[serde(default, skip_serializing_if = "is_default_storage_profile")]
+    pub storage_profile: StorageProfile,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metrics: Option<Metrics>,
 
@@ -401,6 +439,11 @@ fn is_default_write_mode(mode: &WriteMode) -> bool {
     *mode == WriteMode::WriteThrough
 }
 
+#[expect(clippy::trivially_copy_pass_by_ref)]
+fn is_default_storage_profile(storage_profile: &StorageProfile) -> bool {
+    *storage_profile == StorageProfile::Auto
+}
+
 const fn default_true() -> bool {
     true
 }
@@ -434,6 +477,7 @@ impl Default for Acceleration {
             primary_key: None,
             on_conflict: HashMap::default(),
             write_mode: WriteMode::default(),
+            storage_profile: StorageProfile::default(),
             metrics: None,
             partition_by: vec![],
             snapshots: SnapshotBehavior::Disabled,
@@ -569,6 +613,52 @@ mod tests {
                 accel.refresh_mode,
                 Some(expected),
                 "unexpected parse for '{yaml_value}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_deserialize_all_storage_modes() {
+        for (yaml_value, expected) in [
+            ("auto", StorageProfile::Auto),
+            ("local_ssd", StorageProfile::LocalSsd),
+            ("ssd", StorageProfile::LocalSsd),
+            ("nvme", StorageProfile::LocalSsd),
+            ("ebs", StorageProfile::Ebs),
+            ("azure_disk", StorageProfile::Ebs),
+            ("managed_disk", StorageProfile::Ebs),
+            ("network_disk", StorageProfile::Ebs),
+            ("tmpfs", StorageProfile::Tmpfs),
+            ("ram", StorageProfile::Tmpfs),
+            ("ramdisk", StorageProfile::Tmpfs),
+            ("ramfs", StorageProfile::Tmpfs),
+            ("memory", StorageProfile::Tmpfs),
+        ] {
+            let yaml = format!("storage_profile: {yaml_value}");
+            let accel: Acceleration = yaml::from_str(&yaml)
+                .unwrap_or_else(|_| panic!("should parse storage_profile '{yaml_value}'"));
+            assert_eq!(
+                accel.storage_profile, expected,
+                "unexpected parse for '{yaml_value}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_storage_display_round_trip() {
+        for storage in [
+            StorageProfile::Auto,
+            StorageProfile::LocalSsd,
+            StorageProfile::Ebs,
+            StorageProfile::Tmpfs,
+        ] {
+            let s = storage.to_string();
+            let yaml = format!("storage_profile: {s}");
+            let accel: Acceleration = yaml::from_str(&yaml)
+                .unwrap_or_else(|_| panic!("should parse storage_profile '{s}'"));
+            assert_eq!(
+                accel.storage_profile, storage,
+                "round-trip failed for '{s}'"
             );
         }
     }


### PR DESCRIPTION
## Summary

- Add `storage_profile` to acceleration config and runtime acceleration settings.
- Resolve acceleration storage as local SSD, EBS-class disk, tmpfs, or unknown.
- Apply storage-aware defaults across DuckDB, partitioned DuckDB, SQLite, Turso, and Cayenne file-mode accelerators.

## Validation

- Ran `cargo fmt --package spicepod --package runtime`.
- Skipped build/test checks per request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->