### PR TITLE
Remove dataset `on_schema_change` Policy from rc.5 release notes

### DIFF
--- a/docs/release_notes/v2.0.0-rc.5.md
+++ b/docs/release_notes/v2.0.0-rc.5.md
@@ -23,7 +23,6 @@ Highlights in this release candidate include:
 - **HTTP Rate-Control persistence** — rate-limit state persisted in object storage across restarts
 - **`refresh_mode: snapshot`** — point-in-time snapshot acceleration with SQLite/Turso WAL flushing
 - **Storage-profile accelerator tuning** — accelerators auto-tune defaults based on local SSD, EBS-class disk, or tmpfs
-- **Dataset `on_schema_change` policy** — explicit source-schema-drift policy at the dataset level
 - **Provider-Aware LLM Prompt Caching** — automatic prompt caching for OpenAI-compatible providers that support it
 - **Responses API** — support across all model providers with streaming `response.output_text.delta`, plus `Authorization: Bearer` header support
 
@@ -194,22 +193,6 @@ A new `refresh_mode: snapshot` provides point-in-time snapshot acceleration ([#1
 ### Storage-Profile Accelerator Tuning
 
 Acceleration configs gain a new `storage_profile` field ([#10913](https://github.com/spiceai/spiceai/pull/10913)). The runtime detects whether the acceleration store is backed by local SSD, EBS-class network disk, tmpfs, or unknown storage, and applies storage-aware defaults across DuckDB, partitioned DuckDB, SQLite, Turso, and Cayenne file-mode accelerators. Explicit per-accelerator parameters always override the profile defaults.
-
-### Dataset `on_schema_change` Policy
-
-Datasets gain a top-level `on_schema_change` policy for source-schema drift ([#10908](https://github.com/spiceai/spiceai/pull/10908)), applying to both accelerated and non-accelerated datasets:
-
-- `block` (default): continue serving queries against the registered schema; do not apply schema changes automatically.
-- `fail`: surface an error when the projected source schema diverges from the registered dataset schema.
-- `append_new_columns`: allow additive source columns; reject removals and incompatible changes.
-- `sync_all_columns`: keep the registered dataset schema synchronized with the projected source schema.
-
-```yaml
-datasets:
-  - from: postgres:public.orders
-    name: orders
-    on_schema_change: fail
-```
 
 ### Provider-Aware LLM Prompt Caching
 


### PR DESCRIPTION
## 📝 Summary

Not yet fully supported / implemented

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781896050&installation_id=128462479&pr_number=10964&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F10964&signature=c2e101e055b7796ec46ddacf73ef3544a77ab5446c8064ded95e6d33b7577710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->