### PR TITLE
fix(cluster): make partition assignment startup-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16121,6 +16121,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
+ "dashmap",
  "data_components",
  "datafusion",
  "datafusion-expr",

--- a/crates/runtime-cluster/Cargo.toml
+++ b/crates/runtime-cluster/Cargo.toml
@@ -19,6 +19,7 @@ arrow_tools = { path = "../arrow_tools" }
 async-stream.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
+dashmap = "6.1.0"
 data_components = { path = "../data_components" }
 datafusion.workspace = true
 datafusion-expr = { workspace = true }

--- a/crates/runtime-cluster/src/correlated.rs
+++ b/crates/runtime-cluster/src/correlated.rs
@@ -1,0 +1,255 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Request/response correlation for the scheduler↔executor control stream.
+//!
+//! The control stream is a single bidirectional `mpsc` pair per executor connection.
+//! Some scheduler→executor commands need a typed reply correlated by `request_id`
+//! (metrics, partition-update acks, etc.). [`CorrelatedResponses`] holds the
+//! `request_id → oneshot::Sender<Resp>` map per response type, and
+//! [`send_correlated`] drives the full register-send-await-cleanup lifecycle so
+//! callers don't reimplement it per RPC.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use snafu::prelude::*;
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+/// Per-response-type pending-request registry. Keyed by `request_id`.
+///
+/// Cheap to clone (internal `Arc<DashMap>`). One instance per response type per
+/// connection (e.g. one for `MetricsResponse`, one for `Ack`).
+#[derive(Debug)]
+pub struct CorrelatedResponses<Resp> {
+    pending: Arc<DashMap<String, oneshot::Sender<Resp>>>,
+}
+
+impl<Resp> Default for CorrelatedResponses<Resp> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Resp> Clone for CorrelatedResponses<Resp> {
+    fn clone(&self) -> Self {
+        Self {
+            pending: Arc::clone(&self.pending),
+        }
+    }
+}
+
+impl<Resp> CorrelatedResponses<Resp> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            pending: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Registers a pending request and returns the receiver to await its response.
+    /// Prefer [`send_correlated`] for the common case; this is exposed for callers
+    /// that need to interleave the register/send steps.
+    pub fn register(&self, id: String) -> oneshot::Receiver<Resp> {
+        let (tx, rx) = oneshot::channel();
+        self.pending.insert(id, tx);
+        rx
+    }
+
+    /// Drops the pending entry without delivering. Used to clean up on send
+    /// failure or timeout.
+    pub fn remove(&self, id: &str) {
+        self.pending.remove(id);
+    }
+
+    /// Atomically removes the pending entry and delivers the response.
+    /// Returns `true` if the `request_id` was known and the receiver hadn't dropped.
+    pub fn deliver(&self, id: &str, resp: Resp) -> bool {
+        match self.pending.remove(id) {
+            Some((_, sender)) => sender.send(resp).is_ok(),
+            None => false,
+        }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.pending.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+/// Failure modes for [`send_correlated`].
+#[derive(Debug, Snafu)]
+pub enum CorrelationError {
+    #[snafu(display("Failed to send request: control stream channel closed"))]
+    SendFailed,
+
+    #[snafu(display("Response channel closed before delivery"))]
+    Cancelled,
+
+    #[snafu(display("Timed out after {duration:?} waiting for response"))]
+    Timeout { duration: Duration },
+}
+
+/// Drives the full lifecycle of a correlated request: generates a `request_id`,
+/// registers a pending response slot, builds and sends the request, waits for the
+/// response (optionally bounded by a timeout), and cleans up the slot on every
+/// failure path.
+///
+/// `build_req` receives the generated `request_id` so the caller can place it into
+/// the appropriate field of whatever request message type it's constructing.
+///
+/// Pass `Some(duration)` to bound the wait; `None` to wait indefinitely (the
+/// caller is then responsible for ensuring the pending entry doesn't leak — e.g.
+/// the message channel itself will drop the sender on disconnect).
+pub async fn send_correlated<Req, Resp>(
+    request_tx: &mpsc::Sender<Req>,
+    pending: &CorrelatedResponses<Resp>,
+    build_req: impl FnOnce(String) -> Req,
+    timeout: Option<Duration>,
+) -> Result<Resp, CorrelationError> {
+    let id = Uuid::new_v4().to_string();
+    let rx = pending.register(id.clone());
+
+    if request_tx.send(build_req(id.clone())).await.is_err() {
+        pending.remove(&id);
+        return SendFailedSnafu.fail();
+    }
+
+    let recv_result = match timeout {
+        Some(duration) => match tokio::time::timeout(duration, rx).await {
+            Ok(inner) => inner,
+            Err(_) => {
+                pending.remove(&id);
+                return TimeoutSnafu { duration }.fail();
+            }
+        },
+        None => rx.await,
+    };
+
+    match recv_result {
+        Ok(resp) => Ok(resp),
+        // Sender was dropped without delivering (e.g. pending entry was
+        // explicitly removed via [`CorrelatedResponses::remove`]).
+        Err(_) => CancelledSnafu.fail(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn register_then_deliver_completes_receiver() {
+        let pending: CorrelatedResponses<u32> = CorrelatedResponses::new();
+        let rx = pending.register("a".to_string());
+        assert_eq!(pending.len(), 1);
+
+        assert!(pending.deliver("a", 42));
+        assert_eq!(rx.await.unwrap(), 42);
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deliver_unknown_id_returns_false() {
+        let pending: CorrelatedResponses<u32> = CorrelatedResponses::new();
+        assert!(!pending.deliver("missing", 1));
+    }
+
+    #[tokio::test]
+    async fn remove_cancels_pending_receiver() {
+        let pending: CorrelatedResponses<u32> = CorrelatedResponses::new();
+        let rx = pending.register("a".to_string());
+        pending.remove("a");
+        // Sender was dropped, receiver sees Err.
+        assert!(rx.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_correlated_happy_path() {
+        let (tx, mut rx) = mpsc::channel::<(String, u32)>(8);
+        let pending: CorrelatedResponses<u32> = CorrelatedResponses::new();
+        let pending_for_responder = pending.clone();
+
+        // Simulated responder: takes the (id, value) off the channel and delivers.
+        tokio::spawn(async move {
+            while let Some((id, value)) = rx.recv().await {
+                pending_for_responder.deliver(&id, value * 2);
+            }
+        });
+
+        let resp = send_correlated(
+            &tx,
+            &pending,
+            |id| (id, 21),
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp, 42);
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_correlated_no_timeout_waits_until_delivered() {
+        let (tx, mut rx) = mpsc::channel::<(String, u32)>(8);
+        let pending: CorrelatedResponses<u32> = CorrelatedResponses::new();
+        let pending_for_responder = pending.clone();
+
+        tokio::spawn(async move {
+            while let Some((id, value)) = rx.recv().await {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                pending_for_responder.deliver(&id, value + 1);
+            }
+        });
+
+        let resp = send_correlated(&tx, &pending, |id| (id, 7), None).await.unwrap();
+        assert_eq!(resp, 8);
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_correlated_send_failure_cleans_up() {
+        let (tx, rx) = mpsc::channel::<String>(1);
+        drop(rx); // close the receiver so send fails
+        let pending: CorrelatedResponses<u32> = CorrelatedResponses::new();
+
+        let err = send_correlated(&tx, &pending, |id| id, Some(Duration::from_secs(1)))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CorrelationError::SendFailed));
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_correlated_timeout_cleans_up() {
+        let (tx, _rx) = mpsc::channel::<String>(1);
+        let pending: CorrelatedResponses<u32> = CorrelatedResponses::new();
+
+        let err = send_correlated(&tx, &pending, |id| id, Some(Duration::from_millis(50)))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CorrelationError::Timeout { .. }));
+        assert!(pending.is_empty());
+    }
+}

--- a/crates/runtime-cluster/src/correlated.rs
+++ b/crates/runtime-cluster/src/correlated.rs
@@ -65,6 +65,7 @@ impl<Resp> CorrelatedResponses<Resp> {
     /// Registers a pending request and returns the receiver to await its response.
     /// Prefer [`send_correlated`] for the common case; this is exposed for callers
     /// that need to interleave the register/send steps.
+    #[must_use]
     pub fn register(&self, id: String) -> oneshot::Receiver<Resp> {
         let (tx, rx) = oneshot::channel();
         self.pending.insert(id, tx);
@@ -118,9 +119,22 @@ pub enum CorrelationError {
 /// `build_req` receives the generated `request_id` so the caller can place it into
 /// the appropriate field of whatever request message type it's constructing.
 ///
-/// Pass `Some(duration)` to bound the wait; `None` to wait indefinitely (the
-/// caller is then responsible for ensuring the pending entry doesn't leak — e.g.
-/// the message channel itself will drop the sender on disconnect).
+/// Pass `Some(duration)` to bound the wait; `None` to wait indefinitely. The
+/// pending entry lives in the [`CorrelatedResponses`] map regardless of
+/// `request_tx` state — closing the outbound channel does not drop the
+/// pending sender. With `None`, the caller is responsible for ensuring some
+/// other path eventually drops the pending entry to unblock the receiver
+/// (e.g. dropping the entire [`CorrelatedResponses`] when the executor
+/// connection is torn down, or calling [`CorrelatedResponses::remove`]).
+///
+/// # Errors
+///
+/// - [`CorrelationError::SendFailed`] if the outbound channel is closed.
+/// - [`CorrelationError::Timeout`] if `timeout` is `Some(_)` and elapses
+///   before a response arrives.
+/// - [`CorrelationError::Cancelled`] if the pending entry is removed (e.g.
+///   via [`CorrelatedResponses::remove`]) or the registry is dropped
+///   before delivery.
 pub async fn send_correlated<Req, Resp>(
     request_tx: &mpsc::Sender<Req>,
     pending: &CorrelatedResponses<Resp>,
@@ -135,15 +149,14 @@ pub async fn send_correlated<Req, Resp>(
         return SendFailedSnafu.fail();
     }
 
-    let recv_result = match timeout {
-        Some(duration) => match tokio::time::timeout(duration, rx).await {
-            Ok(inner) => inner,
-            Err(_) => {
-                pending.remove(&id);
-                return TimeoutSnafu { duration }.fail();
-            }
-        },
-        None => rx.await,
+    let recv_result = if let Some(duration) = timeout {
+        let Ok(inner) = tokio::time::timeout(duration, rx).await else {
+            pending.remove(&id);
+            return TimeoutSnafu { duration }.fail();
+        };
+        inner
+    } else {
+        rx.await
     };
 
     match recv_result {
@@ -165,7 +178,10 @@ mod tests {
         assert_eq!(pending.len(), 1);
 
         assert!(pending.deliver("a", 42));
-        assert_eq!(rx.await.unwrap(), 42);
+        assert_eq!(
+            rx.await.expect("deliver should have completed receiver"),
+            42
+        );
         assert!(pending.is_empty());
     }
 
@@ -181,7 +197,7 @@ mod tests {
         let rx = pending.register("a".to_string());
         pending.remove("a");
         // Sender was dropped, receiver sees Err.
-        assert!(rx.await.is_err());
+        rx.await.expect_err("receiver should observe sender drop");
     }
 
     #[tokio::test]
@@ -197,14 +213,9 @@ mod tests {
             }
         });
 
-        let resp = send_correlated(
-            &tx,
-            &pending,
-            |id| (id, 21),
-            Some(Duration::from_secs(1)),
-        )
-        .await
-        .unwrap();
+        let resp = send_correlated(&tx, &pending, |id| (id, 21), Some(Duration::from_secs(1)))
+            .await
+            .expect("send_correlated should succeed");
 
         assert_eq!(resp, 42);
         assert!(pending.is_empty());
@@ -223,7 +234,9 @@ mod tests {
             }
         });
 
-        let resp = send_correlated(&tx, &pending, |id| (id, 7), None).await.unwrap();
+        let resp = send_correlated(&tx, &pending, |id| (id, 7), None)
+            .await
+            .expect("send_correlated should succeed");
         assert_eq!(resp, 8);
         assert!(pending.is_empty());
     }
@@ -236,7 +249,7 @@ mod tests {
 
         let err = send_correlated(&tx, &pending, |id| id, Some(Duration::from_secs(1)))
             .await
-            .unwrap_err();
+            .expect_err("closed channel should fail send");
         assert!(matches!(err, CorrelationError::SendFailed));
         assert!(pending.is_empty());
     }
@@ -248,7 +261,7 @@ mod tests {
 
         let err = send_correlated(&tx, &pending, |id| id, Some(Duration::from_millis(50)))
             .await
-            .unwrap_err();
+            .expect_err("absent response should time out");
         assert!(matches!(err, CorrelationError::Timeout { .. }));
         assert!(pending.is_empty());
     }

--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -31,9 +31,9 @@ use flight_client::cookie::CookieStore;
 use runtime_datafusion::analyzer_rule::TablePartitionProvider;
 use runtime_proto::{MetricsRequest, MetricsResponse, SchedulerControlMessage};
 use snafu::prelude::*;
-use tokio::sync::{RwLock, mpsc, oneshot};
-use uuid::Uuid;
+use tokio::sync::{RwLock, mpsc};
 
+use crate::correlated::{CorrelatedResponses, CorrelationError, send_correlated};
 use crate::{PartitionStore, PartitionValue, executor_selection};
 
 /// Error type for executor registry operations.
@@ -54,10 +54,10 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Represents a single executor's control stream connection.
 #[derive(Debug)]
 pub struct ExecutorConnection {
-    /// Channel to send control messages to this executor
+    /// Channel to send control messages to this executor.
     request_tx: mpsc::Sender<SchedulerControlMessage>,
-    /// Pending metrics requests awaiting responses
-    pending_requests: Arc<RwLock<HashMap<String, oneshot::Sender<MetricsResponse>>>>,
+    /// Pending metrics requests awaiting responses, keyed by `request_id`.
+    pending_metrics: CorrelatedResponses<MetricsResponse>,
 }
 
 impl ExecutorConnection {
@@ -66,51 +66,44 @@ impl ExecutorConnection {
     pub fn new(request_tx: mpsc::Sender<SchedulerControlMessage>) -> Self {
         Self {
             request_tx,
-            pending_requests: Arc::new(RwLock::new(HashMap::new())),
+            pending_metrics: CorrelatedResponses::new(),
         }
     }
 
-    /// Returns a clone of the pending requests map for handling responses.
+    /// Returns a cheap clone of the pending-metrics registry. Used by the
+    /// control-stream inbound handler to deliver `MetricsResponse` messages.
     #[must_use]
-    pub fn pending_requests(
-        &self,
-    ) -> Arc<RwLock<HashMap<String, oneshot::Sender<MetricsResponse>>>> {
-        Arc::clone(&self.pending_requests)
+    pub fn pending_metrics(&self) -> CorrelatedResponses<MetricsResponse> {
+        self.pending_metrics.clone()
     }
 
     /// Sends a metrics request to this executor and waits for the response.
     async fn request_metrics(&self, executor_id: &str) -> Result<MetricsResponse> {
-        let request_id = Uuid::new_v4().to_string();
-        let (response_tx, response_rx) = oneshot::channel();
-
-        // Register the pending request
-        {
-            let mut pending = self.pending_requests.write().await;
-            pending.insert(request_id.clone(), response_tx);
-        }
-
-        // Send the metrics request
-        let message = SchedulerControlMessage {
-            message: Some(
-                runtime_proto::scheduler_control_message::Message::RequestMetrics(MetricsRequest {
-                    request_id: request_id.clone(),
-                }),
-            ),
-        };
-
-        if self.request_tx.send(message).await.is_err() {
-            // Clean up the pending request on send failure
-            let mut pending = self.pending_requests.write().await;
-            pending.remove(&request_id);
-            return Err(Error::SendFailed {
+        send_correlated(
+            &self.request_tx,
+            &self.pending_metrics,
+            |request_id| SchedulerControlMessage {
+                message: Some(
+                    runtime_proto::scheduler_control_message::Message::RequestMetrics(
+                        MetricsRequest { request_id },
+                    ),
+                ),
+            },
+            None,
+        )
+        .await
+        .map_err(|e| match e {
+            CorrelationError::SendFailed => Error::SendFailed {
                 executor_id: executor_id.to_string(),
-            });
-        }
-
-        // Wait for the response
-        response_rx.await.map_err(|_| Error::ReceiveFailed {
-            executor_id: executor_id.to_string(),
-            reason: "response channel closed".to_string(),
+            },
+            CorrelationError::Cancelled => Error::ReceiveFailed {
+                executor_id: executor_id.to_string(),
+                reason: "response channel closed".to_string(),
+            },
+            CorrelationError::Timeout { duration } => Error::ReceiveFailed {
+                executor_id: executor_id.to_string(),
+                reason: format!("timed out after {duration:?}"),
+            },
         })
     }
 }
@@ -241,9 +234,9 @@ impl ExecutorRegistry {
         &self,
         executor_id: String,
         request_tx: mpsc::Sender<SchedulerControlMessage>,
-    ) -> Arc<RwLock<HashMap<String, oneshot::Sender<MetricsResponse>>>> {
+    ) -> CorrelatedResponses<MetricsResponse> {
         let connection = ExecutorConnection::new(request_tx);
-        let pending_requests = connection.pending_requests();
+        let pending_metrics = connection.pending_metrics();
 
         let mut connections = self.connections.write().await;
         if connections.contains_key(&executor_id) {
@@ -253,7 +246,7 @@ impl ExecutorRegistry {
         }
         connections.insert(executor_id, connection);
 
-        pending_requests
+        pending_metrics
     }
 
     /// Unregisters an executor and removes it from all three tracking maps.
@@ -381,12 +374,12 @@ impl ExecutorRegistry {
         for (executor_id, connection) in connections.iter() {
             let executor_id = executor_id.clone();
             let request_tx = connection.request_tx.clone();
-            let pending_requests = connection.pending_requests();
+            let pending_metrics = connection.pending_metrics();
 
             handles.push(tokio::spawn(async move {
                 let temp_connection = ExecutorConnection {
                     request_tx,
-                    pending_requests,
+                    pending_metrics,
                 };
                 let result = temp_connection.request_metrics(&executor_id).await;
                 (executor_id, result)

--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -45,8 +45,30 @@ pub enum Error {
     #[snafu(display("Failed to receive metrics response from executor {executor_id}: {reason}"))]
     ReceiveFailed { executor_id: String, reason: String },
 
+    #[snafu(display("Timed out waiting for ack from executor {executor_id} after {duration:?}"))]
+    AckTimeout {
+        executor_id: String,
+        duration: std::time::Duration,
+    },
+
+    #[snafu(display("Executor {executor_id} reported failure applying command: {error}"))]
+    AckFailed { executor_id: String, error: String },
+
+    #[snafu(display("Executor {executor_id} not registered"))]
+    ExecutorNotRegistered { executor_id: String },
+
     #[snafu(display("Metrics collection failed for executors: [{failed_executors}]"))]
     PartialFailure { failed_executors: String },
+}
+
+impl Error {
+    /// Returns true if this error indicates a transient condition where the
+    /// caller should retry (e.g. executor not yet ready). Returns false for
+    /// permanent failures (e.g. executor unregistered).
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Error::AckTimeout { .. } | Error::AckFailed { .. })
+    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -346,7 +368,61 @@ impl ExecutorRegistry {
         connections.keys().cloned().collect()
     }
 
-    /// Sends a control message to a specific executor.
+    /// Sends a control message to a specific executor and waits for an Ack
+    /// correlated by `request_id`.
+    ///
+    /// `build_command` is given a freshly generated `request_id` and must
+    /// place it onto the underlying message payload (e.g. into
+    /// `UpdatePartitions::request_id`). The executor's message handler is
+    /// expected to send a matching `ExecutorMessage::Ack` back via the
+    /// control stream.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::ExecutorNotRegistered`] if the target is not in the registry.
+    /// - [`Error::SendFailed`] if delivery to the control stream channel fails.
+    /// - [`Error::AckTimeout`] if no ack arrives within `timeout`.
+    /// - [`Error::AckFailed`] if the executor reports an application error.
+    pub async fn send_command_with_ack(
+        &self,
+        executor_id: &str,
+        build_command: impl FnOnce(String) -> SchedulerControlMessage + Send,
+        timeout: std::time::Duration,
+    ) -> Result<()> {
+        let (request_tx, pending_acks) = {
+            let connections = self.connections.read().await;
+            let Some(connection) = connections.get(executor_id) else {
+                return Err(Error::ExecutorNotRegistered {
+                    executor_id: executor_id.to_string(),
+                });
+            };
+            (connection.request_tx.clone(), connection.pending_acks())
+        };
+
+        match send_correlated(&request_tx, &pending_acks, build_command, Some(timeout)).await {
+            Ok(ack) => match ack.error {
+                Some(error) if !error.is_empty() => Err(Error::AckFailed {
+                    executor_id: executor_id.to_string(),
+                    error,
+                }),
+                _ => Ok(()),
+            },
+            Err(CorrelationError::SendFailed) => Err(Error::SendFailed {
+                executor_id: executor_id.to_string(),
+            }),
+            Err(CorrelationError::Cancelled) => Err(Error::ReceiveFailed {
+                executor_id: executor_id.to_string(),
+                reason: "ack channel closed".to_string(),
+            }),
+            Err(CorrelationError::Timeout { duration }) => Err(Error::AckTimeout {
+                executor_id: executor_id.to_string(),
+                duration,
+            }),
+        }
+    }
+
+    /// Sends a control message to a specific executor without waiting for
+    /// acknowledgement.
     ///
     /// # Errors
     ///
@@ -837,5 +913,131 @@ mod tests {
         assert!(registry.ddl_statements_since(3).await.is_empty());
         // Beyond end returns empty
         assert!(registry.ddl_statements_since(100).await.is_empty());
+    }
+
+    /// Spawn a tiny fake executor: receives `SchedulerControlMessage`s from
+    /// `rx`, extracts the request_id from `UpdatePartitions`, and delivers an
+    /// `Ack` (with the provided error, if any) via `pending_acks`.
+    fn spawn_fake_executor_ack(
+        mut rx: mpsc::Receiver<SchedulerControlMessage>,
+        pending_acks: CorrelatedResponses<Ack>,
+        responder_error: Option<String>,
+    ) {
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                if let Some(runtime_proto::scheduler_control_message::Message::UpdatePartitions(
+                    up,
+                )) = msg.message
+                {
+                    let request_id = up.request_id.clone();
+                    if request_id.is_empty() {
+                        continue; // legacy fire-and-forget
+                    }
+                    pending_acks.deliver(
+                        &request_id,
+                        Ack {
+                            request_id,
+                            error: responder_error.clone(),
+                        },
+                    );
+                }
+            }
+        });
+    }
+
+    fn empty_update_partitions(request_id: String) -> SchedulerControlMessage {
+        SchedulerControlMessage {
+            message: Some(
+                runtime_proto::scheduler_control_message::Message::UpdatePartitions(
+                    runtime_proto::UpdatePartitions {
+                        new_partitions: HashMap::new(),
+                        removed_partitions: HashMap::new(),
+                        request_id,
+                    },
+                ),
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_command_with_ack_success() {
+        let registry = make_registry().await;
+        let (tx, rx) = mpsc::channel(8);
+        let handles = registry.register("e1".to_string(), tx).await;
+        spawn_fake_executor_ack(rx, handles.pending_acks.clone(), None);
+
+        let result = registry
+            .send_command_with_ack(
+                "e1",
+                empty_update_partitions,
+                std::time::Duration::from_secs(1),
+            )
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn send_command_with_ack_propagates_application_error() {
+        let registry = make_registry().await;
+        let (tx, rx) = mpsc::channel(8);
+        let handles = registry.register("e1".to_string(), tx).await;
+        spawn_fake_executor_ack(
+            rx,
+            handles.pending_acks.clone(),
+            Some("table not yet loaded".to_string()),
+        );
+
+        let err = registry
+            .send_command_with_ack(
+                "e1",
+                empty_update_partitions,
+                std::time::Duration::from_secs(1),
+            )
+            .await
+            .expect_err("ack with error should fail");
+
+        match err {
+            Error::AckFailed { executor_id, error } => {
+                assert_eq!(executor_id, "e1");
+                assert_eq!(error, "table not yet loaded");
+            }
+            other => panic!("expected AckFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_command_with_ack_times_out_when_no_response() {
+        let registry = make_registry().await;
+        let (tx, _rx) = mpsc::channel(8); // _rx kept alive but never read
+        let _handles = registry.register("e1".to_string(), tx).await;
+
+        let err = registry
+            .send_command_with_ack(
+                "e1",
+                empty_update_partitions,
+                std::time::Duration::from_millis(50),
+            )
+            .await
+            .expect_err("missing ack should time out");
+
+        assert!(matches!(err, Error::AckTimeout { .. }), "got {err:?}");
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn send_command_with_ack_unknown_executor() {
+        let registry = make_registry().await;
+        let err = registry
+            .send_command_with_ack(
+                "ghost",
+                empty_update_partitions,
+                std::time::Duration::from_millis(10),
+            )
+            .await
+            .expect_err("unknown executor should fail");
+
+        assert!(matches!(err, Error::ExecutorNotRegistered { .. }), "got {err:?}");
+        assert!(!err.is_retryable());
     }
 }

--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -29,7 +29,7 @@ use datafusion::{catalog::TableProvider, sql::TableReference};
 use datafusion_expr::{Expr, TableScan};
 use flight_client::cookie::CookieStore;
 use runtime_datafusion::analyzer_rule::TablePartitionProvider;
-use runtime_proto::{MetricsRequest, MetricsResponse, SchedulerControlMessage};
+use runtime_proto::{Ack, MetricsRequest, MetricsResponse, SchedulerControlMessage};
 use snafu::prelude::*;
 use tokio::sync::{RwLock, mpsc};
 
@@ -58,6 +58,10 @@ pub struct ExecutorConnection {
     request_tx: mpsc::Sender<SchedulerControlMessage>,
     /// Pending metrics requests awaiting responses, keyed by `request_id`.
     pending_metrics: CorrelatedResponses<MetricsResponse>,
+    /// Pending control-command acks awaiting responses, keyed by `request_id`.
+    /// Used by commands (e.g. `UpdatePartitions`) that need delivery
+    /// confirmation rather than fire-and-forget.
+    pending_acks: CorrelatedResponses<Ack>,
 }
 
 impl ExecutorConnection {
@@ -67,6 +71,7 @@ impl ExecutorConnection {
         Self {
             request_tx,
             pending_metrics: CorrelatedResponses::new(),
+            pending_acks: CorrelatedResponses::new(),
         }
     }
 
@@ -75,6 +80,14 @@ impl ExecutorConnection {
     #[must_use]
     pub fn pending_metrics(&self) -> CorrelatedResponses<MetricsResponse> {
         self.pending_metrics.clone()
+    }
+
+    /// Returns a cheap clone of the pending-acks registry. Used by the
+    /// control-stream inbound handler to deliver `Ack` messages, and by
+    /// notify-with-ack call sites to await delivery confirmation.
+    #[must_use]
+    pub fn pending_acks(&self) -> CorrelatedResponses<Ack> {
+        self.pending_acks.clone()
     }
 
     /// Sends a metrics request to this executor and waits for the response.
@@ -109,6 +122,15 @@ impl ExecutorConnection {
 }
 
 pub type TablePartitions = HashMap<TableReference, Vec<Expr>>;
+
+/// Cheap-to-clone handles returned to the control-stream inbound dispatcher
+/// at registration time. Routes correlated executor→scheduler messages
+/// (metrics responses, command acks) to whoever is awaiting them.
+#[derive(Debug, Clone)]
+pub struct RegisteredHandles {
+    pub pending_metrics: CorrelatedResponses<MetricsResponse>,
+    pub pending_acks: CorrelatedResponses<Ack>,
+}
 
 /// Append-only log of DDL SQL statements applied to the cluster.
 ///
@@ -234,9 +256,12 @@ impl ExecutorRegistry {
         &self,
         executor_id: String,
         request_tx: mpsc::Sender<SchedulerControlMessage>,
-    ) -> CorrelatedResponses<MetricsResponse> {
+    ) -> RegisteredHandles {
         let connection = ExecutorConnection::new(request_tx);
-        let pending_metrics = connection.pending_metrics();
+        let handles = RegisteredHandles {
+            pending_metrics: connection.pending_metrics(),
+            pending_acks: connection.pending_acks(),
+        };
 
         let mut connections = self.connections.write().await;
         if connections.contains_key(&executor_id) {
@@ -246,7 +271,7 @@ impl ExecutorRegistry {
         }
         connections.insert(executor_id, connection);
 
-        pending_metrics
+        handles
     }
 
     /// Unregisters an executor and removes it from all three tracking maps.
@@ -380,6 +405,7 @@ impl ExecutorRegistry {
                 let temp_connection = ExecutorConnection {
                     request_tx,
                     pending_metrics,
+                    pending_acks: CorrelatedResponses::new(),
                 };
                 let result = temp_connection.request_metrics(&executor_id).await;
                 (executor_id, result)

--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -916,8 +916,8 @@ mod tests {
     }
 
     /// Spawn a tiny fake executor: receives `SchedulerControlMessage`s from
-    /// `rx`, extracts the request_id from `UpdatePartitions`, and delivers an
-    /// `Ack` (with the provided error, if any) via `pending_acks`.
+    /// `rx`, extracts the `request_id` from `UpdatePartitions`, and delivers
+    /// an `Ack` (with the provided error, if any) via `pending_acks`.
     fn spawn_fake_executor_ack(
         mut rx: mpsc::Receiver<SchedulerControlMessage>,
         pending_acks: CorrelatedResponses<Ack>,
@@ -929,14 +929,14 @@ mod tests {
                     up,
                 )) = msg.message
                 {
-                    let request_id = up.request_id.clone();
+                    let request_id = up.request_id;
                     if request_id.is_empty() {
                         continue; // legacy fire-and-forget
                     }
                     pending_acks.deliver(
                         &request_id,
                         Ack {
-                            request_id,
+                            request_id: request_id.clone(),
                             error: responder_error.clone(),
                         },
                     );
@@ -1037,7 +1037,10 @@ mod tests {
             .await
             .expect_err("unknown executor should fail");
 
-        assert!(matches!(err, Error::ExecutorNotRegistered { .. }), "got {err:?}");
+        assert!(
+            matches!(err, Error::ExecutorNotRegistered { .. }),
+            "got {err:?}"
+        );
         assert!(!err.is_retryable());
     }
 }

--- a/crates/runtime-cluster/src/lib.rs
+++ b/crates/runtime-cluster/src/lib.rs
@@ -23,6 +23,7 @@ limitations under the License.
 
 pub mod cluster_state;
 pub mod context;
+pub mod correlated;
 pub mod executor_registry;
 pub mod executor_selection;
 pub mod flight_config;

--- a/crates/runtime-cluster/src/lib.rs
+++ b/crates/runtime-cluster/src/lib.rs
@@ -37,7 +37,9 @@ pub use cluster_state::{
     ClusterState, ClusterStateStore, MutateError, MutateOk, MutationOutcome, PartitionScope,
     SchedulerEntry, SchedulerId,
 };
-pub use executor_registry::{ExecutorRegistry, FederatedPartitionProvider, TablePartitions};
+pub use executor_registry::{
+    ExecutorRegistry, FederatedPartitionProvider, RegisteredHandles, TablePartitions,
+};
 pub use metadata::{
     PartitionMetadata, PartitionValue, TablePartitionMetadata, normalized_table_name,
     partition_value_to_bytes,

--- a/crates/runtime-cluster/src/service.rs
+++ b/crates/runtime-cluster/src/service.rs
@@ -44,7 +44,7 @@ use spicepod::partitioning::PartitionedBy;
 use tokio::sync::RwLock;
 use tokio::time::timeout;
 
-use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use util::fibonacci_backoff::{Backoff, FibonacciBackoffBuilder};
 
 use crate::context::PartitionOperations;
 use crate::executor_registry::{self, ExecutorRegistry};
@@ -1106,6 +1106,18 @@ async fn notify_executors(
     Ok(())
 }
 
+/// How long the scheduler waits for an executor to ack a single
+/// `UpdatePartitions` message before considering the attempt failed.
+const NOTIFY_ACK_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upper bound on the per-attempt backoff between notify retries.
+const NOTIFY_BACKOFF_MAX: Duration = Duration::from_secs(5);
+
+/// Maximum number of retry attempts for a single executor notification.
+/// After exhaustion the assignment stays committed in the partition store;
+/// the next reconcile cycle will re-attempt notification.
+const NOTIFY_MAX_RETRIES: usize = 8;
+
 async fn notify_executor_of_assignments(
     registry: &ExecutorRegistry,
     ops: &dyn PartitionOperations,
@@ -1129,30 +1141,69 @@ async fn notify_executor_of_assignments(
             partitions_bytes.push(bytes.to_vec());
         }
 
-        let command = SchedulerControlMessage {
-            message: Some(SchedulerControlMessageEnum::UpdatePartitions(
-                UpdatePartitions {
-                    new_partitions: HashMap::from([(
-                        table.to_string(),
-                        BytesArray {
-                            items: partitions_bytes,
-                        },
-                    )]),
-                    removed_partitions: HashMap::new(),
-                    // TODO: switched to ack-based send in the next commit; this
-                    // empty request_id keeps the legacy fire-and-forget shape
-                    // until the new call site replaces it.
-                    request_id: String::new(),
-                },
-            )),
-        };
+        let mut backoff = FibonacciBackoffBuilder::new()
+            .max_duration(Some(NOTIFY_BACKOFF_MAX))
+            .max_retries(Some(NOTIFY_MAX_RETRIES))
+            .build();
+        let table_str = table.to_string();
 
-        registry
-            .send_command(executor_id, command)
-            .await
-            .context(SendCommandSnafu {
-                executor_id: executor_id.to_string(),
-            })?;
+        loop {
+            // Clone per attempt — both build_command's FnOnce and a possible
+            // retry require fresh owned data.
+            let partitions_bytes = partitions_bytes.clone();
+            let table_str = table_str.clone();
+            let send_result = registry
+                .send_command_with_ack(
+                    executor_id,
+                    move |request_id| SchedulerControlMessage {
+                        message: Some(SchedulerControlMessageEnum::UpdatePartitions(
+                            UpdatePartitions {
+                                new_partitions: HashMap::from([(
+                                    table_str,
+                                    BytesArray {
+                                        items: partitions_bytes,
+                                    },
+                                )]),
+                                removed_partitions: HashMap::new(),
+                                request_id,
+                            },
+                        )),
+                    },
+                    NOTIFY_ACK_TIMEOUT,
+                )
+                .await;
+
+            match send_result {
+                Ok(()) => break,
+                Err(err) if err.is_retryable() => {
+                    let Some(delay) = backoff.next_duration() else {
+                        tracing::warn!(
+                            executor = %executor_id,
+                            table = %table,
+                            error = %err,
+                            "Exhausted retries notifying executor of partition assignments; \
+                             assignment remains committed and will retry on next reconcile cycle"
+                        );
+                        return Err(err).context(SendCommandSnafu {
+                            executor_id: executor_id.to_string(),
+                        });
+                    };
+                    tracing::debug!(
+                        executor = %executor_id,
+                        table = %table,
+                        delay_ms = delay.as_millis(),
+                        error = %err,
+                        "Executor ack failed for partition update; retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                Err(err) => {
+                    return Err(err).context(SendCommandSnafu {
+                        executor_id: executor_id.to_string(),
+                    });
+                }
+            }
+        }
     }
 
     Ok(())

--- a/crates/runtime-cluster/src/service.rs
+++ b/crates/runtime-cluster/src/service.rs
@@ -772,6 +772,9 @@ async fn notify_executor_to_unload(
                                 items: partitions_bytes,
                             },
                         )]),
+                        // Empty == no ack requested. This call site is the
+                        // unload path; switch to ack-based in a follow-up.
+                        request_id: String::new(),
                     },
                 )),
             },
@@ -1136,6 +1139,10 @@ async fn notify_executor_of_assignments(
                         },
                     )]),
                     removed_partitions: HashMap::new(),
+                    // TODO: switched to ack-based send in the next commit; this
+                    // empty request_id keeps the legacy fire-and-forget shape
+                    // until the new call site replaces it.
+                    request_id: String::new(),
                 },
             )),
         };

--- a/crates/runtime-cluster/src/service.rs
+++ b/crates/runtime-cluster/src/service.rs
@@ -44,7 +44,7 @@ use spicepod::partitioning::PartitionedBy;
 use tokio::sync::RwLock;
 use tokio::time::timeout;
 
-use util::fibonacci_backoff::{Backoff, FibonacciBackoffBuilder};
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
 
 use crate::context::PartitionOperations;
 use crate::executor_registry::{self, ExecutorRegistry};
@@ -1147,11 +1147,21 @@ async fn notify_executor_of_assignments(
             .build();
         let table_str = table.to_string();
 
+        // Wrap the payload in an Arc so each attempt's closure-build clones a
+        // cheap Arc handle instead of the full Vec<Vec<u8>>. We still
+        // materialize an owned Vec inside the closure body when constructing
+        // the proto message — that deep copy is unavoidable because
+        // BytesArray/UpdatePartitions own their data over the wire — but the
+        // Arc keeps it limited to one materialization per actual send rather
+        // than two per loop iteration.
+        let payload = Arc::new(BytesArray {
+            items: partitions_bytes,
+        });
+        let table_str = Arc::new(table_str);
+
         loop {
-            // Clone per attempt — both build_command's FnOnce and a possible
-            // retry require fresh owned data.
-            let partitions_bytes = partitions_bytes.clone();
-            let table_str = table_str.clone();
+            let payload = Arc::clone(&payload);
+            let table_str = Arc::clone(&table_str);
             let send_result = registry
                 .send_command_with_ack(
                     executor_id,
@@ -1159,10 +1169,8 @@ async fn notify_executor_of_assignments(
                         message: Some(SchedulerControlMessageEnum::UpdatePartitions(
                             UpdatePartitions {
                                 new_partitions: HashMap::from([(
-                                    table_str,
-                                    BytesArray {
-                                        items: partitions_bytes,
-                                    },
+                                    (*table_str).clone(),
+                                    (*payload).clone(),
                                 )]),
                                 removed_partitions: HashMap::new(),
                                 request_id,

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -130,6 +130,8 @@ message ExecutorControlMessage {
         ExecutorHeartbeat heartbeat = 2;
         MetricsResponse metrics = 3;
         ExecutorShutdown shutdown = 4;
+        // Acknowledgement for a scheduler command (correlated by request_id).
+        Ack ack = 5;
     }
 }
 
@@ -149,6 +151,9 @@ message UpdatePartitions {
     map<string, BytesArray> new_partitions = 1;
     // Map of table name to list of REMOVED partition expressions to remove.
     map<string, BytesArray> removed_partitions = 2;
+    // Unique identifier for this request, used to correlate the executor's Ack.
+    // Empty string means "no ack expected" (legacy / fire-and-forget callers).
+    string request_id = 3;
 }
 
 // Request message for AllocateInitialPartitions RPC.
@@ -222,6 +227,18 @@ message MetricsResponse {
     string request_id = 1;
     // OTLP ExportMetricsServiceRequest protobuf-encoded metrics.
     bytes otlp_metrics = 2;
+}
+
+// Generic acknowledgement for a scheduler command that needs delivery
+// confirmation (e.g. UpdatePartitions). Correlated by request_id.
+//
+// On success the `error` field is unset. On failure, `error` carries a
+// short human-readable description; the scheduler decides whether to retry.
+message Ack {
+    // Request ID this ack corresponds to.
+    string request_id = 1;
+    // Optional error message. Absent/empty means the command applied successfully.
+    optional string error = 2;
 }
 
 // Physical plan — wrapper with oneof to unambiguously tag each node type.

--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -33,7 +33,7 @@ use futures::StreamExt;
 use runtime_proto::cluster_service_client::ClusterServiceClient;
 use runtime_proto::scheduler_control_message::Message as SchedulerMessage;
 use runtime_proto::{
-    ExecutorControlMessage, ExecutorHeartbeat, ExecutorShutdown, MetricsResponse,
+    Ack, ExecutorControlMessage, ExecutorHeartbeat, ExecutorShutdown, MetricsResponse,
     executor_control_message::Message as ExecutorMessage,
 };
 use tokio::sync::{Notify, RwLock, mpsc};
@@ -52,11 +52,15 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 /// The handler takes two arguments:
 /// 1. `new_partitions`: A map of dataset names to a list of partition values (as byte vectors) that have been assigned.
 /// 2. `removed_partitions`: A map of dataset names to a list of partition values (as byte vectors) that should be unloaded.
+///
+/// The handler returns `Ok(())` on success or `Err(message)` if the update
+/// could not be applied. The message is forwarded to the scheduler as an
+/// [`Ack`] so it can decide whether to retry.
 pub type PartitionUpdateHandler = Arc<
     dyn Fn(
             HashMap<String, Vec<Vec<u8>>>,
             HashMap<String, Vec<Vec<u8>>>,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send>>
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send>>
         + Send
         + Sync,
 >;
@@ -375,23 +379,53 @@ async fn handle_scheduler_message(
         }
         SchedulerMessage::UpdatePartitions(update) => {
             tracing::debug!(
-                "Received UpdatePartitions from scheduler {scheduler_address}: {} new, {} removed",
+                "Received UpdatePartitions from scheduler {scheduler_address}: {} new, {} removed, request_id={}",
                 update.new_partitions.len(),
-                update.removed_partitions.len()
+                update.removed_partitions.len(),
+                update.request_id,
             );
 
-            if let Some(handler) = partition_update_handler {
-                let new_partitions = update
-                    .new_partitions
-                    .into_iter()
-                    .map(|(k, v)| (k, v.items))
-                    .collect();
-                let removed_partitions = update
-                    .removed_partitions
-                    .into_iter()
-                    .map(|(k, v)| (k, v.items))
-                    .collect();
-                handler(new_partitions, removed_partitions).await;
+            let request_id = update.request_id.clone();
+            let new_partitions = update
+                .new_partitions
+                .into_iter()
+                .map(|(k, v)| (k, v.items))
+                .collect();
+            let removed_partitions = update
+                .removed_partitions
+                .into_iter()
+                .map(|(k, v)| (k, v.items))
+                .collect();
+
+            let result = if let Some(handler) = partition_update_handler {
+                handler(new_partitions, removed_partitions).await
+            } else {
+                // No handler configured (e.g. scheduler-role process). Nothing
+                // to apply locally; report success to the sender.
+                Ok(())
+            };
+
+            if let Err(ref e) = result {
+                tracing::error!(
+                    "Failed to apply partition update from {scheduler_address}: {e}"
+                );
+            }
+
+            // Send an Ack only if the scheduler asked for one (non-empty
+            // request_id). Empty == legacy fire-and-forget send_command.
+            if !request_id.is_empty() {
+                let ack = ExecutorControlMessage {
+                    executor_id: executor_id.to_string(),
+                    message: Some(ExecutorMessage::Ack(Ack {
+                        request_id,
+                        error: result.err(),
+                    })),
+                };
+                if let Err(e) = outbound_tx.send(ack).await {
+                    tracing::warn!(
+                        "Failed to send partition-update ack to {scheduler_address}: {e}"
+                    );
+                }
             }
         }
         SchedulerMessage::CancelTasks(cmd) => {

--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -406,9 +406,7 @@ async fn handle_scheduler_message(
             };
 
             if let Err(ref e) = result {
-                tracing::error!(
-                    "Failed to apply partition update from {scheduler_address}: {e}"
-                );
+                tracing::error!("Failed to apply partition update from {scheduler_address}: {e}");
             }
 
             // Send an Ack only if the scheduler asked for one (non-empty

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1499,16 +1499,53 @@ pub async fn initialize_cluster_executor(
         // This also provides scheduler with executor_id to connect over FlightSQL to fetch partitions during SQL queries.
         //
         // This must be done after executor's flight service is ready to accept connections. Otherwise the scheduler will attempt to make connection and fail. Waiting until after `rx_ready` (which is done after the executor has established a network connection to the Scheduler's control plane), should give enough time for executor to bind locally for flight.
-        let initial_partitions = executor_request_initial_partitions(
-            cluster_client.clone(),
-            rt.datafusion().cluster_config.node_advertise_url(),
-            rt.datafusion().ctx.as_ref(),
-        )
-        .await
-        .map_err(|status| FailedToStartClusterExecutor {
-            source: format!("Failed to allocate initial partitions from scheduler: {status}")
-                .into(),
-        })?;
+        //
+        // The scheduler can legitimately return Unavailable during its own
+        // startup window — while load_datasets() is still registering the
+        // accelerated tables, partition expressions can't be serialized.
+        // Retry with fibonacci backoff on Unavailable; surface any other error.
+        let initial_partitions = {
+            let mut backoff = FibonacciBackoffBuilder::new()
+                .max_duration(Some(SCHEDULER_BACKOFF_MAX))
+                .build();
+            loop {
+                match executor_request_initial_partitions(
+                    cluster_client.clone(),
+                    rt.datafusion().cluster_config.node_advertise_url(),
+                    rt.datafusion().ctx.as_ref(),
+                )
+                .await
+                {
+                    Ok(p) => break p,
+                    Err(crate::cluster::partition::Error::PartitionAllocationRequest {
+                        source,
+                    }) if source.code() == tonic::Code::Unavailable => {
+                        let Some(delay) = backoff.next_duration() else {
+                            return Err(FailedToStartClusterExecutor {
+                                source: format!(
+                                    "Failed to allocate initial partitions from scheduler after exhausting retries: {source}"
+                                )
+                                .into(),
+                            });
+                        };
+                        tracing::debug!(
+                            delay_ms = delay.as_millis(),
+                            status = %source.message(),
+                            "Scheduler not ready for allocate_initial_partitions; retrying"
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                    Err(other) => {
+                        return Err(FailedToStartClusterExecutor {
+                            source: format!(
+                                "Failed to allocate initial partitions from scheduler: {other}"
+                            )
+                            .into(),
+                        });
+                    }
+                }
+            }
+        };
         tracing::debug!(
             "For executor={:?}, initial accelerated table partitions={:?}",
             rt.datafusion().cluster_config.node_advertise_url(),

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1362,7 +1362,8 @@ pub async fn initialize_cluster_executor(
         let rt = Arc::clone(&partition_update_handler_rt);
         Box::pin(async move {
             rt.update_partition_assignments(new_partitions, removed_partitions)
-                .await;
+                .await
+                .map_err(|e| e.to_string())
         })
     }));
 

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -84,6 +84,12 @@ use util::session_state::builder_from_existing;
 const SCHEDULER_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 const SCHEDULER_BACKOFF_MAX: Duration = Duration::from_secs(5);
 
+/// Upper bound on retries when the scheduler returns `Unavailable` to
+/// `allocate_initial_partitions` (i.e. its `load_datasets()` hasn't finished
+/// registering all accelerated tables yet). At ~5s per attempt this gives a
+/// few minutes of patience before the executor startup hard-fails.
+const ALLOCATE_INITIAL_PARTITIONS_MAX_RETRIES: usize = 60;
+
 #[derive(Clone)]
 pub enum DistributedNode {
     Scheduler {
@@ -1508,6 +1514,7 @@ pub async fn initialize_cluster_executor(
         let initial_partitions = {
             let mut backoff = FibonacciBackoffBuilder::new()
                 .max_duration(Some(SCHEDULER_BACKOFF_MAX))
+                .max_retries(Some(ALLOCATE_INITIAL_PARTITIONS_MAX_RETRIES))
                 .build();
             loop {
                 match executor_request_initial_partitions(

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -33,8 +33,8 @@ pub use runtime_cluster::{
 pub use runtime_cluster::{executor_selection, service, store, write_through};
 
 pub use startup::{
-    accelerated_tables, executor_request_initial_partitions, initialize_partition_metadata,
-    validate_partition_keys,
+    accelerated_tables, executor_request_initial_partitions, first_unready_accelerated_table,
+    initialize_partition_metadata, validate_partition_keys,
 };
 
 #[derive(Debug, Snafu)]

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -157,6 +157,22 @@ impl PartitionAssignmentTask {
             return Ok(());
         };
 
+        // Defer the cycle while any accelerated table is still loading — the
+        // notify path inside reconcile_all calls partition_value_to_bytes,
+        // which needs each table's schema in the SessionContext. Skipping is
+        // safe: the next periodic tick will retry.
+        let app_snapshot = service.app.read().await.clone();
+        if let Some(app) = app_snapshot
+            && let Some(not_ready) =
+                super::first_unready_accelerated_table(&app, self.df.as_ref()).await
+        {
+            tracing::debug!(
+                table = %not_ready,
+                "Deferring partition assignment cycle: accelerated table not yet registered"
+            );
+            return Ok(());
+        }
+
         service
             .reconcile_all(self.df.as_ref())
             .await

--- a/crates/runtime/src/cluster/partition/startup.rs
+++ b/crates/runtime/src/cluster/partition/startup.rs
@@ -114,6 +114,31 @@ pub fn validate_partition_keys(app: &App) -> Result<()> {
     Ok(())
 }
 
+/// Returns the first accelerated, partitioned table from `app` that isn't
+/// yet registered in `df`'s `SessionContext`, or `None` if every such table
+/// is ready.
+///
+/// Used as a readiness gate by scheduler paths whose partition-expression
+/// serialization needs each accelerated table's schema to be in the catalog
+/// — e.g. `allocate_initial_partitions` and `PartitionAssignmentTask::
+/// run_assignment_cycle`. During the scheduler's own `load_datasets()`
+/// startup window the answer is `Some(table)`; the caller should defer.
+pub async fn first_unready_accelerated_table(
+    app: &Arc<App>,
+    df: &crate::datafusion::DataFusion,
+) -> Option<TableReference> {
+    // Collect without holding any external lock — the caller is expected to
+    // pass an already-snapshotted `Arc<App>` so we don't hold an async
+    // RwLock guard across the get_table awaits.
+    let table_refs: Vec<TableReference> = accelerated_tables(app).into_keys().collect();
+    for table_ref in table_refs {
+        if df.get_table(&table_ref).await.is_none() {
+            return Some(table_ref);
+        }
+    }
+    None
+}
+
 /// Helper to find all tables with acceleration partitioning configured, along with their partitioning columns.
 #[must_use]
 pub fn accelerated_tables(app: &Arc<App>) -> HashMap<TableReference, Vec<PartitionedBy>> {

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -526,7 +526,7 @@ impl ClusterService for ClusterServiceImpl {
             };
 
             // Register the executor with the registry.
-            let pending_requests = executor_registry
+            let pending_metrics = executor_registry
                 .register(executor_id.clone(), outbound_tx_for_registry)
                 .await;
 
@@ -547,12 +547,12 @@ impl ClusterService for ClusterServiceImpl {
                         match result {
                             Some(Ok(msg)) => {
                                 if let Some(message) = msg.message {
-                                    // Handle metrics responses by completing pending requests.
+                                    // Route correlated responses (metrics) to their waiters;
+                                    // anything else goes to the general handler.
                                     if let ExecutorMessage::Metrics(response) = &message {
-                                        let mut pending = pending_requests.write().await;
-                                        if let Some(sender) = pending.remove(&response.request_id) {
-                                            let _ = sender.send(response.clone());
-                                        } else {
+                                        if !pending_metrics
+                                            .deliver(&response.request_id, response.clone())
+                                        {
                                             tracing::warn!(
                                                 "Received metrics response for unknown request_id: {}",
                                                 response.request_id

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -632,6 +632,29 @@ impl ClusterService for ClusterServiceImpl {
             &executor_url
         };
 
+        // Gate on dataset readiness. Partition-expression serialization needs
+        // every accelerated table's schema to be in the SessionContext; if a
+        // dataset is still loading from its source, `partition_value_to_bytes`
+        // would fail with "Table not found when parsing expression" — return
+        // a transient `Unavailable` so the executor retries with backoff.
+        {
+            let app_guard = self.app.read().await;
+            if let Some(app) = app_guard.as_ref() {
+                for table_ref in super::partition::accelerated_tables(app).keys() {
+                    if self.datafusion.get_table(table_ref).await.is_none() {
+                        tracing::debug!(
+                            executor = %executor_id,
+                            table = %table_ref,
+                            "Deferring allocate_initial_partitions: accelerated table not yet registered"
+                        );
+                        return Err(Status::unavailable(format!(
+                            "partition metadata not ready: accelerated table {table_ref} still loading"
+                        )));
+                    }
+                }
+            }
+        }
+
         let tls_config_opt = self.datafusion.cluster_config.client_tls_config();
         match create_executor_flight_client(&executor_url, tls_config_opt) {
             Ok(client) => {
@@ -697,9 +720,17 @@ impl ClusterService for ClusterServiceImpl {
                             {
                                 Ok(bytes) => items.push(bytes.to_vec()),
                                 Err(e) => {
+                                    // The readiness gate above should make this
+                                    // path unreachable for the dataset-not-ready
+                                    // case. Anything that lands here is a real
+                                    // bug (corrupt expression, etc.) — fail loud
+                                    // rather than silently dropping the partition.
                                     tracing::error!(
                                         "Failed to serialize partition expression for table {table_ref}: {e}"
                                     );
+                                    return Err(Status::internal(format!(
+                                        "Failed to serialize partition expression for table {table_ref}: {e}"
+                                    )));
                                 }
                             }
                         }

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -526,7 +526,7 @@ impl ClusterService for ClusterServiceImpl {
             };
 
             // Register the executor with the registry.
-            let pending_metrics = executor_registry
+            let handles = executor_registry
                 .register(executor_id.clone(), outbound_tx_for_registry)
                 .await;
 
@@ -547,24 +547,39 @@ impl ClusterService for ClusterServiceImpl {
                         match result {
                             Some(Ok(msg)) => {
                                 if let Some(message) = msg.message {
-                                    // Route correlated responses (metrics) to their waiters;
+                                    // Route correlated responses (metrics, acks) to their waiters;
                                     // anything else goes to the general handler.
-                                    if let ExecutorMessage::Metrics(response) = &message {
-                                        if !pending_metrics
-                                            .deliver(&response.request_id, response.clone())
-                                        {
-                                            tracing::warn!(
-                                                "Received metrics response for unknown request_id: {}",
-                                                response.request_id
-                                            );
+                                    match &message {
+                                        ExecutorMessage::Metrics(response) => {
+                                            if !handles
+                                                .pending_metrics
+                                                .deliver(&response.request_id, response.clone())
+                                            {
+                                                tracing::warn!(
+                                                    "Received metrics response for unknown request_id: {}",
+                                                    response.request_id
+                                                );
+                                            }
                                         }
-                                    } else {
-                                        handle_executor_message(
-                                            &executor_id,
-                                            &message,
-                                            &datafusion,
-                                        )
-                                        .await;
+                                        ExecutorMessage::Ack(ack) => {
+                                            if !handles
+                                                .pending_acks
+                                                .deliver(&ack.request_id, ack.clone())
+                                            {
+                                                tracing::warn!(
+                                                    "Received ack for unknown request_id: {}",
+                                                    ack.request_id
+                                                );
+                                            }
+                                        }
+                                        _ => {
+                                            handle_executor_message(
+                                                &executor_id,
+                                                &message,
+                                                &datafusion,
+                                            )
+                                            .await;
+                                        }
                                     }
                                 }
                             }
@@ -804,6 +819,11 @@ async fn handle_executor_message(
             tracing::warn!(
                 "Unexpected metrics response in handle_executor_message for {executor_id}"
             );
+        }
+        ExecutorMessage::Ack(_) => {
+            // Acks are handled separately in the stream handler via pending_acks.
+            // This shouldn't be reached, but log if it is.
+            tracing::warn!("Unexpected ack in handle_executor_message for {executor_id}");
         }
         ExecutorMessage::Shutdown(shutdown) => {
             let reason = if shutdown.reason.is_empty() {

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -261,6 +261,17 @@ impl ClusterServiceImpl {
         self.executor_streams.broadcast_poll_now(reason);
     }
 
+    /// Returns the first accelerated table that hasn't yet been registered in
+    /// the local `SessionContext`, or `None` if every accelerated table is
+    /// ready. Snapshots the app under the read lock and releases it before
+    /// the per-table `get_table` lookups so no async guard is held across
+    /// `.await`.
+    async fn first_unready_accelerated_table(&self) -> Option<TableReference> {
+        let app = self.app.read().await.clone();
+        let app = app?;
+        super::partition::first_unready_accelerated_table(&app, self.datafusion.as_ref()).await
+    }
+
     /// Returns the executor registry for use by other components.
     #[must_use]
     pub fn executor_registry(&self) -> Arc<ExecutorRegistry> {
@@ -637,22 +648,15 @@ impl ClusterService for ClusterServiceImpl {
         // dataset is still loading from its source, `partition_value_to_bytes`
         // would fail with "Table not found when parsing expression" — return
         // a transient `Unavailable` so the executor retries with backoff.
-        {
-            let app_guard = self.app.read().await;
-            if let Some(app) = app_guard.as_ref() {
-                for table_ref in super::partition::accelerated_tables(app).keys() {
-                    if self.datafusion.get_table(table_ref).await.is_none() {
-                        tracing::debug!(
-                            executor = %executor_id,
-                            table = %table_ref,
-                            "Deferring allocate_initial_partitions: accelerated table not yet registered"
-                        );
-                        return Err(Status::unavailable(format!(
-                            "partition metadata not ready: accelerated table {table_ref} still loading"
-                        )));
-                    }
-                }
-            }
+        if let Some(not_ready) = self.first_unready_accelerated_table().await {
+            tracing::debug!(
+                executor = %executor_id,
+                table = %not_ready,
+                "Deferring allocate_initial_partitions: accelerated table not yet registered"
+            );
+            return Err(Status::unavailable(format!(
+                "partition metadata not ready: accelerated table {not_ready} still loading"
+            )));
         }
 
         let tls_config_opt = self.datafusion.cluster_config.client_tls_config();

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -244,6 +244,12 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    #[snafu(display("Unable to deserialize partition expression for table {table}: {source}"))]
+    UnableToDeserializeClusterPartitionExpression {
+        table: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     #[snafu(display("Unable to get secret for data connector {data_connector}: {source}"))]
     UnableToGetSecretForDataConnector {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -722,85 +728,86 @@ impl Runtime {
         new_partitions: HashMap<String, Vec<Vec<u8>>>,
         removed_partitions: HashMap<String, Vec<Vec<u8>>>,
     ) -> Result<()> {
-        if let Some(DistributedNode::Executor {
+        let Some(DistributedNode::Executor {
             partition_assignments,
         }) = self.distributed.as_ref()
-        {
-            let mut guard = partition_assignments.write().await;
-
-            // Handle removed partitions
-            for (table_name, partitions) in &removed_partitions {
-                let table_ref = TableReference::parse_str(table_name)
-                    .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
-                if let Some(current_partitions) = guard.get_mut(&table_ref) {
-                    for partition_bytes in partitions {
-                        if let Ok(partition_expr) =
-                            Expr::from_bytes_with_registry(partition_bytes, self.df.ctx.as_ref())
-                        {
-                            current_partitions.retain(|p| p != &partition_expr);
-                        } else {
-                            tracing::warn!(
-                                "Failed to deserialize removed partition expression for table {table_name}"
-                            );
-                        }
-                    }
-                }
-            }
-
-            // Handle new partitions
-            for (table_name, partitions) in &new_partitions {
-                let table_ref = TableReference::parse_str(table_name)
-                    .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
-                let current_partitions = guard.entry(table_ref.clone()).or_default();
-                for partition_bytes in partitions {
-                    if let Ok(partition_expr) = ::datafusion_expr::Expr::from_bytes_with_registry(
-                        partition_bytes,
-                        self.df.ctx.as_ref(),
-                    ) {
-                        if !current_partitions.contains(&partition_expr) {
-                            current_partitions.push(partition_expr);
-                        }
-                    } else {
-                        tracing::warn!(
-                            "Failed to deserialize new partition expression for table {table_name}"
-                        );
-                    }
-                }
-            }
-
-            // Identify all affected tables
-            let affected_tables: HashSet<_> = new_partitions
-                .keys()
-                .chain(removed_partitions.keys())
-                .collect();
-            drop(guard); // drop lock before updating tables
-
-            // Take a snapshot of the current assignments without holding the lock across .await
-            let assignments = {
-                let assignments_guard = partition_assignments.read().await;
-                assignments_guard.clone()
-            };
-
-            // Update all affected tables. If any fails, propagate the first
-            // error so the executor can ack the scheduler with a real reason —
-            // the scheduler can then retry the assignment later.
-            for table_name in affected_tables {
-                let resolved = TableReference::parse_str(table_name)
-                    .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
-
-                self.update_partition_refresh_sql(resolved.clone(), &assignments)
-                    .await?;
-            }
-            Ok(())
-        } else {
+        else {
             tracing::warn!(
                 "Attempted to update partition assignments on a non-executor node. Ignoring."
             );
             // Not an executor — there's nothing for us to apply. Report success
             // so the scheduler doesn't retry; the routing layer is what'd be
             // misconfigured here.
-            Ok(())
+            return Ok(());
+        };
+
+        // Compute the prospective post-update state from a snapshot of the
+        // current map. We apply the DataFusion filter updates against this
+        // *before* committing to shared state, so a per-table failure leaves
+        // the routing map unchanged and the scheduler's retry sees a
+        // consistent starting point on the next attempt.
+        let mut prospective: PartitionAssignments = partition_assignments.read().await.clone();
+
+        for (table_name, partitions) in &removed_partitions {
+            let table_ref = TableReference::parse_str(table_name)
+                .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
+            if let Some(current_partitions) = prospective.get_mut(&table_ref) {
+                for partition_bytes in partitions {
+                    let partition_expr =
+                        Expr::from_bytes_with_registry(partition_bytes, self.df.ctx.as_ref())
+                            .map_err(|source| {
+                                Error::UnableToDeserializeClusterPartitionExpression {
+                                    table: table_name.clone(),
+                                    source: Box::new(source),
+                                }
+                            })?;
+                    current_partitions.retain(|p| p != &partition_expr);
+                }
+            }
         }
+
+        for (table_name, partitions) in &new_partitions {
+            let table_ref = TableReference::parse_str(table_name)
+                .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
+            let current_partitions = prospective.entry(table_ref.clone()).or_default();
+            for partition_bytes in partitions {
+                let partition_expr = ::datafusion_expr::Expr::from_bytes_with_registry(
+                    partition_bytes,
+                    self.df.ctx.as_ref(),
+                )
+                .map_err(|source| {
+                    Error::UnableToDeserializeClusterPartitionExpression {
+                        table: table_name.clone(),
+                        source: Box::new(source),
+                    }
+                })?;
+                if !current_partitions.contains(&partition_expr) {
+                    current_partitions.push(partition_expr);
+                }
+            }
+        }
+
+        let affected_tables: HashSet<_> = new_partitions
+            .keys()
+            .chain(removed_partitions.keys())
+            .collect();
+
+        // Apply DataFusion filter updates against the prospective state. If any
+        // fails, the shared partition_assignments map is not modified — the
+        // scheduler retries the update and we'll re-attempt all tables.
+        for table_name in affected_tables {
+            let resolved = TableReference::parse_str(table_name)
+                .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
+
+            self.update_partition_refresh_sql(resolved.clone(), &prospective)
+                .await?;
+        }
+
+        // All filter updates succeeded — commit the new routing state. Last
+        // step so the planner's view of executor partitions never gets ahead
+        // of what the AcceleratedTables actually know about.
+        *partition_assignments.write().await = prospective;
+        Ok(())
     }
 
     pub(crate) async fn update_partition_refresh_sql(

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -238,6 +238,12 @@ pub enum Error {
     #[snafu(display("Unable to load secrets for data connector: {data_connector}"))]
     UnableToLoadDataConnectorSecrets { data_connector: String },
 
+    #[snafu(display("Unable to update cluster partition filters for table {table}: {source}"))]
+    UnableToUpdateClusterPartitionFilters {
+        table: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     #[snafu(display("Unable to get secret for data connector {data_connector}: {source}"))]
     UnableToGetSecretForDataConnector {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -715,7 +721,7 @@ impl Runtime {
         &self,
         new_partitions: HashMap<String, Vec<Vec<u8>>>,
         removed_partitions: HashMap<String, Vec<Vec<u8>>>,
-    ) {
+    ) -> Result<()> {
         if let Some(DistributedNode::Executor {
             partition_assignments,
         }) = self.distributed.as_ref()
@@ -775,22 +781,25 @@ impl Runtime {
                 assignments_guard.clone()
             };
 
-            // Update all affected tables
+            // Update all affected tables. If any fails, propagate the first
+            // error so the executor can ack the scheduler with a real reason —
+            // the scheduler can then retry the assignment later.
             for table_name in affected_tables {
                 let resolved = TableReference::parse_str(table_name)
                     .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
 
-                if let Err(e) = self
-                    .update_partition_refresh_sql(resolved.clone(), &assignments)
-                    .await
-                {
-                    tracing::warn!("Failed to update partition refresh SQL for {table_name}: {e}");
-                }
+                self.update_partition_refresh_sql(resolved.clone(), &assignments)
+                    .await?;
             }
+            Ok(())
         } else {
             tracing::warn!(
                 "Attempted to update partition assignments on a non-executor node. Ignoring."
             );
+            // Not an executor — there's nothing for us to apply. Report success
+            // so the scheduler doesn't retry; the routing layer is what'd be
+            // misconfigured here.
+            Ok(())
         }
     }
 
@@ -807,20 +816,22 @@ impl Runtime {
             Arc::<str>::clone(&table.schema),
             Arc::<str>::clone(&table.table),
         );
-        if let Err(e) = self
-            .datafusion()
+        // Propagate the filter-update error so the caller (and the executor's
+        // ack to the scheduler) sees the failure rather than just logging it.
+        self.datafusion()
             .update_partition_filters(table_ref.clone(), partition_filters)
             .await
-        {
-            tracing::error!("Failed to update partition filters for {table}: {e}");
-        } else {
-            tracing::info!("Updated partition assignments for {table}");
-            // Trigger a refresh to load the data for the new partitions
-            if let Err(e) = self.datafusion().refresh_table(&table_ref, None).await {
-                tracing::warn!(
-                    "Failed to trigger refresh for {table} after updating partitions: {e}"
-                );
-            }
+            .map_err(|source| Error::UnableToUpdateClusterPartitionFilters {
+                table: table.to_string(),
+                source: Box::new(source),
+            })?;
+
+        tracing::info!("Updated partition assignments for {table}");
+        // Trigger a refresh to load the data for the new partitions. Refresh
+        // failures are non-fatal — the assignment is still valid; data just
+        // hasn't been pulled yet.
+        if let Err(e) = self.datafusion().refresh_table(&table_ref, None).await {
+            tracing::warn!("Failed to trigger refresh for {table} after updating partitions: {e}");
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Fixes #10963.

Distributed acceleration could assign partitions while the scheduler or executors were still loading the accelerated dataset. Partition expression serialization needs the table schema to be registered in DataFusion; during that startup window it failed with `Table taxi_trips not found when parsing expression`.

That failure could leave cluster state split: the partition store recorded an executor assignment, but the executor never applied the partition filters. The visible symptom was queries planning against an empty partition set, such as `EmptyRelation` for `select * from taxi_trips`.

This PR makes partition assignment startup-safe and delivery-aware. Initial partition allocation now waits for accelerated tables to be registered, executors retry transient scheduler readiness failures, and scheduler-to-executor partition updates require an acknowledgement before they are treated as delivered.

## Flow

```text
Before
------
scheduler starts loading dataset
        |
        +--> executor asks for / receives partitions too early
                 |
                 +--> table schema missing in DataFusion
                 |
                 +--> error logged or swallowed
                 |
                 +--> partition store and executor filters diverge

After
-----
scheduler starts loading dataset
        |
        +--> initial allocation returns Unavailable until tables are registered
        |        |
        |        +--> executor retries with backoff
        |
        +--> UpdatePartitions includes request_id
                 |
                 +--> executor applies filters and sends Ack
                 |
                 +--> scheduler retries AckFailed/AckTimeout with backoff
```

## Changes

- Add `CorrelatedResponses<T>` and `send_correlated` for request/response handling on the scheduler/executor control stream.
- Move metrics responses to the new correlation helper without changing metrics behavior.
- Add a generic `Ack` proto message and `request_id` on `UpdatePartitions`.
- Gate `allocate_initial_partitions` until accelerated tables are present in the scheduler catalog, returning `Unavailable` for the startup race window.
- Retry executor initial partition allocation on scheduler `Unavailable` responses.
- Send `Ack` responses from executors after applying `UpdatePartitions`, including application errors.
- Retry scheduler partition notifications when executor acks fail or time out.
- Propagate partition filter update errors instead of logging and swallowing them.
- Add unit coverage for the correlation helper and ack-based command sending.

## Notes

- `UpdatePartitions` with an empty `request_id` still uses the legacy fire-and-forget behavior for callers that have not been migrated.
- `notify_executor_to_unload` still uses fire-and-forget sends. Converting unloads, `CancelTasks`, and `RefreshDataset` to the generic ack path can be follow-up work.

## Test plan

- [ ] `make lint-rust`
- [ ] `cargo test -p runtime-cluster`
- [ ] `cargo test -p runtime`
- [ ] Manual reproduction from #10963: `./scripts/distributed.sh 2` with a Cayenne-partitioned dataset, then query `select * from taxi_trips`
- [ ] CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/10976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781926044&installation_id=128462479&pr_number=10976&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F10976&signature=86b406191bd7f13f16b401e8be8b8fddaf0b8b61d5c638c6ec9e476000cfe98b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
