### PR TITLE
feat(cayenne): fast-path CDC deletes by extracting PK values from filters

### DIFF
--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -286,6 +286,13 @@ impl CayenneDeletionSink {
 
         // If filters encode PK deletion values directly, extract them and write
         // deletion vectors without performing full scan.
+        //
+        // The fast path always returns 0: the extracted key set is the filter's
+        // upper bound on deletions, not a verified per-row count, so we can't
+        // produce a meaningful "rows deleted" number without a scan. Callers
+        // (CDC, `InlineAwareDeletionSink`) must not depend on this count — the
+        // authoritative count for user-visible DELETEs comes from the inline
+        // path in `InlineAwareDeletionSink`.
         match self.try_extract_pks_from_filters(&coerced_filters) {
             Some(ExtractedPkDeletes::Int64(pk_values)) => {
                 tracing::debug!(
@@ -293,7 +300,8 @@ impl CayenneDeletionSink {
                     count = pk_values.len(),
                     "Fast-path delete: extracted Int64 PK values directly from filters, skipping table scan"
                 );
-                return self.persist_int64_pk_deletions(pk_values).await;
+                self.persist_int64_pk_deletions(pk_values).await?;
+                return Ok(0);
             }
             Some(ExtractedPkDeletes::RowKeys(row_keys)) => {
                 tracing::debug!(
@@ -301,7 +309,8 @@ impl CayenneDeletionSink {
                     count = row_keys.len(),
                     "Fast-path delete: extracted row keys directly from filters, skipping table scan"
                 );
-                return self.persist_key_based_deletions(row_keys).await;
+                self.persist_key_based_deletions(row_keys).await?;
+                return Ok(0);
             }
             None => {}
         }

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -81,6 +81,9 @@ mod position_based;
 // File-based deletion for time-based retention (deletes entire expired files)
 pub(crate) mod file_based;
 
+mod pk_filter_extract;
+use pk_filter_extract::ExtractedPkDeletes;
+
 /// Deletion sink for Cayenne tables.
 ///
 /// This sink handles the process of marking rows as deleted by writing
@@ -279,6 +282,28 @@ impl CayenneDeletionSink {
             return self.delete_filtered_rows_position_based(ctx, tables).await;
         }
 
+        // If filters encode PK deletion values directly, extract them and write
+        // deletion vectors without performing full scan.
+        match self.try_extract_pks_from_filters() {
+            Some(ExtractedPkDeletes::Int64(pk_values)) => {
+                tracing::debug!(
+                    table = %table_name,
+                    count = pk_values.len(),
+                    "Fast-path delete: extracted Int64 PK values directly from filters, skipping table scan"
+                );
+                return self.persist_int64_pk_deletions(pk_values).await;
+            }
+            Some(ExtractedPkDeletes::RowKeys(row_keys)) => {
+                tracing::debug!(
+                    table = %table_name,
+                    count = row_keys.len(),
+                    "Fast-path delete: extracted row keys directly from filters, skipping table scan"
+                );
+                return self.persist_key_based_deletions(row_keys).await;
+            }
+            None => {}
+        }
+
         let coerced_filters = self.coerce_filters_for_schema()?;
         let physical_filters = self.build_physical_filters(&coerced_filters)?;
 
@@ -410,6 +435,62 @@ impl CayenneDeletionSink {
                     "PositionBased strategy should have returned early via delete_filtered_rows_position_based"
                 )
             }
+        }
+    }
+
+    /// Attempt to extract primary key values directly from the deletion filters,
+    /// without scanning any data files.
+    ///
+    /// Expects a single filter expr and recognizes the following filter shapes:
+    ///
+    /// - **Single PK**: `pk_col IN (v1, v2, ...)` — a flat `Expr::InList`.
+    /// - **Composite PK**: A balanced OR tree of AND-equality conjunctions, e.g.
+    ///   `(pk1 = a AND pk2 = b) OR (pk1 = c AND pk2 = d)`.
+    fn try_extract_pks_from_filters(&self) -> Option<ExtractedPkDeletes> {
+        if self.filters.len() != 1 {
+            return None;
+        }
+        let filter = &self.filters[0];
+        let pk_columns = &self.table_metadata.primary_key;
+
+        match &self.pk_deletion_strategy {
+            PkDeletionStrategyWithCache::Int64Pk { .. } => {
+                if pk_columns.len() != 1 {
+                    return None;
+                }
+                pk_filter_extract::try_extract_int64_in_list(filter, &pk_columns[0])
+                    .map(ExtractedPkDeletes::Int64)
+            }
+            PkDeletionStrategyWithCache::RowConverterBased { .. } => {
+                let row_converter = self.pk_row_converter.as_ref()?;
+                // Single non-Int64 PK - try InList first.
+                if pk_columns.len() == 1 {
+                    let pk_idx = *self.pk_column_indices.first()?;
+                    let target_type = self.schema.field(pk_idx).data_type();
+                    if let Some(keys) = pk_filter_extract::try_extract_in_list_row_keys(
+                        filter,
+                        &pk_columns[0],
+                        target_type,
+                        row_converter,
+                    ) {
+                        return Some(ExtractedPkDeletes::RowKeys(keys));
+                    }
+                }
+                // Composite PK — balanced OR-of-AND equality tree.
+                let pk_target_types: Vec<&arrow_schema::DataType> = self
+                    .pk_column_indices
+                    .iter()
+                    .map(|&idx| self.schema.field(idx).data_type())
+                    .collect();
+                pk_filter_extract::try_extract_composite_pk_keys(
+                    filter,
+                    pk_columns,
+                    &pk_target_types,
+                    row_converter,
+                )
+                .map(ExtractedPkDeletes::RowKeys)
+            }
+            PkDeletionStrategyWithCache::PositionBased { .. } => None,
         }
     }
 

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -84,6 +84,8 @@ pub(crate) mod file_based;
 mod pk_filter_extract;
 use pk_filter_extract::ExtractedPkDeletes;
 
+const PK_DELETE_FLUSH_BATCH_SIZE: usize = 50_000;
+
 /// Deletion sink for Cayenne tables.
 ///
 /// This sink handles the process of marking rows as deleted by writing
