### PR TITLE
fix(sql-tool): allow writes for ReadWrite API keys

### DIFF
--- a/crates/runtime/src/tools/builtin/sql.rs
+++ b/crates/runtime/src/tools/builtin/sql.rs
@@ -36,13 +36,12 @@ pub struct SqlToolParams {
     query: String,
 }
 
-/// Default description advertised to LLMs / tool selection when the `sql` tool
-/// is in its read-only posture (the default).
-const DEFAULT_READ_ONLY_DESCRIPTION: &str = "Execute a read-only SQL query in the Spice.ai SQL Dialect (DataFusion SQL using PostgreSQL-dialect with Spice.ai functions) against the Spice runtime and return the result rows as JSON. Use this for any deterministic lookup, aggregation, or filter where exact column names are known; prefer `search` for semantic or natural-language lookups. Quote identifiers containing capitals or reserved keywords, and quote each part of `catalog.schema.table` separately (e.g. \"spice\".\"public\".\"my_table\"). Avoid `SELECT *` and columns ending in `_offset` or `_embedding`. DDL and write statements (INSERT/UPDATE/DELETE/COPY/CREATE/DROP) and session-mutating statements (PREPARE/EXECUTE/DEALLOCATE) are rejected; use `list_datasets` and `table_schema` first to discover tables and columns.";
-
-/// Default description advertised to LLMs / tool selection when the operator
-/// has opted the tool into writable mode via [`SqlTool::allow_writes`].
-const DEFAULT_WRITABLE_DESCRIPTION: &str = "Execute an SQL query in the Spice.ai SQL Dialect (DataFusion SQL using PostgreSQL-dialect with Spice.ai functions) against the Spice runtime and return the result rows as JSON. This variant accepts write statements (INSERT/UPDATE/DELETE/DDL) - use with caution and only when mutation is the explicit goal. Quote identifiers containing capitals or reserved keywords, and quote each part of `catalog.schema.table` separately (e.g. \"spice\".\"public\".\"my_table\"). Avoid `SELECT *` and columns ending in `_offset` or `_embedding`. Use `list_datasets` and `table_schema` first to discover tables and columns.";
+/// Default description advertised to LLMs / tool selection. Writes are
+/// permitted only when the calling principal has the `read_write` group
+/// (e.g. the request is authenticated with a `:rw`-tagged API key); the
+/// strict read-only validator is still applied for `ReadOnly` / anonymous
+/// callers and for any deployment that hasn't configured `runtime.auth`.
+const DEFAULT_DESCRIPTION: &str = "Execute an SQL query in the Spice.ai SQL Dialect (DataFusion SQL using PostgreSQL-dialect with Spice.ai functions) against the Spice runtime and return the result rows as JSON. Use this for any deterministic lookup, aggregation, or filter where exact column names are known; prefer `search` for semantic or natural-language lookups. Quote identifiers containing capitals or reserved keywords, and quote each part of `catalog.schema.table` separately (e.g. \"spice\".\"public\".\"my_table\"). Avoid `SELECT *` and columns ending in `_offset` or `_embedding`. Write statements (INSERT/UPDATE/DELETE/DDL) require the request to be authenticated with a ReadWrite API key AND the target dataset to be configured `access: read_write`; otherwise they are rejected. Use `list_datasets` and `table_schema` first to discover tables and columns.";
 
 pub struct SqlTool {
     name: String,
@@ -50,13 +49,6 @@ pub struct SqlTool {
     df: Arc<DataFusion>,
 
     allowed_tables: Option<ResolvedTableAwareAllowlist>,
-    /// When true (the default), the tool rejects any DDL, DML, COPY, or
-    /// `LogicalPlan::Statement` plan (including PREPARE/EXECUTE/DEALLOCATE) at
-    /// execution time. This prevents LLM- or caller-supplied SQL from mutating data
-    /// or session state via the `/v1/tools/sql` surface, even when a referenced
-    /// catalog/dataset is configured writable. Operators that need write access from
-    /// a tool should configure a distinct writable tool rather than flipping this flag.
-    read_only: bool,
 }
 
 impl SqlTool {
@@ -70,33 +62,9 @@ impl SqlTool {
         Self {
             df,
             name: name.unwrap_or("sql").to_string(),
-            description: description
-                .unwrap_or(DEFAULT_READ_ONLY_DESCRIPTION)
-                .to_string(),
+            description: description.unwrap_or(DEFAULT_DESCRIPTION).to_string(),
             allowed_tables,
-            read_only: true,
         }
-    }
-
-    /// Allow write statements (INSERT/UPDATE/DELETE/DDL). Defaults to off.
-    ///
-    /// This is an escape hatch for operators who have deliberately configured a
-    /// separate writable tool and understand that any LLM with tool-use access will
-    /// then be able to mutate the targeted catalog/dataset without per-call
-    /// confirmation. Leave the default in place unless that trade-off is acceptable.
-    ///
-    /// If the tool is still using the default read-only description, it is swapped
-    /// for the writable default so LLM/tool-selection logic is not misled by a
-    /// stale "read-only" advertisement. Operator-supplied descriptions are left
-    /// untouched — callers overriding the description are responsible for keeping
-    /// it accurate.
-    #[must_use]
-    pub fn allow_writes(mut self) -> Self {
-        self.read_only = false;
-        if self.description == DEFAULT_READ_ONLY_DESCRIPTION {
-            self.description = DEFAULT_WRITABLE_DESCRIPTION.to_string();
-        }
-        self
     }
 }
 
@@ -119,7 +87,18 @@ impl SpiceModelTool for SqlTool {
         let tool_use_result: Result<Value, Box<dyn std::error::Error + Send + Sync>> = async {
             let req: SqlToolParams = serde_json::from_str(arg)?;
 
-            let mut query_builder = self.df.query_builder(&req.query).read_only(self.read_only);
+            // Defer the read-only gate to the calling principal. The strict
+            // read-only validator still fires for ReadOnly / anonymous
+            // callers (and for deployments that haven't configured
+            // `runtime.auth` at all, where `current_principal_requires_read_only`
+            // returns `false` only because there is no authenticated
+            // principal — but on the tools surface those requests are
+            // rejected upstream by `require_auth_configured`). ReadWrite
+            // callers fall through to the regular validator, which still
+            // checks per-table writability and `access: read_write`.
+            let read_only = crate::http::v1::current_principal_requires_read_only().await;
+
+            let mut query_builder = self.df.query_builder(&req.query).read_only(read_only);
             if let Some(ref allowlist) = self.allowed_tables {
                 query_builder = query_builder.allow_tables(allowlist.clone());
             }
@@ -150,5 +129,136 @@ impl SpiceModelTool for SqlTool {
                 Err(e)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Read/write gating for the built-in `sql` MCP tool.
+    //!
+    //! The tool defers its read-only posture to the calling principal's
+    //! `read_write` group (the same gate `/v1/sql` and `function_tool`
+    //! use). These tests exercise the three cases that matter:
+    //!
+    //!   * `ReadWrite` principal → INSERT succeeds.
+    //!   * `ReadOnly` principal  → INSERT rejected with "read-only SQL context".
+    //!   * No principal (auth disabled) → INSERT succeeds.
+    //!
+    //! /v1/tools/* is gated by `require_auth_configured` upstream, so in
+    //! practice anonymous callers never reach this code; the third case
+    //! exists to document the behavior shared with the other tool
+    //! surfaces that consult `current_principal_requires_read_only`.
+    use super::*;
+    use crate::{datafusion::builder::DataFusionBuilder, status::RuntimeStatus};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use data_components::arrow::write::MemTable;
+    use datafusion::sql::TableReference;
+    use runtime_auth::{AuthPrincipalRef, AuthRequestContext};
+    use runtime_request_context::{Protocol, RequestContext};
+    use spicepod::component::runtime::ApiKey;
+    use std::sync::Arc;
+    use tokio::runtime::Handle;
+
+    fn test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]))
+    }
+
+    fn build_sql_tool() -> (Arc<DataFusion>, SqlTool) {
+        let df = Arc::new(
+            DataFusionBuilder::new(
+                RuntimeStatus::new(),
+                Arc::new(crate::dataaccelerator::AcceleratorEngineRegistry::new()),
+                Handle::current(),
+            )
+            .build(),
+        );
+
+        // Bare table name (not under `runtime.*`) so the writability
+        // gate is the only thing being exercised — the validator treats
+        // `runtime.*` as a Spice-internal dataset and rejects writes to
+        // it regardless of principal role.
+        let table_name = TableReference::bare("audit");
+        let mem_table = Arc::new(
+            MemTable::try_new(test_schema(), vec![]).expect("mem table should be created"),
+        );
+        df.ctx
+            .register_table(table_name.clone(), mem_table)
+            .expect("table registered");
+
+        // Mark the table writable so a ReadWrite principal's INSERT
+        // reaches the regular validator (which checks per-table
+        // writability) instead of being rejected because no writable
+        // tables exist.
+        df.mark_dataset_writable(&table_name)
+            .expect("dataset marked writable");
+
+        let tool = SqlTool::new(Arc::clone(&df), None, None, None);
+        (df, tool)
+    }
+
+    fn context_with_principal(principal: Option<AuthPrincipalRef>) -> Arc<RequestContext> {
+        let ctx = Arc::new(RequestContext::builder(Protocol::Http).build());
+        if let Some(principal) = principal {
+            ctx.set_auth_principal(principal)
+                .expect("set_auth_principal");
+        }
+        ctx
+    }
+
+    async fn run_insert(tool: &SqlTool) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+        let args = serde_json::json!({
+            "query": "INSERT INTO audit (id, name) VALUES (1, 'unit-test')"
+        })
+        .to_string();
+        tool.call(args.as_str()).await
+    }
+
+    #[tokio::test]
+    async fn read_write_principal_can_insert() {
+        let (_df, tool) = build_sql_tool();
+        let ctx = context_with_principal(Some(Arc::new(ApiKey::ReadWrite {
+            key: "rw-key".into(),
+        }) as AuthPrincipalRef));
+
+        let result = ctx.scope(async { run_insert(&tool).await }).await;
+        assert!(
+            result.is_ok(),
+            "INSERT under ReadWrite principal should succeed; got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_only_principal_is_blocked() {
+        let (_df, tool) = build_sql_tool();
+        let ctx = context_with_principal(Some(Arc::new(ApiKey::ReadOnly {
+            key: "ro-key".into(),
+        }) as AuthPrincipalRef));
+
+        let result = ctx.scope(async { run_insert(&tool).await }).await;
+        let err = result.expect_err("ReadOnly principal must be blocked from INSERT");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("read-only SQL context"),
+            "expected strict read-only error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn anonymous_caller_can_insert() {
+        // Mirrors deployments that haven't configured `runtime.auth`: no
+        // principal is set, the tool surface itself is gated upstream by
+        // `require_auth_configured`, but the inner read-only check
+        // resolves to `false` (writable) — same behavior as /v1/sql.
+        let (_df, tool) = build_sql_tool();
+        let ctx = context_with_principal(None);
+
+        let result = ctx.scope(async { run_insert(&tool).await }).await;
+        assert!(
+            result.is_ok(),
+            "INSERT with no principal should succeed; got {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The built-in `sql` tool always ran with `read_only: true`, so `INSERT`, `UPDATE`, and `DELETE` were rejected even when the request used a `:rw` API key and the target dataset was configured with `access: read_write`.

This change makes the tool use the same principal-based read-only gate as `/v1/sql`, Flight, and function tools. ReadWrite callers now reach the normal SQL validator, which still enforces per-table writability. ReadOnly callers still use the strict read-only validator.

Closes #11029.

## Flow

```text
/v1/tools/sql
      |
      v
current caller principal
      |
      +-- ReadWrite API key --> normal SQL validator --> writable dataset required
      |
      +-- ReadOnly API key  --> strict read-only validator
```

## Changes

- Replaces the hardcoded `SqlTool` read-only flag with `current_principal_requires_read_only()`.
- Removes the unused `SqlTool::allow_writes()` opt-in path and the split read-only/writable default descriptions.
- Updates the default tool description to explain that writes require both a ReadWrite API key and a writable dataset.
- Adds unit coverage for ReadWrite, ReadOnly, and no-principal behavior.

## Notes

- Anonymous requests to `/v1/tools/*` are still blocked upstream when runtime auth is configured.
- The no-principal unit test documents the behavior for auth-disabled/direct-call contexts, matching `/v1/sql`.

## Test plan

- [x] `cargo test -p runtime --lib tools::builtin::sql::tests`
- [x] Related `tools`, `auth`, and `datafusion::sql_validator` test suites still pass.
- [ ] CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782359882&installation_id=128462479&pr_number=11040&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11040&signature=4be70acbda6d222f62bbcd6187bc761b498e4b1bf4ef78246a07a836f1c8427a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
