### PR TITLE
Align HTAP workflow defaults with automated dispatch

### DIFF
--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -25,7 +25,7 @@ on:
         description: 'Duration of the HTAP workload in seconds'
         required: false
         type: string
-        default: '300'
+        default: '600'
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true
@@ -34,10 +34,9 @@ on:
       runner_type:
         description: 'Runner type'
         required: true
-        default: 'spiceai-dev-runners'
+        default: 'spiceai-dev-large-runners'
         type: choice
         options:
-          - 'spiceai-dev-runners'
           - 'spiceai-dev-large-runners'
 jobs:
   run-htap:


### PR DESCRIPTION
## 📝 Summary

Update the `workflow_dispatch` defaults in the HTAP benchmark workflow to match the values used by automated/programmatic dispatch:

- `duration`: `300` → `600` seconds
- `runner_type`: `spiceai-dev-runners` → `spiceai-dev-large-runners`

This keeps manually-triggered runs consistent with scheduled/automated runs.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
