### PR TITLE
feat(chbench): Improve OLTP throughput and reduce PostgreSQL CDC overhead

### DIFF
--- a/.github/actions/setup-chbench-postgres/action.yml
+++ b/.github/actions/setup-chbench-postgres/action.yml
@@ -9,13 +9,19 @@ runs:
       run: |
         docker run -d --name chbench-pg \
           -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=chbench \
-          -p 5432:5432 postgres:16 \
+          -p 5432:5432 \
+          --shm-size=4g \
+          postgres:16 \
           -c max_connections=200 \
           -c wal_level=logical \
           -c synchronous_commit=off \
           -c max_replication_slots=20 \
           -c max_wal_senders=20 \
-          -c shared_buffers=128MB
+          -c shared_buffers=8GB \
+          -c wal_buffers=64MB \
+          -c full_page_writes=off \
+          -c checkpoint_timeout=30min \
+          -c max_wal_size=8GB
 
     - name: Wait for CH-benCH PostgreSQL
       shell: bash

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -86,6 +86,24 @@ jobs:
       - name: Setup CH-benCH PostgreSQL
         uses: ./.github/actions/setup-chbench-postgres
 
+      - name: Start resource monitor
+        run: |
+          echo -e "timestamp\tpg_cpu_pct\tpg_mem\tpg_block_io\tspiced_cpu_pct\tspiced_rss_kb\ttestop_cpu_pct\ttestop_rss_kb" > /tmp/resource-monitor.tsv
+          (while true; do
+            ts=$(date -u +%H:%M:%S)
+            pg=$(docker stats chbench-pg --no-stream --format "{{.CPUPerc}}\t{{.MemUsage}}\t{{.BlockIO}}" 2>/dev/null || echo "0%\t0\t0")
+            spiced_line=$(ps -eo pcpu,rss,comm | grep '[s]piced' | head -1 || true)
+            testop_line=$(ps -eo pcpu,rss,comm | grep '[t]estoperator' | head -1 || true)
+            spiced_cpu=$(echo "$spiced_line" | awk '{print $1+0}')
+            spiced_rss=$(echo "$spiced_line" | awk '{print $2+0}')
+            testop_cpu=$(echo "$testop_line" | awk '{print $1+0}')
+            testop_rss=$(echo "$testop_line" | awk '{print $2+0}')
+            echo -e "${ts}\t${pg}\t${spiced_cpu}\t${spiced_rss}\t${testop_cpu}\t${testop_rss}" >> /tmp/resource-monitor.tsv
+            sleep 10
+          done) &
+          echo $! > /tmp/monitor-pid.txt
+          echo "Resource monitor started (PID: $(cat /tmp/monitor-pid.txt))"
+
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |
           testoperator run htap \
@@ -101,3 +119,19 @@ jobs:
         env:
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          CHBENCH_PG_HOST: 127.0.0.1
+
+      - name: Stop resource monitor
+        if: always()
+        run: |
+          if [ -f /tmp/monitor-pid.txt ]; then
+            kill "$(cat /tmp/monitor-pid.txt)" 2>/dev/null || true
+          fi
+
+      - name: Upload resource monitor
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: resource-monitor
+          path: /tmp/resource-monitor.tsv
+          retention-days: 7