@@ -272,8 +274,6 @@ impl CayenneDeletionSink {
         ctx: &SessionContext,
         tables: &[Arc<ListingTable>],
     ) -> super::super::Result<u64> {
-        const PK_DELETE_FLUSH_BATCH_SIZE: usize = 50_000;
-
         let table_name = &self.table_metadata.table_name;
 
         // For position-based deletion, use the streaming per-file approach directly.
@@ -282,9 +282,11 @@ impl CayenneDeletionSink {
             return self.delete_filtered_rows_position_based(ctx, tables).await;
         }
 
+        let coerced_filters = self.coerce_filters_for_schema()?;
+
         // If filters encode PK deletion values directly, extract them and write
         // deletion vectors without performing full scan.
-        match self.try_extract_pks_from_filters() {
+        match self.try_extract_pks_from_filters(&coerced_filters) {
             Some(ExtractedPkDeletes::Int64(pk_values)) => {
                 tracing::debug!(
                     table = %table_name,
@@ -304,7 +306,6 @@ impl CayenneDeletionSink {
             None => {}
         }
 
-        let coerced_filters = self.coerce_filters_for_schema()?;
         let physical_filters = self.build_physical_filters(&coerced_filters)?;
 
         match &self.pk_deletion_strategy {
@@ -446,11 +447,11 @@ impl CayenneDeletionSink {
     /// - **Single PK**: `pk_col IN (v1, v2, ...)` — a flat `Expr::InList`.
     /// - **Composite PK**: A balanced OR tree of AND-equality conjunctions, e.g.
     ///   `(pk1 = a AND pk2 = b) OR (pk1 = c AND pk2 = d)`.
-    fn try_extract_pks_from_filters(&self) -> Option<ExtractedPkDeletes> {
-        if self.filters.len() != 1 {
+    fn try_extract_pks_from_filters(&self, filters: &[Expr]) -> Option<ExtractedPkDeletes> {
+        if filters.len() != 1 {
             return None;
         }
-        let filter = &self.filters[0];
+        let filter = &filters[0];
         let pk_columns = &self.table_metadata.primary_key;
 
         match &self.pk_deletion_strategy {
@@ -610,13 +611,31 @@ impl CayenneDeletionSink {
             return Ok(0);
         }
 
-        let delete_sequence = self
-            .catalog
-            .increment_sequence_number(&self.table_metadata.table_id)
-            .await?;
+        let table_name = &self.table_metadata.table_name;
+        let mut delete_sequence: Option<i64> = None;
+        let mut deleted_rows: u64 = 0;
+        let mut row_keys_iter = filtered_row_keys.into_iter();
 
-        self.persist_key_based_deletions_with_sequence(filtered_row_keys, delete_sequence)
-            .await
+        loop {
+            let chunk_keys: Vec<Box<[u8]>> = row_keys_iter
+                .by_ref()
+                .take(PK_DELETE_FLUSH_BATCH_SIZE)
+                .collect();
+            if chunk_keys.is_empty() {
+                return Ok(deleted_rows);
+            }
+
+            let chunk_deleted = self
+                .persist_key_based_chunk_with_shared_sequence(chunk_keys, &mut delete_sequence)
+                .await?;
+            deleted_rows =
+                deleted_rows
+                    .checked_add(chunk_deleted)
+                    .ok_or_else(|| Error::Internal {
+                        table: table_name.clone(),
+                        message: "Deleted row count overflowed u64".to_string(),
+                    })?;
+        }
     }
 
     async fn persist_key_based_deletions_with_sequence(
@@ -713,13 +732,31 @@ impl CayenneDeletionSink {
             return Ok(0);
         }
 
-        let delete_sequence = self
-            .catalog
-            .increment_sequence_number(&self.table_metadata.table_id)
-            .await?;
+        let table_name = &self.table_metadata.table_name;
+        let mut delete_sequence: Option<i64> = None;
+        let mut deleted_rows: u64 = 0;
+        let mut pk_values_iter = filtered_pk_values.into_iter();
 
-        self.persist_int64_pk_deletions_with_sequence(filtered_pk_values, delete_sequence)
-            .await
+        loop {
+            let chunk_values: Vec<i64> = pk_values_iter
+                .by_ref()
+                .take(PK_DELETE_FLUSH_BATCH_SIZE)
+                .collect();
+            if chunk_values.is_empty() {
+                return Ok(deleted_rows);
+            }
+
+            let chunk_deleted = self
+                .persist_int64_pk_chunk_with_shared_sequence(chunk_values, &mut delete_sequence)
+                .await?;
+            deleted_rows =
+                deleted_rows
+                    .checked_add(chunk_deleted)
+                    .ok_or_else(|| Error::Internal {
+                        table: table_name.clone(),
+                        message: "Deleted row count overflowed u64".to_string(),
+                    })?;
+        }
     }
 
     async fn persist_int64_pk_deletions_with_sequence(

--- a/crates/cayenne/src/provider/delete/sink/pk_filter_extract.rs
+++ b/crates/cayenne/src/provider/delete/sink/pk_filter_extract.rs
@@ -237,16 +237,16 @@ fn collect_and_eq_pairs<'a>(expr: &'a Expr, pairs: &mut Vec<(&'a Expr, &'a Expr)
         }
 
         let Expr::BinaryExpr(bin) = current else {
-            continue;
+            return false;
         };
 
-        if bin.op == Operator::And {
-            stack.push(&bin.right);
-            stack.push(&bin.left);
-            continue;
-        }
-        if bin.op == Operator::Eq {
-            pairs.push((&bin.left, &bin.right));
+        match bin.op {
+            Operator::And => {
+                stack.push(&bin.right);
+                stack.push(&bin.left);
+            }
+            Operator::Eq => pairs.push((&bin.left, &bin.right)),
+            _ => return false,
         }
     }
 
@@ -507,6 +507,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_composite_pk_extra_predicate_returns_none() {
+        let converter = make_composite_converter();
+        let pk_columns = vec!["pk".to_string(), "sk".to_string()];
+        let target_types = vec![
+            &arrow_schema::DataType::Int64 as &DataType,
+            &arrow_schema::DataType::Utf8 as &DataType,
+        ];
+
+        let expr = make_and_conjunction(1, "x")
+            .and(col("other").gt(Expr::Literal(ScalarValue::Int64(Some(0)), None)));
+        assert!(
+            try_extract_composite_pk_keys(&expr, &pk_columns, &target_types, &converter).is_none()
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Tree-walking helper tests
     // -----------------------------------------------------------------------
@@ -541,6 +557,14 @@ mod tests {
         let mut pairs = Vec::new();
         assert!(collect_and_eq_pairs(&expr, &mut pairs));
         assert_eq!(pairs.len(), 2);
+    }
+
+    #[test]
+    fn test_collect_and_eq_pairs_rejects_non_equality_predicate() {
+        let expr = make_and_conjunction(1, "x")
+            .and(col("other").gt(Expr::Literal(ScalarValue::Int64(Some(0)), None)));
+        let mut pairs = Vec::new();
+        assert!(!collect_and_eq_pairs(&expr, &mut pairs));
     }
 
     #[test]

--- a/crates/cayenne/src/provider/delete/sink/pk_filter_extract.rs
+++ b/crates/cayenne/src/provider/delete/sink/pk_filter_extract.rs
@@ -1,0 +1,644 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Fast-path extraction of primary key values from structured deletion filters.
+//!
+//! Deletion filters arriving at the Cayenne deletion sink may already encode the
+//! exact set of primary key values to delete. When that is the case the engine
+//! can skip scanning data files entirely and write deletion vectors directly.
+//!
+//! This module recognises two filter shapes:
+//!
+//! - **Single PK**: `pk_col IN (v1, v2, ...)` — a flat `Expr::InList`.
+//! - **Composite PK**: A balanced OR tree of AND-equality conjunctions, e.g.
+//!   `(pk1 = a AND pk2 = b) OR (pk1 = c AND pk2 = d)`.
+//!
+
+use arrow::array::ArrayRef;
+use arrow_row::RowConverter;
+use arrow_schema::DataType;
+use datafusion_common::ScalarValue;
+use datafusion_expr::Expr;
+use datafusion_expr::Operator;
+
+/// PK values extracted directly from structured deletion filters
+pub(crate) enum ExtractedPkDeletes {
+    /// Single-column Int64 primary key values from an `IN` list.
+    Int64(Vec<i64>),
+    /// Primary key row keys (serialised via `RowConverter`).
+    RowKeys(Vec<Box<[u8]>>),
+}
+
+// ---------------------------------------------------------------------------
+// Single-PK Int64 extraction
+// ---------------------------------------------------------------------------
+
+/// Try to extract Int64 PK values from an `IN` list expression.
+///
+/// Matches: `pk_col IN (v1, v2, ...)` where every literal is an integer scalar that can be widened to `i64`.
+pub(crate) fn try_extract_int64_in_list(expr: &Expr, pk_name: &str) -> Option<Vec<i64>> {
+    let Expr::InList(in_list) = expr else {
+        return None;
+    };
+    if in_list.negated {
+        return None;
+    }
+    let Expr::Column(col) = in_list.expr.as_ref() else {
+        return None;
+    };
+    if col.name != pk_name {
+        return None;
+    }
+
+    let mut values = Vec::with_capacity(in_list.list.len());
+    for item in &in_list.list {
+        match item {
+            Expr::Literal(ScalarValue::Int64(Some(v)), _) => values.push(*v),
+            Expr::Literal(ScalarValue::Int32(Some(v)), _) => values.push(i64::from(*v)),
+            Expr::Literal(ScalarValue::Int16(Some(v)), _) => values.push(i64::from(*v)),
+            Expr::Literal(ScalarValue::Int8(Some(v)), _) => values.push(i64::from(*v)),
+            _ => return None,
+        }
+    }
+    Some(values)
+}
+
+// ---------------------------------------------------------------------------
+// Single-PK non-Int64 (RowConverter) extraction
+// ---------------------------------------------------------------------------
+
+/// Try to extract row keys from an `IN` list expression for a single non-Int64 PK.
+///
+/// Each literal is converted to a single-element Arrow array, cast to the
+/// schema's data type if needed, and serialised via the `RowConverter`.
+pub(crate) fn try_extract_in_list_row_keys(
+    expr: &Expr,
+    pk_name: &str,
+    target_type: &DataType,
+    row_converter: &RowConverter,
+) -> Option<Vec<Box<[u8]>>> {
+    let Expr::InList(in_list) = expr else {
+        return None;
+    };
+    if in_list.negated {
+        return None;
+    }
+    let Expr::Column(col) = in_list.expr.as_ref() else {
+        return None;
+    };
+    if col.name != pk_name {
+        return None;
+    }
+
+    let mut row_keys = Vec::with_capacity(in_list.list.len());
+    for item in &in_list.list {
+        let Expr::Literal(scalar, _) = item else {
+            return None;
+        };
+        let array = scalar.to_array_of_size(1).ok()?;
+        let array = if array.data_type() == target_type {
+            array
+        } else {
+            arrow::compute::cast(&array, target_type).ok()?
+        };
+        if array.is_null(0) {
+            return None;
+        }
+        let rows = row_converter.convert_columns(&[array]).ok()?;
+        row_keys.push(rows.row(0).as_ref().into());
+    }
+    Some(row_keys)
+}
+
+// ---------------------------------------------------------------------------
+// Composite-PK extraction (balanced OR-of-AND equality tree)
+// ---------------------------------------------------------------------------
+
+/// Try to extract composite PK row keys from a balanced OR-of-AND equality tree.
+///
+/// Each leaf AND conjunction is `pk1 = v1 AND pk2 = v2 AND ...`. The scalar
+/// values are collected in PK column order, converted to Arrow arrays, and
+/// serialised via the `RowConverter`.
+///
+/// - `pk_columns`: PK column names from the table schema, in declaration order.
+/// - `pk_target_types`: the corresponding Arrow data types from the table schema
+///   (same length as `pk_columns`). Used to cast filter literals when needed.
+pub(crate) fn try_extract_composite_pk_keys(
+    expr: &Expr,
+    pk_columns: &[String],
+    pk_target_types: &[&DataType],
+    row_converter: &RowConverter,
+) -> Option<Vec<Box<[u8]>>> {
+    if pk_columns.len() != pk_target_types.len() {
+        return None;
+    }
+    let mut and_conjunctions: Vec<&Expr> = Vec::new();
+    collect_or_leaves(expr, &mut and_conjunctions);
+    if and_conjunctions.is_empty() {
+        return None;
+    }
+
+    let mut row_keys = Vec::with_capacity(and_conjunctions.len());
+    for conjunction in &and_conjunctions {
+        let mut eq_pairs: Vec<(&Expr, &Expr)> = Vec::new();
+        collect_and_eq_pairs(conjunction, &mut eq_pairs);
+        if eq_pairs.len() != pk_columns.len() {
+            return None;
+        }
+
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(pk_columns.len());
+        for (pk_idx, pk_col_name) in pk_columns.iter().enumerate() {
+            let scalar = find_scalar_for_column(&eq_pairs, pk_col_name)?;
+            let array = scalar.to_array_of_size(1).ok()?;
+            let target_type = pk_target_types[pk_idx];
+            let array = if array.data_type() == target_type {
+                array
+            } else {
+                arrow::compute::cast(&array, target_type).ok()?
+            };
+            if array.is_null(0) {
+                return None;
+            }
+            arrays.push(array);
+        }
+
+        let rows = row_converter.convert_columns(&arrays).ok()?;
+        let row = rows.row(0);
+        row_keys.push(row.as_ref().into());
+    }
+
+    Some(row_keys)
+}
+
+// ---------------------------------------------------------------------------
+// Tree-walking helpers
+// ---------------------------------------------------------------------------
+
+/// Recursively collect leaf expressions from a balanced OR tree.
+/// Non-OR nodes are treated as leaves.
+fn collect_or_leaves<'a>(expr: &'a Expr, leaves: &mut Vec<&'a Expr>) {
+    if let Expr::BinaryExpr(bin) = expr
+        && bin.op == Operator::Or
+    {
+        collect_or_leaves(&bin.left, leaves);
+        collect_or_leaves(&bin.right, leaves);
+        return;
+    }
+    leaves.push(expr);
+}
+
+/// Recursively collect `(left, right)` pairs from an AND tree of equalities.
+fn collect_and_eq_pairs<'a>(expr: &'a Expr, pairs: &mut Vec<(&'a Expr, &'a Expr)>) {
+    if let Expr::BinaryExpr(bin) = expr {
+        if bin.op == Operator::And {
+            collect_and_eq_pairs(&bin.left, pairs);
+            collect_and_eq_pairs(&bin.right, pairs);
+            return;
+        }
+        if bin.op == Operator::Eq {
+            pairs.push((&bin.left, &bin.right));
+        }
+    }
+}
+
+/// Find the `ScalarValue` paired with a specific column name in equality pairs.
+fn find_scalar_for_column<'a>(
+    pairs: &[(&'a Expr, &'a Expr)],
+    col_name: &str,
+) -> Option<&'a ScalarValue> {
+    for (left, right) in pairs {
+        if let (Expr::Column(c), Expr::Literal(sv, _)) = (left, right)
+            && c.name == col_name
+        {
+            return Some(sv);
+        }
+        if let (Expr::Literal(sv, _), Expr::Column(c)) = (left, right)
+            && c.name == col_name
+        {
+            return Some(sv);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{Field, Schema};
+    use arrow_row::SortField;
+    use data_components::pk_filter_expr::{
+        balanced_binary, build_pk_in_list_from_batch, get_delete_where_expr_from_batch,
+    };
+    use datafusion_expr::col;
+    use std::sync::Arc;
+
+    // -----------------------------------------------------------------------
+    // Int64 InList tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_int64_in_list_basic() {
+        let expr = col("id").in_list(
+            vec![
+                Expr::Literal(ScalarValue::Int64(Some(1)), None),
+                Expr::Literal(ScalarValue::Int64(Some(2)), None),
+                Expr::Literal(ScalarValue::Int64(Some(3)), None),
+            ],
+            false,
+        );
+        let result = try_extract_int64_in_list(&expr, "id");
+        assert_eq!(result, Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn test_int64_in_list_mixed_int_widths() {
+        let expr = col("id").in_list(
+            vec![
+                Expr::Literal(ScalarValue::Int8(Some(10)), None),
+                Expr::Literal(ScalarValue::Int16(Some(20)), None),
+                Expr::Literal(ScalarValue::Int32(Some(30)), None),
+                Expr::Literal(ScalarValue::Int64(Some(40)), None),
+            ],
+            false,
+        );
+        let result = try_extract_int64_in_list(&expr, "id");
+        assert_eq!(result, Some(vec![10, 20, 30, 40]));
+    }
+
+    #[test]
+    fn test_int64_in_list_wrong_column_returns_none() {
+        let expr = col("other").in_list(
+            vec![Expr::Literal(ScalarValue::Int64(Some(1)), None)],
+            false,
+        );
+        assert!(try_extract_int64_in_list(&expr, "id").is_none());
+    }
+
+    #[test]
+    fn test_int64_in_list_negated_returns_none() {
+        let expr = col("id").in_list(vec![Expr::Literal(ScalarValue::Int64(Some(1)), None)], true);
+        assert!(try_extract_int64_in_list(&expr, "id").is_none());
+    }
+
+    #[test]
+    fn test_int64_in_list_non_integer_literal_returns_none() {
+        let expr = col("id").in_list(
+            vec![
+                Expr::Literal(ScalarValue::Int64(Some(1)), None),
+                Expr::Literal(ScalarValue::Utf8(Some("abc".to_string())), None),
+            ],
+            false,
+        );
+        assert!(try_extract_int64_in_list(&expr, "id").is_none());
+    }
+
+    #[test]
+    fn test_int64_in_list_non_inlist_expr_returns_none() {
+        let expr = col("id").eq(Expr::Literal(ScalarValue::Int64(Some(1)), None));
+        assert!(try_extract_int64_in_list(&expr, "id").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Single-PK RowConverter (non-Int64) InList tests
+    // -----------------------------------------------------------------------
+
+    fn make_utf8_row_converter() -> RowConverter {
+        RowConverter::new(vec![SortField::new(arrow_schema::DataType::Utf8)]).expect("RowConverter")
+    }
+
+    #[test]
+    fn test_in_list_row_keys_utf8() {
+        let converter = make_utf8_row_converter();
+        let expr = col("name").in_list(
+            vec![
+                Expr::Literal(ScalarValue::Utf8(Some("alice".to_string())), None),
+                Expr::Literal(ScalarValue::Utf8(Some("bob".to_string())), None),
+            ],
+            false,
+        );
+        let result =
+            try_extract_in_list_row_keys(&expr, "name", &arrow_schema::DataType::Utf8, &converter);
+        assert!(result.is_some());
+        let keys = result.expect("keys");
+        assert_eq!(keys.len(), 2);
+        // Keys must be non-empty and distinct.
+        assert_ne!(keys[0], keys[1]);
+    }
+
+    #[test]
+    fn test_in_list_row_keys_wrong_column_returns_none() {
+        let converter = make_utf8_row_converter();
+        let expr = col("other").in_list(
+            vec![Expr::Literal(
+                ScalarValue::Utf8(Some("x".to_string())),
+                None,
+            )],
+            false,
+        );
+        assert!(
+            try_extract_in_list_row_keys(&expr, "name", &arrow_schema::DataType::Utf8, &converter)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_in_list_row_keys_negated_returns_none() {
+        let converter = make_utf8_row_converter();
+        let expr = col("name").in_list(
+            vec![Expr::Literal(
+                ScalarValue::Utf8(Some("x".to_string())),
+                None,
+            )],
+            true,
+        );
+        assert!(
+            try_extract_in_list_row_keys(&expr, "name", &arrow_schema::DataType::Utf8, &converter)
+                .is_none()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Composite PK extraction tests
+    // -----------------------------------------------------------------------
+
+    fn make_composite_converter() -> RowConverter {
+        RowConverter::new(vec![
+            SortField::new(arrow_schema::DataType::Int64),
+            SortField::new(arrow_schema::DataType::Utf8),
+        ])
+        .expect("RowConverter")
+    }
+
+    /// Build `(pk = v1 AND sk = v2)` conjunction.
+    fn make_and_conjunction(pk_val: i64, sk_val: &str) -> Expr {
+        col("pk")
+            .eq(Expr::Literal(ScalarValue::Int64(Some(pk_val)), None))
+            .and(col("sk").eq(Expr::Literal(
+                ScalarValue::Utf8(Some(sk_val.to_string())),
+                None,
+            )))
+    }
+
+    #[test]
+    fn test_composite_pk_single_row() {
+        let converter = make_composite_converter();
+        let pk_columns = vec!["pk".to_string(), "sk".to_string()];
+        let target_types = vec![
+            &arrow_schema::DataType::Int64 as &DataType,
+            &arrow_schema::DataType::Utf8 as &DataType,
+        ];
+
+        let expr = make_and_conjunction(1, "hello");
+        let result = try_extract_composite_pk_keys(&expr, &pk_columns, &target_types, &converter);
+        assert!(result.is_some());
+        assert_eq!(result.expect("keys").len(), 1);
+    }
+
+    #[test]
+    fn test_composite_pk_multiple_rows() {
+        let converter = make_composite_converter();
+        let pk_columns = vec!["pk".to_string(), "sk".to_string()];
+        let target_types = vec![
+            &arrow_schema::DataType::Int64 as &DataType,
+            &arrow_schema::DataType::Utf8 as &DataType,
+        ];
+
+        // (pk=1 AND sk='a') OR (pk=2 AND sk='b') OR (pk=3 AND sk='c')
+        let expr = make_and_conjunction(1, "a")
+            .or(make_and_conjunction(2, "b"))
+            .or(make_and_conjunction(3, "c"));
+
+        let result = try_extract_composite_pk_keys(&expr, &pk_columns, &target_types, &converter);
+        assert!(result.is_some());
+        let keys = result.expect("keys");
+        assert_eq!(keys.len(), 3);
+        // All keys must be distinct.
+        assert_ne!(keys[0], keys[1]);
+        assert_ne!(keys[1], keys[2]);
+    }
+
+    #[test]
+    fn test_composite_pk_wrong_column_count_returns_none() {
+        let converter = make_composite_converter();
+        let pk_columns = vec!["pk".to_string(), "sk".to_string()];
+        let target_types = vec![
+            &arrow_schema::DataType::Int64 as &DataType,
+            &arrow_schema::DataType::Utf8 as &DataType,
+        ];
+
+        // Only one equality instead of two — should fail.
+        let expr = col("pk").eq(Expr::Literal(ScalarValue::Int64(Some(1)), None));
+        assert!(
+            try_extract_composite_pk_keys(&expr, &pk_columns, &target_types, &converter).is_none()
+        );
+    }
+
+    #[test]
+    fn test_composite_pk_missing_column_returns_none() {
+        let converter = make_composite_converter();
+        let pk_columns = vec!["pk".to_string(), "sk".to_string()];
+        let target_types = vec![
+            &arrow_schema::DataType::Int64 as &DataType,
+            &arrow_schema::DataType::Utf8 as &DataType,
+        ];
+
+        // Two equalities but wrong column name.
+        let expr = col("pk")
+            .eq(Expr::Literal(ScalarValue::Int64(Some(1)), None))
+            .and(col("wrong").eq(Expr::Literal(
+                ScalarValue::Utf8(Some("x".to_string())),
+                None,
+            )));
+        assert!(
+            try_extract_composite_pk_keys(&expr, &pk_columns, &target_types, &converter).is_none()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Tree-walking helper tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_collect_or_leaves_flat() {
+        let a = col("a").eq(Expr::Literal(ScalarValue::Int64(Some(1)), None));
+        let b = col("b").eq(Expr::Literal(ScalarValue::Int64(Some(2)), None));
+        let c = col("c").eq(Expr::Literal(ScalarValue::Int64(Some(3)), None));
+        let expr = a.or(b).or(c);
+        let mut leaves = Vec::new();
+        collect_or_leaves(&expr, &mut leaves);
+        assert_eq!(leaves.len(), 3);
+    }
+
+    #[test]
+    fn test_collect_or_leaves_single_non_or() {
+        let expr = col("a").eq(Expr::Literal(ScalarValue::Int64(Some(1)), None));
+        let mut leaves = Vec::new();
+        collect_or_leaves(&expr, &mut leaves);
+        assert_eq!(leaves.len(), 1);
+    }
+
+    #[test]
+    fn test_collect_and_eq_pairs() {
+        let expr = col("pk")
+            .eq(Expr::Literal(ScalarValue::Int64(Some(1)), None))
+            .and(col("sk").eq(Expr::Literal(
+                ScalarValue::Utf8(Some("x".to_string())),
+                None,
+            )));
+        let mut pairs = Vec::new();
+        collect_and_eq_pairs(&expr, &mut pairs);
+        assert_eq!(pairs.len(), 2);
+    }
+
+    #[test]
+    fn test_find_scalar_for_column_found() {
+        let left = Expr::Column(datafusion_common::Column::new_unqualified("pk"));
+        let right = Expr::Literal(ScalarValue::Int64(Some(42)), None);
+        let pairs = vec![(&left, &right)];
+        let result = find_scalar_for_column(&pairs, "pk");
+        assert_eq!(result, Some(&ScalarValue::Int64(Some(42))));
+    }
+
+    #[test]
+    fn test_find_scalar_for_column_reversed() {
+        let left = Expr::Literal(ScalarValue::Int64(Some(42)), None);
+        let right = Expr::Column(datafusion_common::Column::new_unqualified("pk"));
+        let pairs = vec![(&left, &right)];
+        let result = find_scalar_for_column(&pairs, "pk");
+        assert_eq!(result, Some(&ScalarValue::Int64(Some(42))));
+    }
+
+    #[test]
+    fn test_find_scalar_for_column_not_found() {
+        let left = Expr::Column(datafusion_common::Column::new_unqualified("other"));
+        let right = Expr::Literal(ScalarValue::Int64(Some(42)), None);
+        let pairs = vec![(&left, &right)];
+        assert!(find_scalar_for_column(&pairs, "pk").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // CDC round-trip tests: construct filter expressions the same way CDC does from RecordBatches,
+    // then verify we can extract the same PK values back.
+    // -----------------------------------------------------------------------
+
+    fn make_int64_pk_batch(values: &[i64]) -> arrow::array::RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let arr: ArrayRef = Arc::new(Int64Array::from(values.to_vec()));
+        arrow::array::RecordBatch::try_new(schema, vec![arr]).expect("batch")
+    }
+
+    fn make_utf8_pk_batch(values: &[&str]) -> arrow::array::RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, false)]));
+        let arr: ArrayRef = Arc::new(StringArray::from(values.to_vec()));
+        arrow::array::RecordBatch::try_new(schema, vec![arr]).expect("batch")
+    }
+
+    fn make_composite_pk_batch(pks: &[i64], sks: &[&str]) -> arrow::array::RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("pk", DataType::Int64, false),
+            Field::new("sk", DataType::Utf8, false),
+        ]));
+        let pk_arr: ArrayRef = Arc::new(Int64Array::from(pks.to_vec()));
+        let sk_arr: ArrayRef = Arc::new(StringArray::from(sks.to_vec()));
+        arrow::array::RecordBatch::try_new(schema, vec![pk_arr, sk_arr]).expect("batch")
+    }
+
+    #[test]
+    fn test_roundtrip_int64_in_list() {
+        let batch = make_int64_pk_batch(&[10, 20, 30]);
+        let expr = build_pk_in_list_from_batch(&[0, 1, 2], "id", &batch).expect("build");
+        let extracted = try_extract_int64_in_list(&expr, "id").expect("should extract");
+        assert_eq!(extracted, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn test_roundtrip_utf8_in_list_row_keys() {
+        let batch = make_utf8_pk_batch(&["alice", "bob"]);
+        let expr = build_pk_in_list_from_batch(&[0, 1], "name", &batch).expect("build");
+
+        let sort_fields = vec![SortField::new(DataType::Utf8)];
+        let converter = RowConverter::new(sort_fields).expect("converter");
+
+        let keys = try_extract_in_list_row_keys(&expr, "name", &DataType::Utf8, &converter)
+            .expect("should extract");
+        assert_eq!(keys.len(), 2);
+
+        // Verify the extracted row keys match the original values.
+        let original_values = vec![
+            ScalarValue::Utf8(Some("alice".to_string())),
+            ScalarValue::Utf8(Some("bob".to_string())),
+        ];
+        for (key, val) in keys.iter().zip(&original_values) {
+            let arr: ArrayRef = val.to_array().expect("to_array");
+            let rows = converter.convert_columns(&[arr]).expect("convert");
+            assert_eq!(&**key, rows.row(0).as_ref());
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_composite_pk() {
+        let batch = make_composite_pk_batch(&[1, 2, 3], &["a", "b", "c"]);
+
+        // Build the filter the same way CDC does: per-row AND conjunctions
+        // combined into a balanced OR tree.
+        let pk_names = vec!["pk".to_string(), "sk".to_string()];
+        let row_conditions: Vec<Expr> = (0..3)
+            .map(|row| {
+                let exprs =
+                    get_delete_where_expr_from_batch(&batch, row, pk_names.clone()).expect("build");
+                balanced_binary(exprs, Expr::and).expect("and")
+            })
+            .collect();
+        let expr = balanced_binary(row_conditions, Expr::or).expect("or");
+
+        let pk_columns = vec!["pk".to_string(), "sk".to_string()];
+        let target_types: Vec<&DataType> = vec![&DataType::Int64, &DataType::Utf8];
+        let sort_fields = vec![
+            SortField::new(DataType::Int64),
+            SortField::new(DataType::Utf8),
+        ];
+        let converter = RowConverter::new(sort_fields).expect("converter");
+
+        let keys = try_extract_composite_pk_keys(&expr, &pk_columns, &target_types, &converter)
+            .expect("should extract");
+        assert_eq!(keys.len(), 3);
+
+        // Verify each extracted key matches the original row.
+        let original_rows: Vec<Vec<ScalarValue>> = vec![
+            vec![
+                ScalarValue::Int64(Some(1)),
+                ScalarValue::Utf8(Some("a".to_string())),
+            ],
+            vec![
+                ScalarValue::Int64(Some(2)),
+                ScalarValue::Utf8(Some("b".to_string())),
+            ],
+            vec![
+                ScalarValue::Int64(Some(3)),
+                ScalarValue::Utf8(Some("c".to_string())),
+            ],
+        ];
+        for (key, row_vals) in keys.iter().zip(&original_rows) {
+            let arrays: Vec<ArrayRef> = row_vals
+                .iter()
+                .map(|val| val.to_array().expect("to_array"))
+                .collect();
+            let row_batch = converter.convert_columns(&arrays).expect("convert");
+            assert_eq!(&**key, row_batch.row(0).as_ref());
+        }
+    }
+}

--- a/crates/cayenne/src/provider/delete/sink/pk_filter_extract.rs
+++ b/crates/cayenne/src/provider/delete/sink/pk_filter_extract.rs
@@ -34,6 +34,8 @@ use datafusion_common::ScalarValue;
 use datafusion_expr::Expr;
 use datafusion_expr::Operator;
 
+const MAX_PK_FILTER_TREE_NODES: usize = 65_536;
+
 /// PK values extracted directly from structured deletion filters
 pub(crate) enum ExtractedPkDeletes {
     /// Single-column Int64 primary key values from an `IN` list.
@@ -103,24 +105,26 @@ pub(crate) fn try_extract_in_list_row_keys(
         return None;
     }
 
-    let mut row_keys = Vec::with_capacity(in_list.list.len());
+    let mut scalars = Vec::with_capacity(in_list.list.len());
     for item in &in_list.list {
         let Expr::Literal(scalar, _) = item else {
             return None;
         };
-        let array = scalar.to_array_of_size(1).ok()?;
-        let array = if array.data_type() == target_type {
-            array
-        } else {
-            arrow::compute::cast(&array, target_type).ok()?
-        };
-        if array.is_null(0) {
-            return None;
-        }
-        let rows = row_converter.convert_columns(&[array]).ok()?;
-        row_keys.push(rows.row(0).as_ref().into());
+        scalars.push(scalar.clone());
     }
-    Some(row_keys)
+
+    let array = ScalarValue::iter_to_array(scalars.into_iter()).ok()?;
+    let array = if array.data_type() == target_type {
+        array
+    } else {
+        arrow::compute::cast(&array, target_type).ok()?
+    };
+    if array.null_count() > 0 {
+        return None;
+    }
+
+    let rows = row_converter.convert_columns(&[array]).ok()?;
+    Some(rows.iter().map(|row| row.as_ref().into()).collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -146,72 +150,107 @@ pub(crate) fn try_extract_composite_pk_keys(
         return None;
     }
     let mut and_conjunctions: Vec<&Expr> = Vec::new();
-    collect_or_leaves(expr, &mut and_conjunctions);
+    if !collect_or_leaves(expr, &mut and_conjunctions) {
+        return None;
+    }
     if and_conjunctions.is_empty() {
         return None;
     }
 
-    let mut row_keys = Vec::with_capacity(and_conjunctions.len());
+    let mut pk_column_values: Vec<Vec<ScalarValue>> = pk_columns
+        .iter()
+        .map(|_| Vec::with_capacity(and_conjunctions.len()))
+        .collect();
+
     for conjunction in &and_conjunctions {
         let mut eq_pairs: Vec<(&Expr, &Expr)> = Vec::new();
-        collect_and_eq_pairs(conjunction, &mut eq_pairs);
+        if !collect_and_eq_pairs(conjunction, &mut eq_pairs) {
+            return None;
+        }
         if eq_pairs.len() != pk_columns.len() {
             return None;
         }
 
-        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(pk_columns.len());
         for (pk_idx, pk_col_name) in pk_columns.iter().enumerate() {
             let scalar = find_scalar_for_column(&eq_pairs, pk_col_name)?;
-            let array = scalar.to_array_of_size(1).ok()?;
-            let target_type = pk_target_types[pk_idx];
-            let array = if array.data_type() == target_type {
-                array
-            } else {
-                arrow::compute::cast(&array, target_type).ok()?
-            };
-            if array.is_null(0) {
-                return None;
-            }
-            arrays.push(array);
+            pk_column_values[pk_idx].push(scalar.clone());
         }
-
-        let rows = row_converter.convert_columns(&arrays).ok()?;
-        let row = rows.row(0);
-        row_keys.push(row.as_ref().into());
     }
 
-    Some(row_keys)
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(pk_columns.len());
+    for (pk_idx, values) in pk_column_values.into_iter().enumerate() {
+        let array = ScalarValue::iter_to_array(values.into_iter()).ok()?;
+        let target_type = pk_target_types[pk_idx];
+        let array = if array.data_type() == target_type {
+            array
+        } else {
+            arrow::compute::cast(&array, target_type).ok()?
+        };
+        if array.null_count() > 0 {
+            return None;
+        }
+        arrays.push(array);
+    }
+
+    let rows = row_converter.convert_columns(&arrays).ok()?;
+    Some(rows.iter().map(|row| row.as_ref().into()).collect())
 }
 
 // ---------------------------------------------------------------------------
 // Tree-walking helpers
 // ---------------------------------------------------------------------------
 
-/// Recursively collect leaf expressions from a balanced OR tree.
+/// Iteratively collect leaf expressions from a balanced OR tree.
 /// Non-OR nodes are treated as leaves.
-fn collect_or_leaves<'a>(expr: &'a Expr, leaves: &mut Vec<&'a Expr>) {
-    if let Expr::BinaryExpr(bin) = expr
-        && bin.op == Operator::Or
-    {
-        collect_or_leaves(&bin.left, leaves);
-        collect_or_leaves(&bin.right, leaves);
-        return;
+fn collect_or_leaves<'a>(expr: &'a Expr, leaves: &mut Vec<&'a Expr>) -> bool {
+    let mut stack = vec![expr];
+    let mut visited = 0usize;
+
+    while let Some(current) = stack.pop() {
+        visited += 1;
+        if visited > MAX_PK_FILTER_TREE_NODES {
+            return false;
+        }
+
+        if let Expr::BinaryExpr(bin) = current
+            && bin.op == Operator::Or
+        {
+            stack.push(&bin.right);
+            stack.push(&bin.left);
+            continue;
+        }
+        leaves.push(current);
     }
-    leaves.push(expr);
+
+    true
 }
 
-/// Recursively collect `(left, right)` pairs from an AND tree of equalities.
-fn collect_and_eq_pairs<'a>(expr: &'a Expr, pairs: &mut Vec<(&'a Expr, &'a Expr)>) {
-    if let Expr::BinaryExpr(bin) = expr {
+/// Iteratively collect `(left, right)` pairs from an AND tree of equalities.
+fn collect_and_eq_pairs<'a>(expr: &'a Expr, pairs: &mut Vec<(&'a Expr, &'a Expr)>) -> bool {
+    let mut stack = vec![expr];
+    let mut visited = 0usize;
+
+    while let Some(current) = stack.pop() {
+        visited += 1;
+        if visited > MAX_PK_FILTER_TREE_NODES {
+            return false;
+        }
+
+        let Expr::BinaryExpr(bin) = current else {
+            continue;
+        };
+
         if bin.op == Operator::And {
-            collect_and_eq_pairs(&bin.left, pairs);
-            collect_and_eq_pairs(&bin.right, pairs);
-            return;
+            stack.push(&bin.right);
+            stack.push(&bin.left);
+            continue;
         }
         if bin.op == Operator::Eq {
             pairs.push((&bin.left, &bin.right));
         }
     }
+
+    true
 }
 
 /// Find the `ScalarValue` paired with a specific column name in equality pairs.
@@ -479,7 +518,7 @@ mod tests {
         let c = col("c").eq(Expr::Literal(ScalarValue::Int64(Some(3)), None));
         let expr = a.or(b).or(c);
         let mut leaves = Vec::new();
-        collect_or_leaves(&expr, &mut leaves);
+        assert!(collect_or_leaves(&expr, &mut leaves));
         assert_eq!(leaves.len(), 3);
     }
 
@@ -487,7 +526,7 @@ mod tests {
     fn test_collect_or_leaves_single_non_or() {
         let expr = col("a").eq(Expr::Literal(ScalarValue::Int64(Some(1)), None));
         let mut leaves = Vec::new();
-        collect_or_leaves(&expr, &mut leaves);
+        assert!(collect_or_leaves(&expr, &mut leaves));
         assert_eq!(leaves.len(), 1);
     }
 
@@ -500,7 +539,7 @@ mod tests {
                 None,
             )));
         let mut pairs = Vec::new();
-        collect_and_eq_pairs(&expr, &mut pairs);
+        assert!(collect_and_eq_pairs(&expr, &mut pairs));
         assert_eq!(pairs.len(), 2);
     }
 

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -134,6 +134,7 @@ pub mod unity_catalog;
 pub mod git;
 pub mod github;
 pub mod key_filter;
+pub mod pk_filter_expr;
 pub mod rate_limit;
 
 pub mod cdc;

--- a/crates/data_components/src/pk_filter_expr.rs
+++ b/crates/data_components/src/pk_filter_expr.rs
@@ -1,0 +1,320 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Primary-key filter expression construction helpers.
+//!
+//! This module provides functions to build `Expr` filter trees that encode a
+//! set of primary key values to delete:
+//!
+//! - **Single PK**: `pk_col IN (v1, v2, ...)` via [`build_pk_in_list`].
+//! - **Composite PK**: Balanced OR tree of AND-equality conjunctions via
+//!   [`build_composite_pk_filter`].
+//!
+//! These are the canonical shapes recognised by the fast-path extractor in
+//! Cayenne's `pk_filter_extract` module.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, RecordBatch};
+use arrow::datatypes::{DataType, SchemaRef};
+use datafusion::common::ScalarValue;
+use datafusion::logical_expr::{Expr, col, lit};
+use snafu::prelude::*;
+
+/// Build `pk_col IN (v1, v2, ...)` from a list of `ScalarValue` literals.
+///
+/// Returns `None` if `values` is empty.
+#[must_use]
+pub fn build_pk_in_list(pk_name: &str, values: Vec<ScalarValue>) -> Option<Expr> {
+    if values.is_empty() {
+        return None;
+    }
+    let literals: Vec<Expr> = values.into_iter().map(|v| Expr::Literal(v, None)).collect();
+    Some(col(pk_name).in_list(literals, false))
+}
+
+/// Build a balanced OR tree of AND-equality conjunctions for composite PKs.
+///
+/// Each entry in `rows` is a list of `(column_name, value)` pairs — one per
+/// PK column, in declaration order. The result is:
+///
+/// ```text
+/// (pk1 = a AND pk2 = b) OR (pk1 = c AND pk2 = d) OR ...
+/// ```
+///
+/// Returns `None` if `rows` is empty or any row is empty.
+#[must_use]
+pub fn build_composite_pk_filter(rows: &[Vec<(&str, ScalarValue)>]) -> Option<Expr> {
+    let mut row_conditions: Vec<Expr> = Vec::with_capacity(rows.len());
+    for row in rows {
+        let eq_exprs: Vec<Expr> = row
+            .iter()
+            .map(|(col_name, val)| col(*col_name).eq(Expr::Literal(val.clone(), None)))
+            .collect();
+        // Return None if any row produces no equalities (empty row).
+        row_conditions.push(balanced_binary(eq_exprs, Expr::and)?);
+    }
+    balanced_binary(row_conditions, Expr::or)
+}
+
+/// Build a balanced binary tree of expressions to avoid deep nesting.
+///
+/// Instead of creating a right-associative chain like `OP(a, OP(b, OP(c, d)))`
+/// which has O(n) depth and risks stack overflow when cloned, this creates a
+/// balanced tree with O(log n) depth.
+pub fn balanced_binary(mut conditions: Vec<Expr>, op: fn(Expr, Expr) -> Expr) -> Option<Expr> {
+    match conditions.len() {
+        0 => None,
+        1 => conditions.into_iter().next(),
+        _ => {
+            let mid = conditions.len() / 2;
+            let right_exprs = conditions.split_off(mid);
+
+            match (
+                balanced_binary(conditions, op),
+                balanced_binary(right_exprs, op),
+            ) {
+                (Some(l), Some(r)) => Some(op(l, r)),
+                (Some(s), None) | (None, Some(s)) => Some(s),
+                (None, None) => None,
+            }
+        }
+    }
+}
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "Expected schema to have field '{field_name}', but it did not. Spice found the schema: {schema} Is the primary key configuration correct?"
+    ))]
+    FieldNotFound {
+        field_name: String,
+        schema: SchemaRef,
+    },
+
+    #[snafu(display("Primary key type not yet supported: {data_type}"))]
+    PrimaryKeyTypeNotYetSupported { data_type: String },
+
+    #[snafu(display("Primary key column '{field_name}' has NULL value at row {row}"))]
+    PrimaryKeyNullValue { field_name: String, row: usize },
+
+    #[snafu(display(
+        "Expected the field in schema '{field_name}' to have type '{expected_type}', but it did not. Spice found the schema: {schema} Is the primary key configuration correct?"
+    ))]
+    ArrayDowncastFailed {
+        field_name: String,
+        expected_type: String,
+        schema: SchemaRef,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Extract the scalar value of a primary key column at a given row.
+///
+/// Returns the `lit(value)` expression for the cell. Supports Int32, Int64,
+/// and Utf8 column types.
+pub fn pk_value_at_row(data: &RecordBatch, row: usize, key: &str) -> Result<Expr> {
+    let data_schema = data.schema();
+    let (primary_key_idx, field) =
+        data_schema
+            .column_with_name(key)
+            .ok_or_else(|| Error::FieldNotFound {
+                field_name: key.to_string(),
+                schema: Arc::clone(&data_schema),
+            })?;
+
+    let key_col = data.column(primary_key_idx);
+    match field.data_type() {
+        DataType::Int32 => {
+            let typed = key_col
+                .as_any()
+                .downcast_ref::<arrow::array::Int32Array>()
+                .context(ArrayDowncastFailedSnafu {
+                    field_name: key.to_string(),
+                    expected_type: "Int32",
+                    schema: Arc::clone(&data_schema),
+                })?;
+            ensure!(
+                !typed.is_null(row),
+                PrimaryKeyNullValueSnafu {
+                    field_name: key.to_string(),
+                    row
+                }
+            );
+            Ok(lit(typed.value(row)))
+        }
+        DataType::Int64 => {
+            let typed = key_col
+                .as_any()
+                .downcast_ref::<arrow::array::Int64Array>()
+                .context(ArrayDowncastFailedSnafu {
+                    field_name: key.to_string(),
+                    expected_type: "Int64",
+                    schema: Arc::clone(&data_schema),
+                })?;
+            ensure!(
+                !typed.is_null(row),
+                PrimaryKeyNullValueSnafu {
+                    field_name: key.to_string(),
+                    row
+                }
+            );
+            Ok(lit(typed.value(row)))
+        }
+        DataType::Utf8 => {
+            let typed = key_col
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .context(ArrayDowncastFailedSnafu {
+                    field_name: key.to_string(),
+                    expected_type: "String",
+                    schema: Arc::clone(&data_schema),
+                })?;
+            ensure!(
+                !typed.is_null(row),
+                PrimaryKeyNullValueSnafu {
+                    field_name: key.to_string(),
+                    row
+                }
+            );
+            Ok(lit(typed.value(row)))
+        }
+        other => Err(Error::PrimaryKeyTypeNotYetSupported {
+            data_type: other.to_string(),
+        }),
+    }
+}
+
+/// Builds an IN list expression for single-column primary key deletes.
+///
+/// Instead of `id = 1 OR id = 2 OR id = 3 ...` (deeply nested tree),
+/// creates `id IN (1, 2, 3, ...)` which is a flat structure with O(1) depth.
+pub fn build_pk_in_list_from_batch(
+    row_indices: &[usize],
+    primary_key: &str,
+    data: &RecordBatch,
+) -> Result<Expr> {
+    let values: Vec<Expr> = row_indices
+        .iter()
+        .map(|&row| pk_value_at_row(data, row, primary_key))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(col(primary_key).in_list(values, false))
+}
+
+/// Builds equality expressions for composite primary key deletes at a given row.
+///
+/// For each primary key column, produces `col(pk) = literal_value`.
+pub fn get_delete_where_expr_from_batch(
+    data: &RecordBatch,
+    row: usize,
+    primary_keys: Vec<String>,
+) -> Result<Vec<Expr>> {
+    let mut delete_where_exprs: Vec<Expr> = Vec::with_capacity(primary_keys.len());
+
+    for primary_key in primary_keys {
+        let expr_val = pk_value_at_row(data, row, &primary_key)?;
+        delete_where_exprs.push(col(primary_key).eq(expr_val));
+    }
+
+    Ok(delete_where_exprs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, Int64Array, StringArray};
+    use arrow::datatypes::{Field, Schema};
+    use std::sync::Arc;
+
+    fn make_int64_batch(values: &[i64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let arr: ArrayRef = Arc::new(Int64Array::from(values.to_vec()));
+        RecordBatch::try_new(schema, vec![arr]).expect("batch")
+    }
+
+    fn make_utf8_batch(values: &[&str]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, false)]));
+        let arr: ArrayRef = Arc::new(StringArray::from(values.to_vec()));
+        RecordBatch::try_new(schema, vec![arr]).expect("batch")
+    }
+
+    fn make_composite_batch(pks: &[i64], sks: &[&str]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("pk", DataType::Int64, false),
+            Field::new("sk", DataType::Utf8, false),
+        ]));
+        let pk_arr: ArrayRef = Arc::new(Int64Array::from(pks.to_vec()));
+        let sk_arr: ArrayRef = Arc::new(StringArray::from(sks.to_vec()));
+        RecordBatch::try_new(schema, vec![pk_arr, sk_arr]).expect("batch")
+    }
+
+    #[test]
+    fn test_pk_value_at_row_int64() {
+        let batch = make_int64_batch(&[10, 20, 30]);
+        let expr = pk_value_at_row(&batch, 1, "id").expect("ok");
+        assert_eq!(expr, lit(20_i64));
+    }
+
+    #[test]
+    fn test_pk_value_at_row_utf8() {
+        let batch = make_utf8_batch(&["alice", "bob"]);
+        let expr = pk_value_at_row(&batch, 0, "name").expect("ok");
+        assert_eq!(expr, lit("alice"));
+    }
+
+    #[test]
+    fn test_pk_value_at_row_missing_column() {
+        let batch = make_int64_batch(&[1]);
+        let err = pk_value_at_row(&batch, 0, "missing").expect_err("should fail");
+        assert!(matches!(err, Error::FieldNotFound { .. }));
+    }
+
+    #[test]
+    fn test_build_pk_in_list_from_batch_int64() {
+        let batch = make_int64_batch(&[10, 20, 30]);
+        let expr = build_pk_in_list_from_batch(&[0, 1, 2], "id", &batch).expect("ok");
+        let Expr::InList(in_list) = &expr else {
+            panic!("expected InList, got {expr:?}");
+        };
+        assert_eq!(in_list.list.len(), 3);
+        assert!(!in_list.negated);
+    }
+
+    #[test]
+    fn test_build_pk_in_list_from_batch_utf8() {
+        let batch = make_utf8_batch(&["alice", "bob", "carol"]);
+        let expr = build_pk_in_list_from_batch(&[0, 2], "name", &batch).expect("ok");
+        let Expr::InList(in_list) = &expr else {
+            panic!("expected InList, got {expr:?}");
+        };
+        assert_eq!(in_list.list.len(), 2);
+    }
+
+    #[test]
+    fn test_get_delete_where_expr_from_batch_composite() {
+        let batch = make_composite_batch(&[1, 2], &["a", "b"]);
+        let exprs =
+            get_delete_where_expr_from_batch(&batch, 0, vec!["pk".to_string(), "sk".to_string()])
+                .expect("ok");
+        assert_eq!(exprs.len(), 2);
+        // Each should be an equality expression
+        for expr in &exprs {
+            assert!(matches!(expr, Expr::BinaryExpr(_)));
+        }
+    }
+}

--- a/crates/data_components/src/pk_filter_expr.rs
+++ b/crates/data_components/src/pk_filter_expr.rs
@@ -116,7 +116,7 @@ pub enum Error {
     ))]
     ArrayDowncastFailed {
         field_name: String,
-        expected_type: String,
+        expected_type: &'static str,
         schema: SchemaRef,
     },
 }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -195,6 +195,11 @@ pub enum Error {
 
     #[snafu(display("No primary keys defined for dataset {dataset_name}"))]
     NoPrimaryKeysDefined { dataset_name: String },
+
+    #[snafu(transparent)]
+    PkFilterExpr {
+        source: data_components::pk_filter_expr::Error,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -2275,7 +2275,7 @@ fn filter_records(
                     .context(super::FailedToFilterUpdatesSnafu)?;
                 Ok((Arc::clone(field), update_data.column(column_idx).to_owned()))
             })
-            .collect::<Result<Vec<_>, _>>()?,
+            .collect::<Result<Vec<_>, super::Error>>()?,
     );
 
     for existing in existing_records {
@@ -2290,7 +2290,7 @@ fn filter_records(
                         .context(super::FailedToFilterUpdatesSnafu)?;
                     Ok((Arc::clone(field), existing.column(column_idx).to_owned()))
                 })
