### PR TITLE
feat(cayenne): maintain join-sizing stats on the write path

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -1804,12 +1804,16 @@ impl MetadataCatalog for CayenneCatalog {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "INSERT OR REPLACE INTO cayenne_table_statistics \
-                      (table_id, statistics_blob, num_rows) \
-                      VALUES (?1, ?2, ?3)",
+                      (table_id, statistics_blob, num_rows, ndv_sketches) \
+                      VALUES (?1, ?2, ?3, ?4)",
                 params: vec![
                     MetastoreValue::Text(stats.table_id.clone()),
                     MetastoreValue::Blob(stats.statistics_blob.clone()),
                     MetastoreValue::Integer(stats.num_rows),
+                    stats
+                        .ndv_sketches
+                        .clone()
+                        .map_or(MetastoreValue::Null, MetastoreValue::Blob),
                 ],
             })
             .await
@@ -1821,7 +1825,7 @@ impl MetadataCatalog for CayenneCatalog {
             .query_helper(
                 QueryParams {
                     sql: r"
-                    SELECT table_id, statistics_blob, num_rows
+                    SELECT table_id, statistics_blob, num_rows, ndv_sketches
                     FROM cayenne_table_statistics
                     WHERE table_id = ?1
                     ",
@@ -1832,6 +1836,7 @@ impl MetadataCatalog for CayenneCatalog {
                         table_id: row.get_string(0)?,
                         statistics_blob: row.get_blob(1)?,
                         num_rows: row.get_i64(2)?,
+                        ndv_sketches: row.get_optional_blob(3)?,
                     })
                 },
             )

