### PR TITLE
perf(cayenne): scale CDC inline flush caps with memory + storage class

### DIFF
--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -366,14 +366,24 @@ fn is_local_path(path: &str) -> bool {
     !path.contains("://") || path.starts_with("file://")
 }
 
-/// Strip a `file:`/`file://` scheme so on-disk storage detection receives a real
-/// filesystem path. `resolve_metadata_dir` can return such URIs (since
-/// `cayenne_file_path` accepts them); feeding `file:///x` straight into
-/// `Path::new` would make `Auto` storage detection misclassify it as `Unknown`.
+/// Strip a `file:`/`file://` scheme (including an optional authority such as
+/// `localhost`) so on-disk storage detection receives a real filesystem path.
+/// `resolve_metadata_dir` can return such URIs (since `cayenne_file_path` accepts
+/// them); feeding `file:///x` or `file://localhost/x` into `Path::new` would make
+/// `Auto` storage detection misclassify it as `Unknown`. Returns a borrowed slice
+/// (no owned path), so callers can pass the result directly as `&str`.
 fn fs_probe_path(path: &str) -> &str {
-    path.strip_prefix("file://")
-        .or_else(|| path.strip_prefix("file:"))
-        .unwrap_or(path)
+    if let Some(rest) = path.strip_prefix("file://") {
+        // `rest` is either `/abs/path` (empty authority, e.g. `file:///x`) or
+        // `authority/abs/path` (e.g. `localhost/abs/path`); the filesystem path
+        // begins at the first '/'.
+        match rest.find('/') {
+            Some(slash) => &rest[slash..],
+            None => rest,
+        }
+    } else {
+        path.strip_prefix("file:").unwrap_or(path)
+    }
 }
 
 impl CayenneAccelerator {
@@ -2626,6 +2636,11 @@ mod tests {
             "/data/cayenne/metadata"
         );
         assert_eq!(fs_probe_path("file:/data/cayenne"), "/data/cayenne");
+        // An explicit authority (e.g. localhost) is dropped down to the path.
+        assert_eq!(
+            fs_probe_path("file://localhost/data/cayenne"),
+            "/data/cayenne"
+        );
         // Plain paths pass through unchanged.
         assert_eq!(
             fs_probe_path("/data/cayenne/metadata"),

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -366,6 +366,16 @@ fn is_local_path(path: &str) -> bool {
     !path.contains("://") || path.starts_with("file://")
 }
 
+/// Strip a `file:`/`file://` scheme so on-disk storage detection receives a real
+/// filesystem path. `resolve_metadata_dir` can return such URIs (since
+/// `cayenne_file_path` accepts them); feeding `file:///x` straight into
+/// `Path::new` would make `Auto` storage detection misclassify it as `Unknown`.
+fn fs_probe_path(path: &str) -> &str {
+    path.strip_prefix("file://")
+        .or_else(|| path.strip_prefix("file:"))
+        .unwrap_or(path)
+}
+
 impl CayenneAccelerator {
     #[must_use]
     pub fn new() -> Self {
@@ -641,9 +651,13 @@ impl CayenneAccelerator {
             // under the Auto profile) for other profiles.
             let inline_flush_caps = if uses_small_write_refresh_profile(acceleration) {
                 let metadata_dir = CayenneAccelerator::resolve_metadata_dir(Some(acceleration));
-                let metastore_storage =
-                    resolve_acceleration_storage_async(acceleration.storage_profile, &metadata_dir)
-                        .await;
+                // `metadata_dir` may be a file:// URI; pass a real filesystem path
+                // so Auto storage detection doesn't misclassify it as Unknown.
+                let metastore_storage = resolve_acceleration_storage_async(
+                    acceleration.storage_profile,
+                    fs_probe_path(&metadata_dir),
+                )
+                .await;
                 let caps = inline_flush_caps_for(
                     crate::resource_monitor::get_total_memory(),
                     metastore_storage,
@@ -2602,6 +2616,22 @@ mod tests {
         // Other remote schemes are NOT local
         assert!(!is_local_path("gs://bucket/prefix"));
         assert!(!is_local_path("az://container/blob"));
+    }
+
+    #[test]
+    fn test_fs_probe_path_strips_file_scheme() {
+        // file:// URIs are reduced to their filesystem path for storage detection.
+        assert_eq!(
+            fs_probe_path("file:///data/cayenne/metadata"),
+            "/data/cayenne/metadata"
+        );
+        assert_eq!(fs_probe_path("file:/data/cayenne"), "/data/cayenne");
+        // Plain paths pass through unchanged.
+        assert_eq!(
+            fs_probe_path("/data/cayenne/metadata"),
+            "/data/cayenne/metadata"
+        );
+        assert_eq!(fs_probe_path("relative/metadata"), "relative/metadata");
     }
 
     #[test]

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -179,6 +179,69 @@ fn default_pk_keyset_cache_mb() -> usize {
     usize::try_from(scaled_mb.clamp(FLOOR_MB, CEIL_MB)).unwrap_or(256)
 }
 
+/// Inline-memtable flush caps for the CDC / small-write path.
+///
+/// The inline memtable accumulates CDC mutations as Arrow-IPC BLOBs in the local
+/// metastore and is re-read on every scan until checkpointed to a Vortex file. A
+/// larger memtable lets memory-rich, fast-storage hosts batch more mutations per
+/// flush — fewer Vortex files, less small-file compaction and scan read-amp,
+/// which is the dominant sustained-ingest cost on large CDC tables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct InlineFlushCaps {
+    max_bytes: i64,
+    max_rows: i64,
+    max_segments: i64,
+}
+
+impl InlineFlushCaps {
+    /// Historical flat small-write caps (2 MiB / 2048 rows / 16 segments). Used
+    /// for non-inlining refresh profiles (where the caps are ignored) and as the
+    /// derivation floor, so hosts at or below the floor are byte-for-byte
+    /// unchanged from prior releases.
+    const FLOOR: Self = Self {
+        max_bytes: SMALL_WRITE_INLINE_FLUSH_MAX_BYTES,
+        max_rows: SMALL_WRITE_INLINE_FLUSH_MAX_ROWS,
+        max_segments: SMALL_WRITE_INLINE_FLUSH_MAX_SEGMENTS,
+    };
+}
+
+/// Derive the inline-memtable flush caps from total machine memory (cgroup-aware
+/// via [`crate::resource_monitor::get_total_memory`]) and the storage class of
+/// the *metastore* — where the memtable BLOBs live and the per-scan re-read cost
+/// (read-amp) is actually paid. Faster media tolerate a larger resident memtable.
+///
+/// Deliberately more conservative than the PK keyset cap (`default_pk_keyset_cache_mb`,
+/// `total_mem/32`, [256 MiB, 8 GiB]): the keyset is a pruning structure, whereas
+/// the memtable is raw, un-pruned data re-read on every scan. The byte budget is
+/// the primary knob; rows and segments are derived from it so bytes stays the
+/// binding flush trigger and the floor ratios (2 MiB → 2048 rows / 16 segments)
+/// are preserved exactly.
+fn inline_flush_caps_for(
+    total_mem_bytes: u64,
+    storage: ResolvedAccelerationStorage,
+) -> InlineFlushCaps {
+    const MIB: u64 = 1024 * 1024;
+    // 2 MiB == SMALL_WRITE_INLINE_FLUSH_MAX_BYTES (coupling asserted in tests):
+    // hosts at/under the floor keep prior behavior exactly.
+    const FLOOR_BYTES: u64 = 2 * MIB;
+    // (divisor, ceiling) per metastore medium: faster re-read → larger memtable.
+    // Tmpfs is RAM-backed, so the memtable double-counts against memory — keep it
+    // smallest. Unknown falls back to the conservative EBS profile.
+    let (divisor, ceil_bytes): (u64, u64) = match storage {
+        ResolvedAccelerationStorage::LocalSsd => (64, 256 * MIB),
+        ResolvedAccelerationStorage::Tmpfs => (256, 64 * MIB),
+        ResolvedAccelerationStorage::Ebs | ResolvedAccelerationStorage::Unknown => (128, 128 * MIB),
+    };
+    let bytes = (total_mem_bytes / divisor).clamp(FLOOR_BYTES, ceil_bytes);
+    let rows = bytes / 1024; // ~1 KiB/row
+    let segments = (bytes / (128 * 1024)).clamp(16, 256); // ~128 KiB/segment, with a fan-in cap
+    InlineFlushCaps {
+        max_bytes: i64::try_from(bytes).unwrap_or(i64::MAX),
+        max_rows: i64::try_from(rows).unwrap_or(i64::MAX),
+        max_segments: i64::try_from(segments).unwrap_or(i64::MAX),
+    }
+}
+
 fn parse_usize(acceleration: &Acceleration, key: &str, default: usize) -> usize {
     acceleration
         .params
@@ -251,6 +314,7 @@ const APPEND_SMALL_WRITE_REFRESH_INTERVAL_THRESHOLD: Duration = Duration::from_s
 fn apply_refresh_mode_defaults(
     config: &mut cayenne::metadata::VortexConfig,
     acceleration: &Acceleration,
+    inline_flush_caps: InlineFlushCaps,
 ) {
     if uses_small_write_refresh_profile(acceleration) {
         config.compaction_trigger_files = SMALL_WRITE_COMPACTION_TRIGGER_FILES;
@@ -258,12 +322,18 @@ fn apply_refresh_mode_defaults(
             SMALL_WRITE_COMPACTION_TRIGGER_PROTECTED_SNAPSHOTS;
         config.compaction_trigger_snapshot_age_ms = SMALL_WRITE_COMPACTION_TRIGGER_SNAPSHOT_AGE_MS;
         config.compaction_background_interval_ms = SMALL_WRITE_COMPACTION_BACKGROUND_INTERVAL_MS;
+        // Per-entry inline-admission caps stay static by design: inlined entries
+        // are re-read on every scan with no zone-map pruning, so raising them is
+        // pure read-amp (see `provider::table` inlining-caps comment).
         config.inline_max_rows = SMALL_WRITE_INLINE_MAX_ROWS;
         config.inline_max_bytes = SMALL_WRITE_INLINE_MAX_BYTES;
         config.inline_max_buffer_bytes = SMALL_WRITE_INLINE_MAX_BUFFER_BYTES;
-        config.inline_flush_max_rows = SMALL_WRITE_INLINE_FLUSH_MAX_ROWS;
-        config.inline_flush_max_segments = SMALL_WRITE_INLINE_FLUSH_MAX_SEGMENTS;
-        config.inline_flush_max_bytes = SMALL_WRITE_INLINE_FLUSH_MAX_BYTES;
+        // Memtable flush caps scale with machine memory + metastore storage class
+        // (see `inline_flush_caps_for`). Explicit operator params still override
+        // these in the param-resolution pass below.
+        config.inline_flush_max_rows = inline_flush_caps.max_rows;
+        config.inline_flush_max_segments = inline_flush_caps.max_segments;
+        config.inline_flush_max_bytes = inline_flush_caps.max_bytes;
     } else {
         config.inline_max_rows = 0;
         config.inline_max_bytes = 0;
@@ -561,7 +631,35 @@ impl CayenneAccelerator {
         }
 
         if let Some(acceleration) = source.acceleration() {
-            apply_refresh_mode_defaults(&mut config, acceleration);
+            // Inline-memtable flush caps scale with machine memory and the
+            // metastore's storage medium (where the memtable BLOBs live and the
+            // per-scan re-read cost is paid). Only the small-write/CDC profile
+            // inlines, so skip the (blocking) storage probe for other profiles.
+            let inline_flush_caps = if uses_small_write_refresh_profile(acceleration) {
+                let metadata_dir = CayenneAccelerator::resolve_metadata_dir(Some(acceleration));
+                let metastore_storage =
+                    resolve_acceleration_storage_async(acceleration.storage_profile, &metadata_dir)
+                        .await;
+                let caps = inline_flush_caps_for(
+                    crate::resource_monitor::get_total_memory(),
+                    metastore_storage,
+                );
+                tracing::debug!(
+                    target: "spiced::acceleration::cayenne",
+                    table = %table_name,
+                    configured = %acceleration.storage_profile,
+                    resolved = ?metastore_storage,
+                    inline_flush_max_bytes = caps.max_bytes,
+                    inline_flush_max_rows = caps.max_rows,
+                    inline_flush_max_segments = caps.max_segments,
+                    "Applying memory/storage-aware inline-memtable flush caps"
+                );
+                caps
+            } else {
+                InlineFlushCaps::FLOOR
+            };
+
+            apply_refresh_mode_defaults(&mut config, acceleration, inline_flush_caps);
 
             config.segment_cache_mb = parse_usize(
                 acceleration,
@@ -2637,6 +2735,16 @@ mod tests {
         assert_eq!(quiet.write_concurrency, Some(2));
     }
 
+    /// Recompute the expected memory/storage-derived flush caps the same way the
+    /// builder does, so assertions stay correct on any host (CI memory and
+    /// storage medium vary). Mirrors `get_vortex_config_with_footer_cache`.
+    async fn expected_inline_flush_caps(acceleration: &Acceleration) -> InlineFlushCaps {
+        let metadata_dir = CayenneAccelerator::resolve_metadata_dir(Some(acceleration));
+        let storage =
+            resolve_acceleration_storage_async(acceleration.storage_profile, &metadata_dir).await;
+        inline_flush_caps_for(crate::resource_monitor::get_total_memory(), storage)
+    }
+
     #[tokio::test]
     async fn test_vortex_config_defaults_use_small_write_refresh_profile() {
         let app = Arc::new(AppBuilder::new("test").build());
@@ -2683,18 +2791,12 @@ mod tests {
                 config.inline_max_buffer_bytes,
                 SMALL_WRITE_INLINE_MAX_BUFFER_BYTES
             );
-            assert_eq!(
-                config.inline_flush_max_rows,
-                SMALL_WRITE_INLINE_FLUSH_MAX_ROWS
-            );
-            assert_eq!(
-                config.inline_flush_max_segments,
-                SMALL_WRITE_INLINE_FLUSH_MAX_SEGMENTS
-            );
-            assert_eq!(
-                config.inline_flush_max_bytes,
-                SMALL_WRITE_INLINE_FLUSH_MAX_BYTES
-            );
+            let expected_caps =
+                expected_inline_flush_caps(dataset.acceleration.as_ref().expect("acceleration"))
+                    .await;
+            assert_eq!(config.inline_flush_max_rows, expected_caps.max_rows);
+            assert_eq!(config.inline_flush_max_segments, expected_caps.max_segments);
+            assert_eq!(config.inline_flush_max_bytes, expected_caps.max_bytes);
         }
 
         let mut dataset = DatasetBuilder::try_new("append_hot".to_string(), "append_hot")
@@ -2721,9 +2823,72 @@ mod tests {
             config.compaction_trigger_protected_snapshots,
             SMALL_WRITE_COMPACTION_TRIGGER_PROTECTED_SNAPSHOTS
         );
+        let expected_caps =
+            expected_inline_flush_caps(dataset.acceleration.as_ref().expect("acceleration")).await;
+        assert_eq!(config.inline_flush_max_rows, expected_caps.max_rows);
+        assert_eq!(config.inline_flush_max_segments, expected_caps.max_segments);
+        assert_eq!(config.inline_flush_max_bytes, expected_caps.max_bytes);
+    }
+
+    #[test]
+    fn test_inline_flush_caps_scale_with_memory_and_storage() {
+        const MIB: u64 = 1024 * 1024;
+        const GIB: u64 = 1024 * MIB;
+
+        // Floor: hosts at/under the floor keep the historical small-write caps.
+        // This also pins the FLOOR_BYTES ↔ SMALL_WRITE_INLINE_FLUSH_MAX_BYTES coupling.
         assert_eq!(
-            config.inline_flush_max_rows,
-            SMALL_WRITE_INLINE_FLUSH_MAX_ROWS
+            inline_flush_caps_for(256 * MIB, ResolvedAccelerationStorage::Ebs),
+            InlineFlushCaps::FLOOR
+        );
+        assert_eq!(InlineFlushCaps::FLOOR.max_bytes, 2_097_152); // 2 MiB
+        assert_eq!(InlineFlushCaps::FLOOR.max_rows, 2_048);
+        assert_eq!(InlineFlushCaps::FLOOR.max_segments, 16);
+
+        // Degenerate inputs never panic; they clamp to the floor / ceiling.
+        assert_eq!(
+            inline_flush_caps_for(0, ResolvedAccelerationStorage::Unknown),
+            InlineFlushCaps::FLOOR
+        );
+        assert_eq!(
+            inline_flush_caps_for(u64::MAX, ResolvedAccelerationStorage::LocalSsd).max_bytes,
+            268_435_456 // 256 MiB ceiling, no overflow
+        );
+
+        // Per-class ceilings on a very large host.
+        assert_eq!(
+            inline_flush_caps_for(1024 * GIB, ResolvedAccelerationStorage::LocalSsd).max_bytes,
+            268_435_456 // 256 MiB
+        );
+        assert_eq!(
+            inline_flush_caps_for(1024 * GIB, ResolvedAccelerationStorage::Ebs).max_bytes,
+            134_217_728 // 128 MiB
+        );
+        assert_eq!(
+            inline_flush_caps_for(1024 * GIB, ResolvedAccelerationStorage::Unknown).max_bytes,
+            134_217_728 // 128 MiB (== Ebs, the safe default)
+        );
+        assert_eq!(
+            inline_flush_caps_for(1024 * GIB, ResolvedAccelerationStorage::Tmpfs).max_bytes,
+            67_108_864 // 64 MiB (RAM-backed → smallest)
+        );
+
+        // Faster medium ⇒ strictly larger memtable at equal memory.
+        let mem = 64 * GIB;
+        let ssd = inline_flush_caps_for(mem, ResolvedAccelerationStorage::LocalSsd);
+        let ebs = inline_flush_caps_for(mem, ResolvedAccelerationStorage::Ebs);
+        let tmpfs = inline_flush_caps_for(mem, ResolvedAccelerationStorage::Tmpfs);
+        assert!(ssd.max_bytes > ebs.max_bytes);
+        assert!(ebs.max_bytes > tmpfs.max_bytes);
+
+        // Mid-range scales between floor and ceiling (4 GiB on Ebs ⇒ 32 MiB), and
+        // rows/segments stay derived from the byte budget.
+        let mid = inline_flush_caps_for(4 * GIB, ResolvedAccelerationStorage::Ebs);
+        assert_eq!(mid.max_bytes, 33_554_432); // 32 MiB
+        assert_eq!(mid.max_rows, mid.max_bytes / 1024);
+        assert_eq!(
+            mid.max_segments,
+            (mid.max_bytes / (128 * 1024)).clamp(16, 256)
         );
     }
 

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -2739,16 +2739,6 @@ mod tests {
         assert_eq!(quiet.write_concurrency, Some(2));
     }
 
-    /// Recompute the expected memory/storage-derived flush caps the same way the
-    /// builder does, so assertions stay correct on any host (CI memory and
-    /// storage medium vary). Mirrors `get_vortex_config_with_footer_cache`.
-    async fn expected_inline_flush_caps(acceleration: &Acceleration) -> InlineFlushCaps {
-        let metadata_dir = CayenneAccelerator::resolve_metadata_dir(Some(acceleration));
-        let storage =
-            resolve_acceleration_storage_async(acceleration.storage_profile, &metadata_dir).await;
-        inline_flush_caps_for(crate::resource_monitor::get_total_memory(), storage)
-    }
-
     #[tokio::test]
     async fn test_vortex_config_defaults_use_small_write_refresh_profile() {
         let app = Arc::new(AppBuilder::new("test").build());
@@ -2795,12 +2785,12 @@ mod tests {
                 config.inline_max_buffer_bytes,
                 SMALL_WRITE_INLINE_MAX_BUFFER_BYTES
             );
-            let expected_caps =
-                expected_inline_flush_caps(dataset.acceleration.as_ref().expect("acceleration"))
-                    .await;
-            assert_eq!(config.inline_flush_max_rows, expected_caps.max_rows);
-            assert_eq!(config.inline_flush_max_segments, expected_caps.max_segments);
-            assert_eq!(config.inline_flush_max_bytes, expected_caps.max_bytes);
+            // Flush caps are memory/storage-derived; exact scaling is pinned in
+            // `test_inline_flush_caps_scale_with_memory_and_storage`. Here assert the
+            // deterministic [floor, ceiling] bounds they hold on any host/medium.
+            assert!((2 * 1_048_576..=256 * 1_048_576).contains(&config.inline_flush_max_bytes));
+            assert!((2_048..=262_144).contains(&config.inline_flush_max_rows));
+            assert!((16..=256).contains(&config.inline_flush_max_segments));
         }
 
         let mut dataset = DatasetBuilder::try_new("append_hot".to_string(), "append_hot")
@@ -2827,11 +2817,9 @@ mod tests {
             config.compaction_trigger_protected_snapshots,
             SMALL_WRITE_COMPACTION_TRIGGER_PROTECTED_SNAPSHOTS
         );
-        let expected_caps =
-            expected_inline_flush_caps(dataset.acceleration.as_ref().expect("acceleration")).await;
-        assert_eq!(config.inline_flush_max_rows, expected_caps.max_rows);
-        assert_eq!(config.inline_flush_max_segments, expected_caps.max_segments);
-        assert_eq!(config.inline_flush_max_bytes, expected_caps.max_bytes);
+        assert!((2 * 1_048_576..=256 * 1_048_576).contains(&config.inline_flush_max_bytes));
+        assert!((2_048..=262_144).contains(&config.inline_flush_max_rows));
+        assert!((16..=256).contains(&config.inline_flush_max_segments));
     }
 
     #[test]

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -196,8 +196,8 @@ struct InlineFlushCaps {
 impl InlineFlushCaps {
     /// Historical flat small-write caps (2 MiB / 2048 rows / 16 segments). Used
     /// for non-inlining refresh profiles (where the caps are ignored) and as the
-    /// derivation floor, so hosts at or below the floor are byte-for-byte
-    /// unchanged from prior releases.
+    /// derivation floor (`inline_flush_caps_for` never returns less than this), so
+    /// no host regresses below the prior flat default.
     const FLOOR: Self = Self {
         max_bytes: SMALL_WRITE_INLINE_FLUSH_MAX_BYTES,
         max_rows: SMALL_WRITE_INLINE_FLUSH_MAX_ROWS,
@@ -213,16 +213,19 @@ impl InlineFlushCaps {
 /// Deliberately more conservative than the PK keyset cap (`default_pk_keyset_cache_mb`,
 /// `total_mem/32`, [256 MiB, 8 GiB]): the keyset is a pruning structure, whereas
 /// the memtable is raw, un-pruned data re-read on every scan. The byte budget is
-/// the primary knob; rows and segments are derived from it so bytes stays the
-/// binding flush trigger and the floor ratios (2 MiB → 2048 rows / 16 segments)
-/// are preserved exactly.
+/// the primary lever; rows and segments are derived from it, preserving the floor
+/// ratios (2 MiB → 2048 rows / 16 segments). `max_segments` is additionally capped
+/// at 256 to bound per-scan merge fan-in, so a workload that accumulates many
+/// small entries can hit the segment trigger before the byte budget.
 fn inline_flush_caps_for(
     total_mem_bytes: u64,
     storage: ResolvedAccelerationStorage,
 ) -> InlineFlushCaps {
     const MIB: u64 = 1024 * 1024;
-    // 2 MiB == SMALL_WRITE_INLINE_FLUSH_MAX_BYTES (coupling asserted in tests):
-    // hosts at/under the floor keep prior behavior exactly.
+    // 2 MiB == SMALL_WRITE_INLINE_FLUSH_MAX_BYTES (coupling asserted in tests).
+    // A hard minimum, so no host drops below the prior flat default; the memory at
+    // which scaling begins above the floor is storage-dependent (~128 MiB on
+    // LocalSsd, 256 MiB on Ebs/Unknown, 512 MiB on Tmpfs).
     const FLOOR_BYTES: u64 = 2 * MIB;
     // (divisor, ceiling) per metastore medium: faster re-read → larger memtable.
     // Tmpfs is RAM-backed, so the memtable double-counts against memory — keep it
@@ -634,7 +637,8 @@ impl CayenneAccelerator {
             // Inline-memtable flush caps scale with machine memory and the
             // metastore's storage medium (where the memtable BLOBs live and the
             // per-scan re-read cost is paid). Only the small-write/CDC profile
-            // inlines, so skip the (blocking) storage probe for other profiles.
+            // inlines, so skip the storage probe (a spawn_blocking /proc-/sys read
+            // under the Auto profile) for other profiles.
             let inline_flush_caps = if uses_small_write_refresh_profile(acceleration) {
                 let metadata_dir = CayenneAccelerator::resolve_metadata_dir(Some(acceleration));
                 let metastore_storage =

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -187,6 +187,7 @@ fn default_pk_keyset_cache_mb() -> usize {
 /// flush — fewer Vortex files, less small-file compaction and scan read-amp,
 /// which is the dominant sustained-ingest cost on large CDC tables.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(clippy::struct_field_names)]
 struct InlineFlushCaps {
     max_bytes: i64,
     max_rows: i64,


### PR DESCRIPTION
## Summary

Under `refresh_mode: changes` (CDC), Cayenne ingests mutations into an **inline memtable** — Arrow-IPC BLOBs in the local metastore — and checkpoints ("flushes") it to a Vortex file under pressure. The flush caps that bound how much CDC data accumulates before a flush were flat constants (**2 MiB / 2048 rows / 16 segments**), identical on a laptop and a large server. On memory-rich hosts that forces premature flushes → more, smaller Vortex files → more compaction and small-file scan read-amplification → throttled sustained CDC ingest while CPU/disk sit idle.

This derives the memtable flush caps from **machine memory × storage class**, so big/fast hosts batch more per flush. Small hosts never regress, and explicit operator params still win.

## Approach

The inline memtable lives in the **metastore (always local)**, *not* the Vortex object store — so the per-scan re-read cost (read-amp) that limits how large we dare grow it is paid on the **metastore medium**. The caps therefore key on the metadata dir's storage class:

```
max_bytes = clamp(get_total_memory() / divisor, 2 MiB floor, ceiling)
  LocalSsd (NVMe): /64,  ceil 256 MiB   // fast re-read → batch more
  Ebs / Unknown:   /128, ceil 128 MiB   // conservative
  Tmpfs:           /256, ceil  64 MiB   // RAM-backed → smallest
max_rows derived as bytes/1024; max_segments as bytes/128KiB, capped at 256
```

- **Floor = 2 MiB** (today's value) is a **hard minimum** — no host regresses below the prior flat default. Scaling above the floor begins at a storage-dependent memory size (~128 MiB on LocalSsd, 256 MiB on Ebs/Unknown, 512 MiB on Tmpfs).
- `max_bytes` is the primary budget; `max_segments` is capped at 256 to bound per-scan merge fan-in, so a many-small-entry workload can hit the segment trigger before the byte budget.
- Deliberately more conservative than the PK keyset cap (#11074, `/32`, 8 GiB ceiling): the keyset is a pruning structure; the memtable is raw, un-pruned data re-read on every scan.
- Mirrors two existing patterns in the same file: `default_pk_keyset_cache_mb` (memory axis) and the storage-aware `target_vortex_file_size_mb` block (storage axis), both cgroup-aware via `resource_monitor::get_total_memory`.

### What stays static (by design)
- **Per-entry inline-admission caps** (`inline_max_rows` = 1024, `inline_max_bytes` = 1 MiB): inlined entries are re-read on every scan with no zone-map pruning, so raising them is pure read-amplification.
- **`inline_max_buffer_bytes`**: with the admission gate fixed, raising the buffer is inert — it only buffers wide-row batches that the 1 MiB gate then rejects.

Explicit `cayenne_inline_flush_*` params (and `inline_memtable_*` aliases) still override the derived default — only the *unset* default changed. The `cayenne` crate stays host-agnostic; all memory/storage awareness lives in the runtime accelerator, exactly as in #11074.

## Testing
- New pure-derivation unit test: floor preservation, per-class ceilings, NVMe > EBS > Tmpfs ordering, rows/segments proportionality, and no-panic on degenerate inputs (`0` / `u64::MAX`).
- Updated the small-write defaults test to assert against the recomputed memory/storage-derived caps (machine-independent).
- `cargo test -p runtime --lib dataaccelerator::cayenne` green (38 passed).
