### PR TITLE
Upgrade to DuckDB 1.5.3 + statically link the VSS (HNSW) extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6256,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=4fbd5d7041d54df04d04cc9707941ece03e30f4f#4fbd5d7041d54df04d04cc9707941ece03e30f4f"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=be0837e39a8c02ad76e3885a94c66aa83fe8e8a2#be0837e39a8c02ad76e3885a94c66aa83fe8e8a2"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -6848,7 +6848,7 @@ checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
 [[package]]
 name = "duckdb"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b80672e038d1abe3d710f092a130661ea482940f#b80672e038d1abe3d710f092a130661ea482940f"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b1cf1723252204caf6262865255cd47e7435cbbe#b1cf1723252204caf6262865255cd47e7435cbbe"
 dependencies = [
  "arrow",
  "calamine",
@@ -10532,7 +10532,7 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 [[package]]
 name = "libduckdb-sys"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b80672e038d1abe3d710f092a130661ea482940f#b80672e038d1abe3d710f092a130661ea482940f"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b1cf1723252204caf6262865255cd47e7435cbbe#b1cf1723252204caf6262865255cd47e7435cbbe"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6256,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=466acff6af701872ba41de99c1783df2a288ddf8#466acff6af701872ba41de99c1783df2a288ddf8"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=5f8236f0b93db58e5de5c86d89ad413824b2c31b#5f8236f0b93db58e5de5c86d89ad413824b2c31b"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -6847,8 +6847,8 @@ checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
 
 [[package]]
 name = "duckdb"
-version = "1.10502.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=119fc5df0568fa165154697eb9c6a302938fe848#119fc5df0568fa165154697eb9c6a302938fe848"
+version = "1.10503.1"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=91d0c71f02fb591ac75cf1415285855863a5d827#91d0c71f02fb591ac75cf1415285855863a5d827"
 dependencies = [
  "arrow",
  "calamine",
@@ -10531,8 +10531,8 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10502.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=119fc5df0568fa165154697eb9c6a302938fe848#119fc5df0568fa165154697eb9c6a302938fe848"
+version = "1.10503.1"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=91d0c71f02fb591ac75cf1415285855863a5d827#91d0c71f02fb591ac75cf1415285855863a5d827"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6256,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=5f8236f0b93db58e5de5c86d89ad413824b2c31b#5f8236f0b93db58e5de5c86d89ad413824b2c31b"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=4fbd5d7041d54df04d04cc9707941ece03e30f4f#4fbd5d7041d54df04d04cc9707941ece03e30f4f"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -6848,7 +6848,7 @@ checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
 [[package]]
 name = "duckdb"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=91d0c71f02fb591ac75cf1415285855863a5d827#91d0c71f02fb591ac75cf1415285855863a5d827"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b80672e038d1abe3d710f092a130661ea482940f#b80672e038d1abe3d710f092a130661ea482940f"
 dependencies = [
  "arrow",
  "calamine",
@@ -10532,7 +10532,7 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 [[package]]
 name = "libduckdb-sys"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=91d0c71f02fb591ac75cf1415285855863a5d827#91d0c71f02fb591ac75cf1415285855863a5d827"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b80672e038d1abe3d710f092a130661ea482940f#b80672e038d1abe3d710f092a130661ea482940f"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,7 +428,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "5f8236f0b93db58e5de5c86d89ad413824b2c31b" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4fbd5d7041d54df04d04cc9707941ece03e30f4f" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" } # spiceai-52.5
@@ -437,7 +437,7 @@ ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 
 # Patch duckdb for direct dependencies and spiceai_duckdb_fork for datafusion-table-providers
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "91d0c71f02fb591ac75cf1415285855863a5d827" } # spiceai-1.5.3
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b80672e038d1abe3d710f092a130661ea482940f" } # spiceai-1.5.3
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6d062676210d095df45eafa6e19fd8" }
 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ delta_kernel = { version = "0.18.2", features = [
 derive_builder = "0.20.2"
 dotenvy = "0.15"
 duration-parse = { path = "crates/duration-parse" }
-duckdb = "1.10502" # 1.10502.x corresponds to DuckDB v1.5.2
+duckdb = "1.10503" # 1.10503.x corresponds to DuckDB v1.5.3
 dyn-hash = "1.0.0"
 fundu = "2.0.1"
 futures = "0.3.32"
@@ -428,7 +428,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "466acff6af701872ba41de99c1783df2a288ddf8" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "5f8236f0b93db58e5de5c86d89ad413824b2c31b" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" } # spiceai-52.5
@@ -437,7 +437,7 @@ ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 
 # Patch duckdb for direct dependencies and spiceai_duckdb_fork for datafusion-table-providers
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "119fc5df0568fa165154697eb9c6a302938fe848" } # spiceai-1.5.2
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "91d0c71f02fb591ac75cf1415285855863a5d827" } # spiceai-1.5.3
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6d062676210d095df45eafa6e19fd8" }
 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,7 +428,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4fbd5d7041d54df04d04cc9707941ece03e30f4f" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "be0837e39a8c02ad76e3885a94c66aa83fe8e8a2" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" } # spiceai-52.5
@@ -437,7 +437,7 @@ ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 
 # Patch duckdb for direct dependencies and spiceai_duckdb_fork for datafusion-table-providers
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b80672e038d1abe3d710f092a130661ea482940f" } # spiceai-1.5.3
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b1cf1723252204caf6262865255cd47e7435cbbe" } # spiceai-1.5.3 + static VSS (DuckDB version pinned to v1.5.3)
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6d062676210d095df45eafa6e19fd8" }
 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113

--- a/crates/search/src/index/duckdb/mod.rs
+++ b/crates/search/src/index/duckdb/mod.rs
@@ -14,10 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{
-    any::Any,
-    sync::{Arc, Mutex, OnceLock},
-};
+use std::{any::Any, sync::Arc};
 
 use arrow::array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
@@ -53,9 +50,6 @@ pub use hnsw::DuckDBHnswOptions;
 pub use metric::DuckDBDistanceMetric;
 
 use query_table::DuckDBVectorQueryTable;
-
-static VSS_INSTALLED: OnceLock<()> = OnceLock::new();
-static VSS_INSTALL_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Clone)]
 pub struct DuckDBVectorQueryContext {
@@ -117,14 +111,15 @@ impl DuckDBVectorIndex {
     }
 
     /// Creates (or no-ops if already present) the HNSW index for this vector column on
-    /// the given DuckDB table. Loads and installs VSS as needed.
+    /// the given DuckDB table. VSS is statically linked into our DuckDB build (see
+    /// duckdb-sources/extension/vss) and auto-loaded; the pool's `LOAD vss` connection
+    /// setup query makes it available, so no `INSTALL vss` is required.
     fn create_hnsw_index_on_table(
         &self,
         table_name: &str,
         conn: &duckdb::Connection,
     ) -> DataFusionResult<()> {
         let embedding_column = embedding_col(&self.embedded_column);
-        install_vss_once(conn)?;
         conn.execute("LOAD vss", []).map_err(to_execution_error)?;
         conn.execute("SET hnsw_enable_experimental_persistence = true", [])
             .map_err(to_execution_error)?;
@@ -288,23 +283,6 @@ impl Index for DuckDBVectorIndex {
 // ---------------------------------------------------------------------------
 // Shared utilities
 // ---------------------------------------------------------------------------
-
-fn install_vss_once(conn: &duckdb::Connection) -> DataFusionResult<()> {
-    if VSS_INSTALLED.get().is_some() {
-        return Ok(());
-    }
-
-    let _install_guard = VSS_INSTALL_LOCK.lock().map_err(|error| {
-        DataFusionError::Execution(format!("Failed to lock DuckDB VSS install guard: {error}"))
-    })?;
-    if VSS_INSTALLED.get().is_none() {
-        conn.execute("INSTALL vss", [])
-            .map_err(to_execution_error)?;
-        let _ = VSS_INSTALLED.set(());
-    }
-
-    Ok(())
-}
 
 pub(super) fn resolve_current_table_name(
     table_rel_name: &RelationName,


### PR DESCRIPTION
## Summary

Upgrades the bundled DuckDB to **v1.5.3** and **statically links the VSS (vector similarity search / HNSW) extension** into it, so HNSW vector search works out of the box — with **no runtime `INSTALL vss`**.

## Background

The DuckDB vector engine (`vectors.engine: duckdb`) builds HNSW indexes via DuckDB's VSS extension. VSS is out-of-tree, so a stock bundled DuckDB doesn't include it, and the runtime previously tried to `INSTALL vss` on demand. On a host where vss was never installed this failed (the install was gated behind a `LOAD vss` connection-setup query that errored first), so:

- HNSW index creation failed at load,
- `vector_search(...)` errored, and
- `/v1/search` **silently returned `{"results":[]}`**.

It also can't work air-gapped, and 404s for custom DuckDB builds whose version hash has no published extensions. Statically compiling VSS into the bundled DuckDB fixes this permanently — the extension is auto-loaded at database open.

## Changes in this PR

- Bump **duckdb-rs** → `a33cc3c3` (DuckDB 1.5.3 **+** statically-linked VSS).
- Bump **datafusion-table-providers** → `f998a9ce` (pins the same duckdb-rs rev, so the graph resolves to a single `libduckdb-sys` — avoids a duplicate `links = "duckdb"` conflict).
- Remove the runtime `INSTALL vss` path (`install_vss_once`) from the DuckDB vector engine in `crates/search/src/index/duckdb/mod.rs`. VSS is now statically linked and auto-loaded; the pool's `LOAD vss` connection-setup query is a no-op success.

## Dependency chain (supporting PRs, all merged)

1. **spiceai/duckdb#16** — vendor the VSS source (`extension/vss`, duckdb-vss pinned to the ABI-matched ref) + an upgrade SKILL.
2. **spiceai/duckdb-rs#37** — wire vss into the bundled cc build (`update_sources.py` + `build_bundled_cc.rs`), regenerate the source tarball, + a maintenance SKILL.
3. **datafusion-contrib/datafusion-table-providers#658** — bump its duckdb-rs pin to match.

## Validation

Built end-to-end against this stack. With **no** `vss.duckdb_extension` file present on the host, the runtime auto-creates the HNSW index at load (no INSTALL/download), `vector_search` / `/v1/search` return correct nearest neighbors, and `duckdb_indexes()` shows the `USING HNSW` index. `HNSWModule`/`VssExtension` symbols are present in the compiled `libduckdb.a`.

## Notes for reviewers

- Future VSS/DuckDB upgrades are documented in `extension/vss/SKILL.md` (duckdb fork) and `crates/libduckdb-sys/SKILL.md` (duckdb-rs fork).
- The search score column is `_score` (the DuckDB vectors doc example using `score` is incorrect — worth a follow-up docs fix).