### PR TITLE
Fix metadata on search indexing

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -103,6 +103,7 @@ use runtime_async::ManagedTokioRuntime;
 use runtime_datafusion::{
     query_engine::Error as QueryEngineError, schema_provider::SpiceSchemaProvider,
 };
+use runtime_datafusion_index::IndexedTableProvider;
 use runtime_table_partition::provider::PartitionTableProvider;
 use schema::ensure_schema_exists;
 use snafu::prelude::*;
@@ -624,7 +625,7 @@ pub enum Table {
     },
 }
 
-fn table_provider_with_spicepod_metadata(
+pub(crate) fn table_provider_with_spicepod_metadata(
     provider: Arc<dyn TableProvider>,
     table_metadata: &HashMap<String, String>,
     columns: &[Column],
@@ -632,6 +633,21 @@ fn table_provider_with_spicepod_metadata(
     let field_metadata = field_metadata_from_columns(columns);
     if table_metadata.is_empty() && field_metadata.is_empty() {
         return provider;
+    }
+
+    // If the provider is an IndexedTableProvider, push the metadata enrichment
+    // inside it so that the IndexTableScan analyzer can still discover it via
+    // downcast_ref::<IndexedTableProvider>().
+    if let Some(indexed) = provider.as_any().downcast_ref::<IndexedTableProvider>() {
+        let enriched_underlying = metadata_enriched_table_provider(
+            indexed.get_underlying(),
+            table_metadata.clone(),
+            field_metadata,
+        );
+        return Arc::new(IndexedTableProvider::with_indexes(
+            enriched_underlying,
+            indexed.get_all_indexes(),
+        ));
     }
 
     metadata_enriched_table_provider(provider, table_metadata.clone(), field_metadata)

--- a/crates/runtime/src/federated_table/mod.rs
+++ b/crates/runtime/src/federated_table/mod.rs
@@ -32,9 +32,9 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
+use crate::datafusion::table_provider_with_spicepod_metadata;
 use arrow::datatypes::SchemaRef;
 use arrow_tools::schema::schema_difference;
-use data_components::{FieldMetadata, metadata_enriched_table_provider};
 use datafusion::catalog::TableProvider;
 use datafusion::common::DataFusionError;
 use runtime_acceleration::dataset_checkpoint::DatasetCheckpointer;
@@ -151,28 +151,6 @@ impl DeferredTableProvider {
     }
 }
 
-fn table_provider_with_dataset_metadata(
-    dataset: &Dataset,
-    provider: Arc<dyn TableProvider>,
-) -> Arc<dyn TableProvider> {
-    let field_metadata = field_metadata_from_columns(&dataset.columns);
-    if dataset.metadata.is_empty() && field_metadata.is_empty() {
-        return provider;
-    }
-
-    metadata_enriched_table_provider(provider, dataset.metadata.clone(), field_metadata)
-}
-
-fn field_metadata_from_columns(columns: &[spicepod::semantic::Column]) -> FieldMetadata {
-    columns
-        .iter()
-        .filter_map(|column| {
-            let metadata = column.metadata();
-            (!metadata.is_empty()).then(|| (column.name.clone(), metadata))
-        })
-        .collect()
-}
-
 impl FederatedTable {
     /// Creates a federated table without checking if the schema matches the existing acceleration checkpoint.
     pub fn new_unchecked(table_provider: Arc<dyn TableProvider>) -> Self {
@@ -187,7 +165,11 @@ impl FederatedTable {
         shutdown_token: CancellationToken,
         allow_schema_mismatch: bool,
     ) -> Self {
-        let table_provider = table_provider_with_dataset_metadata(&dataset, table_provider);
+        let table_provider = table_provider_with_spicepod_metadata(
+            table_provider,
+            &dataset.metadata,
+            &dataset.columns,
+        );
 
         // When `allow_schema_mismatch` is `true`, schema differences are ignored and the
         // table provider is returned immediately. The caller is responsible for handling
@@ -398,8 +380,11 @@ impl FederatedTable {
 
             match table_provider_result {
                 Ok(table_provider) => {
-                    let table_provider =
-                        table_provider_with_dataset_metadata(&dataset, table_provider);
+                    let table_provider = table_provider_with_spicepod_metadata(
+                        table_provider,
+                        &dataset.metadata,
+                        &dataset.columns,
+                    );
                     if tx.send(table_provider).is_err() {
                         tracing::error!(
                             "Failed to send deferred table provider for dataset '{}': Channel closed.",


### PR DESCRIPTION
## 📝 Summary
  - Fixes a bug where adding metadata to any column in a dataset's spicepod config caused vector_search to return zero results. Specifically, it causes zero rows to be inserted into the index.
  - Also consolidate duplicate `table_provider_with_dataset_metadata`  and `table_provider_with_spicepod_metadata`.

## 🔗 Related
Issue started in #10944

