### PR TITLE
fix(cache): run periodic moka maintenance for idle caches

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -339,6 +339,25 @@ impl Caching {
         }
         Ok(())
     }
+
+    /// Drives moka housekeeping on every configured cache. `moka::future::Cache`
+    /// has no background maintenance thread, so invalidation predicates and
+    /// expired entries on a cache with no `get`/`insert` traffic are only
+    /// reclaimed when this runs.
+    pub async fn run_pending_maintenance(&self) {
+        if let Some(results) = &self.results {
+            results.run_pending_tasks().await;
+        }
+        if let Some(plans) = &self.plans {
+            plans.checkpoint().await;
+        }
+        if let Some(search) = &self.search {
+            search.checkpoint().await;
+        }
+        if let Some(embeddings) = &self.embeddings {
+            embeddings.checkpoint().await;
+        }
+    }
 }
 
 // TODO: sunset ``QueryResultsCacheProvider`` in favor of ``CacheProvider``?
@@ -719,6 +738,55 @@ mod tests {
             display_zstd.contains("encoding: zstd"),
             "Display should include encoding: zstd, got: {display_zstd}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_run_pending_maintenance_handles_untouched_caches() {
+        use crate::result::search::CachedSearchResult;
+        use spicepod::component::caching::CacheConfig;
+
+        // A search cache that never receives get/insert traffic, plus a results
+        // cache.
+        let results = Arc::new(
+            QueryResultsCacheProvider::try_new(&SQLResultsCacheConfig::default(), Box::new([]))
+                .expect("valid results cache"),
+        );
+        let search = lru_cache::build_from_config::<CachedSearchResult>(&CacheConfig::default())
+            .expect("valid search cache")
+            .as_tabled_provider();
+
+        let caching = Caching::new()
+            .with_results_cache(results)
+            .with_search_cache(search);
+
+        let table = TableReference::bare("never_read");
+
+        // Each call registers a moka invalidation predicate.
+        for _ in 0..1_000 {
+            caching
+                .invalidate_for_table(table.clone())
+                .expect("invalidation should succeed");
+        }
+
+        // Maintenance drains the predicates; the caches stay empty and functional.
+        caching.run_pending_maintenance().await;
+
+        let results = caching.results.as_ref().expect("results configured");
+        assert_eq!(results.item_count().await, 0);
+        let search = caching.search.as_ref().expect("search configured");
+        assert_eq!(search.item_count().await, 0);
+
+        // Another invalidate + maintenance cycle still works.
+        caching
+            .invalidate_for_table(table)
+            .expect("invalidation should succeed");
+        caching.run_pending_maintenance().await;
+    }
+
+    #[tokio::test]
+    async fn test_run_pending_maintenance_on_empty_caching_is_noop() {
+        // No configured caches: maintenance must be a harmless no-op.
+        Caching::new().run_pending_maintenance().await;
     }
 
     #[tokio::test]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -498,6 +498,10 @@ const METRICS_SERVER: &str = "metrics_server";
 const FLIGHT_SERVER: &str = "flight_server";
 const PODS_WATCHER: &str = "pods_watcher";
 const COMPONENTS_INITIAL_LOAD: &str = "components_initial_load";
+const CACHE_MAINTENANCE: &str = "cache_maintenance";
+
+/// How often [`Runtime::run_cache_maintenance`] drives moka housekeeping.
+const CACHE_MAINTENANCE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 
 // Allow 30 seconds for tasks for graceful shutdown
 const RUNTIME_DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
@@ -926,6 +930,28 @@ impl Runtime {
         }
 
         Ok(())
+    }
+
+    /// Periodically drives moka housekeeping so invalidation predicates and
+    /// expired entries are reclaimed even on caches with no `get`/`insert`
+    /// traffic. Returns immediately when no cache is configured; otherwise loops
+    /// until the task is cancelled at shutdown.
+    pub(crate) async fn run_cache_maintenance(self: Arc<Self>) -> Result<()> {
+        let caching = self.datafusion().caching();
+        if caching.results.is_none()
+            && caching.plans.is_none()
+            && caching.search.is_none()
+            && caching.embeddings.is_none()
+        {
+            return Ok(());
+        }
+
+        let mut interval = tokio::time::interval(CACHE_MAINTENANCE_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            caching.run_pending_maintenance().await;
+        }
     }
 
     /// Periodically recompute and rebroadcast this executor's per-table row-count
@@ -1450,6 +1476,16 @@ impl Runtime {
             })
             .await;
 
+        // `None` cancellation token: the loop is aborted at shutdown.
+        let maintenance_self = Arc::clone(&self);
+        let cache_maintenance_future = self
+            .start_runtime_task(
+                CACHE_MAINTENANCE,
+                None,
+                maintenance_self.run_cache_maintenance(),
+            )
+            .await;
+
         // wait for all servers to shut down or if any of the servers fail to start
         if let Some(cluster_future) = maybe_cluster_future {
             return match tokio::try_join!(
@@ -1457,6 +1493,7 @@ impl Runtime {
                 flight_future,
                 metrics_future,
                 pods_watcher_future,
+                cache_maintenance_future,
                 cluster_future,
                 shutdown_signal_future
             ) {
@@ -1470,6 +1507,7 @@ impl Runtime {
             flight_future,
             metrics_future,
             pods_watcher_future,
+            cache_maintenance_future,
             shutdown_signal_future
         ) {
             Err(err) => Err(err),


### PR DESCRIPTION
## Summary

Fixes #11077.

`Caching::invalidate_for_table` registers moka invalidation predicates after each refresh. moka only drains those predicates when pending tasks run, which normally happens as a side effect of cache `get` or `insert` calls. Idle caches can therefore accumulate predicates indefinitely; the default `search_results` cache is the common case because it stays empty unless search queries run.

This adds a periodic runtime maintenance task that drives moka housekeeping for every configured cache. The existing invalidation behavior stays the same, but predicate buildup and TTL-expired entries are reclaimed even when a cache has no traffic.

## Changes

- Add `Caching::run_pending_maintenance()` to run moka maintenance on results, plan, search, and embedding caches.
- Start a `cache_maintenance` runtime task every 60 seconds through the existing runtime task system, so it is cancelled cleanly on shutdown.
- Make the maintenance path a no-op when no cache is configured.
- Add tests for untouched caches and empty cache configuration.

## Notes

- moka does not expose the invalidation predicate count, so the tests verify maintenance behavior rather than the internal counter directly.
- The leak path was verified manually with `vmmap` against the issue reproduction.

## Test plan

- [x] `cargo test -p cache`
- [x] `cargo check -p runtime`
- [x] `make lint-rust`
- [ ] CI
