### PR TITLE
Normalize `DataType::Null` to `Int32` in acceleration schema for duckdb

### DIFF
--- a/crates/arrow_tools/src/lib.rs
+++ b/crates/arrow_tools/src/lib.rs
@@ -17,3 +17,4 @@ limitations under the License.
 pub mod format;
 pub mod record_batch;
 pub mod schema;
+pub mod type_rewrite;

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -190,32 +190,6 @@ pub fn cast_view_columns(
     RecordBatch::try_new(Arc::clone(target_schema), columns)
 }
 
-/// Replaces Arrow `Dictionary`-encoded fields with the dictionary's value type.
-///
-/// Data accelerators such as `DuckDB` and `SQLite` do not natively support Arrow
-/// Dictionary types.  By unpacking the dictionary encoding at the schema level
-/// (and later casting the data via `arrow_cast::cast`), the downstream
-/// accelerator receives only primitive types it can handle.
-///
-/// For example, `Dictionary(Int32, Utf8)` is normalised to `Utf8`.
-#[must_use]
-pub fn normalize_dictionary_types(schema: &Schema) -> Schema {
-    let transformed_fields: Vec<Field> = schema
-        .fields()
-        .iter()
-        .map(|field| {
-            let new_type = normalize_dictionary_data_type(field.data_type());
-            if &new_type == field.data_type() {
-                field.as_ref().clone()
-            } else {
-                field.as_ref().clone().with_data_type(new_type)
-            }
-        })
-        .collect();
-
-    Schema::new_with_metadata(transformed_fields, schema.metadata().clone())
-}
-
 /// Returns `true` if `schema` contains any `Dictionary`-encoded fields,
 /// including inside nested container types (List, Struct, Map, etc.).
 #[must_use]
@@ -246,72 +220,6 @@ fn data_type_contains_dictionary(data_type: &DataType) -> bool {
             data_type_contains_dictionary(values_field.data_type())
         }
         _ => false,
-    }
-}
-
-/// Recursively replaces `Dictionary(_, value_type)` with `value_type`,
-/// descending into nested container types (List, Struct, Map, etc.).
-fn normalize_dictionary_data_type(data_type: &DataType) -> DataType {
-    match data_type {
-        DataType::Dictionary(_, value_type) => normalize_dictionary_data_type(value_type.as_ref()),
-        DataType::List(field) => {
-            let inner = normalize_dictionary_data_type(field.data_type());
-            DataType::List(Arc::new(field.as_ref().clone().with_data_type(inner)))
-        }
-        DataType::LargeList(field) => {
-            let inner = normalize_dictionary_data_type(field.data_type());
-            DataType::LargeList(Arc::new(field.as_ref().clone().with_data_type(inner)))
-        }
-        DataType::FixedSizeList(field, size) => {
-            let inner = normalize_dictionary_data_type(field.data_type());
-            DataType::FixedSizeList(
-                Arc::new(field.as_ref().clone().with_data_type(inner)),
-                *size,
-            )
-        }
-        DataType::ListView(field) => {
-            let inner = normalize_dictionary_data_type(field.data_type());
-            DataType::ListView(Arc::new(field.as_ref().clone().with_data_type(inner)))
-        }
-        DataType::LargeListView(field) => {
-            let inner = normalize_dictionary_data_type(field.data_type());
-            DataType::LargeListView(Arc::new(field.as_ref().clone().with_data_type(inner)))
-        }
-        DataType::Map(field, sorted) => {
-            let inner = normalize_dictionary_data_type(field.data_type());
-            DataType::Map(
-                Arc::new(field.as_ref().clone().with_data_type(inner)),
-                *sorted,
-            )
-        }
-        DataType::Struct(fields) => {
-            let new_fields: Vec<Field> = fields
-                .iter()
-                .map(|f| {
-                    let inner = normalize_dictionary_data_type(f.data_type());
-                    f.as_ref().clone().with_data_type(inner)
-                })
-                .collect();
-            DataType::Struct(new_fields.into())
-        }
-        DataType::Union(fields, mode) => DataType::Union(
-            fields
-                .iter()
-                .map(|(type_id, f)| {
-                    let inner = normalize_dictionary_data_type(f.data_type());
-                    (type_id, Arc::new(f.as_ref().clone().with_data_type(inner)))
-                })
-                .collect(),
-            *mode,
-        ),
-        DataType::RunEndEncoded(run_ends_field, values_field) => {
-            let inner = normalize_dictionary_data_type(values_field.data_type());
-            DataType::RunEndEncoded(
-                Arc::clone(run_ends_field),
-                Arc::new(values_field.as_ref().clone().with_data_type(inner)),
-            )
-        }
-        other => other.clone(),
     }
 }
 
