### PR TITLE
feat(CH-BenCHmark): rename orders→oorder, add SF10/100/1000 dispatch configurations

### DIFF
--- a/.github/workflows/testoperator_dispatch_htap.yml
+++ b/.github/workflows/testoperator_dispatch_htap.yml
@@ -1,0 +1,82 @@
+name: testoperator dispatch htap
+
+on:
+  workflow_dispatch:
+    inputs:
+      spiced_commit:
+        description: 'An optional commit hash to use for spiced'
+        required: false
+        type: string
+      scale_factor:
+        description: 'Scale factor to run'
+        required: true
+        type: choice
+        options:
+          - 'sf1'
+          - 'sf10'
+          - 'sf100'
+          - 'sf1000'
+
+jobs:
+  dispatch-htap:
+    name: Dispatch HTAP - ${{ github.event.inputs.scale_factor }}
+    runs-on: spiceai-dev-runners
+    concurrency:
+      group: testoperator-dispatch-htap-${{ github.event.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install MinIO
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        id: setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
+          ref: ${{ github.event.ref }}
+
+      - name: Display spiced commit
+        run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
+
+      - name: Build Testoperator
+        uses: ./.github/actions/build-testoperator
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
+      - name: Build spicepod validator
+        id: build-spicepod-validator
+        uses: ./.github/actions/build-spicepod-validator
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
+      - name: Set spicepod validator path
+        run: echo "SPICEPOD_VALIDATOR=${{ steps.build-spicepod-validator.outputs.validator-path }}" >> $GITHUB_ENV
+
+      - name: Validate spicepods - CH-BenCHmark
+        run: |
+          shopt -s globstar nullglob
+          for file in ./test/spicepods/chbench/**/*.yaml; do
+            echo "Validating $file"
+            "$SPICEPOD_VALIDATOR" "$file"
+          done
+
+      - name: Dispatch Testoperator - HTAP - CH-BenCHmark - ${{ github.event.inputs.scale_factor }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/chbench/${{ github.event.inputs.scale_factor }} \
+            --workflow htap
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}

--- a/crates/cayenne/tests/small_files_compaction_test.rs
+++ b/crates/cayenne/tests/small_files_compaction_test.rs
@@ -408,6 +408,7 @@ async fn compaction_collapses_tiny_protected_snapshots(
     let config = VortexConfig {
         target_vortex_file_size_mb: 128,
         compaction_trigger_files: 4,
+        compaction_trigger_protected_snapshots: 4,
         compaction_background_interval_ms: 0,
         ..Default::default()
     };

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -96,7 +96,6 @@ pub(crate) fn create_factory() -> DuckDBTableProviderFactory {
         .with_function_support(deny_spice_functions_for_duckdb().as_ref().clone())
 }
 
-pub(crate) const DEFAULT_MIN_IDLE_CONNECTIONS: u32 = 10;
 pub(crate) const DEFAULT_CONNECTION_POOL_SIZE: u32 = 10;
 pub(crate) const DEFAULT_EBS_CONNECTION_POOL_SIZE: u32 = 4;
 pub(crate) const SPICE_ACCELERATOR_METADATA_KEY: &str = "spice.accelerator";

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -58,7 +58,6 @@ use super::{
 use crate::{
     component::dataset::acceleration::{Engine, Mode},
     dataaccelerator::{FilePathError, storage::resolve_acceleration_storage_async},
-    datafusion::{dialect::new_duckdb_dialect, udf::deny_spice_functions_for_duckdb},
     parameters::ParameterSpec,
     register_data_accelerator, spice_data_base_path,
 };

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -1132,12 +1132,12 @@ mod tests {
         .build();
 
         let state = df.ctx.state();
-        let rule_names: Vec<&str> = state.optimizers().iter().map(|r| r.name()).collect();
 
         assert!(
-            !rule_names
+            !state
+                .optimizers()
                 .iter()
-                .any(|name| *name == "cayenne_propagate_filter_across_equi_join_keys"),
+                .any(|r| r.name() == "cayenne_propagate_filter_across_equi_join_keys"),
             "Cayenne logical filter propagation should be disabled by default"
         );
     }

--- a/crates/test-framework/src/queries/chbench/q10.sql
+++ b/crates/test-framework/src/queries/chbench/q10.sql
@@ -6,7 +6,7 @@ SELECT
     c_phone,
     n_name
 FROM
-    customer, orders, order_line, nation
+    customer, oorder, order_line, nation
 WHERE
     c_id = o_c_id
     AND c_w_id = o_w_id

--- a/crates/test-framework/src/queries/chbench/q12.sql
+++ b/crates/test-framework/src/queries/chbench/q12.sql
@@ -3,7 +3,7 @@ SELECT
     sum(CASE WHEN o_carrier_id = 1 OR o_carrier_id = 2 THEN 1 ELSE 0 END) AS high_line_count,
     sum(CASE WHEN o_carrier_id <> 1 AND o_carrier_id <> 2 THEN 1 ELSE 0 END) AS low_line_count
 FROM
-    orders, order_line
+    oorder, order_line
 WHERE
     ol_w_id = o_w_id
     AND ol_d_id = o_d_id

--- a/crates/test-framework/src/queries/chbench/q13.sql
+++ b/crates/test-framework/src/queries/chbench/q13.sql
@@ -2,7 +2,7 @@ SELECT
     c_count, count(*) AS custdist
 FROM
     (SELECT c_id, count(o_id) AS c_count
-     FROM customer LEFT OUTER JOIN orders ON (
+     FROM customer LEFT OUTER JOIN oorder ON (
          c_w_id = o_w_id
          AND c_d_id = o_d_id
          AND c_id = o_c_id

--- a/crates/test-framework/src/queries/chbench/q18.sql
+++ b/crates/test-framework/src/queries/chbench/q18.sql
@@ -6,7 +6,7 @@ SELECT
     o_ol_cnt,
     sum(ol_amount) AS amount_sum
 FROM
-    customer, orders, order_line
+    customer, oorder, order_line
 WHERE
     c_id = o_c_id
     AND c_w_id = o_w_id

--- a/crates/test-framework/src/queries/chbench/q21.sql
+++ b/crates/test-framework/src/queries/chbench/q21.sql
@@ -3,7 +3,7 @@ SELECT
 FROM
     supplier,
     order_line l1,
-    orders,
+    oorder,
     stock,
     nation
 WHERE

--- a/crates/test-framework/src/queries/chbench/q22.sql
+++ b/crates/test-framework/src/queries/chbench/q22.sql
@@ -9,7 +9,7 @@ WHERE
     AND c_balance > (SELECT avg(c_balance) FROM customer
                      WHERE c_balance > 0.00
                        AND substr(c_phone,1,1) IN ('1','2','3','4','5','6','7'))
-    AND NOT EXISTS (SELECT * FROM orders
+    AND NOT EXISTS (SELECT * FROM oorder
                     WHERE o_c_id = c_id
                       AND o_w_id = c_w_id
                       AND o_d_id = c_d_id)

--- a/crates/test-framework/src/queries/chbench/q3.sql
+++ b/crates/test-framework/src/queries/chbench/q3.sql
@@ -7,7 +7,7 @@ SELECT
 FROM
     customer,
     new_order,
-    orders,
+    oorder,
     order_line
 WHERE c_state LIKE 'A%'
   AND c_id = o_c_id

--- a/crates/test-framework/src/queries/chbench/q4.sql
+++ b/crates/test-framework/src/queries/chbench/q4.sql
@@ -2,7 +2,7 @@ SELECT
     o_ol_cnt,
     count(*) as order_count
 FROM
-    orders
+    oorder
 WHERE exists (SELECT *
               FROM order_line
               WHERE o_id = ol_o_id

--- a/crates/test-framework/src/queries/chbench/q5.sql
+++ b/crates/test-framework/src/queries/chbench/q5.sql
@@ -3,7 +3,7 @@ SELECT
     sum(ol_amount) AS revenue
 FROM
     customer, 
-    orders,
+    oorder,
     order_line,
     stock,
     supplier,

--- a/crates/test-framework/src/queries/chbench/q7.sql
+++ b/crates/test-framework/src/queries/chbench/q7.sql
@@ -4,7 +4,7 @@ SELECT
     extract(year FROM o_entry_d) AS l_year,
     sum(ol_amount) AS revenue
 FROM
-    supplier, stock, order_line, orders, customer, nation n1, nation n2
+    supplier, stock, order_line, oorder, customer, nation n1, nation n2
 WHERE
     ol_supply_w_id = s_w_id
     AND ol_i_id = s_i_id

--- a/crates/test-framework/src/queries/chbench/q8.sql
+++ b/crates/test-framework/src/queries/chbench/q8.sql
@@ -2,7 +2,7 @@ SELECT
     extract(year FROM o_entry_d) AS l_year,
     sum(CASE WHEN n2.n_name = 'INDIA' THEN ol_amount ELSE 0 END) / sum(ol_amount) AS mkt_share
 FROM
-    item, supplier, stock, order_line, orders, customer, nation n1, nation n2, region
+    item, supplier, stock, order_line, oorder, customer, nation n1, nation n2, region
 WHERE
     i_id = s_i_id
     AND ol_i_id = s_i_id

--- a/crates/test-framework/src/queries/chbench/q9.sql
+++ b/crates/test-framework/src/queries/chbench/q9.sql
@@ -2,7 +2,7 @@ SELECT
     n_name, extract(year FROM o_entry_d) AS l_year,
     sum(ol_amount) AS sum_profit
 FROM
-    item, stock, supplier, order_line, orders, nation
+    item, stock, supplier, order_line, oorder, nation
 WHERE
     ol_i_id = s_i_id
     AND ol_supply_w_id = s_w_id

--- a/test/spicepods/chbench/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-arrow.yaml
@@ -57,11 +57,11 @@ datasets:
       on_conflict:
         (no_w_id, no_d_id, no_o_id): upsert
 
-  - from: postgres:orders
-    name: orders
+  - from: postgres:oorder
+    name: oorder
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_orders
+      pg_replication_slot: spice_oorder
     acceleration:
       <<: *arrow_accel
       primary_key: (o_w_id, o_d_id, o_id)

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
@@ -11,6 +11,7 @@ runtime:
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
   query:
+    memory_limit: 40GiB
     target_partitions: 32
 
 datasets:

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
@@ -2,28 +2,157 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned
 
-
 runtime:
   params:
-    cdc_prefetch_buffer: "1024"
-    cdc_max_coalesced_envelopes: "1024"
-    cdc_max_coalesced_bytes: "268435456"  # 256 MB
+    cdc_prefetch_buffer: '1024'
+    cdc_max_coalesced_envelopes: '1024'
+    cdc_max_coalesced_bytes: '67108864' # 64 MB
+    cdc_max_coalesce_age_ms: '2000'
+    cdc_commit_timeout_ms: '60000'
+    cayenne_sort_merge_min_rows: '50000000'
+  query:
+    target_partitions: 32
 
 datasets:
-  # ---- TPC-C core tables (mutated by OLTP workload) ----
+  # ------------------------------------------------------------------
+  # High-volume PK upsert tables.
+  # ------------------------------------------------------------------
 
-  - from: postgres:warehouse
-    name: warehouse
-    params: &postgres_params
+  - from: postgres:district
+    name: district
+    params: &pg_base
       pg_host: 127.0.0.1
-      pg_port: 5432
+      pg_port: '5432'
       pg_db: chbench
       pg_user: bench
       pg_pass: bench
       pg_sslmode: disable
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+      params: &accel_high_volume
+        cayenne_metastore: sqlite
+        cayenne_file_path: ./spice/cayenne/district
+        cayenne_write_concurrency: '16'
+        cayenne_upload_concurrency: '32'
+        cayenne_footer_cache_mb: '256'
+        cayenne_segment_cache_mb: '1024'
+        cayenne_compaction_trigger_protected_snapshots: '4'
+        cayenne_compaction_trigger_snapshot_age_ms: '15000'
+        cayenne_compaction_max_files_per_pick: '64'
+        cayenne_compaction_background_interval_ms: '3000'
+
+  - from: postgres:customer
+    name: customer
+    params:
+      <<: *pg_base
+      pg_replication_slot: spice_customer
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: ./spice/cayenne/customer
+        cayenne_target_file_size_mb: '256'
+
+  - from: postgres:new_order
+    name: new_order
+    params:
+      <<: *pg_base
+      pg_replication_slot: spice_new_order
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: ./spice/cayenne/new_order
+
+  - from: postgres:oorder
+    name: oorder
+    params:
+      <<: *pg_base
+      pg_replication_slot: spice_oorder
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: ./spice/cayenne/oorder
+
+  - from: postgres:order_line
+    name: order_line
+    params:
+      <<: *pg_base
+      pg_replication_slot: spice_order_line
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: ./spice/cayenne/order_line
+        cayenne_write_concurrency: '32'
+        cayenne_target_file_size_mb: '256'
+        cayenne_compaction_trigger_files: '8'
+        cayenne_compaction_trigger_snapshot_age_ms: '30000'
+        cayenne_compaction_max_files_per_pick: '128'
+        cayenne_segment_cache_mb: '2048'
+
+  - from: postgres:stock
+    name: stock
+    params:
+      <<: *pg_base
+      pg_replication_slot: spice_stock
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: ./spice/cayenne/stock
+        cayenne_target_file_size_mb: '256'
+
+  # ------------------------------------------------------------------
+  # Low-volume reference tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:warehouse
+    name: warehouse
+    params:
+      <<: *pg_base
       pg_replication_slot: spice_warehouse
-      pg_replication_initial_snapshot: "true"
-    acceleration: &cayenne_accel
+    acceleration:
       enabled: true
       engine: cayenne
       mode: file
@@ -31,146 +160,86 @@ datasets:
       primary_key: w_id
       on_conflict:
         w_id: upsert
-      params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
-
-  - from: postgres:district
-    name: district
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_district
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (d_w_id, d_id)
-      on_conflict:
-        (d_w_id, d_id): upsert
-      params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
-
-  - from: postgres:customer
-    name: customer
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_customer
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (c_w_id, c_d_id, c_id)
-      on_conflict:
-        (c_w_id, c_d_id, c_id): upsert
-      params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
-
-  - from: postgres:new_order
-    name: new_order
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_new_order
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (no_w_id, no_d_id, no_o_id)
-      on_conflict:
-        (no_w_id, no_d_id, no_o_id): upsert
-      params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
-
-  - from: postgres:orders
-    name: orders
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_orders
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (o_w_id, o_d_id, o_id)
-      on_conflict:
-        (o_w_id, o_d_id, o_id): upsert
-      params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
-
-  - from: postgres:order_line
-    name: order_line
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_order_line
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
-      on_conflict:
-        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
-      params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
+      params: &accel_medium
+        cayenne_metastore: sqlite
+        cayenne_file_path: ./spice/cayenne/warehouse
+        cayenne_write_concurrency: '4'
+        cayenne_upload_concurrency: '4'
+        cayenne_footer_cache_mb: '32'
+        cayenne_segment_cache_mb: '64'
 
   - from: postgres:item
     name: item
     params:
-      <<: *postgres_params
+      <<: *pg_base
       pg_replication_slot: spice_item
     acceleration:
-      <<: *cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
       primary_key: i_id
       on_conflict:
         i_id: upsert
       params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
+        <<: *accel_medium
+        cayenne_file_path: ./spice/cayenne/item
 
-  - from: postgres:stock
-    name: stock
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_stock
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (s_w_id, s_i_id)
-      on_conflict:
-        (s_w_id, s_i_id): upsert
-      params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
+  # ------------------------------------------------------------------
+  # Tiny TPC-H tables.
+  # ------------------------------------------------------------------
 
   - from: postgres:region
     name: region
     params:
-      <<: *postgres_params
+      <<: *pg_base
       pg_replication_slot: spice_region
     acceleration:
-      <<: *cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
       primary_key: r_regionkey
       on_conflict:
         r_regionkey: upsert
-      params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
+      params: &accel_small
+        cayenne_metastore: sqlite
+        cayenne_file_path: ./spice/cayenne/region
+        cayenne_write_concurrency: '2'
+        cayenne_upload_concurrency: '2'
+        cayenne_footer_cache_mb: '8'
+        cayenne_segment_cache_mb: '16'
 
   - from: postgres:nation
     name: nation
     params:
-      <<: *postgres_params
+      <<: *pg_base
       pg_replication_slot: spice_nation
     acceleration:
-      <<: *cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
       primary_key: n_nationkey
       on_conflict:
         n_nationkey: upsert
       params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
+        <<: *accel_small
+        cayenne_file_path: ./spice/cayenne/nation
 
   - from: postgres:supplier
     name: supplier
     params:
-      <<: *postgres_params
+      <<: *pg_base
       pg_replication_slot: spice_supplier
     acceleration:
-      <<: *cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
       primary_key: su_suppkey
       on_conflict:
         su_suppkey: upsert
       params:
-        cayenne_write_concurrency: "4"
-        cayenne_upload_concurrency: "4"
+        <<: *accel_small
+        cayenne_file_path: ./spice/cayenne/supplier

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
@@ -58,11 +58,11 @@ datasets:
       on_conflict:
         (no_w_id, no_d_id, no_o_id): upsert
 
-  - from: postgres:orders
-    name: orders
+  - from: postgres:oorder
+    name: oorder
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_orders
+      pg_replication_slot: spice_oorder
     acceleration:
       <<: *cayenne_accel
       primary_key: (o_w_id, o_d_id, o_id)

--- a/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
@@ -58,11 +58,11 @@ datasets:
       on_conflict:
         (no_w_id, no_d_id, no_o_id): upsert
 
-  - from: postgres:orders
-    name: orders
+  - from: postgres:oorder
+    name: oorder
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_orders
+      pg_replication_slot: spice_oorder
     acceleration:
       <<: *duckdb_accel
       primary_key: (o_w_id, o_d_id, o_id)

--- a/test/spicepods/chbench/federated/postgres.yaml
+++ b/test/spicepods/chbench/federated/postgres.yaml
@@ -22,8 +22,8 @@ datasets:
   - from: postgres:history
     name: history
     params: *postgres_params
-  - from: postgres:orders
-    name: orders
+  - from: postgres:oorder
+    name: oorder
     params: *postgres_params
   - from: postgres:new_order
     name: new_order

--- a/tools/chbench-driver/src/loader.rs
+++ b/tools/chbench-driver/src/loader.rs
@@ -161,7 +161,7 @@ const WAREHOUSE_TABLES: &[(&str, &str, &str)] = &[
         "h_c_id, h_c_d_id, h_d_id, h_w_id, h_date, h_amount, h_data",
     ),
     (
-        "orders",
+        "oorder",
         "o_w_id",
         "o_id, o_d_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local",
     ),
@@ -565,7 +565,7 @@ async fn load_orders(
     d_id: i32,
 ) -> Result<Vec<i32>> {
     let mut sink = BatchSink::new(
-        "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES",
+        "INSERT INTO oorder (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES",
     );
     let mut row = String::new();
 
@@ -597,9 +597,9 @@ async fn load_orders(
             sql_opt_i32(o_carrier_id),
         );
         sink.write_row(&row);
-        sink.maybe_flush(client, "orders").await?;
+        sink.maybe_flush(client, "oorder").await?;
     }
-    sink.flush(client, "orders").await?;
+    sink.flush(client, "oorder").await?;
 
     Ok(ol_cnts)
 }

--- a/tools/chbench-driver/src/schema.rs
+++ b/tools/chbench-driver/src/schema.rs
@@ -28,7 +28,7 @@ pub const ALL_TABLES: &[&str] = &[
     "stock",
     "customer",
     "history",
-    "orders",
+    "oorder",
     "new_order",
     "order_line",
     "nation",
@@ -200,8 +200,8 @@ pub async fn create_tables(client: &Client) -> Result<()> {
             )",
         ),
         (
-            "orders",
-            "CREATE TABLE IF NOT EXISTS orders (
+            "oorder",
+            "CREATE TABLE IF NOT EXISTS oorder (
                 o_id INT NOT NULL,
                 o_d_id INT NOT NULL,
                 o_w_id INT NOT NULL,
@@ -325,7 +325,7 @@ pub async fn create_tables(client: &Client) -> Result<()> {
         ),
         (
             "idx_order",
-            "CREATE INDEX IF NOT EXISTS idx_order ON orders (o_w_id, o_d_id, o_c_id, o_id)",
+            "CREATE INDEX IF NOT EXISTS idx_order ON oorder (o_w_id, o_d_id, o_c_id, o_id)",
         ),
     ];
 
@@ -354,7 +354,7 @@ const MUTATED_TABLES: &[&str] = &[
     "customer",
     "history",
     "new_order",
-    "orders",
+    "oorder",
     "order_line",
     "stock",
 ];
@@ -368,7 +368,7 @@ pub const STALENESS_PROBE_TABLES: &[&str] = &[
     "district",
     "new_order",
     "order_line",
-    "orders",
+    "oorder",
     "stock",
     "warehouse",
 ];

--- a/tools/chbench-driver/src/txn/delivery.rs
+++ b/tools/chbench-driver/src/txn/delivery.rs
@@ -73,24 +73,24 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
 
         // 3. UPDATE orders with carrier
         tx.execute(
-            "UPDATE orders SET o_carrier_id = $1 WHERE o_w_id = $2 AND o_d_id = $3 AND o_id = $4",
+            "UPDATE oorder SET o_carrier_id = $1 WHERE o_w_id = $2 AND o_d_id = $3 AND o_id = $4",
             &[&o_carrier_id, &w_id, &d_id, &no_o_id],
         )
         .await
         .map_err(|source| crate::Error::Sql {
-            action: "delivery: update orders".into(),
+            action: "delivery: update oorder".into(),
             source,
         })?;
 
         // 4. Get customer ID for this order
         let o_row = tx
             .query_one(
-                "SELECT o_c_id FROM orders WHERE o_w_id = $1 AND o_d_id = $2 AND o_id = $3",
+                "SELECT o_c_id FROM oorder WHERE o_w_id = $1 AND o_d_id = $2 AND o_id = $3",
                 &[&w_id, &d_id, &no_o_id],
             )
             .await
             .map_err(|source| crate::Error::Sql {
-                action: "delivery: select orders c_id".into(),
+                action: "delivery: select oorder c_id".into(),
                 source,
             })?;
 

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -123,7 +123,7 @@ pub async fn run(
     )
     .await
     .map_err(|source| crate::Error::Sql {
-        action: "new_order: insert orders".into(),
+        action: "new_order: insert oorder".into(),
         source,
     })?;
 

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -116,9 +116,9 @@ pub async fn run(
     let o_id = d_next_o_id;
     let now = SystemTime::now();
 
-    // 4. INSERT orders
+    // 4. INSERT oorder
     tx.execute(
-        &stmts.insert_orders,
+        &stmts.insert_oorder,
         &[&o_id, &d_id, &w_id, &c_id, &now, &ol_cnt, &all_local],
     )
     .await

--- a/tools/chbench-driver/src/txn/order_status.rs
+++ b/tools/chbench-driver/src/txn/order_status.rs
@@ -106,7 +106,7 @@ pub async fn run(client: &mut Client, rng: &mut impl Rng, warehouses: i32) -> Re
     // SELECT latest order
     let o_row = tx
         .query_opt(
-            "SELECT o_id, o_carrier_id, o_entry_d FROM orders WHERE o_w_id = $1 AND o_d_id = $2 AND o_c_id = $3 ORDER BY o_id DESC LIMIT 1",
+            "SELECT o_id, o_carrier_id, o_entry_d FROM oorder WHERE o_w_id = $1 AND o_d_id = $2 AND o_c_id = $3 ORDER BY o_id DESC LIMIT 1",
             &[&w_id, &d_id, &c_id],
         )
         .await

--- a/tools/chbench-driver/src/txn/prepared.rs
+++ b/tools/chbench-driver/src/txn/prepared.rs
@@ -28,7 +28,7 @@ pub struct NewOrderStmts {
     pub select_customer_warehouse: Statement,
     pub select_district: Statement,
     pub update_district: Statement,
-    pub insert_orders: Statement,
+    pub insert_oorder: Statement,
     pub insert_new_order: Statement,
     pub select_item: Statement,
     /// One prepared statement per district (`s_dist_01` through `s_dist_10`).
@@ -107,14 +107,14 @@ impl PreparedStatements {
                 source,
             })?;
 
-        let insert_orders = client
+        let insert_oorder = client
             .prepare(
                 "INSERT INTO oorder (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) \
                  VALUES ($1, $2, $3, $4, $5, $6, $7)",
             )
             .await
             .map_err(|source| crate::Error::Sql {
-                action: "prepare new_order: insert_orders".into(),
+                action: "prepare new_order: insert_oorder".into(),
                 source,
             })?;
 
@@ -182,7 +182,7 @@ impl PreparedStatements {
             select_customer_warehouse,
             select_district,
             update_district,
-            insert_orders,
+            insert_oorder,
             insert_new_order,
             select_item,
             select_stock,

--- a/tools/chbench-driver/src/txn/prepared.rs
+++ b/tools/chbench-driver/src/txn/prepared.rs
@@ -109,7 +109,7 @@ impl PreparedStatements {
 
         let insert_orders = client
             .prepare(
-                "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) \
+                "INSERT INTO oorder (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) \
                  VALUES ($1, $2, $3, $4, $5, $6, $7)",
             )
             .await

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-arrow.yaml
@@ -3,5 +3,5 @@ tests:
     spicepod_path: accelerated/postgres-arrow.yaml
     runner_type: spiceai-dev-runners
     scale_factor: 1
-    duration: 300
+    duration: 600
     ready_wait: 60

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-tuned.yaml
@@ -3,5 +3,5 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
     runner_type: spiceai-dev-runners
     scale_factor: 1
-    duration: 300
+    duration: 600
     ready_wait: 60

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
@@ -3,5 +3,5 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
     runner_type: spiceai-dev-runners
     scale_factor: 1
-    duration: 300
+    duration: 600
     ready_wait: 60

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
@@ -3,5 +3,5 @@ tests:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
     runner_type: spiceai-dev-runners
     scale_factor: 1
-    duration: 300
+    duration: 600
     ready_wait: 60

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-arrow.yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 10
     duration: 600
     ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
@@ -1,0 +1,7 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-arrow.yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 10
+    duration: 600
+    ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,0 +1,7 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 10
+    duration: 600
+    ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 10
     duration: 600
     ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 10
     duration: 600
     ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
@@ -1,0 +1,7 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file].yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 10
+    duration: 600
+    ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
@@ -1,0 +1,7 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-duckdb[file].yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 10
+    duration: 600
+    ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 10
     duration: 600
     ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 100
+    terminals: 100
+    duration: 600
+    ready_wait: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file].yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 100
+    terminals: 100
+    duration: 600
+    ready_wait: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-duckdb[file].yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 100
+    terminals: 100
+    duration: 600
+    ready_wait: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 1000
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 1000
+    terminals: 100
+    duration: 600
+    ready_wait: 600

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-large-runner
+    runner_type: spiceai-dev-large-runners
     scale_factor: 1000
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-duckdb[file].yaml
+    runner_type: spiceai-dev-large-runner
+    scale_factor: 1000
+    terminals: 100
+    duration: 600
+    ready_wait: 600

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -356,6 +356,7 @@ fn emit_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
             worst_lag_ms = l_ms;
         }
     }
+    println!();
 
     // Headline: worst replication lag across all datasets.
     crate::metrics::REPLICATION_LAG_MS.record(worst_lag_ms, &[]);

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -58,11 +58,15 @@ impl StalenessReport {
     /// Print a human-readable data freshness summary and record OTEL metrics.
     pub fn emit(&self) {
         println!("\nData Freshness");
+        println!(
+            "  {:<14} {:>10} {:>10} {:>10} {:>10}",
+            "dataset", "p50_ms", "p99_ms", "max_ms", "samples"
+        );
         for table in &self.probe_tables {
             if let Some(stats) = self.tables.get(table.as_str()) {
                 println!(
-                    "  {:<14} P50={:>5}ms  P99={:>5}ms  max={:>5}ms  ({} samples)",
-                    format!("{table}:"),
+                    "  {:<14} {:>10} {:>10} {:>10} {:>10}",
+                    table,
                     stats.p50.as_millis(),
                     stats.p99.as_millis(),
                     stats.max.as_millis(),
@@ -74,7 +78,6 @@ impl StalenessReport {
                     .record(p99_ms, &[KeyValue::new("dataset", table.clone())]);
             }
         }
-        println!("  ─────────────────");
         println!("  worst P99:     {}ms", self.worst_p99.as_millis());
         #[expect(clippy::cast_precision_loss)]
         let worst_ms = self.worst_p99.as_millis() as f64;


### PR DESCRIPTION
## 📝 Summary

Improve  the CH-BenCHmark infrastructure:

- **Rename `orders` → `oorder`**: Align table name with official TPC-C naming (avoids SQL reserved word `ORDER`). Updated chbench driver DDL/transactions, analytical queries (q3–q22), and all spicepod configs.
-  Update `postgres-cayenne[file]-cdc-tuned.yaml` configuration with higher write/upload concurrency, segment/footer caches, and coalesce tuning.
- **Add dispatch configs**: New sf10, sf100, sf1000 scale factor dispatch configurations.
- **Dedicated HTAP dispatch workflow**: `testoperator_dispatch_htap.yml` with `scale_factor` (sf1/sf10/sf100/sf1000) and optional `spiced_commit` inputs.
- **Improve staleness report format**: Columnar header row matching replication metrics style.
- **Extend benchmark duration**: All sf1 dispatches updated to 600s.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->