### PR TITLE
fix: delegate truncate in PolyTableProvider and MetadataEnrichedTableProvider

### DIFF
--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -226,6 +226,10 @@ impl TableProvider for MetadataEnrichedTableProvider {
     fn statistics(&self) -> Option<Statistics> {
         self.inner.statistics()
     }
+
+    async fn truncate(&self, state: &dyn Session) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.inner.truncate(state).await
+    }
 }
 
 #[async_trait]

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -171,4 +171,8 @@ impl TableProvider for PolyTableProvider {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.write.update(state, assignments, filters).await
     }
+
+    async fn truncate(&self, state: &dyn Session) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.write.truncate(state).await
+    }
 }


### PR DESCRIPTION
## Summary

`PolyTableProvider` is the core wrapper used by all accelerator engines (DuckDB, Turso, Postgres, SQLite, Cayenne). It delegated `insert_into`, `delete_from`, and `update` to the inner write provider but was missing `truncate` — so `TRUNCATE TABLE` on any accelerated table fell through to DataFusion's default `not_impl_err!` with a confusing "TRUNCATE not supported for Base table" error.

`MetadataEnrichedTableProvider` (wraps Postgres catalog tables with FK metadata) had the same missing delegation.

This PR adds the missing `truncate` delegation to both wrappers.

## Fix

- `PolyTableProvider::truncate` delegates to `self.write.truncate(state)`
- `MetadataEnrichedTableProvider::truncate` delegates to `self.inner.truncate(state)`

## Test plan

- `cargo check -p data_components` passes
- `cargo fmt` clean
- Minimal change: each delegation is a one-line forwarding call matching the existing `insert_into`/`delete_from`/`update` pattern
- Performance impact: none

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782127386&installation_id=128462479&pr_number=11017&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11017&signature=e14602f21fbb84514206612ebfa3b5621443bf4aef22a90435dcc7d7f04dbb49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->