@@ -565,33 +473,6 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_dictionary_types() {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int64, false),
-            Field::new(
-                "status",
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-                true,
-            ),
-            Field::new("name", DataType::Utf8, false),
-            Field::new(
-                "category",
-                DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::LargeUtf8)),
-                false,
-            ),
-        ]);
-
-        let normalized = normalize_dictionary_types(&schema);
-
-        assert_eq!(normalized.field(0).data_type(), &DataType::Int64);
-        assert_eq!(normalized.field(1).data_type(), &DataType::Utf8);
-        assert!(normalized.field(1).is_nullable());
-        assert_eq!(normalized.field(2).data_type(), &DataType::Utf8);
-        assert_eq!(normalized.field(3).data_type(), &DataType::LargeUtf8);
-        assert!(!normalized.field(3).is_nullable());
-    }
-
-    #[test]
     fn test_has_dictionary_types() {
         let no_dict_schema = Schema::new(vec![
             Field::new("id", DataType::Int64, false),
@@ -608,93 +489,6 @@ mod tests {
             ),
         ]);
         assert!(has_dictionary_types(&dict_schema));
-    }
-
-    #[test]
-    fn test_normalize_schema_without_dictionary_is_noop() {
-        let schema = Schema::new(vec![
-            Field::new("id", DataType::Int64, false),
-            Field::new("name", DataType::Utf8, false),
-        ]);
-
-        let normalized = normalize_dictionary_types(&schema);
-        assert_eq!(schema, normalized);
-    }
-
-    #[test]
-    fn test_normalize_preserves_metadata() {
-        let mut metadata = HashMap::new();
-        metadata.insert("key".to_string(), "value".to_string());
-
-        let mut field_metadata = HashMap::new();
-        field_metadata.insert("custom_key".to_string(), "custom_value".to_string());
-
-        let schema = Schema::new_with_metadata(
-            vec![
-                Field::new(
-                    "col",
-                    DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-                    false,
-                )
-                .with_metadata(field_metadata.clone()),
-            ],
-            metadata.clone(),
-        );
-
-        let normalized = normalize_dictionary_types(&schema);
-        assert_eq!(normalized.metadata(), &metadata);
-        assert_eq!(normalized.field(0).data_type(), &DataType::Utf8);
-        assert_eq!(
-            normalized.field(0).metadata(),
-            &field_metadata,
-            "field-level metadata must be preserved after normalization"
-        );
-    }
-
-    #[test]
-    fn test_normalize_nested_dictionary_in_list() {
-        let schema = Schema::new(vec![Field::new(
-            "tags",
-            DataType::List(Arc::new(Field::new(
-                "item",
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-                true,
-            ))),
-            false,
-        )]);
-
-        let normalized = normalize_dictionary_types(&schema);
-        let expected = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
-        assert_eq!(normalized.field(0).data_type(), &expected);
-    }
-
-    #[test]
-    fn test_normalize_nested_dictionary_in_struct() {
-        let schema = Schema::new(vec![Field::new(
-            "record",
-            DataType::Struct(
-                vec![
-                    Field::new("id", DataType::Int64, false),
-                    Field::new(
-                        "status",
-                        DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
-                        true,
-                    ),
-                ]
-                .into(),
-            ),
-            false,
-        )]);
-
-        let normalized = normalize_dictionary_types(&schema);
-        let expected = DataType::Struct(
-            vec![
-                Field::new("id", DataType::Int64, false),
-                Field::new("status", DataType::Utf8, true),
-            ]
-            .into(),
-        );
-        assert_eq!(normalized.field(0).data_type(), &expected);
     }
 
     #[test]
@@ -736,43 +530,6 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_nested_dictionary_in_union() {
-        use arrow_schema::{UnionFields, UnionMode};
-
-        let union_fields = UnionFields::try_new(
-            vec![0, 1],
-            vec![
-                Field::new("int_val", DataType::Int32, false),
-                Field::new(
-                    "dict_val",
-                    DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
-                    true,
-                ),
-            ],
-        )
-        .expect("union fields");
-        let schema = Schema::new(vec![Field::new(
-            "mixed",
-            DataType::Union(union_fields, UnionMode::Dense),
-            false,
-        )]);
-
-        let normalized = normalize_dictionary_types(&schema);
-        let expected_union = UnionFields::try_new(
-            vec![0, 1],
-            vec![
-                Field::new("int_val", DataType::Int32, false),
-                Field::new("dict_val", DataType::Utf8, true),
-            ],
-        )
-        .expect("expected union fields");
-        assert_eq!(
-            normalized.field(0).data_type(),
-            &DataType::Union(expected_union, UnionMode::Dense)
-        );
-    }
-
-    #[test]
     fn test_has_dictionary_types_in_union() {
         use arrow_schema::{UnionFields, UnionMode};
 
@@ -809,64 +566,6 @@ mod tests {
             false,
         )]);
         assert!(!has_dictionary_types(&no_dict_schema));
-    }
-
-    #[test]
-    fn test_normalize_nested_dictionary_in_list_view() {
-        let schema = Schema::new(vec![Field::new(
-            "tags",
-            DataType::ListView(Arc::new(Field::new(
-                "item",
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-                true,
-            ))),
-            false,
-        )]);
-
-        let normalized = normalize_dictionary_types(&schema);
-        let expected = DataType::ListView(Arc::new(Field::new("item", DataType::Utf8, true)));
-        assert_eq!(normalized.field(0).data_type(), &expected);
-    }
-
-    #[test]
-    fn test_normalize_nested_dictionary_in_large_list_view() {
-        let schema = Schema::new(vec![Field::new(
-            "tags",
-            DataType::LargeListView(Arc::new(Field::new(
-                "item",
-                DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::LargeUtf8)),
-                true,
-            ))),
-            false,
-        )]);
-
-        let normalized = normalize_dictionary_types(&schema);
-        let expected =
-            DataType::LargeListView(Arc::new(Field::new("item", DataType::LargeUtf8, true)));
-        assert_eq!(normalized.field(0).data_type(), &expected);
-    }
-
-    #[test]
-    fn test_normalize_nested_dictionary_in_run_end_encoded() {
-        let schema = Schema::new(vec![Field::new(
-            "encoded",
-            DataType::RunEndEncoded(
-                Arc::new(Field::new("run_ends", DataType::Int32, false)),
-                Arc::new(Field::new(
-                    "values",
-                    DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
-                    true,
-                )),
-            ),
-            false,
-        )]);
-
-        let normalized = normalize_dictionary_types(&schema);
-        let expected = DataType::RunEndEncoded(
-            Arc::new(Field::new("run_ends", DataType::Int32, false)),
-            Arc::new(Field::new("values", DataType::Utf8, true)),
-        );
-        assert_eq!(normalized.field(0).data_type(), &expected);
     }
 
     #[test]

