### PR TITLE
Cherry-pick fixes for release/2.0 RC5

### DIFF
--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -50,6 +50,9 @@ on:
           - 'postgres-catalog'
           - 'mysql-catalog'
           - 'mssql-catalog'
+          - 'turso'
+          - 'bigquery'
+          - 'scylladb'
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true
@@ -142,6 +145,22 @@ jobs:
             echo "MYSQL_DB=tpch_sf1" >> $GITHUB_ENV
           fi
 
+      - name: Install ADBC BigQuery Driver
+        if: ${{ contains(github.event.inputs.spicepod_path, 'adbc[bigquery]') }}
+        uses: ./.github/actions/setup-adbc-bigquery
+
+      - name: Set up Python
+        if: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Setup ScyllaDB
+        if: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') }}
+        uses: ./.github/actions/setup-scylladb
+        with:
+          keyspace: tpch_sf1
+
       - name: Run the throughput test - ${{ github.event.inputs.spicepod_path }}
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
@@ -199,6 +218,10 @@ jobs:
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           MONGODB_HOST: ${{ vars.TEST_MONGODB_HOST }}
           MONGODB_PASSWORD: ${{ secrets.TEST_MONGODB_PASSWORD }}
+          BIGQUERY_SERVICE_ACCOUNT_JSON: ${{ secrets.BIGQUERY_SERVICE_ACCOUNT_JSON }}
+          SCYLLADB_HOST: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && '127.0.0.1' || '' }}
+          SCYLLADB_PORT: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && '9042' || '' }}
+          SCYLLADB_KEYSPACE: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && 'tpch_sf1' || '' }}
 
       - name: Run the throughput test (with overrides) - ${{ github.event.inputs.spicepod_path }}
         if: ${{ github.event.inputs.query_overrides != '' }}
@@ -258,3 +281,7 @@ jobs:
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           MONGODB_HOST: ${{ vars.TEST_MONGODB_HOST }}
           MONGODB_PASSWORD: ${{ secrets.TEST_MONGODB_PASSWORD }}
