### PR TITLE
feat(cayenne): allow inline writes with pending deletions (deletes/upserts)

### DIFF
--- a/crates/cayenne/src/provider/delete.rs
+++ b/crates/cayenne/src/provider/delete.rs
@@ -50,6 +50,6 @@ pub(crate) use sink::file_based::FileBasedDeletionSink;
 // Crate-internal types used by table.rs
 pub(crate) use filter_exec::{Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec};
 pub(crate) use vector_io::{
-    DeletionIdentifier, DeletionVectorWriteSpec, DeletionVectorWriter,
+    DeletionIdentifier, DeletionVectorWriteResult, DeletionVectorWriteSpec, DeletionVectorWriter,
     detect_deletion_type_and_read,
 };

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -1072,16 +1072,6 @@ mod tests {
         .expect("to create upsert batch");
         insert_batch(&provider, batch2).await;
 
-        let table_id = provider.table_id().to_string();
-        let pre_restart_insert_records = catalog
-            .get_insert_records(&table_id)
-            .await
-            .expect("Failed to read insert records before restart");
-        assert!(
-            !pre_restart_insert_records.is_empty(),
-            "Upsert should persist insert records in catalog"
-        );
-
         // Restart by creating fresh catalog/provider instances.
         drop(provider);
         drop(catalog);
@@ -1097,22 +1087,14 @@ mod tests {
         let catalog_trait2: Arc<dyn MetadataCatalog> =
             Arc::clone(&catalog2) as Arc<dyn MetadataCatalog>;
 
-        let persisted_insert_records = catalog2
-            .get_insert_records(&table_id)
-            .await
-            .expect("Failed to read insert records after restart");
-        assert!(
-            !persisted_insert_records.is_empty(),
-            "Insert records should survive restart"
-        );
-
         let ctx2 = SessionContext::new();
         let provider2 = CayenneTableProviderBuilder::new(catalog_trait2, ctx2.runtime_env())
             .open("users")
             .await
             .expect("Failed to reopen table after restart");
 
-        ctx2.register_table("users", Arc::new(provider2) as Arc<dyn TableProvider>)
+        let provider2 = Arc::new(provider2);
+        ctx2.register_table("users", Arc::clone(&provider2) as Arc<dyn TableProvider>)
             .expect("Failed to register reopened table");
 
         let df = ctx2

--- a/crates/cayenne/src/provider/mutation_writer.rs
+++ b/crates/cayenne/src/provider/mutation_writer.rs
@@ -341,7 +341,7 @@ impl<'a> AppendMutationWriter<'a> {
         );
 
         let inline_policy = InlineMutationPolicy::from_blocking_conditions([
-            pending_pk_deletions,
+            false,
             false,
             self.table.metadata().partition_column.is_some(),
             self.table.has_retention_delete_filters(),
@@ -506,15 +506,16 @@ impl<'a> AppendMutationWriter<'a> {
                 });
             }
 
-            if !state.on_conflict_deletions.has_file_deletions()
-                && self
-                    .table
-                    .try_inline_batches_with_inlined_deletions(
-                        buffer.batches(),
-                        &state.on_conflict_deletions.deleted_inlined_pk_i64,
-                        &state.on_conflict_deletions.deleted_inlined_row_keys,
-                    )
-                    .await?
+            if self
+                .table
+                .try_inline_batches_with_inlined_deletions(
+                    buffer.batches(),
+                    &state.on_conflict_deletions.deleted_inlined_pk_i64,
+                    &state.on_conflict_deletions.deleted_inlined_row_keys,
+                    &state.on_conflict_deletions.deleted_pk_i64,
+                    &state.on_conflict_deletions.deleted_row_keys,
+                )
+                .await?
             {
                 let stats_acc = ColumnStatsAccumulator::new(&schema);
                 for batch in buffer.batches() {

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -21,8 +21,9 @@ use super::constants::{
     DEFAULT_DATA_FILE_ID, STAGING_DIR_NAME, STAGING_WAL_FILENAME, STAGING_WAL_TMP_FILENAME,
 };
 use super::delete::{
-    CayenneDeletionSink, DeletionIdentifier, DeletionVectorWriteSpec, DeletionVectorWriter,
-    FileBasedDeletionSink, Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
+    CayenneDeletionSink, DeletionIdentifier, DeletionVectorWriteResult, DeletionVectorWriteSpec,
+    DeletionVectorWriter, FileBasedDeletionSink, Int64PkDeletionFilterExec,
+    KeyBasedDeletionFilterExec,
 };
 use super::mutation_writer::AppendMutationWriter;
 use super::streaming::StreamingExec;
@@ -1591,15 +1592,6 @@ pub(crate) struct OnConflictDeletions {
     pub(crate) deleted_inlined_pk_i64: Vec<i64>,
     /// Deleted inlined row keys.
     pub(crate) deleted_inlined_row_keys: Vec<Box<[u8]>>,
-}
-
-impl OnConflictDeletions {
-    #[must_use]
-    pub(crate) fn has_file_deletions(&self) -> bool {
-        !self.delete_specs.is_empty()
-            || !self.deleted_pk_i64.is_empty()
-            || !self.deleted_row_keys.is_empty()
-    }
 }
 
 #[derive(Clone)]
@@ -4578,6 +4570,49 @@ impl CayenneTableProvider {
         Ok(rewrite)
     }
 
+    /// Update the in-memory PK deletion cache to immediately hide file-backed
+    /// rows that have been superseded by inlined data.
+    fn update_file_deletion_cache(
+        &self,
+        deleted_pk_i64: &[i64],
+        deleted_row_keys: &[Box<[u8]>],
+        delete_sequence: i64,
+    ) {
+        match &self.pk_deletion_strategy {
+            PkDeletionStrategyWithCache::Int64Pk { deletion_snapshot } => {
+                if deleted_pk_i64.is_empty() {
+                    return;
+                }
+                let current = deletion_snapshot.load_full();
+                let updated_deleted = current
+                    .deleted_pk
+                    .extend_max(deleted_pk_i64.iter().map(|&pk| (pk, delete_sequence)));
+                deletion_snapshot.store(Arc::new(Int64PkDeletionSnapshot::from_arcs(
+                    Arc::new(updated_deleted),
+                    Arc::clone(&current.insert_records),
+                )));
+            }
+            PkDeletionStrategyWithCache::RowConverterBased { deletion_snapshot } => {
+                if deleted_row_keys.is_empty() {
+                    return;
+                }
+                let current = deletion_snapshot.load_full();
+                let updated_deleted = current.deleted_row_keys.extend_max(
+                    deleted_row_keys
+                        .iter()
+                        .map(|key| (key.clone(), delete_sequence)),
+                );
+                deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_arcs(
+                    Arc::new(updated_deleted),
+                    Arc::clone(&current.insert_records),
+                )));
+            }
+            PkDeletionStrategyWithCache::PositionBased { .. } => {
+                // Position-based tables don't support upserts.
+            }
+        }
+    }
+
     async fn commit_inlined_data_mutation(
         &self,
         rewrite: InlinedDataRewrite,
@@ -4608,6 +4643,74 @@ impl CayenneTableProvider {
         self.inlined_generation.fetch_add(1, Ordering::Release);
 
         Ok(())
+    }
+
+    /// Convert typed PK values into raw key bytes for deletion vector writing.
+    ///
+    /// For `Int64Pk` tables, encodes each i64 as big-endian bytes.
+    /// For `RowConverterBased` tables, passes through the already-encoded row keys.
+    /// Position-based tables don't support upserts and return an empty vec.
+    fn build_pk_deletion_row_keys(
+        &self,
+        deleted_pk_i64: &[i64],
+        deleted_row_keys: Vec<Box<[u8]>>,
+    ) -> Vec<Box<[u8]>> {
+        match &self.pk_deletion_strategy {
+            PkDeletionStrategyWithCache::Int64Pk { .. } => deleted_pk_i64
+                .iter()
+                .map(|&pk| pk.to_be_bytes().to_vec().into_boxed_slice())
+                .collect(),
+            PkDeletionStrategyWithCache::RowConverterBased { .. } => deleted_row_keys,
+            PkDeletionStrategyWithCache::PositionBased { .. } => vec![],
+        }
+    }
+
+    /// Write key-based deletion vectors to disk and commit them to the catalog.
+    ///
+    /// This is the shared mechanical step used by both the snapshot upsert path
+    /// ([`Self::apply_on_conflict_deletions`]) and the inline upsert path
+    /// ([`Self::persist_file_deletions_after_inlined_insert`]). It handles:
+    ///
+    /// 1. Building deletion vector specs from raw row keys
+    /// 2. Writing deletion vector files via [`DeletionVectorWriter`]
+    /// 3. Committing delete files + optional insert records to the catalog
+    async fn write_and_commit_deletion_vectors(
+        &self,
+        delete_sequence: i64,
+        row_keys: Vec<Box<[u8]>>,
+        insert_pk_bytes: Vec<Vec<u8>>,
+        insert_sequence: i64,
+    ) -> CatalogResult<Option<Vec<DeletionVectorWriteResult>>> {
+        if row_keys.is_empty() {
+            return Ok(None);
+        }
+
+        let mut temp_metadata = self.table_metadata.clone();
+        temp_metadata.current_sequence_number = delete_sequence;
+        let writer = DeletionVectorWriter::new(&temp_metadata);
+
+        let specs = vec![DeletionVectorWriteSpec::new_key_based(row_keys)];
+        let results = writer.write(specs).await?;
+
+        if results.is_empty() {
+            return Ok(None);
+        }
+
+        let delete_files: Vec<crate::metadata::DeleteFile> =
+            results.iter().map(|r| r.delete_file.clone()).collect();
+        self.catalog
+            .commit_on_conflict_deletions(
+                delete_files,
+                &self.table_metadata.table_id,
+                insert_pk_bytes,
+                insert_sequence,
+            )
+            .await
+            .map_err(|err| CatalogError::InvalidOperationNoSource {
+                message: format!("Failed to commit deletion vectors: {err}"),
+            })?;
+
+        Ok(Some(results))
     }
 
     /// Apply deletion vectors generated by on-conflict (upsert) handling.
@@ -4695,88 +4798,21 @@ impl CayenneTableProvider {
         let delete_sequence = base;
         let insert_sequence = base + 1;
 
-        // Create a temporary metadata with the fresh delete sequence number.
-        // The table_metadata's current_sequence_number is stale (set at table open time),
-        // so we must use the actual delete_sequence we just reserved.
-        let mut temp_metadata = self.table_metadata.clone();
-        temp_metadata.current_sequence_number = delete_sequence;
-        let writer = DeletionVectorWriter::new(&temp_metadata);
+        let row_keys = self.build_pk_deletion_row_keys(&deleted_pk_i64, deleted_row_keys);
+        let insert_pk_bytes: Vec<Vec<u8>> =
+            row_keys.iter().map(|key| key.as_ref().to_vec()).collect();
 
-        // For on-conflict (upsert) handling, use key-based deletion vectors.
-        // Position-based tables don't support upserts, so we always use row keys here.
-        // Move `deleted_row_keys` into the spec; the cache-extend block below
-        // takes owned keys from the write result so we avoid a Vec<Box<[u8]>>
-        // clone plus the per-element clones for both extend_max calls. See
-        // `benches/apply_on_conflict_keys_double_clone.rs`.
-        let row_keys_for_deletion: Vec<Box<[u8]>> = match &self.pk_deletion_strategy {
-            PkDeletionStrategyWithCache::Int64Pk { .. } => deleted_pk_i64
-                .iter()
-                .map(|&pk| pk.to_be_bytes().to_vec().into_boxed_slice())
-                .collect(),
-            PkDeletionStrategyWithCache::RowConverterBased { .. } => deleted_row_keys,
-            PkDeletionStrategyWithCache::PositionBased { .. } => {
-                // Position-based tables don't support upserts
-                vec![]
-            }
-        };
-
-        let pk_bytes_list_for_insert_records: Vec<Vec<u8>> = row_keys_for_deletion
-            .iter()
-            .map(|key| key.as_ref().to_vec())
-            .collect();
-
-        let specs = if row_keys_for_deletion.is_empty() {
-            vec![]
-        } else {
-            vec![DeletionVectorWriteSpec::new_key_based(
-                row_keys_for_deletion,
-            )]
-        };
-
-        let results = writer.write(specs).await?;
-
-        if results.is_empty() {
-            return Ok(());
-        }
-
-        // Track new position-based deletions for the in-memory cache update
-        // below. This walks the same `results` list we'd otherwise enumerate
-        // during per-file `add_delete_file` calls.
-        let mut new_deleted_rows = RoaringBitmap::new();
-        for result in &results {
-            if let DeletionIdentifier::PositionBased { row_ids, .. } = &result.identifiers {
-                for &row_id in row_ids {
-                    if let Ok(row_id_u32) = u32::try_from(row_id) {
-                        new_deleted_rows.insert(row_id_u32);
-                    }
-                }
-            }
-        }
-
-        // Atomically commit every delete-file row AND every insert-record row
-        // in one catalog transaction. Replaces the legacy
-        // `add_delete_file × N` + `add_insert_records_batch` sequence which
-        // left a crash window where deletion records could persist without
-        // their corresponding insert sequences — see
-        // `crates/cayenne/benches/apply_on_conflict_rpc_ceiling.rs` for the
-        // metastore call-count shape and atomicity tradeoff.
-        let delete_files: Vec<crate::metadata::DeleteFile> =
-            results.iter().map(|r| r.delete_file.clone()).collect();
-        self.catalog
-            .commit_on_conflict_deletions(
-                delete_files,
-                &self.table_metadata.table_id,
-                pk_bytes_list_for_insert_records,
+        let Some(results) = self
+            .write_and_commit_deletion_vectors(
+                delete_sequence,
+                row_keys,
+                insert_pk_bytes,
                 insert_sequence,
             )
-            .await
-            .map_err(|err| CatalogError::InvalidOperationNoSource {
-                message: format!("Failed to commit on-conflict deletions: {err}"),
-            })?;
-
-        // For PK-based strategies, keep old delete files to preserve deletion history.
-        // Each upsert round may affect a different subset of PKs, so removing old files
-        // would lose deletion records for PKs not in the current round.
+            .await?
+        else {
+            return Ok(());
+        };
 
         // Update the appropriate cache based on deletion strategy.
         // This follows Iceberg's pattern where deletes are tracked by PK + sequence number.
@@ -4858,6 +4894,36 @@ impl CayenneTableProvider {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    /// Persist file-backed PK deletion vectors to disk for durability.
+    ///
+    /// Called after replacement data has been inlined and the in-memory deletion
+    /// cache has already been updated (by [`Self::update_file_deletion_cache`]
+    /// inside [`Self::try_inline_batches_with_inlined_deletions`]). This method
+    /// writes the durable deletion vectors and commits them to the catalog so
+    /// that the deletions survive a restart.
+    pub(crate) async fn persist_file_deletions_after_inlined_insert(
+        &self,
+        deleted_pk_i64: &[i64],
+        deleted_row_keys: &[Box<[u8]>],
+        delete_sequence: i64,
+    ) -> CatalogResult<()> {
+        let has_file_deletions = !deleted_pk_i64.is_empty() || !deleted_row_keys.is_empty();
+
+        if !has_file_deletions {
+            return Ok(());
+        }
+
+        let row_keys = self.build_pk_deletion_row_keys(deleted_pk_i64, deleted_row_keys.to_vec());
+
+        // Commit delete files only — no insert records (inline data bypasses
+        // the deletion filter, so no protected insert sequence is needed).
+        // The in-memory deletion cache was already updated by the caller.
+        self.write_and_commit_deletion_vectors(delete_sequence, row_keys, vec![], 0)
+            .await?;
 
         Ok(())
     }
@@ -6452,6 +6518,8 @@ impl CayenneTableProvider {
         batches: &[RecordBatch],
         deleted_inlined_pk_i64: &[i64],
         deleted_inlined_row_keys: &[Box<[u8]>],
+        file_deleted_pk_i64: &[i64],
+        file_deleted_row_keys: &[Box<[u8]>],
     ) -> Result<bool> {
         let total_rows = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
         if total_rows == 0 {
@@ -6467,6 +6535,30 @@ impl CayenneTableProvider {
         if ipc_bytes.len() > inline_max_bytes {
             return Ok(false);
         }
+
+        // --- Past this point, inlining WILL proceed (all size checks passed). ---
+
+        let has_file_deletions =
+            !file_deleted_pk_i64.is_empty() || !file_deleted_row_keys.is_empty();
+
+        // Reserve the deletion sequence BEFORE `commit_inlined_data_mutation` so
+        // the inline entry gets a strictly higher sequence number.
+        let delete_seq = if has_file_deletions {
+            Some(
+                self.catalog
+                    .increment_sequence_number(&self.table_metadata.table_id)
+                    .await
+                    .map_err(|err| Error::Catalog {
+                        source: CatalogError::InvalidOperationNoSource {
+                            message: format!(
+                                "Failed to pre-reserve deletion sequence for inline insert: {err}"
+                            ),
+                        },
+                    })?,
+            )
+        } else {
+            None
+        };
 
         let rewrite = self
             .build_inlined_data_rewrite_for_pk_keys(
@@ -6488,11 +6580,26 @@ impl CayenneTableProvider {
         )
         .await?;
 
+        // Update in-memory deletion cache and persist deletion vectors for
+        // file-backed PKs replaced by the inlined data.
+        if let Some(delete_seq) = delete_seq {
+            self.update_file_deletion_cache(file_deleted_pk_i64, file_deleted_row_keys, delete_seq);
+
+            self.persist_file_deletions_after_inlined_insert(
+                file_deleted_pk_i64,
+                file_deleted_row_keys,
+                delete_seq,
+            )
+            .await
+            .map_err(|err| Error::Catalog { source: err })?;
+        }
+
         tracing::debug!(
-            "Inlined {} rows for table {} after removing {} replaced inline row(s)",
+            "Inlined {} rows for table {} after removing {} replaced inline row(s), file_pk_deletions={}",
             total_rows,
             self.table_metadata.table_name,
             removed_rows,
+            file_deleted_pk_i64.len() + file_deleted_row_keys.len(),
         );
 
         Ok(true)

--- a/crates/cayenne/tests/inline_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/inline_with_pending_deletions_test.rs
@@ -531,3 +531,224 @@ async fn test_checkpoint_after_inlined_upsert_impl(fixture: TestFixture) -> Test
 }
 
 test_with_backends!(test_checkpoint_after_inlined_upsert_impl);
+
+// =============================================================================
+// Test 7: Two successive inline upserts on same PK
+// =============================================================================
+//
+// Insert to file → upsert PK (inlined) → upsert same PK again (inlined).
+// The second upsert must see the first inline row as a conflict source,
+// rewrite the inline entry, and only the latest value should be visible.
+// Also verifies correctness after restart.
+
+async fn test_double_inline_upsert_same_pk_impl(fixture: TestFixture) -> TestResult<()> {
+    let schema = simple_schema();
+    let (table, ctx) = setup_table(
+        &fixture,
+        "dbl_upsert",
+        Arc::clone(&schema),
+        vec!["id".into()],
+    )
+    .await?;
+
+    // Initial insert to file.
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+    assert_eq!(row_count(&ctx, "dbl_upsert").await?, n);
+
+    // First inline upsert: PK 0 → value 1111.
+    let upsert1 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![0])),
+            Arc::new(Int64Array::from(vec![1111])),
+        ],
+    )?;
+    insert_batch(&table, upsert1).await?;
+
+    // Second inline upsert: PK 0 → value 2222 (conflict is now the inline row).
+    let upsert2 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![0])),
+            Arc::new(Int64Array::from(vec![2222])),
+        ],
+    )?;
+    insert_batch(&table, upsert2).await?;
+
+    // Row count unchanged — no duplicates.
+    assert_eq!(row_count(&ctx, "dbl_upsert").await?, n);
+
+    // Only the latest value is visible.
+    let v = query_value(&ctx, "SELECT value FROM dbl_upsert WHERE id = 0").await?;
+    assert_eq!(v, vec![2222], "second upsert value should win");
+
+    // ---- Restart ----
+    let connection_string = format!("sqlite://{}", fixture.db_path().to_string_lossy());
+    drop(table);
+    drop(ctx);
+
+    let catalog2 = Arc::new(CayenneCatalog::new(&connection_string)?);
+    catalog2.init().await?;
+    let catalog_trait2: Arc<dyn MetadataCatalog> =
+        Arc::clone(&catalog2) as Arc<dyn MetadataCatalog>;
+
+    let ctx2 = SessionContext::new();
+    let provider2 = cayenne::CayenneTableProviderBuilder::new(catalog_trait2, ctx2.runtime_env())
+        .open("dbl_upsert")
+        .await?;
+    let provider2 = Arc::new(provider2);
+    ctx2.register_table(
+        "dbl_upsert",
+        Arc::clone(&provider2) as Arc<dyn TableProvider>,
+    )?;
+
+    assert_eq!(row_count(&ctx2, "dbl_upsert").await?, n);
+    let v = query_value(&ctx2, "SELECT value FROM dbl_upsert WHERE id = 0").await?;
+    assert_eq!(v, vec![2222], "latest value should survive restart");
+
+    Ok(())
+}
+
+test_with_backends!(test_double_inline_upsert_same_pk_impl);
+
+// =============================================================================
+// Test 8: Delete of an inlined PK
+// =============================================================================
+//
+// Insert to file → upsert PK (inlined) → delete that same PK.
+// The delete must remove both the file-backed deletion vector AND the inline
+// row, resulting in 0 rows for that PK.
+
+async fn test_delete_of_inlined_pk_impl(fixture: TestFixture) -> TestResult<()> {
+    let schema = simple_schema();
+    let (table, ctx) = setup_table(
+        &fixture,
+        "del_inline",
+        Arc::clone(&schema),
+        vec!["id".into()],
+    )
+    .await?;
+
+    // Initial insert to file.
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+    assert_eq!(row_count(&ctx, "del_inline").await?, n);
+
+    // Upsert PK 0 → inlined with new value.
+    let upsert = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![0])),
+            Arc::new(Int64Array::from(vec![9999])),
+        ],
+    )?;
+    insert_batch(&table, upsert).await?;
+
+    // Verify upsert worked.
+    let v = query_value(&ctx, "SELECT value FROM del_inline WHERE id = 0").await?;
+    assert_eq!(v, vec![9999]);
+
+    // Delete PK 0 — must remove the inlined row too.
+    delete_by_id(&table, 0).await?;
+
+    // PK 0 is gone entirely.
+    let v = query_value(&ctx, "SELECT value FROM del_inline WHERE id = 0").await?;
+    assert!(v.is_empty(), "deleted inlined PK should not be visible");
+
+    // Total rows decreased by 1.
+    assert_eq!(row_count(&ctx, "del_inline").await?, n - 1);
+
+    Ok(())
+}
+
+test_with_backends!(test_delete_of_inlined_pk_impl);
+
+// =============================================================================
+// Test 9: Mixed inline + file conflicts in one upsert batch
+// =============================================================================
+//
+// Insert to file → upsert PK A (inlined) → upsert batch containing both PK A
+// (conflict with inline) and PK B (conflict with file).  Both conflict sources
+// must be resolved in a single `try_inline_batches_with_inlined_deletions` call.
+
+async fn test_mixed_inline_and_file_conflicts_impl(fixture: TestFixture) -> TestResult<()> {
+    let schema = simple_schema();
+    let (table, ctx) = setup_table(
+        &fixture,
+        "mixed_conflict",
+        Arc::clone(&schema),
+        vec!["id".into()],
+    )
+    .await?;
+
+    // Initial insert to file: ids 0..n.
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+    assert_eq!(row_count(&ctx, "mixed_conflict").await?, n);
+
+    // Upsert PK 0 → inlined (conflict with file, now PK 0 lives inline).
+    let upsert1 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![0])),
+            Arc::new(Int64Array::from(vec![1000])),
+        ],
+    )?;
+    insert_batch(&table, upsert1).await?;
+
+    // Now upsert both PK 0 (inline conflict) and PK 1 (file conflict) together.
+    let upsert_mixed = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![0, 1])),
+            Arc::new(Int64Array::from(vec![5555, 6666])),
+        ],
+    )?;
+    insert_batch(&table, upsert_mixed).await?;
+
+    // Row count unchanged — two replacements, no new PKs.
+    assert_eq!(row_count(&ctx, "mixed_conflict").await?, n);
+
+    // Both PKs have latest values.
+    let v0 = query_value(&ctx, "SELECT value FROM mixed_conflict WHERE id = 0").await?;
+    assert_eq!(v0, vec![5555], "PK 0 should have mixed-upsert value");
+
+    let v1 = query_value(&ctx, "SELECT value FROM mixed_conflict WHERE id = 1").await?;
+    assert_eq!(v1, vec![6666], "PK 1 should have mixed-upsert value");
+
+    // Other PKs untouched.
+    let v2 = query_value(&ctx, "SELECT value FROM mixed_conflict WHERE id = 2").await?;
+    assert_eq!(v2, vec![20], "PK 2 should be unchanged");
+
+    Ok(())
+}
+
+test_with_backends!(test_mixed_inline_and_file_conflicts_impl);

