### PR TITLE
fix: include PartitionedDuckDB in snapshot engine mappings

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -529,7 +529,9 @@ fn validate_distributed_engine(
 fn engine_to_acceleration_engine(engine: Engine) -> Option<AccelerationEngine> {
     match engine {
         #[cfg(feature = "duckdb")]
-        Engine::DuckDB | Engine::TableModePartitionedDuckDB => Some(AccelerationEngine::DuckDB),
+        Engine::DuckDB | Engine::PartitionedDuckDB | Engine::TableModePartitionedDuckDB => {
+            Some(AccelerationEngine::DuckDB)
+        }
         #[cfg(feature = "sqlite")]
         Engine::Sqlite => Some(AccelerationEngine::Sqlite),
         #[cfg(feature = "turso")]
@@ -3895,9 +3897,9 @@ async fn build_snapshot_creation_config(
     ))]
     let acceleration_engine = match acceleration_settings.engine {
         #[cfg(feature = "duckdb")]
-        Engine::DuckDB => AccelerationEngine::DuckDB,
-        #[cfg(feature = "duckdb")]
-        Engine::TableModePartitionedDuckDB => AccelerationEngine::DuckDB,
+        Engine::DuckDB | Engine::PartitionedDuckDB | Engine::TableModePartitionedDuckDB => {
+            AccelerationEngine::DuckDB
+        }
         #[cfg(feature = "sqlite")]
         Engine::Sqlite => AccelerationEngine::Sqlite,
         #[cfg(feature = "turso")]


### PR DESCRIPTION
## Summary
- `Engine::PartitionedDuckDB` (file-based DuckDB partitioning) was missing from the DuckDB arm in both `engine_to_acceleration_engine()` and `build_snapshot_creation_config()`
- The match grouped `DuckDB` and `TableModePartitionedDuckDB` but not `PartitionedDuckDB`, so datasets using file-based partitioned DuckDB silently had snapshots disabled (`engine_to_acceleration_engine` returned `None`) and snapshot creation failed with `UnsupportedAccelerationEngineForSnapshots`
- Other functions (e.g. `Display`, `to_unpartitioned()`) correctly group all three DuckDB variants

## Fix
- Adds `Engine::PartitionedDuckDB` to both DuckDB match arms so all three DuckDB variants map to `AccelerationEngine::DuckDB`

## Test plan
- `cargo check -p runtime` passes
- Verified no other DuckDB groupings in the codebase are missing `PartitionedDuckDB` (functions that use `.to_unpartitioned()` already handle it correctly)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782382885&installation_id=128462479&pr_number=11045&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11045&signature=ae9b2bbe48fcc409adf0a5e3d88341c594803aa7730dfcc13005a891d198fa9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->