--- a/test/spicepods/chbench/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-arrow.yaml
@@ -79,17 +79,6 @@ datasets:
       on_conflict:
         (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
 
-  - from: postgres:item
-    name: item
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_item
-    acceleration:
-      <<: *arrow_accel
-      primary_key: i_id
-      on_conflict:
-        i_id: upsert
-
   - from: postgres:stock
     name: stock
     params:
@@ -101,13 +90,28 @@ datasets:
       on_conflict:
         (s_w_id, s_i_id): upsert
 
+  # ---- Static reference tables (no OLTP mutations, full refresh) ----
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: arrow
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+
   - from: postgres:region
     name: region
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_region
     acceleration:
-      <<: *arrow_accel
+      enabled: true
+      engine: arrow
+      refresh_mode: full
       primary_key: r_regionkey
       on_conflict:
         r_regionkey: upsert
@@ -116,9 +120,10 @@ datasets:
     name: nation
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_nation
     acceleration:
-      <<: *arrow_accel
+      enabled: true
+      engine: arrow
+      refresh_mode: full
       primary_key: n_nationkey
       on_conflict:
         n_nationkey: upsert
@@ -127,9 +132,10 @@ datasets:
     name: supplier
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_supplier
     acceleration:
-      <<: *arrow_accel
+      enabled: true
+      engine: arrow
+      refresh_mode: full
       primary_key: su_suppkey
       on_conflict:
         su_suppkey: upsert

--- a/test/spicepods/chbench/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-arrow.yaml
@@ -2,20 +2,23 @@ version: v1
 kind: Spicepod
 name: postgres-arrow
 
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: 5432
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 
   - from: postgres:warehouse
     name: warehouse
-    params: &postgres_params
-      pg_host: 127.0.0.1
-      pg_port: 5432
-      pg_db: chbench
-      pg_user: bench
-      pg_pass: bench
-      pg_sslmode: disable
+    params:
+      <<: *postgres_params
       pg_replication_slot: spice_warehouse
-      pg_replication_initial_snapshot: "true"
+      pg_replication_initial_snapshot: 'true'
     acceleration: &arrow_accel
       enabled: true
       engine: arrow
@@ -29,6 +32,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *arrow_accel
       primary_key: (d_w_id, d_id)
@@ -40,6 +44,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *arrow_accel
       primary_key: (c_w_id, c_d_id, c_id)
@@ -51,6 +56,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *arrow_accel
       primary_key: (no_w_id, no_d_id, no_o_id)
@@ -62,6 +68,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *arrow_accel
       primary_key: (o_w_id, o_d_id, o_id)
@@ -73,6 +80,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *arrow_accel
       primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
@@ -84,6 +92,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *arrow_accel
       primary_key: (s_w_id, s_i_id)

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
@@ -168,16 +168,19 @@ datasets:
         cayenne_upload_concurrency: '4'
         cayenne_segment_cache_mb: '64'
 
+  # ------------------------------------------------------------------
+  # Static reference tables (no OLTP mutations, full refresh).
+  # ------------------------------------------------------------------
+
   - from: postgres:item
     name: item
     params:
       <<: *pg_base
-      pg_replication_slot: spice_item
     acceleration:
       enabled: true
       engine: cayenne
       mode: file
-      refresh_mode: changes
+      refresh_mode: full
       primary_key: i_id
       on_conflict:
         i_id: upsert
@@ -185,20 +188,15 @@ datasets:
         <<: *accel_medium
         cayenne_file_path: ./spice/cayenne/item
 
-  # ------------------------------------------------------------------
-  # Tiny TPC-H tables.
-  # ------------------------------------------------------------------
-
   - from: postgres:region
     name: region
     params:
       <<: *pg_base
-      pg_replication_slot: spice_region
     acceleration:
       enabled: true
       engine: cayenne
       mode: file
-      refresh_mode: changes
+      refresh_mode: full
       primary_key: r_regionkey
       on_conflict:
         r_regionkey: upsert
@@ -213,12 +211,11 @@ datasets:
     name: nation
     params:
       <<: *pg_base
-      pg_replication_slot: spice_nation
     acceleration:
       enabled: true
       engine: cayenne
       mode: file
-      refresh_mode: changes
+      refresh_mode: full
       primary_key: n_nationkey
       on_conflict:
         n_nationkey: upsert
@@ -230,12 +227,11 @@ datasets:
     name: supplier
     params:
       <<: *pg_base
-      pg_replication_slot: spice_supplier
     acceleration:
       enabled: true
       engine: cayenne
       mode: file
-      refresh_mode: changes
+      refresh_mode: full
       primary_key: su_suppkey
       on_conflict:
         su_suppkey: upsert

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
@@ -15,6 +15,14 @@ runtime:
     memory_limit: 40GiB
     target_partitions: 32
 
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: '5432'
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
 datasets:
   # ------------------------------------------------------------------
   # High-volume PK upsert tables.
@@ -22,13 +30,8 @@ datasets:
 
   - from: postgres:district
     name: district
-    params: &pg_base
-      pg_host: 127.0.0.1
-      pg_port: '5432'
-      pg_db: chbench
-      pg_user: bench
-      pg_pass: bench
-      pg_sslmode: disable
+    params:
+      <<: *postgres_params
       pg_replication_slot: spice_district
       pg_replication_initial_snapshot: 'true'
       pg_replication_bootstrap_batch_size: '1048576'
@@ -42,7 +45,7 @@ datasets:
         (d_w_id, d_id): upsert
       params: &accel_high_volume
         cayenne_metastore: sqlite
-        cayenne_file_path: ./spice/cayenne/district
+        cayenne_file_path: .spice/cayenne/district
         cayenne_write_concurrency: '16'
         cayenne_upload_concurrency: '32'
         cayenne_segment_cache_mb: '1024'
@@ -54,8 +57,10 @@ datasets:
   - from: postgres:customer
     name: customer
     params:
-      <<: *pg_base
+      <<: *postgres_params
       pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
     acceleration:
       enabled: true
       engine: cayenne
@@ -66,14 +71,16 @@ datasets:
         (c_w_id, c_d_id, c_id): upsert
       params:
         <<: *accel_high_volume
-        cayenne_file_path: ./spice/cayenne/customer
+        cayenne_file_path: .spice/cayenne/customer
         cayenne_target_file_size_mb: '256'
 
   - from: postgres:new_order
     name: new_order
     params:
-      <<: *pg_base
+      <<: *postgres_params
       pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
     acceleration:
       enabled: true
       engine: cayenne
@@ -84,13 +91,15 @@ datasets:
         (no_w_id, no_d_id, no_o_id): upsert
       params:
         <<: *accel_high_volume
-        cayenne_file_path: ./spice/cayenne/new_order
+        cayenne_file_path: .spice/cayenne/new_order
 
   - from: postgres:oorder
     name: oorder
     params:
-      <<: *pg_base
+      <<: *postgres_params
       pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
     acceleration:
       enabled: true
       engine: cayenne
@@ -101,13 +110,15 @@ datasets:
         (o_w_id, o_d_id, o_id): upsert
       params:
         <<: *accel_high_volume
-        cayenne_file_path: ./spice/cayenne/oorder
+        cayenne_file_path: .spice/cayenne/oorder
 
   - from: postgres:order_line
     name: order_line
     params:
-      <<: *pg_base
+      <<: *postgres_params
       pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
     acceleration:
       enabled: true
       engine: cayenne
@@ -118,7 +129,7 @@ datasets:
         (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
       params:
         <<: *accel_high_volume
-        cayenne_file_path: ./spice/cayenne/order_line
+        cayenne_file_path: .spice/cayenne/order_line
         cayenne_write_concurrency: '32'
         cayenne_target_file_size_mb: '256'
         cayenne_compaction_trigger_files: '8'
@@ -129,8 +140,10 @@ datasets:
   - from: postgres:stock
     name: stock
     params:
-      <<: *pg_base
+      <<: *postgres_params
       pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
     acceleration:
       enabled: true
       engine: cayenne
@@ -141,7 +154,7 @@ datasets:
         (s_w_id, s_i_id): upsert
       params:
         <<: *accel_high_volume
-        cayenne_file_path: ./spice/cayenne/stock
+        cayenne_file_path: .spice/cayenne/stock
         cayenne_target_file_size_mb: '256'
 
   # ------------------------------------------------------------------
@@ -151,8 +164,10 @@ datasets:
   - from: postgres:warehouse
     name: warehouse
     params:
-      <<: *pg_base
+      <<: *postgres_params
       pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
     acceleration:
       enabled: true
       engine: cayenne
@@ -163,7 +178,7 @@ datasets:
         w_id: upsert
       params: &accel_medium
         cayenne_metastore: sqlite
-        cayenne_file_path: ./spice/cayenne/warehouse
+        cayenne_file_path: .spice/cayenne/warehouse
         cayenne_write_concurrency: '4'
         cayenne_upload_concurrency: '4'
         cayenne_segment_cache_mb: '64'
@@ -175,7 +190,7 @@ datasets:
   - from: postgres:item
     name: item
     params:
-      <<: *pg_base
+      <<: *postgres_params
     acceleration:
       enabled: true
       engine: cayenne
@@ -186,12 +201,12 @@ datasets:
         i_id: upsert
       params:
         <<: *accel_medium
-        cayenne_file_path: ./spice/cayenne/item
+        cayenne_file_path: .spice/cayenne/item
 
   - from: postgres:region
     name: region
     params:
-      <<: *pg_base
+      <<: *postgres_params
     acceleration:
       enabled: true
       engine: cayenne
@@ -202,7 +217,7 @@ datasets:
         r_regionkey: upsert
       params: &accel_small
         cayenne_metastore: sqlite
-        cayenne_file_path: ./spice/cayenne/region
+        cayenne_file_path: .spice/cayenne/region
         cayenne_write_concurrency: '2'
         cayenne_upload_concurrency: '2'
         cayenne_segment_cache_mb: '16'
@@ -210,7 +225,7 @@ datasets:
   - from: postgres:nation
     name: nation
     params:
-      <<: *pg_base
+      <<: *postgres_params
     acceleration:
       enabled: true
       engine: cayenne
@@ -221,12 +236,12 @@ datasets:
         n_nationkey: upsert
       params:
         <<: *accel_small
-        cayenne_file_path: ./spice/cayenne/nation
+        cayenne_file_path: .spice/cayenne/nation
 
   - from: postgres:supplier
     name: supplier
     params:
-      <<: *pg_base
+      <<: *postgres_params
     acceleration:
       enabled: true
       engine: cayenne
@@ -237,4 +252,4 @@ datasets:
         su_suppkey: upsert
       params:
         <<: *accel_small
-        cayenne_file_path: ./spice/cayenne/supplier
+        cayenne_file_path: .spice/cayenne/supplier

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
@@ -80,17 +80,6 @@ datasets:
       on_conflict:
         (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
 
-  - from: postgres:item
-    name: item
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_item
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: i_id
-      on_conflict:
-        i_id: upsert
-
   - from: postgres:stock
     name: stock
     params:
@@ -102,13 +91,30 @@ datasets:
       on_conflict:
         (s_w_id, s_i_id): upsert
 
+  # ---- Static reference tables (no OLTP mutations, full refresh) ----
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+
   - from: postgres:region
     name: region
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_region
     acceleration:
-      <<: *cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
       primary_key: r_regionkey
       on_conflict:
         r_regionkey: upsert
@@ -117,9 +123,11 @@ datasets:
     name: nation
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_nation
     acceleration:
-      <<: *cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
       primary_key: n_nationkey
       on_conflict:
         n_nationkey: upsert
@@ -128,9 +136,11 @@ datasets:
     name: supplier
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_supplier
     acceleration:
-      <<: *cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
       primary_key: su_suppkey
       on_conflict:
         su_suppkey: upsert

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
@@ -2,20 +2,23 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]
 
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: 5432
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 
   - from: postgres:warehouse
     name: warehouse
-    params: &postgres_params
-      pg_host: 127.0.0.1
-      pg_port: 5432
-      pg_db: chbench
-      pg_user: bench
-      pg_pass: bench
-      pg_sslmode: disable
+    params:
+      <<: *postgres_params
       pg_replication_slot: spice_warehouse
-      pg_replication_initial_snapshot: "true"
+      pg_replication_initial_snapshot: 'true'
     acceleration: &cayenne_accel
       enabled: true
       engine: cayenne
@@ -30,6 +33,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *cayenne_accel
       primary_key: (d_w_id, d_id)
@@ -41,6 +45,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *cayenne_accel
       primary_key: (c_w_id, c_d_id, c_id)
@@ -52,6 +57,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *cayenne_accel
       primary_key: (no_w_id, no_d_id, no_o_id)
@@ -63,6 +69,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *cayenne_accel
       primary_key: (o_w_id, o_d_id, o_id)
@@ -74,6 +81,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *cayenne_accel
       primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
@@ -85,6 +93,7 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
     acceleration:
       <<: *cayenne_accel
       primary_key: (s_w_id, s_i_id)

--- a/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
@@ -2,21 +2,24 @@ version: v1
 kind: Spicepod
 name: postgres-duckdb[file]
 
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: 5432
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 
   - from: postgres:warehouse
     name: warehouse
-    params: &postgres_params
-      pg_host: 127.0.0.1
-      pg_port: 5432
-      pg_db: chbench
-      pg_user: bench
-      pg_pass: bench
-      pg_sslmode: disable
+    params:
+      <<: *postgres_params
       pg_replication_slot: spice_warehouse
-      pg_replication_initial_snapshot: "true"
-    acceleration: &duckdb_accel
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
       enabled: true
       engine: duckdb
       mode: file
@@ -30,8 +33,12 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: changes
       primary_key: (d_w_id, d_id)
       on_conflict:
         (d_w_id, d_id): upsert
@@ -41,8 +48,12 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: changes
       primary_key: (c_w_id, c_d_id, c_id)
       on_conflict:
         (c_w_id, c_d_id, c_id): upsert
@@ -52,8 +63,12 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: changes
       primary_key: (no_w_id, no_d_id, no_o_id)
       on_conflict:
         (no_w_id, no_d_id, no_o_id): upsert
@@ -63,8 +78,12 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: changes
       primary_key: (o_w_id, o_d_id, o_id)
       on_conflict:
         (o_w_id, o_d_id, o_id): upsert
@@ -74,8 +93,12 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: changes
       primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
       on_conflict:
         (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
@@ -85,8 +108,12 @@ datasets:
     params:
       <<: *postgres_params
       pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: changes
       primary_key: (s_w_id, s_i_id)
       on_conflict:
         (s_w_id, s_i_id): upsert
@@ -144,3 +171,4 @@ datasets:
       primary_key: su_suppkey
       on_conflict:
         su_suppkey: upsert
+

--- a/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
@@ -80,17 +80,6 @@ datasets:
       on_conflict:
         (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
 
-  - from: postgres:item
-    name: item
-    params:
-      <<: *postgres_params
-      pg_replication_slot: spice_item
-    acceleration:
-      <<: *duckdb_accel
-      primary_key: i_id
-      on_conflict:
-        i_id: upsert
-
   - from: postgres:stock
     name: stock
     params:
@@ -102,13 +91,30 @@ datasets:
       on_conflict:
         (s_w_id, s_i_id): upsert
 
+  # ---- Static reference tables (no OLTP mutations, full refresh) ----
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+
   - from: postgres:region
     name: region
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_region
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: full
       primary_key: r_regionkey
       on_conflict:
         r_regionkey: upsert
@@ -117,9 +123,11 @@ datasets:
     name: nation
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_nation
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: full
       primary_key: n_nationkey
       on_conflict:
         n_nationkey: upsert
@@ -128,9 +136,11 @@ datasets:
     name: supplier
     params:
       <<: *postgres_params
-      pg_replication_slot: spice_supplier
     acceleration:
-      <<: *duckdb_accel
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: full
       primary_key: su_suppkey
       on_conflict:
         su_suppkey: upsert

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -135,7 +135,26 @@ pub async fn run(
             source,
         })?;
 
-    // 6-9. Process each order line: select item, select/update stock, insert order_line
+    // 6-9. Process order lines in two phases (similar to BenchBase-style batching):
+    //   Phase 1: Sequential reads (SELECT item + SELECT stock FOR UPDATE)
+    //   Phase 2: Single batch_execute for all writes (UPDATE stock + INSERT order_line)
+
+    // Collected write data from Phase 1.
+    struct LineWrite {
+        s_quantity: i32,
+        ol_quantity: i32,
+        remote: i32,
+        ol_i_id: i32,
+        ol_supply_w_id: i32,
+        ol_number: i32,
+        ol_amount: f64,
+        ol_dist_info: String,
+    }
+
+    #[expect(clippy::cast_sign_loss)]
+    let mut writes: Vec<LineWrite> = Vec::with_capacity(ol_cnt as usize);
+
+    // Phase 1: reads — pipeline SELECT item + SELECT stock per item.
     for (ol_number_0, &(ol_i_id, ol_supply_w_id, ol_quantity, remote)) in items.iter().enumerate() {
         let ol_number = i32::try_from(ol_number_0).unwrap_or(0) + 1;
 
@@ -148,26 +167,21 @@ pub async fn run(
             return Ok(());
         }
 
-        // Select item
-        let item_row = tx
-            .query_one(&stmts.select_item, &[&ol_i_id])
-            .await
-            .map_err(|source| crate::Error::Sql {
-                action: "new_order: select item".into(),
-                source,
-            })?;
+        // Pipeline: SELECT item + SELECT stock FOR UPDATE in one round-trip
+        let stock_stmt = &stmts.select_stock[usize::try_from(d_id - 1).unwrap_or(0)];
+        let item_params: [&(dyn tokio_postgres::types::ToSql + Sync); 1] = [&ol_i_id];
+        let stock_params_sel: [&(dyn tokio_postgres::types::ToSql + Sync); 2] =
+            [&ol_i_id, &ol_supply_w_id];
+        let (item_row, stock_row) = tokio::try_join!(
+            tx.query_one(&stmts.select_item, &item_params),
+            tx.query_one(stock_stmt, &stock_params_sel),
+        )
+        .map_err(|source| crate::Error::Sql {
+            action: "new_order: select item+stock".into(),
+            source,
+        })?;
 
         let i_price: f64 = item_row.get(0);
-
-        // Select stock FOR UPDATE (pre-prepared per district)
-        let stock_stmt = &stmts.select_stock[usize::try_from(d_id - 1).unwrap_or(0)];
-        let stock_row = tx
-            .query_one(stock_stmt, &[&ol_i_id, &ol_supply_w_id])
-            .await
-            .map_err(|source| crate::Error::Sql {
-                action: "new_order: select stock".into(),
-                source,
-            })?;
 
         let mut s_quantity: i32 = stock_row.get(0);
         let ol_dist_info: String = stock_row.get(2);
@@ -177,48 +191,66 @@ pub async fn run(
             s_quantity += 91;
         }
 
-        // Update stock
-        tx.execute(
-            &stmts.update_stock,
-            &[
-                &s_quantity,
-                &ol_quantity,
-                &remote,
-                &ol_i_id,
-                &ol_supply_w_id,
-            ],
-        )
-        .await
-        .map_err(|source| crate::Error::Sql {
-            action: "new_order: update stock".into(),
-            source,
-        })?;
-
-        // Calculate amount
         let ol_amount =
             f64::from(ol_quantity) * i_price * (1.0 + w_tax + d_tax) * (1.0 - c_discount);
 
-        // Insert order_line
-        tx.execute(
-            &stmts.insert_order_line,
-            &[
-                &o_id,
-                &d_id,
-                &w_id,
-                &ol_number,
-                &ol_i_id,
-                &ol_supply_w_id,
-                &ol_quantity,
-                &ol_amount,
-                &ol_dist_info,
-            ],
+        writes.push(LineWrite {
+            s_quantity,
+            ol_quantity,
+            remote,
+            ol_i_id,
+            ol_supply_w_id,
+            ol_number,
+            ol_amount,
+            ol_dist_info,
+        });
+    }
+
+    // Phase 2: batch all writes in a single round-trip via simple query protocol.
+    //
+    // Uses `batch_execute` (simple query)  which does not support prepared statements
+    // but batching is still faster than using prepared statements with multiple round-trips.
+    use std::fmt::Write;
+    let mut batch_sql = String::with_capacity(writes.len() * 200);
+
+    for w in &writes {
+        write!(
+            &mut batch_sql,
+            "UPDATE stock SET s_quantity = {}, s_ytd = s_ytd + {}, \
+             s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + {} \
+             WHERE s_i_id = {} AND s_w_id = {};",
+            w.s_quantity, w.ol_quantity, w.remote, w.ol_i_id, w.ol_supply_w_id
         )
+        .unwrap_or(());
+    }
+
+    batch_sql.push_str(
+        "INSERT INTO order_line \
+         (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, \
+          ol_quantity, ol_amount, ol_dist_info) VALUES ",
+    );
+    for (i, w) in writes.iter().enumerate() {
+        if i > 0 {
+            batch_sql.push(',');
+        }
+        // ol_dist_info is a fixed 24-char alphanumeric string from stock table;
+        // escape single quotes defensively.
+        let escaped_dist = w.ol_dist_info.replace('\'', "''");
+        write!(
+            &mut batch_sql,
+            "({}, {}, {}, {}, {}, {}, {}, {}, '{escaped_dist}')",
+            o_id, d_id, w_id, w.ol_number, w.ol_i_id, w.ol_supply_w_id, w.ol_quantity, w.ol_amount
+        )
+        .unwrap_or(());
+    }
+    batch_sql.push(';');
+
+    tx.batch_execute(&batch_sql)
         .await
         .map_err(|source| crate::Error::Sql {
-            action: "new_order: insert order_line".into(),
+            action: "new_order: batch write stock+order_line".into(),
             source,
         })?;
-    }
 
     tx.commit().await.map_err(|source| crate::Error::Sql {
         action: "new_order: commit".into(),

--- a/tools/chbench-driver/src/txn/new_order.rs
+++ b/tools/chbench-driver/src/txn/new_order.rs
@@ -28,6 +28,7 @@ use super::TerminalAssignment;
 use super::prepared::NewOrderStmts;
 use crate::Result;
 use crate::rand as tpcc_rand;
+use std::fmt::Write;
 
 /// # Errors
 ///
@@ -38,6 +39,18 @@ pub async fn run(
     assignment: &TerminalAssignment,
     stmts: &NewOrderStmts,
 ) -> Result<()> {
+    // Collected write data from Phase 1.
+    struct LineWrite {
+        s_quantity: i32,
+        ol_quantity: i32,
+        remote: i32,
+        ol_i_id: i32,
+        ol_supply_w_id: i32,
+        ol_number: i32,
+        ol_amount: f64,
+        ol_dist_info: String,
+    }
+
     let w_id = assignment.home_w_id;
     let d_id = rng.random_range(assignment.district_lo..=assignment.district_hi);
     let c_id = tpcc_rand::rand_customer_id(rng);
@@ -139,18 +152,6 @@ pub async fn run(
     //   Phase 1: Sequential reads (SELECT item + SELECT stock FOR UPDATE)
     //   Phase 2: Single batch_execute for all writes (UPDATE stock + INSERT order_line)
 
-    // Collected write data from Phase 1.
-    struct LineWrite {
-        s_quantity: i32,
-        ol_quantity: i32,
-        remote: i32,
-        ol_i_id: i32,
-        ol_supply_w_id: i32,
-        ol_number: i32,
-        ol_amount: f64,
-        ol_dist_info: String,
-    }
-
     #[expect(clippy::cast_sign_loss)]
     let mut writes: Vec<LineWrite> = Vec::with_capacity(ol_cnt as usize);
 
@@ -210,18 +211,18 @@ pub async fn run(
     //
     // Uses `batch_execute` (simple query)  which does not support prepared statements
     // but batching is still faster than using prepared statements with multiple round-trips.
-    use std::fmt::Write;
     let mut batch_sql = String::with_capacity(writes.len() * 200);
 
     for w in &writes {
-        write!(
+        if let Err(e) = write!(
             &mut batch_sql,
             "UPDATE stock SET s_quantity = {}, s_ytd = s_ytd + {}, \
              s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + {} \
              WHERE s_i_id = {} AND s_w_id = {};",
             w.s_quantity, w.ol_quantity, w.remote, w.ol_i_id, w.ol_supply_w_id
-        )
-        .unwrap_or(());
+        ) {
+            eprintln!("Failed to format stock UPDATE SQL: {e}");
+        }
     }
 
     batch_sql.push_str(
@@ -236,12 +237,13 @@ pub async fn run(
         // ol_dist_info is a fixed 24-char alphanumeric string from stock table;
         // escape single quotes defensively.
         let escaped_dist = w.ol_dist_info.replace('\'', "''");
-        write!(
+        if let Err(e) = write!(
             &mut batch_sql,
             "({}, {}, {}, {}, {}, {}, {}, {}, '{escaped_dist}')",
             o_id, d_id, w_id, w.ol_number, w.ol_i_id, w.ol_supply_w_id, w.ol_quantity, w.ol_amount
-        )
-        .unwrap_or(());
+        ) {
+            eprintln!("Failed to format order_line VALUES SQL: {e}");
+        }
     }
     batch_sql.push(';');
 


### PR DESCRIPTION
## 📝 Summary

Improve CH-benCHmark TPC-C throughput ~2x (~60k → ~122k tpmC at SF15). This allows to generate higher OLTP throughput using the same CI runners eliminating the need for new dedicated runners to generated 100k+ tpmC test throughput.

- Batch NewOrder writes into a single `batch_execute` to reduce per-transaction network round-trips from ~40 to ~11.

- Reduce replication slot overhead: Switch static reference tables (item, region, nation, supplier) from CDC to full refresh. Eliminates 4 replication slots that decoded the entire WAL stream for zero changes.

- Tune PostgreSQL for write-heavy workloads: Increase shared_buffers, disable full_page_writes, extend checkpoint interval to reduce WAL volume.

- Add CI resource monitoring: collect and upload as benchmark artifact CPU/memory samples for performance analysis (spiced, testoperator, Postgres source)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782142479&installation_id=128462479&pr_number=11018&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11018&signature=8f7d4c404272b0b163adb220de7ed9e61252cd0d0490493c3ce0ce8e398b0640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->