--- a/crates/arrow_tools/src/type_rewrite.rs
+++ b/crates/arrow_tools/src/type_rewrite.rs
@@ -1,0 +1,557 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field, IntervalUnit, Schema};
+
+/// A rewrite rule applied by [`apply_rules`] to every [`DataType`] node in a schema.
+///
+/// Rules are applied post-order: children are rewritten before the parent sees them.
+pub trait TypeRewriteRule: Send + Sync {
+    /// Return `Some(replacement)` when the rule applies, `None` to leave the type unchanged.
+    fn rewrite(&self, dt: &DataType) -> Option<DataType>;
+}
+
+/// Rewrites `DataType::Dictionary(_, value_type)` → `value_type` (recursively).
+///
+/// Used by accelerators (`DuckDB`, `SQLite`, Turso) that do not support Arrow Dictionary encoding.
+pub struct DictionaryUnwrap;
+impl TypeRewriteRule for DictionaryUnwrap {
+    fn rewrite(&self, dt: &DataType) -> Option<DataType> {
+        match dt {
+            DataType::Dictionary(_, value_type) => Some(value_type.as_ref().clone()),
+            _ => None,
+        }
+    }
+}
+
+/// Rewrites `DataType::Null` → `DataType::Int32`.
+///
+/// `DuckDB` has no Null type and silently coerces it to INT32 when creating tables.
+pub struct NullToInt32;
+impl TypeRewriteRule for NullToInt32 {
+    fn rewrite(&self, dt: &DataType) -> Option<DataType> {
+        matches!(dt, DataType::Null).then_some(DataType::Int32)
+    }
+}
+
+/// Rewrites `DataType::Interval(YearMonth | DayTime)` → `DataType::Interval(MonthDayNano)`.
+///
+/// `DuckDB`'s native INTERVAL storage uses the `MonthDayNano` layout.
+pub struct IntervalToMonthDayNano;
+impl TypeRewriteRule for IntervalToMonthDayNano {
+    fn rewrite(&self, dt: &DataType) -> Option<DataType> {
+        match dt {
+            DataType::Interval(IntervalUnit::YearMonth | IntervalUnit::DayTime) => {
+                Some(DataType::Interval(IntervalUnit::MonthDayNano))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Applies `rules` to every type in `schema`, descending post-order into nested container types.
+///
+/// Returns a new schema with the same metadata; fields whose types are unchanged are cloned as-is.
+#[must_use]
+pub fn apply_rules(schema: &Schema, rules: &[&dyn TypeRewriteRule]) -> Schema {
+    let fields: Vec<Field> = schema
+        .fields()
+        .iter()
+        .map(|f| {
+            let new_type = rewrite_data_type(f.data_type(), rules);
+            if &new_type == f.data_type() {
+                f.as_ref().clone()
+            } else {
+                f.as_ref().clone().with_data_type(new_type)
+            }
+        })
+        .collect();
+    Schema::new_with_metadata(fields, schema.metadata().clone())
+}
+
+/// Replaces Arrow `Dictionary`-encoded fields with the dictionary's value type.
+///
+/// Data accelerators such as `DuckDB` and `SQLite` do not natively support Arrow
+/// Dictionary types.  By unpacking the dictionary encoding at the schema level
+/// (and later casting the data via `arrow_cast::cast`), the downstream
+/// accelerator receives only primitive types it can handle.
+///
+/// For example, `Dictionary(Int32, Utf8)` is normalised to `Utf8`.
+#[must_use]
+pub fn normalize_dictionary_types(schema: &Schema) -> Schema {
+    apply_rules(schema, &[&DictionaryUnwrap])
+}
+
+/// Post-order recursive type rewriter: children are rewritten before the parent.
+fn rewrite_data_type(dt: &DataType, rules: &[&dyn TypeRewriteRule]) -> DataType {
+    let dt = match dt {
+        DataType::Dictionary(key_type, value_type) => {
+            let inner = rewrite_data_type(value_type.as_ref(), rules);
+            DataType::Dictionary(key_type.clone(), Box::new(inner))
+        }
+        DataType::List(field) => {
+            let inner = rewrite_data_type(field.data_type(), rules);
+            DataType::List(Arc::new(field.as_ref().clone().with_data_type(inner)))
+        }
+        DataType::LargeList(field) => {
+            let inner = rewrite_data_type(field.data_type(), rules);
+            DataType::LargeList(Arc::new(field.as_ref().clone().with_data_type(inner)))
+        }
+        DataType::FixedSizeList(field, size) => {
+            let inner = rewrite_data_type(field.data_type(), rules);
+            DataType::FixedSizeList(
+                Arc::new(field.as_ref().clone().with_data_type(inner)),
+                *size,
+            )
+        }
+        DataType::ListView(field) => {
+            let inner = rewrite_data_type(field.data_type(), rules);
+            DataType::ListView(Arc::new(field.as_ref().clone().with_data_type(inner)))
+        }
+        DataType::LargeListView(field) => {
+            let inner = rewrite_data_type(field.data_type(), rules);
+            DataType::LargeListView(Arc::new(field.as_ref().clone().with_data_type(inner)))
+        }
+        DataType::Map(field, sorted) => {
+            let inner = rewrite_data_type(field.data_type(), rules);
+            DataType::Map(
+                Arc::new(field.as_ref().clone().with_data_type(inner)),
+                *sorted,
+            )
+        }
+        DataType::Struct(fields) => {
+            let new_fields: Vec<Field> = fields
+                .iter()
+                .map(|f| {
+                    let inner = rewrite_data_type(f.data_type(), rules);
+                    f.as_ref().clone().with_data_type(inner)
+                })
+                .collect();
+            DataType::Struct(new_fields.into())
+        }
+        DataType::Union(fields, mode) => DataType::Union(
+            fields
+                .iter()
+                .map(|(type_id, f)| {
+                    let inner = rewrite_data_type(f.data_type(), rules);
+                    (type_id, Arc::new(f.as_ref().clone().with_data_type(inner)))
+                })
+                .collect(),
+            *mode,
+        ),
+        DataType::RunEndEncoded(run_ends, values) => {
+            let inner = rewrite_data_type(values.data_type(), rules);
+            DataType::RunEndEncoded(
+                Arc::clone(run_ends),
+                Arc::new(values.as_ref().clone().with_data_type(inner)),
+            )
+        }
+        other => other.clone(),
+    };
+    for rule in rules {
+        if let Some(rewritten) = rule.rewrite(&dt) {
+            return rewritten;
+        }
+    }
+    dt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field, IntervalUnit, Schema, UnionFields, UnionMode};
+
+    #[test]
+    fn null_to_int32_top_level() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("untyped", DataType::Null, true),
+            Field::new("name", DataType::Utf8, false),
+        ]);
+        let result = apply_rules(&schema, &[&NullToInt32]);
+        assert_eq!(result.field(0).data_type(), &DataType::Int64);
+        assert_eq!(result.field(1).data_type(), &DataType::Int32);
+        assert_eq!(result.field(2).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn null_to_int32_nested_in_list() {
+        let schema = Schema::new(vec![Field::new(
+            "col",
+            DataType::List(Arc::new(Field::new("item", DataType::Null, true))),
+            false,
+        )]);
+        let result = apply_rules(&schema, &[&NullToInt32]);
+        let expected = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+        assert_eq!(result.field(0).data_type(), &expected);
+    }
+
+    #[test]
+    fn null_to_int32_nested_in_struct() {
+        let schema = Schema::new(vec![Field::new(
+            "rec",
+            DataType::Struct(
+                vec![
+                    Field::new("id", DataType::Int32, false),
+                    Field::new("val", DataType::Null, true),
+                ]
+                .into(),
+            ),
+            false,
+        )]);
+        let result = apply_rules(&schema, &[&NullToInt32]);
+        let expected = DataType::Struct(
+            vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new("val", DataType::Int32, true),
+            ]
+            .into(),
+        );
+        assert_eq!(result.field(0).data_type(), &expected);
+    }
+
+    #[test]
+    fn interval_year_month_normalized() {
+        let schema = Schema::new(vec![Field::new(
+            "dur",
+            DataType::Interval(IntervalUnit::YearMonth),
+            true,
+        )]);
+        let result = apply_rules(&schema, &[&IntervalToMonthDayNano]);
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::Interval(IntervalUnit::MonthDayNano)
+        );
+    }
+
+    #[test]
+    fn interval_day_time_normalized() {
+        let schema = Schema::new(vec![Field::new(
+            "dur",
+            DataType::Interval(IntervalUnit::DayTime),
+            true,
+        )]);
+        let result = apply_rules(&schema, &[&IntervalToMonthDayNano]);
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::Interval(IntervalUnit::MonthDayNano)
+        );
+    }
+
+    #[test]
+    fn interval_month_day_nano_unchanged() {
+        let schema = Schema::new(vec![Field::new(
+            "dur",
+            DataType::Interval(IntervalUnit::MonthDayNano),
+            true,
+        )]);
+        let result = apply_rules(&schema, &[&IntervalToMonthDayNano]);
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::Interval(IntervalUnit::MonthDayNano)
+        );
+    }
+
+    #[test]
+    fn multiple_rules_applied_in_order() {
+        let schema = Schema::new(vec![
+            Field::new("untyped", DataType::Null, true),
+            Field::new(
+                "dict",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                false,
+            ),
+            Field::new("dur", DataType::Interval(IntervalUnit::DayTime), true),
+        ]);
+        let result = apply_rules(
+            &schema,
+            &[&DictionaryUnwrap, &NullToInt32, &IntervalToMonthDayNano],
+        );
+        assert_eq!(result.field(0).data_type(), &DataType::Int32);
+        assert_eq!(result.field(1).data_type(), &DataType::Utf8);
+        assert_eq!(
+            result.field(2).data_type(),
+            &DataType::Interval(IntervalUnit::MonthDayNano)
+        );
+    }
+
+    #[test]
+    fn apply_rules_preserves_metadata() {
+        use std::collections::HashMap;
+        let mut meta = HashMap::new();
+        meta.insert("key".to_string(), "val".to_string());
+        let mut fmeta = HashMap::new();
+        fmeta.insert("fkey".to_string(), "fval".to_string());
+        let schema = Schema::new_with_metadata(
+            vec![Field::new("x", DataType::Null, true).with_metadata(fmeta.clone())],
+            meta.clone(),
+        );
+        let result = apply_rules(&schema, &[&NullToInt32]);
+        assert_eq!(result.metadata(), &meta);
+        assert_eq!(result.field(0).metadata(), &fmeta);
+        assert_eq!(result.field(0).data_type(), &DataType::Int32);
+    }
+
+    #[test]
+    fn noop_when_no_rules_match() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let result = apply_rules(&schema, &[&NullToInt32]);
+        assert_eq!(result, schema);
+    }
+
+    #[test]
+    fn dictionary_inside_dict_unwrap_then_null_rule() {
+        // Dictionary(Int32, Null) — after DictionaryUnwrap → Null — after NullToInt32 → Int32
+        let schema = Schema::new(vec![Field::new(
+            "col",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Null)),
+            true,
+        )]);
+        let result = apply_rules(&schema, &[&DictionaryUnwrap, &NullToInt32]);
+        assert_eq!(result.field(0).data_type(), &DataType::Int32);
+    }
+
+    #[test]
+    fn interval_nested_in_union() {
+        let union_fields = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("i32", DataType::Int32, false),
+                Field::new("dur", DataType::Interval(IntervalUnit::YearMonth), true),
+            ],
+        )
+        .expect("union fields");
+        let schema = Schema::new(vec![Field::new(
+            "mixed",
+            DataType::Union(union_fields, UnionMode::Dense),
+            false,
+        )]);
+        let result = apply_rules(&schema, &[&IntervalToMonthDayNano]);
+        let expected_fields = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("i32", DataType::Int32, false),
+                Field::new("dur", DataType::Interval(IntervalUnit::MonthDayNano), true),
+            ],
+        )
+        .expect("expected union fields");
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::Union(expected_fields, UnionMode::Dense)
+        );
+    }
+
+    #[test]
+    fn test_normalize_dictionary_types() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "status",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                true,
+            ),
+            Field::new("name", DataType::Utf8, false),
+            Field::new(
+                "category",
+                DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::LargeUtf8)),
+                false,
+            ),
+        ]);
+        let normalized = normalize_dictionary_types(&schema);
+        assert_eq!(normalized.field(0).data_type(), &DataType::Int64);
+        assert_eq!(normalized.field(1).data_type(), &DataType::Utf8);
+        assert!(normalized.field(1).is_nullable());
+        assert_eq!(normalized.field(2).data_type(), &DataType::Utf8);
+        assert_eq!(normalized.field(3).data_type(), &DataType::LargeUtf8);
+        assert!(!normalized.field(3).is_nullable());
+    }
+
+    #[test]
+    fn test_normalize_schema_without_dictionary_is_noop() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]);
+        let normalized = normalize_dictionary_types(&schema);
+        assert_eq!(schema, normalized);
+    }
+
+    #[test]
+    fn test_normalize_preserves_metadata() {
+        use std::collections::HashMap;
+        let mut metadata = HashMap::new();
+        metadata.insert("key".to_string(), "value".to_string());
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert("custom_key".to_string(), "custom_value".to_string());
+        let schema = Schema::new_with_metadata(
+            vec![
+                Field::new(
+                    "col",
+                    DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                    false,
+                )
+                .with_metadata(field_metadata.clone()),
+            ],
+            metadata.clone(),
+        );
+        let normalized = normalize_dictionary_types(&schema);
+        assert_eq!(normalized.metadata(), &metadata);
+        assert_eq!(normalized.field(0).data_type(), &DataType::Utf8);
+        assert_eq!(
+            normalized.field(0).metadata(),
+            &field_metadata,
+            "field-level metadata must be preserved after normalization"
+        );
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_list() {
+        let schema = Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                true,
+            ))),
+            false,
+        )]);
+        let normalized = normalize_dictionary_types(&schema);
+        let expected = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
+        assert_eq!(normalized.field(0).data_type(), &expected);
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_struct() {
+        let schema = Schema::new(vec![Field::new(
+            "record",
+            DataType::Struct(
+                vec![
+                    Field::new("id", DataType::Int64, false),
+                    Field::new(
+                        "status",
+                        DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+                        true,
+                    ),
+                ]
+                .into(),
+            ),
+            false,
+        )]);
+        let normalized = normalize_dictionary_types(&schema);
+        let expected = DataType::Struct(
+            vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("status", DataType::Utf8, true),
+            ]
+            .into(),
+        );
+        assert_eq!(normalized.field(0).data_type(), &expected);
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_union() {
+        let union_fields = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("int_val", DataType::Int32, false),
+                Field::new(
+                    "dict_val",
+                    DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+                    true,
+                ),
+            ],
+        )
+        .expect("union fields");
+        let schema = Schema::new(vec![Field::new(
+            "mixed",
+            DataType::Union(union_fields, UnionMode::Dense),
+            false,
+        )]);
+        let normalized = normalize_dictionary_types(&schema);
+        let expected_union = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("int_val", DataType::Int32, false),
+                Field::new("dict_val", DataType::Utf8, true),
+            ],
+        )
+        .expect("expected union fields");
+        assert_eq!(
+            normalized.field(0).data_type(),
+            &DataType::Union(expected_union, UnionMode::Dense)
+        );
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_list_view() {
+        let schema = Schema::new(vec![Field::new(
+            "tags",
+            DataType::ListView(Arc::new(Field::new(
+                "item",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                true,
+            ))),
+            false,
+        )]);
+        let normalized = normalize_dictionary_types(&schema);
+        let expected = DataType::ListView(Arc::new(Field::new("item", DataType::Utf8, true)));
+        assert_eq!(normalized.field(0).data_type(), &expected);
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_large_list_view() {
+        let schema = Schema::new(vec![Field::new(
+            "tags",
+            DataType::LargeListView(Arc::new(Field::new(
+                "item",
+                DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::LargeUtf8)),
+                true,
+            ))),
+            false,
+        )]);
+        let normalized = normalize_dictionary_types(&schema);
+        let expected =
+            DataType::LargeListView(Arc::new(Field::new("item", DataType::LargeUtf8, true)));
+        assert_eq!(normalized.field(0).data_type(), &expected);
+    }
+
+    #[test]
+    fn test_normalize_nested_dictionary_in_run_end_encoded() {
+        let schema = Schema::new(vec![Field::new(
+            "encoded",
+            DataType::RunEndEncoded(
+                Arc::new(Field::new("run_ends", DataType::Int32, false)),
+                Arc::new(Field::new(
+                    "values",
+                    DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+                    true,
+                )),
+            ),
+            false,
+        )]);
+        let normalized = normalize_dictionary_types(&schema);
+        let expected = DataType::RunEndEncoded(
+            Arc::new(Field::new("run_ends", DataType::Int32, false)),
+            Arc::new(Field::new("values", DataType::Utf8, true)),
+        );
+        assert_eq!(normalized.field(0).data_type(), &expected);
+    }
+}

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -394,9 +394,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("optimizer_duckdb_aggregate_pushdown"),
 ];
 
