### PR TITLE
feat(chbench): Use dev-large runners for SF1, increase staleness probe interval to 5s

### DIFF
--- a/tools/testoperator/dispatch/chbench/sf1/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-arrow.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-arrow.yaml
-    runner_type: spiceai-dev-runners
+    runner_type: spiceai-dev-large-runners
     scale_factor: 1
     duration: 600
     ready_wait: 60

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
-    runner_type: spiceai-dev-runners
+    runner_type: spiceai-dev-large-runners
     scale_factor: 1
     duration: 600
     ready_wait: 60

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
-    runner_type: spiceai-dev-runners
+    runner_type: spiceai-dev-large-runners
     scale_factor: 1
     duration: 600
     ready_wait: 60

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-runners
+    runner_type: spiceai-dev-large-runners
     scale_factor: 1
     duration: 600
     ready_wait: 60

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 //! Staleness gap measurement for HTAP benchmarks.
 //!
-//! Probes TPC-C tables every 1s by comparing `MAX(_bench_ts)` between the
+//! Probes TPC-C tables every 5s by comparing `MAX(_bench_ts)` between the
 //! source and the Spice accelerated copy. The gap is the replication
 //! staleness — how far behind Spice is from the source at any given moment.
 //!
@@ -102,7 +102,7 @@ async fn run_staleness_probe(
     spice_client: spiceai::Client,
     cancel: CancellationToken,
 ) -> anyhow::Result<StalenessReport> {
-    let poll_interval = Duration::from_secs(1);
+    let poll_interval = Duration::from_secs(5);
     let probe_tables = driver.probe_tables();
 
     // Per-table gap samples (microseconds).


### PR DESCRIPTION
## 📝 Summary


Aligns SF1 CH-benCH dispatch configs with higher scale factors:
- Switch SF1 HTAP dispatch configs from `spiceai-dev-runners` to `spiceai-dev-large-runners` for consistency with SF10/SF100.
- Increase staleness probe polling interval from 1s to 5s to reduce query overhead on the accelerated tables during the benchmark.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->