### PR TITLE
[release/2.0] Cherry-pick #11008: fix EmbeddingTable logical plan for search CI

### DIFF
--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -823,7 +823,12 @@ impl TableProvider for EmbeddingTable {
     }
 
     fn get_logical_plan(&self) -> Option<Cow<'_, LogicalPlan>> {
-        self.base_table.get_logical_plan()
+        // EmbeddingTable augments the base table's schema with computed
+        // embedding columns. The base table's logical plan does not represent
+        // those columns, so forwarding it would cause `LogicalPlanBuilder::scan`
+        // to inline a plan whose schema is missing the embedding columns —
+        // any subsequent projection of those columns then fails.
+        None
     }
 
     fn schema(&self) -> SchemaRef {

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_mixed_datasets_fail_fast_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_mixed_datasets_fail_fast_error_response.snap
@@ -1,0 +1,5 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: err.to_string()
+---
+HTTP error: 400 Bad Request - Search cannot be run on plain because it has no embeddings or full text search indexes.

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_non_searchable_dataset_errors_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_non_searchable_dataset_errors_error_response.snap
@@ -1,0 +1,5 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: err.to_string()
+---
+HTTP error: 400 Bad Request - Search cannot be run on plain because it has no embeddings or full text search indexes.

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_searchable_dataset_no_matches_returns_empty_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__explicit_searchable_dataset_no_matches_returns_empty_response.snap
@@ -1,0 +1,8 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: "normalize_search_response(resp, round_scores)"
+---
+{
+  "duration_ms": "duration_ms_val",
+  "results": []
+}


### PR DESCRIPTION
Cherry-picks commit 729899b359 (PR #11008) from trunk into `release/2.0`.

This backport includes:
- `EmbeddingTable::get_logical_plan()` returning `None` to avoid inlining a base logical plan that lacks derived embedding columns (fixes `No field named answer_embedding` in view/search paths).
- The three missing integration-model snapshot files added by #11008.

Cherry-picked commit:
- 729899b359d47bbbcf30a84a867a85ff8932d57d