-/// DuckDB has no Null type and silently coerces it to INT32. Normalize any
+/// `DuckDB` has no Null type and silently coerces it to INT32. Normalize any
 /// `DataType::Null` fields to `DataType::Int32` so the schema Spice stores
-/// matches what DuckDB actually creates, preventing a mismatch on reads.
+/// matches what `DuckDB` actually creates, preventing a mismatch on reads.
 fn normalize_null_schema(
     schema: &datafusion::common::DFSchemaRef,
 ) -> datafusion::common::Result<datafusion::common::DFSchemaRef> {

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -2257,15 +2257,21 @@ mod tests {
         super::normalize_schema_for_duckdb(&mut cmd).expect("normalize succeeds");
         let arrow = cmd.schema.as_arrow();
         assert_eq!(
-            arrow.field_with_name("id").unwrap().data_type(),
+            arrow.field_with_name("id").expect("id field").data_type(),
             &DataType::Int64
         );
         assert_eq!(
-            arrow.field_with_name("untyped").unwrap().data_type(),
+            arrow
+                .field_with_name("untyped")
+                .expect("untyped field")
+                .data_type(),
             &DataType::Int32
         );
         assert_eq!(
-            arrow.field_with_name("name").unwrap().data_type(),
+            arrow
+                .field_with_name("name")
+                .expect("name field")
+                .data_type(),
             &DataType::Utf8
         );
     }
@@ -2280,7 +2286,7 @@ mod tests {
         super::normalize_schema_for_duckdb(&mut cmd).expect("normalize succeeds");
         let arrow = cmd.schema.as_arrow();
         assert_eq!(
-            arrow.field_with_name("dur").unwrap().data_type(),
+            arrow.field_with_name("dur").expect("dur field").data_type(),
             &DataType::Interval(IntervalUnit::MonthDayNano)
         );
     }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -38,10 +38,8 @@ use crate::{
     parameters::ParameterSpec,
     register_data_accelerator, spice_data_base_path,
 };
-use arrow::datatypes::{DataType, Field, Schema};
 use async_trait::async_trait;
 use data_components::poly::PolyTableProvider;
-use datafusion::common::ToDFSchema;
 use datafusion::error::DataFusionError;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::{
@@ -394,34 +392,11 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("optimizer_duckdb_aggregate_pushdown"),
 ];
 
-/// `DuckDB` has no Null type and silently coerces it to INT32. Normalize any
-/// `DataType::Null` fields to `DataType::Int32` so the schema Spice stores
-/// matches what `DuckDB` actually creates, preventing a mismatch on reads.
-fn normalize_null_schema(
-    schema: &datafusion::common::DFSchemaRef,
-) -> datafusion::common::Result<datafusion::common::DFSchemaRef> {
-    let arrow_schema = schema.as_arrow();
-    if !arrow_schema
-        .fields()
-        .iter()
-        .any(|f| f.data_type() == &DataType::Null)
-    {
-        return Ok(Arc::clone(schema));
-    }
-    let normalized_fields: Vec<Field> = arrow_schema
-        .fields()
-        .iter()
-        .map(|f| {
-            if f.data_type() == &DataType::Null {
-                f.as_ref().clone().with_data_type(DataType::Int32)
-            } else {
-                f.as_ref().clone()
-            }
-        })
-        .collect();
-    let normalized = Schema::new_with_metadata(normalized_fields, arrow_schema.metadata().clone());
-    ToDFSchema::to_dfschema_ref(Arc::new(normalized))
-}
+static DUCKDB_TYPE_REWRITE_RULES: &[&dyn arrow_tools::type_rewrite::TypeRewriteRule] = &[
+    &arrow_tools::type_rewrite::DictionaryUnwrap,
+    &arrow_tools::type_rewrite::IntervalToMonthDayNano,
+    &arrow_tools::type_rewrite::NullToInt32,
+];
 
 #[async_trait]
 impl DataAccelerator for DuckDBAccelerator {
@@ -537,7 +512,7 @@ impl DataAccelerator for DuckDBAccelerator {
         _partition_by: Vec<PartitionedBy>,
         _runtime_env: Option<Arc<RuntimeEnv>>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
-        cmd.schema = normalize_null_schema(&cmd.schema)
+        normalize_schema_for_duckdb(&mut cmd)
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         if let Some(duckdb_file) = cmd.options.remove("file") {
@@ -1018,6 +993,17 @@ fn make_on_refresh_write_handler(
 }
 
 register_data_accelerator!(Engine::DuckDB, DuckDBAccelerator);
+
+fn normalize_schema_for_duckdb(cmd: &mut CreateExternalTable) -> datafusion::common::Result<()> {
+    use datafusion::common::ToDFSchema;
+    let arrow_schema = cmd.schema.as_arrow();
+    let normalized =
+        arrow_tools::type_rewrite::apply_rules(arrow_schema, DUCKDB_TYPE_REWRITE_RULES);
+    if normalized != *arrow_schema {
+        cmd.schema = ToDFSchema::to_dfschema_ref(Arc::new(normalized))?;
+    }
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {
@@ -2075,7 +2061,7 @@ mod tests {
         ]));
 
         // Normalize the schema (Dictionary -> Utf8).
-        let accel_schema = Arc::new(arrow_tools::schema::normalize_dictionary_types(
+        let accel_schema = Arc::new(arrow_tools::type_rewrite::normalize_dictionary_types(
             &source_schema,
         ));
         assert_eq!(accel_schema.field(1).data_type(), &DataType::Utf8);
@@ -2241,18 +2227,35 @@ mod tests {
         );
     }
 
+    fn cmd_with_schema(schema: Arc<Schema>) -> CreateExternalTable {
+        let df_schema = ToDFSchema::to_dfschema_ref(schema).expect("valid schema");
+        CreateExternalTable {
+            schema: df_schema,
+            name: TableReference::bare("t"),
+            location: String::new(),
+            file_type: String::new(),
+            table_partition_cols: vec![],
+            if_not_exists: true,
+            or_replace: false,
+            definition: None,
+            order_exprs: vec![],
+            unbounded: false,
+            options: HashMap::default(),
+            constraints: Constraints::new_unverified(vec![]),
+            column_defaults: HashMap::default(),
+            temporary: false,
+        }
+    }
+
     #[test]
-    fn normalize_null_schema_converts_null_fields_to_int32() {
-        let schema = Arc::new(Schema::new(vec![
+    fn normalize_schema_for_duckdb_null_to_int32() {
+        let mut cmd = cmd_with_schema(Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("untyped", DataType::Null, true),
             Field::new("name", DataType::Utf8, true),
-        ]));
-        let df_schema = ToDFSchema::to_dfschema_ref(schema).expect("valid schema");
-
-        let result = super::normalize_null_schema(&df_schema).expect("normalize succeeds");
-
-        let arrow = result.as_arrow();
+        ])));
+        super::normalize_schema_for_duckdb(&mut cmd).expect("normalize succeeds");
+        let arrow = cmd.schema.as_arrow();
         assert_eq!(
             arrow.field_with_name("id").unwrap().data_type(),
             &DataType::Int64
@@ -2268,18 +2271,32 @@ mod tests {
     }
 
     #[test]
-    fn normalize_null_schema_is_noop_when_no_null_fields() {
+    fn normalize_schema_for_duckdb_interval_to_month_day_nano() {
+        use datafusion::arrow::datatypes::IntervalUnit;
+        let mut cmd = cmd_with_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("dur", DataType::Interval(IntervalUnit::YearMonth), true),
+        ])));
+        super::normalize_schema_for_duckdb(&mut cmd).expect("normalize succeeds");
+        let arrow = cmd.schema.as_arrow();
+        assert_eq!(
+            arrow.field_with_name("dur").unwrap().data_type(),
+            &DataType::Interval(IntervalUnit::MonthDayNano)
+        );
+    }
+
+    #[test]
+    fn normalize_schema_for_duckdb_is_noop_when_no_rules_match() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("name", DataType::Utf8, true),
         ]));
