### PR TITLE
Expose Cayenne footer cache and CDC metrics

### DIFF
--- a/crates/cayenne/README.md
+++ b/crates/cayenne/README.md
@@ -192,8 +192,8 @@ pub trait MetadataCatalog: Send + Sync {
 ```rust
 pub struct VortexConfig {
     // Vortex caches and file shape
-    pub footer_cache_mb: usize,               // default 128 (currently ignored in 2.0.0-unstable)
-    pub segment_cache_mb: usize,              // default 256 (currently ignored in 2.0.0-unstable)
+    pub footer_cache_mb: usize,               // default 128
+    pub segment_cache_mb: usize,              // default 256 (currently ignored until Vortex exposes segment cache sizing)
     pub target_vortex_file_size_mb: usize,    // default 128
 
     // Encoding / sort

--- a/crates/cayenne/README.md
+++ b/crates/cayenne/README.md
@@ -194,7 +194,7 @@ pub struct VortexConfig {
     // Vortex caches and file shape
     pub footer_cache_mb: usize,               // default 128
     pub segment_cache_mb: usize,              // default 256 (currently ignored until Vortex exposes segment cache sizing)
-    pub target_vortex_file_size_mb: usize,    // default 128
+    pub target_vortex_file_size_mb: usize,    // default 256
 
     // Encoding / sort
     pub sort_columns: Vec<String>,            // default []

--- a/crates/cayenne/README.md
+++ b/crates/cayenne/README.md
@@ -187,12 +187,12 @@ pub trait MetadataCatalog: Send + Sync {
 - **`InlinedDataStats`** — `{ total_rows, segment_count, total_bytes }` aggregated from `cayenne_inlined_data` for memtable-pressure decisions.
 - **`PartitionMetadata`** — composite partition key, partition path, record/byte counts.
 - **`TableStatistics`** — serialized `FileStatistics` blob plus `num_rows`; populated from Vortex file footers and read by the DataFusion planner.
-- **`VortexConfig`** — Vortex-side tuning. All fields configurable per dataset via `cayenne_*` runtime parameters. The runtime applies refresh-mode defaults before parsing explicit params: `refresh_mode: caching`, `changes`, and `append` with `refresh_check_interval <= 5m` favor small incremental writes, while manual/cron/long-interval append plus `refresh_mode: full`, `snapshot`, `disabled`, and unspecified refresh modes favor large Vortex writes by default. Append workloads can be small or large depending on caller batch size, so tune the inline and compaction parameters explicitly if refresh cadence does not reflect write size.
+- **`VortexConfig`** — Vortex-side tuning. Most fields are configurable per dataset via `cayenne_*` runtime parameters. Footer metadata cache sizing is runtime-global and configured with `runtime.params.cayenne_footer_cache_mb`; when set, the configured value is stored in the metastore for compatibility validation during dataset registration. The runtime applies refresh-mode defaults before parsing explicit params: `refresh_mode: caching`, `changes`, and `append` with `refresh_check_interval <= 5m` favor small incremental writes, while manual/cron/long-interval append plus `refresh_mode: full`, `snapshot`, `disabled`, and unspecified refresh modes favor large Vortex writes by default. Append workloads can be small or large depending on caller batch size, so tune the inline and compaction parameters explicitly if refresh cadence does not reflect write size.
 
 ```rust
 pub struct VortexConfig {
     // Vortex caches and file shape
-    pub footer_cache_mb: usize,               // default 128
+    pub footer_cache_mb: Option<usize>,       // None unless runtime.params.cayenne_footer_cache_mb is set
     pub segment_cache_mb: usize,              // default 256 (currently ignored until Vortex exposes segment cache sizing)
     pub target_vortex_file_size_mb: usize,    // default 256
 

--- a/crates/cayenne/src/catalog_provider.rs
+++ b/crates/cayenne/src/catalog_provider.rs
@@ -261,8 +261,10 @@ impl CayenneCatalogProvider {
     }
 
     fn vortex_config_from_config(provider_config: &CayenneCatalogProviderConfig) -> VortexConfig {
-        let mut config = VortexConfig::default();
-        config.footer_cache_mb = provider_config.footer_cache_mb;
+        let mut config = VortexConfig {
+            footer_cache_mb: provider_config.footer_cache_mb,
+            ..Default::default()
+        };
         if let Some(v) = provider_config.segment_cache_mb {
             config.segment_cache_mb = v;
         }

--- a/crates/cayenne/src/catalog_provider.rs
+++ b/crates/cayenne/src/catalog_provider.rs
@@ -49,7 +49,7 @@ pub struct CayenneCatalogProviderConfig {
     pub metadata_dir: Option<String>,
     /// Base path used when data/metadata directories are not explicitly set.
     pub spice_data_base_path: String,
-    /// Footer cache size in MB.
+    /// Runtime-global footer cache size in MB, when explicitly configured by a caller.
     pub footer_cache_mb: Option<usize>,
     /// Segment cache size in MB.
     pub segment_cache_mb: Option<usize>,
@@ -262,9 +262,7 @@ impl CayenneCatalogProvider {
 
     fn vortex_config_from_config(provider_config: &CayenneCatalogProviderConfig) -> VortexConfig {
         let mut config = VortexConfig::default();
-        if let Some(v) = provider_config.footer_cache_mb {
-            config.footer_cache_mb = v;
-        }
+        config.footer_cache_mb = provider_config.footer_cache_mb;
         if let Some(v) = provider_config.segment_cache_mb {
             config.segment_cache_mb = v;
         }

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -2728,8 +2728,11 @@ async fn ensure_snapshot_directory_exists(table: &TableMetadata) -> CatalogResul
 /// Checks if the existing stored configuration matches the new [`CreateTableOptions`].
 ///
 /// Returns `true` if the configuration matches (no recreation needed).
-/// Only compares data-affecting fields; runtime tuning parameters like cache sizes
-/// and write/upload concurrency are excluded since they don't affect data correctness.
+/// Only compares data-affecting fields by default; runtime tuning parameters like
+/// write/upload concurrency are excluded since they don't affect data correctness.
+/// When a runtime-global footer cache value is explicitly configured, compare it
+/// to any value stored in the metastore so configuration drift is surfaced during
+/// dataset registration.
 fn configuration_matches(stored: &TableMetadata, options: &CreateTableOptions) -> bool {
     // Compare primary keys
     if stored.primary_key != options.primary_key {
@@ -2758,6 +2761,13 @@ fn configuration_matches(stored: &TableMetadata, options: &CreateTableOptions) -
         return false;
     }
     if stored.vortex_config.compression_strategy != options.vortex_config.compression_strategy {
+        return false;
+    }
+    if let (Some(stored_footer_cache_mb), Some(configured_footer_cache_mb)) = (
+        stored.vortex_config.footer_cache_mb,
+        options.vortex_config.footer_cache_mb,
+    ) && stored_footer_cache_mb != configured_footer_cache_mb
+    {
         return false;
     }
 
@@ -2837,6 +2847,16 @@ fn log_configuration_differences(
         differences.push(format!(
             "compression_strategy: {:?} -> {:?}",
             stored.vortex_config.compression_strategy, options.vortex_config.compression_strategy
+        ));
+    }
+
+    if let (Some(stored_footer_cache_mb), Some(configured_footer_cache_mb)) = (
+        stored.vortex_config.footer_cache_mb,
+        options.vortex_config.footer_cache_mb,
+    ) && stored_footer_cache_mb != configured_footer_cache_mb
+    {
+        differences.push(format!(
+            "footer_cache_mb: {stored_footer_cache_mb} -> {configured_footer_cache_mb}"
         ));
     }
 
@@ -4353,7 +4373,7 @@ mod tests {
 
         // Change only cache sizes (non-data-affecting) — should NOT trigger recreation
         let vortex_config = crate::metadata::VortexConfig {
-            footer_cache_mb: 512,
+            footer_cache_mb: Some(512),
             segment_cache_mb: 1024,
             upload_concurrency: 8,
             write_concurrency: Some(16),
@@ -5297,6 +5317,64 @@ mod tests {
         );
 
         // Cleanup
+        let db_path = test_db.strip_prefix("sqlite://").unwrap_or(&test_db);
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(format!("{db_path}-shm"));
+        let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_existing_table_configuration_checks_configured_footer_cache() {
+        let test_db = format!(
+            "sqlite://./.test_footer_cache_validate_{}.db",
+            uuid::Uuid::now_v7()
+        );
+        let catalog = CayenneCatalog::new(&test_db).expect("Failed to create catalog");
+        catalog.init().await.expect("Failed to initialize catalog");
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "id",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+
+        let options = CreateTableOptions {
+            table_name: "footer_cache_validate_table".to_string(),
+            schema: Arc::clone(&schema),
+            primary_key: vec![],
+            on_conflict: None,
+            base_path: "/tmp/cayenne_footer_cache_validate_test".to_string(),
+            partition_column: None,
+            vortex_config: crate::metadata::VortexConfig {
+                footer_cache_mb: Some(128),
+                ..Default::default()
+            },
+        };
+        catalog
+            .create_table(options)
+            .await
+            .expect("Failed to create table");
+
+        let changed_options = CreateTableOptions {
+            table_name: "footer_cache_validate_table".to_string(),
+            schema: Arc::clone(&schema),
+            primary_key: vec![],
+            on_conflict: None,
+            base_path: "/tmp/cayenne_footer_cache_validate_test".to_string(),
+            partition_column: None,
+            vortex_config: crate::metadata::VortexConfig {
+                footer_cache_mb: Some(256),
+                ..Default::default()
+            },
+        };
+        let result = catalog
+            .validate_existing_table_configuration("footer_cache_validate_table", &changed_options)
+            .await;
+        assert!(
+            matches!(&result, Err(CatalogError::ChangedConfiguration { .. })),
+            "Expected ChangedConfiguration error from footer cache validation, got: {result:?}"
+        );
+
         let db_path = test_db.strip_prefix("sqlite://").unwrap_or(&test_db);
         let _ = std::fs::remove_file(db_path);
         let _ = std::fs::remove_file(format!("{db_path}-shm"));

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -472,6 +472,8 @@ impl CayenneCatalog {
     ) -> CatalogResult<TableMetadata> {
         match self.get_table(table_name).await {
             Ok(stored_metadata) => {
+                log_runtime_footer_cache_drift(table_name, &stored_metadata, options);
+
                 if configuration_matches(&stored_metadata, options) {
                     return Ok(stored_metadata);
                 }
@@ -2728,11 +2730,8 @@ async fn ensure_snapshot_directory_exists(table: &TableMetadata) -> CatalogResul
 /// Checks if the existing stored configuration matches the new [`CreateTableOptions`].
 ///
 /// Returns `true` if the configuration matches (no recreation needed).
-/// Only compares data-affecting fields by default; runtime tuning parameters like
-/// write/upload concurrency are excluded since they don't affect data correctness.
-/// When a runtime-global footer cache value is explicitly configured, compare it
-/// to any value stored in the metastore so configuration drift is surfaced during
-/// dataset registration.
+/// Only compares data-affecting fields; runtime tuning parameters like cache sizes
+/// and write/upload concurrency are excluded since they don't affect data correctness.
 fn configuration_matches(stored: &TableMetadata, options: &CreateTableOptions) -> bool {
     // Compare primary keys
     if stored.primary_key != options.primary_key {
@@ -2763,13 +2762,6 @@ fn configuration_matches(stored: &TableMetadata, options: &CreateTableOptions) -
     if stored.vortex_config.compression_strategy != options.vortex_config.compression_strategy {
         return false;
     }
-    if let (Some(stored_footer_cache_mb), Some(configured_footer_cache_mb)) = (
-        stored.vortex_config.footer_cache_mb,
-        options.vortex_config.footer_cache_mb,
-    ) && stored_footer_cache_mb != configured_footer_cache_mb
-    {
-        return false;
-    }
 
     // Compare base path (path change means data is in a different location)
     if stored.path != options.base_path {
@@ -2794,6 +2786,25 @@ fn validate_create_table_options(options: &CreateTableOptions) -> CatalogResult<
     }
 
     Ok(())
+}
+
+fn log_runtime_footer_cache_drift(
+    table_name: &str,
+    stored: &TableMetadata,
+    options: &CreateTableOptions,
+) {
+    if let (Some(stored_footer_cache_mb), Some(configured_footer_cache_mb)) = (
+        stored.vortex_config.footer_cache_mb,
+        options.vortex_config.footer_cache_mb,
+    ) && stored_footer_cache_mb != configured_footer_cache_mb
+    {
+        tracing::warn!(
+            table = table_name,
+            stored_footer_cache_mb,
+            configured_footer_cache_mb,
+            "Cayenne table was registered with a different runtime.params.cayenne_footer_cache_mb than the value stored in the metastore; using the current runtime value"
+        );
+    }
 }
 
 /// Logs a warning describing exactly which configuration fields differ between the
@@ -2847,16 +2858,6 @@ fn log_configuration_differences(
         differences.push(format!(
             "compression_strategy: {:?} -> {:?}",
             stored.vortex_config.compression_strategy, options.vortex_config.compression_strategy
-        ));
-    }
-
-    if let (Some(stored_footer_cache_mb), Some(configured_footer_cache_mb)) = (
-        stored.vortex_config.footer_cache_mb,
-        options.vortex_config.footer_cache_mb,
-    ) && stored_footer_cache_mb != configured_footer_cache_mb
-    {
-        differences.push(format!(
-            "footer_cache_mb: {stored_footer_cache_mb} -> {configured_footer_cache_mb}"
         ));
     }
 
@@ -5324,7 +5325,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_existing_table_configuration_checks_configured_footer_cache() {
+    async fn test_validate_existing_table_configuration_allows_configured_footer_cache_drift() {
         let test_db = format!(
             "sqlite://./.test_footer_cache_validate_{}.db",
             uuid::Uuid::now_v7()
@@ -5371,8 +5372,8 @@ mod tests {
             .validate_existing_table_configuration("footer_cache_validate_table", &changed_options)
             .await;
         assert!(
-            matches!(&result, Err(CatalogError::ChangedConfiguration { .. })),
-            "Expected ChangedConfiguration error from footer cache validation, got: {result:?}"
+            result.is_ok(),
+            "Expected Ok for footer cache runtime tuning drift, got: {result:?}"
         );
 
         let db_path = test_db.strip_prefix("sqlite://").unwrap_or(&test_db);

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -285,13 +285,12 @@ impl PkConflictDetection {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct VortexConfig {
-    /// Footer cache size in MB.
-    ///
-    /// Currently ignored in Spice.ai `2.0.0-unstable`.
+    /// Footer metadata cache size in MB.
     pub footer_cache_mb: usize,
     /// Segment cache size in MB.
     ///
-    /// Currently ignored in Spice.ai `2.0.0-unstable`.
+    /// Currently ignored because the current Vortex DataFusion API does not expose
+    /// segment cache sizing.
     pub segment_cache_mb: usize,
     /// Target size for individual Vortex files in MB. When writes exceed this size,
     /// a new Vortex file will be created in the same listing directory. This allows

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -290,7 +290,7 @@ pub struct VortexConfig {
     pub footer_cache_mb: Option<usize>,
     /// Segment cache size in MB.
     ///
-    /// Currently ignored because the current Vortex DataFusion API does not expose
+    /// Currently ignored because the current Vortex `DataFusion` API does not expose
     /// segment cache sizing.
     pub segment_cache_mb: usize,
     /// Target size for individual Vortex files in MB. When writes exceed this size,

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -295,7 +295,7 @@ pub struct VortexConfig {
     /// Target size for individual Vortex files in MB. When writes exceed this size,
     /// a new Vortex file will be created in the same listing directory. This allows
     /// for better parallelism and more granular statistics for query optimization.
-    /// Defaults to 128 MB.
+    /// Defaults to 256 MB.
     pub target_vortex_file_size_mb: usize,
     /// Columns to sort data by on refresh operations (empty = no sorting)
     pub sort_columns: Vec<String>,
@@ -459,8 +459,8 @@ impl Default for VortexConfig {
             // Larger caches improve read performance
             footer_cache_mb: 128,
             segment_cache_mb: 256,
-            // Smaller files = better parallelism and predicate pushdown
-            target_vortex_file_size_mb: 128,
+            // Balanced file size for scan throughput and write amplification
+            target_vortex_file_size_mb: 256,
             // No sort columns by default
             sort_columns: Vec::new(),
             compression_strategy: CompressionStrategy::default(),

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -285,8 +285,9 @@ impl PkConflictDetection {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct VortexConfig {
-    /// Footer metadata cache size in MB.
-    pub footer_cache_mb: usize,
+    /// Runtime-global footer metadata cache size in MB, when explicitly configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub footer_cache_mb: Option<usize>,
     /// Segment cache size in MB.
     ///
     /// Currently ignored because the current Vortex DataFusion API does not expose
@@ -456,8 +457,7 @@ fn default_inline_flush_max_bytes() -> i64 {
 impl Default for VortexConfig {
     fn default() -> Self {
         Self {
-            // Larger caches improve read performance
-            footer_cache_mb: 128,
+            footer_cache_mb: None,
             segment_cache_mb: 256,
             // Balanced file size for scan throughput and write amplification
             target_vortex_file_size_mb: 256,

--- a/crates/cayenne/src/provider/compaction.rs
+++ b/crates/cayenne/src/provider/compaction.rs
@@ -330,9 +330,9 @@ mod tests {
             .collect()
     }
 
-    /// Helper: target file size of 128 MiB, matching the default.
+    /// Helper: target file size of 256 MiB, matching the default.
     fn default_cfg() -> CompactionPickerConfig {
-        CompactionPickerConfig::new(8, 32, 128 * 1024 * 1024)
+        CompactionPickerConfig::new(8, 32, 256 * 1024 * 1024)
     }
 
     #[test]
@@ -377,7 +377,7 @@ mod tests {
     fn picker_returns_none_when_total_bytes_below_target() {
         let cfg = default_cfg();
         // 8 small files of 1 MiB each — meets trigger_files but total = 8 MiB,
-        // well below the 32 MiB Small-tier byte threshold (target_size / 4).
+        // well below the 64 MiB Small-tier byte threshold (target_size / 4).
         let files = entries(&[1024 * 1024; 8]);
         assert!(pick_candidates(files.iter().cloned(), &cfg).is_none());
     }
@@ -417,7 +417,7 @@ mod tests {
     #[test]
     fn picker_returns_none_when_only_one_file_above_target() {
         let cfg = default_cfg();
-        let files = entries(&[256 * 1024 * 1024]);
+        let files = entries(&[512 * 1024 * 1024]);
         assert!(pick_candidates(files.iter().cloned(), &cfg).is_none());
     }
 
@@ -445,7 +445,7 @@ mod tests {
     fn picker_promotes_to_mid_tier_when_small_tier_drained() {
         let cfg = default_cfg();
         // Simulate post-merge state: small tier is empty, mid tier has 8 files
-        // totaling > 128 MiB.
+        // totaling > 256 MiB.
         let files = entries(&[64 * 1024 * 1024; 8]);
         let candidate = pick_candidates(files.iter().cloned(), &cfg).expect("expected a candidate");
         assert_eq!(candidate.tier, Tier::Mid);
@@ -455,7 +455,7 @@ mod tests {
     fn picker_skips_settled_files() {
         let cfg = default_cfg();
         // All files at exactly target size — none are candidates.
-        let files = entries(&[128 * 1024 * 1024; 16]);
+        let files = entries(&[256 * 1024 * 1024; 16]);
         assert!(pick_candidates(files.iter().cloned(), &cfg).is_none());
     }
 

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -33,13 +33,13 @@ use crate::metadata::{PkConflictDetection, VortexConfig};
 ///
 /// # Sharing
 ///
-/// The internal `VortexFormat` contains footer and segment caches backed by
-/// [`moka::future::Cache`], which uses `Arc` internally. Sharing a `CayenneContext`
-/// across table providers means they all share the same caches, reducing memory
-/// usage when working with partitioned datasets.
+/// The shared `RuntimeEnv` carries the DataFusion file metadata cache used by
+/// Vortex for cached footer metadata. Sharing a `CayenneContext` across table
+/// providers means they share that runtime-level cache, reducing repeated footer
+/// reads when working with partitioned datasets.
 #[derive(Debug)]
 pub struct CayenneContext {
-    /// Vortex format with shared footer/segment caches.
+    /// Shared Vortex format for reading and writing data files.
     vortex_format: Arc<VortexFormat>,
     /// Configuration for encoding, compression, and file sizing.
     config: VortexConfig,
@@ -58,11 +58,12 @@ pub struct CayenneContext {
 impl CayenneContext {
     /// Create a new Cayenne context from configuration.
     ///
-    /// This creates a new `VortexFormat` with caches sized according to the config.
+    /// This creates a new `VortexFormat` and applies cache sizing to the shared runtime.
     /// The returned `Arc` should be shared across all table providers that should
     /// use the same caches.
     #[must_use]
     pub fn new(config: &VortexConfig, runtime_env: Arc<RuntimeEnv>) -> Arc<Self> {
+        Self::configure_runtime_caches(config, &runtime_env);
         let vortex_format = Self::create_vortex_format(config);
         Arc::new(Self {
             vortex_format,
@@ -75,7 +76,7 @@ impl CayenneContext {
 
     /// Get the Vortex file format for creating listing tables.
     ///
-    /// The format contains shared footer and segment caches.
+    /// The format uses the shared runtime cache for file metadata.
     #[must_use]
     pub fn file_format(&self) -> &Arc<VortexFormat> {
         &self.vortex_format
@@ -238,14 +239,8 @@ impl CayenneContext {
         // `session.write_options().with_strategy(...)`, not at the VortexFormat level
         let vortex_session = VortexSession::default();
 
-        // Configure VortexFormat - it creates its own VortexFileCache internally
+        // Configure VortexFormat.
         let default_config = VortexConfig::default();
-        if config.footer_cache_mb != default_config.footer_cache_mb {
-            tracing::warn!(
-                footer_cache_mb = config.footer_cache_mb,
-                "Vortex config `footer_cache_mb` is currently ignored in Spice.ai 2.0.0-unstable"
-            );
-        }
         if config.segment_cache_mb != default_config.segment_cache_mb {
             tracing::warn!(
                 segment_cache_mb = config.segment_cache_mb,
@@ -261,6 +256,14 @@ impl CayenneContext {
 
         Arc::new(VortexFormat::new_with_options(vortex_session, vortex_opts))
     }
+
+    fn configure_runtime_caches(config: &VortexConfig, runtime_env: &RuntimeEnv) {
+        let footer_cache_bytes = config.footer_cache_mb.saturating_mul(1024 * 1024);
+        runtime_env
+            .cache_manager
+            .get_file_metadata_cache()
+            .update_cache_limit(footer_cache_bytes);
+    }
 }
 
 #[cfg(test)]
@@ -273,5 +276,23 @@ mod tests {
         let context = CayenneContext::new(&VortexConfig::default(), runtime_env);
 
         assert!(context.file_format().options().projection_pushdown);
+    }
+
+    #[test]
+    fn cayenne_applies_footer_cache_size_to_runtime_metadata_cache() {
+        let runtime_env = Arc::new(RuntimeEnv::default());
+        let config = VortexConfig {
+            footer_cache_mb: 8,
+            ..VortexConfig::default()
+        };
+        let context = CayenneContext::new(&config, runtime_env);
+
+        assert_eq!(
+            context
+                .runtime_env()
+                .cache_manager
+                .get_metadata_cache_limit(),
+            8 * 1024 * 1024
+        );
     }
 }

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -58,12 +58,10 @@ pub struct CayenneContext {
 impl CayenneContext {
     /// Create a new Cayenne context from configuration.
     ///
-    /// This creates a new `VortexFormat` and applies cache sizing to the shared runtime.
-    /// The returned `Arc` should be shared across all table providers that should
-    /// use the same caches.
+    /// This creates a new `VortexFormat`. The shared runtime's file metadata cache
+    /// is configured once by the owning runtime before table providers are created.
     #[must_use]
     pub fn new(config: &VortexConfig, runtime_env: Arc<RuntimeEnv>) -> Arc<Self> {
-        Self::configure_runtime_caches(config, &runtime_env);
         let vortex_format = Self::create_vortex_format(config);
         Arc::new(Self {
             vortex_format,
@@ -256,14 +254,6 @@ impl CayenneContext {
 
         Arc::new(VortexFormat::new_with_options(vortex_session, vortex_opts))
     }
-
-    fn configure_runtime_caches(config: &VortexConfig, runtime_env: &RuntimeEnv) {
-        let footer_cache_bytes = config.footer_cache_mb.saturating_mul(1024 * 1024);
-        runtime_env
-            .cache_manager
-            .get_file_metadata_cache()
-            .update_cache_limit(footer_cache_bytes);
-    }
 }
 
 #[cfg(test)]
@@ -276,23 +266,5 @@ mod tests {
         let context = CayenneContext::new(&VortexConfig::default(), runtime_env);
 
         assert!(context.file_format().options().projection_pushdown);
-    }
-
-    #[test]
-    fn cayenne_applies_footer_cache_size_to_runtime_metadata_cache() {
-        let runtime_env = Arc::new(RuntimeEnv::default());
-        let config = VortexConfig {
-            footer_cache_mb: 8,
-            ..VortexConfig::default()
-        };
-        let context = CayenneContext::new(&config, runtime_env);
-
-        assert_eq!(
-            context
-                .runtime_env()
-                .cache_manager
-                .get_metadata_cache_limit(),
-            8 * 1024 * 1024
-        );
     }
 }

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -33,7 +33,7 @@ use crate::metadata::{PkConflictDetection, VortexConfig};
 ///
 /// # Sharing
 ///
-/// The shared `RuntimeEnv` carries the DataFusion file metadata cache used by
+/// The shared `RuntimeEnv` carries the `DataFusion` file metadata cache used by
 /// Vortex for cached footer metadata. Sharing a `CayenneContext` across table
 /// providers means they share that runtime-level cache, reducing repeated footer
 /// reads when working with partitioned datasets.

--- a/crates/cayenne/src/provider/sink.rs
+++ b/crates/cayenne/src/provider/sink.rs
@@ -47,7 +47,7 @@ use super::table::CayenneTableProvider;
 ///
 /// File sizing is delegated to the downstream Vortex/DataFusion writer using
 /// the configured target file size (`VortexConfig.target_vortex_file_size_mb`,
-/// default 128 MB).
+/// default 256 MB).
 ///
 /// # Performance
 ///

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -21,8 +21,12 @@ use crate::cluster::PartitionStore;
 use crate::cluster::ResolvedClusterConfig;
 use crate::cluster::SchedulerHeartbeatStore;
 use crate::cluster::partition::service::PartitionService;
+#[cfg(not(windows))]
+use crate::component::dataset::acceleration::Engine;
 use crate::config::ClusterRole;
 use crate::config::Config;
+#[cfg(not(windows))]
+use crate::dataaccelerator::cayenne::CayenneAccelerator;
 use crate::datafusion::udf::register_udfs;
 use crate::metrics_reader::MetricsReader;
 use crate::{
@@ -50,6 +54,8 @@ use tokio::sync::{Mutex, RwLock};
 use util::{in_tracing_context, in_tracing_context_async};
 
 type DatafusionConfigurationCallback = fn(&mut DataFusion);
+
+const CAYENNE_FOOTER_CACHE_MB_PARAM: &str = "cayenne_footer_cache_mb";
 
 pub struct RuntimeBuilder {
     app: Option<Arc<app::App>>,
@@ -242,8 +248,22 @@ impl RuntimeBuilder {
             &spicepod_rt.params,
             "cayenne_sort_merge_memory_pool_fraction",
         );
+        let cayenne_footer_cache_mb =
+            parse_usize_runtime_param(&spicepod_rt.params, CAYENNE_FOOTER_CACHE_MB_PARAM);
         let cayenne_filter_propagation_enabled =
             parse_cayenne_filter_propagation(&spicepod_rt.params).is_enabled();
+
+        #[cfg(not(windows))]
+        if cayenne_footer_cache_mb.is_some() {
+            self.accelerator_engine_registry
+                .register_accelerator_engine(
+                    Engine::Cayenne,
+                    Arc::new(CayenneAccelerator::with_footer_cache_mb(
+                        cayenne_footer_cache_mb,
+                    )),
+                )
+                .await;
+        }
 
         let caching = Runtime::init_caching(Some(&spicepod_rt.caching));
         let io_runtime = self.io_runtime.clone().unwrap_or_else(|| Handle::current());
@@ -392,6 +412,7 @@ impl RuntimeBuilder {
         .with_url_tables(url_tables_enabled)
         .cayenne_sort_merge_min_rows(cayenne_sort_merge_min_rows)
         .cayenne_sort_merge_memory_pool_fraction(cayenne_sort_merge_memory_pool_fraction)
+        .cayenne_footer_cache_mb(cayenne_footer_cache_mb)
         .cayenne_filter_propagation_enabled(cayenne_filter_propagation_enabled);
 
         if let Some(DistributedNode::Scheduler {

--- a/crates/runtime/src/catalogconnector/cayenne/mod.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/mod.rs
@@ -42,9 +42,6 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("metadata_dir").description(
         "Local directory for Cayenne SQLite metadata. Defaults to spice data directory.",
     ),
-    ParameterSpec::component("footer_cache_mb")
-        .description("Vortex footer cache size in MB. Default: 128.")
-        .default("128"),
     ParameterSpec::component("segment_cache_mb")
         .description("Vortex segment cache size in MB. Default: 256.")
         .default("256"),
@@ -117,12 +114,6 @@ impl CayenneCatalogConnector {
             .ok()
             .map(ToOwned::to_owned);
 
-        let footer_cache_mb = self
-            .params
-            .get("footer_cache_mb")
-            .expose()
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok());
         let segment_cache_mb = self
             .params
             .get("segment_cache_mb")
@@ -209,7 +200,7 @@ impl CayenneCatalogConnector {
             data_dir,
             metadata_dir,
             spice_data_base_path: crate::spice_data_base_path(),
-            footer_cache_mb,
+            footer_cache_mb: None,
             segment_cache_mb,
             target_file_size_mb,
             compression_strategy,

--- a/crates/runtime/src/catalogconnector/cayenne/mod.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/mod.rs
@@ -49,8 +49,8 @@ pub const PARAMETERS: &[ParameterSpec] = &[
         .description("Vortex segment cache size in MB. Default: 256.")
         .default("256"),
     ParameterSpec::component("target_file_size_mb")
-        .description("Target Vortex file size in MB. Default: 128.")
-        .default("128"),
+        .description("Target Vortex file size in MB. Default: 256.")
+        .default("256"),
     ParameterSpec::component("compression_strategy")
         .description("Compression: 'btrblocks' (default) or 'zstd'.")
         .default("btrblocks"),

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -145,6 +145,7 @@ pub(crate) fn transform_schema_for_vortex(
 
 pub struct CayenneAccelerator {
     catalog: Arc<OnceCell<Arc<dyn cayenne::MetadataCatalog>>>,
+    footer_cache_mb: Option<usize>,
     /// Shared semaphore that bounds the number of concurrent per-table
     /// background compactions across all Cayenne tables registered with this
     /// accelerator. Sized at `available_parallelism()` so a fleet of tables
@@ -275,12 +276,18 @@ fn is_local_path(path: &str) -> bool {
 impl CayenneAccelerator {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_footer_cache_mb(None)
+    }
+
+    #[must_use]
+    pub fn with_footer_cache_mb(footer_cache_mb: Option<usize>) -> Self {
         let permits = std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
             .unwrap_or(1)
             .max(1);
         Self {
             catalog: Arc::new(OnceCell::new()),
+            footer_cache_mb,
             compaction_semaphore: Arc::new(tokio::sync::Semaphore::new(permits)),
         }
     }
@@ -469,11 +476,21 @@ impl CayenneAccelerator {
     /// Parse Vortex encoding configuration from acceleration parameters.
     /// This allows fine-grained control over which SIMD-optimized encodings to use.
     ///
+    #[cfg(test)]
     async fn get_vortex_config(
         table_name: &str,
         source: &dyn AccelerationSource,
     ) -> cayenne::metadata::VortexConfig {
+        Self::get_vortex_config_with_footer_cache(table_name, source, None).await
+    }
+
+    async fn get_vortex_config_with_footer_cache(
+        table_name: &str,
+        source: &dyn AccelerationSource,
+        footer_cache_mb: Option<usize>,
+    ) -> cayenne::metadata::VortexConfig {
         let mut config = cayenne::metadata::VortexConfig::default();
+        config.footer_cache_mb = footer_cache_mb;
 
         // Storage-aware default for target Vortex file size on local disk.
         // Smaller files reduce write amplification on EBS-class network
@@ -524,12 +541,6 @@ impl CayenneAccelerator {
         if let Some(acceleration) = source.acceleration() {
             apply_refresh_mode_defaults(&mut config, acceleration);
 
-            // Parse cache options - use VortexConfig defaults if not specified
-            config.footer_cache_mb = parse_usize(
-                acceleration,
-                "cayenne_footer_cache_mb",
-                config.footer_cache_mb,
-            );
             config.segment_cache_mb = parse_usize(
                 acceleration,
                 "cayenne_segment_cache_mb",
@@ -705,7 +716,7 @@ impl CayenneAccelerator {
             );
 
             tracing::debug!(
-                "Cayenne Vortex config: footer_cache={}MB, segment_cache={}MB, target_file_size={}MB, upload_concurrency={}, write_concurrency_override={:?}, sort_columns={:?}, compression_strategy={:?}, pk_conflict_detection={}, compaction_trigger_files={}, compaction_trigger_protected_snapshots={}, compaction_trigger_snapshot_age_ms={}, compaction_max_levels={}, compaction_max_files_per_pick={}, compaction_background_interval_ms={}, inline_max_rows={}, inline_max_bytes={}, inline_max_buffer_bytes={}, inline_flush_max_rows={}, inline_flush_max_segments={}, inline_flush_max_bytes={}",
+                "Cayenne Vortex config: runtime_footer_cache={:?}MB, segment_cache={}MB, target_file_size={}MB, upload_concurrency={}, write_concurrency_override={:?}, sort_columns={:?}, compression_strategy={:?}, pk_conflict_detection={}, compaction_trigger_files={}, compaction_trigger_protected_snapshots={}, compaction_trigger_snapshot_age_ms={}, compaction_max_levels={}, compaction_max_files_per_pick={}, compaction_background_interval_ms={}, inline_max_rows={}, inline_max_bytes={}, inline_max_buffer_bytes={}, inline_flush_max_rows={}, inline_flush_max_segments={}, inline_flush_max_bytes={}",
                 config.footer_cache_mb,
                 config.segment_cache_mb,
                 config.target_vortex_file_size_mb,
@@ -872,7 +883,9 @@ impl CayenneAccelerator {
 
         // Check if using S3 Express One Zone storage
         let is_s3_express = s3::is_s3_express_data_path(source);
-        let vortex_config = Self::get_vortex_config(table_name, source).await;
+        let vortex_config =
+            Self::get_vortex_config_with_footer_cache(table_name, source, self.footer_cache_mb)
+                .await;
 
         // Build S3 object store if using S3 Express One Zone storage
         let object_store =
@@ -1016,8 +1029,8 @@ fn wrap_with_native_vector_indexes(
 const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
     ParameterSpec,
     S3_PARAMS_LEN,
-    25,
-    { S3_PARAMS_LEN + 25 },
+    24,
+    { S3_PARAMS_LEN + 24 },
 >(
     S3_PARAMETERS,
     [
@@ -1034,9 +1047,6 @@ const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
             .description("How to handle data types not natively supported by Cayenne (internally using Vortex format) (Time32, Time64, Duration, Interval, etc.). Options: 'string' (convert schema to Utf8, default - requires data source to provide string data), 'error' (fail on unsupported types), 'warn' (include in schema, may fail on insert), 'ignore' (skip unsupported fields)")
             .one_of(&["string", "error", "ignore", "warn"])
             .default("string"),
-        ParameterSpec::component("footer_cache_mb")
-            .description("Size of the in-memory Vortex footer cache in MB. Larger values improve query performance for repeated scans. Default: 128 MB")
-            .default("128"),
         ParameterSpec::component("segment_cache_mb")
             .description("Size of the in-memory Vortex segment cache in MB. Set > 0 to cache decompressed data segments. Default: 256 MB")
             .default("256"),
@@ -1605,7 +1615,12 @@ impl DataAccelerator for CayenneAccelerator {
             // Create partition creator
             let unsupported_type_action = Self::get_unsupported_type_action(source);
             let is_s3_express = s3::is_s3_express_data_path(source);
-            let vortex_config = Self::get_vortex_config(&table_name, source).await;
+            let vortex_config = Self::get_vortex_config_with_footer_cache(
+                &table_name,
+                source,
+                self.footer_cache_mb,
+            )
+            .await;
 
             // Log S3 Express configuration for partitioned tables
             if is_s3_express {

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -489,8 +489,10 @@ impl CayenneAccelerator {
         source: &dyn AccelerationSource,
         footer_cache_mb: Option<usize>,
     ) -> cayenne::metadata::VortexConfig {
-        let mut config = cayenne::metadata::VortexConfig::default();
-        config.footer_cache_mb = footer_cache_mb;
+        let mut config = cayenne::metadata::VortexConfig {
+            footer_cache_mb,
+            ..Default::default()
+        };
 
         // Storage-aware default for target Vortex file size on local disk.
         // Smaller files reduce write amplification on EBS-class network

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -192,7 +192,7 @@ impl AcceleratorEngineRegistry {
         }
     }
 
-    async fn register_accelerator_engine(
+    pub(crate) async fn register_accelerator_engine(
         &self,
         engine: Engine,
         accelerator_engine: Arc<dyn DataAccelerator>,

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -159,6 +159,7 @@ pub struct DataFusionBuilder {
     url_tables_enabled: bool,
     cayenne_sort_merge_min_rows: Option<usize>,
     cayenne_sort_merge_memory_pool_fraction: Option<f64>,
+    cayenne_footer_cache_mb: Option<usize>,
     cayenne_filter_propagation_enabled: bool,
     /// Arbitrary additional analyzer rules.
     additional_analyzer_rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>>,
@@ -210,6 +211,7 @@ impl DataFusionBuilder {
             url_tables_enabled: false,
             cayenne_sort_merge_min_rows: None,
             cayenne_sort_merge_memory_pool_fraction: None,
+            cayenne_footer_cache_mb: None,
             cayenne_filter_propagation_enabled: false,
             additional_analyzer_rules: vec![],
             executor_registry: None,
@@ -319,6 +321,12 @@ impl DataFusionBuilder {
     }
 
     #[must_use]
+    pub fn cayenne_footer_cache_mb(mut self, footer_cache_mb: Option<usize>) -> Self {
+        self.cayenne_footer_cache_mb = footer_cache_mb;
+        self
+    }
+
+    #[must_use]
     pub fn cayenne_filter_propagation_enabled(mut self, enabled: bool) -> Self {
         self.cayenne_filter_propagation_enabled = enabled;
         self
@@ -399,6 +407,8 @@ impl DataFusionBuilder {
                 effective_memory_limit,
                 self.temp_directory.clone(),
                 self.io_runtime.clone(),
+                self.cayenne_footer_cache_mb
+                    .map(|size_mb| size_mb.saturating_mul(1024 * 1024)),
             ));
 
         #[cfg(feature = "duckdb")]
@@ -868,6 +878,7 @@ fn runtime_env_with_effective_memory_limit(
     effective_memory_limit: u64,
     temp_directory: Option<String>,
     io_runtime: Handle,
+    metadata_cache_limit_bytes: Option<usize>,
 ) -> Arc<RuntimeEnv> {
     let disk_manager_builder = if let Some(directory) = temp_directory {
         let mode = DiskManagerMode::Directories(vec![directory.into()]);
@@ -891,12 +902,16 @@ fn runtime_env_with_effective_memory_limit(
         topn,
     ));
 
-    match RuntimeEnvBuilder::default()
+    let mut runtime_env_builder = RuntimeEnvBuilder::default()
         .with_object_store_registry(Arc::new(SpiceObjectStoreRegistry::new(io_runtime)))
         .with_memory_pool(memory_pool)
-        .with_disk_manager_builder(disk_manager_builder)
-        .build_arc()
-    {
+        .with_disk_manager_builder(disk_manager_builder);
+
+    if let Some(limit) = metadata_cache_limit_bytes {
+        runtime_env_builder = runtime_env_builder.with_metadata_cache_limit(limit);
+    }
+
+    match runtime_env_builder.build_arc() {
         Ok(runtime_env) => runtime_env,
         Err(e) => {
             unreachable!("Tests ensure this should never fail: {e}");
@@ -934,6 +949,7 @@ mod tests {
 
     use super::{
         DataFusionBuilder, configure_hash_join_memory_limits, exact_join_filter_memory_limit,
+        runtime_env_with_effective_memory_limit,
     };
     use crate::dataaccelerator::AcceleratorEngineRegistry;
     use crate::status;
@@ -985,6 +1001,21 @@ mod tests {
             0,
             exact_join_filter_memory_limit(1),
             "Very small memory limits should not exceed the configured memory fraction"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_runtime_env_applies_metadata_cache_limit() {
+        let runtime_env = runtime_env_with_effective_memory_limit(
+            1024 * 1024,
+            None,
+            tokio::runtime::Handle::current(),
+            Some(8 * 1024 * 1024),
+        );
+
+        assert_eq!(
+            runtime_env.cache_manager.get_metadata_cache_limit(),
+            8 * 1024 * 1024
         );
     }
 

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
@@ -10,6 +10,7 @@ runtime:
     cdc_max_coalesce_age_ms: '2000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
+    cayenne_footer_cache_mb: '256'
   query:
     memory_limit: 40GiB
     target_partitions: 32
@@ -44,7 +45,6 @@ datasets:
         cayenne_file_path: ./spice/cayenne/district
         cayenne_write_concurrency: '16'
         cayenne_upload_concurrency: '32'
-        cayenne_footer_cache_mb: '256'
         cayenne_segment_cache_mb: '1024'
         cayenne_compaction_trigger_protected_snapshots: '4'
         cayenne_compaction_trigger_snapshot_age_ms: '15000'
@@ -166,7 +166,6 @@ datasets:
         cayenne_file_path: ./spice/cayenne/warehouse
         cayenne_write_concurrency: '4'
         cayenne_upload_concurrency: '4'
-        cayenne_footer_cache_mb: '32'
         cayenne_segment_cache_mb: '64'
 
   - from: postgres:item
@@ -208,7 +207,6 @@ datasets:
         cayenne_file_path: ./spice/cayenne/region
         cayenne_write_concurrency: '2'
         cayenne_upload_concurrency: '2'
-        cayenne_footer_cache_mb: '8'
         cayenne_segment_cache_mb: '16'
 
   - from: postgres:nation

--- a/tools/cayenne-flightsql/src/main.rs
+++ b/tools/cayenne-flightsql/src/main.rs
@@ -23,7 +23,7 @@ use clap::Parser;
 use data_components::RefreshableCatalogProvider as _;
 use datafusion::{
     catalog::{CatalogProvider as _, SchemaProvider},
-    execution::SessionStateBuilder,
+    execution::{SessionStateBuilder, runtime_env::RuntimeEnvBuilder},
     prelude::{SessionConfig, SessionContext},
 };
 use datafusion_ddl::{DdlAnalyzerRule, DdlExtensionPlanner, new_shared_store};
@@ -95,6 +95,11 @@ enum Error {
         source: cayenne::catalog_provider::Error,
     },
 
+    #[snafu(display("Failed to initialize DataFusion runtime environment: {source}"))]
+    RuntimeEnv {
+        source: datafusion::error::DataFusionError,
+    },
+
     #[snafu(display("Failed to refresh Cayenne catalog: {source}"))]
     CayenneCatalogRefresh {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -139,10 +144,18 @@ async fn main() -> Result<()> {
             .clone_from(&args.default_schema);
     }
 
+    let mut runtime_env_builder = RuntimeEnvBuilder::new();
+    if let Some(footer_cache_mb) = args.cayenne_footer_cache_mb {
+        runtime_env_builder = runtime_env_builder
+            .with_metadata_cache_limit(footer_cache_mb.saturating_mul(1024 * 1024));
+    }
+    let runtime_env = runtime_env_builder.build_arc().context(RuntimeEnvSnafu)?;
+
     // Register DdlExtensionPlanner so that CREATE TABLE / DROP TABLE / CREATE SCHEMA
     // executed via Flight SQL create real Cayenne (Vortex) tables, not in-memory ones.
     let state = SessionStateBuilder::new()
         .with_config(session_config)
+        .with_runtime_env(runtime_env)
         .with_default_features()
         .with_query_planner(Arc::new(
             ExtensionPlanQueryPlanner::from_extension_planners(vec![Arc::new(DdlExtensionPlanner)]),

--- a/tools/spicepodschema/tests/spicepod.accelerators.yaml
+++ b/tools/spicepodschema/tests/spicepod.accelerators.yaml
@@ -7,6 +7,10 @@ version: v1
 kind: Spicepod
 name: schema-test-accelerators
 
+runtime:
+  params:
+    cayenne_footer_cache_mb: "256"
+
 datasets:
   # ===========================================================================
   # Arrow Accelerator
@@ -135,4 +139,3 @@ datasets:
         cayenne_file_path: ./data/accel.cayenne
         cayenne_metastore: sqlite
         file_watcher: "true"
-        cayenne_footer_cache_mb: "256"

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -149,6 +149,7 @@ runtime:
   # Runtime params
   params:
     custom_runtime_param: value
+    cayenne_footer_cache_mb: '256'
     http_max_concurrent_requests: '8'
     http_requests_per_second_limit: '10'
     http_requests_per_minute_limit: '300'
@@ -592,7 +593,6 @@ datasets:
         cayenne_cayenne_s3_client_timeout: 30s
         cayenne_cayenne_s3_allow_http: 'false'
         cayenne_cayenne_s3_zone_ids: zone1,zone2
-        cayenne_footer_cache_mb: '256'
         cayenne_segment_cache_mb: '512'
         cayenne_cayenne_target_file_size_mb: '128'
         cayenne_sort_columns: id,timestamp

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -281,6 +281,8 @@ fn emit_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
     let mut inserts: BTreeMap<String, f64> = BTreeMap::new();
     let mut updates: BTreeMap<String, f64> = BTreeMap::new();
     let mut deletes: BTreeMap<String, f64> = BTreeMap::new();
+    let mut recv_errors: BTreeMap<String, f64> = BTreeMap::new();
+    let mut reconnects: BTreeMap<String, f64> = BTreeMap::new();
 
     let gauge_metrics = [
         (
@@ -296,6 +298,14 @@ fn emit_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
         ),
         ("dataset_postgres_replication_updates_total", &mut updates),
         ("dataset_postgres_replication_deletes_total", &mut deletes),
+        (
+            "dataset_postgres_replication_recv_errors_total",
+            &mut recv_errors,
+        ),
+        (
+            "dataset_postgres_replication_reconnects_total",
+            &mut reconnects,
+        ),
     ];
 
     for (metric_name, map) in gauge_metrics {
@@ -326,18 +336,40 @@ fn emit_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
         }
     }
 
-    if lag_ms.is_empty() && inserts.is_empty() {
+    if lag_ms.is_empty()
+        && lag_bytes.is_empty()
+        && inserts.is_empty()
+        && updates.is_empty()
+        && deletes.is_empty()
+        && recv_errors.is_empty()
+        && reconnects.is_empty()
+    {
         return;
     }
 
     println!("\nReplication Metrics (last scrape from spiced)");
     // Header
     println!(
-        "  {:<14} {:>10} {:>12} {:>10} {:>10} {:>10}",
-        "dataset", "lag_ms", "lag_bytes", "inserts", "updates", "deletes"
+        "  {:<14} {:>10} {:>12} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "dataset",
+        "lag_ms",
+        "lag_bytes",
+        "inserts",
+        "updates",
+        "deletes",
+        "recv_errs",
+        "reconnects"
     );
 
-    let all_datasets: BTreeSet<&String> = lag_ms.keys().chain(inserts.keys()).collect();
+    let all_datasets: BTreeSet<&String> = lag_ms
+        .keys()
+        .chain(lag_bytes.keys())
+        .chain(inserts.keys())
+        .chain(updates.keys())
+        .chain(deletes.keys())
+        .chain(recv_errors.keys())
+        .chain(reconnects.keys())
+        .collect();
 
     let mut worst_lag_ms: f64 = 0.0;
     for dataset in &all_datasets {
@@ -346,8 +378,10 @@ fn emit_replication_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
         let ins = inserts.get(*dataset).copied().unwrap_or(0.0);
         let upd = updates.get(*dataset).copied().unwrap_or(0.0);
         let del = deletes.get(*dataset).copied().unwrap_or(0.0);
+        let recv = recv_errors.get(*dataset).copied().unwrap_or(0.0);
+        let reconn = reconnects.get(*dataset).copied().unwrap_or(0.0);
         println!(
-            "  {dataset:<14} {l_ms:>10.0} {l_bytes:>12.0} {ins:>10.0} {upd:>10.0} {del:>10.0}",
+            "  {dataset:<14} {l_ms:>10.0} {l_bytes:>12.0} {ins:>10.0} {upd:>10.0} {del:>10.0} {recv:>10.0} {reconn:>10.0}",
         );
 
         crate::metrics::REPLICATION_LAG_MS


### PR DESCRIPTION
## Summary

- Move Cayenne footer metadata cache sizing to `runtime.params.cayenne_footer_cache_mb` and apply it once when the shared DataFusion `RuntimeEnv` is built.
- Remove dataset/catalog Cayenne footer-cache params so table registration no longer mutates the shared runtime cache from `CayenneContext::new`.
- Store an explicitly configured footer-cache value in Cayenne metastore metadata and validate it during dataset registration; existing tables without the value remain compatible.
- Keep `segment_cache_mb` warning behavior because Vortex 52.x does not expose segment cache sizing.
- Add HTAP replication diagnostic output for Postgres CDC receive errors and reconnect counts.

## Related

N/A

## Breaking Changes

None.

## Docs

Updated `crates/cayenne/README.md`, schema test spicepods, and CH-BenCH tuned spicepod examples for the runtime-global footer cache parameter.

## Notes for Reviewers

`runtime.params.cayenne_footer_cache_mb` is intentionally runtime-global because it configures DataFusion file metadata cache sizing shared by all Cayenne datasets and other file metadata consumers on the same `RuntimeEnv`.

Validation:
- `cargo fmt --check --package cayenne --package runtime --package cayenne-flightsql`
- `cargo test -p cayenne footer_cache --lib`
- `cargo test -p cayenne cayenne_enables_vortex_projection_pushdown_by_default --lib`
- `cargo check -p runtime`
- `cargo check -p cayenne-flightsql`