--- a/crates/cayenne/tests/inline_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/inline_with_pending_deletions_test.rs
@@ -1,0 +1,521 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Tests that inline writes proceed when pending deletions exist and when
+//! upserts conflict with file-backed PKs.
+
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use cayenne::metadata::DEFAULT_INLINE_MAX_ROWS;
+use cayenne::{
+    CayenneCatalog, CayenneTableProvider, MetadataCatalog, metadata::CreateTableOptions,
+};
+use common::TestFixture;
+use datafusion::datasource::TableProvider;
+use datafusion::execution::context::SessionContext;
+use datafusion::prelude::{col, lit};
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+use std::sync::Arc;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn simple_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]))
+}
+
+fn utf8_pk_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("email", DataType::Utf8, false),
+        Field::new("items_bought", DataType::Int64, false),
+    ]))
+}
+
+async fn setup_table(
+    fixture: &TestFixture,
+    table_name: &str,
+    schema: Arc<Schema>,
+    primary_key: Vec<String>,
+) -> TestResult<(Arc<CayenneTableProvider>, SessionContext)> {
+    let table_options = CreateTableOptions {
+        table_name: table_name.to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: primary_key.clone(),
+        on_conflict: Some(OnConflict::Upsert(ColumnReference::new(primary_key))),
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: cayenne::metadata::VortexConfig::default(),
+    };
+
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let ctx = SessionContext::new();
+    let table = Arc::new(
+        CayenneTableProvider::create_table(catalog, table_options, ctx.runtime_env()).await?,
+    );
+    ctx.register_table(table_name, Arc::clone(&table) as Arc<dyn TableProvider>)?;
+    Ok((table, ctx))
+}
+
+async fn insert_batch(table: &CayenneTableProvider, batch: RecordBatch) -> TestResult<u64> {
+    common::insert_batch(table, batch).await.map_err(Into::into)
+}
+
+async fn query_value(ctx: &SessionContext, sql: &str) -> TestResult<Vec<i64>> {
+    let df = ctx.sql(sql).await?;
+    let batches = df.collect().await?;
+    let mut values = Vec::new();
+    for batch in &batches {
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("expected Int64Array");
+        for i in 0..col.len() {
+            values.push(col.value(i));
+        }
+    }
+    Ok(values)
+}
+
+async fn row_count(ctx: &SessionContext, table_name: &str) -> TestResult<usize> {
+    let df = ctx.sql(&format!("SELECT * FROM {table_name}")).await?;
+    let batches = df.collect().await?;
+    Ok(batches.iter().map(RecordBatch::num_rows).sum())
+}
+
+async fn delete_by_id(table: &CayenneTableProvider, id: i64) -> TestResult<u64> {
+    let ctx = SessionContext::new();
+    let plan = table
+        .delete_from(&ctx.state(), vec![col("id").eq(lit(id))])
+        .await?;
+    let results = datafusion_physical_plan::collect(plan, ctx.task_ctx()).await?;
+    Ok(results
+        .first()
+        .and_then(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .and_then(|a| a.values().first())
+        .copied()
+        .unwrap_or(0))
+}
+
+// =============================================================================
+// Test 1: Insert goes inline despite pending deletions
+// =============================================================================
+//
+// Write rows to file → delete one PK → insert a *new* PK.
+// The new PK must be inlined (not fall through to a protected snapshot),
+// and query results must be correct.
+
+async fn test_insert_inlines_despite_pending_deletions_impl(
+    fixture: TestFixture,
+) -> TestResult<()> {
+    let schema = simple_schema();
+    let (table, ctx) =
+        setup_table(&fixture, "pending_del", schema.clone(), vec!["id".into()]).await?;
+
+    // Initial insert: enough rows to go to file (exceeds inline limit).
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+
+    // Verify initial state.
+    assert_eq!(row_count(&ctx, "pending_del").await?, n);
+
+    // Delete PK 0 → creates a pending deletion in the cache.
+    delete_by_id(&table, 0).await?;
+
+    // Insert a NEW PK (not conflicting) while pending deletions exist.
+    // Previously this fell through to a protected snapshot; now it should inline.
+    let new_id = i64::try_from(n)? + 100;
+    let new_batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![new_id])),
+            Arc::new(Int64Array::from(vec![9999])),
+        ],
+    )?;
+    insert_batch(&table, new_batch).await?;
+
+    // Query correctness: total rows = n - 1 (deleted PK 0) + 1 (new PK).
+    assert_eq!(row_count(&ctx, "pending_del").await?, n);
+
+    // The new PK is queryable with the correct value.
+    let vals = query_value(
+        &ctx,
+        &format!("SELECT value FROM pending_del WHERE id = {new_id}"),
+    )
+    .await?;
+    assert_eq!(vals, vec![9999]);
+
+    // Deleted PK 0 is gone.
+    let vals = query_value(&ctx, "SELECT value FROM pending_del WHERE id = 0").await?;
+    assert!(vals.is_empty(), "deleted PK 0 should not be visible");
+
+    Ok(())
+}
+
+test_with_backends!(test_insert_inlines_despite_pending_deletions_impl);
+
+// =============================================================================
+// Test 2: Upsert with file-backed conflict inlines + writes deletion vector
+// =============================================================================
+//
+// Write PK to file → upsert same PK with new value.
+// The replacement must be inlined, the old file-backed row hidden by a
+// deletion vector, and queries return only the new value.
+
+async fn test_upsert_file_conflict_inlines_impl(fixture: TestFixture) -> TestResult<()> {
+    let schema = simple_schema();
+    let (table, ctx) =
+        setup_table(&fixture, "file_upsert", schema.clone(), vec!["id".into()]).await?;
+
+    // Initial insert: exceeds inline limit so data goes to file.
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+    assert_eq!(row_count(&ctx, "file_upsert").await?, n);
+
+    // Upsert PK 0 with a new value (1 row → fits inline).
+    let upsert_batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![0])),
+            Arc::new(Int64Array::from(vec![7777])),
+        ],
+    )?;
+    insert_batch(&table, upsert_batch).await?;
+
+    // Total row count unchanged (upsert replaces, not duplicates).
+    assert_eq!(row_count(&ctx, "file_upsert").await?, n);
+
+    // PK 0 returns the updated value.
+    let vals = query_value(&ctx, "SELECT value FROM file_upsert WHERE id = 0").await?;
+    assert_eq!(vals, vec![7777], "PK 0 should have the upserted value");
+
+    Ok(())
+}
+
+test_with_backends!(test_upsert_file_conflict_inlines_impl);
+
+// =============================================================================
+// Test 3: Inlined upsert survives restart
+// =============================================================================
+//
+// Same as test 2 but verifies correctness after dropping the provider and
+// reopening from the catalog.  This exercises the pre-reserved deletion
+// sequence ordering that keeps `filter_inlined_batch_for_deletions` from
+// discarding the inline row.
+
+async fn test_inlined_upsert_survives_restart_impl(fixture: TestFixture) -> TestResult<()> {
+    let schema = utf8_pk_schema();
+    let (table, _ctx) = setup_table(
+        &fixture,
+        "restart_tbl",
+        schema.clone(),
+        vec!["email".into()],
+    )
+    .await?;
+
+    // Initial insert: large enough to go to file.
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let mut emails: Vec<String> = (0..n).map(|i| format!("user{i}@test.com")).collect();
+    emails[0] = "alice@test.com".to_string();
+    let mut vals: Vec<i64> = (0..i64::try_from(n)?).collect();
+    vals[0] = 100;
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(emails)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+
+    // Upsert alice with new value → inlined.
+    let upsert = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["alice@test.com"])),
+            Arc::new(Int64Array::from(vec![999])),
+        ],
+    )?;
+    insert_batch(&table, upsert).await?;
+
+    let connection_string = format!("sqlite://{}", fixture.db_path().to_string_lossy());
+
+    // ---- Restart ----
+    drop(table);
+
+    let catalog2 = Arc::new(CayenneCatalog::new(&connection_string)?);
+    catalog2.init().await?;
+    let catalog_trait2: Arc<dyn MetadataCatalog> =
+        Arc::clone(&catalog2) as Arc<dyn MetadataCatalog>;
+
+    let ctx2 = SessionContext::new();
+    let provider2 = cayenne::CayenneTableProviderBuilder::new(catalog_trait2, ctx2.runtime_env())
+        .open("restart_tbl")
+        .await?;
+    let provider2 = Arc::new(provider2);
+    ctx2.register_table(
+        "restart_tbl",
+        Arc::clone(&provider2) as Arc<dyn TableProvider>,
+    )?;
+
+    // Alice must still be visible with the upserted value.
+    let vals = query_value(
+        &ctx2,
+        "SELECT items_bought FROM restart_tbl WHERE email = 'alice@test.com'",
+    )
+    .await?;
+    assert_eq!(
+        vals,
+        vec![999],
+        "alice should have the upserted value after restart"
+    );
+
+    // Total row count is preserved.
+    assert_eq!(row_count(&ctx2, "restart_tbl").await?, n);
+
+    Ok(())
+}
+
+test_with_backends!(test_inlined_upsert_survives_restart_impl);
+
+// =============================================================================
+// Test 4: Interleaved delete + insert + upsert (TPC-C pattern)
+// =============================================================================
+//
+// Simulates TPC-C new_order: delete oldest PK, insert newest PK, upsert an
+// existing PK — all while pending deletions exist.
+
+async fn test_interleaved_delete_insert_upsert_impl(fixture: TestFixture) -> TestResult<()> {
+    let schema = simple_schema();
+    let (table, ctx) = setup_table(&fixture, "tpcc", schema.clone(), vec!["id".into()]).await?;
+
+    // Initial insert to file: ids 1..=N.
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let ids: Vec<i64> = (1..=i64::try_from(n)?).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+    assert_eq!(row_count(&ctx, "tpcc").await?, n);
+
+    // Round 1: delete id=1, insert new id=N+1, upsert id=2.
+    let high = i64::try_from(n)? + 1;
+    delete_by_id(&table, 1).await?;
+
+    let insert_batch_1 = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![high])),
+            Arc::new(Int64Array::from(vec![high * 10])),
+        ],
+    )?;
+    insert_batch(&table, insert_batch_1).await?;
+
+    let upsert_batch_1 = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![2])),
+            Arc::new(Int64Array::from(vec![2222])),
+        ],
+    )?;
+    insert_batch(&table, upsert_batch_1).await?;
+
+    // Row count: n - 1 (del id=1) + 1 (new id=N+1) = n. Upsert replaces, no change.
+    assert_eq!(row_count(&ctx, "tpcc").await?, n);
+
+    // Verify values.
+    let v = query_value(&ctx, "SELECT value FROM tpcc WHERE id = 1").await?;
+    assert!(v.is_empty(), "id=1 should be deleted");
+
+    let v = query_value(&ctx, &format!("SELECT value FROM tpcc WHERE id = {high}")).await?;
+    assert_eq!(v, vec![high * 10], "newly inserted id should be visible");
+
+    let v = query_value(&ctx, "SELECT value FROM tpcc WHERE id = 2").await?;
+    assert_eq!(v, vec![2222], "upserted id=2 should have new value");
+
+    // Round 2: another cycle while prior pending deletions exist.
+    let high2 = high + 1;
+    delete_by_id(&table, 3).await?;
+
+    let insert_batch_2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![high2])),
+            Arc::new(Int64Array::from(vec![high2 * 10])),
+        ],
+    )?;
+    insert_batch(&table, insert_batch_2).await?;
+
+    // n - 1 (del id=3) + 1 (new id=high2) = n.
+    assert_eq!(row_count(&ctx, "tpcc").await?, n);
+
+    Ok(())
+}
+
+test_with_backends!(test_interleaved_delete_insert_upsert_impl);
+
+// =============================================================================
+// Test 5: Composite PK (RowConverterBased) upsert with file conflict inlines
+// =============================================================================
+//
+// Same as test 2 but with a composite primary key to exercise the
+// `RowConverterBased` deletion strategy branch.
+
+async fn test_composite_pk_upsert_file_conflict_inlines_impl(
+    fixture: TestFixture,
+) -> TestResult<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("region", DataType::Utf8, false),
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+    let (table, ctx) = setup_table(
+        &fixture,
+        "composite_pk",
+        schema.clone(),
+        vec!["region".into(), "id".into()],
+    )
+    .await?;
+
+    // Initial insert to file.
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let regions: Vec<String> = (0..n)
+        .map(|i| if i % 2 == 0 { "east" } else { "west" }.into())
+        .collect();
+    let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(regions)),
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+    assert_eq!(row_count(&ctx, "composite_pk").await?, n);
+
+    // Upsert (east, 0) → inlined.
+    let upsert = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["east"])),
+            Arc::new(Int64Array::from(vec![0])),
+            Arc::new(Int64Array::from(vec![5555])),
+        ],
+    )?;
+    insert_batch(&table, upsert).await?;
+
+    assert_eq!(row_count(&ctx, "composite_pk").await?, n);
+
+    let v = query_value(
+        &ctx,
+        "SELECT value FROM composite_pk WHERE region = 'east' AND id = 0",
+    )
+    .await?;
+    assert_eq!(v, vec![5555], "composite PK upsert should return new value");
+
+    Ok(())
+}
+
+test_with_backends!(test_composite_pk_upsert_file_conflict_inlines_impl);
+
+// =============================================================================
+// Test 6: Checkpoint after inlined upsert materialises correctly
+// =============================================================================
+//
+// After an inlined upsert with file-backed conflict, trigger a checkpoint and
+// verify the data is correct in the flushed state.
+
+async fn test_checkpoint_after_inlined_upsert_impl(fixture: TestFixture) -> TestResult<()> {
+    let schema = simple_schema();
+    let (table, ctx) = setup_table(&fixture, "ckpt", schema.clone(), vec!["id".into()]).await?;
+
+    // Initial insert to file.
+    let n = DEFAULT_INLINE_MAX_ROWS + 1;
+    let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )?;
+    insert_batch(&table, batch).await?;
+
+    // Upsert PK 0 → inlined.
+    let upsert = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![0])),
+            Arc::new(Int64Array::from(vec![4242])),
+        ],
+    )?;
+    insert_batch(&table, upsert).await?;
+
+    // Checkpoint: flush inline data to a Vortex file.
+    table.checkpoint_inlined_data().await?;
+
+    // Data correctness survives checkpoint.
+    assert_eq!(row_count(&ctx, "ckpt").await?, n);
+    let v = query_value(&ctx, "SELECT value FROM ckpt WHERE id = 0").await?;
+    assert_eq!(v, vec![4242], "upserted value should survive checkpoint");
+
+    Ok(())
+}
+
+test_with_backends!(test_checkpoint_after_inlined_upsert_impl);

