### PR TITLE
fix(tests): unbreak integration_models search CI

### DIFF
--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -823,7 +823,12 @@ impl TableProvider for EmbeddingTable {
     }
 
     fn get_logical_plan(&self) -> Option<Cow<'_, LogicalPlan>> {
-        self.base_table.get_logical_plan()
+        // EmbeddingTable augments the base table's schema with computed
+        // embedding columns. The base table's logical plan does not represent
+        // those columns, so forwarding it would cause `LogicalPlanBuilder::scan`
+        // to inline a plan whose schema is missing the embedding columns —
+        // any subsequent projection of those columns then fails.
+        None
     }
 
     fn schema(&self) -> SchemaRef {

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_mixed_datasets_fail_fast_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_mixed_datasets_fail_fast_error_response.snap
@@ -1,0 +1,5 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: err.to_string()
+---
+HTTP error: 400 Bad Request - Search cannot be run on plain because it has no embeddings or full text search indexes.

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_non_searchable_dataset_errors_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_non_searchable_dataset_errors_error_response.snap
@@ -1,0 +1,5 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: err.to_string()
+---
+HTTP error: 400 Bad Request - Search cannot be run on plain because it has no embeddings or full text search indexes.

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_searchable_dataset_no_matches_returns_empty_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_searchable_dataset_no_matches_returns_empty_response.snap
@@ -1,0 +1,8 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: "normalize_search_response(resp, round_scores)"
+---
+{
+  "duration_ms": "duration_ms_val",
+  "results": []
+}


### PR DESCRIPTION
## Summary

Two independent fixes that have been keeping the `integration tests (models)` workflow red on trunk:

- **`EmbeddingTable::get_logical_plan` now returns `None`** instead of forwarding to `base_table.get_logical_plan()`. The forwarding was added in #10795 as part of the `#[deny(clippy::missing_trait_methods)]` sweep, but the inner `ViewTable`'s logical plan only knows about base columns. `LogicalPlanBuilder::scan` inlines that plan, then any projection of the embedding columns that `EmbeddingTable` adds on top fails with `Schema error: No field named answer_embedding`. This broke `test_multi_column_search_view` consistently and is the most likely cause of the flaky `s3_vectors::search::multiple_embeddings` / `with_chunking` runs (both also use views with column-level embeddings). The fix mirrors the existing `IndexedTableProvider::get_logical_plan` pattern.

- **Add the three missing snapshot files** for `test_explicit_dataset_searchability_validation`. The test was added in #10968 without committing snapshots, so it has been failing on every run since.

## Test plan

- [x] `cargo nextest run -p runtime --test integration_models -- test_explicit_dataset_searchability_validation` — passes (was failing).
- [x] `cargo nextest run -p runtime --test integration_models -- test_multi_column_search_view` — passes in ~13s (was timing out at 122s).
- [x] `cargo nextest run -p runtime --test integration_models -E 'test(/models::search::/)'` — 21/23 pass; remaining 2 failures are environmental on my Mac (missing `SPICE_SECRET_OPENAI_API_KEY` for `test_multi_embedding_model_search`; missing local DuckDB `vss` extension for `test_duckdb_hnsw_search_vector_engine_and_embeddings_config`) and unrelated to the changes.
- [x] `make lint-rust` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782019876&installation_id=128462479&pr_number=11008&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11008&signature=23e60cbd243c902733bd4344782807f71941cb3bd512c4c1db5733f4a8e99e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->