### PR TITLE
Explicit error if `v1/search` requests a table without search index

### DIFF
--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -207,7 +207,8 @@ pub(crate) async fn post(
         Err(e) => {
             let error_type = match e {
                 VectorSearchError::NoTablesWithSearchFound {}
-                | VectorSearchError::CannotVectorSearchDataset { .. } => StatusCode::BAD_REQUEST,
+                | VectorSearchError::CannotVectorSearchDataset { .. }
+                | VectorSearchError::CannotSearchDataset { .. } => StatusCode::BAD_REQUEST,
                 VectorSearchError::SearchPipelineError { ref source } if source.is_user_error() => {
                     StatusCode::BAD_REQUEST
                 }

--- a/crates/runtime/src/search/mod.rs
+++ b/crates/runtime/src/search/mod.rs
@@ -46,6 +46,12 @@ pub enum Error {
     #[snafu(display("Vector search cannot be run on {}.", data_source.to_quoted_string()))]
     CannotVectorSearchDataset { data_source: TableReference },
 
+    #[snafu(display(
+        "Search cannot be run on {} because it has no embeddings or full text search indexes.",
+        data_source.to_quoted_string()
+    ))]
+    CannotSearchDataset { data_source: TableReference },
+
     #[snafu(display("Failed to execute search query: {}", format_datafusion_error(source)))]
     DataFusionError {
         source: datafusion::error::DataFusionError,

--- a/crates/runtime/src/search/search_engine.rs
+++ b/crates/runtime/src/search/search_engine.rs
@@ -321,6 +321,7 @@ impl SearchEngine {
             additional_columns,
             keywords,
         } = req;
+        let explicit_datasets_requested = data_source_opt.is_some();
 
         let tables = match data_source_opt {
             Some(ts) => ts.iter().map(TableReference::from).collect(),
@@ -367,6 +368,12 @@ impl SearchEngine {
                     if let Some(mut fts) = full_text_search_candidates(&self.df, &tbl).await.transpose()? {
                         telemetry::track_text_search(&request_context.to_dimensions());
                         generators.append(&mut fts);
+                    }
+
+                    if explicit_datasets_requested && generators.is_empty() {
+                        return Err(Error::CannotSearchDataset {
+                            data_source: tbl.clone(),
+                        });
                     }
 
                     // Ensure columns for a specific table aren't used on all tables.

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -1632,6 +1632,52 @@ async fn test_text_search() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
+async fn test_explicit_dataset_searchability_validation() -> Result<(), anyhow::Error> {
+    run_search(
+        AppBuilder::new("search_app")
+            .with_dataset(get_mega_science_dataset(
+                Some("searchable"),
+                None,
+                Some(
+                    Column::new("answer")
+                        .with_full_text_search(FullTextSearchConfig::enabled().with_row_id("id")),
+                ),
+            ))
+            .with_dataset(get_mega_science_dataset(Some("plain"), None, None))
+            .build(),
+        vec![
+            SearchTestCase::new(
+                "explicit_non_searchable_dataset_errors",
+                SearchTestType::Http(json!({
+                    "text": "second",
+                    "limit": 4,
+                    "datasets": ["plain"],
+                })),
+            )
+            .should_fail(),
+            SearchTestCase::new(
+                "explicit_mixed_datasets_fail_fast",
+                SearchTestType::Http(json!({
+                    "text": "second",
+                    "limit": 4,
+                    "datasets": ["searchable", "plain"],
+                })),
+            )
+            .should_fail(),
+            SearchTestCase::new(
+                "explicit_searchable_dataset_no_matches_returns_empty",
+                SearchTestType::Http(json!({
+                    "text": "query-that-will-not-match-any-megascience-row-xyz",
+                    "limit": 4,
+                    "datasets": ["searchable"],
+                })),
+            ),
+        ],
+    )
+    .await
+}
+
+#[tokio::test]
 async fn test_text_search_view() -> Result<(), anyhow::Error> {
     let (ds, views) = get_mega_science_view(
         Some("qs"),


### PR DESCRIPTION
## 📝 Summary
Fixes a /v1/search regression where explicitly requested datasets without search capability (no embeddings and no full-text indexes) returned 200 with empty results instead of an error.

A previous change treated `NoCandidatesGenerated` as a non-error and dropped per-table None results, which conflated:
 1. searchable dataset with zero matches, and  
 2. non-searchable dataset with zero generators.

As a result, non-searchable explicit datasets were silently accepted. Behavior after this change
 - datasets: ["non_searchable"] -> 400 with actionable error.
 - datasets: ["searchable", "non_searchable"] -> 400 (fail-fast).
 - datasets: ["searchable"] with no matches -> 200 with empty results.
 - datasets omitted -> unchanged behavior (auto-select searchable tables).

## 🔗 Related
Resolves #10955

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781908409&installation_id=128462479&pr_number=10968&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F10968&signature=ea964ef917571aebf2b4293a51cb16cc0a9e1f0ae07e367fd8a3697f3f40c6e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->