--- a/crates/cayenne/tests/inline_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/inline_with_pending_deletions_test.rs
@@ -139,15 +139,20 @@ async fn test_insert_inlines_despite_pending_deletions_impl(
     fixture: TestFixture,
 ) -> TestResult<()> {
     let schema = simple_schema();
-    let (table, ctx) =
-        setup_table(&fixture, "pending_del", schema.clone(), vec!["id".into()]).await?;
+    let (table, ctx) = setup_table(
+        &fixture,
+        "pending_del",
+        Arc::clone(&schema),
+        vec!["id".into()],
+    )
+    .await?;
 
     // Initial insert: enough rows to go to file (exceeds inline limit).
     let n = DEFAULT_INLINE_MAX_ROWS + 1;
     let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
     let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
     let batch = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(ids)),
             Arc::new(Int64Array::from(vals)),
@@ -165,7 +170,7 @@ async fn test_insert_inlines_despite_pending_deletions_impl(
     // Previously this fell through to a protected snapshot; now it should inline.
     let new_id = i64::try_from(n)? + 100;
     let new_batch = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(vec![new_id])),
             Arc::new(Int64Array::from(vec![9999])),
@@ -203,15 +208,20 @@ test_with_backends!(test_insert_inlines_despite_pending_deletions_impl);
 
 async fn test_upsert_file_conflict_inlines_impl(fixture: TestFixture) -> TestResult<()> {
     let schema = simple_schema();
-    let (table, ctx) =
-        setup_table(&fixture, "file_upsert", schema.clone(), vec!["id".into()]).await?;
+    let (table, ctx) = setup_table(
+        &fixture,
+        "file_upsert",
+        Arc::clone(&schema),
+        vec!["id".into()],
+    )
+    .await?;
 
     // Initial insert: exceeds inline limit so data goes to file.
     let n = DEFAULT_INLINE_MAX_ROWS + 1;
     let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
     let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
     let batch = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(ids)),
             Arc::new(Int64Array::from(vals)),