-        let df_schema = ToDFSchema::to_dfschema_ref(schema).expect("valid schema");
-
-        let result = super::normalize_null_schema(&df_schema).expect("normalize succeeds");
-
+        let mut cmd = cmd_with_schema(Arc::clone(&schema));
+        let schema_before = Arc::clone(&cmd.schema);
+        super::normalize_schema_for_duckdb(&mut cmd).expect("normalize succeeds");
         assert!(
-            Arc::ptr_eq(&df_schema, &result),
-            "should return the same Arc"
+            Arc::ptr_eq(&schema_before, &cmd.schema),
+            "schema Arc should be unchanged when no rules match"
         );
     }
 }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -38,8 +38,10 @@ use crate::{
     parameters::ParameterSpec,
     register_data_accelerator, spice_data_base_path,
 };
+use arrow::datatypes::{DataType, Field, Schema};
 use async_trait::async_trait;
 use data_components::poly::PolyTableProvider;
+use datafusion::common::ToDFSchema;
 use datafusion::error::DataFusionError;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::{
@@ -392,6 +394,35 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("optimizer_duckdb_aggregate_pushdown"),
 ];
 
+/// DuckDB has no Null type and silently coerces it to INT32. Normalize any
+/// `DataType::Null` fields to `DataType::Int32` so the schema Spice stores
+/// matches what DuckDB actually creates, preventing a mismatch on reads.
+fn normalize_null_schema(
+    schema: &datafusion::common::DFSchemaRef,
+) -> datafusion::common::Result<datafusion::common::DFSchemaRef> {
+    let arrow_schema = schema.as_arrow();
+    if !arrow_schema
+        .fields()
+        .iter()
+        .any(|f| f.data_type() == &DataType::Null)
+    {
+        return Ok(Arc::clone(schema));
+    }
+    let normalized_fields: Vec<Field> = arrow_schema
+        .fields()
+        .iter()
+        .map(|f| {
+            if f.data_type() == &DataType::Null {
+                f.as_ref().clone().with_data_type(DataType::Int32)
+            } else {
+                f.as_ref().clone()
+            }
+        })
+        .collect();
+    let normalized = Schema::new_with_metadata(normalized_fields, arrow_schema.metadata().clone());
+    ToDFSchema::to_dfschema_ref(Arc::new(normalized))
+}
+
 #[async_trait]
 impl DataAccelerator for DuckDBAccelerator {
     fn as_any(&self) -> &dyn Any {
@@ -506,6 +537,9 @@ impl DataAccelerator for DuckDBAccelerator {
         _partition_by: Vec<PartitionedBy>,
         _runtime_env: Option<Arc<RuntimeEnv>>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+        cmd.schema = normalize_null_schema(&cmd.schema)
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+
         if let Some(duckdb_file) = cmd.options.remove("file") {
             cmd.options.insert("open".to_string(), duckdb_file);
         }
@@ -2204,6 +2238,48 @@ mod tests {
         assert!(
             DuckDBAccelerator::storage_setup_queries(ResolvedAccelerationStorage::Unknown)
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn normalize_null_schema_converts_null_fields_to_int32() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("untyped", DataType::Null, true),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let df_schema = ToDFSchema::to_dfschema_ref(schema).expect("valid schema");
+
+        let result = super::normalize_null_schema(&df_schema).expect("normalize succeeds");
+
+        let arrow = result.as_arrow();
+        assert_eq!(
+            arrow.field_with_name("id").unwrap().data_type(),
+            &DataType::Int64
+        );
+        assert_eq!(
+            arrow.field_with_name("untyped").unwrap().data_type(),
+            &DataType::Int32
+        );
+        assert_eq!(
+            arrow.field_with_name("name").unwrap().data_type(),
+            &DataType::Utf8
+        );
+    }
+
+    #[test]
+    fn normalize_null_schema_is_noop_when_no_null_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let df_schema = ToDFSchema::to_dfschema_ref(schema).expect("valid schema");
+
+        let result = super::normalize_null_schema(&df_schema).expect("normalize succeeds");
+
+        assert!(
+            Arc::ptr_eq(&df_schema, &result),
+            "should return the same Arc"
         );
     }
 }

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -2372,8 +2372,28 @@ mod accelerator_compat_tests {
                             table_type
                         );
                     }
+                } else if matches!(engine, Engine::DuckDB) {
+                    // DuckDB normalises YearMonth/DayTime intervals to MonthDayNano
+                    // because its native INTERVAL type maps to the MonthDayNano layout.
+                    let expected_type = match original_type {
+                        DataType::Interval(
+                            arrow::datatypes::IntervalUnit::YearMonth
+                            | arrow::datatypes::IntervalUnit::DayTime,
+                        ) => &DataType::Interval(arrow::datatypes::IntervalUnit::MonthDayNano),
+                        other => other,
+                    };
+                    assert_eq!(
+                        expected_type,
+                        table_type,
+                        "{:?}: Field {} ({}) data type mismatch. Expected {:?}, got {:?}",
+                        engine,
+                        i,
+                        original_field.name(),
+                        expected_type,
+                        table_type
+                    );
                 } else {
-                    // For non-Vortex engines, types should match exactly
+                    // For all other engines, types should match exactly
                     assert_eq!(
                         original_type,
                         table_type,

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -253,7 +253,7 @@ impl AcceleratorEngineRegistry {
         let schema = if needs_dictionary_normalization
             && arrow_tools::schema::has_dictionary_types(&schema)
         {
-            let normalized = arrow_tools::schema::normalize_dictionary_types(&schema);
+            let normalized = arrow_tools::type_rewrite::normalize_dictionary_types(&schema);
             tracing::debug!(
                 "Normalized Arrow Dictionary types in schema for {engine} acceleration"
             );

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -742,7 +742,7 @@ mod tests {
         ]));
 
         // Normalize the schema so the accelerator sees plain Utf8 instead of Dictionary.
-        let accel_schema = Arc::new(arrow_tools::schema::normalize_dictionary_types(
+        let accel_schema = Arc::new(arrow_tools::type_rewrite::normalize_dictionary_types(
             &source_schema,
         ));
         assert_eq!(accel_schema.field(1).data_type(), &DataType::Utf8);

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2535,7 +2535,7 @@ impl DataFusion {
             let normalized_refresh_schema = if needs_dict_normalization
                 && arrow_tools::schema::has_dictionary_types(refresh_schema)
             {
-                Arc::new(arrow_tools::schema::normalize_dictionary_types(
+                Arc::new(arrow_tools::type_rewrite::normalize_dictionary_types(
                     refresh_schema,
                 ))
             } else {

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -1117,7 +1117,7 @@ async fn test_duckdb_connection_pool_concurrent_queries() -> Result<(), String> 
 }
 
 /// A Parquet file written with an all-null column has `DataType::Null` in its Arrow schema
-/// metadata (logical type Unknown). DuckDB doesn't have a Null type and silently coerces
+/// metadata (logical type Unknown). `DuckDB` doesn't have a Null type and silently coerces
 /// it to INT32 when creating the acceleration table. Without the fix this produces a schema
 /// mismatch at query time; with the fix the accelerator normalises the column to INT32 before
 /// creating the table so both sides agree.

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -1115,3 +1115,140 @@ async fn test_duckdb_connection_pool_concurrent_queries() -> Result<(), String> 
         })
         .await
 }
+
+/// A Parquet file written with an all-null column has `DataType::Null` in its Arrow schema
+/// metadata (logical type Unknown). DuckDB doesn't have a Null type and silently coerces
+/// it to INT32 when creating the acceleration table. Without the fix this produces a schema
+/// mismatch at query time; with the fix the accelerator normalises the column to INT32 before
+/// creating the table so both sides agree.
+#[tokio::test]
+async fn duckdb_acceleration_null_typed_parquet_column() -> Result<(), String> {
+    use arrow::array::{Int64Array, NullArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::parquet::arrow::ArrowWriter;
+
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            // Build a parquet file whose `untyped` column carries DataType::Null — the same
+            // situation as a pyarrow file where every value in a column is null and the
+            // column was never given an explicit type.
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("untyped", DataType::Null, true),
+            ]));
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from(vec![1, 2, 3])),
+                    Arc::new(NullArray::new(3)),
+                ],
+            )
+            .map_err(|e| format!("failed to create batch: {e}"))?;
+
+            let temp_dir =
+                tempfile::tempdir().map_err(|e| format!("failed to create temp dir: {e}"))?;
+            let parquet_path = temp_dir.path().join("null_col.parquet");
+            {
+                let file = std::fs::File::create(&parquet_path)
+                    .map_err(|e| format!("failed to create parquet file: {e}"))?;
+                let mut writer = ArrowWriter::try_new(file, Arc::clone(&schema), None)
+                    .map_err(|e| format!("failed to create ArrowWriter: {e}"))?;
+                writer
+                    .write(&batch)
+                    .map_err(|e| format!("failed to write batch: {e}"))?;
+                writer
+                    .close()
+                    .map_err(|e| format!("failed to close writer: {e}"))?;
+            }
+
+            let mut dataset = Dataset::new(
+                format!("duckdb:read_parquet('{}')", parquet_path.display()),
+                "null_col_parquet".to_string(),
+            );
+            dataset.name = "null_col_parquet".to_string();
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                engine: Some("duckdb".to_string()),
+                mode: Mode::Memory,
+                refresh_mode: Some(RefreshMode::Full),
+                ..Acceleration::default()
+            });
+
+            let app = AppBuilder::new("duckdb_null_col_test")
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err("Timed out waiting for dataset to load".to_string());
+                }
+                () = Arc::clone(&cloned_rt).load_components() => {}
+            }
+
+            runtime_ready_check(&cloned_rt).await;
+
+            let result = cloned_rt
+                .datafusion()
+                .query_builder("SELECT id, untyped FROM null_col_parquet ORDER BY id")
+                .build()
+                .run()
+                .await
+                .map_err(|e| format!("query failed: {e}"))?;
+
+            let batches: Vec<RecordBatch> = result
+                .data
+                .try_collect()
+                .await
+                .map_err(|e| format!("failed to collect results: {e}"))?;
+
+            assert_batches_eq!(
+                [
+                    "+----+---------+",
+                    "| id | untyped |",
+                    "+----+---------+",
+                    "| 1  |         |",
+                    "| 2  |         |",
+                    "| 3  |         |",
+                    "+----+---------+",
+                ],
+                &batches
+            );
+
+            let result = cloned_rt
+                .datafusion()
+                .query_builder("describe null_col_parquet")
+                .build()
+                .run()
+                .await
+                .map_err(|e| format!("query failed: {e}"))?;
+
+            let batches: Vec<RecordBatch> = result
+                .data
+                .try_collect()
+                .await
+                .map_err(|e| format!("failed to collect results: {e}"))?;
+
+            assert_batches_eq!(
+                [
+                    "+-------------+-----------+-------------+",
+                    "| column_name | data_type | is_nullable |",
+                    "+-------------+-----------+-------------+",
+                    "| id          | Int64     | YES         |",
+                    "| untyped     | Int32     | YES         |",
+                    "+-------------+-----------+-------------+",
+                ],
+                &batches
+            );
+
+            Ok(())
+        })
+        .await
+}


### PR DESCRIPTION
## 📝 Summary

DuckDB has no `Null` type and coerces it to `INT32` when creating a table, but the schema Spice stores retains `DataType::Null`, causing a mismatch on reads. 

Fix normalizes `DataType::Null` → `Int32` before the schema reaches DuckDB.

Plus unit and integration tests.