### PR TITLE
fix(tests): wait for chat prompt before sending in expect test

### DIFF
--- a/test/models/chat_01_simple.exp
+++ b/test/models/chat_01_simple.exp
@@ -8,7 +8,16 @@ spawn spice chat
 proc chat {message}  {
     global timeout
 
-     send "$message\r"
+    # Wait for the chat prompt to be ready before sending
+    expect {
+        "chat> " {}
+        timeout {
+            send_user "Timeout waiting for chat prompt\n"
+            exit 1
+        }
+    }
+
+    send "$message\r"
 
     expect {
         " ERROR " {
@@ -29,10 +38,7 @@ proc chat {message}  {
     send_user "Model returned expected response\n"
 }
 
-expect "chat>"
-
 chat "What datasets you have access to?"
-sleep 1
 
 chat "How many issues stored in database?"
 


### PR DESCRIPTION
## Summary
- Fixes flaky `chat_01_simple.exp` e2e test that fails with `spawn id exp5 not open`
- The `chat` proc now waits for the `chat>` prompt before sending each message, ensuring the `spice chat` process is still alive and ready
- Removes redundant initial `expect "chat>"` and `sleep 1` since prompt synchronization is now handled inside the proc

## Test plan
- [ ] CI e2e model chat test passes without `spawn id not open` errors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782005719&installation_id=128462479&pr_number=11000&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11000&signature=8c98dd2bd41b640cf60a32648fb2d09f9d1f2b9a0c11d90bbf70b8cb18411d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->