### PR TITLE
Fix fetched_at for HTTP connector

### DIFF
--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -38,7 +38,7 @@ const HTTP_RESULT_COLUMNS: [&str; 7] = [
     "content",
     RESPONSE_STATUS_COLUMN,
     "response_headers",
-    "fetched_at",
+    "_fetched_at",
 ];
 
 /// Filter out transient HTTP error responses (5xx server errors and 429 Too Many Requests)

--- a/crates/data_components/src/http/json_nest.rs
+++ b/crates/data_components/src/http/json_nest.rs
@@ -41,7 +41,7 @@ limitations under the License.
 //! In addition, declared columns whose names match one of the HTTP
 //! connector's built-in metadata fields (`request_path`,
 //! `request_query`, `request_body`, `request_headers`, `content`,
-//! `response_status`, `response_headers`, `fetched_at`) are *passed
+//! `response_status`, `response_headers`, `_fetched_at`) are *passed
 //! through* from the HTTP request/response rather than being decomposed
 //! from the JSON body. This lets queries reference both decomposed
 //! columns and the original HTTP metadata (e.g. for direct fetches via

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -850,7 +850,7 @@ impl HttpTableProvider {
                 true,
             ),
             Field::new(
-                "fetched_at",
+                "_fetched_at",
                 DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None),
                 true,
             ),
@@ -1818,7 +1818,7 @@ impl HttpExec {
                 }
                 Ok(Arc::new(builder.finish()) as ArrayRef)
             }