--- a/crates/cayenne/src/hll.rs
+++ b/crates/cayenne/src/hll.rs
@@ -1,0 +1,451 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A small, mergeable [`HyperLogLog`] cardinality sketch maintained incrementally
+//! on the Cayenne write path, plus a [`NdvSketches`] container that holds one
+//! sketch per (integer) column and (de)serializes them for the metastore.
+//!
+//! Why a purpose-built sketch: `DataFusion`'s `approx_distinct` `HyperLogLog` is
+//! private to its aggregate executor and not importable, and no other HLL crate
+//! is in the dependency graph. The estimate only needs to be accurate enough to
+//! *size distributed joins* on sparse integer keys (e.g. CDC `o_custkey` spanning
+//! ~1e9 with ~1M distinct), so a standard register-array HLL at precision
+//! [`PRECISION`] (≈1.6% standard error) is more than sufficient.
+//!
+//! Mergeability is the reason this is incremental rather than recomputed: HLL is
+//! a register-wise max, so a write's sketch folds into the metastore aggregate
+//! exactly the way min/max already do, and slices accumulate across writes with
+//! no full-table rescan. Deletes are not represented (HLL can't remove elements),
+//! which leaves the NDV a *superset* under deletes — the safe direction for join
+//! sizing (it only loosens the effective-max range). Reset on table overwrite.
+
+use std::collections::BTreeMap;
+
+/// Number of register-index bits. `m = 2^PRECISION` registers. At 12 bits that
+/// is 4096 one-byte registers (4 KiB) per column with ~1.6% standard error
+/// (`1.04 / sqrt(m)`) — ample to distinguish ~1M / ~15M / ~60M distinct keys and
+/// to keep the per-column metastore blob small enough to merge on every commit.
+const PRECISION: u8 = 12;
+
+/// Serialization format version for [`NdvSketches`]. Bump on any layout change so
+/// older blobs are skipped rather than misread.
+const SKETCH_FORMAT_VERSION: u8 = 1;
+
+/// A `HyperLogLog` sketch over 64-bit hashed values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HyperLogLog {
+    /// Index bits (`m = 1 << precision`). Stored so a deserialized sketch only
+    /// merges with another of the same precision.
+    precision: u8,
+    /// `m` one-byte registers holding the max observed rank per bucket.
+    registers: Vec<u8>,
+}
+
+impl HyperLogLog {
+    /// Create an empty sketch at the default [`PRECISION`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_precision(PRECISION)
+    }
+
+    #[must_use]
+    fn with_precision(precision: u8) -> Self {
+        let m = 1usize << precision;
+        Self {
+            precision,
+            registers: vec![0u8; m],
+        }
+    }
+
+    /// Number of registers, `m = 2^precision`.
+    fn m(&self) -> usize {
+        1usize << self.precision
+    }
+
+    /// Fold a precomputed 64-bit hash into the sketch.
+    ///
+    /// The top `precision` bits select the register; the remaining bits' leading
+    /// zero count (+1) is the rank. With a 64-bit hash the max meaningful rank is
+    /// `64 - precision + 1`, so no large-range correction is needed.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "idx < 2^precision and rank <= 64 - precision + 1 are both small and in range"
+    )]
+    pub fn add_hash(&mut self, hash: u64) {
+        let p = u32::from(self.precision);
+        let idx = (hash >> (64 - p)) as usize;
+        // Place the remaining (64 - p) bits at the top so leading_zeros counts
+        // only them; an all-zero remainder yields the capped max rank.
+        let remaining = hash << p;
+        let rank = (remaining.leading_zeros() + 1).min(64 - p + 1) as u8;
+        if rank > self.registers[idx] {
+            self.registers[idx] = rank;
+        }
+    }
+
+    /// Add a raw integer value (sign-extended to `i128` so all integer widths
+    /// share one stable hashing path).
+    pub fn add_i128(&mut self, value: i128) {
+        // Explicit byte hashing (not `Hash`) so the mapping is stable across
+        // runs and builds — the sketch is persisted and merged over time.
+        let hash = hash_index::hash_key_bytes(&[&value.to_le_bytes()]);
+        self.add_hash(hash);
+    }
+
+    /// Merge another sketch into this one (register-wise max). No-op on a
+    /// precision mismatch (treated as incompatible rather than panicking).
+    pub fn merge(&mut self, other: &Self) {
+        if self.precision != other.precision || self.registers.len() != other.registers.len() {
+            tracing::warn!(
+                "HyperLogLog::merge: precision/size mismatch ({}/{} vs {}/{}); skipping",
+                self.precision,
+                self.registers.len(),
+                other.precision,
+                other.registers.len(),
+            );
+            return;
+        }
+        for (dst, src) in self.registers.iter_mut().zip(other.registers.iter()) {
+            if *src > *dst {
+                *dst = *src;
+            }
+        }
+    }
+
+    /// Estimate the distinct cardinality.
+    #[must_use]
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "register/zero counts <= 2^18 are exact in f64; the estimate is rounded and clamped >= 0 before the u64 cast"
+    )]
+    pub fn estimate(&self) -> u64 {
+        let m = self.m();
+        let m_f = m as f64;
+
+        let mut sum = 0.0_f64;
+        let mut zeros = 0usize;
+        for &r in &self.registers {
+            sum += 2.0_f64.powi(-i32::from(r));
+            if r == 0 {
+                zeros += 1;
+            }
+        }
+
+        // alpha_m constant (Flajolet et al.).
+        let alpha = match m {
+            16 => 0.673,
+            32 => 0.697,
+            64 => 0.709,
+            _ => 0.7213 / (1.0 + 1.079 / m_f),
+        };
+
+        let raw = alpha * m_f * m_f / sum;
+
+        // Small-range correction: linear counting when registers are mostly empty.
+        let estimate = if raw <= 2.5 * m_f && zeros > 0 {
+            m_f * (m_f / zeros as f64).ln()
+        } else {
+            raw
+        };
+
+        // 64-bit hashes make the large-range (2^32) correction unnecessary.
+        estimate.round().max(0.0) as u64
+    }
+
+    /// True if no value has been added.
+    fn is_empty(&self) -> bool {
+        self.registers.iter().all(|&r| r == 0)
+    }
+}
+
+impl Default for HyperLogLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Per-column NDV sketches, keyed by column index in the table schema. Only
+/// integer columns (join-key candidates) get a sketch.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NdvSketches {
+    columns: BTreeMap<u32, HyperLogLog>,
+}
+
+impl NdvSketches {
+    /// Create an empty container with no per-column sketches.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// True if no column has a sketch.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.columns.is_empty()
+    }
+
+    /// Get (creating if absent) the sketch for `column_index`.
+    pub fn entry(&mut self, column_index: u32) -> &mut HyperLogLog {
+        self.columns.entry(column_index).or_default()
+    }
+
+    /// The estimated distinct count for `column_index`, if a sketch exists and is
+    /// non-empty.
+    #[must_use]
+    pub fn estimate(&self, column_index: u32) -> Option<u64> {
+        let hll = self.columns.get(&column_index)?;
+        if hll.is_empty() {
+            return None;
+        }
+        Some(hll.estimate())
+    }
+
+    /// Merge `other` into `self` (per-column register-wise max; union of columns).
+    pub fn merge(&mut self, other: &Self) {
+        for (idx, hll) in &other.columns {
+            self.columns
+                .entry(*idx)
+                .and_modify(|existing| existing.merge(hll))
+                .or_insert_with(|| hll.clone());
+        }
+    }
+
+    /// Serialize to a compact blob:
+    /// `[version u8][precision u8][num_columns u32][ (col_idx u32, registers[m]) * ]`.
+    /// Empty (no-column) sketch sets serialize to `None` so callers can store SQL
+    /// `NULL`.
+    #[must_use]
+    pub fn serialize(&self) -> Option<Vec<u8>> {
+        // Drop empty sketches so we don't persist all-zero registers.
+        let present: Vec<(&u32, &HyperLogLog)> =
+            self.columns.iter().filter(|(_, h)| !h.is_empty()).collect();
+        if present.is_empty() {
+            return None;
+        }
+        let precision = present[0].1.precision;
+        let m = 1usize << precision;
+        let mut out = Vec::with_capacity(2 + 4 + present.len() * (4 + m));
+        out.push(SKETCH_FORMAT_VERSION);
+        out.push(precision);
+        out.extend_from_slice(
+            &u32::try_from(present.len())
+                .unwrap_or(u32::MAX)
+                .to_le_bytes(),
+        );
+        for (idx, hll) in present {
+            // Skip columns whose precision differs from the header's (shouldn't
+            // happen — all columns use PRECISION).
+            if hll.registers.len() != m {
+                continue;
+            }
+            out.extend_from_slice(&idx.to_le_bytes());
+            out.extend_from_slice(&hll.registers);
+        }
+        Some(out)
+    }
+
+    /// Deserialize a blob produced by [`Self::serialize`]. Returns `None` on a
+    /// version mismatch or malformed input (callers fall back to no NDV).
+    #[must_use]
+    pub fn deserialize(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 6 {
+            return None;
+        }
+        let version = bytes[0];
+        if version != SKETCH_FORMAT_VERSION {
+            return None;
+        }
+        let precision = bytes[1];
+        if precision == 0 || precision > 18 {
+            return None;
+        }
+        let m = 1usize << precision;
+        let num_columns = u32::from_le_bytes(bytes[2..6].try_into().ok()?) as usize;
+        let mut offset = 6usize;
+        let mut columns = BTreeMap::new();
+        for _ in 0..num_columns {
+            if offset + 4 + m > bytes.len() {
+                return None;
+            }
+            let idx = u32::from_le_bytes(bytes[offset..offset + 4].try_into().ok()?);
+            offset += 4;
+            let registers = bytes[offset..offset + m].to_vec();
+            offset += m;
+            columns.insert(
+                idx,
+                HyperLogLog {
+                    precision,
+                    registers,
+                },
+            );
+        }
+        Some(Self { columns })
+    }
+
+    /// Merge a serialized blob into `self` in place. Convenience for the persist
+    /// path, mirroring `merge_serialized_stats` for min/max.
+    pub fn merge_serialized(&mut self, existing_blob: &[u8]) {
+        if let Some(existing) = Self::deserialize(existing_blob) {
+            self.merge(&existing);
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::cast_precision_loss)]
+mod tests {
+    use super::*;
+
+    fn build(distinct: u64) -> HyperLogLog {
+        let mut hll = HyperLogLog::new();
+        for v in 0..distinct {
+            hll.add_i128(i128::from(v));
+        }
+        hll
+    }
+
+    fn within_error(estimate: u64, actual: u64, rel: f64) -> bool {
+        let diff = (estimate as f64 - actual as f64).abs();
+        diff <= rel * actual as f64
+    }
+
+    #[test]
+    fn empty_estimate_is_zero() {
+        assert_eq!(HyperLogLog::new().estimate(), 0);
+        assert!(HyperLogLog::new().is_empty());
+    }
+
+    #[test]
+    fn small_cardinality_linear_counting_is_accurate() {
+        for &n in &[1u64, 5, 50, 500] {
+            let est = build(n).estimate();
+            assert!(
+                within_error(est, n, 0.10),
+                "n={n} est={est} outside 10% (small range / linear counting)"
+            );
+        }
+    }
+
+    #[test]
+    fn large_cardinality_within_standard_error() {
+        // ~1.6% standard error at PRECISION=12; allow generous slack for the test.
+        for &n in &[100_000u64, 1_000_000] {
+            let est = build(n).estimate();
+            assert!(within_error(est, n, 0.05), "n={n} est={est} outside 5%");
+        }
+    }
+
+    #[test]
+    fn duplicates_do_not_inflate() {
+        let mut hll = HyperLogLog::new();
+        for _ in 0..10_000 {
+            hll.add_i128(42);
+        }
+        let est = hll.estimate();
+        assert!(
+            est <= 3,
+            "duplicate-only sketch estimated {est}, expected ~1"
+        );
+    }
+
+    #[test]
+    fn merge_equals_union() {
+        // Two disjoint halves merged ≈ full set.
+        let mut a = HyperLogLog::new();
+        let mut b = HyperLogLog::new();
+        for v in 0..500_000i128 {
+            a.add_i128(v);
+        }
+        for v in 500_000..1_000_000i128 {
+            b.add_i128(v);
+        }
+        a.merge(&b);
+        let est = a.estimate();
+        assert!(
+            within_error(est, 1_000_000, 0.05),
+            "merged est={est} outside 5% of 1,000,000"
+        );
+    }
+
+    #[test]
+    fn merge_idempotent_on_same_sketch() {
+        // Re-merging the same sketch (e.g. an inline-checkpoint re-persist) must
+        // not change the estimate.
+        let a = build(200_000);
+        let before = a.estimate();
+        let mut merged = a.clone();
+        merged.merge(&a);
+        assert_eq!(merged.estimate(), before);
+    }
+
+    #[test]
+    fn sketches_serialize_roundtrip_and_merge() {
+        let mut s = NdvSketches::new();
+        for v in 0..100_000i128 {
+            s.entry(2).add_i128(v);
+            s.entry(5).add_i128(v * 7);
+        }
+        let blob = s.serialize().expect("non-empty");
+        let back = NdvSketches::deserialize(&blob).expect("roundtrip");
+        assert_eq!(s, back);
+        assert!(within_error(
+            back.estimate(2).expect("col 2 estimate present"),
+            100_000,
+            0.05
+        ));
+        // Column with no sketch -> None.
+        assert_eq!(back.estimate(9), None);
+
+        // merge_serialized accumulates a second disjoint half into column 2.
+        let mut s2 = NdvSketches::new();
+        for v in 100_000..200_000i128 {
+            s2.entry(2).add_i128(v);
+        }
+        s2.merge_serialized(&blob);
+        assert!(
+            within_error(
+                s2.estimate(2).expect("col 2 estimate present"),
+                200_000,
+                0.05
+            ),
+            "merged column 2 est={:?}",
+            s2.estimate(2)
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_bad_input() {
+        assert!(NdvSketches::deserialize(&[]).is_none());
+        assert!(NdvSketches::deserialize(&[99, 12, 0, 0, 0, 0]).is_none()); // bad version
+        let mut s = NdvSketches::new();
+        s.entry(0).add_i128(1);
+        let mut blob = s.serialize().expect("serialize non-empty sketch");
+        blob.truncate(blob.len() - 10); // corrupt length
+        assert!(NdvSketches::deserialize(&blob).is_none());
+    }
+
+    #[test]
+    fn empty_sketches_serialize_to_none() {
+        let s = NdvSketches::new();
+        assert!(s.serialize().is_none());
+        let mut s2 = NdvSketches::new();
+        // touch a column but add nothing -> still empty registers
+        let _ = s2.entry(3);
+        assert!(s2.serialize().is_none());
+    }
+}

--- a/crates/cayenne/src/lib.rs
+++ b/crates/cayenne/src/lib.rs
@@ -61,6 +61,7 @@ pub mod catalog_provider;
 pub mod cayenne_catalog;
 #[cfg(feature = "partition-table-provider")]
 pub mod ddl;
+pub mod hll;
 #[cfg(feature = "partition-table-provider")]
 pub use ddl::CayenneDdlHandler;
 pub mod logical_optimizer;

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -650,12 +650,11 @@ pub struct CreateTableOptions {
 
 /// Table-level statistics stored as a serialized Vortex [`FileStatistics`] blob.
 ///
-/// Stores per-column statistics (min, max, null count, sum, etc.) captured from
-/// the most recent write (the write's `ColumnStatsAccumulator`). The row in
-/// `cayenne_table_statistics` is keyed by `table_id` and upserted on every write,
-/// so entries represent last-write-wins snapshots rather than aggregates across
-/// every file ever produced; a future change will merge new writes into the
-/// existing blob.
+/// Stores per-column statistics (min, max, null count) maintained incrementally
+/// on the write path. The row in `cayenne_table_statistics` is keyed by
+/// `table_id` and upserted on every write: each write's `ColumnStatsAccumulator`
+/// is *merged* into the existing blob (min/max widen, null counts accumulate),
+/// so the entry is a running per-table aggregate, not a last-write snapshot.
 ///
 /// Consumers should treat these values as optimization hints only. Uses Vortex's
 /// native statistics format for zero-conversion overhead and compatibility with
@@ -666,14 +665,20 @@ pub struct CreateTableOptions {
 pub struct TableStatistics {
     /// Table this stats entry belongs to (`UUIDv7`)
     pub table_id: String,
-    /// Serialized Vortex `FileStatistics` flatbuffer bytes. Today the write
-    /// path populates only min, max, and null count per column; other fields
-    /// supported by the Vortex format (sum, NaN count, `is_constant`, etc.)
-    /// remain `Absent` until future writer work fills them in.
+    /// Serialized Vortex `FileStatistics` flatbuffer bytes (per-column min, max,
+    /// and null count). Other fields supported by the Vortex format (sum, NaN
+    /// count, `is_constant`, etc.) remain `Absent`.
     pub statistics_blob: Vec<u8>,
-    /// Row count captured by the most recent write's accumulator (not an
-    /// aggregate across every file ever produced — see the struct docs).
+    /// Live row count, maintained incrementally on commit: inserts add and
+    /// supersedes/deletes subtract, so it tracks `SELECT COUNT(*)` rather than
+    /// the sum of every insert ever made. Compaction and overwrite reset it to
+    /// the authoritative rewritten count.
     pub num_rows: i64,
+    /// Serialized per-column NDV (distinct-count) `HyperLogLog` sketches
+    /// ([`crate::hll::NdvSketches`]), `None` when no integer column has a sketch.
+    /// Merged across writes register-wise; used to size distributed joins on
+    /// sparse integer keys. See [`crate::hll`].
+    pub ndv_sketches: Option<Vec<u8>>,
 }
 
 /// A small batch of insert data inlined directly in the metastore.

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -109,7 +109,7 @@ pub const EXPECTED_TABLES: &[ExpectedTable] = &[
     },
     ExpectedTable {
         name: "cayenne_table_statistics",
-        columns: &["table_id", "statistics_blob", "num_rows"],
+        columns: &["table_id", "statistics_blob", "num_rows", "ndv_sketches"],
     },
     ExpectedTable {
         name: "cayenne_pk_index",
@@ -339,6 +339,14 @@ pub trait MetastoreRow: Send {
     ///
     /// Returns an error if the column index is out of bounds.
     fn get_optional_string(&self, index: usize) -> CatalogResult<Option<String>>;
+
+    /// Get an optional blob (binary) value from the row by column index.
+    /// Returns `None` for SQL `NULL`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the column index is out of bounds.
+    fn get_optional_blob(&self, index: usize) -> CatalogResult<Option<Vec<u8>>>;
 }
 
 /// Trait for types that can be extracted from a metastore row.

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -363,16 +363,16 @@ impl SqliteMetastore {
     /// Schema for the `cayenne_table_statistics` table.
     ///
     /// Stores a single row per table holding a serialized Vortex `FileStatistics`
-    /// flatbuffer blob. The row is upserted on every write and currently reflects
-    /// the accumulator from the most recent write (min, max, null count) — a
-    /// last-write-wins snapshot, not an aggregate across every file. Consumers
-    /// must treat these values as optimization hints until cross-write merging
-    /// lands.
+    /// flatbuffer blob (min, max, null count), a live `num_rows` count, and an
+    /// optional `ndv_sketches` blob of per-column `HyperLogLog` sketches. The row is
+    /// upserted on every write and merged into the running per-table aggregate.
+    /// Consumers must treat these values as optimization hints.
     const TABLE_STATISTICS_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_table_statistics (
             table_id TEXT NOT NULL PRIMARY KEY,
             statistics_blob BLOB NOT NULL,
             num_rows BIGINT NOT NULL DEFAULT 0,
+            ndv_sketches BLOB,
             FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE
         )
     ";
@@ -505,6 +505,16 @@ impl MetastoreRow for SqliteRow {
             })?;
         Option::<String>::from_value(value)
     }
+
+    fn get_optional_blob(&self, index: usize) -> CatalogResult<Option<Vec<u8>>> {
+        let value = self
+            .values
+            .get(index)
+            .ok_or_else(|| CatalogError::Database {
+                message: format!("Column index {index} out of bounds"),
+            })?;
+        Option::<Vec<u8>>::from_value(value)
+    }
 }
 
 /// Convert `rusqlite::Value` to `MetastoreValue`.
@@ -563,6 +573,10 @@ impl MetastoreBackend for SqliteMetastore {
                 // Ignore errors when the column already exists to keep init idempotent.
                 let _ = conn.execute(
                     "ALTER TABLE cayenne_table ADD COLUMN on_conflict_json TEXT",
+                    [],
+                );
+                let _ = conn.execute(
+                    "ALTER TABLE cayenne_table_statistics ADD COLUMN ndv_sketches BLOB",
                     [],
                 );
 

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -291,6 +291,7 @@ impl TursoMetastore {
             table_id TEXT NOT NULL PRIMARY KEY,
             statistics_blob BLOB NOT NULL,
             num_rows BIGINT NOT NULL DEFAULT 0,
+            ndv_sketches BLOB,
             FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE
         )
     ";
@@ -420,6 +421,16 @@ impl MetastoreRow for TursoRow<'_> {
             }),
         }
     }