-                .collect::<Result<Vec<_>, _>>()?,
+                .collect::<Result<Vec<_>, super::Error>>()?,
         );
 
         comparators.push((

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -47,7 +47,9 @@ use arrow::{
 use arrow_schema::SchemaRef;
 use async_stream::stream;
 use data_components::poly::PolyTableProvider;
-use data_components::{FieldMetadata, MetadataEnrichedTableProvider, metadata_enriched_table_provider};
+use data_components::{
+    FieldMetadata, MetadataEnrichedTableProvider, metadata_enriched_table_provider,
+};
 use datafusion::catalog::MemoryCatalogProvider;
 use datafusion::datasource::{DefaultTableSource, TableType};
 use datafusion::execution::SessionStateBuilder;
@@ -2471,9 +2473,10 @@ mod tests {
     #[test]
     fn table_provider_with_existing_metadata_preserves_indexed_provider() {
         let schema = Arc::new(Schema::new_with_metadata(
-            vec![Field::new("id", DataType::Int64, false).with_metadata(
-                [("field_meta".to_string(), "field_value".to_string())].into(),
-            )],
+            vec![
+                Field::new("id", DataType::Int64, false)
+                    .with_metadata([("field_meta".to_string(), "field_value".to_string())].into()),
+            ],
             [("table_meta".to_string(), "table_value".to_string())].into(),
         ));
         let batch = RecordBatch::try_new(
@@ -2487,10 +2490,9 @@ mod tests {
         );
         let index: Arc<dyn runtime_datafusion_index::Index + Send + Sync> =
             Arc::new(TestRefreshIndex);
-        let indexed_provider: Arc<dyn TableProvider> = Arc::new(IndexedTableProvider::with_indexes(
-            mem_table,
-            vec![Arc::clone(&index)],
-        ));
+        let indexed_provider: Arc<dyn TableProvider> = Arc::new(
+            IndexedTableProvider::with_indexes(mem_table, vec![Arc::clone(&index)]),
+        );
 
         let wrapped = table_provider_with_existing_metadata(indexed_provider);
         let indexed = wrapped
@@ -2508,7 +2510,10 @@ mod tests {
 
         let wrapped_schema = wrapped.schema();
         assert_eq!(
-            wrapped_schema.metadata().get("table_meta").map(String::as_str),
+            wrapped_schema
+                .metadata()
+                .get("table_meta")
+                .map(String::as_str),
             Some("table_value")
         );
         let id_field = wrapped_schema

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -47,7 +47,7 @@ use arrow::{
 use arrow_schema::SchemaRef;
 use async_stream::stream;
 use data_components::poly::PolyTableProvider;
-use data_components::{FieldMetadata, metadata_enriched_table_provider};
+use data_components::{FieldMetadata, MetadataEnrichedTableProvider, metadata_enriched_table_provider};
 use datafusion::catalog::MemoryCatalogProvider;
 use datafusion::datasource::{DefaultTableSource, TableType};
 use datafusion::execution::SessionStateBuilder;
@@ -74,14 +74,15 @@ use runtime_datafusion::execution_plan::schema_cast::EnsureSchema;
 use runtime_datafusion::extension::ExtensionPlanQueryPlanner;
 use runtime_datafusion::extension::bytes_processed::BytesProcessedPhysicalOptimizer;
 use runtime_datafusion::optimizer_rule::avoid_vector_columns_on_index::AvoidDerivedVectorColumnOnIndexRule;
-use runtime_datafusion_index::analyzer::{
-    IndexTableScanExtensionPlanner, IndexTableScanOptimizerRule,
+use runtime_datafusion_index::{
+    IndexedTableProvider,
+    analyzer::{IndexTableScanExtensionPlanner, IndexTableScanOptimizerRule},
 };
 use runtime_object_store::registry::default_runtime_env;
 use runtime_request_context::{AsyncMarker, RequestContext};
 use snafu::{OptionExt, ResultExt};
 use spicepod::metric::Metrics;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::time::{Duration, UNIX_EPOCH};
@@ -121,6 +122,62 @@ fn table_provider_with_existing_metadata(
 
     if table_metadata.is_empty() && field_metadata.is_empty() {
         return provider;
+    }
+
+    metadata_enriched_table_provider_preserving_indexes(provider, table_metadata, field_metadata)
+}
+
+fn metadata_enriched_table_provider_preserving_indexes(
+    provider: Arc<dyn TableProvider>,
+    table_metadata: HashMap<String, String>,
+    field_metadata: FieldMetadata,
+) -> Arc<dyn TableProvider> {
+    if table_metadata.is_empty() && field_metadata.is_empty() {
+        return provider;
+    }
+
+    if let Some(indexed) = provider.as_any().downcast_ref::<IndexedTableProvider>() {
+        let enriched_underlying = metadata_enriched_table_provider_preserving_indexes(
+            indexed.get_underlying(),
+            table_metadata,
+            field_metadata,
+        );
+
+        return Arc::new(IndexedTableProvider::with_indexes(
+            enriched_underlying,
+            indexed.get_all_indexes(),
+        ));
+    }
+
+    if let Some(metadata_enriched) = provider
+        .as_any()
+        .downcast_ref::<MetadataEnrichedTableProvider>()
+    {
+        return metadata_enriched_table_provider_preserving_indexes(
+            Arc::clone(metadata_enriched.get_inner_ref()),
+            table_metadata,
+            field_metadata,
+        );
+    }
+
+    if let Some(adaptor) = provider
+        .as_any()
+        .downcast_ref::<FederatedTableProviderAdaptor>()
+    {
+        let Some(table_provider) = &adaptor.table_provider else {
+            return Arc::clone(&provider);
+        };
+
+        let enriched_provider = metadata_enriched_table_provider_preserving_indexes(
+            Arc::clone(table_provider),
+            table_metadata,
+            field_metadata,
+        );
+
+        return Arc::new(FederatedTableProviderAdaptor::new_with_provider(
+            Arc::clone(&adaptor.source),
+            enriched_provider,
+        ));
     }
 
     metadata_enriched_table_provider(provider, table_metadata, field_metadata)
@@ -2392,6 +2449,76 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use std::sync::Arc;
     use tokio::sync::Mutex;
+
+    #[derive(Debug)]
+    struct TestRefreshIndex;
+
+    #[async_trait::async_trait]
+    impl runtime_datafusion_index::Index for TestRefreshIndex {
+        fn name(&self) -> &'static str {
+            "test_refresh_index"
+        }
+
+        fn required_columns(&self) -> Vec<String> {
+            vec!["id".to_string()]
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[test]
+    fn table_provider_with_existing_metadata_preserves_indexed_provider() {
+        let schema = Arc::new(Schema::new_with_metadata(
+            vec![Field::new("id", DataType::Int64, false).with_metadata(
+                [("field_meta".to_string(), "field_value".to_string())].into(),
+            )],
+            [("table_meta".to_string(), "table_value".to_string())].into(),
+        ));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1_i64]))],
+        )
+        .expect("record batch should be created");
+        let mem_table: Arc<dyn TableProvider> = Arc::new(
+            MemTable::try_new(Arc::clone(&schema), vec![vec![batch]])
+                .expect("mem table should be created"),
+        );
+        let index: Arc<dyn runtime_datafusion_index::Index + Send + Sync> =
+            Arc::new(TestRefreshIndex);
+        let indexed_provider: Arc<dyn TableProvider> = Arc::new(IndexedTableProvider::with_indexes(
+            mem_table,
+            vec![Arc::clone(&index)],
+        ));
+
+        let wrapped = table_provider_with_existing_metadata(indexed_provider);
+        let indexed = wrapped
+            .as_any()
+            .downcast_ref::<IndexedTableProvider>()
+            .expect("indexed provider should remain the outer provider");
+        assert_eq!(indexed.get_all_indexes().len(), 1);
+        assert!(
+            indexed
+                .get_underlying()
+                .as_any()
+                .downcast_ref::<MetadataEnrichedTableProvider>()
+                .is_some()
+        );
+
+        let wrapped_schema = wrapped.schema();
+        assert_eq!(
+            wrapped_schema.metadata().get("table_meta").map(String::as_str),
+            Some("table_value")
+        );
+        let id_field = wrapped_schema
+            .field_with_name("id")
+            .expect("id field should exist");
+        assert_eq!(
+            id_field.metadata().get("field_meta").map(String::as_str),
+            Some("field_value")
+        );
+    }
 
     #[test]
     fn test_data_load_tracing_tracks_bytes_and_rows() {

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -40,6 +40,7 @@ use data_components::kafka::{
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SessionState;
+#[cfg(test)]
 use datafusion::logical_expr::Expr;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::lit;
@@ -52,7 +53,9 @@ use opentelemetry::KeyValue;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion_index::IndexedTableProvider;
 use runtime_table_partition::provider::PartitionTableProvider;
-use snafu::{OptionExt, ResultExt};
+#[cfg(test)]
+use snafu::OptionExt;
+use snafu::ResultExt;
 use std::collections::HashSet;
 use std::hash::BuildHasherDefault;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -140,6 +143,7 @@ impl WriteChangeOutcome {
 ///    println!("Primary key value as DataFusion expression: {}", expr_value);
 /// }
 /// ```
+#[cfg(test)]
 macro_rules! extract_primary_key {
     ($key_col:expr, $key:expr, $data_schema:expr, $array_type:ty, $data_type_str:expr, $row:expr) => {{
         let key_col = $key_col.as_any().downcast_ref::<$array_type>().context(
@@ -1474,6 +1478,7 @@ pub(crate) fn get_primary_key_value(
     get_primary_key_value_at_row(data, 0, key)
 }
 
+#[cfg(test)]
 pub(crate) fn get_primary_key_value_at_row(
     data: &RecordBatch,
     row: usize,

--- a/crates/runtime/src/accelerated_table/refresh_task/deletion.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/deletion.rs
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #[cfg(test)]
-use crate::accelerated_table::refresh_task::changes::get_primary_key_value;
-use crate::accelerated_table::refresh_task::changes::get_primary_key_value_at_row;
 use arrow::array::RecordBatch;
 use data_components::cdc::ChangeBatch;
-use datafusion::logical_expr::{Expr, col};
+use data_components::pk_filter_expr::{self, balanced_binary};
+use datafusion::logical_expr::Expr;
+#[cfg(test)]
+use datafusion::logical_expr::col;
 
 #[cfg(test)]
 pub fn build_batch_delete_expr<F, G>(
@@ -90,7 +91,7 @@ pub fn build_batch_delete_expr_from_change_batch(
 
     let data_batch = change_batch.data_batch();
     if first_row_pks.len() == 1 {
-        return Ok(Some(build_in_list_expr_from_batch(
+        return Ok(Some(pk_filter_expr::build_pk_in_list_from_batch(
             row_indices,
             &first_row_pks[0],
             &data_batch,
@@ -101,7 +102,8 @@ pub fn build_batch_delete_expr_from_change_batch(
         .iter()
         .map(|&row| {
             let primary_keys = change_batch.primary_keys(row);
-            let exprs = get_delete_where_expr_from_batch(&data_batch, row, primary_keys)?;
+            let exprs =
+                pk_filter_expr::get_delete_where_expr_from_batch(&data_batch, row, primary_keys)?;
             balanced_binary(exprs, Expr::and).ok_or_else(|| {
                 crate::accelerated_table::Error::NoPrimaryKeysDefined {
                     dataset_name: dataset_name.to_string(),
@@ -111,42 +113,6 @@ pub fn build_batch_delete_expr_from_change_batch(
         .collect::<crate::accelerated_table::Result<Vec<_>>>()?;
 
     Ok(balanced_binary(row_conditions, Expr::or))
-}
-
-/// Builds a balanced binary tree of expressions to avoid deep nesting.
-///
-/// Instead of creating a right-associative chain like `OP(a, OP(b, OP(c, d)))` which
-/// has O(n) depth and causes stack overflow when cloned, this creates a balanced tree
-/// with O(log n) depth.
-///
-/// For 975 rows, depth goes from 975 to ~10.
-fn balanced_binary(conditions: Vec<Expr>, op: fn(Expr, Expr) -> Expr) -> Option<Expr> {
-    balanced_binary_impl(conditions, op)
-}
-
-fn balanced_binary_impl(mut conditions: Vec<Expr>, op: fn(Expr, Expr) -> Expr) -> Option<Expr> {
-    match conditions.len() {
-        0 => None,
-        1 => Some(
-            conditions
-                .into_iter()
-                .next()
-                .unwrap_or_else(|| unreachable!("len checked")),
-        ),
-        _ => {
-            let mid = conditions.len() / 2;
-            let right_exprs = conditions.split_off(mid);
-
-            match (
-                balanced_binary_impl(conditions, op),
-                balanced_binary_impl(right_exprs, op),
-            ) {
-                (Some(l), Some(r)) => Some(op(l, r)),
-                (Some(s), None) | (None, Some(s)) => Some(s),
-                (None, None) => None,
-            }
-        }
-    }
 }
 
 /// Builds an IN list expression for single-column primary key deletes.
@@ -162,28 +128,12 @@ fn build_in_list_expr<G>(
 where
     G: Fn(usize) -> RecordBatch,
 {
+    // Each closure call returns a single-row batch; extract the value at row 0.
     let values: Vec<Expr> = row_indices
         .iter()
         .map(|&row| {
             let row_data = get_row_data(row);
-            let (_, expr_val) = get_primary_key_value(&row_data, primary_key)?;
-            Ok(expr_val)
-        })
-        .collect::<crate::accelerated_table::Result<Vec<_>>>()?;
-
-    Ok(col(primary_key).in_list(values, false))
-}
-
-fn build_in_list_expr_from_batch(
-    row_indices: &[usize],
-    primary_key: &str,
-    data: &RecordBatch,
-) -> crate::accelerated_table::Result<Expr> {
-    let values: Vec<Expr> = row_indices
-        .iter()
-        .map(|&row| {
-            let (_, expr_val) = get_primary_key_value_at_row(data, row, primary_key)?;
-            Ok(expr_val)
+            Ok(pk_filter_expr::pk_value_at_row(&row_data, 0, primary_key)?)
         })
         .collect::<crate::accelerated_table::Result<Vec<_>>>()?;
 
@@ -195,29 +145,12 @@ fn get_delete_where_expr(
     data: &RecordBatch,
     primary_keys: Vec<String>,
 ) -> crate::accelerated_table::Result<Vec<Expr>> {
-    let mut delete_where_exprs: Vec<Expr> = vec![];
-
-    for primary_key in primary_keys {
-        let (_, expr_val) = get_primary_key_value(data, &primary_key)?;
-        delete_where_exprs.push(col(primary_key).eq(expr_val));
-    }
-
-    Ok(delete_where_exprs)
-}
-
-fn get_delete_where_expr_from_batch(
-    data: &RecordBatch,
-    row: usize,
-    primary_keys: Vec<String>,
-) -> crate::accelerated_table::Result<Vec<Expr>> {
-    let mut delete_where_exprs: Vec<Expr> = Vec::with_capacity(primary_keys.len());
-
-    for primary_key in primary_keys {
-        let (_, expr_val) = get_primary_key_value_at_row(data, row, &primary_key)?;
-        delete_where_exprs.push(col(primary_key).eq(expr_val));
-    }
-
-    Ok(delete_where_exprs)
+    // Single-row batch; build equalities via the shared helper at row 0.
+    Ok(pk_filter_expr::get_delete_where_expr_from_batch(
+        data,
+        0,
+        primary_keys,
+    )?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 📝 Summary

PR adds fast-path delete in Cayenne: when deletion filters already encode PK values (single or composite), extract them directly and write deletion vectors without full table scan.

## Changes

- Extract shared PK filter expression helpers into `data_components::pk_filter_expr` to deduplicate between Cayenne and the runtime CDC layer
- Add fast-path delete in Cayenne: when deletion filters already encode PK values (single or composite), extract them directly and write deletion vectors without scanning data files


## Supported filter shapes

The fast path recognises filter expressions produced by the CDC change-processing layer:

| PK type | Filter shape | Example |
|---|---|---|
| Single Int64 PK | `pk IN (v1, v2, ...)` | `id IN (1, 2, 3)` |
| Single non-Int64 PK | `pk IN (v1, v2, ...)` | `name IN ('alice', 'bob')` |
| Composite PK | Balanced OR tree of AND equalities | `(pk1 = 1 AND pk2 = 'a') OR (pk1 = 2 AND pk2 = 'b')` |

Unrecognised shapes fall through to the existing full-scan path.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782386072&installation_id=128462479&pr_number=11049&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11049&signature=2ec4f4549e3ad9734d5bb69834f3d949b1ab18b38528db3dca3d1c2cbfa2dc7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->