### PR TITLE
perf(cdc): Last-write-wins dedup in `group_into_sub_batches` to reduce sub-batch splits

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1516,6 +1516,7 @@ pub(crate) fn get_primary_key_value_at_row(
 /// last-write-wins deduplication (the newer row replaces the older one)
 struct OpBatchAccumulator {
     rows: Vec<usize>,
+    needs_sort: bool,
     /// Maps encoded PK to index into `rows`, enabling replacement on same-bucket PK collision.
     pk_to_pos: HashMap<Vec<u8>, usize, BuildHasherDefault<twox_hash::XxHash3_64>>,
 }
@@ -1524,6 +1525,7 @@ impl OpBatchAccumulator {
     fn new() -> Self {
         Self {
             rows: Vec::new(),
+            needs_sort: false,
             pk_to_pos: HashMap::default(),
         }
     }
@@ -1541,6 +1543,9 @@ impl OpBatchAccumulator {
             // Same-bucket collision: replace the earlier row with the newer
             // one. The old row is superseded because CDC rows carry the
             // full row state.
+            if pos + 1 < self.rows.len() {
+                self.needs_sort = true;
+            }
             self.rows[pos] = row_id;
         } else {
             let pos = self.rows.len();
@@ -1557,6 +1562,10 @@ impl OpBatchAccumulator {
         out: &mut Vec<(ChangeOperationType, Vec<usize>)>,
     ) {
         if !self.rows.is_empty() {
+            if self.needs_sort {
+                self.rows.sort_unstable();
+                self.needs_sort = false;
+            }
             out.push((op, std::mem::take(&mut self.rows)));
             self.pk_to_pos.clear();
         }
@@ -2180,11 +2189,12 @@ mod tests {
 
         // Last-write-wins: pk1 appears at rows 0, 1, 3 — each successive
         // occurrence replaces the previous in-place. pk2 at row 2 is kept.
-        // Final bucket: position 0 holds row 3 (latest pk1), position 1 holds row 2 (pk2).
+        // The final bucket is ordered by row index to preserve contiguous-slice fast paths.
         assert_eq!(result.len(), 1);
 
         assert_eq!(result[0].0, ChangeOperationType::Upsert);
-        assert_eq!(result[0].1, vec![3, 2]);
+        assert_eq!(result[0].1, vec![2, 3]);
+        assert_eq!(contiguous_row_span(&result[0].1), Some((2, 2)));
     }
 
     #[test]
@@ -2206,7 +2216,8 @@ mod tests {
             "Same composite key should replace, not split"
         );
         assert_eq!(result[0].0, ChangeOperationType::Upsert);
-        assert_eq!(result[0].1, vec![2, 1]);
+        assert_eq!(result[0].1, vec![1, 2]);
+        assert_eq!(contiguous_row_span(&result[0].1), Some((1, 2)));
     }
 
     #[test]

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -53,7 +53,7 @@ use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion_index::IndexedTableProvider;
 use runtime_table_partition::provider::PartitionTableProvider;
 use snafu::{OptionExt, ResultExt};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
@@ -1507,18 +1507,40 @@ pub(crate) fn get_primary_key_value_at_row(
 }
 
 /// An active batch accumulating row indices for a single operation type.
-/// Tracks the set of primary keys it contains so that PK conflicts can be
-/// detected in O(1) per row.
+/// Tracks primary keys so that same-PK collisions within the bucket apply
+/// last-write-wins deduplication (the newer row replaces the older one)
 struct OpBatchAccumulator {
     rows: Vec<usize>,
-    pks: HashSet<Vec<u8>, BuildHasherDefault<twox_hash::XxHash3_64>>,
+    /// Maps encoded PK to index into `rows`, enabling replacement on same-bucket PK collision.
+    pk_to_pos: HashMap<Vec<u8>, usize, BuildHasherDefault<twox_hash::XxHash3_64>>,
 }
 
 impl OpBatchAccumulator {
     fn new() -> Self {
         Self {
             rows: Vec::new(),
-            pks: HashSet::default(),
+            pk_to_pos: HashMap::default(),
+        }
+    }
+
+    /// Returns `true` if `pk` is already tracked in this bucket.
+    fn contains_pk(&self, pk: &[u8]) -> bool {
+        self.pk_to_pos.contains_key(pk)
+    }
+
+    /// Insert `row_id` under `pk`. If the PK already exists in this bucket,
+    /// the previous row index is replaced in-place (last-write-wins).
+    /// See [`group_into_sub_batches`] for the rationale.
+    fn insert_or_replace(&mut self, pk: Vec<u8>, row_id: usize) {
+        if let Some(&pos) = self.pk_to_pos.get(&pk) {
+            // Same-bucket collision: replace the earlier row with the newer
+            // one. The old row is superseded because CDC rows carry the
+            // full row state.
+            self.rows[pos] = row_id;
+        } else {
+            let pos = self.rows.len();
+            self.rows.push(row_id);
+            self.pk_to_pos.insert(pk, pos);
         }
     }
 
@@ -1531,7 +1553,7 @@ impl OpBatchAccumulator {
     ) {
         if !self.rows.is_empty() {
             out.push((op, std::mem::take(&mut self.rows)));
-            self.pks.clear();
+            self.pk_to_pos.clear();
         }
     }
 }
@@ -1539,11 +1561,21 @@ impl OpBatchAccumulator {
 /// Groups rows into sub-batches based on operation type and primary key
 /// conflicts across active operation buckets.
 ///
-/// Uses a streaming conflict-window algorithm: two active buckets (upsert,
-/// delete) accumulate rows concurrently. When an incoming row's PK already
-/// exists in *either* bucket, only the conflicting bucket is flushed — the
-/// other keeps accumulating. Truncate and Unknown act as barriers that flush
-/// everything.
+/// Uses a streaming conflict-window algorithm with **last-write-wins
+/// deduplication**: two active buckets (upsert, delete) accumulate rows
+/// concurrently. When an incoming row's PK already exists in the *other*
+/// bucket, that bucket is flushed to preserve cross-operation ordering.
+/// When the PK collides within the *same* bucket the earlier row index is
+/// replaced in-place — CDC rows are full-state snapshots, so only the
+/// latest row per PK is required and intermediate states can be safely dropped.
+///
+/// For deletes a same-bucket PK collision is unexpected in practice (a
+/// source would have to emit two consecutive deletes for the same key
+/// without an intervening upsert), but is still safe — deleting the same
+/// PK twice is idempotent. We use the same replace path for both operation
+/// types to keep the logic simple.
+///
+/// Truncate and Unknown act as barriers that flush everything.
 #[must_use]
 fn group_into_sub_batches(change_batch: &ChangeBatch) -> Vec<(ChangeOperationType, Vec<usize>)> {
     let num_rows = change_batch.record.num_rows();
@@ -1577,29 +1609,40 @@ fn group_into_sub_batches(change_batch: &ChangeBatch) -> Vec<(ChangeOperationTyp
             continue;
         }
 
-        // When PKs are available, flush only the bucket(s) that already
-        // contain this PK so that per-PK ordering is preserved without
-        // unnecessarily breaking up non-conflicting batches.
+        // When PKs are available, use last-write-wins within the same
+        // bucket (CDC rows are full-state snapshots so only the latest
+        // row per PK matters) and flush only on *cross-bucket* conflicts
+        // to preserve inter-operation ordering.
         if has_pks {
             let primary_key = encode_primary_key(&data_batch, &pk_col_indices, row_id);
 
-            if upserts.pks.contains(&primary_key) {
-                upserts.flush_into(ChangeOperationType::Upsert, &mut out);
-            }
-            if deletes.pks.contains(&primary_key) {
-                deletes.flush_into(ChangeOperationType::Delete, &mut out);
+            // Cross-bucket conflict: the *other* bucket already has this
+            // PK, so flush it to preserve operation ordering.
+            match op_type {
+                ChangeOperationType::Upsert => {
+                    if deletes.contains_pk(&primary_key) {
+                        deletes.flush_into(ChangeOperationType::Delete, &mut out);
+                    }
+                }
+                ChangeOperationType::Delete => {
+                    if upserts.contains_pk(&primary_key) {
+                        upserts.flush_into(ChangeOperationType::Upsert, &mut out);
+                    }
+                }
+                ChangeOperationType::Truncate | ChangeOperationType::Unknown => {
+                    unreachable!("unexpected op type {op_type:?} after barrier check")
+                }
             }
 
+            // Same-bucket collision: replace the old row (last-write-wins).
             let batch = match op_type {
                 ChangeOperationType::Upsert => &mut upserts,
                 ChangeOperationType::Delete => &mut deletes,
                 ChangeOperationType::Truncate | ChangeOperationType::Unknown => {
-                    // Handled as barriers above; this is unreachable.
                     unreachable!("unexpected op type {op_type:?} after barrier check")
                 }
             };
-            batch.rows.push(row_id);
-            batch.pks.insert(primary_key);
+            batch.insert_or_replace(primary_key, row_id);
         } else {
             // No PKs — fall back to grouping consecutive same-op rows
             // (can't detect conflicts without keys).
@@ -2059,18 +2102,16 @@ mod tests {
 
         let result = group_into_sub_batches(&change_batch);
 
-        // Should split when duplicate primary key is encountered within same operation type
+        // Last-write-wins: row 0 (pk1,v1) is replaced by row 1 (pk1,v2)
+        // within the same upsert bucket, so only one sub-batch remains.
         assert_eq!(
             result.len(),
-            2,
-            "Should split into two sub-batches when duplicate key is found"
+            1,
+            "Same-bucket PK collision should replace, not split"
         );
 
         assert_eq!(result[0].0, ChangeOperationType::Upsert);
-        assert_eq!(result[0].1, vec![0]);
-
-        assert_eq!(result[1].0, ChangeOperationType::Upsert);
-        assert_eq!(result[1].1, vec![1, 2]);
+        assert_eq!(result[0].1, vec![1, 2]);
     }
 
     #[test]
@@ -2132,19 +2173,13 @@ mod tests {
 
         let result = group_into_sub_batches(&change_batch);
 
-        // First batch: id=1 (row 0)
-        // Second batch: id=1 (row 1, duplicate), id=2 (row 2, new)
-        // Third batch: id=1 (row 3, duplicate again)
-        assert_eq!(result.len(), 3);
+        // Last-write-wins: pk1 appears at rows 0, 1, 3 — each successive
+        // occurrence replaces the previous in-place. pk2 at row 2 is kept.
+        // Final bucket: position 0 holds row 3 (latest pk1), position 1 holds row 2 (pk2).
+        assert_eq!(result.len(), 1);
 
         assert_eq!(result[0].0, ChangeOperationType::Upsert);
-        assert_eq!(result[0].1, vec![0]);
-
-        assert_eq!(result[1].0, ChangeOperationType::Upsert);
-        assert_eq!(result[1].1, vec![1, 2]);
-
-        assert_eq!(result[2].0, ChangeOperationType::Upsert);
-        assert_eq!(result[2].1, vec![3]);
+        assert_eq!(result[0].1, vec![3, 2]);
     }
 
     #[test]
@@ -2158,16 +2193,15 @@ mod tests {
 
         let result = group_into_sub_batches(&change_batch);
 
-        // Composite keys are formatted differently, so these should be distinct
+        // Last-write-wins: composite key (1,"Alice") at row 0 is replaced
+        // by row 2. Key (2,"Bob") at row 1 is distinct and kept.
         assert_eq!(
             result.len(),
-            2,
-            "Different composite keys should not cause split"
+            1,
+            "Same composite key should replace, not split"
         );
         assert_eq!(result[0].0, ChangeOperationType::Upsert);
-        assert_eq!(result[0].1, vec![0, 1]);
-        assert_eq!(result[1].0, ChangeOperationType::Upsert);
-        assert_eq!(result[1].1, vec![2]);
+        assert_eq!(result[0].1, vec![2, 1]);
     }
 
     #[test]
@@ -2282,6 +2316,115 @@ mod tests {
         assert_eq!(result[0].1, vec![0]);
         assert_eq!(result[1].0, ChangeOperationType::Delete);
         assert_eq!(result[1].1, vec![1]);
+    }
+
+    #[test]
+    fn test_last_write_wins_keeps_only_latest_row() {
+        // 5 upserts to the same PK — only the last row should survive.
+        let change_batch = create_test_change_batch(
+            vec!["c", "u", "u", "u", "u"],
+            &[vec!["id"], vec!["id"], vec!["id"], vec!["id"], vec!["id"]],
+            vec![1, 1, 1, 1, 1],
+            vec![Some("v1"), Some("v2"), Some("v3"), Some("v4"), Some("v5")],
+        );
+
+        let result = group_into_sub_batches(&change_batch);
+
+        assert_eq!(
+            result.len(),
+            1,
+            "All same-PK upserts should collapse to one batch"
+        );
+        assert_eq!(result[0].0, ChangeOperationType::Upsert);
+        assert_eq!(
+            result[0].1,
+            vec![4],
+            "Only the last row (index 4) should survive"
+        );
+    }
+
+    #[test]
+    fn test_last_write_wins_cross_bucket_still_flushes() {
+        // U(pk1), D(pk2), U(pk1) — the second U(pk1) replaces the first
+        // within the upsert bucket (no cross-bucket conflict for pk1 in
+        // deletes). D(pk2) stays in its own bucket.
+        let change_batch = create_test_change_batch(
+            vec!["c", "d", "u"],
+            &[vec!["id"], vec!["id"], vec!["id"]],
+            vec![1, 2, 1],
+            vec![Some("A"), Some("B"), Some("A_v2")],
+        );
+
+        let result = group_into_sub_batches(&change_batch);
+
+        // pk1 never appears in the delete bucket, so no cross-bucket flush.
+        // Same-bucket replace: row 0 replaced by row 2 for pk1.
+        assert_eq!(result.len(), 2, "Upsert bucket (deduped) + delete bucket");
+        assert_eq!(result[0].0, ChangeOperationType::Upsert);
+        assert_eq!(result[0].1, vec![2]);
+        assert_eq!(result[1].0, ChangeOperationType::Delete);
+        assert_eq!(result[1].1, vec![1]);
+    }
+
+    #[test]
+    fn test_full_pk_lifecycle_upsert_delete_upsert() {
+        // U(pk1) → D(pk1) → U(pk1) — row created, deleted, re-created.
+        // Two consecutive cross-bucket flushes for the same PK.
+        let change_batch = create_test_change_batch(
+            vec!["c", "d", "c"],
+            &[vec!["id"], vec!["id"], vec!["id"]],
+            vec![1, 1, 1],
+            vec![Some("v1"), Some("v1_del"), Some("v2")],
+        );
+
+        let result = group_into_sub_batches(&change_batch);
+
+        assert_eq!(
+            result.len(),
+            3,
+            "Full lifecycle needs 3 ordered sub-batches"
+        );
+        assert_eq!(result[0].0, ChangeOperationType::Upsert);
+        assert_eq!(result[0].1, vec![0]);
+        assert_eq!(result[1].0, ChangeOperationType::Delete);
+        assert_eq!(result[1].1, vec![1]);
+        assert_eq!(result[2].0, ChangeOperationType::Upsert);
+        assert_eq!(result[2].1, vec![2]);
+    }
+
+    #[test]
+    fn test_truncate_resets_dedup_state() {
+        // U(pk1,v1), U(pk1,v2), T, U(pk1,v3), U(pk1,v4) — dedup works
+        // independently on each side of the truncate barrier. The post-
+        // truncate pk1 must not collide with the pre-truncate pk1.
+        let change_batch = create_test_change_batch(
+            vec!["c", "u", "t", "c", "u"],
+            &[vec!["id"], vec!["id"], vec!["id"], vec!["id"], vec!["id"]],
+            vec![1, 1, 99, 1, 1],
+            vec![Some("v1"), Some("v2"), Some("T"), Some("v3"), Some("v4")],
+        );
+
+        let result = group_into_sub_batches(&change_batch);
+
+        assert_eq!(
+            result.len(),
+            3,
+            "Deduped upsert + truncate + deduped upsert"
+        );
+        assert_eq!(result[0].0, ChangeOperationType::Upsert);
+        assert_eq!(
+            result[0].1,
+            vec![1],
+            "Pre-truncate: only v2 survives (last-write-wins)"
+        );
+        assert_eq!(result[1].0, ChangeOperationType::Truncate);
+        assert_eq!(result[1].1, vec![2]);
+        assert_eq!(result[2].0, ChangeOperationType::Upsert);
+        assert_eq!(
+            result[2].1,
+            vec![4],
+            "Post-truncate: only v4 survives (last-write-wins)"
+        );
     }
 
     fn make_mem_table() -> Arc<MemTable> {

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -2097,7 +2097,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duplicate_primary_key_causes_split() {
+    fn test_duplicate_primary_key_replaces_in_place() {
         let change_batch = create_test_change_batch(
             vec!["c", "c", "c"],
             &[vec!["id"], vec!["id"], vec!["id"]],

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::implicit_hasher)]
+#[cfg(feature = "bedrock")]
+use llms::bedrock::chat::{BedrockConverse, guardrail::GuardRail};
 use llms::{
     HealthCheck,
     anthropic::Anthropic,
-    bedrock::chat::{BedrockConverse, guardrail::GuardRail},
     chat::{Chat, Error as LlmError},
     google::Google,
     openai::{ChatBackend, UsageTier},


### PR DESCRIPTION
## 📝 Summary

CDC sub-batch grouping flushes and creates a new sub-batch every time a primary key repeats within the same operation bucket. For workloads where a small number of rows are updated frequently (e.g., ~10 distinct PKs receiving ~128 updates in a burst), this produces ~27 sub-batches — each triggering a separate `insert_into` plan execution.


## Solution

Since CDC rows are full-state snapshots (not deltas), when the same PK appears twice in the same operation bucket (e.g., two consecutive upserts for pk1), the earlier row is entirely superseded. Instead of flushing, we replace the earlier row index in-place (last-write-wins).

What changed:
- `OpBatchAccumulator` now uses `HashMap<PK, position>` instead of `HashSet<PK>`, enabling fast lookup and in-place replacement of superseded rows
- Same-bucket PK collisions replace the old row index rather than flushing
- Cross-bucket collisions (e.g., upsert pk1 → delete pk1) still flush to preserve inter-operation ordering

Example impact: 128 rows with ~10 distinct PKs → 1 sub-batch of ~10 rows instead of 27 sub-batches. ~27x fewer `insert_into` plans.

Safety:

- CDC create/update/read rows carry the complete row state
- Cross-operation ordering is preserved via cross-bucket/operation flush


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

The upsert/last-write-wins behavior at the accelerator layer is controlled by the `on_conflict` configuration on the primary key:

```yaml
acceleration:
  refresh_mode: changes
  primary_key: w_id
  on_conflict:
    w_id: upsert
```

I considered adding a check inside `group_into_sub_batches` to verify that `on_conflict: upsert` is configured for the primary key before applying last-write-wins dedup. However, this is the expected configuration for all CDC/changes streams: without it, duplicate PK inserts would fail at the accelerator anyway. Adding the check here would introduce unnecessary coupling and complexity, instead, the right approach is a more global validation on daatset configuration that verifies `on_conflict: upsert` is set on the primary key whenever refresh_mode: changes is configured, and warns or errors at spicepod load time if it's missing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spiceai/codesmith/spiceai/pr/11059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782482667&installation_id=128462479&pr_number=11059&repository=spiceai%2Fspiceai&return_to=https%3A%2F%2Fgithub.com%2Fspiceai%2Fspiceai%2Fpull%2F11059&signature=a6e96b8b39429c404104a3ab8c3873eb5ec87750c8f7093a53bcfd3359d586ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->