+
+    fn get_optional_blob(&self, index: usize) -> CatalogResult<Option<Vec<u8>>> {
+        match self.raw_value(index)? {
+            TursoValue::Blob(b) => Ok(Some(b)),
+            TursoValue::Null | TursoValue::Real(_) => Ok(None),
+            other => Err(CatalogError::Database {
+                message: format!("Expected blob or null at index {index}, found {other:?}"),
+            }),
+        }
+    }
 }
 
 /// Convert Turso Value to `MetastoreValue`, consuming the source so the
@@ -510,6 +521,12 @@ impl MetastoreBackend for TursoMetastore {
         let _ = conn
             .execute(
                 "ALTER TABLE cayenne_table ADD COLUMN on_conflict_json TEXT",
+                (),
+            )
+            .await;
+        let _ = conn
+            .execute(
+                "ALTER TABLE cayenne_table_statistics ADD COLUMN ndv_sketches BLOB",
                 (),
             )
             .await;

--- a/crates/cayenne/src/provider/mutation_writer.rs
+++ b/crates/cayenne/src/provider/mutation_writer.rs
@@ -385,18 +385,23 @@ impl<'a> AppendMutationWriter<'a> {
 
         let needs_new_snapshot = pending_pk_deletions || may_have_on_conflict_deletions;
 
-        let (total_rows, write_stats_acc, validated_keys) = if needs_new_snapshot {
+        // `superseded` = existing rows replaced by this upsert (deleted as part
+        // of the conflict resolution). The live-row delta is `inserted -
+        // superseded`, which keeps the metastore `num_rows` tracking COUNT(*)
+        // under CDC upsert instead of summing every insert.
+        let (total_rows, write_stats_acc, validated_keys, superseded) = if needs_new_snapshot {
             let new_snapshot_start = Instant::now();
-            let (rows, stats_acc, validated_keys) = self
+            let (rows, stats_acc, validated_keys, superseded) = self
                 .write_new_snapshot_after_validation(prepared_stream, &post_validation)
                 .await?;
             tracing::debug!(
                 table = self.table.table_name(),
                 rows,
+                superseded,
                 duration_ms = new_snapshot_start.elapsed().as_millis(),
                 "New snapshot write and publish completed"
             );
-            (rows, stats_acc, validated_keys)
+            (rows, stats_acc, validated_keys, superseded)
         } else {
             let target_size_bytes = self.context.target_file_size_bytes();
             let write_start = Instant::now();
@@ -417,19 +422,24 @@ impl<'a> AppendMutationWriter<'a> {
                 validated_keys,
             } = take_post_validation(&post_validation);
 
+            let superseded = on_conflict_deletions.total_superseded();
             self.table
                 .apply_on_conflict_deletions(on_conflict_deletions)
                 .await?;
 
-            (rows, stats_acc, validated_keys)
+            (rows, stats_acc, validated_keys, superseded)
         };
 
         let retention_requested = self.table.has_retention_delete_filters();
 
+        let live_rows_delta = i64::try_from(total_rows)
+            .unwrap_or(i64::MAX)
+            .saturating_sub(i64::try_from(superseded).unwrap_or(i64::MAX));
         self.table.schedule_post_write_maintenance(
             Some(write_stats_acc),
             needs_new_snapshot,
             retention_requested,
+            live_rows_delta,
         );
 
         if retention_requested {
@@ -454,6 +464,7 @@ impl<'a> AppendMutationWriter<'a> {
         u64,
         Arc<ColumnStatsAccumulator>,
         std::collections::HashSet<arrow_row::OwnedRow>,
+        usize,
     )> {
         let new_snapshot_id = uuid::Uuid::now_v7().to_string();
         let target_size_bytes = self.context.target_file_size_bytes();
@@ -482,6 +493,7 @@ impl<'a> AppendMutationWriter<'a> {
             validated_keys,
         } = take_post_validation(post_validation);
 
+        let superseded = on_conflict_deletions.total_superseded();
         let deletion_start = Instant::now();
         self.table
             .apply_on_conflict_deletions(on_conflict_deletions)
@@ -504,7 +516,7 @@ impl<'a> AppendMutationWriter<'a> {
             .await?;
         record_cayenne_write_phase(self.table.table_name(), "publish", publish_start);
 
-        Ok((rows, stats_acc, validated_keys))
+        Ok((rows, stats_acc, validated_keys, superseded))
     }
 
     async fn try_inline_or_restream(
@@ -552,8 +564,18 @@ impl<'a> AppendMutationWriter<'a> {
                     stats_acc.update(batch);
                 }
 
-                self.table
-                    .schedule_post_write_maintenance(Some(Arc::new(stats_acc)), false, false);
+                // Net live-row delta: inlined inserts minus rows superseded by
+                // this inline upsert (across inlined + file-backed deletes).
+                let superseded = state.on_conflict_deletions.total_superseded();
+                let live_rows_delta = i64::try_from(buffer.total_rows())
+                    .unwrap_or(i64::MAX)
+                    .saturating_sub(i64::try_from(superseded).unwrap_or(i64::MAX));
+                self.table.schedule_post_write_maintenance(
+                    Some(Arc::new(stats_acc)),
+                    false,
+                    false,
+                    live_rows_delta,
+                );
 
                 self.table
                     .schedule_inline_checkpoint_if_memtable_pressure_exceeded();

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -295,11 +295,18 @@ struct PostWriteMaintenanceState {
     /// Set when the writer wants retention filters applied. Coalesces — multiple
     /// writes scheduling retention collapse to one scan per debounce window.
     retention_requested: bool,
+    /// Net change to the live row count across the coalesced writes
+    /// (`inserted - superseded - deleted`). Accumulated alongside `stats` and
+    /// applied as a [`RowCountUpdate::Delta`] when the stats are persisted.
+    live_rows_delta: i64,
 }
 
 impl PostWriteMaintenanceState {
     fn is_empty(&self) -> bool {
-        self.stats.is_none() && !self.refresh_listing && !self.retention_requested
+        self.stats.is_none()
+            && !self.refresh_listing
+            && !self.retention_requested
+            && self.live_rows_delta == 0
     }
 }
 
@@ -422,8 +429,16 @@ impl CayenneCdcWrite {
             } else {
                 self.table.record_file_pk_keys(&self.validated_file_keys);
             }
-            self.table
-                .schedule_post_write_maintenance(self.stats, false, retention_requested);
+            // This staged-append path only runs when `can_stage_for_pipeline`
+            // (no pending or on-conflict deletions — see `write_cdc_pipelined`),
+            // so it is a pure append: every written row is a new live row.
+            let live_rows_delta = i64::try_from(rows).unwrap_or(i64::MAX);
+            self.table.schedule_post_write_maintenance(
+                self.stats,
+                false,
+                retention_requested,
+                live_rows_delta,
+            );
             Ok(rows)
         } else {
             Ok(self.rows)
@@ -441,6 +456,26 @@ impl CayenneCdcWrite {
 struct ColumnStatsState {
     columns: Vec<vortex::array::stats::StatsSet>,
     seeded: Vec<bool>,
+    /// Per-column NDV (distinct-count) `HyperLogLog` sketch, `Some` only for
+    /// integer columns (join-key candidates). Parallel to `columns` for O(1)
+    /// access on the write hot path. See [`crate::hll`].
+    ndv: Vec<Option<crate::hll::HyperLogLog>>,
+}
+
+/// How a stats persist updates the live `num_rows` count, keeping it tracking
+/// `SELECT COUNT(*)` rather than the sum of every insert ever made.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RowCountUpdate {
+    /// Add a signed net delta for this commit (`inserted - superseded - deleted`).
+    /// Used by the normal write/CDC-upsert path.
+    Delta(i64),
+    /// Replace with an authoritative live count. Used by compaction and overwrite
+    /// rewrites, which materialize exactly the live rows and so bound any drift
+    /// the incremental deltas might accumulate.
+    Set(i64),
+    /// Leave the count unchanged — rows moved, not added (e.g. the inline-data
+    /// checkpoint flush, whose rows were already counted on insert).
+    Unchanged,
 }
 
 /// Accumulates per-column statistics across multiple `RecordBatch`es during a write.
@@ -481,15 +516,65 @@ impl ColumnStatsAccumulator {
                 ))
             })
             .collect();
+        // NDV sketches only for integer columns (join-key candidates); other
+        // columns get `None` so the write path skips them.
+        let ndv: Vec<Option<crate::hll::HyperLogLog>> = schema
+            .fields()
+            .iter()
+            .map(|f| Self::supports_ndv(f.data_type()).then(crate::hll::HyperLogLog::new))
+            .collect();
         Self {
             state: std::sync::Mutex::new(ColumnStatsState {
                 columns: vec![vortex::array::stats::StatsSet::default(); num_cols],
                 seeded: vec![false; num_cols],
+                ndv,
             }),
             dtypes,
             row_count: std::sync::atomic::AtomicI64::new(0),
             schema: schema.clone(),
         }
+    }
+
+    /// Whether to maintain an NDV sketch for `dt`. Restricted to integer types:
+    /// these are the join-key candidates (e.g. `*_custkey`, `*_orderkey`) whose
+    /// distinct count can diverge sharply from their min/max range under sparse
+    /// CDC keys. Mirrors the consumer-side `supports_ndv` in the cluster reporter.
+    fn supports_ndv(dt: &DataType) -> bool {
+        matches!(
+            dt,
+            DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+        )
+    }
+
+    /// Fold every non-null value of an integer Arrow column into `hll`. Iterates
+    /// the typed array directly (no `ScalarValue` boxing) to keep the write hot
+    /// path cheap, sign-extending to `i128` so all widths share one hash path.
+    fn add_int_column_to_hll(col: &dyn arrow::array::Array, hll: &mut crate::hll::HyperLogLog) {
+        macro_rules! fold {
+            ($array_ty:ty) => {{
+                if let Some(a) = col.as_any().downcast_ref::<$array_ty>() {
+                    for v in a.iter().flatten() {
+                        hll.add_i128(i128::from(v));
+                    }
+                    return;
+                }
+            }};
+        }
+        fold!(Int8Array);
+        fold!(Int16Array);
+        fold!(Int32Array);
+        fold!(Int64Array);
+        fold!(UInt8Array);
+        fold!(UInt16Array);
+        fold!(UInt32Array);
+        fold!(UInt64Array);
     }
 
     /// Update accumulated stats from a `RecordBatch`.
@@ -531,6 +616,11 @@ impl ColumnStatsAccumulator {
             } else {
                 state.columns[i] = batch_stats;
                 state.seeded[i] = true;
+            }
+
+            // Maintain the per-column NDV sketch for integer columns.
+            if let Some(Some(hll)) = state.ndv.get_mut(i) {
+                Self::add_int_column_to_hll(col.as_ref(), hll);
             }
         }
     }
