### PR TITLE
Improve error messsage for 'params.spiceai_region'

### DIFF
--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -241,7 +241,7 @@ impl SpiceCloudPlatformCatalog {
                 return Err(super::Error::InvalidConfigurationNoSource {
                     connector: "spice.ai".into(),
                     message: format!(
-                        "Invalid Spice Cloud region: {region}. Specify a valid region, for example us-east-1. To list available regions, run: spice cloud regions"
+                        "Invalid Spice Cloud region: {region}. Specify a valid region, for example 'spiceai_region: us-east-1'. To list available regions, run: 'spice cloud regions'"
                     ),
                     connector_component: ConnectorComponent::from(catalog),
                 });
@@ -252,7 +252,7 @@ impl SpiceCloudPlatformCatalog {
 
         Err(super::Error::InvalidConfigurationNoSource {
             connector: "spice.ai".into(),
-            message: "Missing Spice Cloud region. Specify a valid region, for example us-east-1. To list available regions, run: spice cloud regions".to_string(),
+            message: "Missing Spice Cloud region. Specify a valid region, for example 'spiceai_region: us-east-1'. To list available regions, run: 'spice cloud regions'".to_string(),
             connector_component: ConnectorComponent::from(catalog),
         })
     }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -89,7 +89,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Invalid Spice Cloud region: {region}. Specify a valid region, for example us-east-1. To list available regions, run: spice cloud regions"
+        "Invalid Spice Cloud region: {region}. Specify a valid region, for example 'spiceai_region: us-east-1'. To list available regions, run: 'spice cloud regions'"
     ))]
     InvalidRegion { region: String },
 


### PR DESCRIPTION
## 📝 Summary
Current error message is suggests we should use `params.region: us-east-1`, but it is `spiceai_region: us-east-1`. 
```
Failed to initialize catalog connector: 
  Cannot setup the catalog scp (spice.ai) with an invalid configuration. Missing Spice Cloud region. 
  Specify a valid region, for example us-east-1. To list available regions, run: spice cloud regions
```

Improved docs: https://github.com/spiceai/docs/pull/1754