### PR TITLE
fix: restore hashicorp_vault to spiced default features

### DIFF
--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -116,6 +116,7 @@ default = [
     "models",
     "aws-secrets-manager",
     "azure-keyvault",
+    "hashicorp_vault",
     "keyring-secret-store",
 ]
 delta_lake = ["connector-delta-lake", "runtime/delta_lake"]


### PR DESCRIPTION
## Summary
- When runtime's default features were moved to spiced in #11037, `hashicorp_vault` was accidentally omitted from the new default list
- The other four former runtime defaults (`keyring-secret-store`, `aws-secrets-manager`, `sharepoint`, `bedrock`) were all transferred correctly, but `hashicorp_vault` was not
- Users relying on HashiCorp Vault for secret management would find it silently unavailable after upgrading, causing runtime failures when resolving Vault-stored credentials

## Fix
- Adds `hashicorp_vault` back to the `default` feature list in `bin/spiced/Cargo.toml`

## Test plan
- Verified the feature is defined in spiced (`hashicorp_vault = ["runtime/hashicorp_vault"]`) and was present in the old runtime defaults
- `cargo check -p spiced` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782382913&installation_id=128462479&pr_number=11047&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11047&signature=c45e58c3dc3dd71409d4b26ca881fa0034971a50930de8405b0d43ea8877a974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->