@@ -820,12 +910,16 @@ impl ColumnStatsAccumulator {
             return;
         }
 
-        let (other_columns, other_seeded) = {
+        let (other_columns, other_seeded, other_ndv) = {
             let Ok(other_state) = other.state.lock() else {
                 tracing::warn!("ColumnStatsAccumulator: mutex poisoned in merge_from(), skipping");
                 return;
             };
-            (other_state.columns.clone(), other_state.seeded.clone())
+            (
+                other_state.columns.clone(),
+                other_state.seeded.clone(),
+                other_state.ndv.clone(),
+            )
         };
 
         let Ok(mut state) = self.state.lock() else {
@@ -856,6 +950,37 @@ impl ColumnStatsAccumulator {
                 state.seeded[idx] = true;
             }
         }
+
+        // Merge per-column NDV sketches (register-wise max).
+        for (idx, other_hll) in other_ndv.into_iter().enumerate() {
+            let (Some(other_hll), Some(slot)) = (other_hll, state.ndv.get_mut(idx)) else {
+                continue;
+            };
+            match slot {
+                Some(hll) => hll.merge(&other_hll),
+                None => *slot = Some(other_hll),
+            }
+        }
+    }
+
+    /// Snapshot the accumulated per-column NDV sketches as an [`NdvSketches`]
+    /// container (column index -> sketch), for serialization/merge on persist.
+    fn to_ndv_sketches(&self) -> crate::hll::NdvSketches {
+        let mut sketches = crate::hll::NdvSketches::new();
+        let Ok(state) = self.state.lock() else {
+            tracing::warn!(
+                "ColumnStatsAccumulator: mutex poisoned in to_ndv_sketches(), returning empty"
+            );
+            return sketches;
+        };
+        for (idx, slot) in state.ndv.iter().enumerate() {
+            if let Some(hll) = slot
+                && let Ok(col_idx) = u32::try_from(idx)
+            {
+                *sketches.entry(col_idx) = hll.clone();
+            }
+        }
+        sketches
     }
 
     pub(crate) fn to_file_statistics_blob_with_row_count(&self) -> Option<(Vec<u8>, i64)> {
@@ -1833,6 +1958,20 @@ pub(crate) struct OnConflictDeletions {
     pub(crate) deleted_inlined_pk_i64: Vec<i64>,
     /// Deleted inlined row keys.
     pub(crate) deleted_inlined_row_keys: Vec<Box<[u8]>>,
+}
+
+impl OnConflictDeletions {
+    /// Total number of existing rows superseded (deleted) by this upsert across
+    /// all strategies (position deletes + file-backed + inlined). Used to net the
+    /// live row count: an upsert that replaces N existing rows adds
+    /// `inserted - N` live rows, not `inserted`.
+    pub(crate) fn total_superseded(&self) -> usize {
+        self.delete_specs.values().map(Vec::len).sum::<usize>()
+            + self.deleted_pk_i64.len()
+            + self.deleted_row_keys.len()
+            + self.deleted_inlined_pk_i64.len()
+            + self.deleted_inlined_row_keys.len()
+    }
 }
 
 #[derive(Clone)]
@@ -3907,10 +4046,39 @@ impl CayenneTableProvider {
             })
             .ok()?;
 
