### PR TITLE
fix: add missing truncate delegation and guards for wrapper TableProviders

### DIFF
--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -223,6 +223,10 @@ impl TableProvider for MetadataEnrichedTableProvider {
         self.inner.update(state, assignments, filters).await
     }
 
+    async fn truncate(&self, state: &dyn Session) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.inner.truncate(state).await
+    }
+
     fn statistics(&self) -> Option<Statistics> {
         self.inner.statistics()
     }

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -171,4 +171,8 @@ impl TableProvider for PolyTableProvider {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.write.update(state, assignments, filters).await
     }
+
+    async fn truncate(&self, state: &dyn Session) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.write.truncate(state).await
+    }
 }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1804,7 +1804,28 @@ impl TableProvider for AcceleratedTable {
     }
 
     async fn truncate(&self, state: &dyn Session) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        self.accelerator.truncate(state).await
+        if self.refresh_mode == RefreshMode::Snapshot {
+            return Err(datafusion::error::DataFusionError::Execution(format!(
+                "truncate on accelerated table {} is not permitted when refresh_mode is 'snapshot'; the accelerator is driven exclusively from the snapshot store",
+                self.dataset_name
+            )));
+        }
+
+        self.update_last_updated_at();
+
+        match &self.write_mode {
+            WriteMode::AcceleratorOnly => self.accelerator.truncate(state).await,
+            WriteMode::WriteThrough => {
+                let federated_table = self.federated.table_provider().await;
+                federated_table.truncate(state).await
+            }
+            WriteMode::WriteBack | WriteMode::DualWrite { .. } => {
+                Err(datafusion::error::DataFusionError::Plan(
+                    "TRUNCATE is not supported for write_back or dual_write accelerated tables"
+                        .to_string(),
+                ))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- `AcceleratedTable::truncate` bypassed the `RefreshMode::Snapshot` guard, `WriteMode` routing, and `update_last_updated_at()` call that `insert_into`, `delete_from`, and `update` all apply. A `TRUNCATE TABLE` in snapshot mode would silently mutate data the next snapshot refresh overwrites; in `WriteThrough` mode, the truncate would hit only the local accelerator instead of the federated source.
- `PolyTableProvider` and `MetadataEnrichedTableProvider` delegated `insert_into`, `delete_from`, and `update` to their inner provider but were missing `truncate`, causing `TRUNCATE TABLE` to hit DataFusion's default `NotImplemented` error for any DuckDB/SQLite/Postgres/Turso-accelerated or Postgres-federated dataset.

## Fix
- Add snapshot-mode guard, `update_last_updated_at()`, and `WriteMode` routing to `AcceleratedTable::truncate`, matching the guards on all sibling DML methods.
- Add `truncate` delegation to `PolyTableProvider` and `MetadataEnrichedTableProvider`.
- `WriteBack` and `DualWrite` modes return a structured error for truncate since those paths require staged/async semantics that truncate doesn't support.

## Test plan
- `cargo check -p runtime -p data_components` passes
- `cargo clippy -p runtime -p data_components` passes
- `cargo fmt` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782037081&installation_id=128462479&pr_number=11014&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11014&signature=42efbe9c72c9a29aec723cb727888931c5584cc4518a28f5db9052ba7fca9538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->