### PR TITLE
Handle federation in 'MetadataEnrichedTableProvider' correctly

### DIFF
--- a/crates/data_components/src/postgres/provider.rs
+++ b/crates/data_components/src/postgres/provider.rs
@@ -28,6 +28,7 @@ use datafusion::catalog::{CatalogProvider, SchemaProvider};
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result as DFResult;
 use datafusion::sql::TableReference;
+use datafusion_federation::FederatedTableProviderAdaptor;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 use globset::GlobSet;
 use snafu::prelude::*;
@@ -487,9 +488,10 @@ async fn build_table_providers_for_schema(
                 let mut table_metadata = HashMap::new();
                 if let Some(fks) = foreign_keys.get(&table_name) {
                     match serde_json::to_string(fks) {
-                        Ok(fk_json) => {
-                            table_metadata.insert(FOREIGN_KEYS_METADATA_KEY.to_string(), fk_json);
-                        }
+                        Ok(fk_json) => add_metadata_to_table(
+                            provider,
+                            HashMap::from([(FOREIGN_KEYS_METADATA_KEY.to_string(), fk_json)]),
+                        ),
                         Err(e) => {
                             tracing::warn!(
                                 schema = %schema_name,
@@ -530,6 +532,32 @@ async fn build_table_providers_for_schema(
     }
 
     tables
+}
+
+fn add_metadata_to_table(
+    inner: Arc<dyn TableProvider>,
+    metadata: HashMap<String, String>,
+) -> Arc<dyn TableProvider> {
+    match inner
+        .as_any()
+        .downcast_ref::<FederatedTableProviderAdaptor>()
+    {
+        None => Arc::new(MetadataEnrichedTableProvider::new(inner, metadata)),
+        Some(FederatedTableProviderAdaptor {
+            source,
+            table_provider: Some(inner),
+        }) => Arc::new(FederatedTableProviderAdaptor::new_with_provider(
+            Arc::clone(&source),
+            Arc::new(MetadataEnrichedTableProvider::new(
+                Arc::clone(inner),
+                metadata,
+            )),
+        )),
+        Some(FederatedTableProviderAdaptor {
+            source,
+            table_provider: None,
+        }) => Arc::new(FederatedTableProviderAdaptor::new(Arc::clone(source))),
+    }
 }
 
 fn table_comments_metadata(comments: &TableComments) -> (HashMap<String, String>, FieldMetadata) {


### PR DESCRIPTION
## 📝 Summary
`MetadataEnrichedTableProvider` broke federation. This initially just affected postgres, but now more connectors.

## 🔗 Related
Bug introduced in #10849 
Extended in #10944

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782262051&installation_id=128462479&pr_number=11022&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11022&signature=9fdcde16040e813c6adca57ebd51f3b3d2e5c01b7816f0a3c9d75dcec32ef166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->