### PR TITLE
Remove `unwrap` from test code and drop `clippy::unwrap_used` suppressions

### DIFF
--- a/crates/data_components/src/sharepoint/auth/saml.rs
+++ b/crates/data_components/src/sharepoint/auth/saml.rs
@@ -240,7 +240,6 @@ fn validate_assertion_encoding(assertion: &str) -> Result<()> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests use unwrap to assert happy paths")]
 mod tests {
     use std::collections::VecDeque;
     use std::sync::Arc;
@@ -252,18 +251,19 @@ mod tests {
     fn base64url_assertion_validates() {
         // "hello world" in base64url
         let s = general_purpose::URL_SAFE_NO_PAD.encode("hello world");
-        validate_assertion_encoding(&s).unwrap();
+        validate_assertion_encoding(&s).expect("base64url assertion should validate");
     }
 
     #[test]
     fn padded_base64url_also_validates() {
         let s = general_purpose::URL_SAFE.encode("hi");
-        validate_assertion_encoding(&s).unwrap();
+        validate_assertion_encoding(&s).expect("padded base64url assertion should validate");
     }
 
     #[test]
     fn rejects_bogus_assertion() {
-        let err = validate_assertion_encoding("!!not-base64!!").unwrap_err();
+        let err = validate_assertion_encoding("!!not-base64!!")
+            .expect_err("invalid base64 assertion should be rejected");
         assert!(matches!(err, Error::AssertionEncoding { .. }));
     }
 
@@ -406,8 +406,14 @@ mod tests {
             scope: None,
             authority_host_override: Some(base),
         });
-        let t1 = flow.acquire_token().await.unwrap();
-        let t2 = flow.acquire_token().await.unwrap();
+        let t1 = flow
+            .acquire_token()
+            .await
+            .expect("first acquire_token should succeed");
+        let t2 = flow
+            .acquire_token()
+            .await
+            .expect("second acquire_token should hit cache and succeed");
         assert_eq!(t1.access_token.expose_secret(), "T1");
         assert_eq!(t2.access_token.expose_secret(), "T1");
         // Cache hit on the second call — only one HTTP request total.
@@ -428,7 +434,10 @@ mod tests {
             scope: None,
             authority_host_override: Some(base),
         });