@@ -222,7 +232,7 @@ async fn test_upsert_file_conflict_inlines_impl(fixture: TestFixture) -> TestRes
 
     // Upsert PK 0 with a new value (1 row → fits inline).
     let upsert_batch = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(vec![0])),
             Arc::new(Int64Array::from(vec![7777])),
@@ -256,7 +266,7 @@ async fn test_inlined_upsert_survives_restart_impl(fixture: TestFixture) -> Test
     let (table, _ctx) = setup_table(
         &fixture,
         "restart_tbl",
-        schema.clone(),
+        Arc::clone(&schema),
         vec!["email".into()],
     )
     .await?;
@@ -268,7 +278,7 @@ async fn test_inlined_upsert_survives_restart_impl(fixture: TestFixture) -> Test
     let mut vals: Vec<i64> = (0..i64::try_from(n)?).collect();
     vals[0] = 100;
     let batch = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(StringArray::from(emails)),
             Arc::new(Int64Array::from(vals)),
@@ -278,7 +288,7 @@ async fn test_inlined_upsert_survives_restart_impl(fixture: TestFixture) -> Test
 
     // Upsert alice with new value → inlined.
     let upsert = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(StringArray::from(vec!["alice@test.com"])),
             Arc::new(Int64Array::from(vec![999])),