+          BIGQUERY_SERVICE_ACCOUNT_JSON: ${{ secrets.BIGQUERY_SERVICE_ACCOUNT_JSON }}
+          SCYLLADB_HOST: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && '127.0.0.1' || '' }}
+          SCYLLADB_PORT: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && '9042' || '' }}
+          SCYLLADB_KEYSPACE: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && 'tpch_sf1' || '' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,6 +4143,7 @@ version = "2.0.0-rc.5"
 dependencies = [
  "async-trait",
  "chrono",
+ "data_components",
  "datafusion",
  "datafusion-table-providers",
  "linkme",
@@ -4215,6 +4216,7 @@ dependencies = [
  "snafu",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -518,30 +518,34 @@ impl CayenneCatalog {
         pk_bytes_list: &[Vec<u8>],
         sequence_number: i64,
     ) -> (String, Vec<MetastoreValue>) {
-        let mut values_parts = Vec::with_capacity(pk_bytes_list.len());
+        use std::fmt::Write as _;
+
+        const PREFIX: &str = "INSERT OR REPLACE INTO cayenne_insert_record \
+             (insert_record_id, table_id, pk_bytes, sequence_number) VALUES ";
+        // Each "(?N, ?N, ?N, ?N)" row is ≤ 32 bytes for the placeholder counts we hit.
+        let mut sql = String::with_capacity(PREFIX.len() + pk_bytes_list.len() * 32);
+        sql.push_str(PREFIX);
         let mut params = Vec::with_capacity(pk_bytes_list.len() * 4);
-        let table_id = table_id.to_string();
 
         for (i, pk_bytes) in pk_bytes_list.iter().enumerate() {
             let base = i * 4 + 1; // SQLite params are 1-indexed
-            values_parts.push(format!(
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            // `write!` into a `String` is infallible.
+            let _ = write!(
+                sql,
                 "(?{}, ?{}, ?{}, ?{})",
                 base,
                 base + 1,
                 base + 2,
                 base + 3
-            ));
+            );
             params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
-            params.push(MetastoreValue::Text(table_id.clone()));
+            params.push(MetastoreValue::Text(table_id.to_string()));
             params.push(MetastoreValue::Blob(pk_bytes.clone()));
             params.push(MetastoreValue::Integer(sequence_number));
         }
-
-        let sql = format!(
-            "INSERT OR REPLACE INTO cayenne_insert_record \
-             (insert_record_id, table_id, pk_bytes, sequence_number) VALUES {}",
-            values_parts.join(", ")
-        );
 
         (sql, params)
     }
@@ -554,13 +558,37 @@ impl CayenneCatalog {
     fn build_insert_delete_files_chunk_sql(
         delete_files: &[DeleteFile],
     ) -> (String, Vec<MetastoreValue>) {
+        use std::fmt::Write as _;
+
         const PARAMS_PER_ROW: usize = 9;
-        let mut values_parts = Vec::with_capacity(delete_files.len());
+        const PREFIX: &str = "INSERT INTO cayenne_delete_file (\
+                 delete_file_id, table_id, path, path_is_relative, \
+                 format, delete_count, file_size_bytes, source_data_file_path, sequence_number\
+             ) VALUES ";
+        const SUFFIX: &str = " \
+             ON CONFLICT(table_id, path) DO UPDATE SET \
+                 path = CASE \
+                     WHEN cayenne_delete_file.path_is_relative = excluded.path_is_relative \
+                         AND cayenne_delete_file.format = excluded.format \
+                         AND cayenne_delete_file.delete_count = excluded.delete_count \
+                         AND cayenne_delete_file.file_size_bytes = excluded.file_size_bytes \
+                         AND cayenne_delete_file.source_data_file_path IS excluded.source_data_file_path \
+                         AND cayenne_delete_file.sequence_number = excluded.sequence_number \
+                     THEN cayenne_delete_file.path \
+                     ELSE NULL \
+                 END";
+        // Each "(?N, ?N, ?N, ?N, ?N, ?N, ?N, ?N, ?N)" row averages ~64 bytes.
+        let mut sql = String::with_capacity(PREFIX.len() + SUFFIX.len() + delete_files.len() * 64);
+        sql.push_str(PREFIX);
         let mut params = Vec::with_capacity(delete_files.len() * PARAMS_PER_ROW);
 
         for (i, delete_file) in delete_files.iter().enumerate() {
             let base = i * PARAMS_PER_ROW + 1; // 1-indexed
-            values_parts.push(format!(
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            let _ = write!(
+                sql,
                 "(?{}, ?{}, ?{}, ?{}, ?{}, ?{}, ?{}, ?{}, ?{})",
                 base,
                 base + 1,
@@ -571,7 +599,7 @@ impl CayenneCatalog {
                 base + 6,
                 base + 7,
                 base + 8,
-            ));
+            );
             params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
             params.push(MetastoreValue::Text(delete_file.table_id.clone()));
             params.push(MetastoreValue::Text(delete_file.path.clone()));
@@ -588,25 +616,7 @@ impl CayenneCatalog {
             params.push(MetastoreValue::Integer(delete_file.sequence_number));
         }
 
-        let sql = format!(
-            "INSERT INTO cayenne_delete_file (\
-                 delete_file_id, table_id, path, path_is_relative, \
-                 format, delete_count, file_size_bytes, source_data_file_path, sequence_number\
-             ) VALUES {} \
-             ON CONFLICT(table_id, path) DO UPDATE SET \
-                 path = CASE \
-                     WHEN cayenne_delete_file.path_is_relative = excluded.path_is_relative \
-                         AND cayenne_delete_file.format = excluded.format \
-                         AND cayenne_delete_file.delete_count = excluded.delete_count \
-                         AND cayenne_delete_file.file_size_bytes = excluded.file_size_bytes \
-                         AND cayenne_delete_file.source_data_file_path IS excluded.source_data_file_path \
-                         AND cayenne_delete_file.sequence_number = excluded.sequence_number \
-                     THEN cayenne_delete_file.path \
-                     ELSE NULL \
-                 END",
-            values_parts.join(", ")
-        );
-
+        sql.push_str(SUFFIX);
         (sql, params)
     }
 }
@@ -1090,20 +1100,23 @@ impl MetadataCatalog for CayenneCatalog {
         table_id: &str,
         delete_file_ids: &[String],
     ) -> CatalogResult<()> {
+        use std::fmt::Write as _;
+
+        const PREFIX: &str =
+            "DELETE FROM cayenne_delete_file WHERE table_id = ?1 AND delete_file_id IN (";
+
         if delete_file_ids.is_empty() {
             return Ok(());
         }
-
-        let placeholders = delete_file_ids
-            .iter()
-            .enumerate()
-            .map(|(idx, _)| format!("?{}", idx + 2))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let sql = format!(
-            "DELETE FROM cayenne_delete_file WHERE table_id = ?1 AND delete_file_id IN ({placeholders})"
-        );
+        let mut sql = String::with_capacity(PREFIX.len() + delete_file_ids.len() * 6 + 1);
+        sql.push_str(PREFIX);
+        for idx in 0..delete_file_ids.len() {
+            if idx > 0 {
+                sql.push_str(", ");
+            }
+            let _ = write!(sql, "?{}", idx + 2);
+        }
+        sql.push(')');
 
         let mut params = Vec::with_capacity(delete_file_ids.len() + 1);
         params.push(MetastoreValue::Text(table_id.to_string()));
@@ -1371,10 +1384,14 @@ impl MetadataCatalog for CayenneCatalog {
                 source: Box::new(e),
             })?;
 
-        Ok(results
-            .into_iter()
-            .map(|(pk, seq)| (pk.into_boxed_slice(), seq))
-            .collect())
+        // Pre-size the map so the load path skips bucket reallocations as the
+        // insert-record set grows; `collect()` starts from capacity 0 and grows
+        // by doubling.
+        let mut map = std::collections::HashMap::<Box<[u8]>, i64>::with_capacity(results.len());
+        for (pk, seq) in results {
+            map.insert(pk.into_boxed_slice(), seq);
+        }
+        Ok(map)
     }
 
     async fn clear_insert_records(&self, table_id: &str) -> CatalogResult<()> {

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -85,7 +85,7 @@ async fn configure_sqlite_connection(
 ///
 /// Pool size is `min(available_parallelism, 32)` (minimum 2). If
 /// `available_parallelism()` fails (rare — e.g. seccomp-restricted
-/// environments), K falls back to 4. `SQLite` WAL mode allows many
+/// environments), `K` falls back to 4. `SQLite` WAL mode allows many
 /// concurrent readers per database file (read-only operations don't take
 /// the WAL write lock), so a larger pool lifts the read-side concurrency
 /// ceiling for metadata-heavy workloads — e.g. 64-core deployments running

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -502,19 +502,22 @@ fn convert_sqlite_value(value: rusqlite::types::ValueRef<'_>) -> MetastoreValue 
             MetastoreValue::Null
         }
         rusqlite::types::ValueRef::Text(t) => {
-            MetastoreValue::Text(String::from_utf8_lossy(t).to_string())
+            // `into_owned()` on a `Cow::Owned` (invalid UTF-8 fallback) keeps the
+            // already-allocated String. `.to_string()` would clone it again.
+            MetastoreValue::Text(String::from_utf8_lossy(t).into_owned())
         }
         rusqlite::types::ValueRef::Blob(b) => MetastoreValue::Blob(b.to_vec()),
     }
 }
 
-/// Convert `MetastoreValue` to a `rusqlite::types::Value`.
-fn to_sqlite_value(value: &MetastoreValue) -> rusqlite::types::Value {
+/// Convert `MetastoreValue` to a `rusqlite::types::Value`, consuming the
+/// source so Text/Blob payloads move without an extra heap copy.
+fn to_sqlite_value(value: MetastoreValue) -> rusqlite::types::Value {
     match value {
-        MetastoreValue::Integer(i) => rusqlite::types::Value::Integer(*i),
-        MetastoreValue::Text(s) => rusqlite::types::Value::Text(s.clone()),
-        MetastoreValue::Bool(b) => rusqlite::types::Value::Integer(i64::from(*b)),
-        MetastoreValue::Blob(b) => rusqlite::types::Value::Blob(b.clone()),
+        MetastoreValue::Integer(i) => rusqlite::types::Value::Integer(i),
+        MetastoreValue::Text(s) => rusqlite::types::Value::Text(s),
+        MetastoreValue::Bool(b) => rusqlite::types::Value::Integer(i64::from(b)),
+        MetastoreValue::Blob(b) => rusqlite::types::Value::Blob(b),
         MetastoreValue::Null => rusqlite::types::Value::Null,
     }
 }
@@ -603,7 +606,7 @@ impl MetastoreBackend for SqliteMetastore {
         let guard = self.pool().await?.acquire().await;
         let sql = params.sql.to_string();
         let param_values: Vec<rusqlite::types::Value> =
-            params.params.iter().map(to_sqlite_value).collect();
+            params.params.into_iter().map(to_sqlite_value).collect();
 
         guard
             .call(move |conn| {
@@ -668,7 +671,7 @@ impl MetastoreBackend for SqliteMetastore {
         let guard = self.pool().await?.acquire().await;
         let sql = params.sql.to_string();
         let param_values: Vec<rusqlite::types::Value> =
-            params.params.iter().map(to_sqlite_value).collect();
+            params.params.into_iter().map(to_sqlite_value).collect();
 
         // Execute query and extract row values inside the closure
         let row_values = guard
@@ -711,7 +714,7 @@ impl MetastoreBackend for SqliteMetastore {
         let guard = self.pool().await?.acquire().await;
         let sql = params.sql.to_string();
         let param_values: Vec<rusqlite::types::Value> =
-            params.params.iter().map(to_sqlite_value).collect();
+            params.params.into_iter().map(to_sqlite_value).collect();
 
         // Execute query and collect all row values inside the closure
         let all_row_values = guard
@@ -880,7 +883,7 @@ impl MetastoreTransaction for SqliteTransaction {
         })?;
         let sql = params.sql.to_string();
         let param_values: Vec<rusqlite::types::Value> =
-            params.params.iter().map(to_sqlite_value).collect();
+            params.params.into_iter().map(to_sqlite_value).collect();
 
         conn.call(move |conn| {
             let params_refs: Vec<&dyn rusqlite::ToSql> = param_values
@@ -907,7 +910,7 @@ impl MetastoreTransaction for SqliteTransaction {
         })?;
         let sql = params.sql.to_string();
         let param_values: Vec<rusqlite::types::Value> =
-            params.params.iter().map(to_sqlite_value).collect();
+            params.params.into_iter().map(to_sqlite_value).collect();
 
         conn.call(move |conn| {
             let params_refs: Vec<&dyn rusqlite::ToSql> = param_values

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -347,7 +347,7 @@ impl TursoRow<'_> {
 
 impl MetastoreRow for TursoRow<'_> {
     fn get_value(&self, index: usize) -> CatalogResult<MetastoreValue> {
-        Ok(convert_turso_value(&self.raw_value(index)?))
+        Ok(convert_turso_value(self.raw_value(index)?))
     }
 
     fn get_i64(&self, index: usize) -> CatalogResult<i64> {
@@ -411,27 +411,29 @@ impl MetastoreRow for TursoRow<'_> {
     }
 }
 
-/// Convert Turso Value to `MetastoreValue`.
-fn convert_turso_value(value: &TursoValue) -> MetastoreValue {
+/// Convert Turso Value to `MetastoreValue`, consuming the source so the
+/// Text/Blob payload moves without an extra heap copy.
+fn convert_turso_value(value: TursoValue) -> MetastoreValue {
     match value {
         TursoValue::Null => MetastoreValue::Null,
-        TursoValue::Integer(i) => MetastoreValue::Integer(*i),
+        TursoValue::Integer(i) => MetastoreValue::Integer(i),
         TursoValue::Real(_) => {
             // We don't use real numbers in metadata
             MetastoreValue::Null
         }
-        TursoValue::Text(t) => MetastoreValue::Text(t.clone()),
-        TursoValue::Blob(b) => MetastoreValue::Blob(b.clone()),
+        TursoValue::Text(t) => MetastoreValue::Text(t),
+        TursoValue::Blob(b) => MetastoreValue::Blob(b),
     }
 }
 
-/// Convert `MetastoreValue` to Turso Value.
-fn to_turso_value(value: &MetastoreValue) -> TursoValue {
+/// Convert `MetastoreValue` to Turso Value, consuming the source so Text/Blob
+/// payloads move without an extra heap copy.
+fn to_turso_value(value: MetastoreValue) -> TursoValue {
     match value {
-        MetastoreValue::Integer(i) => TursoValue::Integer(*i),
-        MetastoreValue::Text(s) => TursoValue::Text(s.clone()),
-        MetastoreValue::Bool(b) => TursoValue::Integer(i64::from(*b)),
-        MetastoreValue::Blob(b) => TursoValue::Blob(b.clone()),
+        MetastoreValue::Integer(i) => TursoValue::Integer(i),
+        MetastoreValue::Text(s) => TursoValue::Text(s),
+        MetastoreValue::Bool(b) => TursoValue::Integer(i64::from(b)),
+        MetastoreValue::Blob(b) => TursoValue::Blob(b),
         MetastoreValue::Null => TursoValue::Null,
     }
 }
@@ -556,7 +558,7 @@ impl MetastoreBackend for TursoMetastore {
     async fn execute(&self, params: ExecuteParams<'_>) -> CatalogResult<()> {
         let conn = self.pool().await?.acquire().await;
 
-        let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
+        let turso_params: Vec<TursoValue> = params.params.into_iter().map(to_turso_value).collect();
 
         let mut stmt = conn
             .prepare_cached(params.sql)
@@ -602,7 +604,7 @@ impl MetastoreBackend for TursoMetastore {
     {
         let conn = self.pool().await?.acquire().await;
 
-        let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
+        let turso_params: Vec<TursoValue> = params.params.into_iter().map(to_turso_value).collect();
 
         let mut stmt =
             conn.prepare_cached(params.sql)
@@ -636,7 +638,7 @@ impl MetastoreBackend for TursoMetastore {
     {
         let conn = self.pool().await?.acquire().await;
 
-        let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
+        let turso_params: Vec<TursoValue> = params.params.into_iter().map(to_turso_value).collect();
 
         let mut stmt =
             conn.prepare_cached(params.sql)
@@ -736,7 +738,7 @@ impl MetastoreTransaction for TursoTransaction {
             message: "Transaction already completed".to_string(),
         })?;
 
-        let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
+        let turso_params: Vec<TursoValue> = params.params.into_iter().map(to_turso_value).collect();
 
         let mut stmt = conn
             .prepare_cached(params.sql)
@@ -756,7 +758,7 @@ impl MetastoreTransaction for TursoTransaction {
         let conn = self.conn.as_ref().ok_or_else(|| CatalogError::Database {
             message: "Transaction already completed".to_string(),
         })?;
-        let turso_params: Vec<TursoValue> = params.params.iter().map(to_turso_value).collect();
+        let turso_params: Vec<TursoValue> = params.params.into_iter().map(to_turso_value).collect();
 
         let mut stmt = conn
             .prepare_cached(params.sql)
@@ -775,7 +777,7 @@ impl MetastoreTransaction for TursoTransaction {
         (0..row.column_count())
             .map(|i| {
                 row.get_value(i)
-                    .map(|v| convert_turso_value(&v))
+                    .map(convert_turso_value)
                     .map_err(convert_turso_error)
             })
             .collect::<CatalogResult<_>>()

--- a/crates/cayenne/src/provider/compaction.rs
+++ b/crates/cayenne/src/provider/compaction.rs
@@ -154,8 +154,12 @@ pub(crate) fn pick_candidates<P: Clone>(
     files: impl IntoIterator<Item = FileEntry<P>>,
     cfg: &CompactionPickerConfig,
 ) -> Option<CompactionCandidate<P>> {
-    let mut small = Vec::new();
-    let mut mid = Vec::new();
+    let files = files.into_iter();
+    // Reserve based on the iterator's size_hint so the buckets do not
+    // re-allocate as they grow when the caller knows the total file count.
+    let hint = files.size_hint().0;
+    let mut small = Vec::with_capacity(hint);
+    let mut mid = Vec::with_capacity(hint);
 
     for entry in files {
         match Tier::classify(entry.size_bytes, &cfg.tiers) {
@@ -199,8 +203,14 @@ fn pick_from_bucket<P: Clone>(
         return None;
     }
 
-    bucket.sort_by_key(|entry| entry.size_bytes);
+    // We only need the K smallest entries — `select_nth_unstable_by_key` runs
+    // in O(N) expected time vs O(N log N) for a full sort, and the candidate
+    // downstream consumers (path collection + byte sum) don't depend on
+    // ordering within the picked set. See `compaction_picker` bench.
     let max_pick = cfg.max_files_per_pick.min(bucket.len());
+    if max_pick < bucket.len() {
+        let _ = bucket.select_nth_unstable_by_key(max_pick, |entry| entry.size_bytes);
+    }
     let picked = &bucket[..max_pick];
     let picked_bytes: u64 = picked.iter().map(|entry| entry.size_bytes).sum();
     let paths = picked.iter().map(|entry| entry.path.clone()).collect();

--- a/crates/cayenne/src/provider/delete/filter_exec.rs
+++ b/crates/cayenne/src/provider/delete/filter_exec.rs
@@ -47,7 +47,7 @@ limitations under the License.
 //! 2. Apply the mask in one shot via [`arrow::compute::filter_record_batch`].
 
 use crate::provider::deletion_index::{DeletionIndex, KeyDeletionIndex};
-use arrow::array::{ArrayRef, BooleanArray};
+use arrow::array::{ArrayRef, BooleanArray, BooleanBufferBuilder};
 use arrow_row::RowConverter;
 use datafusion_execution::SendableRecordBatchStream;
 use datafusion_physical_plan::DisplayAs;
@@ -405,7 +405,10 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                     };
 
                     // Build keep mask: bloom-prefiltered probe per row + visibility check.
-                    let mut keep_mask: Vec<bool> = Vec::with_capacity(batch_size);
+                    // Use `BooleanBufferBuilder` so the mask lives as a packed bitmap
+                    // (1 bit per row instead of 1 byte) and skips the `Vec<bool>` →
+                    // `BooleanArray` conversion pass.
+                    let mut keep_mask = BooleanBufferBuilder::new(batch_size);
                     let mut keep_count: usize = 0;
                     for row in &rows {
                         let key: &[u8] = row.as_ref();
@@ -415,7 +418,7 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                             &self.insert_records,
                             self.min_delete_seq_to_apply,
                         );
-                        keep_mask.push(visible);
+                        keep_mask.append(visible);
                         keep_count += usize::from(visible);
                     }
 
@@ -436,7 +439,7 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                     }
 
                     // Apply mask in one shot via Arrow's filter kernel.
-                    let filter_array = BooleanArray::from(keep_mask);
+                    let filter_array = BooleanArray::new(keep_mask.finish(), None);
                     let filtered_batch =
                         match arrow::compute::filter_record_batch(&batch, &filter_array) {
                             Ok(filtered) => filtered,
@@ -661,9 +664,12 @@ impl futures::Stream for Int64PkDeletionFilterStream {
 
                     // Build keep mask: bloom-prefiltered probe per row + visibility check.
                     // Iterate over `pk_array.values()` (a contiguous &[i64] slice) so the
-                    // hot loop stays branchless on column access.
+                    // hot loop stays branchless on column access. The mask uses a packed
+                    // bitmap (`BooleanBufferBuilder`, 1 bit per row) instead of a
+                    // `Vec<bool>` to save 8× the per-batch heap footprint and skip the
+                    // `BooleanArray` re-pack pass.
                     let pk_slice = pk_array.values();
-                    let mut keep_mask: Vec<bool> = Vec::with_capacity(batch_size);
+                    let mut keep_mask = BooleanBufferBuilder::new(batch_size);
                     let mut keep_count: usize = 0;
                     for &pk_value in pk_slice {
                         let visible = is_pk_visible_i64(
@@ -672,7 +678,7 @@ impl futures::Stream for Int64PkDeletionFilterStream {
                             &self.insert_records,
                             self.min_delete_seq_to_apply,
                         );
-                        keep_mask.push(visible);
+                        keep_mask.append(visible);
                         keep_count += usize::from(visible);
                     }
 
@@ -693,7 +699,7 @@ impl futures::Stream for Int64PkDeletionFilterStream {
                     }
 
                     // Apply mask in one shot via Arrow's filter kernel.
-                    let filter_array = BooleanArray::from(keep_mask);
+                    let filter_array = BooleanArray::new(keep_mask.finish(), None);
                     let filtered_batch =
                         match arrow::compute::filter_record_batch(&batch, &filter_array) {
                             Ok(filtered) => filtered,

--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -46,7 +46,6 @@ use datafusion_catalog::TableProvider;
 use datafusion_common::ScalarValue;
 use datafusion_expr::Expr;
 use object_store::{ObjectMeta, ObjectStore};
-use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex as TokioMutex;
@@ -101,7 +100,7 @@ pub struct FileBasedDeletionSink {
     /// Metadata catalog for clearing snapshot sequence records.
     catalog: Arc<dyn MetadataCatalog>,
     /// In-memory protected snapshots map (shared with `CayenneTableProvider`).
-    protected_snapshots: Arc<RwLock<HashMap<String, i64>>>,
+    protected_snapshots: Arc<ArcSwap<HashMap<String, i64>>>,
     /// Table ID for catalog operations.
     table_id: String,
     /// Table base path for constructing snapshot directory paths.
@@ -141,7 +140,7 @@ impl FileBasedDeletionSink {
         filter: Expr,
         table_name: String,
         catalog: Arc<dyn MetadataCatalog>,
-        protected_snapshots: Arc<RwLock<HashMap<String, i64>>>,
+        protected_snapshots: Arc<ArcSwap<HashMap<String, i64>>>,
         table_id: String,
         table_path: String,
         runtime_env: Arc<RuntimeEnv>,
@@ -464,8 +463,12 @@ impl FileBasedDeletionSink {
                 continue;
             }
 
-            // 2. Remove from in-memory map
-            self.protected_snapshots.write().remove(snapshot_id);
+            // 2. Remove from in-memory map (copy-on-write atomic publish)
+            self.protected_snapshots.rcu(|current| {
+                let mut new_map = (**current).clone();
+                new_map.remove(snapshot_id);
+                Arc::new(new_map)
+            });
 
             // 3. Delete the empty snapshot directory
             let snapshot_dir = std::path::PathBuf::from(&self.table_path)

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -519,6 +519,10 @@ impl CayenneDeletionSink {
 
         let mut matching_positions: Vec<u64> = Vec::new();
         let mut row_position: u64 = 0;
+        // Resolved on the first chunk and reused across the stream — schema is
+        // stable per file, so the per-chunk `index_of` lookups become wasted
+        // work as files grow past one chunk.
+        let mut key_indices: Option<Vec<usize>> = None;
 
         while let Some(chunk_result) = stream.next().await {
             let chunk = chunk_result.map_err(|e| Error::Vortex {
@@ -548,21 +552,27 @@ impl CayenneDeletionSink {
                 })?;
             let batch = arrow::record_batch::RecordBatch::from(struct_array);
 
-            // Resolve key column indices (once per chunk — schema is stable across chunks).
-            let key_indices: Vec<usize> = key_columns
-                .iter()
-                .map(|col_name| {
-                    batch
-                        .schema()
-                        .index_of(col_name)
-                        .map_err(|_| Error::Internal {
-                            table: table_name.clone(),
-                            message: format!(
-                                "Key column '{col_name}' not found in Vortex file schema"
-                            ),
-                        })
-                })
-                .collect::<crate::provider::Result<Vec<_>>>()?;
+            let key_indices: &[usize] = if let Some(indices) = &key_indices {
+                indices.as_slice()
+            } else {
+                let resolved: Vec<usize> = key_columns
+                    .iter()
+                    .map(|col_name| {
+                        batch
+                            .schema()
+                            .index_of(col_name)
+                            .map_err(|_| Error::Internal {
+                                table: table_name.clone(),
+                                message: format!(
+                                    "Key column '{col_name}' not found in Vortex file schema"
+                                ),
+                            })
+                    })
+                    .collect::<crate::provider::Result<Vec<_>>>()?;
+                key_indices = Some(resolved);
+                // SAFETY: we just assigned `Some` above
+                key_indices.as_deref().unwrap_or(&[])
+            };
 
             for row_idx in 0..batch.num_rows() {
                 let key: Vec<datafusion_common::ScalarValue> = key_indices
@@ -695,8 +705,10 @@ impl CayenneDeletionSink {
                 });
             updated_bitmap.extend(unique_new_row_ids.iter().copied());
 
+            // RoaringBitmap::iter yields strictly-increasing values, so the writer
+            // can skip its sort/dedup pass — see `position_delete_redundant_walks` bench.
             let combined_ids: Vec<u64> = updated_bitmap.iter().map(u64::from).collect();
-            specs.push(DeletionVectorWriteSpec::new_position_based(
+            specs.push(DeletionVectorWriteSpec::new_position_based_sorted(
                 file_path.clone(),
                 combined_ids,
             ));

--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -73,6 +73,9 @@ pub enum DeletionIdentifier {
     PositionBased {
         file_path: String,
         row_ids: Vec<u64>,
+        /// When `true`, `row_ids` is already strictly increasing and the writer
+        /// can skip its sort/dedup pass.
+        pre_sorted: bool,
     },
     /// Primary key-based row keys (for tables with primary key).
     KeyBased(Vec<Box<[u8]>>),
@@ -103,10 +106,35 @@ impl DeletionVectorWriteSpec {
     /// Create a new specification with position-based row IDs for a specific data file.
     ///
     /// The row IDs should be file-local positions (0 to N-1 within the specified file).
+    /// The writer sorts and deduplicates them; use [`Self::new_position_based_sorted`]
+    /// instead when the caller can guarantee monotone-unique input to skip the redundant
+    /// O(N log N) pass.
+    ///
+    /// Currently only the test suite exercises this constructor; production
+    /// code uses the `_sorted` variant.
+    #[cfg(test)]
     #[must_use]
     pub fn new_position_based(file_path: String, row_ids: Vec<u64>) -> Self {
         Self {
-            identifiers: DeletionIdentifier::PositionBased { file_path, row_ids },
+            identifiers: DeletionIdentifier::PositionBased {
+                file_path,
+                row_ids,
+                pre_sorted: false,
+            },
+        }
+    }
+
+    /// Same as [`Self::new_position_based`] but the caller guarantees `row_ids` is
+    /// strictly increasing (sorted + deduplicated). The writer skips the redundant
+    /// sort/dedup pass. See `position_delete_redundant_walks` bench.
+    #[must_use]
+    pub fn new_position_based_sorted(file_path: String, row_ids: Vec<u64>) -> Self {
+        Self {
+            identifiers: DeletionIdentifier::PositionBased {
+                file_path,
+                row_ids,
+                pre_sorted: true,
+            },
         }
     }
 
@@ -223,9 +251,17 @@ impl<'a> DeletionVectorWriter<'a> {
                 DeletionIdentifier::PositionBased {
                     file_path: source_file,
                     mut row_ids,
+                    pre_sorted,
                 } => {
-                    row_ids.sort_unstable();
-                    row_ids.dedup();
+                    if pre_sorted {
+                        debug_assert!(
+                            row_ids.windows(2).all(|w| w[0] < w[1]),
+                            "pre_sorted=true but row_ids is not strictly increasing",
+                        );
+                    } else {
+                        row_ids.sort_unstable();
+                        row_ids.dedup();
+                    }
                     let count = row_ids.len();
                     let schema = position_based_deletion_schema();
                     let batch = build_position_based_batch(&schema, &row_ids)?;
@@ -236,6 +272,7 @@ impl<'a> DeletionVectorWriter<'a> {
                         DeletionIdentifier::PositionBased {
                             file_path: source_file.clone(),
                             row_ids,
+                            pre_sorted,
                         },
                         Some(source_file),
                     )
@@ -467,7 +504,9 @@ pub fn detect_deletion_type_and_read(
 fn build_position_based_batch(schema: &SchemaRef, row_ids: &[u64]) -> Result<RecordBatch> {
     let deleted_at = Utc::now().timestamp_micros();
 
-    let row_id_array = UInt64Array::from(row_ids.to_vec());
+    // `from_iter_values` builds directly from the slice; `from(Vec)` would
+    // require an extra `to_vec()` allocation we never need to keep.
+    let row_id_array = UInt64Array::from_iter_values(row_ids.iter().copied());
     let deleted_at_array = Int64Array::from(vec![deleted_at; row_ids.len()]);
 
     Ok(RecordBatch::try_new(

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -191,9 +191,11 @@ impl DeletionIndex {
         let mut entries_arc = Arc::clone(&self.entries);
         let entries = Arc::make_mut(&mut entries_arc);
         let mut max_sequence_number = self.max_sequence_number;
+        let additions = additions.into_iter();
         // Track newly-inserted keys so the bloom can be updated incrementally
-        // without re-iterating the entire entry set.
-        let mut new_keys: Vec<i64> = Vec::new();
+        // without re-iterating the entire entry set. Pre-size from the
+        // iterator's hint to skip Vec growth reallocations.
+        let mut new_keys: Vec<i64> = Vec::with_capacity(additions.size_hint().0);
         for (pk, seq) in additions {
             let stored_sequence = match entries.entry(pk) {
                 std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -386,9 +388,12 @@ impl KeyDeletionIndex {
         let mut entries_arc = Arc::clone(&self.entries);
         let entries = Arc::make_mut(&mut entries_arc);
         let mut max_sequence_number = self.max_sequence_number;
-        // Track newly-inserted keys so the bloom can be updated incrementally
-        // without re-iterating the entire entry set.
-        let mut new_keys: Vec<Box<[u8]>> = Vec::new();
+        let additions = additions.into_iter();
+        // Hash newly-inserted keys inline so the bloom can be updated
+        // incrementally without paying for a `Box<[u8]>` clone per key (the
+        // bloom only needs the hash, not the byte slice). Pre-size from the
+        // iterator's hint to skip Vec growth reallocations.
+        let mut new_hashes: Vec<u64> = Vec::with_capacity(additions.size_hint().0);
         for (key, seq) in additions {
             let stored_sequence = match entries.entry(key) {
                 std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -401,9 +406,8 @@ impl KeyDeletionIndex {
                     }
                 }
                 std::collections::hash_map::Entry::Vacant(e) => {
-                    let key_clone: Box<[u8]> = e.key().clone();
+                    new_hashes.push(hash_key(&e.key().as_ref()));
                     e.insert(seq);
-                    new_keys.push(key_clone);
                     seq
                 }
             };
@@ -430,8 +434,8 @@ impl KeyDeletionIndex {
         }
 
         let mut bloom = self.bloom.clone();
-        for key in &new_keys {
-            bloom.insert(hash_key(&key.as_ref()));
+        for h in new_hashes {
+            bloom.insert(h);
         }
         Self {
             entries: entries_arc,

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1173,7 +1173,10 @@ pub struct CayenneTableProvider {
     ///
     /// Maps `snapshot_id` -> `minimum_sequence` (all deletes with seq <= `min_seq` don't apply).
     /// At scan time, data from these snapshots is scanned without deletion filtering.
-    protected_snapshots: Arc<RwLock<HashMap<String, i64>>>,
+    /// Snapshot-id → max-delete-sequence-at-creation. Wait-free reads via
+    /// `ArcSwap`: scan paths take `Arc::clone` instead of cloning the
+    /// `HashMap`; writes use `rcu` to publish a copy-on-write update.
+    protected_snapshots: Arc<ArcSwap<HashMap<String, i64>>>,
     /// Table-scoped warning dedupe for protected snapshot ids that cannot
     /// provide a `UUIDv7` timestamp for age-triggered maintenance.
     protected_snapshot_age_warning_keys: Arc<ParkingMutex<BoundedWarningKeys>>,
@@ -1517,6 +1520,9 @@ impl DeletionSink for InlineAwareDeletionSink {
 
         if deleted > 0 {
             self.table.clear_cached_pk_keyset();
+            if file_deleted > 0 && self.table.pk_deletion_strategy.is_position_based() {
+                self.table.clear_scan_file_statistics_cache();
+            }
         }
 
         Ok(deleted)
@@ -2070,10 +2076,8 @@ impl CayenneTableProvider {
             // Read the LIVE protected set after the grace period. During the
             // sleep, CDC writers may have created new protected snapshots that
             // must not be deleted.
-            let protected_snapshot_ids: HashSet<String> = {
-                let guard = self.protected_snapshots.read();
-                guard.keys().cloned().collect()
-            };
+            let protected_snapshot_ids: HashSet<String> =
+                self.protected_snapshots.load().keys().cloned().collect();
             if let Err(err) = self
                 .cleanup_old_snapshots_s3(current_snapshot, &protected_snapshot_ids)
                 .await
@@ -2096,10 +2100,8 @@ impl CayenneTableProvider {
                 // caused a race: compaction clears `protected_snapshots` at
                 // commit time, new CDC writes re-populate it, then the stale
                 // (empty) captured set causes cleanup to delete them.
-                let protected_snapshot_ids: HashSet<String> = {
-                    let guard = protected_snapshots.read();
-                    guard.keys().cloned().collect()
-                };
+                let protected_snapshot_ids: HashSet<String> =
+                    protected_snapshots.load().keys().cloned().collect();
                 let _ = tokio::task::spawn_blocking(move || {
                     if let Err(e) = Self::cleanup_old_snapshots_blocking(
                         &table_path,
@@ -3135,7 +3137,7 @@ impl CayenneTableProvider {
             object_store_registered_runtime_envs: Arc::new(ParkingMutex::new(
                 object_store_registered_runtime_envs,
             )),
-            protected_snapshots: Arc::new(RwLock::new(protected_snapshots)),
+            protected_snapshots: Arc::new(ArcSwap::from_pointee(protected_snapshots)),
             protected_snapshot_age_warning_keys: Arc::new(ParkingMutex::new(
                 BoundedWarningKeys::default(),
             )),
@@ -3288,10 +3290,11 @@ impl CayenneTableProvider {
         // Add to protected snapshots so scan applies only NEWER deletions (seq > max_delete_seq)
         // We do NOT clear old protected snapshots because they may contain data that's still valid.
         // Each protected snapshot applies its own partial deletion filter based on when it was created.
-        {
-            let mut guard = self.protected_snapshots.write();
-            guard.insert(new_snapshot_id.clone(), max_delete_seq);
-        }
+        self.protected_snapshots.rcu(|current| {
+            let mut new_map = (**current).clone();
+            new_map.insert(new_snapshot_id.clone(), max_delete_seq);
+            Arc::new(new_map)
+        });
 
         // The listing table stays as-is. Protected snapshots are handled at scan time.
         // See the doc comment above for why we do NOT update current_snapshot.
@@ -3315,10 +3318,11 @@ impl CayenneTableProvider {
             .await?;
 
         let max_delete_seq = self.get_max_delete_sequence();
-        {
-            let mut guard = self.protected_snapshots.write();
-            guard.insert(snapshot_id.to_string(), max_delete_seq);
-        }
+        self.protected_snapshots.rcu(|current| {
+            let mut new_map = (**current).clone();
+            new_map.insert(snapshot_id.to_string(), max_delete_seq);
+            Arc::new(new_map)
+        });
 
         Ok(())
     }
@@ -3649,29 +3653,41 @@ impl CayenneTableProvider {
             self.has_pending_deletions() || self.inlined_row_count.load(Ordering::Relaxed) > 0;
 
         let cache = self.table_statistics.read();
-        let stats = if has_pending_visibility_changes {
-            // Prefer the pre-converted inexact cache; fall back to transforming
-            // on-the-fly if the cache hasn't been populated yet (e.g. test seed).
-            match cache.optimizer_inexact.clone() {
-                Some(inexact) => inexact,
-                None => Self::statistics_to_inexact(cache.optimizer.clone()?),
-            }
+        let cached_ref: Option<&Statistics> = if has_pending_visibility_changes {
+            cache.optimizer_inexact.as_ref()
         } else {
-            cache.optimizer.clone()?
+            cache.optimizer.as_ref()
         };
-        drop(cache);
 
-        if stats.column_statistics.len() > TABLE_STATISTICS_FULL_COLUMN_SYNC_LIMIT {
-            tracing::trace!(
-                table = self.table_metadata.table_name.as_str(),
-                column_count = stats.column_statistics.len(),
-                full_column_sync_limit = TABLE_STATISTICS_FULL_COLUMN_SYNC_LIMIT,
-                "Returning top-level table statistics only for wide table"
-            );
-            return Some(Self::top_level_statistics_only(&stats, false));
+        if let Some(source) = cached_ref {
+            // Wide-table fast path: build the top-level summary directly from a
+            // borrowed reference instead of cloning the full column_statistics
+            // vector only to discard it. See `cached_table_statistics_wide` bench.
+            if source.column_statistics.len() > TABLE_STATISTICS_FULL_COLUMN_SYNC_LIMIT {
+                tracing::trace!(
+                    table = self.table_metadata.table_name.as_str(),
+                    column_count = source.column_statistics.len(),
+                    full_column_sync_limit = TABLE_STATISTICS_FULL_COLUMN_SYNC_LIMIT,
+                    "Returning top-level table statistics only for wide table"
+                );
+                return Some(Self::top_level_statistics_only(source, false));
+            }
+            return Some(source.clone());
         }
 
-        Some(stats)
+        // Cache-miss visibility-overlay path: cache.optimizer_inexact is None,
+        // so transform optimizer on-the-fly. Rare — test seed only.
+        if has_pending_visibility_changes {
+            let optimizer = cache.optimizer.clone()?;
+            drop(cache);
+            let inexact = Self::statistics_to_inexact(optimizer);
+            if inexact.column_statistics.len() > TABLE_STATISTICS_FULL_COLUMN_SYNC_LIMIT {
+                return Some(Self::top_level_statistics_only(&inexact, false));
+            }
+            return Some(inexact);
+        }
+
+        None
     }
 
     fn top_level_statistics_only(stats: &Statistics, inexact: bool) -> Statistics {
@@ -3721,6 +3737,10 @@ impl CayenneTableProvider {
         cache.optimizer = None;
         cache.optimizer_inexact = None;
         cache.raw = None;
+    }
+
+    fn clear_scan_file_statistics_cache(&self) {
+        self.scan_file_statistics.clear();
     }
 
     fn take_cached_pk_keyset(&self) -> Option<CachedPkKeyset> {
@@ -3844,11 +3864,9 @@ impl CayenneTableProvider {
         pk_indices: &[usize],
         converter: &RowConverter,
     ) -> Result<CachedPkKeyset> {
-        // Clone protected snapshots to avoid holding locks across await points
-        let protected_snapshots = {
-            let guard = self.protected_snapshots.read();
-            guard.clone()
-        };
+        // Wait-free Arc::clone — the inner HashMap is shared, not cloned,
+        // so the scan does not pay an O(N) String + i64 clone per call.
+        let protected_snapshots = self.protected_snapshots.load_full();
 
         let ctx = self.create_session_context();
         // Only read PK columns - no need to load all columns for keyset building
@@ -3914,7 +3932,7 @@ impl CayenneTableProvider {
         // Process each protected snapshot with a PARTIAL deletion filter.
         // Only deletions with seq > max_delete_seq_at_creation apply, mirroring
         // scan()'s apply_partial_deletion_filter().
-        for (snapshot_id, max_delete_seq_at_creation) in &protected_snapshots {
+        for (snapshot_id, max_delete_seq_at_creation) in protected_snapshots.iter() {
             let snapshot_plan = self
                 .create_snapshot_scan_plan(
                     &ctx.state(),
@@ -4453,7 +4471,16 @@ impl CayenneTableProvider {
                     return Ok((Some(batch), 0));
                 }
 
-                let converter = self.build_pk_converter(pk_indices)?;
+                // Reuse the table's cached RowConverter when available — building
+                // a fresh one revalidates each SortField.
+                let owned_converter;
+                let converter: &RowConverter = if let Some(c) = self.pk_row_converter.as_deref() {
+                    c
+                } else {
+                    owned_converter = self.build_pk_converter(pk_indices)?;
+                    &owned_converter
+                };
+
                 let pk_columns: Vec<_> = pk_indices
                     .iter()
                     .map(|idx| Arc::clone(batch.column(*idx)))
@@ -5470,10 +5497,8 @@ impl CayenneTableProvider {
         &self,
         current_snapshot_id: &str,
     ) -> Result<Vec<(String, u64)>> {
-        let protected_snapshot_ids: Vec<String> = {
-            let guard = self.protected_snapshots.read();
-            guard.keys().cloned().collect()
-        };
+        let protected_snapshot_ids: Vec<String> =
+            self.protected_snapshots.load().keys().cloned().collect();
 
         let mut seen_snapshot_ids = HashSet::with_capacity(protected_snapshot_ids.len() + 1);
         let mut files = Vec::new();
@@ -5497,7 +5522,7 @@ impl CayenneTableProvider {
     }
 
     fn protected_snapshot_maintenance_trigger(&self) -> Option<SnapshotMaintenanceTrigger> {
-        let protected_snapshots = self.protected_snapshots.read();
+        let protected_snapshots = self.protected_snapshots.load();
         protected_snapshot_maintenance_trigger(
             &self.protected_snapshot_age_warning_keys,
             &protected_snapshots,
@@ -5881,6 +5906,9 @@ impl CayenneTableProvider {
         // Refresh deletion cache after applying retention filters
         if deleted_count > 0 {
             self.clear_cached_pk_keyset();
+            if self.pk_deletion_strategy.is_position_based() {
+                self.clear_scan_file_statistics_cache();
+            }
             self.refresh_deletion_cache().await?;
         }
 
@@ -5968,10 +5996,7 @@ impl CayenneTableProvider {
         }
 
         // Clear protected snapshots - after compaction all data is in the main snapshot
-        {
-            let mut guard = self.protected_snapshots.write();
-            guard.clear();
-        }
+        self.protected_snapshots.store(Arc::new(HashMap::new()));
 
         self.clear_cached_pk_keyset();
 
@@ -6092,10 +6117,8 @@ impl CayenneTableProvider {
             message: format!("Failed to reload protected snapshots during refresh: {e}"),
         })?;
 
-        {
-            let mut guard = self.protected_snapshots.write();
-            *guard = fresh_protected_snapshots;
-        }
+        self.protected_snapshots
+            .store(Arc::new(fresh_protected_snapshots));
 
         // Reload the current snapshot ID from the catalog.
         let fresh_metadata = self
@@ -7517,10 +7540,9 @@ impl CayenneTableProvider {
         pk_indices_in_projection: &[usize],
         deletion_snapshot: &PkDeletionSnapshot,
     ) -> datafusion_common::Result<Vec<Arc<dyn ExecutionPlan>>> {
-        let protected_snapshots = {
-            let guard = self.protected_snapshots.read();
-            guard.clone()
-        };
+        // Wait-free Arc::clone — the inner HashMap is shared, not cloned,
+        // so the scan does not pay an O(N) String + i64 clone per call.
+        let protected_snapshots = self.protected_snapshots.load_full();
 
         if protected_snapshots.is_empty() {
             return Ok(Vec::new());
@@ -7549,16 +7571,16 @@ impl CayenneTableProvider {
 
         let mut plans = Vec::with_capacity(protected_snapshots.len());
 
-        for (snapshot_id, max_delete_seq_at_creation) in protected_snapshots {
+        for (snapshot_id, max_delete_seq_at_creation) in protected_snapshots.iter() {
             let plan = self
-                .create_snapshot_scan_plan(state, &snapshot_id, projection, filters, limit)
+                .create_snapshot_scan_plan(state, snapshot_id, projection, filters, limit)
                 .await?;
 
             // Apply partial deletion filter - only deletions with seq > max_delete_seq_at_creation
             let filtered_plan = self.apply_partial_deletion_filter(
                 plan,
                 pk_indices_in_projection,
-                max_delete_seq_at_creation,
+                *max_delete_seq_at_creation,
                 deletion_snapshot,
             )?;
 
@@ -7569,7 +7591,10 @@ impl CayenneTableProvider {
     }
 
     fn snapshot_scan_schema(file_schema: &SchemaRef, options: &ListingOptions) -> SchemaRef {
-        let mut builder = SchemaBuilder::from(file_schema.as_ref().clone());
+        // `SchemaBuilder::from(&Schema)` clones the metadata HashMap, but we then
+        // overwrite that metadata via `.with_metadata(...)` below. Building from
+        // `Fields` skips the wasted first clone.
+        let mut builder = SchemaBuilder::from(file_schema.fields());
         for (name, data_type) in &options.table_partition_cols {
             builder.push(Field::new(name, data_type.clone(), false));
         }
@@ -7738,6 +7763,8 @@ impl CayenneTableProvider {
         limit: Option<usize>,
         scan_schema: SchemaRef,
     ) -> datafusion_common::Result<SnapshotFilesForScan> {
+        let collect_stats = options.collect_stat
+            && !(self.pk_deletion_strategy.is_position_based() && self.has_pending_deletions());
         let store = state.runtime_env().object_store(table_url)?;
         let meta_fetch_concurrency = state.config_options().execution.meta_fetch_concurrency;
         let file_list = pruned_partition_list(
@@ -7753,7 +7780,7 @@ impl CayenneTableProvider {
         let files = file_list
             .map(|part_file| async {
                 let part_file = part_file?;
-                let statistics = if options.collect_stat {
+                let statistics = if collect_stats {
                     self.collect_scan_file_statistics(
                         state,
                         &store,
@@ -7769,7 +7796,7 @@ impl CayenneTableProvider {
             .buffer_unordered(meta_fetch_concurrency);
 
         let (file_group, inexact_stats) =
-            Self::collect_scan_files_with_limit(files, limit, options.collect_stat).await?;
+            Self::collect_scan_files_with_limit(files, limit, collect_stats).await?;
 
         let threshold = state.config_options().optimizer.preserve_file_partitions;
         let (file_groups, grouped_by_partition) =
@@ -7791,12 +7818,8 @@ impl CayenneTableProvider {
                 (file_group.split_files(options.target_partitions), false)
             };
 
-        let (file_groups, statistics) = compute_all_files_statistics(
-            file_groups,
-            scan_schema,
-            options.collect_stat,
-            inexact_stats,
-        )?;
+        let (file_groups, statistics) =
+            compute_all_files_statistics(file_groups, scan_schema, collect_stats, inexact_stats)?;
 
         Ok(SnapshotFilesForScan {
             file_groups,
@@ -8478,9 +8501,10 @@ impl TableProvider for CayenneTableProvider {
         } else {
             // Apply projection to inlined batches if needed
             let proj_schema = if let Some(ref proj) = effective_projection {
+                let schema_fields = self.table_metadata.schema.fields();
                 let fields: Vec<arrow_schema::FieldRef> = proj
                     .iter()
-                    .map(|&i| self.table_metadata.schema.field(i).clone().into())
+                    .map(|&i| Arc::clone(&schema_fields[i]))
                     .collect();
                 Arc::new(arrow_schema::Schema::new(fields))
             } else {
@@ -8610,6 +8634,10 @@ impl TableProvider for CayenneTableProvider {
     }
 
     fn statistics(&self) -> Option<datafusion_common::Statistics> {
+        if self.pk_deletion_strategy.is_position_based() && self.has_pending_deletions() {
+            return None;
+        }
+
         // Prefer the metastore-persisted table statistics (loaded from Vortex
         // file footers) when present — they cover columns the ListingTable
         // does not expose synchronously without rescanning footers.
@@ -8754,11 +8782,15 @@ impl TableProvider for CayenneTableProvider {
                 .build()?;
         }
 
-        let mut proj_exprs = Vec::new();
+        let assignment_by_col: HashMap<&str, &Expr> = assignments
+            .iter()
+            .map(|(name, expr)| (name.as_str(), expr))
+            .collect();
+        let mut proj_exprs = Vec::with_capacity(schema.fields().len());
         for field in schema.fields() {
             let col_name = field.name();
-            if let Some((_, expr)) = assignments.iter().find(|(name, _)| name == col_name) {
-                proj_exprs.push(expr.clone().alias(col_name));
+            if let Some(expr) = assignment_by_col.get(col_name.as_str()) {
+                proj_exprs.push((*expr).clone().alias(col_name));
             } else {
                 proj_exprs.push(datafusion_expr::col(col_name));
             }
@@ -8927,6 +8959,7 @@ impl CayenneTableProvider {
             .map_err(|e| datafusion_common::DataFusionError::External(Box::new(e)))?;
         if deleted > 0 {
             self.clear_cached_pk_keyset();
+            self.clear_scan_file_statistics_cache();
         }
         Ok(deleted)
     }
@@ -8943,17 +8976,14 @@ impl CayenneTableProvider {
     fn build_protected_snapshot_listing_tables(
         &self,
     ) -> datafusion_common::Result<Vec<(String, Arc<ListingTable>)>> {
-        let protected_snapshots = {
-            let guard = self.protected_snapshots.read();
-            guard.clone()
-        };
+        let protected_snapshots = self.protected_snapshots.load();
 
         let mut result = Vec::with_capacity(protected_snapshots.len());
-        for (snapshot_id, _) in protected_snapshots {
+        for snapshot_id in protected_snapshots.keys() {
             let snapshot_url = Self::snapshot_dir_url(
                 &self.table_metadata.path,
                 &self.table_metadata.table_id,
-                &snapshot_id,
+                snapshot_id,
             );
 
             let listing_table = Self::create_listing_table(
@@ -8967,7 +8997,7 @@ impl CayenneTableProvider {
                     "Failed to create listing table for protected snapshot {snapshot_id}: {e}"
                 ))
             })?;
-            result.push((snapshot_id, listing_table));
+            result.push((snapshot_id.clone(), listing_table));
         }
         Ok(result)
     }

--- a/crates/data-connectors/connector-mysql/Cargo.toml
+++ b/crates/data-connectors/connector-mysql/Cargo.toml
@@ -25,6 +25,7 @@ description = "MySQL data connector for Spice.ai runtime"
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true
+data_components = { path = "../../data_components", features = ["mysql"] }
 datafusion.workspace = true
 datafusion-table-providers = { workspace = true, features = ["mysql", "mysql-federation"] }
 linkme.workspace = true

--- a/crates/data-connectors/connector-mysql/src/lib.rs
+++ b/crates/data-connectors/connector-mysql/src/lib.rs
@@ -23,7 +23,7 @@ use datafusion_table_providers::sql::db_connection_pool::{
     Error as DbConnectionPoolError, dbconnection,
     mysqlpool::{self, MySQLConnectionPool},
 };
-use mysql_async::Metrics;
+use mysql_async::{Metrics, prelude::Queryable};
 use opentelemetry::KeyValue;
 use runtime::component::ComponentType;
 use runtime::component::dataset::Dataset;
@@ -36,6 +36,7 @@ use runtime::parameters::ParameterSpec;
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::any::Any;
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -58,6 +59,7 @@ const DEFAULT_CONNECTION_POOL_MAX: usize = 5;
 
 pub struct MySQL {
     mysql_factory: MySQLTableFactory,
+    pool: Arc<MySQLConnectionPool>,
 }
 
 impl std::fmt::Debug for MySQL {
@@ -258,9 +260,12 @@ impl DataConnectorFactory for MySQLFactory {
                     }
                 },
             };
-            let mysql_factory = MySQLTableFactory::new(pool);
+            let mysql_factory = MySQLTableFactory::new(Arc::clone(&pool));
 
-            Ok(Arc::new(MySQL { mysql_factory }) as Arc<dyn DataConnector>)
+            Ok(Arc::new(MySQL {
+                mysql_factory,
+                pool,
+            }) as Arc<dyn DataConnector>)
         })
     }
 
@@ -274,6 +279,74 @@ impl DataConnectorFactory for MySQLFactory {
 
     fn reserved_keywords(&self) -> &'static [&'static str] {
         RESERVED_KEYWORDS
+    }
+}
+
+async fn mysql_comment_metadata(
+    pool: &Arc<MySQLConnectionPool>,
+    table_reference: &datafusion::sql::TableReference,
+) -> std::result::Result<
+    (HashMap<String, String>, data_components::FieldMetadata),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    let connection = pool.connect_direct().await?;
+    let mut conn = connection.conn.lock().await;
+    let table_schema = table_reference
+        .schema()
+        .or_else(|| table_reference.catalog())
+        .map(ToString::to_string);
+    let table_name = table_reference.table().to_string();
+
+    let rows: Vec<data_components::mysql::provider::MySqlTableMetadataRow> = conn
+        .exec(
+            "SELECT \
+                 NULLIF(t.TABLE_COMMENT, '') AS TABLE_COMMENT, \
+                 c.COLUMN_NAME, \
+                 NULLIF(c.COLUMN_COMMENT, '') AS COLUMN_COMMENT, \
+                 c.COLUMN_TYPE \
+             FROM information_schema.TABLES t \
+             LEFT JOIN information_schema.COLUMNS c \
+                 ON c.TABLE_SCHEMA = t.TABLE_SCHEMA \
+                 AND c.TABLE_NAME = t.TABLE_NAME \
+             WHERE t.TABLE_SCHEMA = COALESCE(?, DATABASE()) \
+             AND t.TABLE_NAME = ? \
+             ORDER BY c.ORDINAL_POSITION",
+            (table_schema, table_name),
+        )
+        .await?;
+
+    Ok(data_components::mysql::provider::mysql_metadata_from_rows(
+        rows,
+    ))
+}
+
+async fn enrich_with_mysql_comments(
+    pool: &Arc<MySQLConnectionPool>,
+    dataset: &Dataset,
+    table_reference: &datafusion::sql::TableReference,
+    provider: Arc<dyn TableProvider>,
+) -> Arc<dyn TableProvider> {
+    match mysql_comment_metadata(pool, table_reference).await {
+        Ok((table_metadata, field_metadata)) => {
+            if table_metadata.is_empty() && field_metadata.is_empty() {
+                provider
+            } else {
+                data_components::metadata_enriched_table_provider(
+                    provider,
+                    table_metadata,
+                    field_metadata,
+                )
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                dataset = %dataset.name,
+                source = %dataset.path(),
+                error = %error,
+                "Failed to query MySQL comments; registering without comment metadata"
+            );
+            provider
+        }
     }
 }
 
@@ -299,8 +372,14 @@ impl DataConnector for MySQL {
 
         // Call the inherent method directly instead of using Read trait
         // (orphan rule prevents trait impl in external crate)
+        let table_reference = tbl.clone();
         match self.mysql_factory.table_provider(tbl).await {
-            Ok(provider) => Ok(provider),
+            Ok(provider) => {
+                Ok(
+                    enrich_with_mysql_comments(&self.pool, dataset, &table_reference, provider)
+                        .await,
+                )
+            }
             Err(e) => {
                 if let Some(err_source) = e.source()
                     && let Some(dbconnection::Error::UndefinedTable {

--- a/crates/data-connectors/connector-postgres/Cargo.toml
+++ b/crates/data-connectors/connector-postgres/Cargo.toml
@@ -36,6 +36,7 @@ secrecy.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
+tracing.workspace = true
 
 [features]
 default = []

--- a/crates/data-connectors/connector-postgres/src/lib.rs
+++ b/crates/data-connectors/connector-postgres/src/lib.rs
@@ -40,6 +40,7 @@ use runtime::parameters::ParameterSpec;
 use secrecy::SecretBox;
 use snafu::prelude::*;
 use std::any::Any;
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -55,6 +56,7 @@ pub enum Error {
 /// `PostgreSQL` data connector.
 pub struct Postgres {
     factory: PostgresTableFactory,
+    pool: Arc<PostgresConnectionPool>,
     params: runtime::parameters::Parameters,
     replication_metrics:
         std::sync::Arc<data_components::postgres_replication::ReplicationMetricsCollector>,
@@ -200,9 +202,11 @@ impl DataConnectorFactory for PostgresFactory {
                         .unwrap_or(datafusion_table_providers::UnsupportedTypeAction::String);
                     let pool = pool.with_unsupported_type_action(unsupported_type_action);
 
-                    let factory = PostgresTableFactory::new(Arc::new(pool));
+                    let pool = Arc::new(pool);
+                    let factory = PostgresTableFactory::new(Arc::clone(&pool));
                     Ok(Arc::new(Postgres {
                         factory,
+                        pool,
                         params: params_for_replication,
                         replication_metrics:
                             data_components::postgres_replication::ReplicationMetricsCollector::new(
@@ -254,6 +258,68 @@ impl DataConnectorFactory for PostgresFactory {
     }
 }
 
+async fn postgres_comment_metadata(
+    pool: &Arc<PostgresConnectionPool>,
+    table_path: &str,
+) -> std::result::Result<
+    (HashMap<String, String>, data_components::FieldMetadata),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    let conn = pool.connect_direct().await?;
+    let rows = conn
+        .conn
+        .query(
+            "SELECT \
+                 obj_description(c.oid, 'pg_class') AS table_comment, \
+                 a.attname AS column_name, \
+                 col_description(c.oid, a.attnum) AS column_comment, \
+                 format_type(a.atttypid, a.atttypmod) AS column_source_type \
+             FROM pg_catalog.pg_class c \
+             JOIN pg_catalog.pg_attribute a \
+                 ON a.attrelid = c.oid \
+                 AND a.attnum > 0 \
+                 AND NOT a.attisdropped \
+             WHERE c.oid = to_regclass($1) \
+             ORDER BY a.attnum",
+            &[&table_path],
+        )
+        .await?;
+    let rows = rows
+        .iter()
+        .map(|row| (row.get(0), row.get(1), row.get(2), row.get(3)));
+
+    Ok(data_components::postgres::provider::postgres_metadata_from_rows(rows))
+}
+
+async fn enrich_with_postgres_comments(
+    pool: &Arc<PostgresConnectionPool>,
+    dataset: &Dataset,
+    provider: Arc<dyn TableProvider>,
+) -> Arc<dyn TableProvider> {
+    match postgres_comment_metadata(pool, dataset.path()).await {
+        Ok((table_metadata, field_metadata)) => {
+            if table_metadata.is_empty() && field_metadata.is_empty() {
+                provider
+            } else {
+                data_components::metadata_enriched_table_provider(
+                    provider,
+                    table_metadata,
+                    field_metadata,
+                )
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                dataset = %dataset.name,
+                source = %dataset.path(),
+                error = %error,
+                "Failed to query PostgreSQL comments; registering without comment metadata"
+            );
+            provider
+        }
+    }
+}
+
 #[async_trait]
 impl DataConnector for Postgres {
     fn as_any(&self) -> &dyn Any {
@@ -269,7 +335,10 @@ impl DataConnector for Postgres {
             .read_write_table_provider(dataset.path().into())
             .await
         {
-            Ok(provider) => Some(Ok(provider)),
+            Ok(provider) => Some(Ok(enrich_with_postgres_comments(
+                &self.pool, dataset, provider,
+            )
+            .await)),
             Err(e) => {
                 if let Some(err_source) = e.source() {
                     match err_source.downcast_ref::<dbconnection::Error>() {
@@ -298,7 +367,7 @@ impl DataConnector for Postgres {
                     }
                 }
 
-                Some(Err(DataConnectorError::UnableToGetReadProvider {
+                Some(Err(DataConnectorError::UnableToGetReadWriteProvider {
                     dataconnector: "postgres".to_string(),
                     connector_component: ConnectorComponent::from(dataset),
                     source: e,
@@ -312,7 +381,7 @@ impl DataConnector for Postgres {
         dataset: &Dataset,
     ) -> DataConnectorResult<Arc<dyn TableProvider>> {
         match self.factory.table_provider(dataset.path().into()).await {
-            Ok(provider) => Ok(provider),
+            Ok(provider) => Ok(enrich_with_postgres_comments(&self.pool, dataset, provider).await),
             Err(e) => {
                 if let Some(err_source) = e.source() {
                     match err_source.downcast_ref::<dbconnection::Error>() {

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -66,6 +66,7 @@ use crate::schema_discovery::{
     DatasetPermissions, NoPermissionsCheck, PermissionCheckResult, SchemaProbeResult,
     discover_schema,
 };
+use crate::{COMMENT_METADATA_KEY, PARTITION_METADATA_KEY, SOURCE_TYPE_METADATA_KEY};
 use tracing::Instrument;
 use util::retry_strategy::BackoffMethod;
 
@@ -722,7 +723,10 @@ impl SqlWarehouseApi {
             })?;
 
             result.log_warnings(table);
-            Ok(result.schema)
+            let token = self.token_provider.get_token();
+            Ok(self
+                .enrich_schema_with_partition_columns(&token, table, result.schema)
+                .await)
         }
         .instrument(tracing::info_span!(
             target: "task_history",
@@ -898,10 +902,65 @@ impl SqlWarehouseApi {
         let escaped_schema = table_schema.replace('\'', "''");
         let escaped_catalog = table_catalog.replace('\'', "''");
         let sql = format!(
-            "SELECT column_name, {data_type_column}, is_nullable FROM information_schema.columns WHERE table_name = '{escaped_table}' AND table_schema = '{escaped_schema}' AND table_catalog = '{escaped_catalog}'"
+            "SELECT c.column_name, c.{data_type_column}, c.is_nullable, c.comment, t.comment FROM information_schema.columns c LEFT JOIN information_schema.tables t ON c.table_catalog = t.table_catalog AND c.table_schema = t.table_schema AND c.table_name = t.table_name WHERE c.table_name = '{escaped_table}' AND c.table_schema = '{escaped_schema}' AND c.table_catalog = '{escaped_catalog}' ORDER BY c.ordinal_position"
         );
         // Databricks SQL Statements API max wait_timeout is 50s.
         // https://docs.databricks.com/api/workspace/statementexecution/executestatement
+        Ok(json!({
+            "warehouse_id": self.sql_warehouse_id,
+            "catalog": table_catalog,
+            "schema": table_schema,
+            "statement": sql,
+            "format": "JSON_ARRAY",
+            "disposition": "INLINE",
+            "wait_timeout": "50s",
+            "on_wait_timeout": "CONTINUE",
+        }))
+    }
+
+    async fn enrich_schema_with_partition_columns(
+        &self,
+        token: &str,
+        table: &TableReference,
+        schema: SchemaRef,
+    ) -> SchemaRef {
+        match self.get_partition_columns(token, table).await {
+            Ok(partition_columns) => schema_with_partition_metadata(schema, &partition_columns),
+            Err(error) => {
+                tracing::warn!(
+                    table = %table,
+                    error = %error,
+                    "Failed to query Databricks partition columns; registering without partition metadata"
+                );
+                schema
+            }
+        }
+    }
+
+    async fn get_partition_columns(
+        &self,
+        token: &str,
+        table: &TableReference,
+    ) -> Result<Vec<String>, Error> {
+        let payload = self.create_describe_detail_payload(table)?;
+        let response = self.execute_sql_statement(token, &payload).await?;
+        let response = self.wait_for_statement_completion(token, response).await?;
+        partition_columns_from_describe_detail_json(&response, &table.to_string())
+    }
+
+    fn create_describe_detail_payload(&self, table: &TableReference) -> Result<Value, Error> {
+        let table_schema = table.schema().ok_or_else(|| Error::FullyQualifiedPath {
+            reason: "missing schema".into(),
+        })?;
+        let table_catalog = table.catalog().ok_or_else(|| Error::FullyQualifiedPath {
+            reason: "missing catalog".into(),
+        })?;
+        let sql = format!(
+            "DESCRIBE DETAIL `{}`.`{}`.`{}`",
+            table_catalog.replace('`', "``"),
+            table_schema.replace('`', "``"),
+            table.table().replace('`', "``"),
+        );
         Ok(json!({
             "warehouse_id": self.sql_warehouse_id,
             "catalog": table_catalog,
@@ -1530,6 +1589,7 @@ fn schema_from_json(json_value: &Value, dataset_name: &str) -> Result<SchemaRef,
     }
 
     let mut fields = Vec::new();
+    let mut schema_metadata = HashMap::new();
 
     for (i, row) in data_array.iter().enumerate() {
         let row_array = row
@@ -1579,7 +1639,17 @@ fn schema_from_json(json_value: &Value, dataset_name: &str) -> Result<SchemaRef,
                 reason: format!("data_array[{i}][2] (is_nullable) is not a string"),
             })?;
 
-        let field: Field = Field::new(col_name, data_type, nullable);
+        if let Some(table_comment) = optional_string(row_array.get(4)) {
+            schema_metadata
+                .entry(COMMENT_METADATA_KEY.to_string())
+                .or_insert_with(|| table_comment.to_string());
+        }
+
+        let field = field_with_optional_metadata(
+            Field::new(col_name, data_type, nullable),
+            optional_string(row_array.get(3)),
+            Some(data_type_str),
+        );
 
         fields.push(field);
     }
@@ -1590,7 +1660,7 @@ fn schema_from_json(json_value: &Value, dataset_name: &str) -> Result<SchemaRef,
         });
     }
 
-    Ok(Arc::new(Schema::new(fields)))
+    Ok(Arc::new(Schema::new_with_metadata(fields, schema_metadata)))
 }
 
 /// Parses a schema from a `DESCRIBE TABLE` response.
@@ -1666,7 +1736,11 @@ fn schema_from_describe_json(json_value: &Value, dataset_name: &str) -> Result<S
             .map_err(|reason| Error::ParseError { reason })?;
 
         // DESCRIBE TABLE does not report nullability; default to nullable.
-        fields.push(Field::new(col_name, data_type, true));
+        fields.push(field_with_optional_metadata(
+            Field::new(col_name, data_type, true),
+            optional_string(row_array.get(2)),
+            Some(data_type_str),
+        ));
     }
 
     if fields.is_empty() {
@@ -1676,6 +1750,138 @@ fn schema_from_describe_json(json_value: &Value, dataset_name: &str) -> Result<S
     }
 
     Ok(Arc::new(Schema::new(fields)))
+}
+
+fn optional_string(value: Option<&Value>) -> Option<&str> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn field_with_optional_metadata(
+    field: Field,
+    comment: Option<&str>,
+    source_type: Option<&str>,
+) -> Field {
+    let mut metadata = HashMap::new();
+    if let Some(comment) = comment {
+        metadata.insert(COMMENT_METADATA_KEY.to_string(), comment.to_string());
+    }
+    if let Some(source_type) = source_type.map(str::trim).filter(|value| !value.is_empty()) {
+        metadata.insert(
+            SOURCE_TYPE_METADATA_KEY.to_string(),
+            source_type.to_string(),
+        );
+    }
+
+    if metadata.is_empty() {
+        return field;
+    }
+
+    field.with_metadata(metadata)
+}
+
+fn schema_with_partition_metadata(schema: SchemaRef, partition_columns: &[String]) -> SchemaRef {
+    if partition_columns.is_empty() {
+        return schema;
+    }
+
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            if partition_columns
+                .iter()
+                .any(|partition_column| partition_column == field.name())
+            {
+                let mut metadata = field.metadata().clone();
+                metadata.insert(PARTITION_METADATA_KEY.to_string(), "true".to_string());
+                Arc::new(field.as_ref().clone().with_metadata(metadata))
+            } else {
+                Arc::clone(field)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Arc::new(Schema::new_with_metadata(fields, schema.metadata().clone()))
+}
+
+fn partition_columns_from_describe_detail_json(
+    json_value: &Value,
+    dataset_name: &str,
+) -> Result<Vec<String>, Error> {
+    SqlWarehouseApi::verify_response_status(json_value)?;
+
+    let result = json_value
+        .get("result")
+        .ok_or_else(|| Error::UnexpectedSchemaResponse {
+            dataset_name: dataset_name.to_string(),
+            reason: "missing result object in DESCRIBE DETAIL response".to_string(),
+        })?;
+
+    let data_array = result
+        .get("data_array")
+        .and_then(Value::as_array)
+        .ok_or_else(|| Error::UnexpectedSchemaResponse {
+            dataset_name: dataset_name.to_string(),
+            reason: "missing or invalid data_array in DESCRIBE DETAIL response".to_string(),
+        })?;
+
+    let Some(row) = data_array.first() else {
+        return Ok(Vec::new());
+    };
+
+    let row_array = row
+        .as_array()
+        .ok_or_else(|| Error::UnexpectedSchemaResponse {
+            dataset_name: dataset_name.to_string(),
+            reason: "DESCRIBE DETAIL row is not an array".to_string(),
+        })?;
+
+    let Some(partition_columns) = row_array.get(7) else {
+        return Ok(Vec::new());
+    };
+
+    partition_column_names(partition_columns).ok_or_else(|| Error::UnexpectedSchemaResponse {
+        dataset_name: dataset_name.to_string(),
+        reason: "DESCRIBE DETAIL partitionColumns is not a string array".to_string(),
+    })
+}
+
+fn partition_column_names(value: &Value) -> Option<Vec<String>> {
+    match value {
+        Value::Array(values) => Some(
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+                .collect(),
+        ),
+        Value::String(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Some(Vec::new());
+            }
+            serde_json::from_str::<Vec<String>>(trimmed)
+                .ok()
+                .or_else(|| {
+                    Some(
+                        trimmed
+                            .trim_matches(['[', ']'])
+                            .split(',')
+                            .map(|value| value.trim().trim_matches('"'))
+                            .filter(|value| !value.is_empty())
+                            .map(ToString::to_string)
+                            .collect(),
+                    )
+                })
+        }
+        Value::Null => Some(Vec::new()),
+        _ => None,
+    }
 }
 
 struct SqlWarehouseConnection {
@@ -1907,6 +2113,78 @@ mod tests {
     }
 
     #[test]
+    fn test_schema_from_json_preserves_comment_metadata() {
+        let response = make_schema_response(&json!([
+            ["id", "int", "NO", "stable identifier", "customer dimension"],
+            [
+                "name",
+                "string",
+                "YES",
+                "display name",
+                "customer dimension"
+            ],
+            ["amount", "double", "NO", "", "customer dimension"]
+        ]));
+
+        let schema = schema_from_json(&response, "test_table").expect("should parse schema");
+
+        assert_eq!(
+            schema
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("customer dimension")
+        );
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("stable identifier")
+        );
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get(SOURCE_TYPE_METADATA_KEY)
+                .map(String::as_str),
+            Some("int")
+        );
+        assert_eq!(
+            schema
+                .field(1)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("display name")
+        );
+        assert_eq!(
+            schema
+                .field(1)
+                .metadata()
+                .get(SOURCE_TYPE_METADATA_KEY)
+                .map(String::as_str),
+            Some("string")
+        );
+        assert!(
+            schema
+                .field(2)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .is_none()
+        );
+        assert_eq!(
+            schema
+                .field(2)
+                .metadata()
+                .get(SOURCE_TYPE_METADATA_KEY)
+                .map(String::as_str),
+            Some("double")
+        );
+    }
+
+    #[test]
     fn test_schema_from_json_many_types() {
         let response = make_schema_response(&json!([
             ["col_bigint", "bigint", "NO"],
@@ -1932,6 +2210,51 @@ mod tests {
         );
         assert_eq!(schema.field(6).data_type(), &DataType::Binary);
         assert_eq!(schema.field(7).data_type(), &DataType::Decimal128(10, 2));
+    }
+
+    #[test]
+    fn test_partition_columns_from_describe_detail_metadata() {
+        let response = make_schema_response(&json!([[
+            "delta",
+            "table-id",
+            "customers",
+            null,
+            "s3://bucket/customers",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+            ["event_date", "region"]
+        ]]));
+
+        let partition_columns = partition_columns_from_describe_detail_json(&response, "customers")
+            .expect("should parse partition columns");
+
+        assert_eq!(partition_columns, vec!["event_date", "region"]);
+    }
+
+    #[test]
+    fn test_schema_with_partition_metadata_marks_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("event_date", DataType::Date32, true),
+            Field::new("value", DataType::Int64, true),
+        ]));
+
+        let schema = schema_with_partition_metadata(schema, &["event_date".to_string()]);
+
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get(PARTITION_METADATA_KEY)
+                .map(String::as_str),
+            Some("true")
+        );
+        assert!(
+            schema
+                .field(1)
+                .metadata()
+                .get(PARTITION_METADATA_KEY)
+                .is_none()
+        );
     }
 
     #[test]
@@ -2762,7 +3085,7 @@ mod tests {
             "SQL should reference full_data_type: {stmt_full}"
         );
         assert!(
-            !stmt_full.contains(", data_type,"),
+            !stmt_full.contains(", c.data_type,"),
             "SQL should not reference plain data_type: {stmt_full}"
         );
         let payload_plain = api
@@ -2772,7 +3095,7 @@ mod tests {
             .as_str()
             .expect("statement should be string");
         assert!(
-            stmt_plain.contains(", data_type,"),
+            stmt_plain.contains(", c.data_type,"),
             "SQL should reference data_type: {stmt_plain}"
         );
         assert!(
@@ -4349,6 +4672,14 @@ mod tests {
 
         assert_eq!(schema.field(0).name(), "id");
         assert_eq!(schema.field(0).data_type(), &DataType::Int32);
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("primary key")
+        );
         assert!(
             schema.field(0).is_nullable(),
             "DESCRIBE TABLE defaults to nullable"
@@ -4356,10 +4687,25 @@ mod tests {
 
         assert_eq!(schema.field(1).name(), "name");
         assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
+        assert_eq!(
+            schema
+                .field(1)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("user name")
+        );
         assert!(schema.field(1).is_nullable());
 
         assert_eq!(schema.field(2).name(), "amount");
         assert_eq!(schema.field(2).data_type(), &DataType::Float64);
+        assert!(
+            schema
+                .field(2)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .is_none()
+        );
     }
 
     /// DESCRIBE TABLE with metadata rows (partition info) after a blank separator.

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -28,7 +28,7 @@ use futures::Stream;
 use rdkafka::{
     ClientConfig, Message, Offset,
     config::RDKafkaLogLevel,
-    consumer::{CommitMode, Consumer, StreamConsumer},
+    consumer::{BaseConsumer, CommitMode, Consumer, Rebalance, StreamConsumer},
     message::BorrowedMessage,
     topic_partition_list::TopicPartitionList,
     util::get_rdkafka_version,
@@ -217,11 +217,19 @@ pub struct KafkaMetrics {
 
 struct KafkaConsumerContext {
     metrics: Arc<KafkaMetrics>,
+    /// Offsets to seek to on the first partition assignment (restored from sidecar).
+    /// Populated at construction so the stash is in place before `subscribe()` can
+    /// trigger a rebalance. The first `Rebalance::Assign` takes the value; later
+    /// rebalances see `None` and fall back to the group-committed offset.
+    restore_offsets: std::sync::Mutex<Option<TopicPartitionList>>,
 }
 
 impl KafkaConsumerContext {
-    fn new(metrics: Arc<KafkaMetrics>) -> Self {
-        Self { metrics }
+    fn new(metrics: Arc<KafkaMetrics>, restore_offsets: Option<TopicPartitionList>) -> Self {
+        Self {
+            metrics,
+            restore_offsets: std::sync::Mutex::new(restore_offsets),
+        }
     }
 }
 
@@ -320,7 +328,35 @@ impl rdkafka::ClientContext for KafkaConsumerContext {
     }
 }
 
-impl rdkafka::consumer::ConsumerContext for KafkaConsumerContext {}
+impl rdkafka::consumer::ConsumerContext for KafkaConsumerContext {
+    fn post_rebalance(&self, base_consumer: &BaseConsumer<Self>, rebalance: &Rebalance<'_>) {
+        if let Rebalance::Assign(_) = rebalance {
+            // On first assignment after subscribe, seek to sidecar offsets if available.
+            // Take the offsets so this only fires once on success.
+            let offsets = self
+                .restore_offsets
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+
+            if let Some(tpl) = offsets {
+                match base_consumer.seek_partitions(tpl.clone(), Duration::from_secs(5)) {
+                    Ok(_) => {
+                        tracing::info!("Restored Kafka consumer offsets from sidecar");
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to seek to restored offsets: {e}");
+                        // Re-insert offsets so the next rebalance retries the seek.
+                        *self
+                            .restore_offsets
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(tpl);
+                    }
+                }
+            }
+        }
+    }
+}
 
 pub struct KafkaConsumer {
     group_id: String,
@@ -329,11 +365,16 @@ pub struct KafkaConsumer {
 }
 
 impl KafkaConsumer {
+    /// Construct a consumer for an existing consumer group, restoring partition
+    /// offsets from the sidecar before any rebalance can fire. Pass an empty
+    /// slice for `restore_offsets` when there is nothing to restore.
     pub fn create_with_existing_group_id(
         group_id: impl Into<String>,
         kafka_config: &KafkaConfig,
+        restore_offsets: &[KafkaOffset],
     ) -> Result<Self> {
-        Self::create(group_id.into(), kafka_config)
+        let restore = Self::build_restore_tpl(restore_offsets)?;
+        Self::create(group_id.into(), kafka_config, restore)
     }
 
     pub fn create_for_dataset(
@@ -344,6 +385,7 @@ impl KafkaConsumer {
         Self::create(
             group_id.unwrap_or_else(|| Self::generate_group_id(dataset)),
             kafka_config,
+            None,
         )
     }
 
@@ -408,9 +450,12 @@ impl KafkaConsumer {
             .context(UnableToCommitConsumerStateSnafu)
     }
 
-    pub fn restore_offsets(&self, offsets: &[KafkaOffset]) -> Result<()> {
+    /// Build a [`TopicPartitionList`] from sidecar offsets. Returns `None` when
+    /// the slice is empty so callers can pass the result straight into
+    /// [`KafkaConsumer::create`] for the no-restore case.
+    fn build_restore_tpl(offsets: &[KafkaOffset]) -> Result<Option<TopicPartitionList>> {
         if offsets.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
 
         let mut topic_partition_list = TopicPartitionList::new();
@@ -426,11 +471,7 @@ impl KafkaConsumer {
                 })?;
         }
 
-        self.consumer
-            .commit(&topic_partition_list, CommitMode::Sync)
-            .context(UnableToRestoreOffsetsSnafu {
-                message: "Failed to commit sidecar offsets to Kafka".to_string(),
-            })
+        Ok(Some(topic_partition_list))
     }
 
     pub fn restart_topic(&self, topic: &str) -> Result<()> {
@@ -490,7 +531,11 @@ impl KafkaConsumer {
         &self.metrics
     }
 
-    fn create(group_id: String, kafka_config: &KafkaConfig) -> Result<Self> {
+    fn create(
+        group_id: String,
+        kafka_config: &KafkaConfig,
+        restore_offsets: Option<TopicPartitionList>,
+    ) -> Result<Self> {
         tracing::debug!("Using kafka group_id: {}", group_id);
 
         let (_, version) = get_rdkafka_version();
@@ -548,7 +593,10 @@ impl KafkaConsumer {
 
         let consumer: StreamConsumer<KafkaConsumerContext> = config
             .set_log_level(RDKafkaLogLevel::Debug)
-            .create_with_context(KafkaConsumerContext::new(Arc::clone(&metrics)))
+            .create_with_context(KafkaConsumerContext::new(
+                Arc::clone(&metrics),
+                restore_offsets,
+            ))
             .context(UnableToCreateConsumerSnafu)?;
 
         Ok(Self {
@@ -571,7 +619,7 @@ impl KafkaConsumer {
         let temp_group_id = format!("spice-schema-peek-{}", uuid::Uuid::new_v4());
         let mut peek_config = kafka_config.clone();
         peek_config.metrics_store = None; // Avoid skewing real consumer metrics
-        let temp_consumer = Self::create(temp_group_id, &peek_config)?;
+        let temp_consumer = Self::create(temp_group_id, &peek_config, None)?;
 
         // Fetch topic metadata to discover partitions
         let metadata = temp_consumer

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -15,10 +15,12 @@ limitations under the License.
 */
 
 #![allow(clippy::missing_errors_doc)]
-use std::{any::Any, borrow::Cow, collections::HashMap, error::Error, sync::Arc};
+use std::{
+    any::Any, borrow::Cow, collections::HashMap, error::Error, hash::BuildHasher, sync::Arc,
+};
 
 use async_trait::async_trait;
-use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::{
     catalog::{CatalogProvider, Session},
     common::{Constraints, Statistics},
@@ -29,6 +31,7 @@ use datafusion::{
     prelude::Expr,
     sql::TableReference,
 };
+use datafusion_federation::FederatedTableProviderAdaptor;
 
 /// Schema-level metadata key for foreign key relationships.
 ///
@@ -43,6 +46,26 @@ use datafusion::{
 /// ]
 /// ```
 pub const FOREIGN_KEYS_METADATA_KEY: &str = "foreign_keys";
+
+/// Canonical Arrow metadata key for user-facing table and column comments.
+pub const COMMENT_METADATA_KEY: &str = "comment";
+
+/// Canonical Arrow field metadata key for the source-native column type.
+pub const SOURCE_TYPE_METADATA_KEY: &str = "source_type";
+
+/// Canonical Arrow field metadata key marking source partition columns.
+pub const PARTITION_METADATA_KEY: &str = "partition";
+
+/// Canonical Arrow field metadata key marking source clustering columns.
+///
+/// Values are one-based ordinals when the source reports clustering order.
+pub const CLUSTERING_METADATA_KEY: &str = "clustering";
+
+/// Canonical Arrow schema metadata key for a source-native clustering expression.
+pub const CLUSTERING_KEY_METADATA_KEY: &str = "clustering_key";
+
+/// Metadata to merge into fields, keyed by field name.
+pub type FieldMetadata = HashMap<String, HashMap<String, String>>;
 
 pub mod arrow;
 #[cfg(feature = "clickhouse")]
@@ -138,13 +161,103 @@ impl MetadataEnrichedTableProvider {
     ///
     /// Keys in `extra_metadata` will overwrite any pre-existing schema metadata with the same key.
     #[must_use]
-    pub fn new(inner: Arc<dyn TableProvider>, extra_metadata: HashMap<String, String>) -> Self {
+    pub fn new<S>(inner: Arc<dyn TableProvider>, extra_metadata: HashMap<String, String, S>) -> Self
+    where
+        S: BuildHasher,
+    {
+        Self::new_with_field_metadata(inner, extra_metadata, &FieldMetadata::new())
+    }
+
+    /// Wrap `inner`, merging schema-level metadata and per-field metadata into its schema.
+    ///
+    /// Keys in `extra_metadata` overwrite pre-existing schema metadata with the same key. Keys in
+    /// `field_metadata` overwrite pre-existing field metadata for matching field names.
+    #[must_use]
+    pub fn new_with_field_metadata<S>(
+        inner: Arc<dyn TableProvider>,
+        extra_metadata: HashMap<String, String, S>,
+        field_metadata: &FieldMetadata,
+    ) -> Self
+    where
+        S: BuildHasher,
+    {
         let base = inner.schema();
         let mut metadata = base.metadata().clone();
         metadata.extend(extra_metadata);
-        let schema = Arc::new(base.as_ref().clone().with_metadata(metadata));
+
+        let fields = base
+            .fields()
+            .iter()
+            .map(|field| {
+                if let Some(extra) = field_metadata.get(field.name().as_str()) {
+                    let mut metadata = field.metadata().clone();
+                    metadata.extend(
+                        extra
+                            .iter()
+                            .map(|(key, value)| (key.clone(), value.clone())),
+                    );
+                    Arc::new(field.as_ref().clone().with_metadata(metadata))
+                } else {
+                    Arc::clone(field)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let schema = Arc::new(Schema::new_with_metadata(fields, metadata));
         Self { inner, schema }
     }
+
+    #[must_use]
+    pub fn get_inner_ref(&self) -> &Arc<dyn TableProvider> {
+        &self.inner
+    }
+}
+
+/// Wrap `provider` with schema metadata while preserving federation pushdown when possible.
+///
+/// `datafusion-federation` discovers federated tables by downcasting to
+/// [`FederatedTableProviderAdaptor`]. If metadata enrichment is placed outside that adaptor, the
+/// federated table is hidden from the analyzer and pushdown is lost. When the provider is already a
+/// federated adaptor with a fallback provider, keep the adaptor as the outer provider and enrich the
+/// fallback provider instead.
+#[must_use]
+pub fn metadata_enriched_table_provider<S>(
+    provider: Arc<dyn TableProvider>,
+    extra_metadata: HashMap<String, String, S>,
+    field_metadata: FieldMetadata,
+) -> Arc<dyn TableProvider>
+where
+    S: BuildHasher,
+{
+    if extra_metadata.is_empty() && field_metadata.is_empty() {
+        return provider;
+    }
+
+    if let Some(adaptor) = provider
+        .as_any()
+        .downcast_ref::<FederatedTableProviderAdaptor>()
+    {
+        let Some(table_provider) = &adaptor.table_provider else {
+            return Arc::clone(&provider);
+        };
+
+        let enriched_provider = metadata_enriched_table_provider(
+            Arc::clone(table_provider),
+            extra_metadata,
+            field_metadata,
+        );
+
+        return Arc::new(FederatedTableProviderAdaptor::new_with_provider(
+            Arc::clone(&adaptor.source),
+            enriched_provider,
+        ));
+    }
+
+    Arc::new(MetadataEnrichedTableProvider::new_with_field_metadata(
+        provider,
+        extra_metadata,
+        &field_metadata,
+    ))
 }
 
 impl std::fmt::Debug for MetadataEnrichedTableProvider {
@@ -247,4 +360,125 @@ pub trait ReadWrite: Send + Sync {
 #[async_trait]
 pub trait RefreshableCatalogProvider: CatalogProvider {
     async fn refresh(&self) -> Result<(), Box<dyn Error + Send + Sync>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field};
+    use datafusion::error::DataFusionError;
+    use datafusion::logical_expr::TableSource;
+    use datafusion_federation::{
+        FederatedTableProviderAdaptor, FederatedTableSource, FederationAnalyzerForLogicalPlan,
+        FederationProvider,
+    };
+
+    #[derive(Debug)]
+    struct TestFederationProvider;
+
+    impl FederationProvider for TestFederationProvider {
+        fn name(&self) -> &'static str {
+            "test"
+        }
+
+        fn compute_context(&self) -> Option<String> {
+            Some("test-context".to_string())
+        }
+
+        fn analyzer(&self, _plan: &LogicalPlan) -> Option<FederationAnalyzerForLogicalPlan> {
+            None
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestFederatedSource {
+        schema: SchemaRef,
+    }
+
+    impl TableSource for TestFederatedSource {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn schema(&self) -> SchemaRef {
+            Arc::clone(&self.schema)
+        }
+    }
+
+    impl FederatedTableSource for TestFederatedSource {
+        fn federation_provider(&self) -> Arc<dyn FederationProvider> {
+            Arc::new(TestFederationProvider)
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestTableProvider {
+        schema: SchemaRef,
+    }
+
+    #[async_trait]
+    impl TableProvider for TestTableProvider {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn schema(&self) -> SchemaRef {
+            Arc::clone(&self.schema)
+        }
+
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+
+        async fn scan(
+            &self,
+            _state: &dyn Session,
+            _projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            Err(DataFusionError::NotImplemented("scan".to_string()))
+        }
+    }
+
+    #[test]
+    fn metadata_enrichment_preserves_federated_table_provider_adaptor() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, true)]));
+        let source: Arc<dyn FederatedTableSource> = Arc::new(TestFederatedSource {
+            schema: Arc::clone(&schema),
+        });
+        let fallback: Arc<dyn TableProvider> = Arc::new(TestTableProvider { schema });
+        let provider: Arc<dyn TableProvider> = Arc::new(
+            FederatedTableProviderAdaptor::new_with_provider(source, fallback),
+        );
+
+        let field_metadata = HashMap::from([(
+            "id".to_string(),
+            HashMap::from([("source_type".to_string(), "BIGINT".to_string())]),
+        )]);
+        let enriched = metadata_enriched_table_provider(
+            provider,
+            HashMap::from([("comment".to_string(), "orders".to_string())]),
+            field_metadata,
+        );
+
+        let adaptor = enriched
+            .as_any()
+            .downcast_ref::<FederatedTableProviderAdaptor>()
+            .expect("metadata enrichment should preserve the federated adaptor");
+        let schema = adaptor.schema();
+        assert_eq!(
+            schema.metadata().get("comment").map(String::as_str),
+            Some("orders")
+        );
+        assert_eq!(
+            schema
+                .field_with_name("id")
+                .expect("id field should exist")
+                .metadata()
+                .get("source_type")
+                .map(String::as_str),
+            Some("BIGINT")
+        );
+    }
 }

--- a/crates/data_components/src/mysql/provider.rs
+++ b/crates/data_components/src/mysql/provider.rs
@@ -32,7 +32,10 @@ use globset::GlobSet;
 use mysql_async::prelude::Queryable;
 use snafu::prelude::*;
 
-use crate::{Read, RefreshableCatalogProvider};
+use crate::{
+    COMMENT_METADATA_KEY, FieldMetadata, Read, RefreshableCatalogProvider,
+    SOURCE_TYPE_METADATA_KEY, metadata_enriched_table_provider,
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -47,6 +50,30 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// System schemas to exclude from discovery.
 const SYSTEM_SCHEMAS: &[&str] = &["information_schema", "mysql", "performance_schema", "sys"];
+
+#[derive(Debug, Clone, Default)]
+struct TableComments {
+    table_comment: Option<String>,
+    column_comments: HashMap<String, String>,
+    column_source_types: HashMap<String, String>,
+}
+
+pub type MySqlTableMetadataRow = (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+type MySqlSchemaMetadataRow = (
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+type CommentMap = HashMap<String, TableComments>;
 
 /// A catalog provider for `MySQL` that discovers schemas and tables
 /// by querying `information_schema`.
@@ -190,6 +217,17 @@ impl MySQLSchemaProvider {
 
     async fn refresh_tables(&self) -> Result<()> {
         let table_names = self.list_tables().await?;
+        let comments = match self.list_comments().await {
+            Ok(comments) => comments,
+            Err(error) => {
+                tracing::warn!(
+                    schema = %self.schema_name,
+                    error = %error,
+                    "Failed to query MySQL comments for schema, continuing without comment metadata"
+                );
+                HashMap::new()
+            }
+        };
 
         let mut tables = HashMap::new();
         for table_name in table_names {
@@ -209,7 +247,10 @@ impl MySQLSchemaProvider {
 
             match self.table_creator.table_provider(table_ref).await {
                 Ok(provider) => {
-                    tables.insert(table_name, provider);
+                    tables.insert(
+                        table_name.clone(),
+                        provider_with_comments(provider, comments.get(&table_name)),
+                    );
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -249,6 +290,126 @@ impl MySQLSchemaProvider {
 
         Ok(rows)
     }
+
+    async fn list_comments(&self) -> Result<CommentMap> {
+        let mut conn = self.pool.get_conn().await.context(ConnectionFailedSnafu)?;
+
+        let rows: Vec<MySqlSchemaMetadataRow> = conn
+            .exec(
+                "SELECT \
+                     t.TABLE_NAME, \
+                     NULLIF(t.TABLE_COMMENT, '') AS TABLE_COMMENT, \
+                     c.COLUMN_NAME, \
+                     NULLIF(c.COLUMN_COMMENT, '') AS COLUMN_COMMENT, \
+                     c.COLUMN_TYPE \
+                 FROM information_schema.TABLES t \
+                 LEFT JOIN information_schema.COLUMNS c \
+                     ON c.TABLE_SCHEMA = t.TABLE_SCHEMA \
+                     AND c.TABLE_NAME = t.TABLE_NAME \
+                 WHERE t.TABLE_SCHEMA = ? \
+                 AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') \
+                 ORDER BY t.TABLE_NAME, c.ORDINAL_POSITION",
+                (&self.schema_name,),
+            )
+            .await
+            .context(QueryFailedSnafu)?;
+
+        let mut comments_by_table = HashMap::new();
+        for (table_name, table_comment, column_name, column_comment, column_source_type) in rows {
+            let comments: &mut TableComments = comments_by_table.entry(table_name).or_default();
+            if comments.table_comment.is_none()
+                && let Some(comment) = table_comment
+            {
+                comments.table_comment = Some(comment);
+            }
+            if let Some(column_name) = column_name {
+                if let Some(comment) = column_comment {
+                    comments
+                        .column_comments
+                        .insert(column_name.clone(), comment);
+                }
+                if let Some(source_type) =
+                    column_source_type.filter(|source_type| !source_type.is_empty())
+                {
+                    comments
+                        .column_source_types
+                        .insert(column_name, source_type);
+                }
+            }
+        }
+
+        Ok(comments_by_table)
+    }
+}
+
+fn provider_with_comments(
+    provider: Arc<dyn TableProvider>,
+    comments: Option<&TableComments>,
+) -> Arc<dyn TableProvider> {
+    let Some(comments) = comments else {
+        return provider;
+    };
+
+    let (table_metadata, field_metadata) = table_comments_metadata(comments);
+
+    if table_metadata.is_empty() && field_metadata.is_empty() {
+        provider
+    } else {
+        metadata_enriched_table_provider(provider, table_metadata, field_metadata)
+    }
+}
+
+fn table_comments_metadata(comments: &TableComments) -> (HashMap<String, String>, FieldMetadata) {
+    let mut table_metadata = HashMap::new();
+    if let Some(comment) = &comments.table_comment {
+        table_metadata.insert(COMMENT_METADATA_KEY.to_string(), comment.clone());
+    }
+
+    let mut field_metadata = FieldMetadata::new();
+    for (column, source_type) in &comments.column_source_types {
+        field_metadata
+            .entry(column.clone())
+            .or_default()
+            .insert(SOURCE_TYPE_METADATA_KEY.to_string(), source_type.clone());
+    }
+    for (column, comment) in &comments.column_comments {
+        field_metadata
+            .entry(column.clone())
+            .or_default()
+            .insert(COMMENT_METADATA_KEY.to_string(), comment.clone());
+    }
+
+    (table_metadata, field_metadata)
+}
+
+#[must_use]
+pub fn mysql_metadata_from_rows(
+    rows: impl IntoIterator<Item = MySqlTableMetadataRow>,
+) -> (HashMap<String, String>, FieldMetadata) {
+    let mut comments = TableComments::default();
+    for (table_comment, column_name, column_comment, column_source_type) in rows {
+        if comments.table_comment.is_none()
+            && let Some(comment) = table_comment.filter(|comment| !comment.is_empty())
+        {
+            comments.table_comment = Some(comment);
+        }
+        if let Some(column_name) = column_name {
+            if let Some(comment) = column_comment.filter(|comment| !comment.is_empty()) {
+                comments
+                    .column_comments
+                    .insert(column_name.clone(), comment);
+            }
+            if let Some(source_type) =
+                column_source_type.filter(|source_type| !source_type.is_empty())
+            {
+                comments
+                    .column_source_types
+                    .insert(column_name, source_type);
+            }
+        }
+    }
+
+    table_comments_metadata(&comments)
 }
 
 #[async_trait]

--- a/crates/data_components/src/postgres/provider.rs
+++ b/crates/data_components/src/postgres/provider.rs
@@ -33,7 +33,8 @@ use globset::GlobSet;
 use snafu::prelude::*;
 
 use crate::{
-    FOREIGN_KEYS_METADATA_KEY, MetadataEnrichedTableProvider, Read, RefreshableCatalogProvider,
+    COMMENT_METADATA_KEY, FOREIGN_KEYS_METADATA_KEY, FieldMetadata, Read,
+    RefreshableCatalogProvider, SOURCE_TYPE_METADATA_KEY, metadata_enriched_table_provider,
 };
 
 #[derive(Debug, Snafu)]
@@ -66,6 +67,18 @@ struct ForeignKeyConstraint {
 
 /// FK constraints grouped by source table name within a schema.
 type ForeignKeyMap = HashMap<String, Vec<ForeignKeyConstraint>>;
+
+#[derive(Debug, Clone, Default)]
+struct TableComments {
+    table_comment: Option<String>,
+    column_comments: HashMap<String, String>,
+    column_source_types: HashMap<String, String>,
+}
+
+pub type PostgresTableMetadataRow = (Option<String>, String, Option<String>, String);
+
+/// Comment metadata grouped by source table name within a schema.
+type CommentMap = HashMap<String, TableComments>;
 
 /// A catalog provider for `PostgreSQL` that discovers schemas and tables
 /// by querying `information_schema`.
@@ -117,6 +130,17 @@ impl PostgresCatalogProvider {
                     HashMap::new()
                 }
             };
+            let comments = match self.list_comments(schema_name).await {
+                Ok(comments) => comments,
+                Err(e) => {
+                    tracing::warn!(
+                        schema = %schema_name,
+                        error = %e,
+                        "Failed to query comments for schema, continuing without comment metadata"
+                    );
+                    HashMap::new()
+                }
+            };
 
             let schema_provider = PostgresSchemaProvider::new(
                 Arc::clone(&self.pool),
@@ -124,7 +148,9 @@ impl PostgresCatalogProvider {
                 Arc::clone(&self.table_creator),
                 self.include.clone(),
             );
-            schema_provider.refresh_tables(&foreign_keys).await?;
+            schema_provider
+                .refresh_tables(&foreign_keys, &comments)
+                .await?;
             schemas.insert(schema_name.clone(), Arc::new(schema_provider));
         }
 
@@ -216,6 +242,70 @@ impl PostgresCatalogProvider {
             .collect();
 
         Ok(fk_map)
+    }
+
+    /// Query table and column comments for tables in the given schema.
+    async fn list_comments(&self, schema_name: &str) -> Result<CommentMap> {
+        let conn = self
+            .pool
+            .connect_direct()
+            .await
+            .context(ConnectionFailedSnafu)?;
+
+        let rows = conn
+            .conn
+            .query(
+                "SELECT \
+                     c.relname AS table_name, \
+                     obj_description(c.oid, 'pg_class') AS table_comment, \
+                     a.attname AS column_name, \
+                     col_description(c.oid, a.attnum) AS column_comment, \
+                     format_type(a.atttypid, a.atttypmod) AS column_source_type \
+                 FROM pg_catalog.pg_class c \
+                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+                 LEFT JOIN pg_catalog.pg_attribute a \
+                     ON a.attrelid = c.oid \
+                     AND a.attnum > 0 \
+                     AND NOT a.attisdropped \
+                 WHERE n.nspname = $1 \
+                 AND c.relkind IN ('r', 'p', 'v', 'm', 'f') \
+                 ORDER BY c.relname, a.attnum",
+                &[&schema_name],
+            )
+            .await
+            .context(QueryFailedSnafu)?;
+
+        let mut comments_by_table = HashMap::new();
+        for row in &rows {
+            let table_name: String = row.get(0);
+            let table_comment: Option<String> = row.get(1);
+            let column_name: Option<String> = row.get(2);
+            let column_comment: Option<String> = row.get(3);
+            let column_source_type: Option<String> = row.get(4);
+
+            let comments: &mut TableComments = comments_by_table.entry(table_name).or_default();
+            if comments.table_comment.is_none()
+                && let Some(comment) = table_comment.filter(|comment| !comment.is_empty())
+            {
+                comments.table_comment = Some(comment);
+            }
+            if let Some(column_name) = column_name {
+                if let Some(comment) = column_comment.filter(|comment| !comment.is_empty()) {
+                    comments
+                        .column_comments
+                        .insert(column_name.clone(), comment);
+                }
+                if let Some(source_type) =
+                    column_source_type.filter(|source_type| !source_type.is_empty())
+                {
+                    comments
+                        .column_source_types
+                        .insert(column_name, source_type);
+                }
+            }
+        }
+
+        Ok(comments_by_table)
     }
 
     async fn list_schemas(&self) -> Result<Vec<String>> {
@@ -316,7 +406,11 @@ impl PostgresSchemaProvider {
         }
     }
 
-    async fn refresh_tables(&self, foreign_keys: &ForeignKeyMap) -> Result<()> {
+    async fn refresh_tables(
+        &self,
+        foreign_keys: &ForeignKeyMap,
+        comments: &CommentMap,
+    ) -> Result<()> {
         let table_names = self.list_tables().await?;
 
         let tables = build_table_providers_for_schema(
@@ -325,6 +419,7 @@ impl PostgresSchemaProvider {
             &self.table_creator,
             self.include.as_deref(),
             foreign_keys,
+            comments,
         )
         .await;
 
@@ -374,6 +469,7 @@ async fn build_table_providers_for_schema(
     table_creator: &Arc<dyn Read>,
     include: Option<&GlobSet>,
     foreign_keys: &ForeignKeyMap,
+    comments: &CommentMap,
 ) -> HashMap<String, Arc<dyn TableProvider>> {
     let mut tables = HashMap::new();
 
@@ -388,13 +484,11 @@ async fn build_table_providers_for_schema(
 
         match table_creator.table_provider(table_ref).await {
             Ok(provider) => {
-                let provider = if let Some(fks) = foreign_keys.get(&table_name) {
+                let mut table_metadata = HashMap::new();
+                if let Some(fks) = foreign_keys.get(&table_name) {
                     match serde_json::to_string(fks) {
                         Ok(fk_json) => {
-                            let extra =
-                                HashMap::from([(FOREIGN_KEYS_METADATA_KEY.to_string(), fk_json)]);
-                            Arc::new(MetadataEnrichedTableProvider::new(provider, extra))
-                                as Arc<dyn TableProvider>
+                            table_metadata.insert(FOREIGN_KEYS_METADATA_KEY.to_string(), fk_json);
                         }
                         Err(e) => {
                             tracing::warn!(
@@ -403,11 +497,24 @@ async fn build_table_providers_for_schema(
                                 error = %e,
                                 "Failed to serialize foreign key metadata for table {schema_name}.{table_name}; registering without FK metadata"
                             );
-                            provider
                         }
                     }
-                } else {
+                }
+
+                let field_metadata =
+                    comments
+                        .get(&table_name)
+                        .map_or_else(HashMap::new, |comments| {
+                            let (comment_metadata, field_metadata) =
+                                table_comments_metadata(comments);
+                            table_metadata.extend(comment_metadata);
+                            field_metadata
+                        });
+
+                let provider = if table_metadata.is_empty() && field_metadata.is_empty() {
                     provider
+                } else {
+                    metadata_enriched_table_provider(provider, table_metadata, field_metadata)
                 };
                 tables.insert(table_name, provider);
             }
@@ -423,6 +530,55 @@ async fn build_table_providers_for_schema(
     }
 
     tables
+}
+
+fn table_comments_metadata(comments: &TableComments) -> (HashMap<String, String>, FieldMetadata) {
+    let mut table_metadata = HashMap::new();
+    if let Some(comment) = &comments.table_comment {
+        table_metadata.insert(COMMENT_METADATA_KEY.to_string(), comment.clone());
+    }
+
+    let mut field_metadata = FieldMetadata::new();
+    for (column, source_type) in &comments.column_source_types {
+        field_metadata
+            .entry(column.clone())
+            .or_default()
+            .insert(SOURCE_TYPE_METADATA_KEY.to_string(), source_type.clone());
+    }
+    for (column, comment) in &comments.column_comments {
+        field_metadata
+            .entry(column.clone())
+            .or_default()
+            .insert(COMMENT_METADATA_KEY.to_string(), comment.clone());
+    }
+
+    (table_metadata, field_metadata)
+}
+
+#[must_use]
+pub fn postgres_metadata_from_rows(
+    rows: impl IntoIterator<Item = PostgresTableMetadataRow>,
+) -> (HashMap<String, String>, FieldMetadata) {
+    let mut comments = TableComments::default();
+    for (table_comment, column_name, column_comment, column_source_type) in rows {
+        if comments.table_comment.is_none()
+            && let Some(comment) = table_comment.filter(|comment| !comment.is_empty())
+        {
+            comments.table_comment = Some(comment);
+        }
+        if let Some(comment) = column_comment.filter(|comment| !comment.is_empty()) {
+            comments
+                .column_comments
+                .insert(column_name.clone(), comment);
+        }
+        if !column_source_type.is_empty() {
+            comments
+                .column_source_types
+                .insert(column_name, column_source_type);
+        }
+    }
+
+    table_comments_metadata(&comments)
 }
 
 #[async_trait]
@@ -459,9 +615,10 @@ impl SchemaProvider for PostgresSchemaProvider {
 #[cfg(test)]
 mod tests {
     use super::{
-        ForeignKeyConstraint, ForeignKeyMap, build_table_providers_for_schema, is_table_included,
+        CommentMap, ForeignKeyConstraint, ForeignKeyMap, TableComments,
+        build_table_providers_for_schema, is_table_included,
     };
-    use crate::{FOREIGN_KEYS_METADATA_KEY, Read};
+    use crate::{COMMENT_METADATA_KEY, FOREIGN_KEYS_METADATA_KEY, Read, SOURCE_TYPE_METADATA_KEY};
     use async_trait::async_trait;
     use datafusion::catalog::Session;
     use datafusion::datasource::{TableProvider, TableType};
@@ -484,7 +641,13 @@ mod tests {
         }
 
         fn schema(&self) -> arrow::datatypes::SchemaRef {
-            Arc::new(arrow::datatypes::Schema::empty())
+            Arc::new(arrow::datatypes::Schema::new(vec![
+                arrow::datatypes::Field::new(
+                    "customer_id",
+                    arrow::datatypes::DataType::Int64,
+                    true,
+                ),
+            ]))
         }
 
         fn table_type(&self) -> TableType {
@@ -573,6 +736,7 @@ mod tests {
         let include = make_include(&["public.orders"]);
         let table_creator: Arc<dyn Read> = Arc::<MockRead>::clone(&read);
         let no_fks: ForeignKeyMap = HashMap::new();
+        let no_comments: CommentMap = HashMap::new();
 
         let tables = build_table_providers_for_schema(
             "public",
@@ -580,6 +744,7 @@ mod tests {
             &table_creator,
             Some(&include),
             &no_fks,
+            &no_comments,
         )
         .await;
 
@@ -595,6 +760,7 @@ mod tests {
         let read = Arc::new(MockRead::new(fail_tables));
         let table_creator: Arc<dyn Read> = Arc::<MockRead>::clone(&read);
         let no_fks: ForeignKeyMap = HashMap::new();
+        let no_comments: CommentMap = HashMap::new();
 
         let tables = build_table_providers_for_schema(
             "public",
@@ -602,6 +768,7 @@ mod tests {
             &table_creator,
             None,
             &no_fks,
+            &no_comments,
         )
         .await;
 
@@ -622,6 +789,7 @@ mod tests {
         let read = Arc::new(MockRead::new(fail_tables));
         let table_creator: Arc<dyn Read> = Arc::<MockRead>::clone(&read);
         let no_fks: ForeignKeyMap = HashMap::new();
+        let no_comments: CommentMap = HashMap::new();
 
         let tables: HashMap<String, Arc<dyn TableProvider>> = build_table_providers_for_schema(
             "public",
@@ -629,6 +797,7 @@ mod tests {
             &table_creator,
             None,
             &no_fks,
+            &no_comments,
         )
         .await;
 
@@ -639,6 +808,7 @@ mod tests {
     async fn test_build_table_providers_injects_foreign_key_metadata() {
         let read = Arc::new(MockRead::new(HashSet::new()));
         let table_creator: Arc<dyn Read> = Arc::<MockRead>::clone(&read);
+        let no_comments: CommentMap = HashMap::new();
 
         let mut fk_map: ForeignKeyMap = HashMap::new();
         fk_map.insert(
@@ -656,6 +826,7 @@ mod tests {
             &table_creator,
             None,
             &fk_map,
+            &no_comments,
         )
         .await;
 
@@ -688,6 +859,7 @@ mod tests {
     async fn test_build_table_providers_injects_composite_foreign_key() {
         let read = Arc::new(MockRead::new(HashSet::new()));
         let table_creator: Arc<dyn Read> = Arc::<MockRead>::clone(&read);
+        let no_comments: CommentMap = HashMap::new();
 
         let mut fk_map: ForeignKeyMap = HashMap::new();
         fk_map.insert(
@@ -705,6 +877,7 @@ mod tests {
             &table_creator,
             None,
             &fk_map,
+            &no_comments,
         )
         .await;
 
@@ -727,6 +900,66 @@ mod tests {
         assert_eq!(
             fks[0]["foreign_columns"],
             serde_json::json!(["id", "line_num"])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_table_providers_injects_comment_metadata() {
+        let read = Arc::new(MockRead::new(HashSet::new()));
+        let table_creator: Arc<dyn Read> = Arc::<MockRead>::clone(&read);
+        let no_fks: ForeignKeyMap = HashMap::new();
+
+        let mut comments: CommentMap = HashMap::new();
+        comments.insert(
+            "orders".to_string(),
+            TableComments {
+                table_comment: Some("order facts".to_string()),
+                column_comments: HashMap::from([(
+                    "customer_id".to_string(),
+                    "customer dimension key".to_string(),
+                )]),
+                column_source_types: HashMap::from([(
+                    "customer_id".to_string(),
+                    "bigint".to_string(),
+                )]),
+            },
+        );
+
+        let tables = build_table_providers_for_schema(
+            "public",
+            vec!["orders".to_string()],
+            &table_creator,
+            None,
+            &no_fks,
+            &comments,
+        )
+        .await;
+
+        let provider = tables.get("orders").expect("orders table should exist");
+        let schema = provider.schema();
+        assert_eq!(
+            schema
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("order facts")
+        );
+        let field = schema
+            .field_with_name("customer_id")
+            .expect("customer_id field should exist");
+        assert_eq!(
+            field
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("customer dimension key")
+        );
+        assert_eq!(
+            field
+                .metadata()
+                .get(SOURCE_TYPE_METADATA_KEY)
+                .map(String::as_str),
+            Some("bigint")
         );
     }
 }

--- a/crates/data_components/src/snowflake/mod.rs
+++ b/crates/data_components/src/snowflake/mod.rs
@@ -35,11 +35,14 @@ use datafusion_table_providers::sql::{
     db_connection_pool::DbConnectionPool, sql_provider_datafusion::SqlTable,
 };
 use snowflake_api::SnowflakeApi;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
 use crate::schema_discovery::{NoPermissionsCheck, SchemaProbeResult, discover_schema};
-use crate::{Read, ReadWrite};
+use crate::{
+    CLUSTERING_KEY_METADATA_KEY, CLUSTERING_METADATA_KEY, COMMENT_METADATA_KEY, Read, ReadWrite,
+    SOURCE_TYPE_METADATA_KEY,
+};
 
 pub type SnowflakeConnectionPool =
     dyn DbConnectionPool<Arc<SnowflakeApi>, &'static dyn Sync> + Send + Sync;
@@ -151,11 +154,22 @@ async fn probe_snowflake_information_schema(
         "information_schema.columns".to_string()
     };
 
+    let tables_from_clause = if let Some(c) = table_reference.catalog() {
+        let escaped = c.replace('"', "\"\"");
+        format!("\"{escaped}\".information_schema.tables")
+    } else {
+        "information_schema.tables".to_string()
+    };
+
     let sql = format!(
-        "SELECT column_name, data_type, is_nullable, numeric_precision, numeric_scale \
-         FROM {from_clause} \
-         WHERE table_name = '{table}'{schema_filter}{catalog_filter} \
-         ORDER BY ordinal_position"
+        "SELECT c.column_name, c.data_type, c.is_nullable, c.numeric_precision, c.numeric_scale, c.comment, t.comment, t.clustering_key \
+         FROM {from_clause} c \
+         LEFT JOIN {tables_from_clause} t \
+             ON c.table_catalog = t.table_catalog \
+             AND c.table_schema = t.table_schema \
+             AND c.table_name = t.table_name \
+         WHERE c.table_name = '{table}'{schema_filter}{catalog_filter} \
+         ORDER BY c.ordinal_position"
     );
 
     match api.exec(&sql).await {
@@ -239,7 +253,7 @@ fn is_snowflake_access_denied(msg: &str) -> bool {
 /// Parses the JSON response from `information_schema.columns`.
 ///
 /// Expected columns: `column_name`, `data_type`, `is_nullable`,
-/// `numeric_precision`, `numeric_scale`.
+/// `numeric_precision`, `numeric_scale`, `comment`, `table_comment`, `clustering_key`.
 fn parse_information_schema_json(
     resp: &serde_json::Value,
     table_name: &str,
@@ -255,6 +269,7 @@ fn parse_information_schema_json(
     }
 
     let mut fields = Vec::new();
+    let mut schema_metadata = HashMap::new();
     for (i, row) in rows.iter().enumerate() {
         let row = row
             .as_array()
@@ -285,11 +300,34 @@ fn parse_information_schema_json(
         });
 
         let data_type = map_snowflake_sql_type(data_type_str, precision, scale);
+        let source_type = snowflake_source_type(data_type_str, precision, scale);
 
-        fields.push(Field::new(col_name, data_type, is_nullable));
+        if let Some(table_comment) = optional_json_string(row.get(6)) {
+            schema_metadata
+                .entry(COMMENT_METADATA_KEY.to_string())
+                .or_insert_with(|| table_comment.to_string());
+        }
+        if let Some(clustering_key) = optional_json_string(row.get(7)) {
+            schema_metadata
+                .entry(CLUSTERING_KEY_METADATA_KEY.to_string())
+                .or_insert_with(|| clustering_key.to_string());
+        }
+
+        fields.push(field_with_optional_metadata(
+            Field::new(col_name, data_type, is_nullable),
+            optional_json_string(row.get(5)),
+            Some(&source_type),
+        ));
     }
 
-    Ok(Arc::new(Schema::new(fields)))
+    let fields = fields_with_clustering_metadata(
+        fields,
+        schema_metadata
+            .get(CLUSTERING_KEY_METADATA_KEY)
+            .map(String::as_str),
+    );
+
+    Ok(Arc::new(Schema::new_with_metadata(fields, schema_metadata)))
 }
 
 /// Parses an Arrow response from `information_schema.columns`.
@@ -300,6 +338,7 @@ fn parse_information_schema_arrow(
     use arrow::array::AsArray;
 
     let mut fields = Vec::new();
+    let mut schema_metadata = HashMap::new();
     for batch in batches {
         if batch.num_columns() < 3 {
             return Err("information_schema Arrow response has fewer than 3 columns".to_string());
@@ -330,6 +369,21 @@ fn parse_information_schema_arrow(
         } else {
             None
         };
+        let comments: Option<&arrow::array::StringArray> = if batch.num_columns() > 5 {
+            batch.column(5).as_string_opt()
+        } else {
+            None
+        };
+        let table_comments: Option<&arrow::array::StringArray> = if batch.num_columns() > 6 {
+            batch.column(6).as_string_opt()
+        } else {
+            None
+        };
+        let clustering_keys: Option<&arrow::array::StringArray> = if batch.num_columns() > 7 {
+            batch.column(7).as_string_opt()
+        } else {
+            None
+        };
 
         for i in 0..batch.num_rows() {
             let col_name = col_names.value(i);
@@ -343,7 +397,23 @@ fn parse_information_schema_arrow(
                 .and_then(|s| s.parse::<i8>().ok());
 
             let data_type = map_snowflake_sql_type(data_type_str, precision, scale);
-            fields.push(Field::new(col_name, data_type, is_nullable));
+            let source_type = snowflake_source_type(data_type_str, precision, scale);
+            if let Some(table_comment) = optional_arrow_string(table_comments, i) {
+                schema_metadata
+                    .entry(COMMENT_METADATA_KEY.to_string())
+                    .or_insert_with(|| table_comment.to_string());
+            }
+            if let Some(clustering_key) = optional_arrow_string(clustering_keys, i) {
+                schema_metadata
+                    .entry(CLUSTERING_KEY_METADATA_KEY.to_string())
+                    .or_insert_with(|| clustering_key.to_string());
+            }
+
+            fields.push(field_with_optional_metadata(
+                Field::new(col_name, data_type, is_nullable),
+                optional_arrow_string(comments, i),
+                Some(&source_type),
+            ));
         }
     }
 
@@ -353,7 +423,165 @@ fn parse_information_schema_arrow(
         ));
     }
 
-    Ok(Arc::new(Schema::new(fields)))
+    let fields = fields_with_clustering_metadata(
+        fields,
+        schema_metadata
+            .get(CLUSTERING_KEY_METADATA_KEY)
+            .map(String::as_str),
+    );
+
+    Ok(Arc::new(Schema::new_with_metadata(fields, schema_metadata)))
+}
+
+fn optional_json_string(value: Option<&serde_json::Value>) -> Option<&str> {
+    value
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional_arrow_string(array: Option<&arrow::array::StringArray>, index: usize) -> Option<&str> {
+    array
+        .filter(|array| !array.is_null(index))
+        .map(|array| array.value(index).trim())
+        .filter(|value| !value.is_empty())
+}
+
+fn field_with_optional_metadata(
+    field: Field,
+    comment: Option<&str>,
+    source_type: Option<&str>,
+) -> Field {
+    let mut metadata = HashMap::new();
+    if let Some(comment) = comment {
+        metadata.insert(COMMENT_METADATA_KEY.to_string(), comment.to_string());
+    }
+    if let Some(source_type) = source_type.map(str::trim).filter(|value| !value.is_empty()) {
+        metadata.insert(
+            SOURCE_TYPE_METADATA_KEY.to_string(),
+            source_type.to_string(),
+        );
+    }
+
+    if metadata.is_empty() {
+        return field;
+    }
+
+    field.with_metadata(metadata)
+}
+
+fn fields_with_clustering_metadata(fields: Vec<Field>, clustering_key: Option<&str>) -> Vec<Field> {
+    let Some(clustering_key) = clustering_key else {
+        return fields;
+    };
+    let clustering_columns = snowflake_clustering_columns(clustering_key);
+    if clustering_columns.is_empty() {
+        return fields;
+    }
+
+    fields
+        .into_iter()
+        .map(|field| {
+            let position = clustering_columns
+                .iter()
+                .position(|column| column == field.name())
+                .or_else(|| {
+                    clustering_columns
+                        .iter()
+                        .position(|column| column.eq_ignore_ascii_case(field.name()))
+                });
+
+            if let Some(position) = position {
+                let mut metadata = field.metadata().clone();
+                metadata.insert(
+                    CLUSTERING_METADATA_KEY.to_string(),
+                    (position + 1).to_string(),
+                );
+                field.with_metadata(metadata)
+            } else {
+                field
+            }
+        })
+        .collect()
+}
+
+fn snowflake_source_type(sql_type: &str, precision: Option<u8>, scale: Option<i8>) -> String {
+    let upper = sql_type.to_uppercase();
+    if matches!(upper.as_str(), "NUMBER" | "DECIMAL" | "NUMERIC") {
+        match (precision, scale) {
+            (Some(precision), Some(scale)) => format!("{upper}({precision},{scale})"),
+            (Some(precision), None) => format!("{upper}({precision})"),
+            _ => upper,
+        }
+    } else {
+        sql_type.to_string()
+    }
+}
+
+fn snowflake_clustering_columns(clustering_key: &str) -> Vec<String> {
+    let mut expression = clustering_key.trim();
+    if let Some(inner) = expression
+        .strip_prefix("LINEAR(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        expression = inner;
+    } else if let Some(inner) = expression
+        .strip_prefix('(')
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        expression = inner;
+    }
+
+    split_snowflake_clustering_expression(expression)
+        .into_iter()
+        .filter_map(simple_snowflake_identifier)
+        .collect()
+}
+
+fn split_snowflake_clustering_expression(expression: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut depth = 0;
+    let mut in_quotes = false;
+    let mut chars = expression.char_indices().peekable();
+
+    while let Some((index, ch)) = chars.next() {
+        match ch {
+            '"' => {
+                if in_quotes && chars.peek().is_some_and(|(_, next)| *next == '"') {
+                    let _ = chars.next();
+                } else {
+                    in_quotes = !in_quotes;
+                }
+            }
+            '(' if !in_quotes => depth += 1,
+            ')' if !in_quotes && depth > 0 => depth -= 1,
+            ',' if !in_quotes && depth == 0 => {
+                parts.push(expression[start..index].trim());
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+
+    parts.push(expression[start..].trim());
+    parts
+}
+
+fn simple_snowflake_identifier(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() || value.contains('(') || value.contains(')') {
+        return None;
+    }
+
+    let value = value
+        .rsplit_once('.')
+        .map_or(value, |(_, column)| column.trim());
+    if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
+        Some(value[1..value.len() - 1].replace("\"\"", "\""))
+    } else {
+        Some(value.to_string())
+    }
 }
 
 /// Maps a Snowflake SQL `DATA_TYPE` name to an Arrow `DataType`.
@@ -511,6 +739,123 @@ impl SnowflakeTableFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_information_schema_json_preserves_comment_metadata() {
+        let rows = serde_json::json!([
+            [
+                "ID",
+                "NUMBER",
+                "NO",
+                38,
+                0,
+                "stable identifier",
+                "customer dimension",
+                "LINEAR(ID, NAME)"
+            ],
+            [
+                "NAME",
+                "VARCHAR",
+                "YES",
+                null,
+                null,
+                "display name",
+                "customer dimension",
+                "LINEAR(ID, NAME)"
+            ],
+            [
+                "AMOUNT",
+                "NUMBER",
+                "YES",
+                12,
+                2,
+                "",
+                "customer dimension",
+                "LINEAR(ID, NAME)"
+            ]
+        ]);
+
+        let schema = parse_information_schema_json(&rows, "CUSTOMERS")
+            .expect("information_schema rows should parse");
+
+        assert_eq!(
+            schema
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("customer dimension")
+        );
+        assert_eq!(
+            schema
+                .metadata()
+                .get(CLUSTERING_KEY_METADATA_KEY)
+                .map(String::as_str),
+            Some("LINEAR(ID, NAME)")
+        );
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("stable identifier")
+        );
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get(SOURCE_TYPE_METADATA_KEY)
+                .map(String::as_str),
+            Some("NUMBER(38,0)")
+        );
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get(CLUSTERING_METADATA_KEY)
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            schema
+                .field(1)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("display name")
+        );
+        assert_eq!(
+            schema
+                .field(1)
+                .metadata()
+                .get(SOURCE_TYPE_METADATA_KEY)
+                .map(String::as_str),
+            Some("VARCHAR")
+        );
+        assert_eq!(
+            schema
+                .field(1)
+                .metadata()
+                .get(CLUSTERING_METADATA_KEY)
+                .map(String::as_str),
+            Some("2")
+        );
+        assert!(
+            schema
+                .field(2)
+                .metadata()
+                .get(COMMENT_METADATA_KEY)
+                .is_none()
+        );
+        assert_eq!(
+            schema
+                .field(2)
+                .metadata()
+                .get(SOURCE_TYPE_METADATA_KEY)
+                .map(String::as_str),
+            Some("NUMBER(12,2)")
+        );
+    }
 
     /// Every Snowflake `information_schema.columns` `DATA_TYPE` we support, paired
     /// with its expected Arrow mapping. Covers integer/decimal/float variants,

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
@@ -72,6 +73,8 @@ pub enum Error {
 }
 
 static UTC_TIMEZONE: LazyLock<Arc<str>> = LazyLock::new(|| Arc::from("UTC"));
+const COMMENT_METADATA_KEY: &str = "comment";
+const SOURCE_TYPE_METADATA_KEY: &str = "source_type";
 
 pub struct SnowflakeConnection {
     pub api: Arc<SnowflakeApi>,
@@ -675,7 +678,22 @@ pub fn parse_schema_from_json(resp: &serde_json::Value) -> Result<SchemaRef, Err
             .as_str()
             .is_none_or(|s| s.to_uppercase() == "TRUE");
 
-        fields.push(Field::new(column_name, data_type, is_nullable));
+        let mut metadata = HashMap::from([(
+            SOURCE_TYPE_METADATA_KEY.to_string(),
+            data_type_str.to_string(),
+        )]);
+        if let Some(comment) = column
+            .get(5)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|comment| !comment.is_empty())
+        {
+            metadata.insert(COMMENT_METADATA_KEY.to_string(), comment.to_string());
+        }
+
+        let field = Field::new(column_name, data_type, is_nullable).with_metadata(metadata);
+
+        fields.push(field);
     }
 
     Ok(Arc::new(Schema::new(fields)))
@@ -1306,6 +1324,38 @@ mod tests {
                 "Nullability mismatch for {name}"
             );
         }
+    }
+
+    #[test]
+    fn test_parse_schema_from_json_preserves_column_comment() {
+        let rows = serde_json::json!([[
+            "db",
+            "schema",
+            "customer_id",
+            r#"{"type":"FIXED","precision":38,"scale":0,"nullable":true}"#,
+            "TRUE",
+            "customer dimension key"
+        ]]);
+
+        let schema =
+            parse_schema_from_json(&rows).expect("Should parse SHOW COLUMNS JSON into a Schema");
+
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get("comment")
+                .map(String::as_str),
+            Some("customer dimension key")
+        );
+        assert_eq!(
+            schema
+                .field(0)
+                .metadata()
+                .get("source_type")
+                .map(String::as_str),
+            Some(r#"{"type":"FIXED","precision":38,"scale":0,"nullable":true}"#)
+        );
     }
 
     #[test]

--- a/crates/runtime-datafusion-udfs/src/user_functions/args_inliner.rs
+++ b/crates/runtime-datafusion-udfs/src/user_functions/args_inliner.rs
@@ -1,0 +1,393 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Inline literal table-function arguments into a [`LogicalPlan`].
+//!
+//! SQL table functions expose their scalar arguments via a one-row `args`
+//! `MemTable`. Because the `MemTable` is only populated at execution time,
+//! the planner sees column references rather than literals, which prevents
+//! filter pushdown for connectors that need concrete values (e.g. the HTTP
+//! connector's `request_path`).
+//!
+//! Since all scalar args are guaranteed to be literals (enforced by
+//! [`super::sql::literal_arg`]), this module walks the *unoptimized*
+//! [`LogicalPlan`] produced by `ctx.sql(body)` and replaces every
+//! `Expr::Column` that references the `args` table with the corresponding
+//! `Expr::Literal`.  The optimizer then sees constants and can fold /
+//! push down as usual.
+//!
+//! This follows the same pattern as `DataFusion`'s own
+//! [`LogicalPlan::replace_params_with_values`], which replaces
+//! `Expr::Placeholder` with `Expr::Literal`.
+
+use std::collections::HashMap;
+
+use arrow::datatypes::Schema;
+use datafusion::{
+    common::{
+        Column, Result as DataFusionResult,
+        tree_node::{Transformed, TreeNode},
+    },
+    logical_expr::{LogicalPlan, Projection, TableScan, expr::Alias},
+    prelude::Expr,
+    scalar::ScalarValue,
+};
+
+use super::sql::SQL_TABLE_ARGS_TABLE_NAME;
+
+/// Returns `true` if `table_name` refers to the `args` table.
+fn is_args_table_ref(table_name: &datafusion::sql::TableReference) -> bool {
+    table_name
+        .table()
+        .eq_ignore_ascii_case(SQL_TABLE_ARGS_TABLE_NAME)
+}
+
+/// If `plan` is `Projection([single_expr], TableScan("args"))` and
+/// `single_expr` is a literal, return that literal.  This detects the
+/// pattern left behind after column→literal replacement inside scalar
+/// subqueries.
+fn try_extract_literal_from_args_subquery(plan: &LogicalPlan) -> Option<Expr> {
+    if let LogicalPlan::Projection(Projection { expr, input, .. }) = plan
+        // Single projected expression over a TableScan on `args`.
+        && let [expr] = expr.as_slice()
+        && let LogicalPlan::TableScan(TableScan { table_name, .. }) = input.as_ref()
+        && is_args_table_ref(table_name)
+    {
+        let inner = match expr {
+            Expr::Alias(Alias { expr, .. }) => expr,
+            other => other,
+        };
+        if matches!(inner, Expr::Literal(..)) {
+            return Some(inner.clone());
+        }
+    }
+    None
+}
+
+/// Recursively collapse `Expr::ScalarSubquery` nodes whose inner plan
+/// is `Projection([literal], TableScan("args"))`.
+///
+/// `DataFusion`'s `Expr::transform_up` explicitly skips `ScalarSubquery`
+/// children, so we must walk the expression tree manually to find and
+/// replace them.
+fn collapse_args_subqueries(expr: Expr) -> Expr {
+    match expr {
+        Expr::ScalarSubquery(ref subquery) => {
+            if let Some(literal) = try_extract_literal_from_args_subquery(&subquery.subquery) {
+                literal
+            } else {
+                expr
+            }
+        }
+        // Recurse into expression types that can contain ScalarSubquery.
+        Expr::BinaryExpr(mut bin) => {
+            *bin.left = collapse_args_subqueries(*bin.left);
+            *bin.right = collapse_args_subqueries(*bin.right);
+            Expr::BinaryExpr(bin)
+        }
+        Expr::Not(inner) => Expr::Not(Box::new(collapse_args_subqueries(*inner))),
+        Expr::IsNotNull(inner) => Expr::IsNotNull(Box::new(collapse_args_subqueries(*inner))),
+        Expr::IsNull(inner) => Expr::IsNull(Box::new(collapse_args_subqueries(*inner))),
+        Expr::IsTrue(inner) => Expr::IsTrue(Box::new(collapse_args_subqueries(*inner))),
+        Expr::IsFalse(inner) => Expr::IsFalse(Box::new(collapse_args_subqueries(*inner))),
+        Expr::Negative(inner) => Expr::Negative(Box::new(collapse_args_subqueries(*inner))),
+        Expr::Cast(mut cast) => {
+            *cast.expr = collapse_args_subqueries(*cast.expr);
+            Expr::Cast(cast)
+        }
+        Expr::TryCast(mut cast) => {
+            *cast.expr = collapse_args_subqueries(*cast.expr);
+            Expr::TryCast(cast)
+        }
+        Expr::Alias(mut alias) => {
+            *alias.expr = collapse_args_subqueries(*alias.expr);
+            Expr::Alias(alias)
+        }
+        Expr::ScalarFunction(mut func) => {
+            func.args = func
+                .args
+                .into_iter()
+                .map(collapse_args_subqueries)
+                .collect();
+            Expr::ScalarFunction(func)
+        }
+        Expr::Case(mut case) => {
+            case.expr = case.expr.map(|o| Box::new(collapse_args_subqueries(*o)));
+            case.when_then_expr = case
+                .when_then_expr
+                .into_iter()
+                .map(|(w, t)| {
+                    (
+                        Box::new(collapse_args_subqueries(*w)),
+                        Box::new(collapse_args_subqueries(*t)),
+                    )
+                })
+                .collect();
+            case.else_expr = case
+                .else_expr
+                .map(|e| Box::new(collapse_args_subqueries(*e)));
+            Expr::Case(case)
+        }
+        // For any other expression type, return as-is.
+        other => other,
+    }
+}
+
+/// Walk an unoptimized [`LogicalPlan`] and replace every `Expr::Column`
+/// referencing the `args` table with the corresponding `Expr::Literal`.
+///
+/// Also collapses `Expr::ScalarSubquery` nodes that, after column
+/// replacement, reduce to a single literal projected from `args`.
+///
+/// This operates on the plan produced *before* optimization, so the
+/// optimizer's filter-pushdown passes see concrete literal values instead
+/// of column references to a `MemTable`.
+pub(super) fn inline_args_into_plan(
+    plan: LogicalPlan,
+    schema: &Schema,
+    values: &[ScalarValue],
+) -> DataFusionResult<LogicalPlan> {
+    if schema.fields().is_empty() {
+        return Ok(plan);
+    }
+
+    let arg_map: HashMap<String, ScalarValue> = schema
+        .fields()
+        .iter()
+        .zip(values)
+        .map(|(field, value)| (field.name().to_ascii_lowercase(), value.clone()))
+        .collect();
+
+    // Pass 1: replace `Expr::Column` refs to `args` with literals inside
+    // all plans (including subquery plans).
+    let plan = plan
+        .transform_up_with_subqueries(|plan| {
+            plan.map_expressions(|expr| {
+                expr.transform_up(|e| {
+                    if let Expr::Column(Column {
+                        ref relation,
+                        ref name,
+                        ..
+                    }) = e
+                    {
+                        let key = name.to_ascii_lowercase();
+                        let should_replace = match relation {
+                            Some(r) => is_args_table_ref(r) && arg_map.contains_key(&key),
+                            None => arg_map.contains_key(&key),
+                        };
+                        if should_replace && let Some(value) = arg_map.get(&key) {
+                            return Ok(Transformed::yes(Expr::Literal(value.clone(), None)));
+                        }
+                    }
+                    Ok(Transformed::no(e))
+                })
+            })
+        })?
+        .data;
+
+    // Pass 2: collapse `Expr::ScalarSubquery` nodes whose inner plan is
+    // now `Projection([literal], TableScan("args"))`.  This turns the
+    // subquery into a bare literal so the optimizer can push it down.
+    //
+    // We use a manual expression walk because DataFusion's
+    // `Expr::transform_up` explicitly skips `ScalarSubquery` children.
+    plan.transform_up_with_subqueries(|plan| {
+        plan.map_expressions(|expr| {
+            let collapsed = collapse_args_subqueries(expr.clone());
+            if collapsed == expr {
+                Ok(Transformed::no(expr))
+            } else {
+                Ok(Transformed::yes(collapsed))
+            }
+        })
+    })
+    .map(|res| res.data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::Field as ArrowField;
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+
+    /// Register a one-row `args` `MemTable` and plan the body SQL, returning
+    /// the unoptimized plan.
+    async fn plan_body(body: &str, schema: &Schema, values: &[ScalarValue]) -> LogicalPlan {
+        let ctx = SessionContext::new();
+        let schema_ref = Arc::new(schema.clone());
+
+        // Build the one-row args MemTable.
+        let arrays: Vec<_> = values
+            .iter()
+            .map(|v| v.to_array().expect("to_array"))
+            .collect();
+        let batch = arrow::record_batch::RecordBatch::try_new(Arc::clone(&schema_ref), arrays)
+            .expect("batch");
+        let table = MemTable::try_new(schema_ref, vec![vec![batch]]).expect("memtable");
+        ctx.register_table("args", Arc::new(table))
+            .expect("register");
+
+        // Also register a dummy `raw_users` table so body SQL can reference it.
+        let users_schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            ArrowField::new("content", arrow::datatypes::DataType::Utf8, true),
+            ArrowField::new("request_path", arrow::datatypes::DataType::Utf8, true),
+        ]));
+        let users_table = MemTable::try_new(users_schema, vec![vec![]]).expect("users memtable");
+        ctx.register_table("raw_users", Arc::new(users_table))
+            .expect("register users");
+
+        // Also register a dummy `t` table.
+        let t_schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            ArrowField::new("id", arrow::datatypes::DataType::Int64, true),
+            ArrowField::new("name", arrow::datatypes::DataType::Utf8, true),
+            ArrowField::new("active", arrow::datatypes::DataType::Boolean, true),
+            ArrowField::new("col", arrow::datatypes::DataType::Utf8, true),
+        ]));
+        let t_table = MemTable::try_new(t_schema, vec![vec![]]).expect("t memtable");
+        ctx.register_table("t", Arc::new(t_table))
+            .expect("register t");
+
+        ctx.sql(body)
+            .await
+            .expect("plan body")
+            .into_unoptimized_plan()
+    }
+
+    fn utf8_schema(names: &[&str]) -> Schema {
+        Schema::new(
+            names
+                .iter()
+                .map(|n| ArrowField::new(*n, arrow::datatypes::DataType::Utf8, true))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Format the plan to a string for assertion.
+    fn plan_str(plan: &LogicalPlan) -> String {
+        format!("{plan}")
+    }
+
+    #[tokio::test]
+    async fn inline_replaces_scalar_subquery() {
+        let schema = utf8_schema(&["username"]);
+        let values = vec![ScalarValue::Utf8(Some("pg".into()))];
+        let body = "SELECT content FROM raw_users WHERE request_path = (SELECT username FROM args)";
+        let plan = plan_body(body, &schema, &values).await;
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        let s = plan_str(&rewritten);
+        assert!(
+            s.contains("Utf8(\"pg\")"),
+            "Expected inlined literal in plan: {s}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_replaces_expression_over_args() {
+        let schema = utf8_schema(&["username"]);
+        let values = vec![ScalarValue::Utf8(Some("pg".into()))];
+        let body = "SELECT content FROM raw_users WHERE request_path = (SELECT concat('/users/', username) FROM args)";
+        let plan = plan_body(body, &schema, &values).await;
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        let s = plan_str(&rewritten);
+        assert!(
+            s.contains("Utf8(\"pg\")"),
+            "Expected inlined literal in plan: {s}"
+        );
+        assert!(s.contains("concat"), "Should still contain concat: {s}");
+    }
+
+    #[tokio::test]
+    async fn inline_replaces_from_args_direct() {
+        // Body uses `FROM args` directly — columns should still be replaced.
+        let schema = Schema::new(vec![ArrowField::new(
+            "x",
+            arrow::datatypes::DataType::Int64,
+            true,
+        )]);
+        let values = vec![ScalarValue::Int64(Some(42))];
+        let body = "SELECT x AS value, x * 2 AS doubled FROM args";
+        let plan = plan_body(body, &schema, &values).await;
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        let s = plan_str(&rewritten);
+        assert!(
+            s.contains("Int64(42)"),
+            "Expected inlined literal 42 in plan: {s}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_handles_multiple_args() {
+        let schema = Schema::new(vec![
+            ArrowField::new("a", arrow::datatypes::DataType::Utf8, true),
+            ArrowField::new("b", arrow::datatypes::DataType::Int64, true),
+        ]);
+        let values = vec![
+            ScalarValue::Utf8(Some("hello".into())),
+            ScalarValue::Int64(Some(99)),
+        ];
+        let body =
+            "SELECT * FROM t WHERE name = (SELECT a FROM args) AND id = (SELECT b FROM args)";
+        let plan = plan_body(body, &schema, &values).await;
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        let s = plan_str(&rewritten);
+        assert!(
+            s.contains("Utf8(\"hello\")"),
+            "Expected inlined 'hello': {s}"
+        );
+        assert!(s.contains("Int64(99)"), "Expected inlined 99: {s}");
+    }
+
+    #[tokio::test]
+    async fn inline_empty_schema_is_noop() {
+        let schema = Schema::empty();
+        let values: Vec<ScalarValue> = vec![];
+        // With an empty schema, just plan against `t` directly (no args table).
+        let ctx = SessionContext::new();
+        let t_schema = Arc::new(Schema::new(vec![ArrowField::new(
+            "id",
+            arrow::datatypes::DataType::Int64,
+            true,
+        )]));
+        let t_table = MemTable::try_new(t_schema, vec![vec![]]).expect("t memtable");
+        ctx.register_table("t", Arc::new(t_table))
+            .expect("register t");
+        let plan = ctx
+            .sql("SELECT * FROM t")
+            .await
+            .expect("plan")
+            .into_unoptimized_plan();
+        let original = plan_str(&plan);
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        assert_eq!(original, plan_str(&rewritten));
+    }
+
+    #[tokio::test]
+    async fn inline_handles_boolean_and_null() {
+        let schema = Schema::new(vec![ArrowField::new(
+            "flag",
+            arrow::datatypes::DataType::Boolean,
+            true,
+        )]);
+        let values = vec![ScalarValue::Boolean(Some(true))];
+        let body = "SELECT * FROM t WHERE active = (SELECT flag FROM args)";
+        let plan = plan_body(body, &schema, &values).await;
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        let s = plan_str(&rewritten);
+        assert!(s.contains("Boolean(true)"), "Expected inlined boolean: {s}");
+    }
+}

--- a/crates/runtime-datafusion-udfs/src/user_functions/mod.rs
+++ b/crates/runtime-datafusion-udfs/src/user_functions/mod.rs
@@ -42,6 +42,7 @@ use datafusion::sql::{
 use snafu::Snafu;
 use spicepod::component::function::{Function, FunctionKind};
 
+mod args_inliner;
 mod arrow_type;
 #[cfg(feature = "http-functions")]
 pub mod remote;

--- a/crates/runtime-datafusion-udfs/src/user_functions/sql.rs
+++ b/crates/runtime-datafusion-udfs/src/user_functions/sql.rs
@@ -65,7 +65,9 @@ use spicepod::component::function::{
 };
 use util::session_state::builder_from_existing;
 
-const SQL_TABLE_ARGS_TABLE_NAME: &str = "args";
+use crate::user_functions::args_inliner::inline_args_into_plan;
+
+pub(crate) const SQL_TABLE_ARGS_TABLE_NAME: &str = "args";
 
 /// Monotonic identifier for built SQL UDFs — used as the basis for
 /// [`Hash`] / [`Eq`] since physical expressions cannot derive them.
@@ -522,7 +524,10 @@ impl TableProvider for SqlTableProvider {
             &self.name,
         )
         .await?;
-        let mut df = ctx.sql(&self.body).await?;
+
+        let (session_state, plan) = ctx.sql(&self.body).await?.into_parts();
+        let inlined_plan = inline_args_into_plan(plan, self.arg_schema.as_ref(), &self.args)?;
+        let mut df = DataFrame::new(session_state, inlined_plan);
         validate_output_schema(&self.name, df.schema().as_arrow(), self.schema.as_ref())
             .map_err(|e| DataFusionError::Execution(e.to_string()))?;
         if let Some(limit) = limit {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -47,6 +47,7 @@ use arrow::{
 use arrow_schema::SchemaRef;
 use async_stream::stream;
 use data_components::poly::PolyTableProvider;
+use data_components::{FieldMetadata, metadata_enriched_table_provider};
 use datafusion::catalog::MemoryCatalogProvider;
 use datafusion::datasource::{DefaultTableSource, TableType};
 use datafusion::execution::SessionStateBuilder;
@@ -103,6 +104,27 @@ const NANOS_TO_MILLIS: u128 = 1_000_000;
 // Callback which is called after each batch of streaming data is processed by the `RefreshTask`.
 type StreamBatchProcessCallback =
     Arc<Mutex<Box<dyn FnMut() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>>>;
+
+fn table_provider_with_existing_metadata(
+    provider: Arc<dyn TableProvider>,
+) -> Arc<dyn TableProvider> {
+    let schema = provider.schema();
+    let table_metadata = schema.metadata().clone();
+    let field_metadata = schema
+        .fields()
+        .iter()
+        .filter_map(|field| {
+            let metadata = field.metadata().clone();
+            (!metadata.is_empty()).then(|| (field.name().clone(), metadata))
+        })
+        .collect::<FieldMetadata>();
+
+    if table_metadata.is_empty() && field_metadata.is_empty() {
+        return provider;
+    }
+
+    metadata_enriched_table_provider(provider, table_metadata, field_metadata)
+}
 
 #[derive(Debug, Clone, Default)]
 struct RefreshStat {
@@ -1503,6 +1525,7 @@ impl RefreshTask {
             );
         }
 
+        let federated_provider = table_provider_with_existing_metadata(federated_provider);
         if let Err(e) = ctx.register_table(dataset_name.clone(), federated_provider) {
             tracing::error!("Unable to register federated table: {e}");
         }

--- a/crates/runtime/src/catalogconnector/adbc.rs
+++ b/crates/runtime/src/catalogconnector/adbc.rs
@@ -20,7 +20,9 @@ limitations under the License.
 //! and provides schema/table discovery using the ADBC metadata API.
 
 use super::{CatalogConnector, ConnectorComponent, ParameterSpec};
-use crate::dataconnector::adbc::{build_db_options, build_join_context, dialect_for_driver};
+use crate::dataconnector::adbc::{
+    build_db_options, build_join_context, dialect_for_driver, enrich_with_bigquery_metadata,
+};
 use crate::{Runtime, component::catalog::Catalog, dataconnector::parameters::ConnectorParams};
 use adbc_core::options::AdbcVersion;
 use adbc_core::{Driver as _, LOAD_FLAG_DEFAULT};
@@ -436,8 +438,19 @@ impl AdbcCatalogProvider {
                     async move {
                         let table_ref =
                             TableReference::partial(schema_ref.to_owned(), table_name.clone());
-                        let result: ProviderResult =
-                            table_factory.table_provider(table_ref, dialect).await;
+                        let result: ProviderResult = match table_factory
+                            .table_provider(table_ref.clone(), dialect)
+                            .await
+                        {
+                            Ok(provider) => Ok(enrich_with_bigquery_metadata(
+                                &self.driver_name,
+                                &self.pool,
+                                &table_ref,
+                                provider,
+                            )
+                            .await),
+                            Err(error) => Err(error),
+                        };
                         (table_name, result)
                     }
                 }),

--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -241,7 +241,7 @@ impl SpiceCloudPlatformCatalog {
                 return Err(super::Error::InvalidConfigurationNoSource {
                     connector: "spice.ai".into(),
                     message: format!(
-                        "Invalid Spice Cloud region: {region}. Specify a valid region, for example us-east-1. To list available regions, run: spice cloud regions"
+                        "Invalid Spice Cloud region: {region}. Specify a valid region, for example 'spiceai_region: us-east-1'. To list available regions, run: 'spice cloud regions'"
                     ),
                     connector_component: ConnectorComponent::from(catalog),
                 });
@@ -252,7 +252,7 @@ impl SpiceCloudPlatformCatalog {
 
         Err(super::Error::InvalidConfigurationNoSource {
             connector: "spice.ai".into(),
-            message: "Missing Spice Cloud region. Specify a valid region, for example us-east-1. To list available regions, run: spice cloud regions".to_string(),
+            message: "Missing Spice Cloud region. Specify a valid region, for example 'spiceai_region: us-east-1'. To list available regions, run: 'spice cloud regions'".to_string(),
             connector_component: ConnectorComponent::from(catalog),
         })
     }

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -25,7 +25,6 @@ use crate::component::access::AccessMode;
 use app::App;
 use datafusion::sql::TableReference;
 use runtime_acceleration::snapshot::SnapshotBehavior;
-use serde_json::Value;
 use snafu::prelude::*;
 use spicepod::{
     acceleration as spicepod_acceleration,
@@ -98,6 +97,8 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
                 a.snapshots_compaction
             });
 
+        let metadata = dataset.metadata();
+
         let acceleration = dataset
             .acceleration
             .map(acceleration::Acceleration::try_from)
@@ -127,11 +128,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
                 .as_ref()
                 .map(Params::as_string_map)
                 .unwrap_or_default(),
-            metadata: dataset
-                .metadata
-                .iter()
-                .map(|(k, v)| (k.clone(), value_to_string(v)))
-                .collect(),
+            metadata,
             columns: dataset.columns,
             has_metadata_table: dataset
                 .has_metadata_table
@@ -390,11 +387,4 @@ fn fts_store_from_column_overrides(
         engine: Some(column_engine),
         params: column_params,
     }))
-}
-
-fn value_to_string(value: &Value) -> String {
-    match value {
-        Value::String(s) => s.clone(),
-        _ => value.to_string(),
-    }
 }

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -16,7 +16,6 @@ limitations under the License.
 
 use app::App;
 use datafusion::sql::TableReference;
-use serde_json::Value;
 use snafu::prelude::*;
 use spicepod::{component::view as spicepod_view, vector::VectorStore};
 use std::{collections::HashMap, fs, sync::Arc, time::Duration};
@@ -37,7 +36,7 @@ use spicepod::semantic::Column;
 pub struct View {
     pub name: TableReference,
     pub sql: Arc<str>,
-    pub metadata: HashMap<String, Value>,
+    pub metadata: HashMap<String, String>,
     pub columns: Vec<Column>,
     pub acceleration: Option<acceleration::Acceleration>,
     pub ready_state: ReadyState,
@@ -161,7 +160,7 @@ impl View {
 pub struct ViewBuilder {
     pub name: TableReference,
     pub sql: String,
-    pub metadata: HashMap<String, Value>,
+    pub metadata: HashMap<String, String>,
     pub columns: Vec<Column>,
     pub acceleration: Option<acceleration::Acceleration>,
     pub ready_state: ReadyState,
@@ -185,6 +184,8 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
                 name: table_reference.to_string(),
             });
         };
+
+        let metadata = view.metadata();
 
         let acceleration = view
             .acceleration
@@ -213,7 +214,7 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
         Ok(ViewBuilder {
             name: table_reference,
             sql,
-            metadata: view.metadata,
+            metadata,
             columns: view.columns,
             acceleration,
             ready_state: ReadyState::from(view.ready_state),

--- a/crates/runtime/src/dataconnector/adbc.rs
+++ b/crates/runtime/src/dataconnector/adbc.rs
@@ -18,15 +18,19 @@ use crate::component::dataset::Dataset;
 use adbc_core::options::{AdbcVersion, OptionDatabase};
 use adbc_core::{Driver as _, LOAD_FLAG_DEFAULT};
 use adbc_driver_manager::ManagedDriver;
+use arrow::array::{Array, ArrayRef, LargeStringArray, StringArray};
 use async_trait::async_trait;
+use data_components::{FieldMetadata, metadata_enriched_table_provider};
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use datafusion::sql::unparser::dialect::{BigQueryDialect, Dialect};
 use datafusion_table_providers::adbc::AdbcTableFactory;
-use datafusion_table_providers::sql::db_connection_pool::JoinPushDown;
 use datafusion_table_providers::sql::db_connection_pool::adbcpool::{
     ADBCPool, AdbcConnectionPoolBuilder,
 };
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
+use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, JoinPushDown};
+use futures::TryStreamExt;
 use sha2::{Digest, Sha256};
 use snafu::prelude::*;
 use std::any::Any;
@@ -94,7 +98,8 @@ pub struct Adbc {
     /// Wrapped in `Option` so `Drop` can move the factory to a blocking thread
     /// for cleanup. ADBC drivers perform synchronous FFI calls during drop
     /// (e.g. closing network sessions) that must not run on the async runtime.
-    adbc_factory: Option<AdbcTableFactory<adbc_driver_manager::ManagedDatabase>>,
+    factory: Option<AdbcTableFactory<adbc_driver_manager::ManagedDatabase>>,
+    pool: Weak<ADBCPool<adbc_driver_manager::ManagedDatabase>>,
     driver_name: String,
 }
 
@@ -106,7 +111,7 @@ impl std::fmt::Debug for Adbc {
 
 impl Drop for Adbc {
     fn drop(&mut self) {
-        if let Some(factory) = self.adbc_factory.take() {
+        if let Some(factory) = self.factory.take() {
             // Send to the dedicated cleanup thread so we don't stall the Tokio
             // runtime. If the bounded queue is full or the worker is gone,
             // offload to a dedicated overflow thread instead of dropping inline.
@@ -521,13 +526,227 @@ impl AdbcFactory {
                 }
             })?;
 
-        let adbc_factory = AdbcTableFactory::new(pool).with_federation_enabled(federation_enabled);
+        let adbc_factory =
+            AdbcTableFactory::new(Arc::clone(&pool)).with_federation_enabled(federation_enabled);
 
         Ok(Arc::new(Adbc {
-            adbc_factory: Some(adbc_factory),
+            factory: Some(adbc_factory),
+            pool: Arc::downgrade(&pool),
             driver_name: driver_name_owned,
         }) as Arc<dyn DataConnector>)
     }
+}
+
+async fn enrich_with_bigquery_metadata_from_weak_pool(
+    driver_name: &str,
+    pool: &Weak<ADBCPool<adbc_driver_manager::ManagedDatabase>>,
+    table_reference: &TableReference,
+    provider: Arc<dyn TableProvider>,
+) -> Arc<dyn TableProvider> {
+    let Some(pool) = pool.upgrade() else {
+        tracing::warn!(
+            table = %table_reference,
+            "Failed to query BigQuery schema metadata via ADBC because the connection pool is shutting down; registering without source metadata"
+        );
+        return provider;
+    };
+
+    enrich_with_bigquery_metadata(driver_name, &pool, table_reference, provider).await
+}
+
+pub(crate) async fn enrich_with_bigquery_metadata(
+    driver_name: &str,
+    pool: &Arc<ADBCPool<adbc_driver_manager::ManagedDatabase>>,
+    table_reference: &TableReference,
+    provider: Arc<dyn TableProvider>,
+) -> Arc<dyn TableProvider> {
+    if !driver_name.eq_ignore_ascii_case("bigquery") {
+        return provider;
+    }
+
+    match bigquery_schema_metadata(pool, table_reference).await {
+        Ok((table_metadata, field_metadata)) => {
+            if table_metadata.is_empty() && field_metadata.is_empty() {
+                provider
+            } else {
+                metadata_enriched_table_provider(provider, table_metadata, field_metadata)
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                table = %table_reference,
+                error = %error,
+                "Failed to query BigQuery schema metadata via ADBC; registering without source metadata"
+            );
+            provider
+        }
+    }
+}
+
+async fn bigquery_schema_metadata(
+    pool: &Arc<ADBCPool<adbc_driver_manager::ManagedDatabase>>,
+    table_reference: &TableReference,
+) -> std::result::Result<
+    (HashMap<String, String>, FieldMetadata),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    let table_name = bigquery_string_literal(table_reference.table());
+    let table_options = bigquery_information_schema_table(table_reference, "TABLE_OPTIONS");
+    let column_field_paths =
+        bigquery_information_schema_table(table_reference, "COLUMN_FIELD_PATHS");
+    let columns = bigquery_information_schema_table(table_reference, "COLUMNS");
+
+    let table_sql = format!(
+        "SELECT option_value FROM {table_options} WHERE table_name = {table_name} AND option_name = 'description' AND option_value IS NOT NULL AND option_value != ''"
+    );
+    let comment_sql = format!(
+        "SELECT field_path, description FROM {column_field_paths} WHERE table_name = {table_name} AND description IS NOT NULL AND description != ''"
+    );
+    let column_sql = format!(
+        "SELECT column_name, data_type, CASE WHEN is_partitioning_column = 'YES' THEN 'true' ELSE NULL END, CAST(clustering_ordinal_position AS STRING) FROM {columns} WHERE table_name = {table_name}"
+    );
+
+    let mut table_metadata = HashMap::new();
+    if let Some(comment) = first_string_result(pool, table_sql).await? {
+        table_metadata.insert(data_components::COMMENT_METADATA_KEY.to_string(), comment);
+    }
+
+    let mut field_metadata = FieldMetadata::new();
+    for row in string_column_results(pool, column_sql, 4).await? {
+        let [column_name, source_type, partition, clustering] = row.as_slice() else {
+            continue;
+        };
+        let Some(column_name) = column_name else {
+            continue;
+        };
+        let metadata = field_metadata.entry(column_name.clone()).or_default();
+        if let Some(source_type) = source_type {
+            metadata.insert(
+                data_components::SOURCE_TYPE_METADATA_KEY.to_string(),
+                source_type.clone(),
+            );
+        }
+        if partition.as_deref() == Some("true") {
+            metadata.insert(
+                data_components::PARTITION_METADATA_KEY.to_string(),
+                "true".to_string(),
+            );
+        }
+        if let Some(clustering) = clustering {
+            metadata.insert(
+                data_components::CLUSTERING_METADATA_KEY.to_string(),
+                clustering.clone(),
+            );
+        }
+    }
+
+    for row in string_column_results(pool, comment_sql, 2).await? {
+        let [field_path, comment] = row.as_slice() else {
+            continue;
+        };
+        let (Some(field_path), Some(comment)) = (field_path, comment) else {
+            continue;
+        };
+        if field_path.contains('.') {
+            continue;
+        }
+        field_metadata
+            .entry(field_path.clone())
+            .or_default()
+            .insert(
+                data_components::COMMENT_METADATA_KEY.to_string(),
+                comment.clone(),
+            );
+    }
+
+    Ok((table_metadata, field_metadata))
+}
+
+async fn first_string_result(
+    pool: &Arc<ADBCPool<adbc_driver_manager::ManagedDatabase>>,
+    sql: String,
+) -> std::result::Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let conn = Arc::clone(pool).connect().await?;
+    let batches: Vec<_> = query_arrow(conn, sql, None).await?.try_collect().await?;
+    for batch in &batches {
+        if batch.num_columns() == 0 {
+            continue;
+        }
+        let values = batch.column(0);
+        for row in 0..batch.num_rows() {
+            if let Some(value) = string_value(values, row) {
+                return Ok(Some(value.to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+async fn string_column_results(
+    pool: &Arc<ADBCPool<adbc_driver_manager::ManagedDatabase>>,
+    sql: String,
+    column_count: usize,
+) -> std::result::Result<Vec<Vec<Option<String>>>, Box<dyn std::error::Error + Send + Sync>> {
+    let conn = Arc::clone(pool).connect().await?;
+    let batches: Vec<_> = query_arrow(conn, sql, None).await?.try_collect().await?;
+    let mut values = Vec::new();
+    for batch in &batches {
+        if batch.num_columns() < column_count {
+            continue;
+        }
+        for row in 0..batch.num_rows() {
+            values.push(
+                (0..column_count)
+                    .map(|column| string_value(batch.column(column), row).map(ToString::to_string))
+                    .collect(),
+            );
+        }
+    }
+    Ok(values)
+}
+
+fn string_value(array: &ArrayRef, row: usize) -> Option<&str> {
+    if array.is_null(row) {
+        return None;
+    }
+
+    array
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .map(|array| array.value(row))
+        .or_else(|| {
+            array
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .map(|array| array.value(row))
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn bigquery_information_schema_table(table_reference: &TableReference, view: &str) -> String {
+    let mut parts = Vec::new();
+    if let Some(catalog) = table_reference.catalog() {
+        parts.push(catalog.to_string());
+    }
+    if let Some(schema) = table_reference.schema() {
+        parts.push(schema.to_string());
+    }
+    parts.push("INFORMATION_SCHEMA".to_string());
+    parts.push(view.to_string());
+
+    format!(
+        "`{}`",
+        parts
+            .into_iter()
+            .map(|part| part.replace('`', "\\`"))
+            .collect::<Vec<_>>()
+            .join(".")
+    )
+}
+
+fn bigquery_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "\\'"))
 }
 
 impl DataConnectorFactory for AdbcFactory {
@@ -953,17 +1172,18 @@ impl DataConnector for Adbc {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        let adbc_factory = self.adbc_factory.as_ref().ok_or_else(|| {
-            DataConnectorError::UnableToConnectInternal {
-                dataconnector: "adbc".to_string(),
-                connector_component: ConnectorComponent::from(dataset),
-                source: "ADBC connector has been shut down".into(),
-            }
-        })?;
-        let table_reference = dataset.path().into();
+        let adbc_factory =
+            self.factory
+                .as_ref()
+                .ok_or_else(|| DataConnectorError::UnableToConnectInternal {
+                    dataconnector: "adbc".to_string(),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: "ADBC connector has been shut down".into(),
+                })?;
+        let table_reference: TableReference = dataset.path().into();
         let dialect = dialect_for_driver(&self.driver_name);
-        adbc_factory
-            .table_provider(table_reference, dialect)
+        let provider = adbc_factory
+            .table_provider(table_reference.clone(), dialect)
             .await
             .map_err(|e| {
                 classify_adbc_error(e, &self.driver_name, dataset, |dc, cc, src| {
@@ -973,7 +1193,15 @@ impl DataConnector for Adbc {
                         source: src,
                     }
                 })
-            })
+            })?;
+
+        Ok(enrich_with_bigquery_metadata_from_weak_pool(
+            &self.driver_name,
+            &self.pool,
+            &table_reference,
+            provider,
+        )
+        .await)
     }
 
     async fn read_write_provider(
@@ -981,7 +1209,7 @@ impl DataConnector for Adbc {
         dataset: &Dataset,
     ) -> Option<super::DataConnectorResult<Arc<dyn TableProvider>>> {
         let adbc_factory =
-            self.adbc_factory
+            self.factory
                 .as_ref()
                 .ok_or_else(|| DataConnectorError::UnableToConnectInternal {
                     dataconnector: "adbc".to_string(),
@@ -992,23 +1220,33 @@ impl DataConnector for Adbc {
             Ok(f) => f,
             Err(e) => return Some(Err(e)),
         };
-        let table_reference = dataset.path().into();
+        let table_reference: TableReference = dataset.path().into();
         let dialect = dialect_for_driver(&self.driver_name);
 
-        Some(
-            adbc_factory
-                .read_write_table_provider(table_reference, dialect)
-                .await
-                .map_err(|e| {
-                    classify_adbc_error(e, &self.driver_name, dataset, |dc, cc, src| {
-                        DataConnectorError::UnableToGetReadWriteProvider {
-                            dataconnector: dc,
-                            connector_component: cc,
-                            source: src,
-                        }
-                    })
-                }),
-        )
+        let result = match adbc_factory
+            .read_write_table_provider(table_reference.clone(), dialect)
+            .await
+        {
+            Ok(provider) => Ok(enrich_with_bigquery_metadata_from_weak_pool(
+                &self.driver_name,
+                &self.pool,
+                &table_reference,
+                provider,
+            )
+            .await),
+            Err(e) => Err(classify_adbc_error(
+                e,
+                &self.driver_name,
+                dataset,
+                |dc, cc, src| DataConnectorError::UnableToGetReadWriteProvider {
+                    dataconnector: dc,
+                    connector_component: cc,
+                    source: src,
+                },
+            )),
+        };
+
+        Some(result)
     }
 }
 
@@ -1543,6 +1781,24 @@ mod tests {
         assert_ne!(
             compute_adbc_cache_key(&params_a),
             compute_adbc_cache_key(&params_b)
+        );
+    }
+
+    #[test]
+    fn test_bigquery_information_schema_table_uses_comment_source_path() {
+        let table_reference = TableReference::full("project-a", "analytics", "customers");
+
+        assert_eq!(
+            bigquery_information_schema_table(&table_reference, "COLUMN_FIELD_PATHS"),
+            "`project-a.analytics.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`"
+        );
+    }
+
+    #[test]
+    fn test_bigquery_string_literal_escapes_comment_query_value() {
+        assert_eq!(
+            bigquery_string_literal("customer's\\table"),
+            "'customer\\'s\\\\table'"
         );
     }
 

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -362,16 +362,6 @@ impl DataConnector for Debezium {
                     );
                 }
 
-                let kafka_consumer = KafkaConsumer::create_with_existing_group_id(
-                    &metadata.consumer_group_id,
-                    &self.kafka_config,
-                )
-                .boxed()
-                .context(super::UnableToGetReadProviderSnafu {
-                    dataconnector: "debezium",
-                    connector_component: ConnectorComponent::from(dataset),
-                })?;
-
                 ensure!(
                     topic == metadata.topic,
                     super::InvalidConfigurationNoSourceSnafu {
@@ -406,20 +396,26 @@ impl DataConnector for Debezium {
                     (metadata, Arc::new(schema))
                 };
 
+                // Build the consumer with the sidecar offsets already stashed so
+                // the first rebalance callback after `subscribe` seeks before any
+                // messages are delivered.
+                let kafka_consumer = KafkaConsumer::create_with_existing_group_id(
+                    &metadata.consumer_group_id,
+                    &self.kafka_config,
+                    &metadata.offsets,
+                )
+                .boxed()
+                .context(super::UnableToGetReadProviderSnafu {
+                    dataconnector: "debezium",
+                    connector_component: ConnectorComponent::from(dataset),
+                })?;
+
                 kafka_consumer.subscribe(topic).boxed().context(
                     super::UnableToGetReadProviderSnafu {
                         dataconnector: "debezium",
                         connector_component: ConnectorComponent::from(dataset),
                     },
                 )?;
-
-                kafka_consumer
-                    .restore_offsets(&metadata.offsets)
-                    .boxed()
-                    .context(super::UnableToGetReadProviderSnafu {
-                        dataconnector: "debezium",
-                        connector_component: ConnectorComponent::from(dataset),
-                    })?;
 
                 (kafka_consumer, metadata, schema)
             }

--- a/crates/runtime/src/dataconnector/kafka.rs
+++ b/crates/runtime/src/dataconnector/kafka.rs
@@ -495,24 +495,19 @@ async fn init_kafka_consumer(
         );
     }
 
-    let kafka_consumer =
-        KafkaConsumer::create_with_existing_group_id(&metadata.consumer_group_id, kafka_config)
-            .boxed()
-            .context(super::UnableToGetReadProviderSnafu {
-                dataconnector: "kafka",
-                connector_component: ConnectorComponent::from(dataset),
-            })?;
+    let kafka_consumer = KafkaConsumer::create_with_existing_group_id(
+        &metadata.consumer_group_id,
+        kafka_config,
+        &metadata.offsets,
+    )
+    .boxed()
+    .context(super::UnableToGetReadProviderSnafu {
+        dataconnector: "kafka",
+        connector_component: ConnectorComponent::from(dataset),
+    })?;
 
     kafka_consumer
         .subscribe(topic)
-        .boxed()
-        .context(super::UnableToGetReadProviderSnafu {
-            dataconnector: "kafka",
-            connector_component: ConnectorComponent::from(dataset),
-        })?;
-
-    kafka_consumer
-        .restore_offsets(&metadata.offsets)
         .boxed()
         .context(super::UnableToGetReadProviderSnafu {
             dataconnector: "kafka",

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -89,7 +89,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Invalid Spice Cloud region: {region}. Specify a valid region, for example us-east-1. To list available regions, run: spice cloud regions"
+        "Invalid Spice Cloud region: {region}. Specify a valid region, for example 'spiceai_region: us-east-1'. To list available regions, run: 'spice cloud regions'"
     ))]
     InvalidRegion { region: String },
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -68,7 +68,7 @@ use cache::TabledCacheProvider;
 use cache::result::embeddings::CachedEmbeddingResult;
 use cache::result::search::CachedSearchResult;
 use cache::{CacheProvider, Caching, QueryResultsCacheProvider, key::RawCacheKey};
-use data_components::poly::PolyTableProvider;
+use data_components::{FieldMetadata, metadata_enriched_table_provider, poly::PolyTableProvider};
 use datafusion::catalog::CatalogProvider;
 use datafusion::catalog::SchemaProvider;
 use datafusion::common::{Constraint, Constraints, ToDFSchema};
@@ -104,7 +104,7 @@ use runtime_table_partition::provider::PartitionTableProvider;
 use schema::ensure_schema_exists;
 use snafu::prelude::*;
 use spicepod::acceleration::SnapshotsTrigger;
-use spicepod::metric::Metrics;
+use spicepod::{metric::Metrics, semantic::Column};
 use tokio::runtime::Handle;
 use tokio::spawn;
 use tokio::sync::{Mutex, Notify};
@@ -618,6 +618,29 @@ pub enum Table {
     },
 }
 
+fn table_provider_with_spicepod_metadata(
+    provider: Arc<dyn TableProvider>,
+    table_metadata: &HashMap<String, String>,
+    columns: &[Column],
+) -> Arc<dyn TableProvider> {
+    let field_metadata = field_metadata_from_columns(columns);
+    if table_metadata.is_empty() && field_metadata.is_empty() {
+        return provider;
+    }
+
+    metadata_enriched_table_provider(provider, table_metadata.clone(), field_metadata)
+}
+
+fn field_metadata_from_columns(columns: &[Column]) -> FieldMetadata {
+    columns
+        .iter()
+        .filter_map(|column| {
+            let metadata = column.metadata();
+            (!metadata.is_empty()).then(|| (column.name.clone(), metadata))
+        })
+        .collect()
+}
+
 struct PendingSinkRegistration {
     dataset: Arc<Dataset>,
     secrets: Arc<TokioRwLock<Secrets>>,
@@ -969,11 +992,13 @@ impl DataFusion {
                         "Registering dataset {dataset:?} with preloaded accelerated table"
                     );
                     let notifier = accelerated_table.refresher().on_complete_notification();
+                    let table_provider = table_provider_with_spicepod_metadata(
+                        accelerated_table.table_provider(),
+                        &dataset.metadata,
+                        &dataset.columns,
+                    );
                     self.ctx
-                        .register_table(
-                            dataset_table_ref.clone(),
-                            accelerated_table.table_provider(),
-                        )
+                        .register_table(dataset_table_ref.clone(), table_provider)
                         .map_err(find_datafusion_root)
                         .context(UnableToRegisterTableToDataFusionSnafu)?;
                     notifier
@@ -1938,6 +1963,11 @@ impl DataFusion {
                     .build()
                 })?
                 .context(UnableToResolveTableProviderSnafu)?;
+            let read_write_provider = table_provider_with_spicepod_metadata(
+                read_write_provider,
+                &dataset.metadata,
+                &dataset.columns,
+            );
             Arc::new(FederatedTable::new_unchecked(read_write_provider))
         } else {
             Arc::new(federated_read_table)
@@ -2660,11 +2690,14 @@ impl DataFusion {
             .await
             .context(AccelerationRegistrationSnafu)?;
 
+        let table_provider = table_provider_with_spicepod_metadata(
+            Arc::new(accelerated_table).table_provider(),
+            &dataset.metadata,
+            &dataset.columns,
+        );
+
         self.ctx
-            .register_table(
-                dataset.name.clone(),
-                Arc::new(accelerated_table).table_provider(),
-            )
+            .register_table(dataset.name.clone(), table_provider)
             .map_err(find_datafusion_root)
             .context(UnableToRegisterTableToDataFusionSnafu)?;
 
@@ -2924,6 +2957,12 @@ impl DataFusion {
         self.register_metadata_table(dataset, Arc::clone(&source))
             .await?;
 
+        let source_table_provider = table_provider_with_spicepod_metadata(
+            source_table_provider,
+            &dataset.metadata,
+            &dataset.columns,
+        );
+
         self.ctx
             .register_table(dataset.name.clone(), source_table_provider)
             .map_err(find_datafusion_root)
@@ -3072,6 +3111,8 @@ impl DataFusion {
             }
 
             // non-accelerated view
+            let tbl_provider =
+                table_provider_with_spicepod_metadata(tbl_provider, &view.metadata, &view.columns);
             if let Err(e) = ctx.register_table(table.clone(), tbl_provider) {
                 tracing::error!("Failed to create view {table}: {e}");
                 status.update_view(
@@ -3104,6 +3145,8 @@ impl DataFusion {
                     name: table.to_string(),
                 })?;
 
+        let view_table =
+            table_provider_with_spicepod_metadata(view_table, &view.metadata, &view.columns);
         let schema = view_table.schema();
 
         // Distributed acceleration is only supported with Arrow, PartitionedArrow, or Cayenne engines.
@@ -3208,10 +3251,16 @@ impl DataFusion {
 
         let is_ready = accelerated_table.refresher().on_complete_notification();
 
+        let table_provider = table_provider_with_spicepod_metadata(
+            Arc::new(accelerated_table).table_provider(),
+            &view.metadata,
+            &view.columns,
+        );
+
         self.ctx
-            .register_table(table.clone(), Arc::new(accelerated_table).table_provider())
+            .register_table(table.clone(), table_provider)
             .map_err(|e| Error::UnableToCreateView {
-                reason: format!("Failed to registed view: {e}"),
+                reason: format!("Failed to register view: {e}"),
             })?;
 
         tracing::info!("{}", view_registered_trace(table, Some(acceleration)));
@@ -4057,6 +4106,89 @@ mod tests {
             vec![Arc::new(Int32Array::from(vec![value])) as arrow::array::ArrayRef],
         )
         .expect("test record batch should be valid")
+    }
+
+    async fn registered_schema_with_metadata(
+        table_name: &str,
+        table_metadata: &HashMap<String, String>,
+        columns: &[Column],
+    ) -> SchemaRef {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let table_provider =
+            Arc::new(MemTable::try_new(schema, vec![vec![]]).expect("mem table should be created"))
+                as Arc<dyn TableProvider>;
+
+        let ctx = SessionContext::new();
+        ctx.register_table(
+            TableReference::bare(table_name),
+            table_provider_with_spicepod_metadata(table_provider, table_metadata, columns),
+        )
+        .expect("table should register");
+
+        ctx.table_provider(table_name)
+            .await
+            .expect("registered table should resolve")
+            .schema()
+    }
+
+    #[tokio::test]
+    async fn dataset_spicepod_metadata_is_registered_on_schema_and_fields() {
+        let mut dataset = spicepod::component::dataset::Dataset::new("test", "dataset_meta");
+        dataset.description = Some("dataset description".to_string());
+        dataset.metadata.insert(
+            "source_owner".to_string(),
+            serde_json::Value::String("analytics".to_string()),
+        );
+
+        let mut id_column = Column::new("id");
+        id_column.description = Some("stable row id".to_string());
+        dataset.columns.push(id_column);
+
+        let metadata = dataset.metadata();
+        let schema =
+            registered_schema_with_metadata("dataset_meta", &metadata, &dataset.columns).await;
+
+        assert_eq!(
+            schema.metadata().get("comment").map(String::as_str),
+            Some("dataset description")
+        );
+        assert_eq!(
+            schema.metadata().get("source_owner").map(String::as_str),
+            Some("analytics")
+        );
+        let id_field = schema.field_with_name("id").expect("id field should exist");
+        assert_eq!(
+            id_field.metadata().get("comment").map(String::as_str),
+            Some("stable row id")
+        );
+    }
+
+    #[tokio::test]
+    async fn view_spicepod_metadata_is_registered_on_schema_and_fields() {
+        let mut view = spicepod::component::view::View::new("view_meta".to_string());
+        view.description = Some("view description".to_string());
+
+        let mut name_column = Column::new("name");
+        name_column.description = Some("display name".to_string());
+        view.columns.push(name_column);
+
+        let metadata = view.metadata();
+        let schema = registered_schema_with_metadata("view_meta", &metadata, &view.columns).await;
+
+        assert_eq!(
+            schema.metadata().get("comment").map(String::as_str),
+            Some("view description")
+        );
+        let name_field = schema
+            .field_with_name("name")
+            .expect("name field should exist");
+        assert_eq!(
+            name_field.metadata().get("comment").map(String::as_str),
+            Some("display name")
+        );
     }
 
     #[test]

--- a/crates/runtime/src/federated_table/mod.rs
+++ b/crates/runtime/src/federated_table/mod.rs
@@ -34,6 +34,7 @@ use std::sync::{
 
 use arrow::datatypes::SchemaRef;
 use arrow_tools::schema::schema_difference;
+use data_components::{FieldMetadata, metadata_enriched_table_provider};
 use datafusion::catalog::TableProvider;
 use datafusion::common::DataFusionError;
 use runtime_acceleration::dataset_checkpoint::DatasetCheckpointer;
@@ -150,6 +151,28 @@ impl DeferredTableProvider {
     }
 }
 
+fn table_provider_with_dataset_metadata(
+    dataset: &Dataset,
+    provider: Arc<dyn TableProvider>,
+) -> Arc<dyn TableProvider> {
+    let field_metadata = field_metadata_from_columns(&dataset.columns);
+    if dataset.metadata.is_empty() && field_metadata.is_empty() {
+        return provider;
+    }
+
+    metadata_enriched_table_provider(provider, dataset.metadata.clone(), field_metadata)
+}
+
+fn field_metadata_from_columns(columns: &[spicepod::semantic::Column]) -> FieldMetadata {
+    columns
+        .iter()
+        .filter_map(|column| {
+            let metadata = column.metadata();
+            (!metadata.is_empty()).then(|| (column.name.clone(), metadata))
+        })
+        .collect()
+}
+
 impl FederatedTable {
     /// Creates a federated table without checking if the schema matches the existing acceleration checkpoint.
     pub fn new_unchecked(table_provider: Arc<dyn TableProvider>) -> Self {
@@ -164,6 +187,8 @@ impl FederatedTable {
         shutdown_token: CancellationToken,
         allow_schema_mismatch: bool,
     ) -> Self {
+        let table_provider = table_provider_with_dataset_metadata(&dataset, table_provider);
+
         // When `allow_schema_mismatch` is `true`, schema differences are ignored and the
         // table provider is returned immediately. The caller is responsible for handling
         // schema evolution (e.g. `file_update` mode detects changes and recreates the acceleration).
@@ -373,6 +398,8 @@ impl FederatedTable {
 
             match table_provider_result {
                 Ok(table_provider) => {
+                    let table_provider =
+                        table_provider_with_dataset_metadata(&dataset, table_provider);
                     if tx.send(table_provider).is_err() {
                         tracing::error!(
                             "Failed to send deferred table provider for dataset '{}': Channel closed.",

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -19,6 +19,7 @@ use std::collections::HashSet;
 use std::{collections::HashMap, sync::Arc};
 
 use app::App;
+use data_components::MetadataEnrichedTableProvider;
 use datafusion::common::Column;
 use datafusion::error::DataFusionError;
 use datafusion::{datasource::TableProvider, sql::TableReference};
@@ -69,6 +70,14 @@ pub(crate) fn find_concrete_table_provider<T: TableProvider + 'static>(
             && let Some(adapted_tbl) = adaptor.table_provider.as_ref()
         {
             current_tbl = adapted_tbl;
+            continue;
+        }
+
+        if let Some(metadata_table) = current_tbl
+            .as_any()
+            .downcast_ref::<MetadataEnrichedTableProvider>()
+        {
+            current_tbl = metadata_table.get_inner_ref();
             continue;
         }
 

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -25,6 +25,7 @@ use super::{Nameable, WithDependsOn, embeddings::ColumnEmbeddingConfig, is_defau
 use crate::acceleration::Acceleration;
 use crate::component::access::AccessMode;
 use crate::fts::FtsStore;
+use crate::metadata::metadata_value_to_string;
 use crate::metric::Metrics;
 use crate::param::Params;
 use crate::semantic::Column;
@@ -319,10 +320,10 @@ impl Dataset {
     pub fn metadata(&self) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
         if let Some(d) = self.description.as_ref() {
-            metadata.insert("description".to_string(), d.clone());
+            metadata.insert("comment".to_string(), d.clone());
         }
         for (k, v) in &self.metadata {
-            metadata.insert(k.clone(), v.to_string());
+            metadata.insert(k.clone(), metadata_value_to_string(v));
         }
         metadata
     }

--- a/crates/spicepod/src/component/view.rs
+++ b/crates/spicepod/src/component/view.rs
@@ -22,7 +22,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::{Nameable, WithDependsOn, dataset::ReadyState, is_default};
-use crate::{acceleration::Acceleration, semantic::Column, vector::VectorStore};
+use crate::{
+    acceleration::Acceleration, metadata::metadata_value_to_string, semantic::Column,
+    vector::VectorStore,
+};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
@@ -99,10 +102,10 @@ impl View {
     pub fn metadata(&self) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
         if let Some(d) = self.description.as_ref() {
-            metadata.insert("description".to_string(), d.clone());
+            metadata.insert("comment".to_string(), d.clone());
         }
         for (k, v) in &self.metadata {
-            metadata.insert(k.clone(), v.to_string());
+            metadata.insert(k.clone(), metadata_value_to_string(v));
         }
         metadata
     }

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -42,6 +42,7 @@ pub mod component;
 pub mod extension;
 pub mod fts;
 mod keywords;
+mod metadata;
 pub mod metric;
 pub mod param;
 pub mod partitioning;

--- a/crates/spicepod/src/metadata.rs
+++ b/crates/spicepod/src/metadata.rs
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use serde_json::Value;
+
+pub(crate) fn metadata_value_to_string(value: &Value) -> String {
+    value
+        .as_str()
+        .map_or_else(|| value.to_string(), ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::metadata_value_to_string;
+    use serde_json::json;
+
+    #[test]
+    fn metadata_value_to_string_preserves_raw_strings() {
+        assert_eq!(
+            metadata_value_to_string(&json!("enabled")),
+            "enabled".to_string()
+        );
+    }
+
+    #[test]
+    fn metadata_value_to_string_serializes_structured_values() {
+        assert_eq!(
+            metadata_value_to_string(&json!({"owner":"analytics"})),
+            "{\"owner\":\"analytics\"}".to_string()
+        );
+    }
+}

--- a/crates/spicepod/src/semantic.rs
+++ b/crates/spicepod/src/semantic.rs
@@ -24,6 +24,7 @@ use serde_json::Value;
 
 use crate::{
     component::embeddings::{EmbeddingAggregation, EmbeddingChunkConfig},
+    metadata::metadata_value_to_string,
     param::Params,
 };
 
@@ -115,10 +116,10 @@ impl Column {
     pub fn metadata(&self) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
         if let Some(d) = self.description.as_ref() {
-            metadata.insert("description".to_string(), d.clone());
+            metadata.insert("comment".to_string(), d.clone());
         }
         for (k, v) in &self.metadata {
-            metadata.insert(k.clone(), v.to_string());
+            metadata.insert(k.clone(), metadata_value_to_string(v));
         }
         metadata
     }


### PR DESCRIPTION
## Summary
Cherry-picks the following from `trunk` into `release/2.0`:

- perf(cayenne): reduce allocation overheads in hot paths (#10950)
- improve error message for 'params.spiceai_region' (#10954)
- add Scylla, bigquery and turso to throughput benchmarking (#11006)
- fix(kafka): seek to sidecar offsets via post_rebalance callback on restart (#11007)

**Note:** Make DuckDB schema cast logic more robust (#10991) was skipped as it is already in `release/2.0`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782089647&installation_id=128462479&pr_number=11016&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11016&signature=4315fe87b93770f7f9a3ba9df5aa659a21cf1d375ba6cb421497968fd0deff93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->