### PR TITLE
Remove default runtime features - enable explicitly in spiced

### DIFF
--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -114,6 +114,9 @@ default = [
     "pingora",
     "scylladb",
     "models",
+    "aws-secrets-manager",
+    "azure-keyvault",
+    "keyring-secret-store",
 ]
 delta_lake = ["connector-delta-lake", "runtime/delta_lake"]
 dev = ["runtime/dev"]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -281,13 +281,6 @@ cosmosdb = ["data_components/cosmosdb"]
 cuda = ["llms/cuda"]
 databricks = ["data_components/databricks", "dep:duration-parse"]
 debezium = ["kafka", "data_components/debezium"]
-default = [
-    "keyring-secret-store",
-    "aws-secrets-manager",
-    "hashicorp_vault",
-    "sharepoint",
-    "bedrock",
-]
 delta_lake = ["data_components/delta_lake"]
 dev = ["openapi", "otel-arrow/dev", "mcp"]
 dremio = []
@@ -326,6 +319,7 @@ keyring-secret-store = ["runtime-secrets/keyring-secret-store"]
 mcp = ["dep:rmcp", "tools/mcp"]
 metal = ["llms/metal"]
 models = [
+    "bedrock",
     "model_components/full",
     "mcp",
     "runtime-datafusion-udfs/models",


### PR DESCRIPTION
Removes the default features from the `runtime` crate. Consumers should enable them explicitly if they need those features. Add them to the `spiced` default feature list so they stay enabled.

`azure-keyvault` is now enabled by default in the OSS build. `hashicorp_vault` is removed from the default feature set.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782350111&installation_id=128462479&pr_number=11037&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11037&signature=ad03c2c4ded8797dfb4850c3209f0e60c93c2996cb063b3591c4d40f4afcab81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->