@@ -335,14 +345,15 @@ test_with_backends!(test_inlined_upsert_survives_restart_impl);
 
 async fn test_interleaved_delete_insert_upsert_impl(fixture: TestFixture) -> TestResult<()> {
     let schema = simple_schema();
-    let (table, ctx) = setup_table(&fixture, "tpcc", schema.clone(), vec!["id".into()]).await?;
+    let (table, ctx) =
+        setup_table(&fixture, "tpcc", Arc::clone(&schema), vec!["id".into()]).await?;
 
     // Initial insert to file: ids 1..=N.
     let n = DEFAULT_INLINE_MAX_ROWS + 1;
     let ids: Vec<i64> = (1..=i64::try_from(n)?).collect();
     let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
     let batch = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(ids)),
             Arc::new(Int64Array::from(vals)),
@@ -356,7 +367,7 @@ async fn test_interleaved_delete_insert_upsert_impl(fixture: TestFixture) -> Tes
     delete_by_id(&table, 1).await?;
 
     let insert_batch_1 = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(vec![high])),
             Arc::new(Int64Array::from(vec![high * 10])),
@@ -365,7 +376,7 @@ async fn test_interleaved_delete_insert_upsert_impl(fixture: TestFixture) -> Tes
     insert_batch(&table, insert_batch_1).await?;
 
     let upsert_batch_1 = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(vec![2])),
             Arc::new(Int64Array::from(vec![2222])),
