### PR TITLE
fix: map Gemini Recitation finish reason to ContentFilter

### DIFF
--- a/crates/llms/src/google/chat.rs
+++ b/crates/llms/src/google/chat.rs
@@ -307,8 +307,12 @@ fn convert_google_response_to_openai(
                     }
                 }
                 google_genai::types::FinishReason::MaxTokens => FinishReason::Length,
-                google_genai::types::FinishReason::Safety => FinishReason::ContentFilter,
-                _ => FinishReason::Stop,
+                google_genai::types::FinishReason::Safety
+                | google_genai::types::FinishReason::Recitation => FinishReason::ContentFilter,
+                google_genai::types::FinishReason::Other
+                | google_genai::types::FinishReason::FinishReasonUnspecified => {
+                    FinishReason::Stop
+                }
             });
 
             ChatChoice {
@@ -403,8 +407,12 @@ fn convert_google_stream_response_to_openai(
                     }
                 }
                 google_genai::types::FinishReason::MaxTokens => FinishReason::Length,
-                google_genai::types::FinishReason::Safety => FinishReason::ContentFilter,
-                _ => FinishReason::Stop,
+                google_genai::types::FinishReason::Safety
+                | google_genai::types::FinishReason::Recitation => FinishReason::ContentFilter,
+                google_genai::types::FinishReason::Other
+                | google_genai::types::FinishReason::FinishReasonUnspecified => {
+                    FinishReason::Stop
+                }
             });
 
             ChatChoiceStream {

--- a/crates/llms/src/google/chat.rs
+++ b/crates/llms/src/google/chat.rs
@@ -310,9 +310,7 @@ fn convert_google_response_to_openai(
                 google_genai::types::FinishReason::Safety
                 | google_genai::types::FinishReason::Recitation => FinishReason::ContentFilter,
                 google_genai::types::FinishReason::Other
-                | google_genai::types::FinishReason::FinishReasonUnspecified => {
-                    FinishReason::Stop
-                }
+                | google_genai::types::FinishReason::FinishReasonUnspecified => FinishReason::Stop,
             });
 
             ChatChoice {
@@ -410,9 +408,7 @@ fn convert_google_stream_response_to_openai(
                 google_genai::types::FinishReason::Safety
                 | google_genai::types::FinishReason::Recitation => FinishReason::ContentFilter,
                 google_genai::types::FinishReason::Other
-                | google_genai::types::FinishReason::FinishReasonUnspecified => {
-                    FinishReason::Stop
-                }
+                | google_genai::types::FinishReason::FinishReasonUnspecified => FinishReason::Stop,
             });
 
             ChatChoiceStream {


### PR DESCRIPTION
## Summary
- The Google Gemini `FinishReason` match used a catch-all `_ => FinishReason::Stop` that mapped `Recitation` (copyright/recitation block), `Other`, and `FinishReasonUnspecified` to `Stop`, making it appear the model completed normally when output was actually blocked or failed
- This affected both the non-streaming and streaming response paths

## Fix
- Maps `Recitation` to `ContentFilter` (it is a content-blocking reason, like `Safety`)
- Lists `Other` and `FinishReasonUnspecified` explicitly instead of using a catch-all, so the compiler catches any future additions to the `FinishReason` enum

## Test plan
- `cargo check -p llms` passes
- Verified the `google_genai::types::FinishReason` enum has exactly 6 variants and all are now handled explicitly in both code paths

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782382900&installation_id=128462479&pr_number=11046&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11046&signature=cf79174e6d5e367d0db6266b4c2bc9f6a2eb4b2450985b48d0c4ec58526dd88f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->