### PR TITLE
feat(cayenne): scale metastore pool to 32 + vs_duckdb_scaling benches (1→128 concurrency, sqlite + turso lanes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ edition = "2024"
 exclude = [".github/"]
 homepage = "https://spice.ai"
 license-file = "LICENSE"
-publish = false
 repository = "https://github.com/spiceai/spiceai"
 rust-version = "1.94.1"
 version = "2.0.0-unstable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ edition = "2024"
 exclude = [".github/"]
 homepage = "https://spice.ai"
 license-file = "LICENSE"
+publish = false
 repository = "https://github.com/spiceai/spiceai"
 rust-version = "1.94.1"
 version = "2.0.0-unstable"

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -238,6 +238,11 @@ required-features = ["duckdb-bench"]
 
 [[bench]]
 harness = false
+name = "vs_duckdb_scaling"
+required-features = ["duckdb-bench"]
+
+[[bench]]
+harness = false
 name = "compaction_picker"
 
 [[bench]]

--- a/crates/cayenne/benches/vs_duckdb_delete.rs
+++ b/crates/cayenne/benches/vs_duckdb_delete.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 
 use arrow::array::UInt64Array;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use datafusion::catalog::TableProvider;
 use datafusion::prelude::SessionContext;
 use datafusion_expr::{col, lit};
 use tokio::runtime::Runtime;

--- a/crates/cayenne/benches/vs_duckdb_helpers/common.rs
+++ b/crates/cayenne/benches/vs_duckdb_helpers/common.rs
@@ -451,6 +451,38 @@ pub async fn cayenne_insert(table: &Arc<CayenneTableProvider>, batch: RecordBatc
         .map_or(0, |rows| rows.value(0))
 }
 
+/// Drive Cayenne's pipelined CDC append path end-to-end for a single batch.
+///
+/// Calls [`CayenneTableProvider::write_cdc_append_stream`] (the entry point
+/// used by `refresh_mode: changes` in spiced's accelerated_table refresh
+/// loop) and then awaits `finish()` so the rows are fully visible — this is
+/// the apples-to-apples comparison against DuckDB's INSERT path, which has
+/// no staged/visibility split.
+///
+/// Returns the number of rows acknowledged by the CDC write.
+pub async fn cayenne_cdc_write(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> u64 {
+    use datafusion::error::DataFusionError;
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use datafusion::prelude::SessionContext;
+
+    let schema = batch.schema();
+    let stream = Box::pin(RecordBatchStreamAdapter::new(
+        schema,
+        futures::stream::iter(vec![Ok::<_, DataFusionError>(batch)]),
+    ));
+    let ctx = SessionContext::new();
+    let cdc_write = table
+        .write_cdc_append_stream(stream, &ctx.task_ctx())
+        .await
+        .expect("cayenne cdc write stage A");
+    let rows = cdc_write.rows();
+    cdc_write
+        .finish()
+        .await
+        .expect("cayenne cdc write stage B finish");
+    rows
+}
+
 /// Insert from a parquet file through Cayenne via DataFusion's parquet
 /// reader. Mirrors spiced's `file:` connector → accelerator ingestion path
 /// and gives parity with `duckdb_insert_parquet` (both engines now consume

--- a/crates/cayenne/benches/vs_duckdb_helpers/common.rs
+++ b/crates/cayenne/benches/vs_duckdb_helpers/common.rs
@@ -459,20 +459,30 @@ pub async fn cayenne_insert(table: &Arc<CayenneTableProvider>, batch: RecordBatc
 /// the apples-to-apples comparison against DuckDB's INSERT path, which has
 /// no staged/visibility split.
 ///
+/// Takes a `task_ctx` reference rather than constructing a fresh
+/// `SessionContext` per call. In tight benches that spawn one writer per
+/// concurrent task and pump many batches, `SessionContext::new()` would
+/// dominate the per-batch cost (~tens to hundreds of µs of setup + allocator
+/// churn). The caller should build one `SessionContext` per writer at spawn
+/// time and pass the same `task_ctx` for every batch — that matches how a
+/// long-running Spice runtime drives the CDC refresh loop in production.
+///
 /// Returns the number of rows acknowledged by the CDC write.
-pub async fn cayenne_cdc_write(table: &Arc<CayenneTableProvider>, batch: RecordBatch) -> u64 {
+pub async fn cayenne_cdc_write(
+    table: &Arc<CayenneTableProvider>,
+    task_ctx: &Arc<datafusion_execution::TaskContext>,
+    batch: RecordBatch,
+) -> u64 {
     use datafusion::error::DataFusionError;
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-    use datafusion::prelude::SessionContext;
 
     let schema = batch.schema();
     let stream = Box::pin(RecordBatchStreamAdapter::new(
         schema,
         futures::stream::iter(vec![Ok::<_, DataFusionError>(batch)]),
     ));
-    let ctx = SessionContext::new();
     let cdc_write = table
-        .write_cdc_append_stream(stream, &ctx.task_ctx())
+        .write_cdc_append_stream(stream, task_ctx)
         .await
         .expect("cayenne cdc write stage A");
     let rows = cdc_write.rows();

--- a/crates/cayenne/benches/vs_duckdb_helpers/common.rs
+++ b/crates/cayenne/benches/vs_duckdb_helpers/common.rs
@@ -503,6 +503,39 @@ pub async fn cayenne_query(table: &Arc<CayenneTableProvider>, sql: &str) -> Vec<
     df.collect().await.expect("cayenne collect")
 }
 
+/// Build a long-lived [`SessionContext`] with the given Cayenne table registered
+/// as `t`. Use this once at fixture-load time and pass the resulting context
+/// into [`cayenne_query_warm`] inside `b.iter` to measure the steady-state
+/// query cost without paying per-iteration `SessionContext::new()` overhead.
+///
+/// The default [`cayenne_query`] path creates a fresh session per call, which
+/// matches one valid usage (e.g. CLI invocation) but over-estimates the
+/// per-query cost a long-running Spice runtime actually pays — Spice keeps a
+/// `SessionContext` alive across the daemon's lifetime, paying setup once at
+/// startup. Reporting both lanes makes the asymmetry quantifiable instead of
+/// hand-wavey.
+pub fn warm_session_for(table: &Arc<CayenneTableProvider>) -> datafusion::prelude::SessionContext {
+    use datafusion::datasource::TableProvider;
+    use datafusion::prelude::SessionContext;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("t", Arc::clone(table) as Arc<dyn TableProvider>)
+        .expect("register table");
+    ctx
+}
+
+/// Run a SQL query through Cayenne reusing the given [`SessionContext`].
+///
+/// Pair with [`warm_session_for`] to measure Cayenne under steady-state session
+/// reuse — see that function's docs for when this is the right lane to read.
+pub async fn cayenne_query_warm(
+    ctx: &datafusion::prelude::SessionContext,
+    sql: &str,
+) -> Vec<RecordBatch> {
+    let df = ctx.sql(sql).await.expect("cayenne sql");
+    df.collect().await.expect("cayenne collect")
+}
+
 /// Run a SQL query against two Cayenne tables registered as `t` and `d`.
 /// Used by the join bench so the SQL matches the DuckDB form.
 pub async fn cayenne_query_join(

--- a/crates/cayenne/benches/vs_duckdb_in_list_delete.rs
+++ b/crates/cayenne/benches/vs_duckdb_in_list_delete.rs
@@ -87,6 +87,7 @@ use std::sync::Arc;
 
 use arrow::array::UInt64Array;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use datafusion::catalog::TableProvider;
 use datafusion::prelude::SessionContext;
 use datafusion_expr::{col, lit};
 use tokio::runtime::Runtime;

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -540,10 +540,11 @@ fn bench_write_scaling(c: &mut Criterion) {
                             tx.send(()).expect("cayenne go-tx (worker exited?)");
                         }
                         // Then drain exactly N new completions. The
-                        // `Throughput::Elements` configuration above
-                        // divides this iteration's wall time by
-                        // `concurrency * WRITE_BATCH_ROWS` so criterion
-                        // reports per-worker throughput.
+                        // `Throughput::Elements(concurrency * WRITE_BATCH_ROWS)`
+                        // declaration tells criterion that this iteration
+                        // processes that many rows total — criterion reports
+                        // the **aggregate** rows/sec across all N writers,
+                        // not a per-worker rate.
                         wait_for_completions(&cayenne_done_rx, concurrency, &bench_ctx);
                     });
                 },
@@ -636,13 +637,20 @@ impl CayenneCdcBgWriter {
     ) -> Self {
         let table = Arc::clone(&fixture.table);
         let handle = rt.spawn(async move {
+            // One SessionContext per writer, reused across every batch.
+            // `cayenne_cdc_write` used to construct a fresh `SessionContext`
+            // per call which added per-batch setup + allocator churn that
+            // a long-running Spice runtime would not pay — see the doc
+            // comment on `cayenne_cdc_write`.
+            let session = datafusion::prelude::SessionContext::new();
+            let task_ctx = session.task_ctx();
             let id_stride = (WRITE_BATCH_ROWS as i64) * 1024 * 1024;
             let mut cursor = writer_id * id_stride;
             let mut written = 0u64;
             while go_rx.recv().await.is_some() {
                 let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
                 cursor += WRITE_BATCH_ROWS as i64;
-                if cayenne_cdc_write(&table, batch).await > 0 {
+                if cayenne_cdc_write(&table, &task_ctx, batch).await > 0 {
                     written += 1;
                 }
                 let _ = done_tx.send(());

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -39,10 +39,15 @@
 //!   since DuckDB has no CDC-pipelined entry point of its own.
 //!
 //! Workers in every lane are pooled per concurrency level (spawned once,
-//! signaled per iteration via per-worker `mpsc` channels), so worker-spawn
-//! cost falls outside criterion's timed region. The bench thread blocks on
-//! `mpsc::Receiver::recv_timeout` to drain completion signals — no CPU-burning
-//! `spin_loop`, no AtomicUsize counter.
+//! signaled per iteration via `mpsc` channels), so worker-spawn cost
+//! falls outside criterion's timed region. The bench thread blocks on
+//! bounded-timeout receives (`tokio::time::timeout` over
+//! `tokio::sync::mpsc` for the async Cayenne reader lane,
+//! `std::sync::mpsc::Receiver::recv_timeout` via `wait_for_completions`
+//! for the threaded DuckDB and write/CDC lanes) — no CPU-burning
+//! `spin_loop`, no AtomicUsize counter, and a stalled or panicked worker
+//! surfaces as a labeled panic naming the bench, lane, and completion
+//! number instead of hanging indefinitely.
 //!
 //! `BenchmarkId::new("…", N)` naming makes the throughput-vs-N curve visible
 //! directly in criterion's HTML output and parse-able from the text logs.
@@ -259,11 +264,26 @@ fn bench_read_scaling(c: &mut Criterion) {
                         for tx in &cayenne_go_txs {
                             tx.send(()).expect("cayenne go-tx (worker exited?)");
                         }
-                        for _ in 0..concurrency {
-                            cayenne_done_rx
-                                .recv()
-                                .await
-                                .expect("cayenne done-rx (worker exited?)");
+                        // Bounded per-completion timeout. If any reader task
+                        // panics or stalls, surface a clear error instead of
+                        // hanging the bench thread indefinitely.
+                        for i in 0..concurrency {
+                            match tokio::time::timeout(
+                                Duration::from_secs(30),
+                                cayenne_done_rx.recv(),
+                            )
+                            .await
+                            {
+                                Ok(Some(())) => {}
+                                Ok(None) => panic!(
+                                    "vs_duckdb_scaling_reads/cayenne_warm: done channel closed at completion {}/{concurrency} (worker exited?)",
+                                    i + 1
+                                ),
+                                Err(_) => panic!(
+                                    "vs_duckdb_scaling_reads/cayenne_warm: stalled waiting for reader completion {}/{concurrency} after 30s",
+                                    i + 1
+                                ),
+                            }
                         }
                     });
                 });
@@ -447,7 +467,7 @@ fn bench_write_scaling(c: &mut Criterion) {
         // writer stalls or panics). Replaces the earlier
         // AtomicUsize + std::hint::spin_loop pattern flagged in PR review.
         let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
-        let mut cayenne_writers: Vec<CayenneBgWriter> = (0..concurrency)
+        let cayenne_writers: Vec<CayenneBgWriter> = (0..concurrency)
             .map(|i| CayenneBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64))
             .collect();
         // Drop the spare sender so the channel closes naturally when all
@@ -460,10 +480,16 @@ fn bench_write_scaling(c: &mut Criterion) {
             &concurrency,
             |b, &_n| {
                 b.iter(|| {
-                    // Wait for one full pass (each writer contributes ≥1
-                    // insert) so a single iteration captures the full
-                    // concurrency cost — not just the latency of one of N
-                    // writers.
+                    // Drain `concurrency` total completed inserts from the
+                    // shared channel — total system throughput across N
+                    // writers, not per-writer fairness. One fast writer
+                    // can contribute multiple of the N counted messages
+                    // in an iteration; that's by design for a
+                    // throughput-under-concurrency measurement. The
+                    // `BenchmarkId::new(_, concurrency)` then divides this
+                    // by `concurrency * WRITE_BATCH_ROWS` to report
+                    // per-worker throughput in criterion's
+                    // `Throughput::Elements` mode.
                     wait_for_completions(
                         &cayenne_rx,
                         concurrency,
@@ -475,14 +501,14 @@ fn bench_write_scaling(c: &mut Criterion) {
 
         // Explicit drop order: writers first (stops the loops + joins the
         // tasks), then the fixture (its TempDir cleans up the data).
-        cayenne_writers.drain(..);
+        drop(cayenne_writers);
         drop(cayenne_fixture);
 
         // --- DuckDB lane ---
         let duckdb_fixture = setup_duckdb("scaling_write");
         let duckdb_db_path = duckdb_fixture.db_path();
         let (duckdb_tx, duckdb_rx) = mpsc::channel::<()>();
-        let mut duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
+        let duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
             .map(|i| {
                 DuckDbBgWriter::spawn(
                     &duckdb_db_path,
@@ -508,7 +534,7 @@ fn bench_write_scaling(c: &mut Criterion) {
             },
         );
 
-        duckdb_writers.drain(..);
+        drop(duckdb_writers);
         drop(duckdb_fixture);
     }
 
@@ -579,7 +605,7 @@ fn bench_cdc_scaling(c: &mut Criterion) {
         // --- Cayenne CDC pipelined lane ---
         let cayenne_fixture = rt.block_on(setup_cayenne("scaling_cdc"));
         let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
-        let mut cayenne_writers: Vec<CayenneCdcBgWriter> = (0..concurrency)
+        let cayenne_writers: Vec<CayenneCdcBgWriter> = (0..concurrency)
             .map(|i| CayenneCdcBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64))
             .collect();
         drop(cayenne_tx);
@@ -598,7 +624,7 @@ fn bench_cdc_scaling(c: &mut Criterion) {
             },
         );
 
-        cayenne_writers.drain(..);
+        drop(cayenne_writers);
         drop(cayenne_fixture);
 
         // --- DuckDB INSERT lane (closest analog — DuckDB has no CDC pipelined
@@ -607,7 +633,7 @@ fn bench_cdc_scaling(c: &mut Criterion) {
         let duckdb_fixture = setup_duckdb("scaling_cdc");
         let duckdb_db_path = duckdb_fixture.db_path();
         let (duckdb_tx, duckdb_rx) = mpsc::channel::<()>();
-        let mut duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
+        let duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
             .map(|i| {
                 DuckDbBgWriter::spawn(&duckdb_db_path, "scaling_cdc", duckdb_tx.clone(), i as i64)
             })
@@ -624,7 +650,7 @@ fn bench_cdc_scaling(c: &mut Criterion) {
             },
         );
 
-        duckdb_writers.drain(..);
+        drop(duckdb_writers);
         drop(duckdb_fixture);
     }
 

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -14,7 +14,10 @@
 //! and query traffic in parallel.
 //!
 //! Three workloads are exercised, each across `[1, 2, 4, 8, 16, 32, 64]`
-//! concurrency levels:
+//! concurrency levels and across **both Cayenne metastore backends**
+//! (`Sqlite` and `Turso`, the latter compiled in when the `turso` feature
+//! is enabled — see `CAYENNE_LANES`). DuckDB runs once per workload as the
+//! external baseline.
 //!
 //! * **`vs_duckdb_scaling_reads`** — N concurrent `SELECT COUNT(*)` queries
 //!   against one pre-loaded 1M-row table. Cayenne uses one long-lived warm
@@ -22,7 +25,8 @@
 //!   Spice runtime). DuckDB opens one fresh `Connection` per OS thread
 //!   from the shared on-disk database path. The bench shows whether
 //!   reader-side scaling is bounded by mutex contention or runs cleanly
-//!   to the core count.
+//!   to the core count. Cayenne lane ids are `cayenne_warm` /
+//!   `cayenne_turso_warm`.
 //!
 //! * **`vs_duckdb_scaling_writes`** — sustained insert throughput driven by
 //!   N concurrent background writer tasks against one table via the generic
@@ -91,9 +95,9 @@ fn wait_for_completions(rx: &mpsc::Receiver<()>, n: usize, ctx: &str) {
 }
 
 use common::{
-    CayenneFixture, cayenne_cdc_write, cayenne_insert, cayenne_query_warm, duckdb_insert_parquet,
-    duckdb_insert_rows, make_batch, schema, setup_cayenne, setup_duckdb, warm_session_for,
-    write_parquet,
+    CAYENNE_LANES, CayenneFixture, cayenne_cdc_write, cayenne_insert, cayenne_query_warm,
+    duckdb_insert_parquet, duckdb_insert_rows, make_batch, schema, setup_cayenne_for, setup_duckdb,
+    warm_session_for, write_parquet,
 };
 
 /// Concurrency levels measured. Spans the typical core counts we care about
@@ -113,38 +117,31 @@ const WRITE_BATCH_ROWS: usize = 1_024;
 // vs_duckdb_scaling_reads — N concurrent COUNT(*) against ONE table
 // ---------------------------------------------------------------------------
 
-/// Owns both the pre-loaded Cayenne table and the matching DuckDB
-/// database. Built once at bench start; reused across every concurrency
-/// level so the data-load cost is paid exactly once.
-///
-/// The DuckDB side stores the on-disk database path rather than a shared
-/// `Connection` because `duckdb::Connection` is not `Send` in this
-/// codebase (`vs_duckdb_concurrent.rs:108` follows the same pattern —
-/// each background-writer thread calls `Connection::open(&db_path)` so
-/// every thread owns its own connection). Reader threads do the same.
-struct ReadFixtures {
-    cayenne: Arc<CayenneFixture>,
-    duckdb_db_path: std::path::PathBuf,
-    _duckdb_temp: tempfile::TempDir,
+/// Pre-built read-side state shared across all Cayenne metastore lanes and
+/// concurrency levels. The DuckDB side stores the on-disk database path
+/// rather than a shared `Connection` because `duckdb::Connection` is not
+/// `Send` in this codebase (`vs_duckdb_concurrent.rs:108` follows the same
+/// pattern — each thread calls `Connection::open(&db_path)` so every thread
+/// owns its own connection). Reader threads do the same.
+struct DuckDbReadFixture {
+    db_path: std::path::PathBuf,
+    _temp: tempfile::TempDir,
     _parquet_dir: tempfile::TempDir,
 }
 
-async fn build_read_fixtures() -> ReadFixtures {
-    let cayenne_fixture = setup_cayenne("scaling_read").await;
-    let batch = make_batch(schema(), 0, READ_ROWS);
-    let _ = cayenne_insert(&cayenne_fixture.table, batch.clone()).await;
-
+/// Build the DuckDB side once, returning a path other threads can open
+/// fresh connections against. The corresponding Cayenne fixture is built
+/// per-lane inside `bench_read_scaling` so each metastore backend gets
+/// its own independent metastore + data dir.
+fn build_duckdb_read_fixture(batch: &arrow::array::RecordBatch) -> DuckDbReadFixture {
     let duckdb_fixture = setup_duckdb("scaling_read");
     let parquet_dir = tempfile::tempdir().expect("parquet dir");
     let parquet_path = parquet_dir.path().join("scaling_read.parquet");
-    write_parquet(&batch, &parquet_path);
+    write_parquet(batch, &parquet_path);
     duckdb_insert_parquet(&duckdb_fixture.conn, "scaling_read", &parquet_path);
-
-    let duckdb_db_path = duckdb_fixture.db_path();
-    ReadFixtures {
-        cayenne: Arc::new(cayenne_fixture),
-        duckdb_db_path,
-        _duckdb_temp: duckdb_fixture._temp_dir,
+    DuckDbReadFixture {
+        db_path: duckdb_fixture.db_path(),
+        _temp: duckdb_fixture._temp_dir,
         _parquet_dir: parquet_dir,
     }
 }
@@ -222,84 +219,106 @@ fn bench_read_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("vs_duckdb_scaling_reads");
     group.sample_size(10);
 
-    let fixtures = rt.block_on(build_read_fixtures());
-    // One warm session per Cayenne table, shared across all reader tasks for
-    // the entire bench run. Mirrors a long-lived Spice daemon holding a
-    // single SessionContext and serving many concurrent queries.
-    let warm_ctx = Arc::new(warm_session_for(&fixtures.cayenne.table));
+    let batch = make_batch(schema(), 0, READ_ROWS);
+    let duckdb_fixture = build_duckdb_read_fixture(&batch);
 
+    // For each Cayenne metastore (Sqlite, optionally Turso): set up the
+    // table once, spawn worker pools per concurrency level, run the
+    // BenchmarkId-prefixed by `lane.lane()`.
+    for &lane in CAYENNE_LANES {
+        let lane_label = format!("{}_warm", lane.lane());
+        let cayenne_fixture = Arc::new(rt.block_on(async {
+            let f = setup_cayenne_for("scaling_read", lane).await;
+            let _ = cayenne_insert(&f.table, batch.clone()).await;
+            f
+        }));
+        // One warm session per Cayenne table, shared across all reader
+        // tasks for this lane. Mirrors a long-lived Spice daemon holding
+        // a single SessionContext and serving many concurrent queries.
+        let warm_ctx = Arc::new(warm_session_for(&cayenne_fixture.table));
+
+        for &concurrency in CONCURRENCIES {
+            group.throughput(Throughput::Elements(concurrency as u64));
+
+            // --- Cayenne pool for this lane: N persistent tokio tasks.
+            //     Per-worker `go_tx`, shared `done_rx`. Worker spawn
+            //     cost is paid once per (lane, concurrency) pair, not
+            //     once per criterion sample.
+            let (cayenne_done_tx, mut cayenne_done_rx) =
+                tokio::sync::mpsc::unbounded_channel::<()>();
+            let mut cayenne_go_txs: Vec<tokio::sync::mpsc::UnboundedSender<()>> =
+                Vec::with_capacity(concurrency);
+            let mut cayenne_workers: Vec<CayenneReader> = Vec::with_capacity(concurrency);
+            for _ in 0..concurrency {
+                let (go_tx, go_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+                cayenne_go_txs.push(go_tx);
+                cayenne_workers.push(CayenneReader::spawn(
+                    &rt,
+                    Arc::clone(&warm_ctx),
+                    go_rx,
+                    cayenne_done_tx.clone(),
+                ));
+            }
+            // Drop the bench's spare done sender so `done_rx.recv()`
+            // returns None once all workers drop their senders during
+            // teardown.
+            drop(cayenne_done_tx);
+
+            let bench_ctx = format!("vs_duckdb_scaling_reads/{lane_label}");
+            group.bench_with_input(
+                BenchmarkId::new(&lane_label, concurrency),
+                &concurrency,
+                |b, &_n| {
+                    b.iter(|| {
+                        rt.block_on(async {
+                            for tx in &cayenne_go_txs {
+                                tx.send(()).expect("cayenne go-tx (worker exited?)");
+                            }
+                            // Bounded per-completion timeout. If any
+                            // reader task panics or stalls, surface a
+                            // clear error instead of hanging the bench
+                            // thread indefinitely.
+                            for i in 0..concurrency {
+                                match tokio::time::timeout(
+                                    Duration::from_secs(30),
+                                    cayenne_done_rx.recv(),
+                                )
+                                .await
+                                {
+                                    Ok(Some(())) => {}
+                                    Ok(None) => panic!(
+                                        "{bench_ctx}: done channel closed at completion {}/{concurrency} (worker exited?)",
+                                        i + 1
+                                    ),
+                                    Err(_) => panic!(
+                                        "{bench_ctx}: stalled waiting for reader completion {}/{concurrency} after 30s",
+                                        i + 1
+                                    ),
+                                }
+                            }
+                        });
+                    });
+                },
+            );
+
+            // Tear down Cayenne workers for this (lane, concurrency).
+            cayenne_go_txs.clear();
+            for w in cayenne_workers.drain(..) {
+                rt.block_on(async { w.handle.await })
+                    .expect("cayenne reader task");
+            }
+        }
+
+        drop(cayenne_fixture);
+    }
+
+    // --- DuckDB lane: run once across all concurrencies (not per
+    //     Cayenne metastore — the DuckDB fixture is independent of
+    //     Cayenne's metastore choice). Same per-worker `go` channel +
+    //     shared `done` channel shape.
     for &concurrency in CONCURRENCIES {
         group.throughput(Throughput::Elements(concurrency as u64));
 
-        // --- Cayenne pool: N persistent tokio tasks. Each iteration the
-        //     bench thread sends one `()` on every worker's `go_tx` and
-        //     drains N `()` messages from the shared `done_rx`. Worker
-        //     spawn cost is paid once per concurrency level — addresses
-        //     the Copilot review on this PR re: thread/task spawn
-        //     overhead being inside the timed region.
-        let (cayenne_done_tx, mut cayenne_done_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-        let mut cayenne_go_txs: Vec<tokio::sync::mpsc::UnboundedSender<()>> =
-            Vec::with_capacity(concurrency);
-        let mut cayenne_workers: Vec<CayenneReader> = Vec::with_capacity(concurrency);
-        for _ in 0..concurrency {
-            let (go_tx, go_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-            cayenne_go_txs.push(go_tx);
-            cayenne_workers.push(CayenneReader::spawn(
-                &rt,
-                Arc::clone(&warm_ctx),
-                go_rx,
-                cayenne_done_tx.clone(),
-            ));
-        }
-        // Drop the bench's spare done sender so `done_rx.recv()` returns
-        // None once all workers drop their senders during teardown.
-        drop(cayenne_done_tx);
-
-        group.bench_with_input(
-            BenchmarkId::new("cayenne_warm", concurrency),
-            &concurrency,
-            |b, &_n| {
-                b.iter(|| {
-                    rt.block_on(async {
-                        for tx in &cayenne_go_txs {
-                            tx.send(()).expect("cayenne go-tx (worker exited?)");
-                        }
-                        // Bounded per-completion timeout. If any reader task
-                        // panics or stalls, surface a clear error instead of
-                        // hanging the bench thread indefinitely.
-                        for i in 0..concurrency {
-                            match tokio::time::timeout(
-                                Duration::from_secs(30),
-                                cayenne_done_rx.recv(),
-                            )
-                            .await
-                            {
-                                Ok(Some(())) => {}
-                                Ok(None) => panic!(
-                                    "vs_duckdb_scaling_reads/cayenne_warm: done channel closed at completion {}/{concurrency} (worker exited?)",
-                                    i + 1
-                                ),
-                                Err(_) => panic!(
-                                    "vs_duckdb_scaling_reads/cayenne_warm: stalled waiting for reader completion {}/{concurrency} after 30s",
-                                    i + 1
-                                ),
-                            }
-                        }
-                    });
-                });
-            },
-        );
-
-        // Tear down Cayenne workers: drop the go senders so each worker's
-        // `go_rx.recv()` returns None and the worker exits.
-        cayenne_go_txs.clear();
-        for w in cayenne_workers.drain(..) {
-            rt.block_on(async { w.handle.await })
-                .expect("cayenne reader task");
-        }
-
-        // --- DuckDB pool: N persistent OS threads with the same per-worker
-        //     `go` channel + shared `done` channel shape.
         let (duckdb_done_tx, duckdb_done_rx) = mpsc::channel::<()>();
         let mut duckdb_go_txs: Vec<mpsc::Sender<()>> = Vec::with_capacity(concurrency);
         let mut duckdb_workers: Vec<DuckDbReader> = Vec::with_capacity(concurrency);
@@ -307,7 +326,7 @@ fn bench_read_scaling(c: &mut Criterion) {
             let (go_tx, go_rx) = mpsc::channel::<()>();
             duckdb_go_txs.push(go_tx);
             duckdb_workers.push(DuckDbReader::spawn(
-                fixtures.duckdb_db_path.clone(),
+                duckdb_fixture.db_path.clone(),
                 go_rx,
                 duckdb_done_tx.clone(),
             ));
@@ -331,13 +350,14 @@ fn bench_read_scaling(c: &mut Criterion) {
             },
         );
 
-        // Tear down DuckDB workers: drop the go senders, then join.
+        // Tear down DuckDB workers for this concurrency.
         duckdb_go_txs.clear();
         for w in duckdb_workers.drain(..) {
             w.handle.join().expect("duckdb reader thread");
         }
     }
 
+    drop(duckdb_fixture);
     group.finish();
 }
 
@@ -454,55 +474,68 @@ fn bench_write_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("vs_duckdb_scaling_writes");
     group.sample_size(10);
 
+    // For each Cayenne metastore lane: run the full concurrency sweep.
+    // Each (lane, concurrency) point gets a fresh fixture because writes
+    // accumulate state on disk and we want every measurement to start
+    // from an empty table.
+    for &lane in CAYENNE_LANES {
+        let lane_label = lane.lane().to_string();
+        for &concurrency in CONCURRENCIES {
+            group.throughput(Throughput::Elements(
+                (concurrency as u64) * (WRITE_BATCH_ROWS as u64),
+            ));
+
+            // --- Cayenne lane ---
+            let cayenne_fixture = rt.block_on(setup_cayenne_for("scaling_write", lane));
+            // Each writer holds a clone of `cayenne_tx`; bench iter reads N
+            // completions from `cayenne_rx` via `wait_for_completions`
+            // (blocking, bounded timeout, surfaces a useful error if any
+            // writer stalls or panics).
+            let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
+            let cayenne_writers: Vec<CayenneBgWriter> = (0..concurrency)
+                .map(|i| {
+                    CayenneBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64)
+                })
+                .collect();
+            // Drop the spare sender so the channel closes naturally when
+            // all writers exit on the teardown signal.
+            drop(cayenne_tx);
+
+            let bench_ctx = format!("vs_duckdb_scaling_writes/{lane_label}");
+            group.bench_with_input(
+                BenchmarkId::new(&lane_label, concurrency),
+                &concurrency,
+                |b, &_n| {
+                    b.iter(|| {
+                        // Drain `concurrency` total completed inserts from
+                        // the shared channel — total system throughput
+                        // across N writers, not per-writer fairness. One
+                        // fast writer can contribute multiple of the N
+                        // counted messages in an iteration; by design for
+                        // a throughput-under-concurrency measurement.
+                        // criterion's `Throughput::Elements` divides by
+                        // `concurrency * WRITE_BATCH_ROWS` to report
+                        // per-worker throughput.
+                        wait_for_completions(&cayenne_rx, concurrency, &bench_ctx);
+                    });
+                },
+            );
+
+            // Explicit drop order: writers first (stops the loops + joins
+            // the tasks), then the fixture (its TempDir cleans up the
+            // data).
+            drop(cayenne_writers);
+            drop(cayenne_fixture);
+        }
+    }
+
+    // --- DuckDB lane: run once per concurrency level (DuckDB has no
+    //     metastore-backend dimension; one independent measurement
+    //     across all Cayenne lanes is the right shape).
     for &concurrency in CONCURRENCIES {
         group.throughput(Throughput::Elements(
             (concurrency as u64) * (WRITE_BATCH_ROWS as u64),
         ));
-
-        // --- Cayenne lane ---
-        let cayenne_fixture = rt.block_on(setup_cayenne("scaling_write"));
-        // Each writer holds a clone of `cayenne_tx`; bench iter reads N
-        // completions from `cayenne_rx` via `wait_for_completions`
-        // (blocking, bounded timeout, surfaces a useful error if any
-        // writer stalls or panics). Replaces the earlier
-        // AtomicUsize + std::hint::spin_loop pattern flagged in PR review.
-        let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
-        let cayenne_writers: Vec<CayenneBgWriter> = (0..concurrency)
-            .map(|i| CayenneBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64))
-            .collect();
-        // Drop the spare sender so the channel closes naturally when all
-        // writers exit on the teardown signal — otherwise `recv_timeout`
-        // would hang on the dangling sender.
-        drop(cayenne_tx);
-
-        group.bench_with_input(
-            BenchmarkId::new("cayenne", concurrency),
-            &concurrency,
-            |b, &_n| {
-                b.iter(|| {
-                    // Drain `concurrency` total completed inserts from the
-                    // shared channel — total system throughput across N
-                    // writers, not per-writer fairness. One fast writer
-                    // can contribute multiple of the N counted messages
-                    // in an iteration; that's by design for a
-                    // throughput-under-concurrency measurement. The
-                    // `BenchmarkId::new(_, concurrency)` then divides this
-                    // by `concurrency * WRITE_BATCH_ROWS` to report
-                    // per-worker throughput in criterion's
-                    // `Throughput::Elements` mode.
-                    wait_for_completions(
-                        &cayenne_rx,
-                        concurrency,
-                        "vs_duckdb_scaling_writes/cayenne",
-                    );
-                });
-            },
-        );
-
-        // Explicit drop order: writers first (stops the loops + joins the
-        // tasks), then the fixture (its TempDir cleans up the data).
-        drop(cayenne_writers);
-        drop(cayenne_fixture);
 
         // --- DuckDB lane ---
         let duckdb_fixture = setup_duckdb("scaling_write");
@@ -597,39 +630,52 @@ fn bench_cdc_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("vs_duckdb_scaling_cdc");
     group.sample_size(10);
 
+    // For each Cayenne metastore lane: run the full concurrency sweep on
+    // the CDC pipelined path. Same structure as `bench_write_scaling`,
+    // but the Cayenne writer pumps `write_cdc_append_stream + finish()`
+    // instead of `insert_into`. Lane id is `cayenne_cdc` (Sqlite) or
+    // `cayenne_turso_cdc` (Turso).
+    for &lane in CAYENNE_LANES {
+        let lane_label = format!("{}_cdc", lane.lane());
+        for &concurrency in CONCURRENCIES {
+            group.throughput(Throughput::Elements(
+                (concurrency as u64) * (WRITE_BATCH_ROWS as u64),
+            ));
+
+            let cayenne_fixture = rt.block_on(setup_cayenne_for("scaling_cdc", lane));
+            let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
+            let cayenne_writers: Vec<CayenneCdcBgWriter> = (0..concurrency)
+                .map(|i| {
+                    CayenneCdcBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64)
+                })
+                .collect();
+            drop(cayenne_tx);
+
+            let bench_ctx = format!("vs_duckdb_scaling_cdc/{lane_label}");
+            group.bench_with_input(
+                BenchmarkId::new(&lane_label, concurrency),
+                &concurrency,
+                |b, &_n| {
+                    b.iter(|| {
+                        wait_for_completions(&cayenne_rx, concurrency, &bench_ctx);
+                    });
+                },
+            );
+
+            drop(cayenne_writers);
+            drop(cayenne_fixture);
+        }
+    }
+
+    // --- DuckDB INSERT lane (closest analog — DuckDB has no CDC pipelined
+    //     equivalent; the comparison answers "if you ran CDC on DuckDB by
+    //     just doing inserts, how fast would it be?"). Runs once per
+    //     concurrency level, independent of Cayenne's metastore choice.
     for &concurrency in CONCURRENCIES {
         group.throughput(Throughput::Elements(
             (concurrency as u64) * (WRITE_BATCH_ROWS as u64),
         ));
 
-        // --- Cayenne CDC pipelined lane ---
-        let cayenne_fixture = rt.block_on(setup_cayenne("scaling_cdc"));
-        let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
-        let cayenne_writers: Vec<CayenneCdcBgWriter> = (0..concurrency)
-            .map(|i| CayenneCdcBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64))
-            .collect();
-        drop(cayenne_tx);
-
-        group.bench_with_input(
-            BenchmarkId::new("cayenne_cdc", concurrency),
-            &concurrency,
-            |b, &_n| {
-                b.iter(|| {
-                    wait_for_completions(
-                        &cayenne_rx,
-                        concurrency,
-                        "vs_duckdb_scaling_cdc/cayenne_cdc",
-                    );
-                });
-            },
-        );
-
-        drop(cayenne_writers);
-        drop(cayenne_fixture);
-
-        // --- DuckDB INSERT lane (closest analog — DuckDB has no CDC pipelined
-        //     equivalent; the comparison answers "if you ran CDC on DuckDB by
-        //     just doing inserts, how fast would it be?") ---
         let duckdb_fixture = setup_duckdb("scaling_cdc");
         let duckdb_db_path = duckdb_fixture.db_path();
         let (duckdb_tx, duckdb_rx) = mpsc::channel::<()>();

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -13,8 +13,10 @@
 //! for 64-core deployments where Spice runs both ingestion (CDC / refresh)
 //! and query traffic in parallel.
 //!
-//! Three workloads are exercised, each across `[1, 2, 4, 8, 16, 32, 64]`
-//! concurrency levels and across **both Cayenne metastore backends**
+//! Three workloads are exercised, each across `[1, 2, 4, 8, 16, 32, 64, 128]`
+//! concurrency levels (64 covers the stated single-machine goal, 128 covers
+//! oversubscription on common 64-core SMT-2 boxes) and across **both
+//! Cayenne metastore backends**
 //! (`Sqlite` and `Turso`, the latter compiled in when the `turso` feature
 //! is enabled — see `CAYENNE_LANES`). DuckDB runs once per workload as the
 //! external baseline.
@@ -101,8 +103,10 @@ use common::{
 };
 
 /// Concurrency levels measured. Spans the typical core counts we care about
-/// (1, 2, 4, 8, 16, 32) up to the 64-core goal stated by the user.
-const CONCURRENCIES: &[usize] = &[1, 2, 4, 8, 16, 32, 64];
+/// (1 → 32) up through the 64-core baseline goal and out to 128 so the
+/// per-iteration curve covers oversubscription on common 64-core deployments
+/// (every workload runs 1× hyperthread + 1× extra-task-per-core headroom).
+const CONCURRENCIES: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128];
 
 /// Rows in the pre-loaded read fixture. Single fixed value because the
 /// variable we're studying is concurrency, not data size.

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -43,12 +43,33 @@ mod common;
 
 use std::hint::black_box;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use duckdb::Connection;
 use tokio::runtime::Runtime;
-use tokio::task::JoinSet;
+
+/// Bounded-timeout wait for `n` writer-completion signals. Replaces the
+/// earlier `AtomicUsize` + `std::hint::spin_loop` pattern that burned an
+/// entire core on the bench thread and could hang indefinitely if a writer
+/// panicked. `recv_timeout` is blocking (no CPU burn), and surfaces a
+/// useful failure message when a writer stalls or dies.
+fn wait_for_completions(rx: &mpsc::Receiver<()>, n: usize, ctx: &str) {
+    // 30s per iteration is generous — even the slowest write workload below
+    // (DuckDB at 64-way concurrency) takes ~95 ms per iteration. A timeout
+    // this far above the steady-state means a real fault, not noise.
+    let per_iter_timeout = Duration::from_secs(30);
+    for i in 0..n {
+        rx.recv_timeout(per_iter_timeout).unwrap_or_else(|err| {
+            panic!(
+                "{ctx}: stalled waiting for writer completion {}/{n} after {per_iter_timeout:?} ({err})",
+                i + 1
+            )
+        });
+    }
+}
 
 use common::{
     CayenneFixture, cayenne_cdc_write, cayenne_insert, cayenne_query_warm, duckdb_insert_parquet,
@@ -102,6 +123,70 @@ async fn build_read_fixtures() -> ReadFixtures {
     }
 }
 
+/// Persistent Cayenne reader worker. Spawned once per concurrency level,
+/// drives one read on every iteration when its dedicated `go_rx` channel
+/// receives a tick, signals completion through the shared `done_tx`.
+/// Per-worker `go` channels (not a broadcast or single shared channel)
+/// avoid lost-permit and multi-consumer-receiver issues — the bench
+/// thread sends exactly one tick to each worker per iteration.
+struct CayenneReader {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl CayenneReader {
+    fn spawn(
+        rt: &Runtime,
+        warm_ctx: Arc<datafusion::prelude::SessionContext>,
+        mut go_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+        done_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    ) -> Self {
+        let handle = rt.spawn(async move {
+            // `go_rx.recv()` returns None when the bench thread drops its
+            // sender — that's the teardown signal, exit the loop cleanly.
+            while go_rx.recv().await.is_some() {
+                let batches = cayenne_query_warm(&warm_ctx, "SELECT COUNT(*) FROM t").await;
+                black_box(batches);
+                // `send` errors only if the bench has dropped its receiver
+                // mid-iteration; benign on teardown.
+                let _ = done_tx.send(());
+            }
+        });
+        Self { handle }
+    }
+}
+
+/// Persistent DuckDB reader worker. OS thread with the same channel shape
+/// as `CayenneReader` — its own `go_rx` for per-worker ticks, a shared
+/// `done_tx` for completion signals. Reused across every criterion sample
+/// so the thread-spawn cost is paid exactly once per concurrency level.
+struct DuckDbReader {
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl DuckDbReader {
+    fn spawn(
+        conn: Connection,
+        go_rx: mpsc::Receiver<()>,
+        done_tx: mpsc::Sender<()>,
+    ) -> Self {
+        let handle = std::thread::spawn(move || {
+            // `recv()` returns Err when the bench drops its sender — exit
+            // cleanly on teardown.
+            while go_rx.recv().is_ok() {
+                let mut stmt = conn
+                    .prepare("SELECT COUNT(*) FROM scaling_read")
+                    .expect("prepare");
+                let mut rows = stmt.query([]).expect("query");
+                let row = rows.next().expect("next").expect("row");
+                let value: i64 = row.get(0).expect("count");
+                black_box(value);
+                let _ = done_tx.send(());
+            }
+        });
+        Self { handle }
+    }
+}
+
 fn bench_read_scaling(c: &mut Criterion) {
     let rt = Runtime::new().expect("runtime");
     let mut group = c.benchmark_group("vs_duckdb_scaling_reads");
@@ -116,58 +201,95 @@ fn bench_read_scaling(c: &mut Criterion) {
     for &concurrency in CONCURRENCIES {
         group.throughput(Throughput::Elements(concurrency as u64));
 
-        let wc = Arc::clone(&warm_ctx);
+        // --- Cayenne pool: N persistent tokio tasks. Each iteration the
+        //     bench thread sends one `()` on every worker's `go_tx` and
+        //     drains N `()` messages from the shared `done_rx`. Worker
+        //     spawn cost is paid once per concurrency level — addresses
+        //     the Copilot review on this PR re: thread/task spawn
+        //     overhead being inside the timed region.
+        let (cayenne_done_tx, mut cayenne_done_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let mut cayenne_go_txs: Vec<tokio::sync::mpsc::UnboundedSender<()>> =
+            Vec::with_capacity(concurrency);
+        let mut cayenne_workers: Vec<CayenneReader> = Vec::with_capacity(concurrency);
+        for _ in 0..concurrency {
+            let (go_tx, go_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+            cayenne_go_txs.push(go_tx);
+            cayenne_workers.push(CayenneReader::spawn(
+                &rt,
+                Arc::clone(&warm_ctx),
+                go_rx,
+                cayenne_done_tx.clone(),
+            ));
+        }
+        // Drop the bench's spare done sender so `done_rx.recv()` returns
+        // None once all workers drop their senders during teardown.
+        drop(cayenne_done_tx);
+
         group.bench_with_input(
             BenchmarkId::new("cayenne_warm", concurrency),
             &concurrency,
-            |b, &n| {
+            |b, &_n| {
                 b.iter(|| {
                     rt.block_on(async {
-                        let mut join_set = JoinSet::new();
-                        for _ in 0..n {
-                            let wc = Arc::clone(&wc);
-                            join_set.spawn(async move {
-                                let batches =
-                                    cayenne_query_warm(&wc, "SELECT COUNT(*) FROM t").await;
-                                black_box(batches);
-                            });
+                        for tx in &cayenne_go_txs {
+                            tx.send(()).expect("cayenne go-tx (worker exited?)");
                         }
-                        while let Some(result) = join_set.join_next().await {
-                            result.expect("cayenne reader task");
+                        for _ in 0..concurrency {
+                            cayenne_done_rx
+                                .recv()
+                                .await
+                                .expect("cayenne done-rx (worker exited?)");
                         }
                     });
                 });
             },
         );
 
-        let conn = Arc::clone(&fixtures.duckdb_conn);
+        // Tear down Cayenne workers: drop the go senders so each worker's
+        // `go_rx.recv()` returns None and the worker exits.
+        cayenne_go_txs.clear();
+        for w in cayenne_workers.drain(..) {
+            rt.block_on(async { w.handle.await }).expect("cayenne reader task");
+        }
+
+        // --- DuckDB pool: N persistent OS threads with the same per-worker
+        //     `go` channel + shared `done` channel shape.
+        let (duckdb_done_tx, duckdb_done_rx) = mpsc::channel::<()>();
+        let mut duckdb_go_txs: Vec<mpsc::Sender<()>> = Vec::with_capacity(concurrency);
+        let mut duckdb_workers: Vec<DuckDbReader> = Vec::with_capacity(concurrency);
+        for _ in 0..concurrency {
+            let conn_clone = fixtures
+                .duckdb_conn
+                .try_clone()
+                .expect("duckdb connection clone");
+            let (go_tx, go_rx) = mpsc::channel::<()>();
+            duckdb_go_txs.push(go_tx);
+            duckdb_workers.push(DuckDbReader::spawn(conn_clone, go_rx, duckdb_done_tx.clone()));
+        }
+        drop(duckdb_done_tx);
+
         group.bench_with_input(
             BenchmarkId::new("duckdb", concurrency),
             &concurrency,
-            |b, &n| {
+            |b, &_n| {
                 b.iter(|| {
-                    let mut handles = Vec::with_capacity(n);
-                    for _ in 0..n {
-                        // duckdb-rs `Connection::try_clone` produces a separate
-                        // cursor sharing the same database; concurrent reads
-                        // are MVCC-safe.
-                        let conn_clone = conn.try_clone().expect("duckdb connection clone");
-                        handles.push(std::thread::spawn(move || {
-                            let mut stmt = conn_clone
-                                .prepare("SELECT COUNT(*) FROM scaling_read")
-                                .expect("prepare");
-                            let mut rows = stmt.query([]).expect("query");
-                            let row = rows.next().expect("next").expect("row");
-                            let value: i64 = row.get(0).expect("count");
-                            black_box(value);
-                        }));
+                    for tx in &duckdb_go_txs {
+                        tx.send(()).expect("duckdb go-tx (worker exited?)");
                     }
-                    for handle in handles {
-                        handle.join().expect("duckdb reader thread");
-                    }
+                    wait_for_completions(
+                        &duckdb_done_rx,
+                        concurrency,
+                        "vs_duckdb_scaling_reads/duckdb",
+                    );
                 });
             },
         );
+
+        // Tear down DuckDB workers: drop the go senders, then join.
+        duckdb_go_txs.clear();
+        for w in duckdb_workers.drain(..) {
+            w.handle.join().expect("duckdb reader thread");
+        }
     }
 
     group.finish();
@@ -178,12 +300,11 @@ fn bench_read_scaling(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 
 /// Sustained-throughput Cayenne writer. Spawns one async task on the runtime
-/// that pumps `cayenne_insert` calls in a tight loop, counting completions.
-/// Dropping the writer stops the loop and joins the task — modeled after
-/// `CayenneBgWriter` in `vs_duckdb_concurrent.rs`, which is the
-/// known-working concurrent-write pattern in this crate.
+/// that pumps `cayenne_insert` calls in a tight loop, signaling each
+/// completion through `tx`. Dropping the writer stops the loop and joins
+/// the task — modeled after `CayenneBgWriter` in `vs_duckdb_concurrent.rs`.
 struct CayenneBgWriter {
-    stop: Arc<std::sync::atomic::AtomicBool>,
+    stop: Arc<AtomicBool>,
     handle: Option<tokio::task::JoinHandle<u64>>,
     rt_handle: tokio::runtime::Handle,
 }
@@ -192,10 +313,10 @@ impl CayenneBgWriter {
     fn spawn(
         rt: &Runtime,
         fixture: &CayenneFixture,
-        counter: Arc<AtomicUsize>,
+        tx: mpsc::Sender<()>,
         writer_id: i64,
     ) -> Self {
-        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop);
         let table = Arc::clone(&fixture.table);
         let handle = rt.spawn(async move {
@@ -210,7 +331,9 @@ impl CayenneBgWriter {
                 cursor += WRITE_BATCH_ROWS as i64;
                 if cayenne_insert(&table, batch).await > 0 {
                     written += 1;
-                    counter.fetch_add(1, Ordering::Relaxed);
+                    // Sender drop after stop is the normal teardown path;
+                    // ignore the error in that case.
+                    let _ = tx.send(());
                 }
             }
             written
@@ -248,10 +371,10 @@ impl DuckDbBgWriter {
     fn spawn(
         db_path: &std::path::Path,
         table_name: &str,
-        counter: Arc<AtomicUsize>,
+        tx: mpsc::Sender<()>,
         writer_id: i64,
     ) -> Self {
-        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop);
         let db_path = db_path.to_path_buf();
         let table_name = table_name.to_string();
@@ -265,7 +388,7 @@ impl DuckDbBgWriter {
                 cursor += WRITE_BATCH_ROWS as i64;
                 duckdb_insert_rows(&conn, &table_name, &batch);
                 written += 1;
-                counter.fetch_add(1, Ordering::Relaxed);
+                let _ = tx.send(());
             }
             written
         });
@@ -297,33 +420,34 @@ fn bench_write_scaling(c: &mut Criterion) {
 
         // --- Cayenne lane ---
         let cayenne_fixture = rt.block_on(setup_cayenne("scaling_write"));
-        let cayenne_counter = Arc::new(AtomicUsize::new(0));
+        // Each writer holds a clone of `cayenne_tx`; bench iter reads N
+        // completions from `cayenne_rx` via `wait_for_completions`
+        // (blocking, bounded timeout, surfaces a useful error if any
+        // writer stalls or panics). Replaces the earlier
+        // AtomicUsize + std::hint::spin_loop pattern flagged in PR review.
+        let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
         let mut cayenne_writers: Vec<CayenneBgWriter> = (0..concurrency)
-            .map(|i| {
-                CayenneBgWriter::spawn(
-                    &rt,
-                    &cayenne_fixture,
-                    Arc::clone(&cayenne_counter),
-                    i as i64,
-                )
-            })
+            .map(|i| CayenneBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64))
             .collect();
+        // Drop the spare sender so the channel closes naturally when all
+        // writers exit on the teardown signal — otherwise `recv_timeout`
+        // would hang on the dangling sender.
+        drop(cayenne_tx);
 
         group.bench_with_input(
             BenchmarkId::new("cayenne", concurrency),
             &concurrency,
             |b, &_n| {
                 b.iter(|| {
-                    let start = cayenne_counter.load(Ordering::Relaxed);
                     // Wait for one full pass (each writer contributes ≥1
                     // insert) so a single iteration captures the full
                     // concurrency cost — not just the latency of one of N
                     // writers.
-                    let target = start + concurrency;
-                    while cayenne_counter.load(Ordering::Relaxed) < target {
-                        std::hint::spin_loop();
-                    }
-                    black_box(());
+                    wait_for_completions(
+                        &cayenne_rx,
+                        concurrency,
+                        "vs_duckdb_scaling_writes/cayenne",
+                    );
                 });
             },
         );
@@ -335,30 +459,25 @@ fn bench_write_scaling(c: &mut Criterion) {
 
         // --- DuckDB lane ---
         let duckdb_fixture = setup_duckdb("scaling_write");
-        let duckdb_counter = Arc::new(AtomicUsize::new(0));
         let duckdb_db_path = duckdb_fixture.db_path();
+        let (duckdb_tx, duckdb_rx) = mpsc::channel::<()>();
         let mut duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
             .map(|i| {
-                DuckDbBgWriter::spawn(
-                    &duckdb_db_path,
-                    "scaling_write",
-                    Arc::clone(&duckdb_counter),
-                    i as i64,
-                )
+                DuckDbBgWriter::spawn(&duckdb_db_path, "scaling_write", duckdb_tx.clone(), i as i64)
             })
             .collect();
+        drop(duckdb_tx);
 
         group.bench_with_input(
             BenchmarkId::new("duckdb", concurrency),
             &concurrency,
             |b, &_n| {
                 b.iter(|| {
-                    let start = duckdb_counter.load(Ordering::Relaxed);
-                    let target = start + concurrency;
-                    while duckdb_counter.load(Ordering::Relaxed) < target {
-                        std::hint::spin_loop();
-                    }
-                    black_box(());
+                    wait_for_completions(
+                        &duckdb_rx,
+                        concurrency,
+                        "vs_duckdb_scaling_writes/duckdb",
+                    );
                 });
             },
         );
@@ -380,7 +499,7 @@ fn bench_write_scaling(c: &mut Criterion) {
 /// `insert_into`. Lets us see whether the Stage-A / Stage-B split actually
 /// translates into higher sustained throughput vs the regular write path.
 struct CayenneCdcBgWriter {
-    stop: Arc<std::sync::atomic::AtomicBool>,
+    stop: Arc<AtomicBool>,
     handle: Option<tokio::task::JoinHandle<u64>>,
     rt_handle: tokio::runtime::Handle,
 }
@@ -389,10 +508,10 @@ impl CayenneCdcBgWriter {
     fn spawn(
         rt: &Runtime,
         fixture: &CayenneFixture,
-        counter: Arc<AtomicUsize>,
+        tx: mpsc::Sender<()>,
         writer_id: i64,
     ) -> Self {
-        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop);
         let table = Arc::clone(&fixture.table);
         let handle = rt.spawn(async move {
@@ -404,7 +523,7 @@ impl CayenneCdcBgWriter {
                 cursor += WRITE_BATCH_ROWS as i64;
                 if cayenne_cdc_write(&table, batch).await > 0 {
                     written += 1;
-                    counter.fetch_add(1, Ordering::Relaxed);
+                    let _ = tx.send(());
                 }
             }
             written
@@ -438,29 +557,22 @@ fn bench_cdc_scaling(c: &mut Criterion) {
 
         // --- Cayenne CDC pipelined lane ---
         let cayenne_fixture = rt.block_on(setup_cayenne("scaling_cdc"));
-        let cayenne_counter = Arc::new(AtomicUsize::new(0));
+        let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
         let mut cayenne_writers: Vec<CayenneCdcBgWriter> = (0..concurrency)
-            .map(|i| {
-                CayenneCdcBgWriter::spawn(
-                    &rt,
-                    &cayenne_fixture,
-                    Arc::clone(&cayenne_counter),
-                    i as i64,
-                )
-            })
+            .map(|i| CayenneCdcBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64))
             .collect();
+        drop(cayenne_tx);
 
         group.bench_with_input(
             BenchmarkId::new("cayenne_cdc", concurrency),
             &concurrency,
             |b, &_n| {
                 b.iter(|| {
-                    let start = cayenne_counter.load(Ordering::Relaxed);
-                    let target = start + concurrency;
-                    while cayenne_counter.load(Ordering::Relaxed) < target {
-                        std::hint::spin_loop();
-                    }
-                    black_box(());
+                    wait_for_completions(
+                        &cayenne_rx,
+                        concurrency,
+                        "vs_duckdb_scaling_cdc/cayenne_cdc",
+                    );
                 });
             },
         );
@@ -472,30 +584,21 @@ fn bench_cdc_scaling(c: &mut Criterion) {
         //     equivalent; the comparison answers "if you ran CDC on DuckDB by
         //     just doing inserts, how fast would it be?") ---
         let duckdb_fixture = setup_duckdb("scaling_cdc");
-        let duckdb_counter = Arc::new(AtomicUsize::new(0));
         let duckdb_db_path = duckdb_fixture.db_path();
+        let (duckdb_tx, duckdb_rx) = mpsc::channel::<()>();
         let mut duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
             .map(|i| {
-                DuckDbBgWriter::spawn(
-                    &duckdb_db_path,
-                    "scaling_cdc",
-                    Arc::clone(&duckdb_counter),
-                    i as i64,
-                )
+                DuckDbBgWriter::spawn(&duckdb_db_path, "scaling_cdc", duckdb_tx.clone(), i as i64)
             })
             .collect();
+        drop(duckdb_tx);
 
         group.bench_with_input(
             BenchmarkId::new("duckdb", concurrency),
             &concurrency,
             |b, &_n| {
                 b.iter(|| {
-                    let start = duckdb_counter.load(Ordering::Relaxed);
-                    let target = start + concurrency;
-                    while duckdb_counter.load(Ordering::Relaxed) < target {
-                        std::hint::spin_loop();
-                    }
-                    black_box(());
+                    wait_for_completions(&duckdb_rx, concurrency, "vs_duckdb_scaling_cdc/duckdb");
                 });
             },
         );

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -19,9 +19,10 @@
 //! * **`vs_duckdb_scaling_reads`** — N concurrent `SELECT COUNT(*)` queries
 //!   against one pre-loaded 1M-row table. Cayenne uses one long-lived warm
 //!   `SessionContext` shared across the N reader tasks (mirrors a running
-//!   Spice runtime). DuckDB uses one `Connection` per task via
-//!   `try_clone()`. The bench shows whether reader-side scaling is bounded
-//!   by mutex contention or runs cleanly to the core count.
+//!   Spice runtime). DuckDB opens one fresh `Connection` per OS thread
+//!   from the shared on-disk database path. The bench shows whether
+//!   reader-side scaling is bounded by mutex contention or runs cleanly
+//!   to the core count.
 //!
 //! * **`vs_duckdb_scaling_writes`** — sustained insert throughput driven by
 //!   N concurrent background writer tasks against one table via the generic
@@ -107,12 +108,18 @@ const WRITE_BATCH_ROWS: usize = 1_024;
 // vs_duckdb_scaling_reads — N concurrent COUNT(*) against ONE table
 // ---------------------------------------------------------------------------
 
-/// Owns both the pre-loaded Cayenne table and the matching DuckDB table.
-/// Built once at bench start; reused across every concurrency level so the
-/// data-load cost is paid exactly once.
+/// Owns both the pre-loaded Cayenne table and the matching DuckDB
+/// database. Built once at bench start; reused across every concurrency
+/// level so the data-load cost is paid exactly once.
+///
+/// The DuckDB side stores the on-disk database path rather than a shared
+/// `Connection` because `duckdb::Connection` is not `Send` in this
+/// codebase (`vs_duckdb_concurrent.rs:108` follows the same pattern —
+/// each background-writer thread calls `Connection::open(&db_path)` so
+/// every thread owns its own connection). Reader threads do the same.
 struct ReadFixtures {
     cayenne: Arc<CayenneFixture>,
-    duckdb_conn: Arc<Connection>,
+    duckdb_db_path: std::path::PathBuf,
     _duckdb_temp: tempfile::TempDir,
     _parquet_dir: tempfile::TempDir,
 }
@@ -128,9 +135,10 @@ async fn build_read_fixtures() -> ReadFixtures {
     write_parquet(&batch, &parquet_path);
     duckdb_insert_parquet(&duckdb_fixture.conn, "scaling_read", &parquet_path);
 
+    let duckdb_db_path = duckdb_fixture.db_path();
     ReadFixtures {
         cayenne: Arc::new(cayenne_fixture),
-        duckdb_conn: Arc::new(duckdb_fixture.conn),
+        duckdb_db_path,
         _duckdb_temp: duckdb_fixture._temp_dir,
         _parquet_dir: parquet_dir,
     }
@@ -170,15 +178,23 @@ impl CayenneReader {
 
 /// Persistent DuckDB reader worker. OS thread with the same channel shape
 /// as `CayenneReader` — its own `go_rx` for per-worker ticks, a shared
-/// `done_tx` for completion signals. Reused across every criterion sample
-/// so the thread-spawn cost is paid exactly once per concurrency level.
+/// `done_tx` for completion signals. Each worker opens its own
+/// `Connection` from the shared on-disk database (DuckDB connections are
+/// not `Send` in this codebase, see `vs_duckdb_concurrent.rs:108` for the
+/// same pattern). Reused across every criterion sample so the
+/// thread-spawn cost is paid exactly once per concurrency level.
 struct DuckDbReader {
     handle: std::thread::JoinHandle<()>,
 }
 
 impl DuckDbReader {
-    fn spawn(conn: Connection, go_rx: mpsc::Receiver<()>, done_tx: mpsc::Sender<()>) -> Self {
+    fn spawn(
+        db_path: std::path::PathBuf,
+        go_rx: mpsc::Receiver<()>,
+        done_tx: mpsc::Sender<()>,
+    ) -> Self {
         let handle = std::thread::spawn(move || {
+            let conn = Connection::open(&db_path).expect("duckdb reader connection open");
             // `recv()` returns Err when the bench drops its sender — exit
             // cleanly on teardown.
             while go_rx.recv().is_ok() {
@@ -268,14 +284,10 @@ fn bench_read_scaling(c: &mut Criterion) {
         let mut duckdb_go_txs: Vec<mpsc::Sender<()>> = Vec::with_capacity(concurrency);
         let mut duckdb_workers: Vec<DuckDbReader> = Vec::with_capacity(concurrency);
         for _ in 0..concurrency {
-            let conn_clone = fixtures
-                .duckdb_conn
-                .try_clone()
-                .expect("duckdb connection clone");
             let (go_tx, go_rx) = mpsc::channel::<()>();
             duckdb_go_txs.push(go_tx);
             duckdb_workers.push(DuckDbReader::spawn(
-                conn_clone,
+                fixtures.duckdb_db_path.clone(),
                 go_rx,
                 duckdb_done_tx.clone(),
             ));

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -13,7 +13,7 @@
 //! for 64-core deployments where Spice runs both ingestion (CDC / refresh)
 //! and query traffic in parallel.
 //!
-//! Two workloads are exercised, each across `[1, 2, 4, 8, 16, 32, 64]`
+//! Three workloads are exercised, each across `[1, 2, 4, 8, 16, 32, 64]`
 //! concurrency levels:
 //!
 //! * **`vs_duckdb_scaling_reads`** — N concurrent `SELECT COUNT(*)` queries
@@ -24,11 +24,24 @@
 //!   by mutex contention or runs cleanly to the core count.
 //!
 //! * **`vs_duckdb_scaling_writes`** — sustained insert throughput driven by
-//!   N concurrent background writer tasks against one table. Each writer
-//!   issues an insert, the runner waits N inserts then samples; criterion's
-//!   `throughput` metric reports rows/sec. Measures whether the per-table
-//!   write path scales with concurrent writers, or whether the per-table
-//!   `write_lock` at `provider/table.rs:1131` serialises them.
+//!   N concurrent background writer tasks against one table via the generic
+//!   `CayenneTableProvider::insert_into` path. Each writer pumps inserts in
+//!   a loop, the bench iter waits for N completions to pass before sampling.
+//!   Measures whether the per-table write path scales with concurrent
+//!   writers, or whether the per-table `write_lock` at
+//!   `provider/table.rs:1131` serialises them.
+//!
+//! * **`vs_duckdb_scaling_cdc`** — same shape as writes, but pumping
+//!   `CayenneTableProvider::write_cdc_append_stream` + `finish()` (the
+//!   production CDC pipelined path used by `refresh_mode: changes`) instead
+//!   of `insert_into`. Compares against DuckDB INSERT as the closest analog
+//!   since DuckDB has no CDC-pipelined entry point of its own.
+//!
+//! Workers in every lane are pooled per concurrency level (spawned once,
+//! signaled per iteration via per-worker `mpsc` channels), so worker-spawn
+//! cost falls outside criterion's timed region. The bench thread blocks on
+//! `mpsc::Receiver::recv_timeout` to drain completion signals — no CPU-burning
+//! `spin_loop`, no AtomicUsize counter.
 //!
 //! `BenchmarkId::new("…", N)` naming makes the throughput-vs-N curve visible
 //! directly in criterion's HTML output and parse-able from the text logs.
@@ -164,11 +177,7 @@ struct DuckDbReader {
 }
 
 impl DuckDbReader {
-    fn spawn(
-        conn: Connection,
-        go_rx: mpsc::Receiver<()>,
-        done_tx: mpsc::Sender<()>,
-    ) -> Self {
+    fn spawn(conn: Connection, go_rx: mpsc::Receiver<()>, done_tx: mpsc::Sender<()>) -> Self {
         let handle = std::thread::spawn(move || {
             // `recv()` returns Err when the bench drops its sender — exit
             // cleanly on teardown.
@@ -249,7 +258,8 @@ fn bench_read_scaling(c: &mut Criterion) {
         // `go_rx.recv()` returns None and the worker exits.
         cayenne_go_txs.clear();
         for w in cayenne_workers.drain(..) {
-            rt.block_on(async { w.handle.await }).expect("cayenne reader task");
+            rt.block_on(async { w.handle.await })
+                .expect("cayenne reader task");
         }
 
         // --- DuckDB pool: N persistent OS threads with the same per-worker
@@ -264,7 +274,11 @@ fn bench_read_scaling(c: &mut Criterion) {
                 .expect("duckdb connection clone");
             let (go_tx, go_rx) = mpsc::channel::<()>();
             duckdb_go_txs.push(go_tx);
-            duckdb_workers.push(DuckDbReader::spawn(conn_clone, go_rx, duckdb_done_tx.clone()));
+            duckdb_workers.push(DuckDbReader::spawn(
+                conn_clone,
+                go_rx,
+                duckdb_done_tx.clone(),
+            ));
         }
         drop(duckdb_done_tx);
 
@@ -310,12 +324,7 @@ struct CayenneBgWriter {
 }
 
 impl CayenneBgWriter {
-    fn spawn(
-        rt: &Runtime,
-        fixture: &CayenneFixture,
-        tx: mpsc::Sender<()>,
-        writer_id: i64,
-    ) -> Self {
+    fn spawn(rt: &Runtime, fixture: &CayenneFixture, tx: mpsc::Sender<()>, writer_id: i64) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop);
         let table = Arc::clone(&fixture.table);
@@ -463,7 +472,12 @@ fn bench_write_scaling(c: &mut Criterion) {
         let (duckdb_tx, duckdb_rx) = mpsc::channel::<()>();
         let mut duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
             .map(|i| {
-                DuckDbBgWriter::spawn(&duckdb_db_path, "scaling_write", duckdb_tx.clone(), i as i64)
+                DuckDbBgWriter::spawn(
+                    &duckdb_db_path,
+                    "scaling_write",
+                    duckdb_tx.clone(),
+                    i as i64,
+                )
             })
             .collect();
         drop(duckdb_tx);
@@ -505,12 +519,7 @@ struct CayenneCdcBgWriter {
 }
 
 impl CayenneCdcBgWriter {
-    fn spawn(
-        rt: &Runtime,
-        fixture: &CayenneFixture,
-        tx: mpsc::Sender<()>,
-        writer_id: i64,
-    ) -> Self {
+    fn spawn(rt: &Runtime, fixture: &CayenneFixture, tx: mpsc::Sender<()>, writer_id: i64) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop);
         let table = Arc::clone(&fixture.table);

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -51,7 +51,7 @@ use tokio::runtime::Runtime;
 use tokio::task::JoinSet;
 
 use common::{
-    CayenneFixture, cayenne_insert, cayenne_query_warm, duckdb_insert_parquet,
+    CayenneFixture, cayenne_cdc_write, cayenne_insert, cayenne_query_warm, duckdb_insert_parquet,
     duckdb_insert_rows, make_batch, schema, setup_cayenne, setup_duckdb, warm_session_for,
     write_parquet,
 };
@@ -245,10 +245,16 @@ struct DuckDbBgWriter {
 }
 
 impl DuckDbBgWriter {
-    fn spawn(db_path: &std::path::Path, counter: Arc<AtomicUsize>, writer_id: i64) -> Self {
+    fn spawn(
+        db_path: &std::path::Path,
+        table_name: &str,
+        counter: Arc<AtomicUsize>,
+        writer_id: i64,
+    ) -> Self {
         let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop);
         let db_path = db_path.to_path_buf();
+        let table_name = table_name.to_string();
         let handle = std::thread::spawn(move || {
             let conn = Connection::open(&db_path).expect("bg duckdb open");
             let id_stride = (WRITE_BATCH_ROWS as i64) * 1024 * 1024;
@@ -257,7 +263,7 @@ impl DuckDbBgWriter {
             while !stop_clone.load(Ordering::Relaxed) {
                 let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
                 cursor += WRITE_BATCH_ROWS as i64;
-                duckdb_insert_rows(&conn, "scaling_write", &batch);
+                duckdb_insert_rows(&conn, &table_name, &batch);
                 written += 1;
                 counter.fetch_add(1, Ordering::Relaxed);
             }
@@ -335,6 +341,7 @@ fn bench_write_scaling(c: &mut Criterion) {
             .map(|i| {
                 DuckDbBgWriter::spawn(
                     &duckdb_db_path,
+                    "scaling_write",
                     Arc::clone(&duckdb_counter),
                     i as i64,
                 )
@@ -363,5 +370,147 @@ fn bench_write_scaling(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_read_scaling, bench_write_scaling);
+// ---------------------------------------------------------------------------
+// vs_duckdb_scaling_cdc — sustained CDC pipelined writes
+// ---------------------------------------------------------------------------
+
+/// Sustained-throughput Cayenne CDC writer. Same shape as `CayenneBgWriter`
+/// but pumps `write_cdc_append_stream` + `finish()` (the production CDC
+/// pipelined path used by `refresh_mode: changes`) instead of the generic
+/// `insert_into`. Lets us see whether the Stage-A / Stage-B split actually
+/// translates into higher sustained throughput vs the regular write path.
+struct CayenneCdcBgWriter {
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<tokio::task::JoinHandle<u64>>,
+    rt_handle: tokio::runtime::Handle,
+}
+
+impl CayenneCdcBgWriter {
+    fn spawn(
+        rt: &Runtime,
+        fixture: &CayenneFixture,
+        counter: Arc<AtomicUsize>,
+        writer_id: i64,
+    ) -> Self {
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_clone = Arc::clone(&stop);
+        let table = Arc::clone(&fixture.table);
+        let handle = rt.spawn(async move {
+            let mut written = 0u64;
+            let id_stride = (WRITE_BATCH_ROWS as i64) * 1024 * 1024;
+            let mut cursor = writer_id * id_stride;
+            while !stop_clone.load(Ordering::Relaxed) {
+                let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
+                cursor += WRITE_BATCH_ROWS as i64;
+                if cayenne_cdc_write(&table, batch).await > 0 {
+                    written += 1;
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            written
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+            rt_handle: rt.handle().clone(),
+        }
+    }
+}
+
+impl Drop for CayenneCdcBgWriter {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = self.rt_handle.block_on(handle);
+        }
+    }
+}
+
+fn bench_cdc_scaling(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_scaling_cdc");
+    group.sample_size(10);
+
+    for &concurrency in CONCURRENCIES {
+        group.throughput(Throughput::Elements(
+            (concurrency as u64) * (WRITE_BATCH_ROWS as u64),
+        ));
+
+        // --- Cayenne CDC pipelined lane ---
+        let cayenne_fixture = rt.block_on(setup_cayenne("scaling_cdc"));
+        let cayenne_counter = Arc::new(AtomicUsize::new(0));
+        let mut cayenne_writers: Vec<CayenneCdcBgWriter> = (0..concurrency)
+            .map(|i| {
+                CayenneCdcBgWriter::spawn(
+                    &rt,
+                    &cayenne_fixture,
+                    Arc::clone(&cayenne_counter),
+                    i as i64,
+                )
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("cayenne_cdc", concurrency),
+            &concurrency,
+            |b, &_n| {
+                b.iter(|| {
+                    let start = cayenne_counter.load(Ordering::Relaxed);
+                    let target = start + concurrency;
+                    while cayenne_counter.load(Ordering::Relaxed) < target {
+                        std::hint::spin_loop();
+                    }
+                    black_box(());
+                });
+            },
+        );
+
+        cayenne_writers.drain(..);
+        drop(cayenne_fixture);
+
+        // --- DuckDB INSERT lane (closest analog — DuckDB has no CDC pipelined
+        //     equivalent; the comparison answers "if you ran CDC on DuckDB by
+        //     just doing inserts, how fast would it be?") ---
+        let duckdb_fixture = setup_duckdb("scaling_cdc");
+        let duckdb_counter = Arc::new(AtomicUsize::new(0));
+        let duckdb_db_path = duckdb_fixture.db_path();
+        let mut duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
+            .map(|i| {
+                DuckDbBgWriter::spawn(
+                    &duckdb_db_path,
+                    "scaling_cdc",
+                    Arc::clone(&duckdb_counter),
+                    i as i64,
+                )
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("duckdb", concurrency),
+            &concurrency,
+            |b, &_n| {
+                b.iter(|| {
+                    let start = duckdb_counter.load(Ordering::Relaxed);
+                    let target = start + concurrency;
+                    while duckdb_counter.load(Ordering::Relaxed) < target {
+                        std::hint::spin_loop();
+                    }
+                    black_box(());
+                });
+            },
+        );
+
+        duckdb_writers.drain(..);
+        drop(duckdb_fixture);
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_read_scaling,
+    bench_write_scaling,
+    bench_cdc_scaling
+);
 criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -1,0 +1,367 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Concurrency scaling benchmarks: does throughput scale with cores?
+//!
+//! The single-thread `vs_duckdb_*` benches measure per-query latency. This
+//! bench measures *throughput under concurrency* — the metric that matters
+//! for 64-core deployments where Spice runs both ingestion (CDC / refresh)
+//! and query traffic in parallel.
+//!
+//! Two workloads are exercised, each across `[1, 2, 4, 8, 16, 32, 64]`
+//! concurrency levels:
+//!
+//! * **`vs_duckdb_scaling_reads`** — N concurrent `SELECT COUNT(*)` queries
+//!   against one pre-loaded 1M-row table. Cayenne uses one long-lived warm
+//!   `SessionContext` shared across the N reader tasks (mirrors a running
+//!   Spice runtime). DuckDB uses one `Connection` per task via
+//!   `try_clone()`. The bench shows whether reader-side scaling is bounded
+//!   by mutex contention or runs cleanly to the core count.
+//!
+//! * **`vs_duckdb_scaling_writes`** — sustained insert throughput driven by
+//!   N concurrent background writer tasks against one table. Each writer
+//!   issues an insert, the runner waits N inserts then samples; criterion's
+//!   `throughput` metric reports rows/sec. Measures whether the per-table
+//!   write path scales with concurrent writers, or whether the per-table
+//!   `write_lock` at `provider/table.rs:1131` serialises them.
+//!
+//! `BenchmarkId::new("…", N)` naming makes the throughput-vs-N curve visible
+//! directly in criterion's HTML output and parse-able from the text logs.
+
+#![cfg(feature = "duckdb-bench")]
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_precision_loss)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use duckdb::Connection;
+use tokio::runtime::Runtime;
+use tokio::task::JoinSet;
+
+use common::{
+    CayenneFixture, cayenne_insert, cayenne_query_warm, duckdb_insert_parquet,
+    duckdb_insert_rows, make_batch, schema, setup_cayenne, setup_duckdb, warm_session_for,
+    write_parquet,
+};
+
+/// Concurrency levels measured. Spans the typical core counts we care about
+/// (1, 2, 4, 8, 16, 32) up to the 64-core goal stated by the user.
+const CONCURRENCIES: &[usize] = &[1, 2, 4, 8, 16, 32, 64];
+
+/// Rows in the pre-loaded read fixture. Single fixed value because the
+/// variable we're studying is concurrency, not data size.
+const READ_ROWS: usize = 1_048_576;
+
+/// Rows per insert batch in the write-scaling workload. Small batch so each
+/// `cayenne_insert` call is short (~1–10 ms) and the per-iteration sample
+/// captures concurrency overhead rather than batch I/O cost.
+const WRITE_BATCH_ROWS: usize = 1_024;
+
+// ---------------------------------------------------------------------------
+// vs_duckdb_scaling_reads — N concurrent COUNT(*) against ONE table
+// ---------------------------------------------------------------------------
+
+/// Owns both the pre-loaded Cayenne table and the matching DuckDB table.
+/// Built once at bench start; reused across every concurrency level so the
+/// data-load cost is paid exactly once.
+struct ReadFixtures {
+    cayenne: Arc<CayenneFixture>,
+    duckdb_conn: Arc<Connection>,
+    _duckdb_temp: tempfile::TempDir,
+    _parquet_dir: tempfile::TempDir,
+}
+
+async fn build_read_fixtures() -> ReadFixtures {
+    let cayenne_fixture = setup_cayenne("scaling_read").await;
+    let batch = make_batch(schema(), 0, READ_ROWS);
+    let _ = cayenne_insert(&cayenne_fixture.table, batch.clone()).await;
+
+    let duckdb_fixture = setup_duckdb("scaling_read");
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+    let parquet_path = parquet_dir.path().join("scaling_read.parquet");
+    write_parquet(&batch, &parquet_path);
+    duckdb_insert_parquet(&duckdb_fixture.conn, "scaling_read", &parquet_path);
+
+    ReadFixtures {
+        cayenne: Arc::new(cayenne_fixture),
+        duckdb_conn: Arc::new(duckdb_fixture.conn),
+        _duckdb_temp: duckdb_fixture._temp_dir,
+        _parquet_dir: parquet_dir,
+    }
+}
+
+fn bench_read_scaling(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_scaling_reads");
+    group.sample_size(10);
+
+    let fixtures = rt.block_on(build_read_fixtures());
+    // One warm session per Cayenne table, shared across all reader tasks for
+    // the entire bench run. Mirrors a long-lived Spice daemon holding a
+    // single SessionContext and serving many concurrent queries.
+    let warm_ctx = Arc::new(warm_session_for(&fixtures.cayenne.table));
+
+    for &concurrency in CONCURRENCIES {
+        group.throughput(Throughput::Elements(concurrency as u64));
+
+        let wc = Arc::clone(&warm_ctx);
+        group.bench_with_input(
+            BenchmarkId::new("cayenne_warm", concurrency),
+            &concurrency,
+            |b, &n| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let mut join_set = JoinSet::new();
+                        for _ in 0..n {
+                            let wc = Arc::clone(&wc);
+                            join_set.spawn(async move {
+                                let batches =
+                                    cayenne_query_warm(&wc, "SELECT COUNT(*) FROM t").await;
+                                black_box(batches);
+                            });
+                        }
+                        while let Some(result) = join_set.join_next().await {
+                            result.expect("cayenne reader task");
+                        }
+                    });
+                });
+            },
+        );
+
+        let conn = Arc::clone(&fixtures.duckdb_conn);
+        group.bench_with_input(
+            BenchmarkId::new("duckdb", concurrency),
+            &concurrency,
+            |b, &n| {
+                b.iter(|| {
+                    let mut handles = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        // duckdb-rs `Connection::try_clone` produces a separate
+                        // cursor sharing the same database; concurrent reads
+                        // are MVCC-safe.
+                        let conn_clone = conn.try_clone().expect("duckdb connection clone");
+                        handles.push(std::thread::spawn(move || {
+                            let mut stmt = conn_clone
+                                .prepare("SELECT COUNT(*) FROM scaling_read")
+                                .expect("prepare");
+                            let mut rows = stmt.query([]).expect("query");
+                            let row = rows.next().expect("next").expect("row");
+                            let value: i64 = row.get(0).expect("count");
+                            black_box(value);
+                        }));
+                    }
+                    for handle in handles {
+                        handle.join().expect("duckdb reader thread");
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// vs_duckdb_scaling_writes — N background writers sustaining inserts
+// ---------------------------------------------------------------------------
+
+/// Sustained-throughput Cayenne writer. Spawns one async task on the runtime
+/// that pumps `cayenne_insert` calls in a tight loop, counting completions.
+/// Dropping the writer stops the loop and joins the task — modeled after
+/// `CayenneBgWriter` in `vs_duckdb_concurrent.rs`, which is the
+/// known-working concurrent-write pattern in this crate.
+struct CayenneBgWriter {
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<tokio::task::JoinHandle<u64>>,
+    rt_handle: tokio::runtime::Handle,
+}
+
+impl CayenneBgWriter {
+    fn spawn(
+        rt: &Runtime,
+        fixture: &CayenneFixture,
+        counter: Arc<AtomicUsize>,
+        writer_id: i64,
+    ) -> Self {
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_clone = Arc::clone(&stop);
+        let table = Arc::clone(&fixture.table);
+        let handle = rt.spawn(async move {
+            let mut written = 0u64;
+            // Each writer uses a disjoint id range so concurrent writers
+            // never produce overlapping primary key candidates — keeps
+            // behavior deterministic across concurrency levels.
+            let id_stride = (WRITE_BATCH_ROWS as i64) * 1024 * 1024;
+            let mut cursor = writer_id * id_stride;
+            while !stop_clone.load(Ordering::Relaxed) {
+                let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
+                cursor += WRITE_BATCH_ROWS as i64;
+                if cayenne_insert(&table, batch).await > 0 {
+                    written += 1;
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            written
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+            rt_handle: rt.handle().clone(),
+        }
+    }
+}
+
+impl Drop for CayenneBgWriter {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            // Block the bench thread on writer settling. The bench thread is
+            // not a runtime worker, so block_on is safe here.
+            let _ = self.rt_handle.block_on(handle);
+        }
+    }
+}
+
+/// Sustained-throughput DuckDB writer. Same shape as `CayenneBgWriter` but
+/// uses a dedicated OS thread and a fresh DuckDB connection opened from the
+/// fixture's on-disk file. Each thread holds its own connection — DuckDB
+/// serializes commits internally, but we want concurrent writers to expose
+/// any reader-side contention on the shared database.
+struct DuckDbBgWriter {
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<std::thread::JoinHandle<u64>>,
+}
+
+impl DuckDbBgWriter {
+    fn spawn(db_path: &std::path::Path, counter: Arc<AtomicUsize>, writer_id: i64) -> Self {
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_clone = Arc::clone(&stop);
+        let db_path = db_path.to_path_buf();
+        let handle = std::thread::spawn(move || {
+            let conn = Connection::open(&db_path).expect("bg duckdb open");
+            let id_stride = (WRITE_BATCH_ROWS as i64) * 1024 * 1024;
+            let mut cursor = writer_id * id_stride;
+            let mut written = 0u64;
+            while !stop_clone.load(Ordering::Relaxed) {
+                let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
+                cursor += WRITE_BATCH_ROWS as i64;
+                duckdb_insert_rows(&conn, "scaling_write", &batch);
+                written += 1;
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+            written
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for DuckDbBgWriter {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn bench_write_scaling(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_scaling_writes");
+    group.sample_size(10);
+
+    for &concurrency in CONCURRENCIES {
+        group.throughput(Throughput::Elements(
+            (concurrency as u64) * (WRITE_BATCH_ROWS as u64),
+        ));
+
+        // --- Cayenne lane ---
+        let cayenne_fixture = rt.block_on(setup_cayenne("scaling_write"));
+        let cayenne_counter = Arc::new(AtomicUsize::new(0));
+        let mut cayenne_writers: Vec<CayenneBgWriter> = (0..concurrency)
+            .map(|i| {
+                CayenneBgWriter::spawn(
+                    &rt,
+                    &cayenne_fixture,
+                    Arc::clone(&cayenne_counter),
+                    i as i64,
+                )
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("cayenne", concurrency),
+            &concurrency,
+            |b, &_n| {
+                b.iter(|| {
+                    let start = cayenne_counter.load(Ordering::Relaxed);
+                    // Wait for one full pass (each writer contributes ≥1
+                    // insert) so a single iteration captures the full
+                    // concurrency cost — not just the latency of one of N
+                    // writers.
+                    let target = start + concurrency;
+                    while cayenne_counter.load(Ordering::Relaxed) < target {
+                        std::hint::spin_loop();
+                    }
+                    black_box(());
+                });
+            },
+        );
+
+        // Explicit drop order: writers first (stops the loops + joins the
+        // tasks), then the fixture (its TempDir cleans up the data).
+        cayenne_writers.drain(..);
+        drop(cayenne_fixture);
+
+        // --- DuckDB lane ---
+        let duckdb_fixture = setup_duckdb("scaling_write");
+        let duckdb_counter = Arc::new(AtomicUsize::new(0));
+        let duckdb_db_path = duckdb_fixture.db_path();
+        let mut duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
+            .map(|i| {
+                DuckDbBgWriter::spawn(
+                    &duckdb_db_path,
+                    Arc::clone(&duckdb_counter),
+                    i as i64,
+                )
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("duckdb", concurrency),
+            &concurrency,
+            |b, &_n| {
+                b.iter(|| {
+                    let start = duckdb_counter.load(Ordering::Relaxed);
+                    let target = start + concurrency;
+                    while duckdb_counter.load(Ordering::Relaxed) < target {
+                        std::hint::spin_loop();
+                    }
+                    black_box(());
+                });
+            },
+        );
+
+        duckdb_writers.drain(..);
+        drop(duckdb_fixture);
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_read_scaling, bench_write_scaling);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -68,7 +68,6 @@ mod common;
 
 use std::hint::black_box;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -384,78 +383,71 @@ fn bench_read_scaling(c: &mut Criterion) {
 // vs_duckdb_scaling_writes — N background writers sustaining inserts
 // ---------------------------------------------------------------------------
 
-/// Sustained-throughput Cayenne writer. Spawns one async task on the runtime
-/// that pumps `cayenne_insert` calls in a tight loop, signaling each
-/// completion through `tx`. Dropping the writer stops the loop and joins
-/// the task — modeled after `CayenneBgWriter` in `vs_duckdb_concurrent.rs`.
+/// Per-iteration Cayenne writer. Waits on its dedicated `go_rx` channel
+/// for a "do one insert" tick from the bench thread, executes one
+/// `cayenne_insert`, signals completion through the shared `done_tx`,
+/// then loops back to wait for the next tick. Workers exit cleanly when
+/// the bench drops its `go_tx` clone (recv returns None / Err).
+///
+/// Why not a sustained loop driven by `AtomicBool::stop`? Sustained
+/// writers race ahead between criterion iterations and leave completed
+/// messages backlogged in the shared channel, so the next iteration
+/// drains the backlog instantly and over-reports throughput. The
+/// go-signal pattern defines a clean iteration boundary: each iter
+/// measures exactly N **new** writes.
 struct CayenneBgWriter {
-    stop: Arc<AtomicBool>,
-    handle: Option<tokio::task::JoinHandle<u64>>,
-    rt_handle: tokio::runtime::Handle,
+    handle: tokio::task::JoinHandle<u64>,
 }
 
 impl CayenneBgWriter {
-    fn spawn(rt: &Runtime, fixture: &CayenneFixture, tx: mpsc::Sender<()>, writer_id: i64) -> Self {
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_clone = Arc::clone(&stop);
+    fn spawn(
+        rt: &Runtime,
+        fixture: &CayenneFixture,
+        mut go_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+        done_tx: mpsc::Sender<()>,
+        writer_id: i64,
+    ) -> Self {
         let table = Arc::clone(&fixture.table);
         let handle = rt.spawn(async move {
-            let mut written = 0u64;
             // Each writer uses a disjoint id range so concurrent writers
             // never produce overlapping primary key candidates — keeps
             // behavior deterministic across concurrency levels.
             let id_stride = (WRITE_BATCH_ROWS as i64) * 1024 * 1024;
             let mut cursor = writer_id * id_stride;
-            while !stop_clone.load(Ordering::Relaxed) {
+            let mut written = 0u64;
+            while go_rx.recv().await.is_some() {
                 let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
                 cursor += WRITE_BATCH_ROWS as i64;
                 if cayenne_insert(&table, batch).await > 0 {
                     written += 1;
-                    // Sender drop after stop is the normal teardown path;
-                    // ignore the error in that case.
-                    let _ = tx.send(());
                 }
+                // Always send a completion (even on a degenerate
+                // zero-rows-returned path) so the bench iter sees
+                // exactly N completions for N go ticks.
+                let _ = done_tx.send(());
             }
             written
         });
-        Self {
-            stop,
-            handle: Some(handle),
-            rt_handle: rt.handle().clone(),
-        }
+        Self { handle }
     }
 }
 
-impl Drop for CayenneBgWriter {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.handle.take() {
-            // Block the bench thread on writer settling. The bench thread is
-            // not a runtime worker, so block_on is safe here.
-            let _ = self.rt_handle.block_on(handle);
-        }
-    }
-}
-
-/// Sustained-throughput DuckDB writer. Same shape as `CayenneBgWriter` but
-/// uses a dedicated OS thread and a fresh DuckDB connection opened from the
-/// fixture's on-disk file. Each thread holds its own connection — DuckDB
-/// serializes commits internally, but we want concurrent writers to expose
-/// any reader-side contention on the shared database.
+/// Per-iteration DuckDB writer. Same go/done channel shape as
+/// [`CayenneBgWriter`], running on a dedicated OS thread with its own
+/// `Connection` opened from the shared DB path (`vs_duckdb_concurrent.rs:108`
+/// follows the same pattern — DuckDB connections aren't `Send`).
 struct DuckDbBgWriter {
-    stop: Arc<std::sync::atomic::AtomicBool>,
-    handle: Option<std::thread::JoinHandle<u64>>,
+    handle: std::thread::JoinHandle<u64>,
 }
 
 impl DuckDbBgWriter {
     fn spawn(
         db_path: &std::path::Path,
         table_name: &str,
-        tx: mpsc::Sender<()>,
+        go_rx: mpsc::Receiver<()>,
+        done_tx: mpsc::Sender<()>,
         writer_id: i64,
     ) -> Self {
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_clone = Arc::clone(&stop);
         let db_path = db_path.to_path_buf();
         let table_name = table_name.to_string();
         let handle = std::thread::spawn(move || {
@@ -463,28 +455,16 @@ impl DuckDbBgWriter {
             let id_stride = (WRITE_BATCH_ROWS as i64) * 1024 * 1024;
             let mut cursor = writer_id * id_stride;
             let mut written = 0u64;
-            while !stop_clone.load(Ordering::Relaxed) {
+            while go_rx.recv().is_ok() {
                 let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
                 cursor += WRITE_BATCH_ROWS as i64;
                 duckdb_insert_rows(&conn, &table_name, &batch);
                 written += 1;
-                let _ = tx.send(());
+                let _ = done_tx.send(());
             }
             written
         });
-        Self {
-            stop,
-            handle: Some(handle),
-        }
-    }
-}
-
-impl Drop for DuckDbBgWriter {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
+        Self { handle }
     }
 }
 
@@ -521,19 +501,32 @@ fn bench_write_scaling(c: &mut Criterion) {
 
             // --- Cayenne lane ---
             let cayenne_fixture = rt.block_on(setup_cayenne_for("scaling_write", lane));
-            // Each writer holds a clone of `cayenne_tx`; bench iter reads N
-            // completions from `cayenne_rx` via `wait_for_completions`
-            // (blocking, bounded timeout, surfaces a useful error if any
-            // writer stalls or panics).
-            let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
-            let cayenne_writers: Vec<CayenneBgWriter> = (0..concurrency)
-                .map(|i| {
-                    CayenneBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64)
-                })
-                .collect();
-            // Drop the spare sender so the channel closes naturally when
-            // all writers exit on the teardown signal.
-            drop(cayenne_tx);
+            // Per-iteration go-signaling: bench sends one tick per
+            // worker to start the iteration's writes; workers each do
+            // exactly ONE insert and send a completion. The bench iter
+            // then drains exactly `concurrency` completions. This
+            // defines a clean per-iteration boundary so backlog from
+            // criterion warm-up or inter-iteration drift can't inflate
+            // the measurement.
+            let (cayenne_done_tx, cayenne_done_rx) = mpsc::channel::<()>();
+            let mut cayenne_go_txs: Vec<tokio::sync::mpsc::UnboundedSender<()>> =
+                Vec::with_capacity(concurrency);
+            let mut cayenne_workers: Vec<CayenneBgWriter> = Vec::with_capacity(concurrency);
+            for i in 0..concurrency {
+                let (go_tx, go_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+                cayenne_go_txs.push(go_tx);
+                cayenne_workers.push(CayenneBgWriter::spawn(
+                    &rt,
+                    &cayenne_fixture,
+                    go_rx,
+                    cayenne_done_tx.clone(),
+                    i as i64,
+                ));
+            }
+            // Drop the bench's spare done sender so a stalled writer
+            // surfaces as a recv timeout / channel-closed error rather
+            // than a quiet hang.
+            drop(cayenne_done_tx);
 
             let bench_ctx = format!("vs_duckdb_scaling_writes/{lane_label}");
             group.bench_with_input(
@@ -541,24 +534,27 @@ fn bench_write_scaling(c: &mut Criterion) {
                 &concurrency,
                 |b, &_n| {
                     b.iter(|| {
-                        // Drain `concurrency` total completed inserts from
-                        // the shared channel — total system throughput
-                        // across N writers, not per-writer fairness. One
-                        // fast writer can contribute multiple of the N
-                        // counted messages in an iteration; by design for
-                        // a throughput-under-concurrency measurement.
-                        // criterion's `Throughput::Elements` divides by
-                        // `concurrency * WRITE_BATCH_ROWS` to report
-                        // per-worker throughput.
-                        wait_for_completions(&cayenne_rx, concurrency, &bench_ctx);
+                        // Kick off exactly one insert per worker for
+                        // this iteration.
+                        for tx in &cayenne_go_txs {
+                            tx.send(()).expect("cayenne go-tx (worker exited?)");
+                        }
+                        // Then drain exactly N new completions. The
+                        // `Throughput::Elements` configuration above
+                        // divides this iteration's wall time by
+                        // `concurrency * WRITE_BATCH_ROWS` so criterion
+                        // reports per-worker throughput.
+                        wait_for_completions(&cayenne_done_rx, concurrency, &bench_ctx);
                     });
                 },
             );
 
-            // Explicit drop order: writers first (stops the loops + joins
-            // the tasks), then the fixture (its TempDir cleans up the
-            // data).
-            drop(cayenne_writers);
+            // Teardown: drop the go senders to close each worker's
+            // receiver, then await each writer.
+            cayenne_go_txs.clear();
+            for w in cayenne_workers.drain(..) {
+                let _ = rt.block_on(async { w.handle.await });
+            }
             drop(cayenne_fixture);
         }
     }
@@ -571,29 +567,34 @@ fn bench_write_scaling(c: &mut Criterion) {
             (concurrency as u64) * (WRITE_BATCH_ROWS as u64),
         ));
 
-        // --- DuckDB lane ---
         let duckdb_fixture = setup_duckdb("scaling_write");
         let duckdb_db_path = duckdb_fixture.db_path();
-        let (duckdb_tx, duckdb_rx) = mpsc::channel::<()>();
-        let duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
-            .map(|i| {
-                DuckDbBgWriter::spawn(
-                    &duckdb_db_path,
-                    "scaling_write",
-                    duckdb_tx.clone(),
-                    i as i64,
-                )
-            })
-            .collect();
-        drop(duckdb_tx);
+        let (duckdb_done_tx, duckdb_done_rx) = mpsc::channel::<()>();
+        let mut duckdb_go_txs: Vec<mpsc::Sender<()>> = Vec::with_capacity(concurrency);
+        let mut duckdb_workers: Vec<DuckDbBgWriter> = Vec::with_capacity(concurrency);
+        for i in 0..concurrency {
+            let (go_tx, go_rx) = mpsc::channel::<()>();
+            duckdb_go_txs.push(go_tx);
+            duckdb_workers.push(DuckDbBgWriter::spawn(
+                &duckdb_db_path,
+                "scaling_write",
+                go_rx,
+                duckdb_done_tx.clone(),
+                i as i64,
+            ));
+        }
+        drop(duckdb_done_tx);
 
         group.bench_with_input(
             BenchmarkId::new("duckdb", concurrency),
             &concurrency,
             |b, &_n| {
                 b.iter(|| {
+                    for tx in &duckdb_go_txs {
+                        tx.send(()).expect("duckdb go-tx (worker exited?)");
+                    }
                     wait_for_completions(
-                        &duckdb_rx,
+                        &duckdb_done_rx,
                         concurrency,
                         "vs_duckdb_scaling_writes/duckdb",
                     );
@@ -601,7 +602,10 @@ fn bench_write_scaling(c: &mut Criterion) {
             },
         );
 
-        drop(duckdb_writers);
+        duckdb_go_txs.clear();
+        for w in duckdb_workers.drain(..) {
+            let _ = w.handle.join();
+        }
         drop(duckdb_fixture);
     }
 
@@ -612,50 +616,40 @@ fn bench_write_scaling(c: &mut Criterion) {
 // vs_duckdb_scaling_cdc — sustained CDC pipelined writes
 // ---------------------------------------------------------------------------
 
-/// Sustained-throughput Cayenne CDC writer. Same shape as `CayenneBgWriter`
-/// but pumps `write_cdc_append_stream` + `finish()` (the production CDC
-/// pipelined path used by `refresh_mode: changes`) instead of the generic
-/// `insert_into`. Lets us see whether the Stage-A / Stage-B split actually
-/// translates into higher sustained throughput vs the regular write path.
+/// Per-iteration Cayenne CDC writer. Same go/done shape as
+/// [`CayenneBgWriter`] but pumps `write_cdc_append_stream` + `finish()`
+/// (the production CDC pipelined path used by `refresh_mode: changes`)
+/// instead of `insert_into`. Lets us compare the Stage-A / Stage-B
+/// split against the generic write path under the same per-iteration
+/// boundary discipline.
 struct CayenneCdcBgWriter {
-    stop: Arc<AtomicBool>,
-    handle: Option<tokio::task::JoinHandle<u64>>,
-    rt_handle: tokio::runtime::Handle,
+    handle: tokio::task::JoinHandle<u64>,
 }
 
 impl CayenneCdcBgWriter {
-    fn spawn(rt: &Runtime, fixture: &CayenneFixture, tx: mpsc::Sender<()>, writer_id: i64) -> Self {
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_clone = Arc::clone(&stop);
+    fn spawn(
+        rt: &Runtime,
+        fixture: &CayenneFixture,
+        mut go_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+        done_tx: mpsc::Sender<()>,
+        writer_id: i64,
+    ) -> Self {
         let table = Arc::clone(&fixture.table);
         let handle = rt.spawn(async move {
-            let mut written = 0u64;
             let id_stride = (WRITE_BATCH_ROWS as i64) * 1024 * 1024;
             let mut cursor = writer_id * id_stride;
-            while !stop_clone.load(Ordering::Relaxed) {
+            let mut written = 0u64;
+            while go_rx.recv().await.is_some() {
                 let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
                 cursor += WRITE_BATCH_ROWS as i64;
                 if cayenne_cdc_write(&table, batch).await > 0 {
                     written += 1;
-                    let _ = tx.send(());
                 }
+                let _ = done_tx.send(());
             }
             written
         });
-        Self {
-            stop,
-            handle: Some(handle),
-            rt_handle: rt.handle().clone(),
-        }
-    }
-}
-
-impl Drop for CayenneCdcBgWriter {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.handle.take() {
-            let _ = self.rt_handle.block_on(handle);
-        }
+        Self { handle }
     }
 }
 
@@ -684,13 +678,22 @@ fn bench_cdc_scaling(c: &mut Criterion) {
             ));
 
             let cayenne_fixture = rt.block_on(setup_cayenne_for("scaling_cdc", lane));
-            let (cayenne_tx, cayenne_rx) = mpsc::channel::<()>();
-            let cayenne_writers: Vec<CayenneCdcBgWriter> = (0..concurrency)
-                .map(|i| {
-                    CayenneCdcBgWriter::spawn(&rt, &cayenne_fixture, cayenne_tx.clone(), i as i64)
-                })
-                .collect();
-            drop(cayenne_tx);
+            let (cayenne_done_tx, cayenne_done_rx) = mpsc::channel::<()>();
+            let mut cayenne_go_txs: Vec<tokio::sync::mpsc::UnboundedSender<()>> =
+                Vec::with_capacity(concurrency);
+            let mut cayenne_workers: Vec<CayenneCdcBgWriter> = Vec::with_capacity(concurrency);
+            for i in 0..concurrency {
+                let (go_tx, go_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+                cayenne_go_txs.push(go_tx);
+                cayenne_workers.push(CayenneCdcBgWriter::spawn(
+                    &rt,
+                    &cayenne_fixture,
+                    go_rx,
+                    cayenne_done_tx.clone(),
+                    i as i64,
+                ));
+            }
+            drop(cayenne_done_tx);
 
             let bench_ctx = format!("vs_duckdb_scaling_cdc/{lane_label}");
             group.bench_with_input(
@@ -698,12 +701,18 @@ fn bench_cdc_scaling(c: &mut Criterion) {
                 &concurrency,
                 |b, &_n| {
                     b.iter(|| {
-                        wait_for_completions(&cayenne_rx, concurrency, &bench_ctx);
+                        for tx in &cayenne_go_txs {
+                            tx.send(()).expect("cayenne cdc go-tx (worker exited?)");
+                        }
+                        wait_for_completions(&cayenne_done_rx, concurrency, &bench_ctx);
                     });
                 },
             );
 
-            drop(cayenne_writers);
+            cayenne_go_txs.clear();
+            for w in cayenne_workers.drain(..) {
+                let _ = rt.block_on(async { w.handle.await });
+            }
             drop(cayenne_fixture);
         }
     }
@@ -719,25 +728,43 @@ fn bench_cdc_scaling(c: &mut Criterion) {
 
         let duckdb_fixture = setup_duckdb("scaling_cdc");
         let duckdb_db_path = duckdb_fixture.db_path();
-        let (duckdb_tx, duckdb_rx) = mpsc::channel::<()>();
-        let duckdb_writers: Vec<DuckDbBgWriter> = (0..concurrency)
-            .map(|i| {
-                DuckDbBgWriter::spawn(&duckdb_db_path, "scaling_cdc", duckdb_tx.clone(), i as i64)
-            })
-            .collect();
-        drop(duckdb_tx);
+        let (duckdb_done_tx, duckdb_done_rx) = mpsc::channel::<()>();
+        let mut duckdb_go_txs: Vec<mpsc::Sender<()>> = Vec::with_capacity(concurrency);
+        let mut duckdb_workers: Vec<DuckDbBgWriter> = Vec::with_capacity(concurrency);
+        for i in 0..concurrency {
+            let (go_tx, go_rx) = mpsc::channel::<()>();
+            duckdb_go_txs.push(go_tx);
+            duckdb_workers.push(DuckDbBgWriter::spawn(
+                &duckdb_db_path,
+                "scaling_cdc",
+                go_rx,
+                duckdb_done_tx.clone(),
+                i as i64,
+            ));
+        }
+        drop(duckdb_done_tx);
 
         group.bench_with_input(
             BenchmarkId::new("duckdb", concurrency),
             &concurrency,
             |b, &_n| {
                 b.iter(|| {
-                    wait_for_completions(&duckdb_rx, concurrency, "vs_duckdb_scaling_cdc/duckdb");
+                    for tx in &duckdb_go_txs {
+                        tx.send(()).expect("duckdb cdc go-tx (worker exited?)");
+                    }
+                    wait_for_completions(
+                        &duckdb_done_rx,
+                        concurrency,
+                        "vs_duckdb_scaling_cdc/duckdb",
+                    );
                 });
             },
         );
 
-        drop(duckdb_writers);
+        duckdb_go_txs.clear();
+        for w in duckdb_workers.drain(..) {
+            let _ = w.handle.join();
+        }
         drop(duckdb_fixture);
     }
 

--- a/crates/cayenne/benches/vs_duckdb_scaling.rs
+++ b/crates/cayenne/benches/vs_duckdb_scaling.rs
@@ -76,6 +76,21 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use duckdb::Connection;
 use tokio::runtime::Runtime;
 
+/// Whether the given Cayenne metastore lane is exercised by the
+/// sustained-writes scaling benches. Returns `false` for Turso today —
+/// the sustained-writes pattern (one fixture, many writes through a
+/// single writer task) reproducibly trips Turso's optimistic concurrency
+/// control. The reader scaling bench is unaffected and still runs both
+/// lanes. See the comment at the top of `bench_write_scaling` for the
+/// full story and the follow-up plan.
+fn lane_supports_sustained_writes(lane: common::Metastore) -> bool {
+    match lane {
+        common::Metastore::Sqlite => true,
+        #[cfg(feature = "turso")]
+        common::Metastore::Turso => false,
+    }
+}
+
 /// Bounded-timeout wait for `n` writer-completion signals. Replaces the
 /// earlier `AtomicUsize` + `std::hint::spin_loop` pattern that burned an
 /// entire core on the bench thread and could hang indefinitely if a writer
@@ -482,7 +497,22 @@ fn bench_write_scaling(c: &mut Criterion) {
     // Each (lane, concurrency) point gets a fresh fixture because writes
     // accumulate state on disk and we want every measurement to start
     // from an empty table.
+    //
+    // Turso writes are intentionally skipped here. The sustained-writes
+    // pattern this bench uses (one fixture, many writes from a single
+    // writer task) reproducibly trips Turso's optimistic concurrency
+    // control on the very first insert with
+    // `"Failed to commit transaction: Write-write conflict"`. The
+    // existing `vs_duckdb_burst/cayenne_turso/*` and
+    // `vs_duckdb_upsert/cayenne_turso/*` benches do work because they
+    // use `iter_batched` with a fresh fixture per criterion sample, so
+    // writes never stack against one Turso instance. The interaction
+    // between Cayenne's mutation path and Turso's K=16 pool needs its
+    // own follow-up — track at the issue named in the PR description.
     for &lane in CAYENNE_LANES {
+        if !lane_supports_sustained_writes(lane) {
+            continue;
+        }
         let lane_label = lane.lane().to_string();
         for &concurrency in CONCURRENCIES {
             group.throughput(Throughput::Elements(
@@ -639,7 +669,14 @@ fn bench_cdc_scaling(c: &mut Criterion) {
     // but the Cayenne writer pumps `write_cdc_append_stream + finish()`
     // instead of `insert_into`. Lane id is `cayenne_cdc` (Sqlite) or
     // `cayenne_turso_cdc` (Turso).
+    //
+    // Turso CDC is skipped here for the same sustained-writes /
+    // write-write-conflict reason as `bench_write_scaling` — see the
+    // long comment there.
     for &lane in CAYENNE_LANES {
+        if !lane_supports_sustained_writes(lane) {
+            continue;
+        }
         let lane_label = format!("{}_cdc", lane.lane());
         for &concurrency in CONCURRENCIES {
             group.throughput(Throughput::Elements(

--- a/crates/cayenne/benches/vs_duckdb_scan.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan.rs
@@ -32,8 +32,8 @@ use tokio::runtime::Runtime;
 
 use common::{
     CayenneFixture, DuckDbFixture, capture_comparison_plans, cayenne_insert, cayenne_query,
-    duckdb_insert_parquet, duckdb_query_scalar, make_batch, schema, setup_cayenne, setup_duckdb,
-    write_parquet,
+    cayenne_query_warm, duckdb_insert_parquet, duckdb_query_scalar, make_batch, schema,
+    setup_cayenne, setup_duckdb, warm_session_for, write_parquet,
 };
 
 const ROW_COUNTS: &[usize] = &[16_384, 131_072, 1_048_576];
@@ -85,6 +85,12 @@ fn bench_scan(c: &mut Criterion) {
             "SELECT SUM(value) FROM scan_bench",
         ));
 
+        // Long-lived SessionContext for the cayenne_warm/ lane. This measures
+        // Cayenne under steady-state session reuse — what a running Spice
+        // daemon actually pays per query, vs the cold-session path measured by
+        // the existing cayenne/ lane.
+        let warm_ctx = Arc::new(warm_session_for(&cayenne_fixture.table));
+
         // --- count_star ---
         let cf = Arc::clone(&cayenne_fixture);
         group.bench_with_input(
@@ -94,6 +100,19 @@ fn bench_scan(c: &mut Criterion) {
                 b.iter(|| {
                     rt.block_on(async {
                         let batches = cayenne_query(&cf.table, "SELECT COUNT(*) FROM t").await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let wc = Arc::clone(&warm_ctx);
+        group.bench_with_input(
+            BenchmarkId::new("cayenne_warm/count_star", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query_warm(&wc, "SELECT COUNT(*) FROM t").await;
                         black_box(batches);
                     });
                 });
@@ -120,6 +139,19 @@ fn bench_scan(c: &mut Criterion) {
                 b.iter(|| {
                     rt.block_on(async {
                         let batches = cayenne_query(&cf.table, "SELECT SUM(value) FROM t").await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let wc = Arc::clone(&warm_ctx);
+        group.bench_with_input(
+            BenchmarkId::new("cayenne_warm/sum_value", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query_warm(&wc, "SELECT SUM(value) FROM t").await;
                         black_box(batches);
                     });
                 });
@@ -161,6 +193,20 @@ fn bench_scan(c: &mut Criterion) {
                 b.iter(|| {
                     rt.block_on(async {
                         let batches = cayenne_query(&cf.table, &cayenne_sql_owned).await;
+                        black_box(batches);
+                    });
+                });
+            },
+        );
+        let wc = Arc::clone(&warm_ctx);
+        let cayenne_sql_warm = cayenne_sql.clone();
+        group.bench_with_input(
+            BenchmarkId::new("cayenne_warm/filter_sum", rows),
+            &rows,
+            |b, &_rows| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let batches = cayenne_query_warm(&wc, &cayenne_sql_warm).await;
                         black_box(batches);
                     });
                 });

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -40,8 +40,15 @@ const DELETE_FILE_TABLE_UNIQUE_INDEX_DDL: &str = "CREATE UNIQUE INDEX IF NOT EXI
 /// for N > K callers share proportionally, reducing the per-table wait from
 /// O(N·RTT) to O(⌈N/K⌉·RTT).
 ///
-/// Pool size is `min(available_parallelism, 8)` (minimum 2). Beyond 8,
-/// `SQLite`'s WAL write serialization is typically the limiting factor anyway.
+/// Pool size is `min(available_parallelism, 32)` (minimum 2). SQLite WAL mode
+/// allows many concurrent readers per database file (read-only operations
+/// don't take the WAL write lock), so a larger pool lifts the read-side
+/// concurrency ceiling for metadata-heavy workloads — e.g. 64-core deployments
+/// running concurrent scans against many tables, where every scan pays one or
+/// more metastore reads (table metadata, snapshot file lists, deletion-vector
+/// loads, stats lookups). Writes still serialize at the WAL layer regardless
+/// of pool size; this is fine because writes are O(commits-per-second) while
+/// reads are O(queries-per-second × per-query-metadata-fanout).
 struct SqliteConnectionPool {
     conns: Vec<Arc<Mutex<tokio_rusqlite::Connection>>>,
     next: AtomicUsize,
@@ -76,9 +83,9 @@ pub struct SqliteMetastore {
     /// Round-robin pool of K independent connections shared across all
     /// operations (reads, writes, and transactions).
     ///
-    /// K = `min(available_parallelism, 8)` (minimum 2). Lazily initialised on
-    /// first use. `begin_transaction` holds an [`OwnedMutexGuard`] on one pool
-    /// slot for the full transaction lifetime.
+    /// K = `min(available_parallelism, 32)` (minimum 2). Lazily initialised
+    /// on first use. `begin_transaction` holds an [`OwnedMutexGuard`] on one
+    /// pool slot for the full transaction lifetime.
     pool: OnceCell<Arc<SqliteConnectionPool>>,
 }
 
@@ -198,7 +205,7 @@ impl SqliteMetastore {
 
     /// Return the connection pool, initialising it lazily on first call.
     ///
-    /// Opens K = `min(available_parallelism, 8)` (minimum 2) connections once
+    /// Opens K = `min(available_parallelism, 32)` (minimum 2) connections once
     /// and reuses them for the lifetime of the metastore. All operations draw
     /// from the same pool; `begin_transaction` holds an [`OwnedMutexGuard`]
     /// on the acquired slot for the full transaction lifetime.
@@ -206,7 +213,7 @@ impl SqliteMetastore {
         self.pool
             .get_or_try_init(|| async {
                 let k = std::thread::available_parallelism()
-                    .map_or(4, |n| n.get().min(8))
+                    .map_or(4, |n| n.get().min(32))
                     .max(2);
                 let mut conns = Vec::with_capacity(k);
                 for _ in 0..k {

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -40,15 +40,18 @@ const DELETE_FILE_TABLE_UNIQUE_INDEX_DDL: &str = "CREATE UNIQUE INDEX IF NOT EXI
 /// for N > K callers share proportionally, reducing the per-table wait from
 /// O(N·RTT) to O(⌈N/K⌉·RTT).
 ///
-/// Pool size is `min(available_parallelism, 32)` (minimum 2). SQLite WAL mode
-/// allows many concurrent readers per database file (read-only operations
-/// don't take the WAL write lock), so a larger pool lifts the read-side
-/// concurrency ceiling for metadata-heavy workloads — e.g. 64-core deployments
-/// running concurrent scans against many tables, where every scan pays one or
-/// more metastore reads (table metadata, snapshot file lists, deletion-vector
-/// loads, stats lookups). Writes still serialize at the WAL layer regardless
-/// of pool size; this is fine because writes are O(commits-per-second) while
-/// reads are O(queries-per-second × per-query-metadata-fanout).
+/// Pool size is `min(available_parallelism, 32)` (minimum 2). If
+/// `available_parallelism()` fails (rare — e.g. seccomp-restricted
+/// environments), K falls back to 4. SQLite WAL mode allows many
+/// concurrent readers per database file (read-only operations don't take
+/// the WAL write lock), so a larger pool lifts the read-side concurrency
+/// ceiling for metadata-heavy workloads — e.g. 64-core deployments running
+/// concurrent scans against many tables, where every scan pays one or more
+/// metastore reads (table metadata, snapshot file lists, deletion-vector
+/// loads, stats lookups). Writes still serialize at the WAL layer
+/// regardless of pool size; this is fine because writes are
+/// O(commits-per-second) while reads are
+/// O(queries-per-second × per-query-metadata-fanout).
 struct SqliteConnectionPool {
     conns: Vec<Arc<Mutex<tokio_rusqlite::Connection>>>,
     next: AtomicUsize,
@@ -83,9 +86,12 @@ pub struct SqliteMetastore {
     /// Round-robin pool of K independent connections shared across all
     /// operations (reads, writes, and transactions).
     ///
-    /// K = `min(available_parallelism, 32)` (minimum 2). Lazily initialised
-    /// on first use. `begin_transaction` holds an [`OwnedMutexGuard`] on one
-    /// pool slot for the full transaction lifetime.
+    /// K = `min(available_parallelism, 32)` (or 4 if
+    /// `available_parallelism()` fails, with a minimum of 2 — see the
+    /// [`SqliteConnectionPool`] doc comment for the rationale). Lazily
+    /// initialised on first use. `begin_transaction` holds an
+    /// [`OwnedMutexGuard`] on one pool slot for the full transaction
+    /// lifetime.
     pool: OnceCell<Arc<SqliteConnectionPool>>,
 }
 

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -205,10 +205,13 @@ impl SqliteMetastore {
 
     /// Return the connection pool, initialising it lazily on first call.
     ///
-    /// Opens K = `min(available_parallelism, 32)` (minimum 2) connections once
-    /// and reuses them for the lifetime of the metastore. All operations draw
-    /// from the same pool; `begin_transaction` holds an [`OwnedMutexGuard`]
-    /// on the acquired slot for the full transaction lifetime.
+    /// Opens K = `min(available_parallelism, 32)` connections once and reuses
+    /// them for the lifetime of the metastore. If `available_parallelism()`
+    /// fails (rare — e.g. seccomp-restricted environments), K falls back to
+    /// 4. K is then clamped to a minimum of 2 so single-core systems still
+    /// have one slot reserved for read-while-write. All operations draw from
+    /// the same pool; `begin_transaction` holds an [`OwnedMutexGuard`] on
+    /// the acquired slot for the full transaction lifetime.
     async fn pool(&self) -> CatalogResult<&Arc<SqliteConnectionPool>> {
         self.pool
             .get_or_try_init(|| async {


### PR DESCRIPTION
## Summary

- Bump SQLite metastore connection pool cap from K=8 to K=32 so metadata-heavy concurrent workloads stop bottlenecking at 8 in-flight ops. SQLite WAL allows many concurrent readers; writes still serialize at WAL. Turso already runs K=16; this brings SQLite closer to parity.
- Add `crates/cayenne/benches/vs_duckdb_scaling.rs` — head-to-head concurrent throughput benchmark at **1 / 2 / 4 / 8 / 16 / 32 / 64 / 128 workers** across **three workloads** (reads, generic writes, CDC pipelined writes) and across **both Cayenne metastore backends** (`sqlite` and `turso` when the `turso` feature is enabled). DuckDB runs once per workload as the external baseline.
- Workers are pooled per concurrency level (spawned once); each iteration uses **per-worker go-channels** and drains exactly N completions — no per-iteration thread spawn inside the timed region, no inter-iteration backlog. Cayenne CDC writers cache one `SessionContext` per writer for batch-level reuse (matches the production refresh loop).
- Bundle two pre-requisite fixes the bench sweep surfaced: missing `use datafusion::catalog::TableProvider` in `vs_duckdb_delete.rs` and `vs_duckdb_in_list_delete.rs` (didn't compile before), and a `cayenne_warm/` lane in `vs_duckdb_scan` that shares a long-lived `SessionContext` across iterations.

## Results

Captured locally. Numbers are criterion medians. Per-iteration values include the wall time to drain N completions, i.e. the full cost of one round of N concurrent operations.

### Reads — `vs_duckdb_scaling_reads` (1 M-row table, `SELECT COUNT(*)`)

| Concurrency | cayenne_warm | cayenne_turso_warm | **DuckDB** |
|---:|---:|---:|---:|
| 1   | 122 µs   | 120 µs   | **45 µs**   |
| 2   | 144 µs   | 138 µs   | **57 µs**   |
| 4   | 168 µs   | 181 µs   | **79 µs**   |
| 8   | 344 µs   | 365 µs   | **152 µs**  |
| 16  | 561 µs   | 586 µs   | **286 µs**  |
| 32  | 1.00 ms  | 1.05 ms  | **614 µs**  |
| 64  | 1.96 ms  | 2.01 ms  | **1.18 ms** |
| 128 | 3.82 ms  | 4.10 ms  | **2.57 ms** |

**DuckDB is consistently 1.5–2.7× faster on reads at every concurrency.** All three lanes scale near-linearly through 128 workers — neither engine hits a contention cliff. SQLite and Turso metastore lanes are within noise of each other across the entire sweep.

### Writes — `vs_duckdb_scaling_writes` (sustained insert throughput, 1 024 rows per batch)

| Concurrency | **cayenne (sqlite)** | DuckDB | Cayenne advantage |
|---:|---:|---:|---:|
| 1   | **1.03 ms**  | 5.46 ms  | 5.3× faster |
| 2   | **2.39 ms**  | 9.56 ms  | 4.0× |
| 4   | **3.73 ms**  | 16.03 ms | 4.3× |
| 8   | **6.26 ms**  | 20.15 ms | 3.2× |
| 16  | **12.85 ms** | 40.06 ms | 3.1× |
| 32  | **18.91 ms** | 77.32 ms | 4.1× |
| 64  | **30.96 ms** | 153.85 ms | 5.0× |
| 128 | **54.33 ms** | 311.68 ms | 5.7× |

Aggregate throughput at concurrency 128: **Cayenne ≈ 2.41 M rows/sec, DuckDB ≈ 420 K rows/sec**. Cayenne writes are 3–6× faster than DuckDB at every concurrency level and the lead grows with N. DuckDB latency degrades superlinearly past 16 writers; Cayenne stays smooth through 128.

### CDC pipelined — `vs_duckdb_scaling_cdc` (`write_cdc_append_stream` + `finish()`)

| Concurrency | **cayenne_cdc (sqlite)** | DuckDB INSERT | Cayenne advantage |
|---:|---:|---:|---:|
| 1   | **921 µs**   | 5.00 ms   | 5.4× faster |
| 2   | **2.14 ms**  | 8.88 ms   | 4.1× |
| 4   | **3.74 ms**  | 13.48 ms  | 3.6× |
| 8   | **5.91 ms**  | 19.12 ms  | 3.2× |
| 16  | **11.91 ms** | 34.44 ms  | 2.9× |
| 32  | **17.12 ms** | 67.04 ms  | 3.9× |
| 64  | **26.72 ms** | 134.13 ms | 5.0× |
| 128 | **45.46 ms** | 268.60 ms | 5.9× |

Aggregate throughput at concurrency 128: **Cayenne CDC ≈ 2.88 M rows/sec, DuckDB INSERT ≈ 488 K rows/sec**. CDC pipelined throughput is within noise of the generic insert path — they share `mutation_writer.rs` and `staging_wal.rs` underneath, as expected. The Stage-A / Stage-B split benefits CDC clients in the *latency* axis (caller can commit source offset after Stage A) which this bench doesn't measure.

### Turso write & CDC are skipped here — known concurrency finding

The first attempt at adding turso to the write/CDC sweeps reproducibly panicked on the first insert with:

```
External(Catalog { source: InvalidOperation {
    message: "Failed to commit inline mutation transaction",
    source: Database { message: "Failed to commit transaction: Write-write conflict" }
}})
```

- The existing `vs_duckdb_burst/cayenne_turso/*` and `vs_duckdb_upsert/cayenne_turso/*` benches exercise turso writes and *do* work, because they use `iter_batched` with a fresh fixture per criterion sample.
- The sustained-writes pattern in this bench (one fixture, many writes from a single writer task) **reproducibly** trips Turso's optimistic concurrency control.
- The reader scaling bench is unaffected (Turso reads through 128 are within noise of SQLite reads above).

Hypothesis: Cayenne's mutation path fans out across multiple Turso pool connections (round-robin K=16) for what's logically one transaction; Turso treats those as conflicting concurrent writes. SQLite WAL is more permissive in the same workload. Filed as a separate finding — `lane_supports_sustained_writes()` in `vs_duckdb_scaling.rs` gates the sustained-writes lanes behind that check until it's resolved.

## Test plan

- [ ] `cargo build --release --package cayenne --benches --features "duckdb-bench turso"` succeeds
- [ ] Run `cargo bench --bench vs_duckdb_scaling --features "duckdb-bench turso"` — all three workloads × 8 concurrency levels run cleanly:
  - reads: `cayenne_warm` (sqlite), `cayenne_turso_warm`, `duckdb` — 24 cells
  - writes: `cayenne` (sqlite), `duckdb` — 16 cells (turso skipped, see above)
  - cdc: `cayenne_cdc` (sqlite), `duckdb` — 16 cells (turso skipped)
- [ ] `vs_duckdb_concurrent` bench produces unchanged numbers — pool widening only adds connections, doesn't change semantics
- [ ] `cayenne_warm/` lane in `vs_duckdb_scan` shaves ~80 µs/query off the existing cold `cayenne/` lane

## Scope NOT in this PR

- 51× `vs_duckdb_concurrent/scan_under_write` gap. Reader-blocks-on-writer specifically. Architectural fix is to migrate scan path off `listing_fence.read()` to a manifest-tracked file index. Multi-week PR.
- Turso sustained-write conflict (new finding from this PR's bench). Needs Cayenne mutation path to pin a logical transaction to one pool connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)