@@ -391,7 +402,7 @@ async fn test_interleaved_delete_insert_upsert_impl(fixture: TestFixture) -> Tes
     delete_by_id(&table, 3).await?;
 
     let insert_batch_2 = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(vec![high2])),
             Arc::new(Int64Array::from(vec![high2 * 10])),
@@ -425,7 +436,7 @@ async fn test_composite_pk_upsert_file_conflict_inlines_impl(
     let (table, ctx) = setup_table(
         &fixture,
         "composite_pk",
-        schema.clone(),
+        Arc::clone(&schema),
         vec!["region".into(), "id".into()],
     )
     .await?;
@@ -438,7 +449,7 @@ async fn test_composite_pk_upsert_file_conflict_inlines_impl(
     let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
     let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
     let batch = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(StringArray::from(regions)),
             Arc::new(Int64Array::from(ids)),
@@ -450,7 +461,7 @@ async fn test_composite_pk_upsert_file_conflict_inlines_impl(
 
     // Upsert (east, 0) → inlined.
     let upsert = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(StringArray::from(vec!["east"])),
             Arc::new(Int64Array::from(vec![0])),
@@ -482,14 +493,15 @@ test_with_backends!(test_composite_pk_upsert_file_conflict_inlines_impl);
 
 async fn test_checkpoint_after_inlined_upsert_impl(fixture: TestFixture) -> TestResult<()> {
     let schema = simple_schema();
-    let (table, ctx) = setup_table(&fixture, "ckpt", schema.clone(), vec!["id".into()]).await?;
+    let (table, ctx) =
+        setup_table(&fixture, "ckpt", Arc::clone(&schema), vec!["id".into()]).await?;
 
     // Initial insert to file.
     let n = DEFAULT_INLINE_MAX_ROWS + 1;
     let ids: Vec<i64> = (0..i64::try_from(n)?).collect();
     let vals: Vec<i64> = ids.iter().map(|i| i * 10).collect();
     let batch = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(ids)),
             Arc::new(Int64Array::from(vals)),
@@ -499,7 +511,7 @@ async fn test_checkpoint_after_inlined_upsert_impl(fixture: TestFixture) -> Test
 
     // Upsert PK 0 → inlined.
     let upsert = RecordBatch::try_new(
-        schema.clone(),
+        Arc::clone(&schema),
         vec![
             Arc::new(Int64Array::from(vec![0])),
             Arc::new(Int64Array::from(vec![4242])),


### PR DESCRIPTION
## 📝 Summary

When CDC writes arrive with pending PK deletions or upsert conflicts against file-backed rows, Cayenne blocked the inline memtable path and fell through to `write_new_snapshot_after_validation`. This created a new Vortex file + protected snapshot per CDC micro-batch (often 1 row), causing hundreds of tiny snapshots and compaction storms in TPC-C workloads where inserts and deletes are constantly interleaved.

### Changes

- Remove `pending_pk_deletions` as an inline-blocking condition — prior deletions in the cache don't conflict with new inline inserts, which are UNION'd after the deletion filter at scan time.
- Remove `has_file_deletions()` gate from `try_inline_or_restream` — file-backed deletion vectors are now written inside `try_inline_batches_with_inlined_deletions` after inline success.
- Reserve the deletion sequence number *before* `commit_inlined_data_mutation` so the inline entry gets a strictly higher sequence (`S+2 > S+1`), ensuring `filter_inlined_batch_for_deletions` keeps the inline row after restart.
- Add `persist_file_deletions_after_inlined_insert` to write key-based deletion vectors without insert records (inline data bypasses the deletion filter, so no protected insert sequence is needed).

### Performance

**Before**: **new_order** deletes processed **6930** (p99_ms freshness **73s**)

```
=== TPC-C OLTP ===
OLTP Report (90.0s)
  tpmC (NewOrder/min): 29947.1
  transactions: 99268 committed, 10 aborted (0.01% abort rate)

Data Freshness
  dataset            p50_ms     p99_ms     max_ms    samples
  new_order           38410      73417      73417         18
  worst P99:     73417ms

Replication Metrics (last scrape from spiced)
  dataset            lag_ms    lag_bytes    inserts    updates    deletes  recv_errs reconnects
  customer               49      1603232          0      80930          0          0          0
  district               72      1903336          0      86239          0          0          0
  item                    0            0          0          0          0          0          0
  nation                  0            0          0          0          0          0          0
  new_order           72515      3280832       8430          0       6930          0          0
  oorder                 48      2126248      44039      38700          0          0          0
  order_line             48      2126248     440472     386977          0          0          0
  region                  0            0          0          0          0          0          0
  stock                4459      3369056          0     417992          0          0          0
  supplier                0            0          0          0          0          0          0
  warehouse              51      2130568          0      42230          0          0          0
```

**After**: **new_order** deletes processed **30480** (p99_ms freshness **24s**)

```
=== TPC-C OLTP ===
OLTP Report (90.0s)
  tpmC (NewOrder/min): 33104.5
  transactions: 109957 committed, 10 aborted (0.01% abort rate)

Data Freshness
  dataset            p50_ms     p99_ms     max_ms    samples
  new_order            8811      24407      24407         18
  worst P99:     24407ms

Replication Metrics (last scrape from spiced)
  dataset            lag_ms    lag_bytes    inserts    updates    deletes  recv_errs reconnects
  customer               33      1048856          0      89679          0          0          0
  district               33      1046120          0      95617          0          0          0
  item                    0            0          0          0          0          0          0
  nation                  0            0          0          0          0          0          0
  new_order           24749      3225680      35031          0      30480          0          0
  oorder                 33      1048856      48758      42820          0          0          0
  order_line             33      1048856     487901     428201          0          0          0
  region                  0            0          0          0          0          0          0
  stock                  33      1048856          0     487901          0          0          0
  supplier                0            0          0          0          0          0          0
  warehouse              33      1004088          0      46859          0          0          0
```
## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782320194&installation_id=128462479&pr_number=11031&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11031&signature=9e67527377389492ca20d7ed6c489ad38b99f7fca1510edf83c3dbf48f8f7eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->