### PR TITLE
chore: fix two typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ The `spiceai/quickstart` Spicepod will add a `taxi_trips` data table to the runt
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```bash
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/crates/model_components/src/modelsource/spiceai.rs
+++ b/crates/model_components/src/modelsource/spiceai.rs
@@ -132,7 +132,7 @@ impl ModelSource for SpiceAI {
             .await
             .context(super::UnableToFetchModelSnafu)?;
 
-        // Given we are still actively developing the model response, we'll only fetch the frist
+        // Given we are still actively developing the model response, we'll only fetch the first
         // export url for now.
         // In future, we can use a proper static model response format to parse the body
         let download_url = data


### PR DESCRIPTION
## Summary

- `README.md:452` - "The SQL REPL inferface" → "The SQL REPL interface"
- `crates/model_components/src/modelsource/spiceai.rs:135` - comment said "fetch the frist export url" → "fetch the first export url"

Doc + comment only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782373626&installation_id=128462479&pr_number=11042&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11042&signature=81777018650e96d06492598c72b7e8dd614a5a51182a3ce48152c9e4af3b5dcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->