-        let err = flow.exchange_once().await.unwrap_err();
+        let err = flow
+            .exchange_once()
+            .await
+            .expect_err("token exchange should fail on rejection");
         match err {
             Error::TokenRejected { code, description } => {
                 assert_eq!(code, "invalid_grant");
@@ -452,7 +461,10 @@ mod tests {
             scope: Some("https://custom.example/.default offline_access".into()),
             authority_host_override: Some(base),
         });
-        let _ = flow.exchange_once().await.unwrap();
+        let _ = flow
+            .exchange_once()
+            .await
+            .expect("exchange_once with custom scope should succeed");
         let req = &captured.lock().await[0];
         assert!(
             req.contains("scope=https%3A%2F%2Fcustom.example%2F.default"),

--- a/crates/data_components/src/sharepoint/object_store.rs
+++ b/crates/data_components/src/sharepoint/object_store.rs
@@ -1239,7 +1239,6 @@ fn graph_err(e: &graph_rs_sdk::GraphFailure) -> object_store::Error {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests use unwrap to assert happy paths")]
 mod tests {
     use super::*;
 
@@ -1259,18 +1258,26 @@ mod tests {
     #[test]
     fn conflict_behavior_from_str() {
         assert_eq!(
-            "replace".parse::<ConflictBehavior>().unwrap(),
+            "replace"
+                .parse::<ConflictBehavior>()
+                .expect("\"replace\" should parse as ConflictBehavior"),
             ConflictBehavior::Replace
         );
         assert_eq!(
-            "fail".parse::<ConflictBehavior>().unwrap(),
+            "fail"
+                .parse::<ConflictBehavior>()
+                .expect("\"fail\" should parse as ConflictBehavior"),
             ConflictBehavior::Fail
         );
         assert_eq!(
-            "rename".parse::<ConflictBehavior>().unwrap(),
+            "rename"
+                .parse::<ConflictBehavior>()
+                .expect("\"rename\" should parse as ConflictBehavior"),
             ConflictBehavior::Rename
         );
-        "bogus".parse::<ConflictBehavior>().unwrap_err();
+        "bogus"
+            .parse::<ConflictBehavior>()
+            .expect_err("\"bogus\" should not parse as ConflictBehavior");
     }
 
     #[test]
@@ -1368,7 +1375,7 @@ mod tests {
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
                 .await
                 .expect("bind mock");
-            let addr = listener.local_addr().unwrap();
+            let addr = listener.local_addr().expect("mock listener local_addr");
             let responses = Arc::new(tokio::sync::Mutex::new(VecDeque::from(responses)));
             let count = Arc::new(AtomicUsize::new(0));
             let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
@@ -1444,7 +1451,9 @@ mod tests {
 
         fn mock_store(endpoint: &str) -> SharepointObjectStore {
             let mut client = GraphClient::new("unused-test-token");
-            client.use_test_endpoint(&Url::parse(&format!("{endpoint}/v1.0")).unwrap());
+            client.use_test_endpoint(
+                &Url::parse(&format!("{endpoint}/v1.0")).expect("test endpoint URL should parse"),
+            );
             SharepointObjectStore::new(
                 Arc::new(client),
                 None,
@@ -1470,12 +1479,12 @@ mod tests {
                         .thread_stack_size(64 * 1024 * 1024)
                         .enable_all()
                         .build()
-                        .unwrap()
+                        .expect("test tokio runtime should build")
                         .block_on(f);
                 })
-                .unwrap()
+                .expect("test runner thread should spawn")
                 .join()
-                .unwrap();
+                .expect("test runner thread should join");
         }
 
         const HEAD_JSON: &str = r#"{
@@ -1490,7 +1499,10 @@ mod tests {
             run_async(async {
                 let (url, count, _captured) = start_mock(vec![MockResp::ok_json(HEAD_JSON)]).await;
                 let store = mock_store(&url);
-                let meta = store.head(&Path::from("Documents/file.csv")).await.unwrap();
+                let meta = store
+                    .head(&Path::from("Documents/file.csv"))
+                    .await
+                    .expect("head should return drive-item metadata");
                 assert_eq!(meta.size, 42);
                 assert_eq!(meta.e_tag.as_deref(), Some("\"abc\""));
                 assert_eq!(meta.version.as_deref(), Some("\"def\""));
@@ -1508,7 +1520,7 @@ mod tests {
                 let err = store
                     .head(&Path::from("Documents/missing.csv"))
                     .await
-                    .unwrap_err();
+                    .expect_err("head of missing object should fail");
                 assert!(
                     matches!(err, object_store::Error::NotFound { .. }),
                     "expected NotFound, got {err:?}"
@@ -1529,7 +1541,7 @@ mod tests {
                 let result = store
                     .get_opts(&Path::from("Documents/file.csv"), GetOptions::default())
                     .await
-                    .unwrap();
+                    .expect("get_opts should return a result");
                 // get_opts uses the fetched payload length as the authoritative
                 // size, not the HEAD-reported size — Graph occasionally
                 // misreports `size`. Body is "hello, world" (12 bytes).
@@ -1538,11 +1550,11 @@ mod tests {
                     GetResultPayload::Stream(mut s) => {
                         let mut all = Vec::new();
                         while let Some(chunk) = s.next().await {
-                            all.extend_from_slice(&chunk.unwrap());
+                            all.extend_from_slice(&chunk.expect("stream chunk should be Ok"));
                         }
                         all
                     }
-                    _ => panic!("expected stream payload"),
+                    GetResultPayload::File(..) => panic!("expected stream payload"),
                 };
                 assert_eq!(bytes, b"hello, world");
                 assert_eq!(count.load(Ordering::SeqCst), 2);
@@ -1557,7 +1569,7 @@ mod tests {
                 store
                     .delete(&Path::from("Documents/file.csv"))
                     .await
-                    .unwrap();
+                    .expect("delete should succeed");
                 assert_eq!(count.load(Ordering::SeqCst), 1);
             });
         }
@@ -1575,7 +1587,7 @@ mod tests {
                 let err = store
                     .delete(&Path::from("Documents/gone.csv"))
                     .await
-                    .unwrap_err();
+                    .expect_err("delete of missing object should fail");
                 assert!(matches!(err, object_store::Error::NotFound { .. }));
             });
         }
@@ -1592,7 +1604,7 @@ mod tests {
                         PutOptions::default(),
                     )
                     .await
-                    .unwrap();
+                    .expect("put_opts should succeed");
                 assert_eq!(result.e_tag.as_deref(), Some("\"abc\""));
                 assert_eq!(result.version.as_deref(), Some("\"def\""));
                 assert_eq!(count.load(Ordering::SeqCst), 1);
@@ -1634,7 +1646,7 @@ mod tests {
                 let mut stream = store.list(Some(&Path::from("Documents")));
                 let mut names = Vec::new();
                 while let Some(item) = stream.next().await {
-                    let meta = item.unwrap();
+                    let meta = item.expect("list item should be Ok");
                     names.push(meta.location.to_string());
                 }
                 // Folders skipped from files-only list; two files across two pages.
@@ -1662,7 +1674,7 @@ mod tests {
                 let result = store
                     .list_with_delimiter(Some(&Path::from("Documents")))
                     .await
-                    .unwrap();
+                    .expect("list_with_delimiter should succeed");
                 assert_eq!(result.objects.len(), 1);
                 assert!(result.objects[0].location.to_string().ends_with("a.csv"));
                 assert_eq!(result.common_prefixes.len(), 1);

--- a/crates/data_components/src/sharepoint/url.rs
+++ b/crates/data_components/src/sharepoint/url.rs
@@ -205,20 +205,20 @@ impl DriveRef {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests use unwrap to assert happy paths")]
 mod tests {
     use super::*;
 
     #[test]
     fn parse_me_root() {
-        let url = SharepointUrl::parse("sharepoint://me/").unwrap();
+        let url = SharepointUrl::parse("sharepoint://me/").expect("sharepoint://me/ should parse");
         assert_eq!(url.drive, DriveRef::Me);
         assert_eq!(url.item_path.as_ref(), "");
     }
 
     #[test]
     fn parse_me_with_path() {
-        let url = SharepointUrl::parse("sharepoint://me/Documents/report.csv").unwrap();
+        let url = SharepointUrl::parse("sharepoint://me/Documents/report.csv")
+            .expect("sharepoint://me/ with path should parse");
         assert_eq!(url.drive, DriveRef::Me);
         assert_eq!(url.item_path.as_ref(), "Documents/report.csv");
     }
@@ -228,7 +228,7 @@ mod tests {
         let url = SharepointUrl::parse(
             "sharepoint://drives/b!abc-def_XYZ/Shared%20Documents/file.parquet",
         )
-        .unwrap();
+        .expect("sharepoint://drives/<id>/... should parse");
         assert_eq!(url.drive, DriveRef::Drive("b!abc-def_XYZ".to_string()));
         assert_eq!(url.item_path.as_ref(), "Shared Documents/file.parquet");
     }
@@ -239,7 +239,7 @@ mod tests {
         let url = SharepointUrl::parse(
             "sharepoint://sites/contoso.sharepoint.com,11111111-2222-3333-4444-555555555555,66666666-7777-8888-9999-aaaaaaaaaaaa/Shared/data.json",
         )
-        .unwrap();
+        .expect("sharepoint://sites/<comma-id>/... should parse");
         match url.drive {
             DriveRef::Site(id) => {
                 assert!(id.starts_with("contoso.sharepoint.com,"));
@@ -254,31 +254,35 @@ mod tests {
     fn parse_user_and_group() {
         let u =
             SharepointUrl::parse("sharepoint://users/48d31887-5fad-4d73-a9f5-3c356e68a038/dir/f")
-                .unwrap();
+                .expect("sharepoint://users/<id>/... should parse");
         assert_eq!(
             u.drive,
             DriveRef::User("48d31887-5fad-4d73-a9f5-3c356e68a038".to_string())
         );
 
-        let g = SharepointUrl::parse("sharepoint://groups/gid-abc/dir/f").unwrap();
+        let g = SharepointUrl::parse("sharepoint://groups/gid-abc/dir/f")
+            .expect("sharepoint://groups/<id>/... should parse");
         assert_eq!(g.drive, DriveRef::Group("gid-abc".to_string()));
     }
 
     #[test]
     fn reject_wrong_scheme() {
-        let err = SharepointUrl::parse("https://example.com/foo").unwrap_err();
+        let err = SharepointUrl::parse("https://example.com/foo")
+            .expect_err("non-sharepoint scheme should be rejected");
         assert!(matches!(err, Error::WrongScheme { .. }));
     }
 
     #[test]
     fn reject_missing_id() {
-        let err = SharepointUrl::parse("sharepoint://drives/").unwrap_err();
+        let err = SharepointUrl::parse("sharepoint://drives/")
+            .expect_err("missing drive id should be rejected");
         assert!(matches!(err, Error::Malformed { .. }));
     }
 
     #[test]
     fn reject_unknown_kind() {
-        let err = SharepointUrl::parse("sharepoint://bogus/id/path").unwrap_err();
+        let err = SharepointUrl::parse("sharepoint://bogus/id/path")
+            .expect_err("unknown drive kind should be rejected");
         assert!(matches!(err, Error::Malformed { .. }));
     }
 }

--- a/crates/hash-index/benches/lookup.rs
+++ b/crates/hash-index/benches/lookup.rs
@@ -17,7 +17,6 @@ limitations under the License.
 // Benchmark code has different lint requirements than production code
 #![allow(
     clippy::expect_used,
-    clippy::unwrap_used,
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,

--- a/crates/vortex/src/convert/exprs.rs
+++ b/crates/vortex/src/convert/exprs.rs
@@ -731,7 +731,7 @@ mod tests {
         assert!(result.is_err());
         assert!(
             result
-                .unwrap_err()
+                .expect_err("unsupported operator should fail to convert")
                 .to_string()
                 .contains("Unsupported datafusion operator")
         );
@@ -742,7 +742,7 @@ mod tests {
         let col_expr = df_expr::Column::new("test_column", 0);
         let result = DefaultExpressionConvertor::default()
             .convert(&col_expr)
-            .unwrap();
+            .expect("column expression should convert");
 
         assert_snapshot!("expr_from_df_column", result.display_tree().to_string());
     }
@@ -752,7 +752,7 @@ mod tests {
         let literal_expr = df_expr::Literal::new(ScalarValue::Int32(Some(42)));
         let result = DefaultExpressionConvertor::default()
             .convert(&literal_expr)
-            .unwrap();
+            .expect("literal expression should convert");
 
         assert_snapshot!("expr_from_df_literal", result.display_tree().to_string());
     }
@@ -766,7 +766,7 @@ mod tests {
 
         let result = DefaultExpressionConvertor::default()
             .convert(&binary_expr)
-            .unwrap();
+            .expect("binary expression should convert");
 
         assert_snapshot!("expr_from_df_binary", result.display_tree().to_string());
     }
@@ -869,7 +869,7 @@ mod tests {
 
         let result = DefaultExpressionConvertor::default()
             .convert(&like_expr)
-            .unwrap();
+            .expect("like expression should convert");
         let like_opts = result.as_::<Like>();
         assert_eq!(
             like_opts,
@@ -895,11 +895,11 @@ mod tests {
                 "no".to_string(),
             )))) as Arc<dyn PhysicalExpr>),
         )
-        .unwrap();
+        .expect("CASE expression with ELSE should build");
 
         let result = DefaultExpressionConvertor::default()
             .convert(&case_expr)
-            .unwrap();
+            .expect("CASE expression with ELSE should convert");
 
         assert_snapshot!(
             "expr_from_df_case_when_with_else",
@@ -915,8 +915,10 @@ mod tests {
                 "yes".to_string(),
             )))) as Arc<dyn PhysicalExpr>,
         )];
-        let case_expr = Arc::new(df_expr::CaseExpr::try_new(None, when_then_expr, None).unwrap())
-            as Arc<dyn PhysicalExpr>;
+        let case_expr = Arc::new(
+            df_expr::CaseExpr::try_new(None, when_then_expr, None)
+                .expect("CASE expression without ELSE should build"),
+        ) as Arc<dyn PhysicalExpr>;
 
         let schema = Schema::new(vec![Field::new("active", DataType::Boolean, false)]);
         assert!(!can_be_pushed_down_impl(&case_expr, &schema));

--- a/crates/vortex/src/convert/scalars.rs
+++ b/crates/vortex/src/convert/scalars.rs
@@ -380,7 +380,9 @@ mod tests {
         #[case] vortex_scalar: Scalar,
         #[case] expected_df_scalar: ScalarValue,
     ) {
-        let result = vortex_scalar.try_to_df().unwrap();
+        let result = vortex_scalar
+            .try_to_df()
+            .expect("primitive vortex scalar should convert to df");
         assert_eq!(result, expected_df_scalar);
     }
 
@@ -396,7 +398,9 @@ mod tests {
         #[case] vortex_scalar: Scalar,
         #[case] expected_df_scalar: ScalarValue,
     ) {
-        let result = vortex_scalar.try_to_df().unwrap();
+        let result = vortex_scalar
+            .try_to_df()
+            .expect("bool/null vortex scalar should convert to df");
         assert_eq!(result, expected_df_scalar);
     }
 
@@ -418,7 +422,9 @@ mod tests {
         #[case] vortex_scalar: Scalar,
         #[case] expected_df_scalar: ScalarValue,
     ) {
-        let result = vortex_scalar.try_to_df().unwrap();
+        let result = vortex_scalar
+            .try_to_df()
+            .expect("string/binary vortex scalar should convert to df");
         assert_eq!(result, expected_df_scalar);
     }
 
@@ -475,7 +481,9 @@ mod tests {
         #[case] vortex_scalar: Scalar,
         #[case] expected_df_scalar: ScalarValue,
     ) {
-        let result = vortex_scalar.try_to_df().unwrap();
+        let result = vortex_scalar
+            .try_to_df()
+            .expect("decimal vortex scalar should convert to df");
         assert_eq!(result, expected_df_scalar);
     }
 
@@ -517,8 +525,12 @@ mod tests {
 
         // For non-null values, convert both back to DataFusion for comparison
         if !result.is_null() {
-            let result_df = result.try_to_df().unwrap();
-            let expected_df = expected_vortex.try_to_df().unwrap();
+            let result_df = result
+                .try_to_df()
+                .expect("converted vortex scalar should convert back to df");
+            let expected_df = expected_vortex
+                .try_to_df()
+                .expect("expected vortex scalar should convert to df");
             assert_eq!(result_df, expected_df);
         }
     }
@@ -606,7 +618,9 @@ mod tests {
     ))]
     #[case::binary(Scalar::binary(ByteBuffer::from(vec![1u8, 2, 3, 4, 5]), Nullability::NonNullable))]
     fn test_round_trip_conversions(#[case] original: Scalar) {
-        let df_scalar = original.try_to_df().unwrap();
+        let df_scalar = original
+            .try_to_df()
+            .expect("original vortex scalar should convert to df");
         let round_trip = Scalar::from_df(&df_scalar)
             .expect("round-trip DataFusion scalar should convert back to Vortex scalar");
 
@@ -627,8 +641,12 @@ mod tests {
 
         if !original.is_null() {
             // For non-null values, compare by converting both to DataFusion scalars
-            let original_df = original.try_to_df().unwrap();
-            let round_trip_df = round_trip.try_to_df().unwrap();
+            let original_df = original
+                .try_to_df()
+                .expect("original vortex scalar should convert to df for comparison");
+            let round_trip_df = round_trip
+                .try_to_df()
+                .expect("round-trip vortex scalar should convert to df for comparison");
             assert_eq!(
                 original_df, round_trip_df,
                 "Value mismatch for scalar: {:?}",
@@ -673,7 +691,9 @@ mod tests {
     )]
     fn test_null_handling(#[case] vortex_null: Scalar, #[case] expected_df_null: ScalarValue) {
         // Test Vortex -> DataFusion
-        let df_result = vortex_null.try_to_df().unwrap();
+        let df_result = vortex_null
+            .try_to_df()
+            .expect("null vortex scalar should convert to df");
         assert_eq!(df_result, expected_df_null);
 
         // Test DataFusion -> Vortex
@@ -694,7 +714,14 @@ mod tests {
     fn test_utf8_variants(#[case] variant: ScalarValue) {
         let result = Scalar::from_df(&variant)
             .expect("UTF-8 DataFusion scalar should convert to Vortex scalar");
-        assert_eq!(result.as_utf8().value().unwrap().as_str(), "test string");
+        assert_eq!(
+            result
+                .as_utf8()
+                .value()
+                .expect("converted scalar should hold a utf8 value")
+                .as_str(),
+            "test string"
+        );
     }
 
     #[rstest]
@@ -709,7 +736,7 @@ mod tests {
             .as_binary()
             .value()
             .cloned()
-            .unwrap()
+            .expect("converted scalar should hold a binary value")
             .into_inner()
             .into();
         assert_eq!(result_bytes, vec![1u8, 2, 3, 4, 5]);

--- a/crates/vortex/src/convert/schema.rs
+++ b/crates/vortex/src/convert/schema.rs
@@ -209,7 +209,8 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let physical_schema = calculate_physical_schema(&dtype, &logical_schema).unwrap();
+        let physical_schema = calculate_physical_schema(&dtype, &logical_schema)
+            .expect("dictionary physical schema should be calculated");
 
         // Should preserve the dictionary type from the logical schema
         assert_eq!(
@@ -239,7 +240,8 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let physical_schema = calculate_physical_schema(&dtype, &logical_schema).unwrap();
+        let physical_schema = calculate_physical_schema(&dtype, &logical_schema)
+            .expect("utf8/binary physical schema should be calculated");
 
         assert_eq!(physical_schema.field(0).data_type(), &DataType::Utf8);
         assert_eq!(physical_schema.field(1).data_type(), &DataType::LargeUtf8);
@@ -262,7 +264,7 @@ mod tests {
         let result = calculate_physical_schema(&dtype, &logical_schema);
         assert!(
             result
-                .unwrap_err()
+                .expect_err("incompatible dtype should fail schema calculation")
                 .to_string()
                 .contains("not compatible with")
         );
@@ -282,7 +284,7 @@ mod tests {
         let result = calculate_physical_schema(&dtype, &logical_schema);
         assert!(
             result
-                .unwrap_err()
+                .expect_err("incompatible dtype should fail schema calculation")
                 .to_string()
                 .contains("not compatible with")
         );
@@ -325,7 +327,8 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let physical_schema = calculate_physical_schema(&dtype, &logical_schema).unwrap();
+        let physical_schema = calculate_physical_schema(&dtype, &logical_schema)
+            .expect("nested struct physical schema should be calculated");
 
         // Check outer structure
         assert_eq!(physical_schema.fields().len(), 2);
@@ -366,7 +369,8 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let physical_schema = calculate_physical_schema(&dtype, &logical_schema).unwrap();
+        let physical_schema = calculate_physical_schema(&dtype, &logical_schema)
+            .expect("list-with-dict physical schema should be calculated");
 
         if let DataType::List(elem_field) = physical_schema.field(0).data_type() {
             assert_eq!(
@@ -389,7 +393,7 @@ mod tests {
         assert!(result.is_err());
         assert!(
             result
-                .unwrap_err()
+                .expect_err("non-struct dtype should fail schema calculation")
                 .to_string()
                 .contains("Expected struct dtype")
         );
@@ -425,7 +429,8 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let physical_schema = calculate_physical_schema(&dtype, &logical_schema).unwrap();
+        let physical_schema = calculate_physical_schema(&dtype, &logical_schema)
+            .expect("metadata-preserving physical schema should be calculated");
 
         assert_eq!(physical_schema.metadata(), &schema_metadata);
         assert_eq!(physical_schema.field(0).metadata(), &field_metadata);
@@ -456,7 +461,8 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let physical_schema = calculate_physical_schema(&dtype, &logical_schema).unwrap();
+        let physical_schema = calculate_physical_schema(&dtype, &logical_schema)
+            .expect("nested-list element-metadata physical schema should be calculated");
 
         if let DataType::List(elem_field) = physical_schema.field(0).data_type() {
             assert_eq!(elem_field.metadata(), &elem_metadata);

--- a/crates/vortex/src/lib.rs
+++ b/crates/vortex/src/lib.rs
@@ -18,7 +18,6 @@
         clippy::redundant_closure_for_method_calls,
         clippy::uninlined_format_args,
         clippy::unreadable_literal,
-        clippy::unwrap_used,
         reason = "vendored upstream tests intentionally keep upstream fixture style"
     )
 )]
@@ -110,7 +109,10 @@ mod common_tests {
                     factory.get_ext().to_uppercase(),
                     Arc::new(DefaultTableFactory::new()),
                 )
-                .with_object_store(&Url::try_from("file://").unwrap(), store.clone());
+                .with_object_store(
+                    &Url::try_from("file://").expect("file:// should parse as a URL"),
+                    store.clone(),
+                );
 
             if let Some(file_formats) = session_state_builder.file_formats() {
                 file_formats.push(factory as _);

--- a/crates/vortex/src/persistent/format.rs
+++ b/crates/vortex/src/persistent/format.rs
@@ -867,7 +867,8 @@ mod tests {
     #[test]
     fn format_plumbs_footer_initial_read_size() {
         let mut opts = VortexTableOptions::default();
-        opts.set("footer_initial_read_size_bytes", "12345").unwrap();
+        opts.set("footer_initial_read_size_bytes", "12345")
+            .expect("setting footer_initial_read_size_bytes should succeed");
 
         let format = VortexFormat::new_with_options(VortexSession::default(), opts);
         assert_eq!(format.options().footer_initial_read_size_bytes, 12345);
@@ -876,7 +877,8 @@ mod tests {
     #[test]
     fn format_plumbs_target_file_size_mb() {
         let mut opts = VortexTableOptions::default();
-        opts.set("target_file_size_mb", "123").unwrap();
+        opts.set("target_file_size_mb", "123")
+            .expect("setting target_file_size_mb should succeed");
 
         let format = VortexFormat::new_with_options(VortexSession::default(), opts);
         assert_eq!(format.options().target_file_size_mb, 123);
@@ -903,18 +905,22 @@ mod tests {
     #[test]
     fn format_plumbs_projection_pushdown_modes() {
         let mut opts = VortexTableOptions::default();
-        opts.set("projection_pushdown", "auto").unwrap();
+        opts.set("projection_pushdown", "auto")
+            .expect("setting projection_pushdown to auto should succeed");
         assert_eq!(opts.projection_pushdown, ProjectionPushdown::Auto);
         assert!(opts.projection_pushdown.enabled());
 
-        opts.set("projection_pushdown", "on").unwrap();
+        opts.set("projection_pushdown", "on")
+            .expect("setting projection_pushdown to on should succeed");
         assert_eq!(opts.projection_pushdown, ProjectionPushdown::On);
         assert!(opts.projection_pushdown.enabled());
 
-        opts.set("projection_pushdown", "true").unwrap();
+        opts.set("projection_pushdown", "true")
+            .expect("setting projection_pushdown to true should succeed");
         assert_eq!(opts.projection_pushdown, ProjectionPushdown::On);
 
-        opts.set("projection_pushdown", "off").unwrap();
+        opts.set("projection_pushdown", "off")
+            .expect("setting projection_pushdown to off should succeed");
         assert_eq!(opts.projection_pushdown, ProjectionPushdown::Off);
         assert!(!opts.projection_pushdown.enabled());
     }
@@ -922,16 +928,20 @@ mod tests {
     #[test]
     fn format_plumbs_scan_concurrency_modes() {
         let mut opts = VortexTableOptions::default();
-        opts.set("scan_concurrency", "auto").unwrap();
+        opts.set("scan_concurrency", "auto")
+            .expect("setting scan_concurrency to auto should succeed");
         assert_eq!(opts.scan_concurrency, ScanConcurrency::Auto);
 
-        opts.set("scan_concurrency", "off").unwrap();
+        opts.set("scan_concurrency", "off")
+            .expect("setting scan_concurrency to off should succeed");
         assert_eq!(opts.scan_concurrency, ScanConcurrency::Off);
 
-        opts.set("scan_concurrency", "00").unwrap();
+        opts.set("scan_concurrency", "00")
+            .expect("setting scan_concurrency to 00 should succeed");
         assert_eq!(opts.scan_concurrency, ScanConcurrency::Off);
 
-        opts.set("scan_concurrency", "3").unwrap();
+        opts.set("scan_concurrency", "3")
+            .expect("setting scan_concurrency to 3 should succeed");
         assert_eq!(opts.scan_concurrency, ScanConcurrency::Explicit(3));
     }
 

--- a/crates/vortex/src/persistent/mod.rs
+++ b/crates/vortex/src/persistent/mod.rs
@@ -209,7 +209,10 @@ mod tests {
 
         // Register an in-memory object store for the test.
         let store = Arc::new(InMemory::new());
-        ctx.register_object_store(&url::Url::try_from("file://").unwrap(), store);
+        ctx.register_object_store(
+            &url::Url::try_from("file://").expect("file:// should parse as a URL"),
+            store,
+        );
 
         // [create]
         ctx.sql(

--- a/crates/vortex/src/persistent/opener.rs
+++ b/crates/vortex/src/persistent/opener.rs
@@ -732,7 +732,8 @@ mod tests {
     async fn test_open() -> anyhow::Result<()> {
         let object_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
         let file_path = "part=1/file.vortex";
-        let batch = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(3)])).unwrap();
+        let batch = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(3)]))
+            .expect("test record batch should build");
         let data_size =
             write_arrow_to_vortex(object_store.clone(), file_path, batch.clone()).await?;
 
@@ -750,7 +751,11 @@ mod tests {
         let filter = logical2physical(&filter, table_schema.table_schema());
 
         let opener = make_opener(object_store.clone(), table_schema.clone(), Some(filter));
-        let stream = opener.open(file.clone()).unwrap().await.unwrap();
+        let stream = opener
+            .open(file.clone())
+            .expect("opener should open file with matching filter")
+            .await
+            .expect("opening matching-filter file should produce a stream");
 
         let data = stream.try_collect::<Vec<_>>().await?;
         let num_batches = data.len();
@@ -763,7 +768,11 @@ mod tests {
         let filter = logical2physical(&filter, table_schema.table_schema());
 
         let opener = make_opener(object_store.clone(), table_schema.clone(), Some(filter));
-        let stream = opener.open(file.clone()).unwrap().await.unwrap();
+        let stream = opener
+            .open(file.clone())
+            .expect("opener should open file with non-matching filter")
+            .await
+            .expect("opening non-matching-filter file should produce a stream");
 
         let data = stream.try_collect::<Vec<_>>().await?;
         let num_batches = data.len();
@@ -778,7 +787,8 @@ mod tests {
         use futures::TryStreamExt;
 
         let object_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
-        let data_batch = record_batch!(("a", Int32, Vec::<i32>::new())).unwrap();
+        let data_batch = record_batch!(("a", Int32, Vec::<i32>::new()))
+            .expect("empty record batch should build");
         let file_path = "part=1/empty.vortex";
         let file_size =
             write_arrow_to_vortex(Arc::clone(&object_store), file_path, data_batch.clone()).await?;
@@ -807,7 +817,8 @@ mod tests {
 
         let file1 = {
             let file1_path = "/path/file1.vortex";
-            let batch1 = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(3)])).unwrap();
+            let batch1 = record_batch!(("a", Int32, vec![Some(1), Some(2), Some(3)]))
+                .expect("Int32 record batch should build");
             let data_size1 =
                 write_arrow_to_vortex(object_store.clone(), file1_path, batch1).await?;
             PartitionedFile::new(file1_path.to_string(), data_size1)
@@ -815,7 +826,8 @@ mod tests {
 
         let file2 = {
             let file2_path = "/path/file2.vortex";
-            let batch2 = record_batch!(("a", Int16, vec![Some(-1), Some(-2), Some(-3)])).unwrap();
+            let batch2 = record_batch!(("a", Int16, vec![Some(-1), Some(-2), Some(-3)]))
+                .expect("Int16 record batch should build");
             let data_size2 =
                 write_arrow_to_vortex(object_store.clone(), file2_path, batch2).await?;
             PartitionedFile::new(file2_path.to_string(), data_size2)
@@ -905,7 +917,7 @@ mod tests {
             ("b", Int32, vec![Some(200), Some(201), Some(202)]),
             ("a", Int32, vec![Some(100), Some(101), Some(102)])
         )
-        .unwrap();
+        .expect("column-order test record batch should build");
         let data_size = write_arrow_to_vortex(object_store.clone(), file_path, batch).await?;
         let file = PartitionedFile::new(file_path.to_string(), data_size);
 
@@ -1046,7 +1058,7 @@ mod tests {
             ("b", Utf8, vec![Some("test")]),
             ("c", Int32, vec![Some(2)])
         )
-        .unwrap();
+        .expect("projection-repro record batch should build");
         let data_size = write_arrow_to_vortex(object_store.clone(), file_path, batch).await?;
 
         // Table schema has columns in DIFFERENT order: c, a, b
@@ -1125,7 +1137,7 @@ mod tests {
                 (0..=9).map(|i| Some(format!("r{}", i))).collect::<Vec<_>>()
             )
         )
-        .unwrap()
+        .expect("10-row test record batch should build")
     }
 
     fn make_test_opener(
@@ -1314,7 +1326,7 @@ mod tests {
             ("a", Int32, vec![Some(1), Some(2), Some(3)]),
             ("b", Int32, vec![Some(10), Some(20), Some(30)])
         )
-        .unwrap();
+        .expect("projection-pushdown record batch should build");
         let data_size =
             write_arrow_to_vortex(object_store.clone(), file_path, batch.clone()).await?;
 

--- a/crates/vortex/src/persistent/sink.rs
+++ b/crates/vortex/src/persistent/sink.rs
@@ -693,7 +693,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .expect("count column should be an Int64Array")
             .value(0);
 
         assert_eq!(
@@ -851,7 +851,8 @@ mod tests {
     fn test_output_file_path_single_file_and_collection() {
         use super::output_file_path;
 
-        let single = ListingTableUrl::parse("file:///tmp/output.vortex").unwrap();
+        let single = ListingTableUrl::parse("file:///tmp/output.vortex")
+            .expect("single-file listing table URL should parse");
         assert_eq!(
             output_file_path(&single, 0, "vortex", true, "wid").to_string(),
             "tmp/output.vortex"
@@ -861,7 +862,8 @@ mod tests {
             "tmp/output_00002.vortex"
         );
 
-        let collection = ListingTableUrl::parse("file:///tmp/table/").unwrap();
+        let collection = ListingTableUrl::parse("file:///tmp/table/")
+            .expect("collection listing table URL should parse");
         assert_eq!(
             output_file_path(&collection, 3, "vortex", false, "wid").to_string(),
             "tmp/table/wid_00003.vortex"
@@ -1067,7 +1069,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .expect("count column should be an Int64Array")
             .value(0);
 
         assert_eq!(count, expected_total_rows, "Total row count mismatch");
@@ -1273,7 +1275,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .expect("count column should be an Int64Array")
             .value(0);
 
         assert_eq!(count, expected_total_rows, "Total row count mismatch");
@@ -1375,7 +1377,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .expect("count column should be an Int64Array")
             .value(0);
         assert_eq!(count, expected_total_rows, "Total row count mismatch");
 
@@ -1460,7 +1462,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .expect("count column should be an Int64Array")
             .value(0);
         assert_eq!(count, expected_total_rows, "Total row count mismatch");
 
@@ -1571,7 +1573,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .expect("count column should be an Int64Array")
             .value(0);
         assert_eq!(count, expected_total_rows, "Total row count mismatch");
 
@@ -1692,7 +1694,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .expect("count column should be an Int64Array")
             .value(0);
         assert_eq!(count, expected_total_rows, "Total row count mismatch");
 
@@ -1813,7 +1815,7 @@ mod tests {
             .column(0)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .expect("count column should be an Int64Array")
             .value(0);
         assert_eq!(count, expected_total_rows, "Total row count mismatch");
 

--- a/crates/yaml/src/lib.rs
+++ b/crates/yaml/src/lib.rs
@@ -272,10 +272,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "tests use unwrap for concise assertions"
-)]
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
@@ -714,13 +710,13 @@ list:
         }
 
         let yaml = "display-name: test";
-        let config: Config = from_str(yaml).unwrap();
+        let config: Config = from_str(yaml).expect("should parse renamed field");
         assert_eq!(config.name, "test");
 
         let config = Config {
             name: "example".into(),
         };
-        let yaml = to_string(&config).unwrap();
+        let yaml = to_string(&config).expect("should serialize renamed field");
         assert!(yaml.contains("display-name:"));
     }
 
@@ -734,12 +730,12 @@ list:
 
         // Test original field name
         let yaml = "name: test";
-        let config: Config = from_str(yaml).unwrap();
+        let config: Config = from_str(yaml).expect("should parse original field name");
         assert_eq!(config.name, "test");
 
         // Test alias
         let yaml = "display_name: test";
-        let config: Config = from_str(yaml).unwrap();
+        let config: Config = from_str(yaml).expect("should parse aliased field name");
         assert_eq!(config.name, "test");
     }
 
@@ -761,7 +757,7 @@ list:
 name: test
 value: 42
 ";
-        let outer: Outer = from_str(yaml).unwrap();
+        let outer: Outer = from_str(yaml).expect("should parse flattened struct");
         assert_eq!(outer.name, "test");
         assert_eq!(outer.inner.value, 42);
     }
@@ -777,7 +773,7 @@ value: 42
 anchor_value: &my_anchor hello
 alias_value: *my_anchor
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse anchor and alias");
         assert_eq!(
             value.get("anchor_value").and_then(|v| v.as_str()),
             Some("hello")
@@ -800,10 +796,10 @@ development:
   database: dev_db
   settings: *defaults
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse anchor mapping");
 
         // Check defaults
-        let defaults = value.get("defaults").unwrap();
+        let defaults = value.get("defaults").expect("defaults key should exist");
         assert_eq!(
             defaults.get("adapter").and_then(|v| v.as_str()),
             Some("postgres")
@@ -814,7 +810,11 @@ development:
         );
 
         // Check that alias resolves correctly
-        let settings = value.get("development").unwrap().get("settings").unwrap();
+        let settings = value
+            .get("development")
+            .expect("development key should exist")
+            .get("settings")
+            .expect("settings key should exist");
         assert_eq!(
             settings.get("adapter").and_then(|v| v.as_str()),
             Some("postgres")
@@ -836,15 +836,18 @@ colors: &colors
 
 primary_colors: *colors
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse anchor sequence");
 
-        let colors = value.get("colors").and_then(|v| v.as_sequence()).unwrap();
+        let colors = value
+            .get("colors")
+            .and_then(|v| v.as_sequence())
+            .expect("colors should be a sequence");
         assert_eq!(colors.len(), 3);
 
         let primary = value
             .get("primary_colors")
             .and_then(|v| v.as_sequence())
-            .unwrap();
+            .expect("primary_colors should be a sequence");
         assert_eq!(primary.len(), 3);
         assert_eq!(primary[0].as_str(), Some("red"));
     }
@@ -858,7 +861,7 @@ second: &second 2
 ref_first: *first
 ref_second: *second
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse multiple anchors");
         assert_eq!(
             value.get("first").and_then(super::value::Value::as_i64),
             Some(1)
@@ -892,8 +895,11 @@ refs:
   - *item1
   - *item2
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let refs = value.get("refs").and_then(|v| v.as_sequence()).unwrap();
+        let value: Value = from_str(yaml).expect("should parse anchors in sequence");
+        let refs = value
+            .get("refs")
+            .and_then(|v| v.as_sequence())
+            .expect("refs should be a sequence");
         assert_eq!(refs[0].get("name").and_then(|v| v.as_str()), Some("first"));
         assert_eq!(refs[1].get("name").and_then(|v| v.as_str()), Some("second"));
     }
@@ -911,8 +917,10 @@ development:
   <<: *defaults
   database: dev_db
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let dev = value.get("development").unwrap();
+        let value: Value = from_str(yaml).expect("should parse merge key");
+        let dev = value
+            .get("development")
+            .expect("development key should exist");
 
         // Check that merge happened
         assert_eq!(dev.get("database").and_then(|v| v.as_str()), Some("dev_db"));
@@ -935,8 +943,10 @@ production:
   <<: *defaults
   host: prod.example.com
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let prod = value.get("production").unwrap();
+        let value: Value = from_str(yaml).expect("should parse merge key override");
+        let prod = value
+            .get("production")
+            .expect("production key should exist");
 
         // adapter should come from merge
         assert_eq!(
@@ -964,8 +974,8 @@ combined:
   <<: [*base, *extra]
   value: 42
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let combined = value.get("combined").unwrap();
+        let value: Value = from_str(yaml).expect("should parse multiple merge sources");
+        let combined = value.get("combined").expect("combined key should exist");
 
         assert_eq!(combined.get("name").and_then(|v| v.as_str()), Some("base"));
         assert_eq!(
@@ -993,17 +1003,32 @@ null1: null
 null2: ~
 null3:
 ";
-        let value: Value = from_str(yaml).unwrap();
-        assert!(value.get("null1").unwrap().is_null());
-        assert!(value.get("null2").unwrap().is_null());
-        assert!(value.get("null3").unwrap().is_null());
+        let value: Value = from_str(yaml).expect("should parse null variations");
+        assert!(
+            value
+                .get("null1")
+                .expect("null1 key should exist")
+                .is_null()
+        );
+        assert!(
+            value
+                .get("null2")
+                .expect("null2 key should exist")
+                .is_null()
+        );
+        assert!(
+            value
+                .get("null3")
+                .expect("null3 key should exist")
+                .is_null()
+        );
 
         // Verify that capitalized versions are strings in YAML 1.2
         let yaml_11_style = r"
 null_cap: Null
 null_upper: NULL
 ";
-        let value: Value = from_str(yaml_11_style).unwrap();
+        let value: Value = from_str(yaml_11_style).expect("should parse capitalized null strings");
         // These are strings in YAML 1.2, not null
         assert_eq!(value.get("null_cap").and_then(|v| v.as_str()), Some("Null"));
         assert_eq!(
@@ -1024,7 +1049,7 @@ false1: false
 false2: False
 false3: FALSE
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse boolean variations");
 
         // True variations (case-insensitive in yaml-rust2)
         assert_eq!(
@@ -1061,7 +1086,7 @@ no_val: no
 on_val: on
 off_val: off
 ";
-        let value: Value = from_str(yaml_11_style).unwrap();
+        let value: Value = from_str(yaml_11_style).expect("should parse YAML 1.1 bool strings");
         assert_eq!(value.get("yes_val").and_then(|v| v.as_str()), Some("yes"));
         assert_eq!(value.get("no_val").and_then(|v| v.as_str()), Some("no"));
         assert_eq!(value.get("on_val").and_then(|v| v.as_str()), Some("on"));
@@ -1077,7 +1102,7 @@ negative: -17
 hex: 0x2A
 octal: 0o52
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse integer formats");
         assert_eq!(
             value.get("decimal").and_then(super::value::Value::as_i64),
             Some(42)
@@ -1107,13 +1132,13 @@ infinity: .inf
 neg_infinity: -.inf
 not_a_number: .nan
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse float formats");
 
         assert!(
             (value
                 .get("float1")
                 .and_then(super::value::Value::as_f64)
-                .unwrap()
+                .expect("float1 should be a float")
                 - 3.15)
                 .abs()
                 < 0.001
@@ -1122,7 +1147,7 @@ not_a_number: .nan
             (value
                 .get("float2")
                 .and_then(super::value::Value::as_f64)
-                .unwrap()
+                .expect("float2 should be a float")
                 - (-0.5))
                 .abs()
                 < 0.001
@@ -1131,7 +1156,7 @@ not_a_number: .nan
             (value
                 .get("scientific")
                 .and_then(super::value::Value::as_f64)
-                .unwrap()
+                .expect("scientific should be a float")
                 - 1200.0)
                 .abs()
                 < 0.001
@@ -1140,28 +1165,28 @@ not_a_number: .nan
             value
                 .get("infinity")
                 .and_then(super::value::Value::as_f64)
-                .unwrap()
+                .expect("infinity should be a float")
                 .is_infinite()
         );
         assert!(
             value
                 .get("neg_infinity")
                 .and_then(super::value::Value::as_f64)
-                .unwrap()
+                .expect("neg_infinity should be a float")
                 .is_infinite()
         );
         assert!(
             value
                 .get("neg_infinity")
                 .and_then(super::value::Value::as_f64)
-                .unwrap()
+                .expect("neg_infinity should be a float")
                 .is_sign_negative()
         );
         assert!(
             value
                 .get("not_a_number")
                 .and_then(super::value::Value::as_f64)
-                .unwrap()
+                .expect("not_a_number should be a float")
                 .is_nan()
         );
     }
@@ -1178,7 +1203,7 @@ double: "hello world"
 single_escape: 'it''s a test'
 double_escape: "line1\nline2"
 "#;
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse quoted strings");
         assert_eq!(
             value.get("single").and_then(|v| v.as_str()),
             Some("hello world")
@@ -1206,8 +1231,11 @@ literal: |
   Line 2
   Line 3
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let literal = value.get("literal").and_then(|v| v.as_str()).unwrap();
+        let value: Value = from_str(yaml).expect("should parse literal block scalar");
+        let literal = value
+            .get("literal")
+            .and_then(|v| v.as_str())
+            .expect("literal should be a string");
         assert!(literal.contains("Line 1"));
         assert!(literal.contains("Line 2"));
         assert!(literal.contains("Line 3"));
@@ -1223,8 +1251,11 @@ folded: >
   line that will be
   folded into one.
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let folded = value.get("folded").and_then(|v| v.as_str()).unwrap();
+        let value: Value = from_str(yaml).expect("should parse folded block scalar");
+        let folded = value
+            .get("folded")
+            .and_then(|v| v.as_str())
+            .expect("folded should be a string");
         // Folded should join lines with spaces
         assert!(folded.contains("This is a long"));
     }
@@ -1241,10 +1272,19 @@ keep: |+
   text
 
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let strip = value.get("strip").and_then(|v| v.as_str()).unwrap();
-        let clip = value.get("clip").and_then(|v| v.as_str()).unwrap();
-        let keep = value.get("keep").and_then(|v| v.as_str()).unwrap();
+        let value: Value = from_str(yaml).expect("should parse block chomping");
+        let strip = value
+            .get("strip")
+            .and_then(|v| v.as_str())
+            .expect("strip should be a string");
+        let clip = value
+            .get("clip")
+            .and_then(|v| v.as_str())
+            .expect("clip should be a string");
+        let keep = value
+            .get("keep")
+            .and_then(|v| v.as_str())
+            .expect("keep should be a string");
 
         // Strip removes all trailing newlines
         assert!(!strip.ends_with('\n'));
@@ -1265,13 +1305,25 @@ keep: |+
 flow: [1, 2, 3, 4, 5]
 nested: [[1, 2], [3, 4]]
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let flow = value.get("flow").and_then(|v| v.as_sequence()).unwrap();
+        let value: Value = from_str(yaml).expect("should parse flow sequence");
+        let flow = value
+            .get("flow")
+            .and_then(|v| v.as_sequence())
+            .expect("flow should be a sequence");
         assert_eq!(flow.len(), 5);
 
-        let nested = value.get("nested").and_then(|v| v.as_sequence()).unwrap();
+        let nested = value
+            .get("nested")
+            .and_then(|v| v.as_sequence())
+            .expect("nested should be a sequence");
         assert_eq!(nested.len(), 2);
-        assert_eq!(nested[0].as_sequence().unwrap().len(), 2);
+        assert_eq!(
+            nested[0]
+                .as_sequence()
+                .expect("nested[0] should be a sequence")
+                .len(),
+            2
+        );
     }
 
     #[test]
@@ -1280,19 +1332,19 @@ nested: [[1, 2], [3, 4]]
 flow: {name: John, age: 30}
 nested: {outer: {inner: value}}
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let flow = value.get("flow").unwrap();
+        let value: Value = from_str(yaml).expect("should parse flow mapping");
+        let flow = value.get("flow").expect("flow key should exist");
         assert_eq!(flow.get("name").and_then(|v| v.as_str()), Some("John"));
         assert_eq!(
             flow.get("age").and_then(super::value::Value::as_i64),
             Some(30)
         );
 
-        let nested = value.get("nested").unwrap();
+        let nested = value.get("nested").expect("nested key should exist");
         assert_eq!(
             nested
                 .get("outer")
-                .unwrap()
+                .expect("outer key should exist")
                 .get("inner")
                 .and_then(|v| v.as_str()),
             Some("value")
@@ -1309,8 +1361,11 @@ config:
   list: [a, b, c]
   map: {key: value}
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let items = value.get("items").and_then(|v| v.as_sequence()).unwrap();
+        let value: Value = from_str(yaml).expect("should parse mixed flow and block");
+        let items = value
+            .get("items")
+            .and_then(|v| v.as_sequence())
+            .expect("items should be a sequence");
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].get("name").and_then(|v| v.as_str()), Some("item1"));
     }
@@ -1323,7 +1378,7 @@ config:
   - b
 : value
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse complex keys");
         assert!(value.is_mapping());
     }
 
@@ -1339,7 +1394,7 @@ config:
 string_num: !!str 123
 float_val: !!float 42
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse explicit type tags");
         // !!str should make it a string
         assert_eq!(
             value.get("string_num").and_then(|v| v.as_str()),
@@ -1348,7 +1403,7 @@ float_val: !!float 42
         // !!float should make it a float
         let float_val = value.get("float_val").and_then(super::value::Value::as_f64);
         assert!(float_val.is_some());
-        assert!((float_val.unwrap() - 42.0).abs() < 0.001);
+        assert!((float_val.expect("float_val should be a float") - 42.0).abs() < 0.001);
     }
 
     // ============================================================
@@ -1365,9 +1420,12 @@ list:
   - item1 # comment
   - item2
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse yaml with comments");
         assert_eq!(value.get("key").and_then(|v| v.as_str()), Some("value"));
-        let list = value.get("list").and_then(|v| v.as_sequence()).unwrap();
+        let list = value
+            .get("list")
+            .and_then(|v| v.as_sequence())
+            .expect("list should be a sequence");
         assert_eq!(list.len(), 2);
     }
 
@@ -1382,16 +1440,21 @@ empty_string: ""
 empty_array: []
 empty_map: {}
 "#;
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse empty values");
         assert_eq!(value.get("empty_string").and_then(|v| v.as_str()), Some(""));
         assert!(
             value
                 .get("empty_array")
                 .and_then(|v| v.as_sequence())
-                .unwrap()
+                .expect("empty_array should be a sequence")
                 .is_empty()
         );
-        assert!(value.get("empty_map").unwrap().is_mapping());
+        assert!(
+            value
+                .get("empty_map")
+                .expect("empty_map key should exist")
+                .is_mapping()
+        );
     }
 
     #[test]
@@ -1402,7 +1465,7 @@ hash: "has # hash"
 bracket: "has [bracket]"
 brace: "has {brace}"
 "#;
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse special characters in strings");
         assert_eq!(
             value.get("colon").and_then(|v| v.as_str()),
             Some("has: colon")
@@ -1428,7 +1491,7 @@ emoji: 🎉
 chinese: 中文
 mixed: "Hello 世界 🌍"
 "#;
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse unicode");
         assert_eq!(value.get("emoji").and_then(|v| v.as_str()), Some("🎉"));
         assert_eq!(value.get("chinese").and_then(|v| v.as_str()), Some("中文"));
         assert_eq!(
@@ -1447,18 +1510,18 @@ level1:
         level5:
           value: deep
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse deeply nested mapping");
         let deep = value
             .get("level1")
-            .unwrap()
+            .expect("level1 key should exist")
             .get("level2")
-            .unwrap()
+            .expect("level2 key should exist")
             .get("level3")
-            .unwrap()
+            .expect("level3 key should exist")
             .get("level4")
-            .unwrap()
+            .expect("level4 key should exist")
             .get("level5")
-            .unwrap()
+            .expect("level5 key should exist")
             .get("value");
         assert_eq!(deep.and_then(|v| v.as_str()), Some("deep"));
     }
@@ -1470,7 +1533,7 @@ large_int: 9223372036854775807
 large_neg: -9223372036854775808
 large_float: 1.7976931348623157e+308
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse large numbers");
         assert_eq!(
             value.get("large_int").and_then(super::value::Value::as_i64),
             Some(i64::MAX)
@@ -1483,7 +1546,7 @@ large_float: 1.7976931348623157e+308
             value
                 .get("large_float")
                 .and_then(super::value::Value::as_f64)
-                .unwrap()
+                .expect("large_float should be a float")
                 > 1e300
         );
     }
@@ -1494,7 +1557,7 @@ large_float: 1.7976931348623157e+308
         let yaml = r"---
 key: value
 ...";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse document markers");
         assert_eq!(value.get("key").and_then(|v| v.as_str()), Some("value"));
     }
 
@@ -1508,11 +1571,11 @@ four_space:
     deeply:
         nested: value
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse indentation variants");
         assert_eq!(
             value
                 .get("two_space")
-                .unwrap()
+                .expect("two_space key should exist")
                 .get("nested")
                 .and_then(|v| v.as_str()),
             Some("value")
@@ -1520,9 +1583,9 @@ four_space:
         assert_eq!(
             value
                 .get("four_space")
-                .unwrap()
+                .expect("four_space key should exist")
                 .get("deeply")
-                .unwrap()
+                .expect("deeply key should exist")
                 .get("nested")
                 .and_then(|v| v.as_str()),
             Some("value")
@@ -1549,10 +1612,10 @@ derived:
     <<: *config
     timeout: 60
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let derived = value.get("derived").unwrap();
+        let value: Value = from_str(yaml).expect("should parse nested anchors and merges");
+        let derived = value.get("derived").expect("derived key should exist");
         assert_eq!(derived.get("name").and_then(|v| v.as_str()), Some("base"));
-        let config = derived.get("config").unwrap();
+        let config = derived.get("config").expect("config key should exist");
         assert_eq!(
             config.get("timeout").and_then(super::value::Value::as_i64),
             Some(60)
@@ -1574,11 +1637,11 @@ use1: *tmpl
 use2: *tmpl
 use3: *tmpl
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse reused anchors");
         assert_eq!(
             value
                 .get("use1")
-                .unwrap()
+                .expect("use1 key should exist")
                 .get("key")
                 .and_then(|v| v.as_str()),
             Some("value")
@@ -1586,7 +1649,7 @@ use3: *tmpl
         assert_eq!(
             value
                 .get("use2")
-                .unwrap()
+                .expect("use2 key should exist")
                 .get("key")
                 .and_then(|v| v.as_str()),
             Some("value")
@@ -1594,7 +1657,7 @@ use3: *tmpl
         assert_eq!(
             value
                 .get("use3")
-                .unwrap()
+                .expect("use3 key should exist")
                 .get("key")
                 .and_then(|v| v.as_str()),
             Some("value")
@@ -1617,8 +1680,8 @@ second: &second
 merged:
   <<: [*first, *second]
 ";
-        let value: Value = from_str(yaml).unwrap();
-        let merged = value.get("merged").unwrap();
+        let value: Value = from_str(yaml).expect("should parse merge priority");
+        let merged = value.get("merged").expect("merged key should exist");
         // First anchor takes precedence for duplicate keys
         assert_eq!(
             merged.get("key").and_then(|v| v.as_str()),
@@ -1645,7 +1708,7 @@ merged:
 binary: !!binary |
   R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse binary data");
         // Binary data is typically returned as a string
         assert!(value.get("binary").is_some());
     }
@@ -1658,7 +1721,7 @@ date1: 2024-01-15
 date2: 2024-01-15T10:30:00Z
 date3: 2024-01-15 10:30:00 -05:00
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse timestamps");
         // Timestamps are typically returned as strings in yaml-rust2
         assert!(value.get("date1").is_some());
         assert!(value.get("date2").is_some());
@@ -1676,7 +1739,7 @@ backslash: "path\\to\\file"
 quote: "say \"hello\""
 unicode: "smiley: \u263A"
 "#;
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse escape sequences");
         assert_eq!(
             value.get("tab").and_then(|v| v.as_str()),
             Some("hello\tworld")
@@ -1703,7 +1766,7 @@ unicode: "smiley: \u263A"
 : complex_value
 simple_key: simple_value
 ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse explicit key");
         assert!(value.is_mapping());
         assert_eq!(
             value.get("complex_key").and_then(|v| v.as_str()),
@@ -1719,11 +1782,11 @@ simple_key: simple_value
     fn test_yaml_empty_document() {
         // Test empty and whitespace-only documents
         let yaml = "";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse empty document");
         assert!(value.is_null());
 
         let yaml = "   \n\n   ";
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse whitespace-only document");
         assert!(value.is_null());
     }
 
@@ -1737,7 +1800,7 @@ url: http://example.com
 time: "10:30:00"
 message: "key: value pair"
 "#;
-        let value: Value = from_str(yaml).unwrap();
+        let value: Value = from_str(yaml).expect("should parse colons in values");
         assert_eq!(
             value.get("url").and_then(|v| v.as_str()),
             Some("http://example.com")
@@ -1776,8 +1839,8 @@ message: "key: value pair"
             .collect(),
         };
 
-        let yaml = to_string(&original).unwrap();
-        let parsed: ComplexConfig = from_str(&yaml).unwrap();
+        let yaml = to_string(&original).expect("should serialize complex config");
+        let parsed: ComplexConfig = from_str(&yaml).expect("should parse complex config back");
         assert_eq!(original, parsed);
     }
 
@@ -2228,12 +2291,18 @@ folded: > # Another header comment
   folded text here
 ";
         let value: Value = from_str(yaml).expect("should parse block scalar with header comment");
-        let literal = value.get("literal").and_then(|v| v.as_str()).unwrap();
+        let literal = value
+            .get("literal")
+            .and_then(|v| v.as_str())
+            .expect("literal should be a string");
         assert!(
             literal.contains("some text here"),
             "literal content should not include the header comment"
         );
-        let folded = value.get("folded").and_then(|v| v.as_str()).unwrap();
+        let folded = value
+            .get("folded")
+            .and_then(|v| v.as_str())
+            .expect("folded should be a string");
         assert!(
             folded.contains("folded text here"),
             "folded content should not include the header comment"
@@ -2252,9 +2321,15 @@ keep: |+ # keep comment
 ";
         let value: Value =
             from_str(yaml).expect("should parse block scalar with chomping + comment");
-        let strip = value.get("strip").and_then(|v| v.as_str()).unwrap();
+        let strip = value
+            .get("strip")
+            .and_then(|v| v.as_str())
+            .expect("strip should be a string");
         assert_eq!(strip, "stripped text");
-        let keep = value.get("keep").and_then(|v| v.as_str()).unwrap();
+        let keep = value
+            .get("keep")
+            .and_then(|v| v.as_str())
+            .expect("keep should be a string");
         assert!(keep.starts_with("kept text"));
     }
 
@@ -2313,7 +2388,10 @@ keep: |+ # keep comment
         let yaml = "{items: [1, 2, 3,], name: test,}";
         let value: Value =
             from_str(yaml).expect("should parse nested flow collections with trailing commas");
-        let items = value.get("items").and_then(|v| v.as_sequence()).unwrap();
+        let items = value
+            .get("items")
+            .and_then(|v| v.as_sequence())
+            .expect("items should be a sequence");
         assert_eq!(items.len(), 3);
     }
 
@@ -2322,7 +2400,10 @@ keep: |+ # keep comment
         // Empty flow sequence
         let yaml = "items: []";
         let value: Value = from_str(yaml).expect("should parse empty flow sequence");
-        let items = value.get("items").and_then(|v| v.as_sequence()).unwrap();
+        let items = value
+            .get("items")
+            .and_then(|v| v.as_sequence())
+            .expect("items should be a sequence");
         assert!(items.is_empty(), "empty flow sequence should have 0 items");
     }
 
@@ -2331,7 +2412,10 @@ keep: |+ # keep comment
         // Empty flow mapping
         let yaml = "data: {}";
         let value: Value = from_str(yaml).expect("should parse empty flow mapping");
-        let data = value.get("data").and_then(|v| v.as_mapping()).unwrap();
+        let data = value
+            .get("data")
+            .and_then(|v| v.as_mapping())
+            .expect("data should be a mapping");
         assert!(data.is_empty(), "empty flow mapping should have 0 entries");
     }
 
@@ -2345,7 +2429,7 @@ keep: |+ # keep comment
         let yaml = "{}";
         let value: Value = from_str(yaml).expect("should parse bare empty mapping");
         assert!(value.is_mapping());
-        assert!(value.as_mapping().unwrap().is_empty());
+        assert!(value.as_mapping().expect("should be a mapping").is_empty());
     }
 
     #[test]
@@ -2378,7 +2462,7 @@ metadata: {}
 - five: six
 ";
         let value: Value = from_str(yaml).expect("should parse compact nested mapping in sequence");
-        let seq = value.as_sequence().unwrap();
+        let seq = value.as_sequence().expect("top level should be a sequence");
         assert_eq!(seq.len(), 2);
         assert_eq!(seq[0].get("one").and_then(|v| v.as_str()), Some("two"));
         assert_eq!(seq[0].get("three").and_then(|v| v.as_str()), Some("four"));
@@ -2395,9 +2479,11 @@ metadata: {}
   - four
 ";
         let value: Value = from_str(yaml).expect("should parse compact nested sequences");
-        let outer = value.as_sequence().unwrap();
+        let outer = value.as_sequence().expect("top level should be a sequence");
         assert_eq!(outer.len(), 2);
-        let inner0 = outer[0].as_sequence().unwrap();
+        let inner0 = outer[0]
+            .as_sequence()
+            .expect("inner element should be a sequence");
         assert_eq!(inner0.len(), 2);
         assert_eq!(inner0[0].as_str(), Some("one"));
         assert_eq!(inner0[1].as_str(), Some("two"));
@@ -2417,7 +2503,10 @@ products:
 ";
         let value: Value =
             from_str(yaml).expect("should parse compact nested mapping in sequence value");
-        let products = value.get("products").and_then(|v| v.as_sequence()).unwrap();
+        let products = value
+            .get("products")
+            .and_then(|v| v.as_sequence())
+            .expect("products should be a sequence");
         assert_eq!(products.len(), 3);
         assert_eq!(
             products[0].get("item").and_then(Value::as_str),
@@ -2440,7 +2529,10 @@ products:
         // Line breaks are folded into spaces, empty lines become line feeds
         let yaml = "value: ' 1st non-empty\n\n 2nd non-empty \n 3rd non-empty '";
         let value: Value = from_str(yaml).expect("should parse multi-line single-quoted scalar");
-        let s = value.get("value").and_then(|v| v.as_str()).unwrap();
+        let s = value
+            .get("value")
+            .and_then(|v| v.as_str())
+            .expect("value should be a string");
         // Per YAML spec, single newline folds to space, blank line becomes \n
         assert_eq!(s, " 1st non-empty\n2nd non-empty 3rd non-empty ");
     }
@@ -2451,7 +2543,10 @@ products:
         let yaml = "value: 'line one\n  line two'";
         let value: Value =
             from_str(yaml).expect("should parse simple multi-line single-quoted scalar");
-        let s = value.get("value").and_then(|v| v.as_str()).unwrap();
+        let s = value
+            .get("value")
+            .and_then(|v| v.as_str())
+            .expect("value should be a string");
         // Single newline folds to space
         assert_eq!(s, "line one line two");
     }


### PR DESCRIPTION
## What

Removes every `clippy::unwrap_used` suppression in the codebase and converts the test-code `unwrap`s they covered to `expect`/`expect_err` with descriptive messages.

`clippy::unwrap_used` is denied on both the `--lib --bins` and `--tests` clippy passes (see `Makefile`), while `expect` is allowed in tests (`clippy.toml`: `allow-expect-in-tests = true`). The suppressions below were the only places test code still used `unwrap`.

### Suppressions removed
- `data_components/sharepoint/{url,object_store,auth/saml}.rs` — `#[expect(clippy::unwrap_used)]` on the test modules
- `yaml/src/lib.rs` — `#[expect(clippy::unwrap_used)]` on `mod tests`
- `vortex/src/lib.rs` — `clippy::unwrap_used` from the crate-level `cfg_attr(test, expect(...))`
- `hash-index/benches/lookup.rs` — `clippy::unwrap_used` from the `#![allow(...)]` list (vestigial; no unwraps under it)

### Conversions
- `.unwrap()` → `.expect("…")` and `.unwrap_err()` → `.expect_err("…")` (the lint covers both), each with a meaningful, distinguishable message.
- ~190 call sites across the `yaml`, `vortex`, and `sharepoint` test modules.

### Kept (intentionally)
- `#![deny(clippy::unwrap_used)]` enforcement in `hash-index` and `yaml` — these are enforcement, not suppressions.
- Doc-comment (`//!`/`///`) `.unwrap()` examples in `yaml` — not linted by clippy and idiomatic in documentation.

### Incidental
- Fixes a pre-existing `match_wildcard_for_single_variants` nit in the sharepoint `object_store` test (`_ =>` → `GetResultPayload::File(..) =>`), exposed only when linting with the `sharepoint` feature (which `make lint-rust` does not enable).

## Testing
`cargo clippy --tests` with the `make lint-rust` tests-pass flags (`-Dclippy::pedantic -Dclippy::unwrap_used -Aclippy::expect_used …`) on `yaml`, `vortex-datafusion`, `hash-index`, and `data_components` (with `--features sharepoint,sharepoint-mock-host`) — clean across all four crates.
