### PR TITLE
fix: route Turso WAL checkpoint through native turso connection (fixes #10657)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16066,6 +16066,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "turso",
  "url",
  "util",
  "uuid 1.21.0",

--- a/crates/runtime-acceleration/Cargo.toml
+++ b/crates/runtime-acceleration/Cargo.toml
@@ -40,6 +40,7 @@ tar = "0.4"
 tempfile.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
+turso = { workspace = true, optional = true }
 url.workspace = true
 util = { path = "../util", features = ["datafusion"] }
 uuid = { version = "1", features = ["v7"] }
@@ -49,7 +50,7 @@ default = []
 duckdb = ["dep:duckdb"]
 snapshots = []
 sqlite = ["dep:rusqlite"]
-turso = ["dep:rusqlite"]
+turso = ["dep:turso"]
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/runtime-acceleration/src/snapshot/engine.rs
+++ b/crates/runtime-acceleration/src/snapshot/engine.rs
@@ -26,7 +26,7 @@ mod duckdb;
 #[cfg(feature = "duckdb")]
 pub use duckdb::DuckDBSnapshotEngine;
 
-#[cfg(any(feature = "sqlite", feature = "turso"))]
+#[cfg(feature = "sqlite")]
 mod sqlite;
 #[cfg(feature = "sqlite")]
 pub use sqlite::SqliteSnapshotEngine;
@@ -43,8 +43,12 @@ pub enum SnapshotEngineError {
     DuckDB { source: duckdb::DuckDBSnapshotError },
 
     #[snafu(display("SQLite snapshot error: {source}"))]
-    #[cfg(any(feature = "sqlite", feature = "turso"))]
+    #[cfg(feature = "sqlite")]
     Sqlite { source: sqlite::SqliteSnapshotError },
+
+    #[snafu(display("Turso snapshot error: {source}"))]
+    #[cfg(feature = "turso")]
+    Turso { source: turso::TursoSnapshotError },
 
     /// Placeholder variant for when no snapshot-capable feature is enabled.
     #[snafu(display(

--- a/crates/runtime-acceleration/src/snapshot/engine/turso.rs
+++ b/crates/runtime-acceleration/src/snapshot/engine/turso.rs
@@ -13,31 +13,59 @@ limitations under the License.
 
 //! Turso (libsql) snapshot engine implementation.
 //!
-//! **Status:** WAL flush is currently a no-op for Turso. The first attempt
-//! reused [`super::sqlite::SqliteSnapshotEngine`] under the assumption that
-//! libsql's on-disk format is byte-compatible with classic `SQLite` for
-//! read-only opens via rusqlite. In practice the integration test surfaced
-//! `"file is not a database"` from rusqlite when opening a libsql primary
-//! file. Tracked in spiceai/spiceai#10657.
+//! Turso accelerator databases share `SQLite`'s on-disk page layout but store
+//! pending writes in a libsql-specific WAL sidecar that `rusqlite` cannot
+//! open ("file is not a database"). The previous implementation routed the
+//! checkpoint pragma through rusqlite and therefore silently lost any
+//! uncheckpointed WAL frames at snapshot time — see spiceai/spiceai#10657.
 //!
-//! Until that issue is fixed by routing the checkpoint pragma through a
-//! turso/libsql-native connection, snapshot creation for Turso accelerators
-//! falls back to the default behavior: `fs::copy` of the live file as-is,
-//! with the same WAL-loss caveat that #10643 originally documented.
-//! `refresh_mode: snapshot` against Turso is therefore disabled for now
-//! (see `tests/snapshot_refresh/turso.rs`).
+//! This engine routes `PRAGMA wal_checkpoint(TRUNCATE)` through the
+//! `turso` crate's native connection so the checkpoint actually runs
+//! against the libsql file. The result-row contract (`busy`, `log`,
+//! `checkpointed`) matches `SQLite`'s, so the same completeness check applies.
 
 use async_trait::async_trait;
+use snafu::prelude::*;
 use std::path::{Path, PathBuf};
 
 use super::SnapshotEngine;
 
-/// Snapshot engine for Turso accelerators.
-///
-/// Currently a no-op (defers WAL flushing to a future libsql-native
-/// implementation; see spiceai/spiceai#10657). The struct exists so that
-/// `create_snapshot_engine` can return a stable, Turso-specific type and
-/// the call sites stay symmetric with the other engine implementations.
+#[derive(Debug, Snafu)]
+pub enum TursoSnapshotError {
+    #[snafu(display("Turso live-database path is not valid UTF-8 and cannot be opened: {path:?}"))]
+    NonUtf8Path { path: PathBuf },
+    #[snafu(display("Failed to open Turso database for snapshot preparation: {path:?}"))]
+    Open { path: PathBuf, source: turso::Error },
+    #[snafu(display("Failed to connect to Turso database for snapshot preparation: {path:?}"))]
+    Connect { path: PathBuf, source: turso::Error },
+    #[snafu(display(
+        "Failed to checkpoint Turso WAL for dataset '{dataset}' at {path:?}: {source}"
+    ))]
+    Checkpoint {
+        dataset: String,
+        path: PathBuf,
+        source: turso::Error,
+    },
+    #[snafu(display(
+        "Turso wal_checkpoint did not return the expected (busy, log, checkpointed) row \
+         for dataset '{dataset}' at {path:?}"
+    ))]
+    CheckpointNoRow { dataset: String, path: PathBuf },
+    #[snafu(display(
+        "Incomplete WAL checkpoint for dataset '{dataset}' at {path:?}: \
+         busy={busy}, log_frames={log_frames}, checkpointed_frames={checkpointed_frames}. \
+         Another connection is holding the WAL or not all frames were flushed; \
+         snapshotting now would lose data."
+    ))]
+    CheckpointIncomplete {
+        dataset: String,
+        path: PathBuf,
+        busy: i64,
+        log_frames: i64,
+        checkpointed_frames: i64,
+    },
+}
+
 pub struct TursoSnapshotEngine;
 
 impl TursoSnapshotEngine {
@@ -57,13 +85,14 @@ impl Default for TursoSnapshotEngine {
 impl SnapshotEngine for TursoSnapshotEngine {
     async fn checkpoint_live(
         &self,
-        _live_path: &Path,
-        _dataset_name: &str,
+        live_path: &Path,
+        dataset_name: &str,
     ) -> Result<(), super::SnapshotEngineError> {
-        // No-op: see spiceai/spiceai#10657. Returning Ok here matches
-        // historical Turso behavior; once the issue is fixed this will route
-        // through a libsql-native checkpoint.
-        Ok(())
+        let path = live_path.to_path_buf();
+        let dataset = dataset_name.to_string();
+
+        let result = checkpoint_via_turso(path, dataset).await;
+        result.map_err(|e| super::SnapshotEngineError::Turso { source: e })
     }
 
     async fn prepare_for_upload(
@@ -71,11 +100,194 @@ impl SnapshotEngine for TursoSnapshotEngine {
         source_path: &Path,
         _dataset_name: &str,
     ) -> Result<PathBuf, super::SnapshotEngineError> {
-        // No-op: pass the copy through unchanged. See spiceai/spiceai#10657.
+        // After `checkpoint_live` has flushed the WAL into the main file and
+        // the caller has performed `fs::copy(live, source_path)`, the copy
+        // contains all data; the WAL/SHM sidecars (if any remained) belong
+        // to the *live* path and are not copied alongside the main file.
+        // Nothing more to do here.
         Ok(source_path.to_path_buf())
     }
 
     fn supports_compaction(&self) -> bool {
         false
+    }
+}
+
+async fn checkpoint_via_turso(
+    live_path: PathBuf,
+    dataset: String,
+) -> Result<(), TursoSnapshotError> {
+    let path_str = live_path
+        .to_str()
+        .ok_or_else(|| TursoSnapshotError::NonUtf8Path {
+            path: live_path.clone(),
+        })?;
+    let database = turso::Builder::new_local(path_str)
+        .build()
+        .await
+        .context(OpenSnafu {
+            path: live_path.clone(),
+        })?;
+
+    let conn = database.connect().context(ConnectSnafu {
+        path: live_path.clone(),
+    })?;
+
+    // PRAGMA wal_checkpoint(TRUNCATE) returns one row `(busy, log,
+    // checkpointed)` matching SQLite's contract. busy != 0 means a
+    // concurrent connection held the WAL; checkpointed < log means not
+    // every frame was flushed. Either case would let post-checkpoint
+    // writes leak past the copy we're about to take, so we surface the
+    // partial-flush as an error.
+    let mut rows = conn
+        .query("PRAGMA wal_checkpoint(TRUNCATE)", ())
+        .await
+        .context(CheckpointSnafu {
+            dataset: dataset.clone(),
+            path: live_path.clone(),
+        })?;
+
+    let row = rows
+        .next()
+        .await
+        .context(CheckpointSnafu {
+            dataset: dataset.clone(),
+            path: live_path.clone(),
+        })?
+        .ok_or_else(|| TursoSnapshotError::CheckpointNoRow {
+            dataset: dataset.clone(),
+            path: live_path.clone(),
+        })?;
+
+    let busy = row
+        .get_value(0)
+        .ok()
+        .as_ref()
+        .and_then(value_as_i64)
+        .unwrap_or(0);
+    let log_frames = row
+        .get_value(1)
+        .ok()
+        .as_ref()
+        .and_then(value_as_i64)
+        .unwrap_or(0);
+    let checkpointed_frames = row
+        .get_value(2)
+        .ok()
+        .as_ref()
+        .and_then(value_as_i64)
+        .unwrap_or(0);
+
+    if busy != 0 || checkpointed_frames < log_frames {
+        return Err(TursoSnapshotError::CheckpointIncomplete {
+            dataset,
+            path: live_path,
+            busy,
+            log_frames,
+            checkpointed_frames,
+        });
+    }
+    Ok(())
+}
+
+fn value_as_i64(value: &turso::Value) -> Option<i64> {
+    match value {
+        turso::Value::Integer(n) => Some(*n),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn write_rows(path: &Path, rows: &[(i64, &str)]) {
+        let database = turso::Builder::new_local(path.to_str().expect("path"))
+            .build()
+            .await
+            .expect("open turso");
+        let conn = database.connect().expect("connect");
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT)", ())
+            .await
+            .expect("create");
+        for (id, name) in rows {
+            conn.execute(
+                "INSERT INTO t(id, name) VALUES (?1, ?2)",
+                (*id, (*name).to_string()),
+            )
+            .await
+            .expect("insert");
+        }
+        // Drop the connection / database to release any in-process handles
+        // before the engine reopens the file.
+        drop(conn);
+        drop(database);
+    }
+
+    async fn count_rows(path: &Path) -> i64 {
+        let database = turso::Builder::new_local(path.to_str().expect("path"))
+            .build()
+            .await
+            .expect("open verify");
+        let conn = database.connect().expect("connect verify");
+        let mut rows = conn
+            .query("SELECT COUNT(*) FROM t", ())
+            .await
+            .expect("count query");
+        let row = rows.next().await.expect("count step").expect("count row");
+        match row.get_value(0).expect("count column") {
+            turso::Value::Integer(n) => n,
+            other => panic!("expected integer count, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn checkpoint_live_then_copy_captures_all_rows() {
+        let tmp = TempDir::new().expect("tmp");
+        let live = tmp.path().join("live.turso");
+        let rows = vec![(1, "a"), (2, "b"), (3, "c")];
+        write_rows(&live, &rows).await;
+
+        let engine = TursoSnapshotEngine::new();
+        engine
+            .checkpoint_live(&live, "ds")
+            .await
+            .expect("checkpoint live");
+
+        // Copy the main file only (no sidecars). If checkpoint truly
+        // flushed the WAL, the copy must contain every row.
+        let copy = tmp.path().join("copy.turso");
+        std::fs::copy(&live, &copy).expect("copy");
+
+        let final_path = engine
+            .prepare_for_upload(&copy, "ds")
+            .await
+            .expect("prepare");
+
+        assert_eq!(
+            count_rows(&final_path).await,
+            i64::try_from(rows.len()).expect("row count fits in i64")
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_live_returns_ok_on_empty_database() {
+        let tmp = TempDir::new().expect("tmp");
+        let live = tmp.path().join("empty.turso");
+        // Create-and-close to materialize the file.
+        {
+            let database = turso::Builder::new_local(live.to_str().expect("path"))
+                .build()
+                .await
+                .expect("open turso");
+            let _ = database.connect().expect("connect");
+        }
+
+        let engine = TursoSnapshotEngine::new();
+        engine
+            .checkpoint_live(&live, "ds_empty")
+            .await
+            .expect("checkpoint live empty");
     }
 }

--- a/crates/runtime/tests/snapshot_refresh/turso.rs
+++ b/crates/runtime/tests/snapshot_refresh/turso.rs
@@ -16,16 +16,11 @@ limitations under the License.
 
 use super::{EngineKind, run_bootstrap_then_refresh_cycle};
 
-// Turso (libsql) WAL flush via rusqlite currently fails with
-// "file is not a database" — the libsql on-disk file isn't byte-compatible
-// with the rusqlite reader. Tracked in spiceai/spiceai#10657.
-//
-// The WAL-flush hook (commit 1 of #10651) is therefore a no-op for Turso
-// today; data loss can occur on snapshot creation if writes are still in
-// the WAL. The integration test stays \#\[ignore\]d until #10657 swaps in
-// a turso-native checkpoint path.
+// Turso WAL flush is now routed through the turso crate's native connection
+// (see `runtime-acceleration::snapshot::engine::TursoSnapshotEngine`), so the
+// snapshot creation path captures all uncheckpointed WAL frames as expected.
+// Closes spiceai/spiceai#10657.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "snapshot_refresh for turso requires a turso-native WAL checkpoint; see spiceai/spiceai#10657"]
 async fn snapshot_refresh_turso_bootstrap_then_refresh() -> Result<(), anyhow::Error> {
     run_bootstrap_then_refresh_cycle("snapshot_refresh_turso", EngineKind::Turso).await
 }


### PR DESCRIPTION
## Summary

Fixes #10657

`SqliteSnapshotEngine::checkpoint_live` was reused for Turso accelerators on the assumption that libsql's on-disk format was byte-compatible with classic SQLite for read-only opens via `rusqlite`. In practice rusqlite fails to open libsql primary files with `"file is not a database"`, so the checkpoint silently fell back to a no-op and any uncheckpointed WAL frames were lost on snapshot creation. `refresh_mode: snapshot` against Turso was therefore disabled via `#[ignore]` on the integration test.

## Changes

- `runtime-acceleration`'s `turso` feature now pulls in `dep:turso` instead of `dep:rusqlite`; the sqlite-engine module is gated on `feature = "sqlite"` only.
- `TursoSnapshotEngine::checkpoint_live` now opens the live file through `turso::Builder::new_local(..)` and runs `PRAGMA wal_checkpoint(TRUNCATE)` over the libsql-native connection. The `(busy, log, checkpointed)` result row contract is the same as SQLite's, so the existing completeness check (busy == 0 and checkpointed >= log) carries over; an incomplete or busy checkpoint surfaces as `TursoSnapshotError::CheckpointIncomplete` rather than silently snapshotting a partial database.
- Adds a dedicated `TursoSnapshotError` enum and a `SnapshotEngineError::Turso` variant so Turso-specific failures aren't conflated with `SqliteSnapshotError`.
- Un-ignores `snapshot_refresh::turso::snapshot_refresh_turso_bootstrap_then_refresh` so the integration test runs again under the existing Snapshot Refresh Mode Integration Tests CI job.

## Test plan
- [x] Added `checkpoint_live_then_copy_captures_all_rows` regression test (would fail on the previous no-op implementation): writes rows to a file-backed Turso DB, checkpoints, copies just the main file, and asserts the copy still contains every row.
- [x] Added `checkpoint_live_returns_ok_on_empty_database` edge case for the empty-WAL path.
- [x] Un-ignored Turso integration test under Snapshot Refresh Mode Integration Tests.
- [x] `make lint` passes (workspace-wide rustfmt and full clippy gate).
- [x] `make test` passes.

## Checklist
- [x] Root cause identified and fixed
- [x] Regression tests added
- [x] Edge cases covered
- [x] No snapshot deletions
- [x] Lint clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782384474&installation_id=128462479&pr_number=11048&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11048&signature=b8401e910a185b167a486be95529997ceac94eff168dc7dfe7148a1281e5a85c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->