### PR TITLE
docs(release): update v2.0.0-rc.5 notes with latest trunk PRs

### DIFF
--- a/docs/release_notes/v2.0.0-rc.5.md
+++ b/docs/release_notes/v2.0.0-rc.5.md
@@ -35,30 +35,30 @@ Highlights in this release candidate include:
 
 Several performance and correctness improvements for Cayenne-backed catalogs and accelerators, grouped by area:
 
-**CDC, write, and ingest throughput**
+#### CDC, Write, and Ingest Throughput
 
 - **CDC throughput, compaction, and scan caching** ([#10852](https://github.com/spiceai/spiceai/pull/10852)): End-to-end improvements to Cayenne CDC ingest throughput, background compaction, and a new scan-result cache for hot reads, with accompanying benchmark coverage.
 - **Parallel Vortex writes** ([#10822](https://github.com/spiceai/spiceai/pull/10822)): Cayenne now writes to multiple Vortex partitions in parallel, reducing ingest latency for large batch writes.
 - **Lock-free deletion caches with bloom-prefiltered probe** ([#10756](https://github.com/spiceai/spiceai/pull/10756)): Deletion tracking uses a lock-free cache with a bloom filter pre-check, significantly reducing contention and false-positive probe cost during high-throughput CDC.
 - **Inline mutations and memtable scaling** ([#10792](https://github.com/spiceai/spiceai/pull/10792), [#10811](https://github.com/spiceai/spiceai/pull/10811)): Cayenne now supports inline mutations against in-memory tables, with improved scaling for mutation, scan, and memtable operations.
 - **Background retention with CDC pipelining for retention-configured tables** ([#10936](https://github.com/spiceai/spiceai/pull/10936)): Retention enforcement runs on a background task and CDC ingest pipelining is enabled by default for tables with a configured retention policy, removing retention as a foreground tax on streaming writes.
-- **Metastore pool scaled to 32 with scaling benches** ([#10943](https://github.com/spiceai/spiceai/pull/10943)): Cayenne's metastore connection pool is scaled to 32 to better serve high-concurrency mutation workloads, with new `vs_duckdb_scaling` benches that sweep 1→128 concurrency across SQLite and Turso metastore lanes.
+- **SQLite metastore pool scaled to 32 with scaling benches** ([#10943](https://github.com/spiceai/spiceai/pull/10943)): Cayenne's SQLite metastore connection pool is scaled to 32 to better serve high-concurrency mutation workloads, with new `vs_duckdb_scaling` benches that sweep 1→128 concurrency across SQLite and Turso metastore lanes.
 
-**Query planning and predicate pushdown**
+#### Query Planning and Predicate Pushdown
 
 - **Join filter propagation** ([#10840](https://github.com/spiceai/spiceai/pull/10840), [#10818](https://github.com/spiceai/spiceai/pull/10818)): Filters from join conditions are propagated across equi-join keys, enabling more aggressive predicate pushdown and eliminating full-partition scans on the probe side. The propagator now also requires dim-side statistics to be safe ([#10863](https://github.com/spiceai/spiceai/pull/10863)).
 - **Range fallback for large join filters** ([#10816](https://github.com/spiceai/spiceai/pull/10816)): Cayenne falls back to a range filter when an in-list join filter would exceed safe planning bounds.
 - **Hot-path clone elimination, PK point-lookup fanout fix, and IN-list rewrite** ([#10916](https://github.com/spiceai/spiceai/pull/10916)): Removes redundant `Arc` and buffer clones on Cayenne hot paths, fixes excessive partition fanout for primary-key point lookups, and rewrites large IN-list filters into a more efficient form; includes microbench coverage to lock in the improvements.
 - **Cayenne HashJoin rewriter disabled** ([#10882](https://github.com/spiceai/spiceai/pull/10882)): The Cayenne HashJoin rewriter optimizer is disabled by default after correctness regressions on specific join shapes.
 
-**Correctness and data integrity**
+#### Correctness and Data Integrity
 
 - **Synchronized partition commits** ([#10819](https://github.com/spiceai/spiceai/pull/10819)): Partition commits are now coordinated across all partitions, preventing partial-visibility inconsistencies in concurrent write workloads.
 - **NULL sentinel for nullable partition expressions** ([#10880](https://github.com/spiceai/spiceai/pull/10880)): Partition expressions over nullable columns (e.g. `bucket(N, col)`) now correctly handle the `NULL` sentinel value during partition pruning, fixing a class of incorrect-result bugs on Cayenne-partitioned tables with nullable partition keys.
 - **Vortex panic on highly compressible data fixed** ([#10855](https://github.com/spiceai/spiceai/pull/10855)): Cayenne no longer panics when Vortex encounters highly compressible columns; the affected encoder path now returns cleanly.
 - **Live protected snapshots after cleanup grace period** ([#10901](https://github.com/spiceai/spiceai/pull/10901)): Cayenne now reads through to live data when a protected snapshot has passed its cleanup grace period, avoiding stale snapshot reads.
 
-**Catalog, configuration, and platform**
+#### Catalog, Configuration, and Platform
 
 - **Catalog maintenance, atomic on-conflict deletions, and refresh-mode tuning** ([#10904](https://github.com/spiceai/spiceai/pull/10904)): A new `commit_on_conflict_deletions` catalog transaction lands delete-file rows and insert-record rows atomically, protected-snapshot deletion indexes are reused with sequence cutoffs instead of rebuilt per snapshot, table statistics are cached under a single provider cache, and Cayenne compaction and inline-write defaults are now tuned by acceleration refresh mode (small-write profile for `caching`/`changes`/short-interval `append`; large-write profile for `full`/`snapshot`/long-interval `append`). `CayennePropagateFilterAcrossEquiJoinKeys` is now gated behind `runtime.params.cayenne_filter_propagation=disabled|enabled` and defaults off.
 - **Non-distributed Cayenne catalog rejected** ([#10821](https://github.com/spiceai/spiceai/pull/10821)): The runtime now rejects Cayenne catalog configurations on non-distributed deployments, surfacing a clear error rather than running with a partially-supported topology.
@@ -66,8 +66,6 @@ Several performance and correctness improvements for Cayenne-backed catalogs and
 - **Vendored Vortex DataFusion** ([#10933](https://github.com/spiceai/spiceai/pull/10933)): The Vortex DataFusion integration is vendored into the Cayenne stack, unblocking targeted patches and faster iteration on the Cayenne planner/execution path.
 
 ### Mutual TLS (mTLS)
-
-
 
 > [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise) feature. See [Enterprise Security](https://docs.spice.ai/docs/enterprise/production/security).
 
@@ -134,19 +132,13 @@ PostgreSQL also gains:
 
 ### Snowflake DML Support
 
-
-
 The [Snowflake](https://spiceai.org/docs/components/data-connectors/snowflake) data connector now supports write-back via `INSERT`, `UPDATE`, and `DELETE` operations ([#10747](https://github.com/spiceai/spiceai/pull/10747)), complementing its existing read capabilities.
 
 ### Arrow Primary Key Upserts
 
-
-
 Arrow-accelerated tables now support native upsert operations using primary key matching ([#10749](https://github.com/spiceai/spiceai/pull/10749)), providing efficient update-or-insert semantics for in-memory datasets.
 
 ### DuckLake Promoted to Beta
-
-
 
 The [DuckLake](https://spiceai.org/docs/components/catalogs/ducklake) Catalog and Data Connector are promoted to **Beta** quality ([#10743](https://github.com/spiceai/spiceai/pull/10743)).
 
@@ -154,21 +146,15 @@ DuckLake catalog tables with `read_write` access now support `INSERT` operations
 
 ### User-Defined Functions
 
-
-
 Spice now supports **user-defined functions (UDFs)** as a first-class spicepod component ([#10571](https://github.com/spiceai/spiceai/pull/10571)), letting you define reusable SQL functions in the spicepod or invoke remote functions over HTTP. The runtime also gains **table user functions** with HTTP server gating ([#10675](https://github.com/spiceai/spiceai/pull/10675)).
 
 A security fix closes a remote-UDF SSRF vector ([#10757](https://github.com/spiceai/spiceai/pull/10757)).
 
 ### Spatial SQL UDFs
 
-
-
 Spice now ships an optional set of geospatial SQL UDFs (`ST_*`) for geometry workloads ([#10833](https://github.com/spiceai/spiceai/pull/10833)). The functions are gated behind a build feature and can be invoked from any SQL surface.
 
 ### On-Demand Dataset Loading
-
-
 
 Datasets can now be marked for **on-demand loading** ([#10629](https://github.com/spiceai/spiceai/pull/10629)). Deferred datasets are registered with a declared schema at startup ([#10669](https://github.com/spiceai/spiceai/pull/10669)) and only fully resolve when first referenced, reducing startup time and memory footprint for spicepods with many seldom-used datasets.
 
@@ -176,19 +162,13 @@ Spicepods also gain **`columns[].type` and `columns[].nullable`** ([#10661](http
 
 ### Internal SMB 3.1.1 Client
 
-
-
 The external `smb` crate has been replaced with an internal SMB 3.1.1 client implementation ([#10516](https://github.com/spiceai/spiceai/pull/10516)), removing a dependency on native C libraries and improving portability and reliability of the [SMB](https://spiceai.org/docs/components/data-connectors/smb) data connector.
 
 ### Unified Query Cancellation
 
-
-
 All query execution paths — HTTP, Flight, FlightSQL, MCP, and internal — now honour a unified cancellation signal ([#10390](https://github.com/spiceai/spiceai/pull/10390)). When a client disconnects, presses `Ctrl-C` in the REPL, or cancels an in-flight HTTP request, the corresponding query is cancelled end-to-end, freeing resources promptly.
 
 ### Dynamic HTTP Connector
-
-
 
 The [HTTP data connector](https://spiceai.org/docs/components/data-connectors/http) gains three significant enhancements:
 
@@ -201,15 +181,11 @@ The [HTTP data connector](https://spiceai.org/docs/components/data-connectors/ht
 
 ### HTTP Rate-Control Persistence
 
-
-
 The HTTP rate-control state (per-endpoint throttle counters) is now persisted in object storage ([#10697](https://github.com/spiceai/spiceai/pull/10697)), ensuring rate limits survive restarts and are consistent across replicas. Rate-control metrics now use an `origin` label rather than the connector name for cleaner aggregation ([#10689](https://github.com/spiceai/spiceai/pull/10689)).
 
 The metrics HTTP endpoint (`/metrics`) is also independently rate-limited ([#10162](https://github.com/spiceai/spiceai/pull/10162)) to prevent scraping from impacting query serving.
 
 ### `refresh_mode: snapshot`
-
-
 
 > [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise) feature. See [Acceleration Snapshots](https://docs.spice.ai/docs/enterprise/features/acceleration-snapshots).
 
@@ -237,21 +213,15 @@ datasets:
 
 ### Provider-Aware LLM Prompt Caching
 
-
-
 LLM calls automatically use **provider-aware prompt caching** ([#10645](https://github.com/spiceai/spiceai/pull/10645)) when the configured model provider supports it (e.g., Anthropic, OpenAI). System prompts and tool descriptions are marked for caching so repeated invocations within the cache window reuse the provider-side cached prefix, reducing latency and cost.
 
 A new **searchable registry mode for LLM tools** ([#10647](https://github.com/spiceai/spiceai/pull/10647)) lets agents discover tools by semantic search rather than enumerating all tools in the system prompt, which scales to large tool inventories.
 
 ### Responses API Improvements
 
-
-
 The [Responses API](https://spiceai.org/docs/api/http/openai-compatible) is now supported across all configured model providers ([#10724](https://github.com/spiceai/spiceai/pull/10724)). Streaming delta events via `response.output_text.delta` are also supported ([#10828](https://github.com/spiceai/spiceai/pull/10828)). The runtime now also accepts `Authorization: Bearer` headers in addition to `x-api-key`, bumps `async-openai`, and stops populating `FunctionToolCall.id` so OpenAI-compatible servers can assign the ID themselves ([#10911](https://github.com/spiceai/spiceai/pull/10911)).
 
 ### Distributed Cluster Improvements
-
-
 
 > [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise) feature. See [High Availability](https://docs.spice.ai/docs/enterprise/production/high-availability).
 
@@ -264,8 +234,6 @@ The [Responses API](https://spiceai.org/docs/api/http/openai-compatible) is now 
 
 ### Caching & Search
 
-
-
 - **Per-principal cache namespacing** ([#10702](https://github.com/spiceai/spiceai/pull/10702)): SQL, search, and caching-accelerator caches are now namespaced per authenticated principal, so cached results never cross identity boundaries.
 - **DuckDB HNSW vector index for accelerated views** ([#10695](https://github.com/spiceai/spiceai/pull/10695)): DuckDB-accelerated views can now use HNSW vector indexes.
 - **DuckDB HNSW activation** ([#10674](https://github.com/spiceai/spiceai/pull/10674)): Vector search SQL is rewritten so the DuckDB query planner can activate `HNSW_INDEX_SCAN`.
@@ -275,15 +243,11 @@ The [Responses API](https://spiceai.org/docs/api/http/openai-compatible) is now 
 
 ### Security Improvements
 
-
-
 - **API key timing-position leak and remote-UDF SSRF** ([#10757](https://github.com/spiceai/spiceai/pull/10757)): Closed a timing-based position-disclosure leak in API key comparison and blocked SSRF via remote UDF endpoint parameters.
 - **Configurable `allowed_hosts` for MCP** ([#10638](https://github.com/spiceai/spiceai/pull/10638)): MCP servers can be restricted to an explicit allowlist of upstream hosts.
 - **GH connector AWS LC RS crypto** ([#10619](https://github.com/spiceai/spiceai/pull/10619)): The GitHub data connector explicitly uses the AWS-LC-RS crypto provider for JWT signing when GitHub App authentication is used.
 
 ### SQL, Query, and Developer Experience
-
-
 
 - **SQL REPL expanded view** ([#10797](https://github.com/spiceai/spiceai/pull/10797)): Toggle `\x` in the REPL for a vertical key-value layout on wide result sets.
 - **EXPLAIN TREE limit display** ([#10779](https://github.com/spiceai/spiceai/pull/10779)): Pushed-down `LIMIT` values are now shown on scan nodes, making TopK optimization visible end-to-end.
@@ -332,8 +296,6 @@ The [Responses API](https://spiceai.org/docs/api/http/openai-compatible) is now 
 - **PostgreSQL foreign key metadata includes catalog name** ([#10917](https://github.com/spiceai/spiceai/pull/10917)): Foreign key metadata discovered from PostgreSQL catalogs now carries the source catalog name, allowing FK relationships to resolve correctly across multi-catalog PostgreSQL deployments.
 
 ### Dependency Updates
-
-
 
 | Dependency / Component | Version |
 | ---------------------- | ------- |

--- a/docs/release_notes/v2.0.0-rc.5.md
+++ b/docs/release_notes/v2.0.0-rc.5.md
@@ -33,20 +33,37 @@ Highlights in this release candidate include:
 
 > [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise) feature. Cayenne is the distributed accelerator powering [Distributed Accelerations](https://docs.spice.ai/docs/enterprise/features/distributed-accelerations).
 
-Several performance and correctness improvements for Cayenne-backed catalogs and accelerators:
+Several performance and correctness improvements for Cayenne-backed catalogs and accelerators, grouped by area:
+
+**CDC, write, and ingest throughput**
 
 - **CDC throughput, compaction, and scan caching** ([#10852](https://github.com/spiceai/spiceai/pull/10852)): End-to-end improvements to Cayenne CDC ingest throughput, background compaction, and a new scan-result cache for hot reads, with accompanying benchmark coverage.
-- **Synchronized partition commits** ([#10819](https://github.com/spiceai/spiceai/pull/10819)): Partition commits are now coordinated across all partitions, preventing partial-visibility inconsistencies in concurrent write workloads.
-- **Join filter propagation** ([#10840](https://github.com/spiceai/spiceai/pull/10840), [#10818](https://github.com/spiceai/spiceai/pull/10818)): Filters from join conditions are propagated across equi-join keys, enabling more aggressive predicate pushdown and eliminating full-partition scans on the probe side. The propagator now also requires dim-side statistics to be safe ([#10863](https://github.com/spiceai/spiceai/pull/10863)).
-- **Range fallback for large join filters** ([#10816](https://github.com/spiceai/spiceai/pull/10816)): Cayenne falls back to a range filter when an in-list join filter would exceed safe planning bounds.
 - **Parallel Vortex writes** ([#10822](https://github.com/spiceai/spiceai/pull/10822)): Cayenne now writes to multiple Vortex partitions in parallel, reducing ingest latency for large batch writes.
 - **Lock-free deletion caches with bloom-prefiltered probe** ([#10756](https://github.com/spiceai/spiceai/pull/10756)): Deletion tracking uses a lock-free cache with a bloom filter pre-check, significantly reducing contention and false-positive probe cost during high-throughput CDC.
 - **Inline mutations and memtable scaling** ([#10792](https://github.com/spiceai/spiceai/pull/10792), [#10811](https://github.com/spiceai/spiceai/pull/10811)): Cayenne now supports inline mutations against in-memory tables, with improved scaling for mutation, scan, and memtable operations.
-- **Non-distributed Cayenne catalog rejected** ([#10821](https://github.com/spiceai/spiceai/pull/10821)): The runtime now rejects Cayenne catalog configurations on non-distributed deployments, surfacing a clear error rather than running with a partially-supported topology.
+- **Background retention with CDC pipelining for retention-configured tables** ([#10936](https://github.com/spiceai/spiceai/pull/10936)): Retention enforcement runs on a background task and CDC ingest pipelining is enabled by default for tables with a configured retention policy, removing retention as a foreground tax on streaming writes.
+- **Metastore pool scaled to 32 with scaling benches** ([#10943](https://github.com/spiceai/spiceai/pull/10943)): Cayenne's metastore connection pool is scaled to 32 to better serve high-concurrency mutation workloads, with new `vs_duckdb_scaling` benches that sweep 1→128 concurrency across SQLite and Turso metastore lanes.
+
+**Query planning and predicate pushdown**
+
+- **Join filter propagation** ([#10840](https://github.com/spiceai/spiceai/pull/10840), [#10818](https://github.com/spiceai/spiceai/pull/10818)): Filters from join conditions are propagated across equi-join keys, enabling more aggressive predicate pushdown and eliminating full-partition scans on the probe side. The propagator now also requires dim-side statistics to be safe ([#10863](https://github.com/spiceai/spiceai/pull/10863)).
+- **Range fallback for large join filters** ([#10816](https://github.com/spiceai/spiceai/pull/10816)): Cayenne falls back to a range filter when an in-list join filter would exceed safe planning bounds.
+- **Hot-path clone elimination, PK point-lookup fanout fix, and IN-list rewrite** ([#10916](https://github.com/spiceai/spiceai/pull/10916)): Removes redundant `Arc` and buffer clones on Cayenne hot paths, fixes excessive partition fanout for primary-key point lookups, and rewrites large IN-list filters into a more efficient form; includes microbench coverage to lock in the improvements.
+- **Cayenne HashJoin rewriter disabled** ([#10882](https://github.com/spiceai/spiceai/pull/10882)): The Cayenne HashJoin rewriter optimizer is disabled by default after correctness regressions on specific join shapes.
+
+**Correctness and data integrity**
+
+- **Synchronized partition commits** ([#10819](https://github.com/spiceai/spiceai/pull/10819)): Partition commits are now coordinated across all partitions, preventing partial-visibility inconsistencies in concurrent write workloads.
+- **NULL sentinel for nullable partition expressions** ([#10880](https://github.com/spiceai/spiceai/pull/10880)): Partition expressions over nullable columns (e.g. `bucket(N, col)`) now correctly handle the `NULL` sentinel value during partition pruning, fixing a class of incorrect-result bugs on Cayenne-partitioned tables with nullable partition keys.
 - **Vortex panic on highly compressible data fixed** ([#10855](https://github.com/spiceai/spiceai/pull/10855)): Cayenne no longer panics when Vortex encounters highly compressible columns; the affected encoder path now returns cleanly.
 - **Live protected snapshots after cleanup grace period** ([#10901](https://github.com/spiceai/spiceai/pull/10901)): Cayenne now reads through to live data when a protected snapshot has passed its cleanup grace period, avoiding stale snapshot reads.
-- **Cayenne HashJoin rewriter disabled** ([#10882](https://github.com/spiceai/spiceai/pull/10882)): The Cayenne HashJoin rewriter optimizer is disabled by default after correctness regressions on specific join shapes.
+
+**Catalog, configuration, and platform**
+
 - **Catalog maintenance, atomic on-conflict deletions, and refresh-mode tuning** ([#10904](https://github.com/spiceai/spiceai/pull/10904)): A new `commit_on_conflict_deletions` catalog transaction lands delete-file rows and insert-record rows atomically, protected-snapshot deletion indexes are reused with sequence cutoffs instead of rebuilt per snapshot, table statistics are cached under a single provider cache, and Cayenne compaction and inline-write defaults are now tuned by acceleration refresh mode (small-write profile for `caching`/`changes`/short-interval `append`; large-write profile for `full`/`snapshot`/long-interval `append`). `CayennePropagateFilterAcrossEquiJoinKeys` is now gated behind `runtime.params.cayenne_filter_propagation=disabled|enabled` and defaults off.
+- **Non-distributed Cayenne catalog rejected** ([#10821](https://github.com/spiceai/spiceai/pull/10821)): The runtime now rejects Cayenne catalog configurations on non-distributed deployments, surfacing a clear error rather than running with a partially-supported topology.
+- **Cayenne catalog removed from generic catalog registration** ([#10914](https://github.com/spiceai/spiceai/pull/10914)): The Cayenne catalog is no longer registered through the generic catalog path, eliminating a duplicate-registration edge case in distributed deployments.
+- **Vendored Vortex DataFusion** ([#10933](https://github.com/spiceai/spiceai/pull/10933)): The Vortex DataFusion integration is vendored into the Cayenne stack, unblocking targeted patches and faster iteration on the Cayenne planner/execution path.
 
 ### Mutual TLS (mTLS)
 
@@ -274,6 +291,7 @@ The [Responses API](https://spiceai.org/docs/api/http/openai-compatible) is now 
 - **CLI manifest editing and improved table layout** ([#10725](https://github.com/spiceai/spiceai/pull/10725)): Improved spicepod manifest editing and direct command modes.
 - **`spice feedback`** ([#10856](https://github.com/spiceai/spiceai/pull/10856)): New CLI command that opens the Spice community Slack directly from the terminal.
 - **OAuth2 client credentials in `spice cloud login`** ([#10586](https://github.com/spiceai/spiceai/pull/10586)): `spice cloud login` now supports OAuth2 client-credentials flow for non-interactive logins.
+- **MCP auth for streamable HTTP tools** ([#10927](https://github.com/spiceai/spiceai/pull/10927)): Streamable HTTP MCP tools now support native authentication via `mcp_auth_token` (sends `Authorization: Bearer <token>`) and `mcp_headers` (custom HTTP headers, comma/semicolon-delimited), both with full Spice secret expansion. `mcp_auth_token` takes precedence over a manually-set `Authorization` header to avoid duplicate auth.
 - **Full version tags in spicepod** ([#10748](https://github.com/spiceai/spiceai/pull/10748)): `version` fields in `spicepod.yaml` now accept full semver tags (e.g. `v2.0.0-rc.5`).
 - **Arbitrary spicepod filenames** ([#10777](https://github.com/spiceai/spiceai/pull/10777)): `spice run` accepts any filename when specifying a spicepod path, with `kind` field validation.
 - **`spice refresh` fixes for views and resolved tables** ([#10759](https://github.com/spiceai/spiceai/pull/10759)).
@@ -310,6 +328,8 @@ The [Responses API](https://spiceai.org/docs/api/http/openai-compatible) is now 
 - **`/v1/search` primary key column casing** ([#10909](https://github.com/spiceai/spiceai/pull/10909)): The `/v1/search` endpoint now preserves the original column casing for primary-key plumbing, fixing [#10631](https://github.com/spiceai/spiceai/issues/10631).
 - **Flight `GetFlightInfo` vs `DoGet` schema mismatch** ([#10864](https://github.com/spiceai/spiceai/pull/10864)): Schemas returned from `GetFlightInfo` now match the schema served by the corresponding `DoGet` stream.
 - **Deduplicated S3 URL-style auto-detection log** ([#10898](https://github.com/spiceai/spiceai/pull/10898)): The `object-store` S3 URL-style auto-detection log is no longer emitted on every request.
+- **Turso write-write conflict retry** ([#10946](https://github.com/spiceai/spiceai/pull/10946)): The `turso-shared` client now retries `BEGIN CONCURRENT` transactions on Turso `Write-write conflict` errors, eliminating spurious failures under concurrent metastore writes.
+- **PostgreSQL foreign key metadata includes catalog name** ([#10917](https://github.com/spiceai/spiceai/pull/10917)): Foreign key metadata discovered from PostgreSQL catalogs now carries the source catalog name, allowing FK relationships to resolve correctly across multi-catalog PostgreSQL deployments.
 
 ### Dependency Updates
 
@@ -521,5 +541,14 @@ Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/p
 - Authorization header + Bump async-openai + `responses_adapter` fix by [@krinart](https://github.com/krinart) in [#10911](https://github.com/spiceai/spiceai/pull/10911)
 - Tune accelerators by storage profile by [@lukekim](https://github.com/lukekim) in [#10913](https://github.com/spiceai/spiceai/pull/10913)
 - feat: add dataset-level on_schema_change config by [@lukekim](https://github.com/lukekim) in [#10908](https://github.com/spiceai/spiceai/pull/10908)
+- Handle `NULL` sentinel for nullable partition expressions by [@Jeadie](https://github.com/Jeadie) in [#10880](https://github.com/spiceai/spiceai/pull/10880)
+- fix: Remove Cayenne Catalog from catalog registration by [@peasee](https://github.com/peasee) in [#10914](https://github.com/spiceai/spiceai/pull/10914)
+- Add catalog name to foreign key metadata in postgres catalog by [@Jeadie](https://github.com/Jeadie) in [#10917](https://github.com/spiceai/spiceai/pull/10917)
+- Cayenne perf: eliminate redundant clones, PK point-lookup fanout fix, IN-list rewrite + microbench coverage by [@lukekim](https://github.com/lukekim) in [#10916](https://github.com/spiceai/spiceai/pull/10916)
+- fix(turso-shared): retry on Turso BEGIN CONCURRENT "Write-write conflict" by [@lukekim](https://github.com/lukekim) in [#10946](https://github.com/spiceai/spiceai/pull/10946)
+- Vendor Vortex DataFusion for Cayenne by [@lukekim](https://github.com/lukekim) in [#10933](https://github.com/spiceai/spiceai/pull/10933)
+- perf(cayenne): background retention + enable CDC pipelining for retention-configured tables by [@lukekim](https://github.com/lukekim) in [#10936](https://github.com/spiceai/spiceai/pull/10936)
+- feat(cayenne): scale metastore pool to 32 + vs_duckdb_scaling benches (1→128 concurrency, sqlite + turso lanes) by [@lukekim](https://github.com/lukekim) in [#10943](https://github.com/spiceai/spiceai/pull/10943)
+- feat(mcp): support auth for streamable HTTP tools by [@phillipleblanc](https://github.com/phillipleblanc) in [#10927](https://github.com/spiceai/spiceai/pull/10927)
 
 **Full Changelog**: <https://github.com/spiceai/spiceai/compare/v2.0.0-rc.4...v2.0.0-rc.5>


### PR DESCRIPTION
Adds release-notes coverage for 9 PRs landed on `trunk` since v2.0.0-rc.5 notes were last edited, and regroups the Cayenne Improvements section into themed subsections.

## What's new in the notes

**Cayenne Improvements**

- NULL sentinel for nullable partition expressions (#10880)
- Hot-path clone elimination, PK point-lookup fanout fix, IN-list rewrite (#10916)
- Background retention + CDC pipelining for retention-configured tables (#10936)
- Metastore pool scaled to 32 with scaling benches (#10943)
- Vendored Vortex DataFusion (#10933)
- Cayenne removed from generic catalog registration (#10914)

The Cayenne section is now grouped under:
- CDC, write, and ingest throughput
- Query planning and predicate pushdown
- Correctness and data integrity
- Catalog, configuration, and platform

**Connector Bug Fixes**

- Turso `BEGIN CONCURRENT` write-write conflict retry (#10946)
- PostgreSQL foreign key metadata now carries catalog name (#10917)

**SQL, Query, and Developer Experience**

- MCP auth (`mcp_auth_token`, `mcp_headers`) for streamable HTTP tools (#10927)

**Changelog**

All 9 new PRs appended to `### Changelog`. No new contributors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->