-        Some(crate::stats::file_statistics_to_df(
-            &file_stats,
-            stats.num_rows,
-        ))
+        let mut df_stats = crate::stats::file_statistics_to_df(&file_stats, stats.num_rows);
+
+        // Overlay per-column NDV estimates from the HyperLogLog sketches as
+        // `distinct_count`. The cluster reporter uses this to encode an
+        // effective max (`min(true_max, min + ndv)`) that survives `UnionExec`,
+        // letting distributed JoinSelection size joins on sparse integer keys.
+        if let Some(blob) = stats.ndv_sketches.as_deref()
+            && let Some(sketches) = crate::hll::NdvSketches::deserialize(blob)
+        {
+            for (idx, col) in df_stats.column_statistics.iter_mut().enumerate() {
+                if let Ok(col_idx) = u32::try_from(idx)
+                    && let Some(ndv) = sketches.estimate(col_idx)
+                    && let Ok(ndv) = usize::try_from(ndv)
+                {
+                    col.distinct_count = datafusion_common::stats::Precision::Inexact(ndv);
+                }
+            }
+        }
+
+        Some(df_stats)
+    }
+
+    /// The incrementally-maintained metastore statistics aggregate (live
+    /// `num_rows` + per-column min/max + integer NDV via `distinct_count`), for
+    /// distributed-join sizing by the cluster executor-statistics reporter.
+    ///
+    /// Unlike [`TableProvider::statistics`], this is **not** gated off while
+    /// position-based deletions are pending — under CDC the aggregate is exactly
+    /// what the coordinator needs, and it is always-fresh (kept warm at
+    /// construction and on every write commit) and O(1) to read.
+    #[must_use]
+    pub fn optimizer_table_statistics(&self) -> Option<Statistics> {
+        self.cached_table_statistics_for_optimizer()
     }
 
     fn cached_table_statistics_for_optimizer(&self) -> Option<Statistics> {
@@ -6175,8 +6343,9 @@ impl CayenneTableProvider {
         stats: Option<Arc<ColumnStatsAccumulator>>,
         refresh_listing: bool,
         retention_requested: bool,
+        live_rows_delta: i64,
     ) {
-        if stats.is_none() && !refresh_listing && !retention_requested {
+        if stats.is_none() && !refresh_listing && !retention_requested && live_rows_delta == 0 {
             return;
         }
 
@@ -6191,6 +6360,9 @@ impl CayenneTableProvider {
             }
             maintenance_state.refresh_listing |= refresh_listing;
             maintenance_state.retention_requested |= retention_requested;
+            maintenance_state.live_rows_delta = maintenance_state
+                .live_rows_delta
+                .saturating_add(live_rows_delta);
         }
 
         if self
@@ -6267,7 +6439,12 @@ impl CayenneTableProvider {
     ) -> CatalogResult<()> {
         let had_stats = state.stats.is_some();
         if let Some(stats) = state.stats {
-            self.persist_table_stats(&stats).await;
+            // The net live-row delta (inserts minus supersedes/deletes) was
+            // accumulated alongside the coalesced stats. Retention deletes below
+            // are not yet netted here (TPC-H has none); compaction's `Set` reset
+            // bounds any resulting drift.
+            self.persist_table_stats(&stats, RowCountUpdate::Delta(state.live_rows_delta))
+                .await;
         }
 
         let mut retention_deleted = 0_u64;
@@ -6723,8 +6900,11 @@ impl CayenneTableProvider {
             self.clear_all_deletion_caches();
 
             // Persist accumulated stats from the rewrite — keeps DataFusion's
-            // synchronous statistics path consistent with the new snapshot.
-            self.persist_table_stats(&stats_acc).await;
+            // synchronous statistics path consistent with the new snapshot. The
+            // rewrite materializes exactly the live rows, so its min/max + NDV +
+            // count are authoritative: replace the aggregate, correcting any
+            // drift the incremental merges/deltas accumulated.
+            self.replace_table_stats_after_rewrite(&stats_acc).await;
         }
 
         // Checkpoint the PK existence index for fast restart (best-effort). The
@@ -7356,78 +7536,136 @@ impl CayenneTableProvider {
         }
     }
 
-    /// Persist table-level statistics by merging the current write with the
-    /// existing metastore aggregate when possible.
+    /// Persist table-level statistics by merging the current write's accumulator
+    /// (min/max/null + NDV sketches) into the existing metastore aggregate and
+    /// applying `num_rows_update` to the live row count.
     ///
     /// Best-effort: logs a warning and continues if stats persistence fails,
     /// since stats are an optimization and not critical for correctness.
-    pub(crate) async fn persist_table_stats(&self, accumulator: &ColumnStatsAccumulator) {
+    pub(crate) async fn persist_table_stats(
+        &self,
+        accumulator: &ColumnStatsAccumulator,
+        num_rows_update: RowCountUpdate,
+    ) {
         let _stats_persistence_guard = self.table_statistics_persistence_lock.lock().await;
-        self.persist_table_stats_locked(accumulator).await;
+        self.persist_table_stats_locked(accumulator, num_rows_update, false)
+            .await;
     }
 
+    /// Replace the aggregate entirely with the overwrite's accumulator and reset
+    /// the live count to the rewritten row count (the prior data is gone, so the
+    /// old min/max/NDV must not survive — see [`RowCountUpdate`]).
     pub(crate) async fn reset_table_stats_after_overwrite(
         &self,
         accumulator: &ColumnStatsAccumulator,
     ) {
         let _stats_persistence_guard = self.table_statistics_persistence_lock.lock().await;
         self.clear_cached_table_statistics_unlocked();
-        self.persist_table_stats_locked(accumulator).await;
+        let new_rows = accumulator.row_count();
+        self.persist_table_stats_locked(accumulator, RowCountUpdate::Set(new_rows), true)
+            .await;
     }
 
-    async fn persist_table_stats_locked(&self, accumulator: &ColumnStatsAccumulator) {
-        let Some((new_blob, new_rows)) = accumulator.to_file_statistics_blob_with_row_count()
+    /// Replace the aggregate with a full live-row rewrite (compaction).
+    ///
+    /// Compaction materializes exactly the live rows, so its accumulator's
+    /// min/max + NDV are the authoritative *live* aggregate. Replacing (rather
+    /// than merging) resets any superset drift accumulated incrementally — e.g.
+    /// min/max widened by since-deleted rows, or an NDV sketch inflated by
+    /// superseded keys — back to the live set, and `Set`s the live count.
+    pub(crate) async fn replace_table_stats_after_rewrite(
+        &self,
+        accumulator: &ColumnStatsAccumulator,
+    ) {
+        let _stats_persistence_guard = self.table_statistics_persistence_lock.lock().await;
+        let new_rows = accumulator.row_count();
+        self.persist_table_stats_locked(accumulator, RowCountUpdate::Set(new_rows), true)
+            .await;
+    }
+
+    /// Persist merged/replaced stats.
+    ///
+    /// `replace_aggregate` true ignores any existing aggregate (overwrite); false
+    /// merges this write into it. `num_rows_update` sets the live count relative
+    /// to the previous aggregate (`Delta`), to an authoritative value (`Set`), or
+    /// leaves it (`Unchanged`).
+    async fn persist_table_stats_locked(
+        &self,
+        accumulator: &ColumnStatsAccumulator,
+        num_rows_update: RowCountUpdate,
+        replace_aggregate: bool,
+    ) {
+        let Some((new_blob, _new_rows)) = accumulator.to_file_statistics_blob_with_row_count()
         else {
             return;
         };
+        let new_ndv = accumulator.to_ndv_sketches();
 
         // Prefer an in-memory cached raw blob (populated by previous persist or load)
         // to avoid a catalog round-trip on every write. Only hit the catalog when
-        // the cache is cold.
-        let cached_raw = {
-            let guard = self.table_statistics.read();
-            guard.raw.clone()
-        };
-
-        let existing_stats = if let Some(raw) = cached_raw {
-            Some(raw)
+        // the cache is cold. Skipped entirely when replacing the aggregate.
+        let existing_stats = if replace_aggregate {
+            None
         } else {
-            match self
-                .catalog
-                .get_table_statistics(&self.table_metadata.table_id)
-                .await
-            {
-                Ok(stats) => stats,
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to load existing table stats for {} before merge: {e}",
-                        self.table_metadata.table_name
-                    );
-                    None
+            let cached_raw = {
+                let guard = self.table_statistics.read();
+                guard.raw.clone()
+            };
+            if let Some(raw) = cached_raw {
+                Some(raw)
+            } else {
+                match self
+                    .catalog
+                    .get_table_statistics(&self.table_metadata.table_id)
+                    .await
+                {
+                    Ok(stats) => stats,
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to load existing table stats for {} before merge: {e}",
+                            self.table_metadata.table_name
+                        );
+                        None
+                    }
                 }
             }
         };
 
-        let (statistics_blob, num_rows) = if let Some(existing) = existing_stats {
-            if let Some(merged_blob) =
-                accumulator.merged_file_statistics_blob(&existing.statistics_blob)
-            {
-                (merged_blob, existing.num_rows.saturating_add(new_rows))
-            } else {
-                tracing::warn!(
-                    "Failed to merge table stats for {}; replacing aggregate stats with current write",
-                    self.table_metadata.table_name
-                );
-                (new_blob, new_rows)
-            }
-        } else {
-            (new_blob, new_rows)
+        // Merge min/max/null blob and NDV sketches into the existing aggregate.
+        let prev_num_rows = existing_stats.as_ref().map_or(0, |e| e.num_rows);
+        let statistics_blob = match &existing_stats {
+            Some(existing) => accumulator
+                .merged_file_statistics_blob(&existing.statistics_blob)
+                .unwrap_or_else(|| {
+                    tracing::warn!(
+                        "Failed to merge table stats for {}; replacing with current write",
+                        self.table_metadata.table_name
+                    );
+                    new_blob.clone()
+                }),
+            None => new_blob,
+        };
+        let mut merged_ndv = new_ndv;
+        if let Some(existing_ndv) = existing_stats
+            .as_ref()
+            .and_then(|e| e.ndv_sketches.as_deref())
+        {
+            merged_ndv.merge_serialized(existing_ndv);
+        }
+        let ndv_sketches = merged_ndv.serialize();
+
+        // Apply the live-row-count update relative to the previous aggregate.
+        let num_rows = match num_rows_update {
+            RowCountUpdate::Delta(delta) => prev_num_rows.saturating_add(delta).max(0),
+            RowCountUpdate::Set(n) => n.max(0),
+            RowCountUpdate::Unchanged => prev_num_rows,
         };
 
         let stats = TableStatistics {
             table_id: self.table_metadata.table_id.clone(),
             statistics_blob,
             num_rows,
+            ndv_sketches,
         };
 
         if let Err(e) = self.catalog.upsert_table_statistics(&stats).await {
@@ -7908,8 +8146,13 @@ impl CayenneTableProvider {
             stats
         };
 
-        // Persist table stats from the checkpoint write (best-effort; logs on error).
-        self.persist_table_stats(&stats).await;
+        // Persist table stats from the checkpoint write (best-effort; logs on
+        // error). The flushed rows were already counted on insert (inline-data
+        // commit) — this only moves them from the metastore to Vortex files — so
+        // the live count is `Unchanged`; only the min/max/NDV blob re-merges
+        // (idempotently).
+        self.persist_table_stats(&stats, RowCountUpdate::Unchanged)
+            .await;
 
         Ok(u64::try_from(total_rows).unwrap_or(u64::MAX))
     }
@@ -10397,6 +10640,7 @@ mod tests {
             table_id: "table_id".to_string(),
             statistics_blob,
             num_rows: 3,
+            ndv_sketches: None,
         };
 
         let stats = CayenneTableProvider::table_statistics_to_df(&schema, &table_stats)

--- a/crates/cayenne/tests/column_stats_test.rs
+++ b/crates/cayenne/tests/column_stats_test.rs
@@ -62,12 +62,14 @@ async fn test_table_statistics_crud(
     let stats = catalog.get_table_statistics(&table_id).await?;
     assert!(stats.is_none(), "Expected no stats initially");
 
-    // Upsert stats with a dummy blob
+    // Upsert stats with a dummy blob and NDV sketch blob
     let dummy_blob = vec![1, 2, 3, 4];
+    let dummy_ndv = vec![9, 8, 7, 6, 5];
     let table_stats = TableStatistics {
         table_id: table_id.clone(),
         statistics_blob: dummy_blob.clone(),
         num_rows: 100,
+        ndv_sketches: Some(dummy_ndv.clone()),
     };
     catalog.upsert_table_statistics(&table_stats).await?;
 
@@ -78,12 +80,14 @@ async fn test_table_statistics_crud(
         .expect("stats should exist");
     assert_eq!(stats.statistics_blob, dummy_blob);
     assert_eq!(stats.num_rows, 100);
+    assert_eq!(stats.ndv_sketches, Some(dummy_ndv));
 
-    // Upsert updates existing stats
+    // Upsert updates existing stats, including clearing the NDV sketches to NULL.
     let updated = TableStatistics {
         table_id: table_id.clone(),
         statistics_blob: vec![5, 6, 7, 8],
         num_rows: 200,
+        ndv_sketches: None,
     };
     catalog.upsert_table_statistics(&updated).await?;
 
@@ -93,6 +97,7 @@ async fn test_table_statistics_crud(
         .expect("stats should exist");
     assert_eq!(stats.statistics_blob, vec![5, 6, 7, 8]);
     assert_eq!(stats.num_rows, 200);
+    assert_eq!(stats.ndv_sketches, None);
 
     // Clear
     catalog.clear_table_statistics(&table_id).await?;
@@ -128,6 +133,7 @@ async fn test_stats_cleared_on_drop_table(
             table_id: table_id.clone(),
             statistics_blob: vec![1, 2, 3],
             num_rows: 100,
+            ndv_sketches: None,
         })
         .await?;
 

--- a/crates/cayenne/tests/commit_overwrite_atomicity_test.rs
+++ b/crates/cayenne/tests/commit_overwrite_atomicity_test.rs
@@ -201,6 +201,7 @@ async fn plant_full_pre_overwrite_state(
             table_id: table_id.to_string(),
             statistics_blob: vec![0xDE, 0xAD, 0xBE, 0xEF],
             num_rows: 42,
+            ndv_sketches: None,
         })
         .await
         .expect("upsert_table_statistics");

--- a/crates/cayenne/tests/incremental_stats_test.rs
+++ b/crates/cayenne/tests/incremental_stats_test.rs
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::clone_on_ref_ptr)]
+#![allow(clippy::cast_precision_loss)]
+
+//! End-to-end tests for incrementally-maintained executor statistics: live
+//! `num_rows` nets supersedes under upsert (not the sum of inserts), and
+//! per-integer-column NDV (distinct-count) sketches are populated and reasonably
+//! accurate — both surfaced via `CayenneTableProvider::optimizer_table_statistics()`.
+
+mod common;
+
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+
+use cayenne::metadata::{CreateTableOptions, VortexConfig};
+use cayenne::{CayenneTableProvider, MetadataCatalog};
+
+use datafusion::common::stats::Precision;
+use datafusion::prelude::SessionContext;
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+
+test_with_backends!(test_live_num_rows_and_ndv_under_upsert);
+
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("val", DataType::Int64, true),
+    ]))
+}
+
+/// Build a batch with `id` in `[start, start+count)` and `val = id * mult`.
+fn batch(start: i64, count: i64, mult: i64) -> RecordBatch {
+    let ids: Vec<i64> = (start..start + count).collect();
+    let vals: Vec<i64> = ids.iter().map(|i| i * mult).collect();
+    RecordBatch::try_new(
+        schema(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )
+    .expect("batch")
+}
+
+fn distinct_count(stats: &datafusion::common::Statistics, col: usize) -> Option<usize> {
+    match stats.column_statistics[col].distinct_count {
+        Precision::Exact(n) | Precision::Inexact(n) => Some(n),
+        Precision::Absent => None,
+    }
+}
+
+fn assert_within(actual: usize, expected: usize, rel: f64, what: &str) {
+    let diff = (actual as f64 - expected as f64).abs();
+    assert!(
+        diff <= rel * expected as f64,
+        "{what}: {actual} not within {}% of {expected}",
+        rel * 100.0
+    );
+}
+
+async fn count_star(ctx: &SessionContext, table: &str) -> usize {
+    let results = ctx
+        .sql(&format!("SELECT COUNT(*) AS c FROM {table}"))
+        .await
+        .expect("count")
+        .collect()
+        .await
+        .expect("collect");
+    let col = results[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("count col");
+    usize::try_from(col.value(0)).unwrap_or(0)
+}
+
+async fn test_live_num_rows_and_ndv_under_upsert(
+    fixture: common::TestFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = SessionContext::new();
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let table = CayenneTableProvider::create_table(
+        catalog,
+        CreateTableOptions {
+            table_name: "inc_stats".to_string(),
+            schema: schema(),
+            primary_key: vec!["id".to_string()],
+            on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+                "id".to_string(),
+            ]))),
+            base_path: fixture.data_path.to_string_lossy().to_string(),
+            partition_column: None,
+            vortex_config: VortexConfig::default(),
+        },
+        ctx.runtime_env(),
+    )
+    .await?;
+    let table = Arc::new(table);
+    ctx.register_table(
+        "inc_stats",
+        Arc::clone(&table) as Arc<dyn datafusion::datasource::TableProvider>,
+    )?;
+
+    // 1. Insert 2000 distinct ids -> num_rows == 2000, NDV(id) ~ 2000.
+    common::insert_batch(&table, batch(1, 2000, 10)).await?;
+    table.flush_pending_maintenance().await?;
+
+    let stats = table
+        .optimizer_table_statistics()
+        .expect("stats present after insert");
+    assert_eq!(
+        stats.num_rows.get_value().copied(),
+        Some(2000),
+        "after first insert, live num_rows should be 2000"
+    );
+    assert_within(
+        distinct_count(&stats, 0).expect("id NDV"),
+        2000,
+        0.10,
+        "id NDV after insert",
+    );
+    assert_within(
+        distinct_count(&stats, 1).expect("val NDV"),
+        2000,
+        0.10,
+        "val NDV after insert",
+    );
+
+    // 2. Upsert ids 1..=1000 (supersede 1000 existing rows). Live count must
+    //    stay 2000 — inserted (1000) - superseded (1000) = 0 net — NOT 3000.
+    common::insert_batch(&table, batch(1, 1000, 100)).await?;
+    table.flush_pending_maintenance().await?;
+
+    assert_eq!(
+        count_star(&ctx, "inc_stats").await,
+        2000,
+        "COUNT(*) after upsert"
+    );
+    let stats = table
+        .optimizer_table_statistics()
+        .expect("stats after upsert");
+    assert_eq!(
+        stats.num_rows.get_value().copied(),
+        Some(2000),
+        "live num_rows must net supersedes (stay 2000, not grow to 3000)"
+    );
+    // No new distinct ids were introduced by the upsert.
+    assert_within(
+        distinct_count(&stats, 0).expect("id NDV"),
+        2000,
+        0.10,
+        "id NDV after upsert",
+    );
+
+    // 3. Insert 1000 brand-new ids -> num_rows == 3000, NDV(id) ~ 3000.
+    common::insert_batch(&table, batch(2001, 1000, 10)).await?;
+    table.flush_pending_maintenance().await?;
+
+    assert_eq!(
+        count_star(&ctx, "inc_stats").await,
+        3000,
+        "COUNT(*) after new insert"
+    );
+    let stats = table
+        .optimizer_table_statistics()
+        .expect("stats after new insert");
+    assert_eq!(
+        stats.num_rows.get_value().copied(),
+        Some(3000),
+        "live num_rows after inserting 1000 new ids"
+    );
+    assert_within(
+        distinct_count(&stats, 0).expect("id NDV"),
+        3000,
+        0.10,
+        "id NDV after new insert",
+    );
+
+    Ok(())
+}

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -126,38 +126,34 @@ pub fn get_partition_filter_exprs(
 /// the column names they're aligned to (so the coordinator can project column
 /// stats onto a possibly-projected leaf scan by name).
 ///
-/// Reports `num_rows` AND per-column min/max (and, for integer columns, an
-/// approximate `distinct_count`) — these are what let the coordinator's planner
-/// estimate join/aggregate output cardinalities and pick hash-join build sides
-/// (q18 swap). Stats are sourced, in order:
+/// Reports `num_rows` AND per-column min/max (with an effective max encoding the
+/// integer NDV) — these let the coordinator's planner estimate join/aggregate
+/// output cardinalities and pick hash-join build sides (q18 swap).
 ///
-/// 1. **Scan-plan statistics** (metadata-only). In append-only ("events") ingest
-///    Cayenne collects per-column min/max from file footers, so the scan plan
-///    carries `num_rows` + bounds with zero extra cost.
-/// 2. **Aggregate query** fallback. Under CDC ("changes") ingest Cayenne disables
-///    footer-stat collection while position-based deletions are pending, so the
-///    scan plan yields no column bounds. Derive `num_rows` + per-column min/max
-///    (+ `approx_distinct` for integer columns) with a single aggregate. Running
-///    through the scan applies the deletion filter, so the values are exact for
-///    the executor's live slice.
+/// Sourced from the **Cayenne metastore aggregate**, which is maintained
+/// incrementally on the write path (a cheap byproduct of ingest) rather than
+/// recomputed: a live `num_rows`, per-column min/max, and per-integer-column NDV
+/// `HyperLogLog` sketches all merged on commit. The read is O(1) and always-fresh,
+/// so there is no recurring full-table rescan and no need to guard against a
+/// degraded result clobbering a richer one. Non-Cayenne providers (or a
+/// pre-write cold aggregate) fall back to the scan plan's footer statistics.
 ///
-/// Why the integer `distinct_count` matters: a join key whose values are *sparse*
-/// over a wide domain (e.g. CDC `o_custkey` ranging to ~1e9 with only ~1M
-/// distinct) has a min/max range far larger than its true NDV. Without a distinct
-/// count, the planner's `max_distinct_count` falls back to the range / row count
-/// and badly over-estimates the key's cardinality, which under-estimates the join
-/// and prevents the build-side swap. Reporting an approximate NDV lets the
-/// planner size the join correctly. (The append-only case doesn't need this — its
-/// keys are dense, so the min/max range already approximates the NDV.)
+/// Why the integer NDV matters: a join key whose values are *sparse* over a wide
+/// domain (e.g. CDC `o_custkey` ranging to ~1e9 with only ~1M distinct) has a
+/// min/max range far larger than its true NDV. Without a distinct count, the
+/// planner's `max_distinct_count` falls back to the range / row count and badly
+/// over-estimates the key's cardinality, under-estimating the join and preventing
+/// the build-side swap. Encoding the NDV into the reported max
+/// ([`encode_ndv_into_bounds`] / [`effective_max_for_ndv`]) makes the range-based
+/// estimate accurate, and survives the per-executor `UnionExec` (which erases
+/// `distinct_count` but preserves min/max). Dense (events) keys are unaffected.
 ///
 /// Note: in clustered mode an executor's accelerated table is registered
 /// *non-partitioned* (`partition_by` is cleared once the executor has partition
 /// assignments — see `init::dataset`), so this goes through the generic table
 /// provider rather than a `PartitionTableProvider`.
 ///
-/// Best-effort: returns `None` when the row count can't be determined. Returns the
-/// decoded [`Statistics`] (the reporter decides how rich they are and handles
-/// encoding/caching — see [`StatsRichness`]).
+/// Best-effort: returns `None` when no statistics are available.
 ///
 /// [`Statistics`]: datafusion::common::Statistics
 pub(crate) async fn local_executor_table_statistics(
@@ -168,16 +164,31 @@ pub(crate) async fn local_executor_table_statistics(
     let schema = provider.schema();
     let column_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
 
-    // Primary: scan-plan statistics (num_rows + per-column min/max). No
-    // projection so column stats cover every column.
+    // Primary: the Cayenne metastore aggregate, maintained incrementally on the
+    // write path (live num_rows + per-column min/max + integer NDV as
+    // distinct_count). It is always-fresh, O(1) to read, and — unlike
+    // `TableProvider::statistics` — available even while position-based deletions
+    // are pending (the CDC case). Encode NDV into the reported max so it survives
+    // `UnionExec` over the per-executor scans.
+    if let Some(cayenne) = provider
+        .as_any()
+        .downcast_ref::<cayenne::CayenneTableProvider>()
+        && let Some(mut stats) = cayenne.optimizer_table_statistics()
+        && stats.num_rows.get_value().is_some()
+    {
+        encode_ndv_into_bounds(&mut stats);
+        return Some((stats, column_names));
+    }
+
+    // Fallback (non-Cayenne providers, or before any write has populated the
+    // aggregate): scan-plan footer statistics — metadata-only, no aggregate
+    // rescan. Used directly only when complete enough for join sizing: num_rows
+    // present AND at least one column carries a min/max bound.
     let session_state = df.ctx.state();
     let scan_stats = match provider.scan(&session_state, None, &[], None).await {
         Ok(plan) => plan.partition_statistics(None).ok(),
         Err(_) => None,
     };
-
-    // Use scan-plan stats directly only when complete enough for join sizing:
-    // num_rows present AND at least one column carries a min/max bound.
     if let Some(stats) = scan_stats
         && stats.num_rows.get_value().is_some()
         && has_any_column_bounds(&stats)
@@ -185,55 +196,27 @@ pub(crate) async fn local_executor_table_statistics(
         return Some((stats, column_names));
     }
 
-    // Fallback (CDC / no footer stats): aggregate query for num_rows + min/max
-    // (+ integer NDV), degrading to a num_rows-only COUNT(*) if it fails. The
-    // reporter is responsible for not clobbering richer cached stats with a
-    // degraded result (see `run_executor_statistics_reporter`).
-    let stats = match aggregate_table_statistics(df, table, &schema).await {
-        Some(stats) => stats,
-        None => count_only_statistics(df, table, &schema)
-            .await
-            .or_else(|| {
-                tracing::debug!(table = %table, "No local statistics available for executor table");
-                None
-            })?,
-    };
-
-    Some((stats, column_names))
+    tracing::debug!(table = %table, "No local statistics available for executor table");
+    None
 }
 
-/// How useful a [`Statistics`] is for distributed join sizing. The reporter uses
-/// this to avoid broadcasting a degraded stat over a previously-cached richer one
-/// (which would make the coordinator's join-build-side choice flap — the q18
-/// swap fires only while the coordinator holds the column stats).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum StatsRichness {
-    /// `num_rows` only — no per-column bounds (e.g. the `COUNT(*)` fallback).
-    RowCountOnly,
-    /// Per-column min/max present, but no distinct counts.
-    Bounds,
-    /// Per-column min/max AND at least one distinct count (best for sizing joins
-    /// on sparse keys — see [`local_executor_table_statistics`]).
-    BoundsAndDistinct,
-}
-
-/// Classify a [`Statistics`] for the reporter's non-degrading cache.
-pub(crate) fn classify_stats_richness(stats: &datafusion::common::Statistics) -> StatsRichness {
+/// Rewrite each integer column's reported max to the effective max
+/// (`min(true_max, min + ndv)`, inexact) using the column's `distinct_count`.
+/// This tightens the min/max *range* to the true NDV so the planner's
+/// range-based distinct estimate is accurate for sparse keys after the
+/// per-executor `UnionExec` (which erases `distinct_count` but preserves
+/// min/max). See [`effective_max_for_ndv`] for the why.
+fn encode_ndv_into_bounds(stats: &mut datafusion::common::Statistics) {
     use datafusion::common::stats::Precision;
-    let mut has_bounds = false;
-    let mut has_distinct = false;
-    for c in &stats.column_statistics {
-        if !matches!(c.min_value, Precision::Absent) || !matches!(c.max_value, Precision::Absent) {
-            has_bounds = true;
+    for col in &mut stats.column_statistics {
+        let ndv = match col.distinct_count {
+            Precision::Exact(n) | Precision::Inexact(n) => Some(n),
+            Precision::Absent => None,
+        };
+        if ndv.is_some() {
+            let true_max = std::mem::replace(&mut col.max_value, Precision::Absent);
+            col.max_value = effective_max_for_ndv(&col.min_value, ndv, true_max);
         }
-        if !matches!(c.distinct_count, Precision::Absent) {
-            has_distinct = true;
-        }
-    }
-    match (has_bounds, has_distinct) {
-        (_, true) => StatsRichness::BoundsAndDistinct,
-        (true, false) => StatsRichness::Bounds,
-        (false, false) => StatsRichness::RowCountOnly,
     }
 }
 
@@ -243,75 +226,6 @@ fn has_any_column_bounds(stats: &datafusion::common::Statistics) -> bool {
     stats.column_statistics.iter().any(|c| {
         !matches!(c.min_value, Precision::Absent) || !matches!(c.max_value, Precision::Absent)
     })
-}
-
-/// Whether `min`/`max` aggregates are supported for `dt` (scalar types only, so
-/// the synthesized aggregate query can't fail on a nested/unsupported column).
-fn supports_minmax(dt: &datafusion::arrow::datatypes::DataType) -> bool {
-    use datafusion::arrow::datatypes::DataType;
-    matches!(
-        dt,
-        DataType::Boolean
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Float16
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Decimal128(_, _)
-            | DataType::Decimal256(_, _)
-            | DataType::Date32
-            | DataType::Date64
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Timestamp(_, _)
-            | DataType::Utf8
-            | DataType::LargeUtf8
-            | DataType::Utf8View
-    )
-}
-
-/// Whether to collect an approximate `distinct_count` for `dt`. Restricted to
-/// integer types: these are the join-key candidates (e.g. `*_custkey`,
-/// `*_orderkey`) whose NDV can diverge sharply from their min/max range under
-/// sparse-key CDC data, and `approx_distinct` (`HyperLogLog`) over one integer
-/// column is cheap to fold into the existing aggregate scan.
-fn supports_ndv(dt: &datafusion::arrow::datatypes::DataType) -> bool {
-    use datafusion::arrow::datatypes::DataType;
-    matches!(
-        dt,
-        DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-    )
-}
-
-/// Quote an identifier for SQL (double-quoted, internal quotes doubled).
-fn quote_ident(name: &str) -> String {
-    format!("\"{}\"", name.replace('"', "\"\""))
-}
-
-/// Convert the single-row aggregate result at `array[0]` into a min/max bound,
-/// treating null (empty/all-null column) as `Absent`.
-fn scalar_bound(
-    array: &datafusion::arrow::array::ArrayRef,
-) -> datafusion::common::stats::Precision<datafusion::common::ScalarValue> {
-    use datafusion::common::ScalarValue;
-    use datafusion::common::stats::Precision;
-    match ScalarValue::try_from_array(array, 0) {
-        Ok(sv) if !sv.is_null() => Precision::Exact(sv),
-        _ => Precision::Absent,
-    }
 }
 
 /// Effective max for a column given its approximate distinct count: the tighter
@@ -365,128 +279,4 @@ fn effective_max_for_ndv(
         (Some(syn), Some(tmax)) if &syn < tmax => Precision::Inexact(syn),
         _ => true_max,
     }
-}
-
-/// Read a non-negative count from the single-row aggregate result at `array[0]`,
-/// accepting either `Int64` (`COUNT`) or `UInt64` (`approx_distinct`).
-fn count_at(array: &datafusion::arrow::array::ArrayRef) -> Option<usize> {
-    use datafusion::arrow::array::{Int64Array, UInt64Array};
-    if let Some(a) = array.as_any().downcast_ref::<Int64Array>() {
-        return usize::try_from(a.value(0)).ok();
-    }
-    if let Some(a) = array.as_any().downcast_ref::<UInt64Array>() {
-        return usize::try_from(a.value(0)).ok();
-    }
-    None
-}
-
-/// Derive `num_rows` + per-column min/max (+ integer `approx_distinct`) for the
-/// executor's local slice of `table` via a single aggregate query. Returns `None`
-/// if the query fails or yields no row.
-async fn aggregate_table_statistics(
-    df: &crate::datafusion::DataFusion,
-    table: &datafusion::sql::TableReference,
-    schema: &datafusion::arrow::datatypes::SchemaRef,
-) -> Option<datafusion::common::Statistics> {
-    use datafusion::common::stats::Precision;
-    use datafusion::common::{ColumnStatistics, Statistics};
-
-    // COUNT(*) at column 0, then per supported column: min, max, and (for integer
-    // columns) approx_distinct. `layout` records each column's result indices.
-    let mut select_exprs: Vec<String> = vec!["COUNT(*) AS __sr_count".to_string()];
-    // (schema field index, min idx, max idx, optional ndv idx) in the result batch.
-    let mut layout: Vec<(usize, usize, usize, Option<usize>)> = Vec::new();
-    let mut next = 1usize;
-    for (idx, field) in schema.fields().iter().enumerate() {
-        if !supports_minmax(field.data_type()) {
-            continue;
-        }
-        let col = quote_ident(field.name());
-        let (min_idx, max_idx) = (next, next + 1);
-        select_exprs.push(format!("min({col}) AS __sr_min{idx}"));
-        select_exprs.push(format!("max({col}) AS __sr_max{idx}"));
-        next += 2;
-        let ndv_idx = if supports_ndv(field.data_type()) {
-            select_exprs.push(format!("approx_distinct({col}) AS __sr_ndv{idx}"));
-            let n = next;
-            next += 1;
-            Some(n)
-        } else {
-            None
-        };
-        layout.push((idx, min_idx, max_idx, ndv_idx));
-    }
-
-    let sql = format!(
-        "SELECT {} FROM {}",
-        select_exprs.join(", "),
-        table.to_quoted_string()
-    );
-    let batches = df.ctx.sql(&sql).await.ok()?.collect().await.ok()?;
-    let batch = batches.into_iter().find(|b| b.num_rows() > 0)?;
-
-    let num_rows = count_at(batch.column(0))?;
-
-    // Per-column bounds for supported columns, keyed by schema field index.
-    let mut bounds: HashMap<usize, ColumnStatistics> = HashMap::new();
-    for (field_idx, min_idx, max_idx, ndv_idx) in layout {
-        let min_value = scalar_bound(batch.column(min_idx));
-        let true_max = scalar_bound(batch.column(max_idx));
-        let ndv = ndv_idx.and_then(|i| count_at(batch.column(i)));
-        let distinct_count = ndv.map_or(Precision::Absent, Precision::Inexact);
-        // Report an *effective* max for integer columns: min(true_max, min + ndv),
-        // marked inexact. The planner estimates a key's distinct count from the
-        // min/max range when no distinct count is available (and `UnionExec` drops
-        // distinct counts when merging the per-executor scans of one table). For a
-        // sparse key — e.g. CDC `o_custkey` spanning ~1e9 with only ~1M distinct —
-        // the raw range hugely over-estimates the NDV, which under-estimates joins
-        // and prevents the q18 build-side swap. Tightening the reported range to
-        // the NDV makes the range-based estimate accurate. min/max survive the
-        // union natively, so this needs no change to `UnionExec`. Dense keys are
-        // unaffected (min + ndv ≈ true_max). Inexact bounds can't trip
-        // empty-relation pruning (that requires Exact(0)), and these federated leaf
-        // stats are planning estimates only (executors re-run the real query).
-        let max_value = effective_max_for_ndv(&min_value, ndv, true_max);
-        bounds.insert(
-            field_idx,
-            ColumnStatistics {
-                null_count: Precision::Absent,
-                min_value,
-                max_value,
-                sum_value: Precision::Absent,
-                distinct_count,
-                byte_size: Precision::Absent,
-            },
-        );
-    }
-
-    // Align column_statistics positionally with the full schema (= column_names).
-    let column_statistics = (0..schema.fields().len())
-        .map(|i| {
-            bounds
-                .remove(&i)
-                .unwrap_or_else(ColumnStatistics::new_unknown)
-        })
-        .collect();
-
-    Some(Statistics {
-        num_rows: Precision::Inexact(num_rows),
-        total_byte_size: Precision::Absent,
-        column_statistics,
-    })
-}
-
-/// Last-resort fallback: `COUNT(*)` → `num_rows` only, no column bounds.
-async fn count_only_statistics(
-    df: &crate::datafusion::DataFusion,
-    table: &datafusion::sql::TableReference,
-    schema: &datafusion::arrow::datatypes::SchemaRef,
-) -> Option<datafusion::common::Statistics> {
-    use datafusion::common::stats::Precision;
-
-    let sql = format!("SELECT COUNT(*) AS n FROM {}", table.to_quoted_string());
-    let batches = df.ctx.sql(&sql).await.ok()?.collect().await.ok()?;
-    let batch = batches.into_iter().find(|b| b.num_rows() > 0)?;
-    let n = count_at(batch.column(0))?;
-    Some(datafusion::common::Statistics::new_unknown(schema).with_num_rows(Precision::Inexact(n)))
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -935,16 +935,13 @@ impl Runtime {
     /// table had no data at initial-load time). A periodic rebroadcast keeps the
     /// coordinator's join-sizing statistics fresh as the executor's local data grows.
     pub(crate) async fn run_executor_statistics_reporter(self: Arc<Self>) {
-        use crate::cluster::partition::{StatsRichness, classify_stats_richness};
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(45));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // Per-table cache of the last *rich* stats we broadcast, so a tick whose
-        // stats computation degrades (e.g. the aggregate query fails under ingest
-        // load and falls back to COUNT(*)) does not clobber the coordinator's
-        // richer stats. Distributed JoinSelection (q18 swap) only picks the small
-        // build side while the coordinator holds the column/distinct stats, so
-        // flapping between rich and degraded would intermittently OOM.
-        let mut last_rich: HashMap<String, (StatsRichness, Vec<u8>, Vec<String>)> = HashMap::new();
+        // The statistics source (`local_executor_table_statistics`) reads the
+        // Cayenne metastore aggregate, which is maintained incrementally on the
+        // write path: always-fresh, O(1), and never degrades to a row-count-only
+        // result mid-ingest. So there is no non-degrading cache here — each tick
+        // simply broadcasts the current aggregate.
         loop {
             interval.tick().await;
             let Some(broadcaster) = self.executor_outbound_broadcaster() else {
@@ -981,48 +978,13 @@ impl Runtime {
             );
             for table in tables {
                 let table_key = table.to_string();
-                match crate::cluster::partition::local_executor_table_statistics(&df, &table).await
+                if let Some((stats, column_names)) =
+                    crate::cluster::partition::local_executor_table_statistics(&df, &table).await
                 {
-                    Some((stats, column_names)) => {
-                        let richness = classify_stats_richness(&stats);
-                        // Adopt the fresh stats when they're at least as rich as
-                        // what we last broadcast (so growing num_rows/min/max stay
-                        // current); otherwise re-broadcast the cached richer stats.
-                        let adopt = last_rich
-                            .get(&table_key)
-                            .is_none_or(|(cached, _, _)| richness >= *cached);
-                        if adopt {
-                            let encoded = runtime_cluster::encode_statistics(&stats);
-                            last_rich.insert(
-                                table_key.clone(),
-                                (richness, encoded.clone(), column_names.clone()),
-                            );
-                            broadcaster
-                                .broadcast_executor_statistics(table_key, encoded, column_names)
-                                .await;
-                        } else if let Some((_, encoded, names)) = last_rich.get(&table_key) {
-                            broadcaster
-                                .broadcast_executor_statistics(
-                                    table_key,
-                                    encoded.clone(),
-                                    names.clone(),
-                                )
-                                .await;
-                        }
-                    }
-                    // Computation failed entirely — keep the coordinator warm with
-                    // the last rich stats rather than going dark for this table.
-                    None => {
-                        if let Some((_, encoded, names)) = last_rich.get(&table_key) {
-                            broadcaster
-                                .broadcast_executor_statistics(
-                                    table_key,
-                                    encoded.clone(),
-                                    names.clone(),
-                                )
-                                .await;
-                        }
-                    }
+                    let encoded = runtime_cluster::encode_statistics(&stats);
+                    broadcaster
+                        .broadcast_executor_statistics(table_key, encoded, column_names)
+                        .await;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Distributed `JoinSelection` needs accurate per-table row counts, min/max bounds, and distinct counts to choose safe hash-join build sides. The previous executor statistics reporter rebuilt those stats by running full aggregate rescans every 45 seconds. Under CDC ingest, that rescan could degrade to row-count-only stats, causing the coordinator's build-side choice to flap and intermittently OOM, for example on TPC-H q18.

This PR moves those stats to the Cayenne write path. Each write updates a metastore aggregate with live `num_rows`, per-column min/max/null stats, and HyperLogLog NDV sketches for integer columns. The executor reporter now reads that aggregate in O(1), encodes NDV into the existing effective-max bounds, and broadcasts current stats without the rescan or non-degrading cache.

Builds on #11089 and #11098.

## Flow

```text
Cayenne write / upsert / rewrite
        |
        v
ColumnStatsAccumulator
  - live row delta
  - min/max/null stats
  - integer-column HLL NDV
        |
        v
cayenne_table_statistics
        |
        v
executor statistics reporter
        |
        v
coordinator JoinSelection
```

## Changes

- Add a mergeable Cayenne `HyperLogLog` / `NdvSketches` implementation and persist sketches in a new nullable `cayenne_table_statistics.ndv_sketches` column for SQLite and Turso metastores.
- Keep `num_rows` live by applying `inserted - superseded` deltas on writes, using authoritative `Set` counts on overwrite and compaction, and leaving counts unchanged for inline checkpoint flushes.
- Expose `CayenneTableProvider::optimizer_table_statistics()` so the cluster reporter can read incremental stats even while CDC position deletes are pending.
- Replace the reporter's aggregate-query fallback and richness cache with an O(1) Cayenne stats read, while keeping scan-plan footer stats as the non-Cayenne fallback.
- Add end-to-end Cayenne coverage for upserted row counts and integer-column NDV, plus HLL accuracy, merge, and serialization tests.

## Notes

- NDV sketches are maintained only for integer columns to keep write-path overhead bounded.
- The planner delivery path is unchanged: NDV is still encoded into effective max bounds so it survives `UnionExec`.
- Retention-delete row-count deltas are not netted yet; compaction resets the aggregate to bound drift.

## Test plan

- [x] Cayenne unit/integration tests, including new HLL and incremental stats coverage
- [x] SpiceBench cluster run: TPC-H SF10, `etl_type=changes`, `tpch_q18` passed 94 times, 21/21 queries passed, no resource-exhausted/OOM errors
- [x] `make lint-rust`
- [x] `cargo fmt`
- [ ] CI
