### PR TITLE
fix: delegate truncate in PolyTableProvider

### DIFF
--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -171,4 +171,8 @@ impl TableProvider for PolyTableProvider {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.write.update(state, assignments, filters).await
     }
+
+    async fn truncate(&self, state: &dyn Session) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.write.truncate(state).await
+    }
 }


### PR DESCRIPTION
## Summary
- `PolyTableProvider` delegates `insert_into`, `delete_from`, and `update` to `self.write` but was missing the `truncate` delegation
- Since every accelerator (DuckDB, SQLite, Turso, Postgres, Cayenne) wraps its provider in `PolyTableProvider`, and `AcceleratedTable::truncate` calls `self.accelerator.truncate()`, `TRUNCATE TABLE` on any accelerated dataset would hit the default trait method and fail with "not implemented"
- This follows the same one-line delegation pattern as the other three DML methods

## Test plan
- `cargo check -p data_components --lib` passes
- `cargo fmt --all -- --check` passes
- Existing accelerator truncate tests exercise this path end-to-end through `AcceleratedTable`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782343125&installation_id=128462479&pr_number=11036&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11036&signature=ae764c766eaef34a0648ec39c8ea748fba5f18b47475393176f03d1704b3502d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->