### PR TITLE
refactor(cdc): reduce CDC sub-batch splits for interleaved upsert/delete workloads

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1506,8 +1506,44 @@ pub(crate) fn get_primary_key_value_at_row(
     }
 }
 
-/// Groups rows into sub-batches based on operation type and primary key uniqueness
-/// Returns a vector of (`operation_type`, `row_indices`) tuples
+/// An active batch accumulating row indices for a single operation type.
+/// Tracks the set of primary keys it contains so that PK conflicts can be
+/// detected in O(1) per row.
+struct OpBatchAccumulator {
+    rows: Vec<usize>,
+    pks: HashSet<Vec<u8>, BuildHasherDefault<twox_hash::XxHash3_64>>,
+}
+
+impl OpBatchAccumulator {
+    fn new() -> Self {
+        Self {
+            rows: Vec::new(),
+            pks: HashSet::default(),
+        }
+    }
+
+    /// Drain accumulated rows into `out` under the given operation type and
+    /// reset PK tracking.
+    fn flush_into(
+        &mut self,
+        op: ChangeOperationType,
+        out: &mut Vec<(ChangeOperationType, Vec<usize>)>,
+    ) {
+        if !self.rows.is_empty() {
+            out.push((op, std::mem::take(&mut self.rows)));
+            self.pks.clear();
+        }
+    }
+}
+
+/// Groups rows into sub-batches based on operation type and primary key
+/// conflicts across active operation buckets.
+///
+/// Uses a streaming conflict-window algorithm: two active buckets (upsert,
+/// delete) accumulate rows concurrently. When an incoming row's PK already
+/// exists in *either* bucket, only the conflicting bucket is flushed — the
+/// other keeps accumulating. Truncate and Unknown act as barriers that flush
+/// everything.
 #[must_use]
 fn group_into_sub_batches(change_batch: &ChangeBatch) -> Vec<(ChangeOperationType, Vec<usize>)> {
     let num_rows = change_batch.record.num_rows();
@@ -1522,56 +1558,72 @@ fn group_into_sub_batches(change_batch: &ChangeBatch) -> Vec<(ChangeOperationTyp
         .iter()
         .filter_map(|name| data_batch.schema().index_of(name).ok())
         .collect();
-
-    let mut sub_batches = Vec::new();
-    let mut current_batch_indices = Vec::new();
-    let mut current_op_type: Option<ChangeOperationType> = None;
-    let mut seen_primary_keys: HashSet<Vec<u8>, BuildHasherDefault<twox_hash::XxHash3_64>> =
-        HashSet::default();
     let has_pks = !pk_col_indices.is_empty();
+
+    let mut upserts = OpBatchAccumulator::new();
+    let mut deletes = OpBatchAccumulator::new();
+    let mut out: Vec<(ChangeOperationType, Vec<usize>)> = Vec::new();
 
     for row_id in 0..num_rows {
         let op = change_batch.op(row_id);
         let op_type = ChangeOperationType::from_operation(&op);
 
-        let primary_key = if has_pks {
-            encode_primary_key(&data_batch, &pk_col_indices, row_id)
-        } else {
-            Vec::new()
-        };
+        // Truncate and Unknown are barriers — flush everything, emit the
+        // barrier row, and continue.
+        if op_type == ChangeOperationType::Truncate || op_type == ChangeOperationType::Unknown {
+            upserts.flush_into(ChangeOperationType::Upsert, &mut out);
+            deletes.flush_into(ChangeOperationType::Delete, &mut out);
+            out.push((op_type, vec![row_id]));
+            continue;
+        }
 
-        let should_split = if let Some(current_type) = current_op_type {
-            current_type != op_type || (has_pks && seen_primary_keys.contains(&primary_key))
-        } else {
-            false
-        };
+        // When PKs are available, flush only the bucket(s) that already
+        // contain this PK so that per-PK ordering is preserved without
+        // unnecessarily breaking up non-conflicting batches.
+        if has_pks {
+            let primary_key = encode_primary_key(&data_batch, &pk_col_indices, row_id);
 
-        if should_split {
-            if !current_batch_indices.is_empty()
-                && let Some(op_type) = current_op_type
-            {
-                sub_batches.push((op_type, std::mem::take(&mut current_batch_indices)));
+            if upserts.pks.contains(&primary_key) {
+                upserts.flush_into(ChangeOperationType::Upsert, &mut out);
+            }
+            if deletes.pks.contains(&primary_key) {
+                deletes.flush_into(ChangeOperationType::Delete, &mut out);
             }
 
-            seen_primary_keys.clear();
-            current_op_type = Some(op_type);
-        } else if current_op_type.is_none() {
-            current_op_type = Some(op_type);
-        }
-
-        current_batch_indices.push(row_id);
-        if has_pks {
-            seen_primary_keys.insert(primary_key);
+            let batch = match op_type {
+                ChangeOperationType::Upsert => &mut upserts,
+                ChangeOperationType::Delete => &mut deletes,
+                ChangeOperationType::Truncate | ChangeOperationType::Unknown => {
+                    // Handled as barriers above; this is unreachable.
+                    unreachable!("unexpected op type {op_type:?} after barrier check")
+                }
+            };
+            batch.rows.push(row_id);
+            batch.pks.insert(primary_key);
+        } else {
+            // No PKs — fall back to grouping consecutive same-op rows
+            // (can't detect conflicts without keys).
+            match op_type {
+                ChangeOperationType::Upsert => {
+                    deletes.flush_into(ChangeOperationType::Delete, &mut out);
+                    upserts.rows.push(row_id);
+                }
+                ChangeOperationType::Delete => {
+                    upserts.flush_into(ChangeOperationType::Upsert, &mut out);
+                    deletes.rows.push(row_id);
+                }
+                ChangeOperationType::Truncate | ChangeOperationType::Unknown => {
+                    unreachable!("unexpected op type {op_type:?} after barrier check")
+                }
+            }
         }
     }
 
-    if !current_batch_indices.is_empty()
-        && let Some(op_type) = current_op_type
-    {
-        sub_batches.push((op_type, current_batch_indices));
-    }
+    // Flush remaining active batches.
+    upserts.flush_into(ChangeOperationType::Upsert, &mut out);
+    deletes.flush_into(ChangeOperationType::Delete, &mut out);
 
-    sub_batches
+    out
 }
 
 fn encode_primary_key(
@@ -1971,7 +2023,9 @@ mod tests {
     }
 
     #[test]
-    fn test_different_operation_types_split() {
+    fn test_different_operation_types_no_pk_conflict_merges() {
+        // U(pk1), D(pk2), U(pk3) — no PK conflicts across buckets,
+        // so upserts merge and deletes merge.
         let change_batch = create_test_change_batch(
             vec!["c", "d", "c"],
             &[vec!["id"], vec!["id"], vec!["id"]],
@@ -1983,18 +2037,15 @@ mod tests {
 
         assert_eq!(
             result.len(),
-            3,
-            "Should split into three sub-batches for different operations"
+            2,
+            "Non-conflicting ops should merge into 2 batches"
         );
 
         assert_eq!(result[0].0, ChangeOperationType::Upsert);
-        assert_eq!(result[0].1, vec![0]);
+        assert_eq!(result[0].1, vec![0, 2]);
 
         assert_eq!(result[1].0, ChangeOperationType::Delete);
         assert_eq!(result[1].1, vec![1]);
-
-        assert_eq!(result[2].0, ChangeOperationType::Upsert);
-        assert_eq!(result[2].1, vec![2]);
     }
 
     #[test]
@@ -2144,7 +2195,9 @@ mod tests {
     }
 
     #[test]
-    fn test_alternating_operations() {
+    fn test_alternating_operations_no_pk_conflict_merges() {
+        // U(pk1), D(pk2), U(pk3), D(pk4) — all distinct PKs,
+        // so upserts merge and deletes merge.
         let change_batch = create_test_change_batch(
             vec!["c", "d", "c", "d"],
             &[vec!["id"], vec!["id"], vec!["id"], vec!["id"]],
@@ -2156,21 +2209,79 @@ mod tests {
 
         assert_eq!(
             result.len(),
-            4,
-            "Alternating operations should create 4 sub-batches"
+            2,
+            "Alternating operations with distinct PKs should merge into 2 batches"
         );
 
         assert_eq!(result[0].0, ChangeOperationType::Upsert);
-        assert_eq!(result[0].1, vec![0]);
+        assert_eq!(result[0].1, vec![0, 2]);
 
         assert_eq!(result[1].0, ChangeOperationType::Delete);
+        assert_eq!(result[1].1, vec![1, 3]);
+    }
+
+    #[test]
+    fn test_cross_op_pk_conflict_flushes_only_conflicting_bucket() {
+        // U(pk1), D(pk2), D(pk1) — pk1 conflicts with upserts bucket,
+        // so upserts is flushed but deletes keeps accumulating.
+        let change_batch = create_test_change_batch(
+            vec!["c", "d", "d"],
+            &[vec!["id"], vec!["id"], vec!["id"]],
+            vec![1, 2, 1],
+            vec![Some("A"), Some("B"), Some("A_del")],
+        );
+
+        let result = group_into_sub_batches(&change_batch);
+
+        assert_eq!(result.len(), 2, "Should flush upserts, then merge deletes");
+        assert_eq!(result[0].0, ChangeOperationType::Upsert);
+        assert_eq!(result[0].1, vec![0]);
+        assert_eq!(result[1].0, ChangeOperationType::Delete);
+        assert_eq!(result[1].1, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_truncate_barrier_flushes_all_buckets() {
+        // U(pk1), D(pk2), T, U(pk3) — truncate flushes both active
+        // buckets, emits the truncate row, then a new upsert batch starts.
+        let change_batch = create_test_change_batch(
+            vec!["c", "d", "t", "c"],
+            &[vec!["id"], vec!["id"], vec!["id"], vec!["id"]],
+            vec![1, 2, 99, 3],
+            vec![Some("A"), Some("B"), Some("T"), Some("C")],
+        );
+
+        let result = group_into_sub_batches(&change_batch);
+
+        assert_eq!(result.len(), 4);
+        assert_eq!(result[0].0, ChangeOperationType::Upsert);
+        assert_eq!(result[0].1, vec![0]);
+        assert_eq!(result[1].0, ChangeOperationType::Delete);
         assert_eq!(result[1].1, vec![1]);
-
-        assert_eq!(result[2].0, ChangeOperationType::Upsert);
+        assert_eq!(result[2].0, ChangeOperationType::Truncate);
         assert_eq!(result[2].1, vec![2]);
-
-        assert_eq!(result[3].0, ChangeOperationType::Delete);
+        assert_eq!(result[3].0, ChangeOperationType::Upsert);
         assert_eq!(result[3].1, vec![3]);
+    }
+
+    #[test]
+    fn test_same_pk_upsert_then_delete_conflict_forces_flush() {
+        // U(pk1), D(pk1) — pk1 is in upserts when delete arrives,
+        // so upserts is flushed first, then delete goes to its bucket.
+        let change_batch = create_test_change_batch(
+            vec!["c", "d"],
+            &[vec!["id"], vec!["id"]],
+            vec![1, 1],
+            vec![Some("A"), Some("A_del")],
+        );
+
+        let result = group_into_sub_batches(&change_batch);
+
+        assert_eq!(result.len(), 2, "PK conflict across ops forces flush");
+        assert_eq!(result[0].0, ChangeOperationType::Upsert);
+        assert_eq!(result[0].1, vec![0]);
+        assert_eq!(result[1].0, ChangeOperationType::Delete);
+        assert_eq!(result[1].1, vec![1]);
     }
 
     fn make_mem_table() -> Arc<MemTable> {


### PR DESCRIPTION
## 📝 Summary

Reduce the number of write round-trips during CDC change processing by merging non-conflicting upserts and deletes into fewer sub-batches.

**Before:** Every op-type change forced a new sub-batch, so `U(pk1), D(pk2), U(pk3)` produced 3 batches and 3 write round-trips. This led to very small batches (few rows) and and high per batch overhard, for example separate IO / disk operation for each delete.

 TRACE runtime::accelerated_table::refresh_task::changes: Processing append/change stream batch: dataset=new_order, rows=182, sub-batches=13


**After:** Non-conflicting rows accumulate across op types. Only rows sharing a PK force a flush. The same sequence now produces 2 batches: `Upsert[pk1, pk3]` + `Delete[pk2]` — fewer, larger writes with less per-batch overhead.

TRACE runtime::accelerated_table::refresh_task::changes: Processing append/change stream batch: dataset=new_order, rows=254, sub-batches=2

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782407430&installation_id=128462479&pr_number=11051&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11051&signature=cab04459d30bf4c0db2c1129eebd4065acb521bbed47d4baf793b9ff6a5a7ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->