### PR TITLE
Correctly mark failed search tests

### DIFF
--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -79,7 +79,8 @@ runs:
             git fetch origin "${BRANCH_NAME}"
             git rebase -X theirs "origin/${BRANCH_NAME}"
           fi
-          git push origin "HEAD:${BRANCH_NAME}"
+          AUTHENTICATED_REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}"
+          git push "${AUTHENTICATED_REMOTE_URL}" "HEAD:${BRANCH_NAME}"
 
           if [[ -n "${EXISTING_PR_NUMBER}" ]]; then
             PR_URL="$(gh pr view "${EXISTING_PR_NUMBER}" --json url --jq .url)"

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -58,17 +58,12 @@ jobs:
             echo "Error: OpenAI API key is not defined."
             exit 1
           fi
-          cargo test --test integration_models -p runtime  --features models,metal,s3_vectors,kafka,duckdb,extended_tests -- search || {
-            if [ "$INSTA_UPDATE" == "always" ]; then
-              echo "Warning: Tests failed but INSTA_UPDATE is enabled. Continuing."
-              exit 0
-            else
-              exit 1
-            fi
-          }
+          cargo test --test integration_models -p runtime --features models,metal,s3_vectors,kafka,duckdb,extended_tests -- search
 
       - name: Push snapshots to branch
-        if: github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule'
+        # `cargo test` will fail if snapshot changes are needed. Always attempt
+        #  to make PR if 'always' update snapshots.
+        if: ${{ always() && (github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule') }}
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📝 Summary
`integration_search.yml` needed to mark `cargo test` as successful, so snapshot updates would make PRs. This masks run failures (ie. error with metal, etc).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782426368&installation_id=128462479&pr_number=11054&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11054&signature=b098587a63b8acce7c79a732601e81c5da632b04aede2d698f9ca8c19fd176b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->