### PR TITLE
Fix Unity Catalog connector deserialization failure with OSS Unity Catalog

### DIFF
--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -578,10 +578,14 @@ pub struct UCColumn {
     pub name: String,
     pub type_text: String,
     pub type_name: String,
-    pub position: i64,
-    pub type_precision: i64,
-    pub type_scale: i64,
-    pub type_json: String,
+    #[serde(default)]
+    pub position: Option<i64>,
+    #[serde(default)]
+    pub type_precision: Option<i64>,
+    #[serde(default)]
+    pub type_scale: Option<i64>,
+    #[serde(default)]
+    pub type_json: Option<String>,
     pub nullable: bool,
 }
 

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -68,6 +68,8 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("aws_endpoint")
         .description("The AWS endpoint to use for S3 storage.")
         .secret(),
+    ParameterSpec::component("aws_allow_http")
+        .description("Enables insecure HTTP connections to the AWS endpoint. Defaults to false."),
     // Azure storage options
     ParameterSpec::component("azure_storage_account_name")
         .description("The storage account to use for Azure storage.")


### PR DESCRIPTION
## Problem

The Unity Catalog catalog connector fails to deserialize the `list_tables` API response from the OSS Unity Catalog server:

```
Failed to initialize catalog connector: Failed to setup the catalog uc (unity_catalog).
Failed to connect to the Unity Catalog API. Check the Unity Catalog API endpoint is valid and accessible.
The following connection error occurred: error decoding response body
```

The `UCColumn` struct required `type_precision`, `type_scale`, `position`, and `type_json` as non-nullable `i64`/`String`, while in the [Unity Catalog ColumnInfo schema](https://github.com/unitycatalog/unitycatalog/blob/47fc969b2f8668e96f4bb00ea148b318a329c7cd/api/all.yaml#L1635-L1674) these fields might be optional:

- `type_precision`: *"Digits of precision; required for DecimalTypes."*
- `type_scale`: *"Digits to right of decimal; Required for DecimalTypes."*
- `position`: *"Ordinal position of column (starting at position 0)."*
- `type_json`: *"Full data type specification, JSON-serialized."*

The OSS Unity Catalog returns `null` for these fields on non-decimal column types.

Additionally added  `aws_allow_http` to the Unity Catalog catalog connector parameter list to support HTTP S3-compatible endpoints (e.g. MinIO) for Delta Lake table storage.

Fixes #11002