-            "fetched_at" => {
+            "_fetched_at" => {
                 use arrow::array::TimestampNanosecondArray;
                 Ok(Arc::new(TimestampNanosecondArray::from(vec![
                     timestamp_nanos;
@@ -1831,7 +1831,7 @@ impl HttpExec {
         }
     }
 
-    /// Compute the per-batch `fetched_at` timestamp in nanoseconds since
+    /// Compute the per-batch `_fetched_at` timestamp in nanoseconds since
     /// the Unix epoch, preferring the response `Date` header and falling
     /// back to the current system time.
     fn compute_fetched_at_nanos(fetch_result: &HttpFetchResult) -> DataFusionResult<i64> {
@@ -4234,7 +4234,7 @@ mod tests {
         assert_eq!(schema.field(4).name(), "content");
         assert_eq!(schema.field(5).name(), "response_status");
         assert_eq!(schema.field(6).name(), "response_headers");
-        assert_eq!(schema.field(7).name(), "fetched_at");
+        assert_eq!(schema.field(7).name(), "_fetched_at");
         assert_eq!(*schema.field(0).data_type(), DataType::Utf8);
         assert_eq!(*schema.field(1).data_type(), DataType::Utf8);
         assert_eq!(*schema.field(2).data_type(), DataType::Utf8);
@@ -4256,7 +4256,7 @@ mod tests {
         assert!(!schema.field(4).is_nullable()); // content is not nullable
         assert!(!schema.field(5).is_nullable()); // response_status is not nullable
         assert!(schema.field(6).is_nullable()); // response_headers is nullable
-        assert!(schema.field(7).is_nullable()); // fetched_at is nullable
+        assert!(schema.field(7).is_nullable()); // _fetched_at is nullable
     }
 
     #[tokio::test]

--- a/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
+++ b/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
@@ -395,12 +395,12 @@ mod tests {
         Arc::new(Schema::new(vec![
             Field::new("request_path", DataType::Utf8, false),
             Field::new("content", DataType::Utf8, true),
-            Field::new("fetched_at", DataType::Int64, true),
+            Field::new("_fetched_at", DataType::Int64, true),
         ]))
     }
 
     fn expected_output_schema() -> SchemaRef {
-        // User expects only 2 columns (no fetched_at)
+        // User expects only 2 columns (no _fetched_at)
         Arc::new(Schema::new(vec![
             Field::new("request_path", DataType::Utf8, false),
             Field::new("content", DataType::Utf8, true),
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     fn test_schema_returns_expected_schema_not_input_schema() {
         // Simulates the cache HIT scenario from GitHub issue #9019:
-        // Input has 3 columns (including internal fetched_at), but user only requested 2 columns.
+        // Input has 3 columns (including internal _fetched_at), but user only requested 2 columns.
         // SchemaCastScanExec should return the expected 2-column schema, not the input's 3-column schema.
         let input = Arc::new(EmptyExec::new(input_schema_with_extra_column()));
         let expected_schema = expected_output_schema();
@@ -421,7 +421,7 @@ mod tests {
         assert_eq!(
             actual_schema.fields().len(),
             2,
-            "Schema should have 2 fields, not 3 (fetched_at should be stripped)"
+            "Schema should have 2 fields, not 3 (_fetched_at should be stripped)"
         );
         assert_eq!(
             actual_schema.field(0).name(),

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -56,7 +56,7 @@ use util::expr::combine_exprs_balanced;
 /// triggering a new revalidation to avoid duplicate upstream requests during the SWR window.
 pub type InFlightRevalidations = Arc<Mutex<HashSet<String>>>;
 
-pub const CACHE_REFRESHED_AT_COLUMN: &str = "fetched_at";
+pub const CACHE_REFRESHED_AT_COLUMN: &str = "_fetched_at";
 
 /// Reserved column name added to caching-mode accelerator storage to scope
 /// cached rows by [`runtime_request_context::CacheNamespace`]. The column is
@@ -2001,7 +2001,7 @@ mod cache_namespace_column_tests {
     fn reserved_column_name_is_case_insensitive() {
         assert!(is_reserved_caching_column(CACHE_NAMESPACE_COLUMN));
         assert!(is_reserved_caching_column("__SPICE_CACHE_NAMESPACE"));
-        assert!(!is_reserved_caching_column("fetched_at"));
+        assert!(!is_reserved_caching_column("_fetched_at"));
         assert!(!is_reserved_caching_column("request_path"));
     }
 
@@ -2995,7 +2995,7 @@ mod tests {
         assert_eq!(
             freshness,
             CacheFreshness::Expired,
-            "Batches without fetched_at column should be expired"
+            "Batches without _fetched_at column should be expired"
         );
     }
 
@@ -3024,7 +3024,7 @@ mod tests {
         assert_eq!(
             freshness,
             CacheFreshness::Expired,
-            "Batches with NULL fetched_at should be expired"
+            "Batches with NULL _fetched_at should be expired"
         );
     }
 

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1415,7 +1415,7 @@ impl TableProvider for AcceleratedTable {
 
         // For caching mode, extend the accelerator scan projection to
         // include the storage-only columns the caching pipeline needs:
-        // `fetched_at` (freshness check inside
+        // `_fetched_at` (freshness check inside
         // `CachingAccelerationScanExec`) and `__spice_cache_namespace`
         // (per-principal isolation `FilterExec` applied below). The added
         // columns are stripped from the user-facing output by
@@ -1611,7 +1611,7 @@ impl TableProvider for AcceleratedTable {
         };
 
         // Compute the target schema based on user's original projection.
-        // SchemaCastScanExec strips extra columns (like fetched_at added for caching)
+        // SchemaCastScanExec strips extra columns (like _fetched_at added for caching)
         // and casts types. The schema should match what the user requested.
         let target_schema = match projection {
             Some(indices) => {
@@ -1846,7 +1846,7 @@ impl TableProvider for AcceleratedTable {
 }
 
 /// Extends projection to include columns required by the caching pipeline
-/// for accelerator scans: `fetched_at` (freshness check) and
+/// for accelerator scans: `_fetched_at` (freshness check) and
 /// `__spice_cache_namespace` (per-principal isolation filter applied as a
 /// hard `FilterExec` on top of the scan).
 ///
@@ -2123,7 +2123,7 @@ mod tests {
         assert_eq!(
             extended,
             vec![0, 2, 3],
-            "Should add fetched_at index at end"
+            "Should add _fetched_at index at end"
         );
     }
 
@@ -2136,7 +2136,7 @@ mod tests {
         assert_eq!(
             extended,
             vec![2, 3],
-            "Should add fetched_at to single column"
+            "Should add _fetched_at to single column"
         );
     }
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -678,7 +678,7 @@ impl RefreshTask {
             RefreshMode::Append => self.get_incremental_append_update(refresh).await,
             RefreshMode::Changes => unreachable!("changes are handled upstream"),
             RefreshMode::Caching => {
-                // For caching mode, identify and refresh stale rows based on fetched_at and TTL
+                // For caching mode, identify and refresh stale rows based on _fetched_at and TTL
                 return self.refresh_stale_cached_rows(refresh).await;
             }
             RefreshMode::Snapshot => {

--- a/crates/runtime/src/dataaccelerator/spice_sys/caching_engine/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/caching_engine/duckdb.rs
@@ -52,7 +52,7 @@ impl CachingEngineSys {
 
         // Update fetched_at for the table
         let update_query = format!(
-            "UPDATE \"{table_name}\" SET fetched_at = (now() AT TIME ZONE 'UTC')::TIMESTAMP_NS"
+            "UPDATE \"{table_name}\" SET _fetched_at = (now() AT TIME ZONE 'UTC')::TIMESTAMP_NS"
         );
         tx.execute(&update_query, []).map_err(Error::external)?;
 

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -2594,7 +2594,7 @@ mod tests {
         // User explicitly declares _fetched_at.
         dataset.columns = vec![
             Column::new("id"),
-            Column::new("fetched_at"),
+            Column::new("_fetched_at"),
             column_with_marker("details", Value::String("*".to_string())),
         ];
         let nesting = parse_http_json_nesting(&dataset)

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -1161,7 +1161,7 @@ fn parse_http_json_nesting(dataset: &Dataset) -> DataConnectorResult<Option<Http
 
     // Ensure `fetched_at` is always present so caching TTL eviction and
     // append-mode `time_column` work even when the user omits the column.
-    const FETCHED_AT: &str = "fetched_at";
+    const FETCHED_AT: &str = "_fetched_at";
     if !column_order.iter().any(|n| n == FETCHED_AT) {
         column_order.push(FETCHED_AT.to_string());
         metadata_fields.insert(FETCHED_AT.to_string());
@@ -1188,7 +1188,7 @@ const HTTP_METADATA_FIELDS: &[&str] = &[
     "content",
     "response_status",
     "response_headers",
-    "fetched_at",
+    "_fetched_at",
 ];
 
 #[async_trait]
@@ -2282,14 +2282,14 @@ mod tests {
         assert_eq!(nesting.json_field_name, "data");
         assert_eq!(
             nesting.column_order,
-            vec!["id", "name", "data", "fetched_at"]
+            vec!["id", "name", "data", "_fetched_at"]
         );
         assert!(nesting.static_fields.contains("id"));
         assert!(nesting.static_fields.contains("name"));
         assert!(!nesting.static_fields.contains("data"));
         assert!(
-            nesting.metadata_fields.contains("fetched_at"),
-            "fetched_at should be auto-injected into metadata_fields"
+            nesting.metadata_fields.contains("_fetched_at"),
+            "_fetched_at should be auto-injected into metadata_fields"
         );
     }
 
@@ -2375,13 +2375,19 @@ mod tests {
         assert_eq!(nesting.json_field_name, "data");
         assert_eq!(
             nesting.column_order,
-            vec!["request_path", "response_status", "id", "data", "fetched_at"]
+            vec![
+                "request_path",
+                "response_status",
+                "id",
+                "data",
+                "_fetched_at"
+            ]
         );
         assert!(nesting.metadata_fields.contains("request_path"));
         assert!(nesting.metadata_fields.contains("response_status"));
         assert!(
-            nesting.metadata_fields.contains("fetched_at"),
-            "fetched_at should be auto-injected into metadata_fields"
+            nesting.metadata_fields.contains("_fetched_at"),
+            "_fetched_at should be auto-injected into metadata_fields"
         );
         assert!(
             !nesting.metadata_fields.contains("id"),
@@ -2391,7 +2397,7 @@ mod tests {
         // fields, otherwise the body would shadow the HTTP metadata.
         assert!(!nesting.static_fields.contains("request_path"));
         assert!(!nesting.static_fields.contains("response_status"));
-        assert!(!nesting.static_fields.contains("fetched_at"));
+        assert!(!nesting.static_fields.contains("_fetched_at"));
         assert!(nesting.static_fields.contains("id"));
     }
 
@@ -2487,7 +2493,7 @@ mod tests {
         ];
         let schema = static_schema_for_https_dataset(&params, &dataset)
             .expect("json_nest dynamic mode -> Some");
-        // 3 user-declared columns + auto-injected fetched_at
+        // 3 user-declared columns + auto-injected _fetched_at
         assert_eq!(schema.fields().len(), 4);
         // User-declared columns default to Utf8.
         for name in &["id", "name", "data"] {
@@ -2499,8 +2505,8 @@ mod tests {
             );
             assert!(f.is_nullable());
         }
-        // Auto-injected fetched_at gets its type from base_table_schema.
-        let fetched_at = schema.field_with_name("fetched_at").unwrap();
+        // Auto-injected _fetched_at gets its type from base_table_schema.
+        let fetched_at = schema.field_with_name("_fetched_at").unwrap();
         assert_eq!(
             fetched_at.data_type(),
             &arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
@@ -2511,7 +2517,7 @@ mod tests {
                 .iter()
                 .map(|f| f.name().clone())
                 .collect::<Vec<_>>(),
-            vec!["id", "name", "data", "fetched_at"]
+            vec!["id", "name", "data", "_fetched_at"]
         );
     }
 
@@ -2526,7 +2532,7 @@ mod tests {
         ];
         let schema = static_schema_for_https_dataset(&params, &dataset)
             .expect("json_nest dynamic mode -> Some");
-        // 3 user-declared columns + auto-injected fetched_at
+        // 3 user-declared columns + auto-injected _fetched_at
         assert_eq!(schema.fields().len(), 4);
         assert_eq!(schema.field(0).name(), "id");
         assert_eq!(schema.field(0).data_type(), &arrow_schema::DataType::Int64);
@@ -2535,7 +2541,7 @@ mod tests {
         assert_eq!(schema.field(1).data_type(), &arrow_schema::DataType::Utf8);
         assert_eq!(schema.field(2).name(), "data");
         assert_eq!(schema.field(2).data_type(), &arrow_schema::DataType::Utf8);
-        assert_eq!(schema.field(3).name(), "fetched_at");
+        assert_eq!(schema.field(3).name(), "_fetched_at");
         assert_eq!(
             schema.field(3).data_type(),
             &arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
@@ -2557,7 +2563,7 @@ mod tests {
     #[tokio::test]
     async fn parse_http_json_nesting_auto_injects_fetched_at() {
         let mut dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
-        // User declares only body columns + catch-all, no fetched_at.
+        // User declares only body columns + catch-all, no _fetched_at.
         dataset.columns = vec![
             Column::new("id"),
             Column::new("title"),
@@ -2568,25 +2574,25 @@ mod tests {
             .expect("expected Some(nesting)");
 
         assert!(
-            nesting.column_order.contains(&"fetched_at".to_string()),
-            "fetched_at should be auto-injected into column_order"
+            nesting.column_order.contains(&"_fetched_at".to_string()),
+            "_fetched_at should be auto-injected into column_order"
         );
         assert!(
-            nesting.metadata_fields.contains("fetched_at"),
-            "fetched_at should be in metadata_fields"
+            nesting.metadata_fields.contains("_fetched_at"),
+            "_fetched_at should be in metadata_fields"
         );
         assert!(
-            !nesting.static_fields.contains("fetched_at"),
-            "fetched_at must not be a static body field"
+            !nesting.static_fields.contains("_fetched_at"),
+            "_fetched_at must not be a static body field"
         );
         // Auto-injected at the end, after user-declared columns.
-        assert_eq!(nesting.column_order.last().unwrap(), "fetched_at");
+        assert_eq!(nesting.column_order.last().unwrap(), "_fetched_at");
     }
 
     #[tokio::test]
     async fn parse_http_json_nesting_does_not_duplicate_fetched_at() {
         let mut dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
-        // User explicitly declares fetched_at.
+        // User explicitly declares _fetched_at.
         dataset.columns = vec![
             Column::new("id"),
             Column::new("fetched_at"),
@@ -2599,12 +2605,12 @@ mod tests {
         let count = nesting
             .column_order
             .iter()
-            .filter(|n| *n == "fetched_at")
+            .filter(|n| *n == "_fetched_at")
             .count();
-        assert_eq!(count, 1, "fetched_at should not be duplicated");
-        assert!(nesting.metadata_fields.contains("fetched_at"));
+        assert_eq!(count, 1, "_fetched_at should not be duplicated");
+        assert!(nesting.metadata_fields.contains("_fetched_at"));
         // When user declares it, it stays in the user's position.
-        assert_eq!(nesting.column_order[1], "fetched_at");
+        assert_eq!(nesting.column_order[1], "_fetched_at");
     }
 
     #[tokio::test]
@@ -2617,15 +2623,16 @@ mod tests {
         let nesting = parse_http_json_nesting(&dataset)
             .expect("parse should succeed")
             .expect("expected Some(nesting)");
-        let schema = build_json_nest_schema(&dataset, &nesting).expect("schema build should succeed");
+        let schema =
+            build_json_nest_schema(&dataset, &nesting).expect("schema build should succeed");
 
         let fetched_at = schema
-            .field_with_name("fetched_at")
-            .expect("fetched_at should be present in the schema");
+            .field_with_name("_fetched_at")
+            .expect("_fetched_at should be present in the schema");
         assert_eq!(
             fetched_at.data_type(),
             &arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
-            "fetched_at should have its base_table_schema type"
+            "_fetched_at should have its base_table_schema type"
         );
     }
 }

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -1136,7 +1136,8 @@ fn parse_http_json_nesting(dataset: &Dataset) -> DataConnectorResult<Option<Http
         });
     }
 
-    let column_order: Vec<String> = dataset.columns.iter().map(|col| col.name.clone()).collect();
+    let mut column_order: Vec<String> =
+        dataset.columns.iter().map(|col| col.name.clone()).collect();
 
     // Reject the catch-all column itself being named after a reserved
     // HTTP metadata field — it would be ambiguous whether the column
@@ -1152,11 +1153,19 @@ fn parse_http_json_nesting(dataset: &Dataset) -> DataConnectorResult<Option<Http
         });
     }
 
-    let metadata_fields: std::collections::HashSet<String> = column_order
+    let mut metadata_fields: std::collections::HashSet<String> = column_order
         .iter()
         .filter(|name| HTTP_METADATA_FIELDS.contains(&name.as_str()))
         .cloned()
         .collect();
+
+    // Ensure `fetched_at` is always present so caching TTL eviction and
+    // append-mode `time_column` work even when the user omits the column.
+    const FETCHED_AT: &str = "fetched_at";
+    if !column_order.iter().any(|n| n == FETCHED_AT) {
+        column_order.push(FETCHED_AT.to_string());
+        metadata_fields.insert(FETCHED_AT.to_string());
+    }
 
     Ok(Some(HttpJsonNesting::new(
         column_order,
@@ -2271,10 +2280,17 @@ mod tests {
             .expect("parse should succeed")
             .expect("expected Some(nesting) when marker is present");
         assert_eq!(nesting.json_field_name, "data");
-        assert_eq!(nesting.column_order, vec!["id", "name", "data"]);
+        assert_eq!(
+            nesting.column_order,
+            vec!["id", "name", "data", "fetched_at"]
+        );
         assert!(nesting.static_fields.contains("id"));
         assert!(nesting.static_fields.contains("name"));
         assert!(!nesting.static_fields.contains("data"));
+        assert!(
+            nesting.metadata_fields.contains("fetched_at"),
+            "fetched_at should be auto-injected into metadata_fields"
+        );
     }
 
     #[tokio::test]
@@ -2359,10 +2375,14 @@ mod tests {
         assert_eq!(nesting.json_field_name, "data");
         assert_eq!(
             nesting.column_order,
-            vec!["request_path", "response_status", "id", "data"]
+            vec!["request_path", "response_status", "id", "data", "fetched_at"]
         );
         assert!(nesting.metadata_fields.contains("request_path"));
         assert!(nesting.metadata_fields.contains("response_status"));
+        assert!(
+            nesting.metadata_fields.contains("fetched_at"),
+            "fetched_at should be auto-injected into metadata_fields"
+        );
         assert!(
             !nesting.metadata_fields.contains("id"),
             "non-reserved column must not be classified as metadata"
@@ -2371,6 +2391,7 @@ mod tests {
         // fields, otherwise the body would shadow the HTTP metadata.
         assert!(!nesting.static_fields.contains("request_path"));
         assert!(!nesting.static_fields.contains("response_status"));
+        assert!(!nesting.static_fields.contains("fetched_at"));
         assert!(nesting.static_fields.contains("id"));
     }
 
@@ -2466,23 +2487,31 @@ mod tests {
         ];
         let schema = static_schema_for_https_dataset(&params, &dataset)
             .expect("json_nest dynamic mode -> Some");
-        assert_eq!(schema.fields().len(), 3);
-        for f in schema.fields() {
+        // 3 user-declared columns + auto-injected fetched_at
+        assert_eq!(schema.fields().len(), 4);
+        // User-declared columns default to Utf8.
+        for name in &["id", "name", "data"] {
+            let f = schema.field_with_name(name).unwrap();
             assert_eq!(
                 f.data_type(),
                 &arrow_schema::DataType::Utf8,
-                "untyped json_nest column should default to Utf8 (field {})",
-                f.name()
+                "untyped json_nest column should default to Utf8 (field {name})",
             );
             assert!(f.is_nullable());
         }
+        // Auto-injected fetched_at gets its type from base_table_schema.
+        let fetched_at = schema.field_with_name("fetched_at").unwrap();
+        assert_eq!(
+            fetched_at.data_type(),
+            &arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
+        );
         assert_eq!(
             schema
                 .fields()
                 .iter()
                 .map(|f| f.name().clone())
                 .collect::<Vec<_>>(),
-            vec!["id", "name", "data"]
+            vec!["id", "name", "data", "fetched_at"]
         );
     }
 
@@ -2497,7 +2526,8 @@ mod tests {
         ];
         let schema = static_schema_for_https_dataset(&params, &dataset)
             .expect("json_nest dynamic mode -> Some");
-        assert_eq!(schema.fields().len(), 3);
+        // 3 user-declared columns + auto-injected fetched_at
+        assert_eq!(schema.fields().len(), 4);
         assert_eq!(schema.field(0).name(), "id");
         assert_eq!(schema.field(0).data_type(), &arrow_schema::DataType::Int64);
         assert!(!schema.field(0).is_nullable());
@@ -2505,6 +2535,11 @@ mod tests {
         assert_eq!(schema.field(1).data_type(), &arrow_schema::DataType::Utf8);
         assert_eq!(schema.field(2).name(), "data");
         assert_eq!(schema.field(2).data_type(), &arrow_schema::DataType::Utf8);
+        assert_eq!(schema.field(3).name(), "fetched_at");
+        assert_eq!(
+            schema.field(3).data_type(),
+            &arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
+        );
     }
 
     #[tokio::test]
@@ -2517,5 +2552,80 @@ mod tests {
         ];
         // Defer the user-facing error to the eager path.
         assert!(static_schema_for_https_dataset(&params, &dataset).is_none());
+    }
+
+    #[tokio::test]
+    async fn parse_http_json_nesting_auto_injects_fetched_at() {
+        let mut dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
+        // User declares only body columns + catch-all, no fetched_at.
+        dataset.columns = vec![
+            Column::new("id"),
+            Column::new("title"),
+            column_with_marker("extra", Value::String("*".to_string())),
+        ];
+        let nesting = parse_http_json_nesting(&dataset)
+            .expect("parse should succeed")
+            .expect("expected Some(nesting)");
+
+        assert!(
+            nesting.column_order.contains(&"fetched_at".to_string()),
+            "fetched_at should be auto-injected into column_order"
+        );
+        assert!(
+            nesting.metadata_fields.contains("fetched_at"),
+            "fetched_at should be in metadata_fields"
+        );
+        assert!(
+            !nesting.static_fields.contains("fetched_at"),
+            "fetched_at must not be a static body field"
+        );
+        // Auto-injected at the end, after user-declared columns.
+        assert_eq!(nesting.column_order.last().unwrap(), "fetched_at");
+    }
+
+    #[tokio::test]
+    async fn parse_http_json_nesting_does_not_duplicate_fetched_at() {
+        let mut dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
+        // User explicitly declares fetched_at.
+        dataset.columns = vec![
+            Column::new("id"),
+            Column::new("fetched_at"),
+            column_with_marker("details", Value::String("*".to_string())),
+        ];
+        let nesting = parse_http_json_nesting(&dataset)
+            .expect("parse should succeed")
+            .expect("expected Some(nesting)");
+
+        let count = nesting
+            .column_order
+            .iter()
+            .filter(|n| *n == "fetched_at")
+            .count();
+        assert_eq!(count, 1, "fetched_at should not be duplicated");
+        assert!(nesting.metadata_fields.contains("fetched_at"));
+        // When user declares it, it stays in the user's position.
+        assert_eq!(nesting.column_order[1], "fetched_at");
+    }
+
+    #[tokio::test]
+    async fn build_json_nest_schema_includes_fetched_at_when_auto_injected() {
+        let mut dataset = test_dataset("http://example.com/api", RefreshMode::Append, None).await;
+        dataset.columns = vec![
+            Column::new("id"),
+            column_with_marker("data", Value::String("*".to_string())),
+        ];
+        let nesting = parse_http_json_nesting(&dataset)
+            .expect("parse should succeed")
+            .expect("expected Some(nesting)");
+        let schema = build_json_nest_schema(&dataset, &nesting).expect("schema build should succeed");
+
+        let fetched_at = schema
+            .field_with_name("fetched_at")
+            .expect("fetched_at should be present in the schema");
+        assert_eq!(
+            fetched_at.data_type(),
+            &arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
+            "fetched_at should have its base_table_schema type"
+        );
     }
 }

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -1161,10 +1161,9 @@ fn parse_http_json_nesting(dataset: &Dataset) -> DataConnectorResult<Option<Http
 
     // Ensure `fetched_at` is always present so caching TTL eviction and
     // append-mode `time_column` work even when the user omits the column.
-    const FETCHED_AT: &str = "_fetched_at";
-    if !column_order.iter().any(|n| n == FETCHED_AT) {
-        column_order.push(FETCHED_AT.to_string());
-        metadata_fields.insert(FETCHED_AT.to_string());
+    if !column_order.iter().any(|n| n == "_fetched_at") {
+        column_order.push("_fetched_at".to_string());
+        metadata_fields.insert("_fetched_at".to_string());
     }
 
     Ok(Some(HttpJsonNesting::new(

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -2496,7 +2496,9 @@ mod tests {
         assert_eq!(schema.fields().len(), 4);
         // User-declared columns default to Utf8.
         for name in &["id", "name", "data"] {
-            let f = schema.field_with_name(name).unwrap();
+            let f = schema
+                .field_with_name(name)
+                .expect("declared json_nest test column should exist in schema");
             assert_eq!(
                 f.data_type(),
                 &arrow_schema::DataType::Utf8,
@@ -2505,7 +2507,9 @@ mod tests {
             assert!(f.is_nullable());
         }
         // Auto-injected _fetched_at gets its type from base_table_schema.
-        let fetched_at = schema.field_with_name("_fetched_at").unwrap();
+        let fetched_at = schema
+            .field_with_name("_fetched_at")
+            .expect("_fetched_at should be present in dynamic json_nest schema");
         assert_eq!(
             fetched_at.data_type(),
             &arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
@@ -2585,7 +2589,13 @@ mod tests {
             "_fetched_at must not be a static body field"
         );
         // Auto-injected at the end, after user-declared columns.
-        assert_eq!(nesting.column_order.last().unwrap(), "_fetched_at");
+        assert_eq!(
+            nesting
+                .column_order
+                .last()
+                .expect("column_order should include auto-injected _fetched_at"),
+            "_fetched_at"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -1524,12 +1524,12 @@ async fn update_cached_dataset_timestamps(dataset: &Dataset) {
         Ok(caching_sys) => {
             if let Err(e) = caching_sys.update_fetched_at() {
                 tracing::warn!(
-                    "Failed to update fetched_at for cached dataset {}: {e}",
+                    "Failed to update _fetched_at for cached dataset {}: {e}",
                     dataset.name
                 );
             } else {
                 tracing::info!(
-                    "Updated fetched_at for all records in cached dataset {}",
+                    "Updated _fetched_at for all records in cached dataset {}",
                     dataset.name
                 );
             }

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -1670,7 +1670,7 @@ async fn test_caching_mode_background_refresh_on_stale() -> Result<(), anyhow::E
 
             assert!(
                 refreshed_fetched_at > initial_fetched_at,
-                "fetched_at should be updated after background refresh (initial: {initial_fetched_at}, refreshed: {refreshed_fetched_at})"
+                "_fetched_at should be updated after background refresh (initial: {initial_fetched_at}, refreshed: {refreshed_fetched_at})"
             );
             eprintln!("TEST: Step 4 complete - cache refreshed in background (new _fetched_at: {}, delta: {} ns)",
                 refreshed_fetched_at,
@@ -1758,7 +1758,7 @@ async fn test_caching_mode_interval_refresh_with_retention() -> Result<(), anyho
             let df = runtime
                 .datafusion()
                 .ctx
-                .sql("SELECT content, fetched_at FROM tvmaze WHERE request_query = 'q=lauren'")
+                .sql("SELECT content, _fetched_at FROM tvmaze WHERE request_query = 'q=lauren'")
                 .await?;
             let results = df.clone().collect().await?;
             assert_eq!(results.len(), 1, "Should have 1 batch");

--- a/crates/runtime/tests/acceleration/caching_mode.rs
+++ b/crates/runtime/tests/acceleration/caching_mode.rs
@@ -1454,7 +1454,7 @@ async fn test_caching_mode_background_refresh_on_miss() -> Result<(), anyhow::Er
                 .await?
                 .filter(col("request_path").eq(lit("/search/people")))?
                 .filter(col("request_query").eq(lit("q=background")))?
-                .select(vec![col("request_path"), col("request_query"), col("fetched_at")])?
+                .select(vec![col("request_path"), col("request_query"), col("_fetched_at")])?
                 .limit(0, Some(1))?;
 
             let batches2 = df2.collect().await?;
@@ -1478,12 +1478,12 @@ async fn test_caching_mode_background_refresh_on_miss() -> Result<(), anyhow::Er
                 .column(2)
                 .as_any()
                 .downcast_ref::<TimestampNanosecondArray>()
-                .expect("fetched_at should be TimestampNanosecondArray");
+                .expect("_fetched_at should be TimestampNanosecondArray");
             assert!(
                 !fetched_at_array2.is_null(0),
-                "fetched_at should be set (background refresh populated cache)"
+                "_fetched_at should be set (background refresh populated cache)"
             );
-            eprintln!("TEST: Step 2 complete - data served from cache with fetched_at timestamp set");
+            eprintln!("TEST: Step 2 complete - data served from cache with _fetched_at timestamp set");
 
             eprintln!("\nTEST SUMMARY:");
             eprintln!("✅ Step 1: Cache miss → fetch from source → background cache population triggered");
@@ -1567,7 +1567,7 @@ async fn test_caching_mode_background_refresh_on_stale() -> Result<(), anyhow::E
                 .await?
                 .filter(col("request_path").eq(lit("/search/people")))?
                 .filter(col("request_query").eq(lit("q=staleness")))?
-                .select(vec![col("request_path"), col("request_query"), col("fetched_at")])?
+                .select(vec![col("request_path"), col("request_query"), col("_fetched_at")])?
                 .limit(0, Some(1))?;
 
             let batches1 = df1.collect().await?;
@@ -1577,15 +1577,15 @@ async fn test_caching_mode_background_refresh_on_stale() -> Result<(), anyhow::E
             );
             assert_eq!(batches1[0].num_rows(), 1, "Should have 1 row");
 
-            // Capture the initial fetched_at timestamp
+            // Capture the initial _fetched_at timestamp
             let batch1 = &batches1[0];
             let fetched_at_array1 = batch1
                 .column(2)
                 .as_any()
                 .downcast_ref::<TimestampNanosecondArray>()
-                .expect("fetched_at should be TimestampNanosecondArray");
+                .expect("_fetched_at should be TimestampNanosecondArray");
             let initial_fetched_at = fetched_at_array1.value(0);
-            eprintln!("TEST: Step 1 complete - cache populated with fresh data (fetched_at: {initial_fetched_at})");
+            eprintln!("TEST: Step 1 complete - cache populated with fresh data (_fetched_at: {initial_fetched_at})");
 
             // Small delay to ensure cache is populated
             tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
@@ -1604,7 +1604,7 @@ async fn test_caching_mode_background_refresh_on_stale() -> Result<(), anyhow::E
                 .await?
                 .filter(col("request_path").eq(lit("/search/people")))?
                 .filter(col("request_query").eq(lit("q=staleness")))?
-                .select(vec![col("request_path"), col("request_query"), col("fetched_at")])?
+                .select(vec![col("request_path"), col("request_query"), col("_fetched_at")])?
                 .limit(0, Some(1))?;
 
             let batches2 = df2.collect().await?;
@@ -1626,18 +1626,18 @@ async fn test_caching_mode_background_refresh_on_stale() -> Result<(), anyhow::E
                 "Should return data (even though stale)"
             );
 
-            // Verify this is still the old data (same fetched_at as initial)
+            // Verify this is still the old data (same _fetched_at as initial)
             let fetched_at_array2 = batch2
                 .column(2)
                 .as_any()
                 .downcast_ref::<TimestampNanosecondArray>()
-                .expect("fetched_at should be TimestampNanosecondArray");
+                .expect("_fetched_at should be TimestampNanosecondArray");
             let stale_fetched_at = fetched_at_array2.value(0);
             assert_eq!(
                 stale_fetched_at, initial_fetched_at,
                 "Should return stale data with original timestamp"
             );
-            eprintln!("TEST: Step 3 complete - stale data returned (fetched_at unchanged: {stale_fetched_at}), background refresh triggered");
+            eprintln!("TEST: Step 3 complete - stale data returned (_fetched_at unchanged: {stale_fetched_at}), background refresh triggered");
 
             // Wait for background refresh to complete
             eprintln!("TEST: Waiting for background refresh to update cache...");
@@ -1652,27 +1652,27 @@ async fn test_caching_mode_background_refresh_on_stale() -> Result<(), anyhow::E
                 .await?
                 .filter(col("request_path").eq(lit("/search/people")))?
                 .filter(col("request_query").eq(lit("q=staleness")))?
-                .select(vec![col("request_path"), col("request_query"), col("fetched_at")])?
+                .select(vec![col("request_path"), col("request_query"), col("_fetched_at")])?
                 .limit(0, Some(1))?;
 
             let batches3 = df3.collect().await?;
             assert!(!batches3.is_empty(), "Should have refreshed cache data");
             assert_eq!(batches3[0].num_rows(), 1, "Should have 1 row");
 
-            // Verify the fetched_at timestamp was updated (background refresh occurred)
+            // Verify the _fetched_at timestamp was updated (background refresh occurred)
             let batch3 = &batches3[0];
             let fetched_at_array3 = batch3
                 .column(2)
                 .as_any()
                 .downcast_ref::<TimestampNanosecondArray>()
-                .expect("fetched_at should be TimestampNanosecondArray");
+                .expect("_fetched_at should be TimestampNanosecondArray");
             let refreshed_fetched_at = fetched_at_array3.value(0);
 
             assert!(
                 refreshed_fetched_at > initial_fetched_at,
                 "fetched_at should be updated after background refresh (initial: {initial_fetched_at}, refreshed: {refreshed_fetched_at})"
             );
-            eprintln!("TEST: Step 4 complete - cache refreshed in background (new fetched_at: {}, delta: {} ns)",
+            eprintln!("TEST: Step 4 complete - cache refreshed in background (new _fetched_at: {}, delta: {} ns)",
                 refreshed_fetched_at,
                 refreshed_fetched_at - initial_fetched_at
             );
@@ -1765,14 +1765,14 @@ async fn test_caching_mode_interval_refresh_with_retention() -> Result<(), anyho
             assert!(results[0].num_rows() > 0, "Should have at least 1 row");
 
             let fetched_at_array = results[0]
-                .column_by_name("fetched_at")
-                .expect("fetched_at column should exist")
+                .column_by_name("_fetched_at")
+                .expect("_fetched_at column should exist")
                 .as_any()
                 .downcast_ref::<TimestampNanosecondArray>()
-                .expect("fetched_at should be TimestampNanosecondArray");
+                .expect("_fetched_at should be TimestampNanosecondArray");
             let initial_fetched_at = fetched_at_array.value(0);
             let initial_row_count = results[0].num_rows();
-            eprintln!("TEST: Step 1 complete - cache populated with {initial_row_count} row(s), initial fetched_at: {initial_fetched_at}");
+            eprintln!("TEST: Step 1 complete - cache populated with {initial_row_count} row(s), initial _fetched_at: {initial_fetched_at}");
 
             // Step 2: Wait for refresh_check_interval to potentially trigger
             // For caching mode, the interval refresh should check for stale data and refresh it
@@ -1785,20 +1785,20 @@ async fn test_caching_mode_interval_refresh_with_retention() -> Result<(), anyho
             let df3 = runtime
                 .datafusion()
                 .ctx
-                .sql("SELECT content, fetched_at FROM tvmaze WHERE request_query = 'q=lauren'")
+                .sql("SELECT content, _fetched_at FROM tvmaze WHERE request_query = 'q=lauren'")
                 .await?;
             let results3 = df3.collect().await?;
             assert_eq!(results3.len(), 1, "Should have 1 batch");
 
             let fetched_at_array3 = results3[0]
-                .column_by_name("fetched_at")
-                .expect("fetched_at column should exist")
+                .column_by_name("_fetched_at")
+                .expect("_fetched_at column should exist")
                 .as_any()
                 .downcast_ref::<TimestampNanosecondArray>()
-                .expect("fetched_at should be TimestampNanosecondArray");
+                .expect("_fetched_at should be TimestampNanosecondArray");
             let refreshed_fetched_at = fetched_at_array3.value(0);
 
-            eprintln!("TEST: Initial fetched_at: {}, After interval: {}, Delta: {} ns",
+            eprintln!("TEST: Initial _fetched_at: {}, After interval: {}, Delta: {} ns",
                 initial_fetched_at, refreshed_fetched_at, refreshed_fetched_at.saturating_sub(initial_fetched_at));
             eprintln!("TEST: Step 3 complete - checked for interval refresh");
 
@@ -1812,24 +1812,24 @@ async fn test_caching_mode_interval_refresh_with_retention() -> Result<(), anyho
             let df5 = runtime
                 .datafusion()
                 .ctx
-                .sql("SELECT content, fetched_at FROM tvmaze WHERE request_query = 'q=lauren'")
+                .sql("SELECT content, _fetched_at FROM tvmaze WHERE request_query = 'q=lauren'")
                 .await?;
             let results5 = df5.collect().await?;
 
             // After retention, the data should either:
-            // 1. Be evicted and cause a fresh fetch (new fetched_at)
+            // 1. Be evicted and cause a fresh fetch (new _fetched_at)
             // 2. Or still be there if retention hasn't run yet
             // We'll check if the fetched_at changed significantly
             if !results5.is_empty() && results5[0].num_rows() > 0 {
                 let fetched_at_array5 = results5[0]
-                    .column_by_name("fetched_at")
-                    .expect("fetched_at column should exist")
+                    .column_by_name("_fetched_at")
+                    .expect("_fetched_at column should exist")
                     .as_any()
                     .downcast_ref::<TimestampNanosecondArray>()
-                    .expect("fetched_at should be TimestampNanosecondArray");
+                    .expect("_fetched_at should be TimestampNanosecondArray");
                 let final_fetched_at = fetched_at_array5.value(0);
 
-                eprintln!("TEST: Final fetched_at: {}, Delta from initial: {} ns",
+                eprintln!("TEST: Final _fetched_at: {}, Delta from initial: {} ns",
                     final_fetched_at, final_fetched_at.saturating_sub(initial_fetched_at));
 
                 // If retention worked and data was re-fetched, it should be significantly newer


### PR DESCRIPTION
## 📝 Summary
  - When `json_object: "*"` is used on an HTTP connector dataset, fetched_at is now automatically included in the schema even if the user doesn't declare it
  - Fixes caching TTL eviction silently failing (rows never evicted) and append-mode `time_column: fetched_at` hard startup error

### UX change
When `json_object: "*"` is specified for HTTP connector, `fetched_at` is still a column. 

## 🔗 Related
Resolves  #10615
