### PR TITLE
fix: add snapshot guard and write-mode routing to AcceleratedTable::truncate

### DIFF
--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -336,6 +336,10 @@ impl TableProvider for MetadataEnrichedTableProvider {
         self.inner.update(state, assignments, filters).await
     }
 
+    async fn truncate(&self, state: &dyn Session) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.inner.truncate(state).await
+    }
+
     fn statistics(&self) -> Option<Statistics> {
         self.inner.statistics()
     }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1804,7 +1804,28 @@ impl TableProvider for AcceleratedTable {
     }
 
     async fn truncate(&self, state: &dyn Session) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        self.accelerator.truncate(state).await
+        if self.refresh_mode == RefreshMode::Snapshot {
+            return Err(datafusion::error::DataFusionError::Execution(format!(
+                "truncate on accelerated table {} is not permitted when refresh_mode is 'snapshot'; the accelerator is driven exclusively from the snapshot store",
+                self.dataset_name
+            )));
+        }
+
+        self.update_last_updated_at();
+
+        match &self.write_mode {
+            WriteMode::AcceleratorOnly => self.accelerator.truncate(state).await,
+            WriteMode::WriteThrough => {
+                let federated_table = self.federated.table_provider().await;
+                federated_table.truncate(state).await
+            }
+            WriteMode::WriteBack | WriteMode::DualWrite { .. } => {
+                Err(datafusion::error::DataFusionError::NotImplemented(format!(
+                    "TRUNCATE is not yet supported for accelerated table {} in {:?} write mode",
+                    self.dataset_name, self.write_mode
+                )))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- `AcceleratedTable::truncate` bypassed the snapshot-mode rejection guard, `update_last_updated_at()`, and write-mode dispatch that `insert_into`, `delete_from`, and `update` all enforce — a `TRUNCATE TABLE` on a snapshot-mode accelerated table silently succeeded (only to be overwritten on the next refresh), and in WriteThrough mode it only truncated the local accelerator without propagating to the federated source
- `MetadataEnrichedTableProvider` had `insert_into`, `delete_from`, and `update` delegations but not `truncate`, causing `TRUNCATE` to fail with a `NotImplemented` error on tables wrapped with metadata enrichment (e.g. BigQuery ADBC connectors)

## Fix
- Adds the same snapshot-mode guard, `update_last_updated_at()` call, and write-mode `match` to `truncate` that the sibling DML methods already have
- For `WriteBack` and `DualWrite` modes, returns `NotImplemented` since no truncate helpers exist yet for these modes (better than silently truncating only the accelerator)
- Adds `truncate` delegation to `MetadataEnrichedTableProvider`

## Test plan
- `cargo check -p runtime` passes
- `cargo check -p data_components` passes
- Manual review: confirmed all four DML methods (`insert_into`, `delete_from`, `update`, `truncate`) now have consistent guards in `AcceleratedTable` and consistent delegation in `MetadataEnrichedTableProvider`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782382868&installation_id=128462479&pr_number=11044&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11044&signature=7b86f8151a57e8d66b655b2f1611252414ff581bc1df5710e86db8ac9454c43c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->