### PR TITLE
fix(search): propagate LIMIT to base TableScan in VectorScanTableProvider (fixes #8368)

### DIFF
--- a/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_limit_pushdown_schema_sufficient.snap
+++ b/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_limit_pushdown_schema_sufficient.snap
@@ -1,0 +1,13 @@
+---
+source: crates/search/src/index/vector_table.rs
+expression: "format!(\"{}\", pretty::pretty_format_batches(&col).map_err(|e| e.to_string())?)"
+---
++---------------+---------------------------------------------------------------------------+
+| plan_type     | plan                                                                      |
++---------------+---------------------------------------------------------------------------+
+| logical_plan  | Projection: my_vectored_table.pk, my_vectored_table.another_column        |
+|               |   Limit: skip=0, fetch=5                                                  |
+|               |     TableScan: my_vectored_table projection=[another_column, pk], fetch=5 |
+| physical_plan | BaseTable: projection=["pk", "another_column"] filter=[] limit=Some(5)    |
+|               |                                                                           |
++---------------+---------------------------------------------------------------------------+

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -219,7 +219,7 @@ impl TableProvider for VectorScanTableProvider {
             &columns_requested,
             filters,
         ) {
-            let lp = Self::apply_proj_and_filter(
+            let mut builder = Self::apply_proj_and_filter(
                 LogicalPlanBuilder::scan(
                     "base_table",
                     Arc::new(DefaultTableSource::new(Arc::clone(&self.table_provider))),
@@ -227,8 +227,18 @@ impl TableProvider for VectorScanTableProvider {
                 )?,
                 &columns_requested,
                 filters,
-            )?
-            .build()?;
+            )?;
+
+            // The caller's TableScan may carry a `fetch` that was just pushed down by
+            // DataFusion's LimitPushdown. The schema-sufficient branch builds a fresh
+            // inner LogicalPlan against the base table, so we must re-apply the limit
+            // here — otherwise the inner plan's TableScan keeps `fetch=None` and the
+            // underlying provider scans the whole table.
+            if limit.is_some() {
+                builder = builder.limit(0, limit)?;
+            }
+
+            let lp = builder.build()?;
 
             return state.create_physical_plan(&lp).await;
         }
@@ -738,6 +748,62 @@ mod tests {
             TableReference::parse_str("my_vectored_table"),
             "SELECT pk, body_embedding from my_vectored_table WHERE another_column != 'something' ORDER BY pk desc LIMIT 5",
             "scan_table_join_for_filter",
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/8368>: when the
+    /// outer query carries a `LIMIT` that DataFusion pushes onto the `TableScan` as
+    /// `fetch=N`, `VectorScanTableProvider::scan` receives `limit=Some(N)`. The
+    /// schema-sufficient branch must re-apply the limit on the inner plan so it
+    /// reaches the base table provider — otherwise the underlying scan runs without
+    /// a limit and reads far more data than necessary.
+    #[tokio::test]
+    pub async fn test_vector_scan_limit_pushdown_schema_sufficient() -> Result<(), String> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("pk", DataType::Int64, false),
+            Field::new("body", DataType::Utf8, false),
+            Field::new("another_column", DataType::Utf8, false),
+        ]));
+
+        let p = VectorScanTableProvider::try_new(
+            Arc::new(ExplainMemTable::new(
+                MemTable::try_new(
+                    Arc::clone(&schema),
+                    vec![vec![one_row_default_record_batch_for_schema(&schema)]],
+                )
+                .expect("could not make MemTable"),
+                "BaseTable",
+            )),
+            &(Arc::new(PretendVectorIndex::new(
+                "body".to_string(),
+                vec![Field::new("pk", DataType::Int64, false)],
+                Schema::new(vec![
+                    Field::new("pk", DataType::Int64, false),
+                    Field::new(
+                        "body_embedding",
+                        DataType::new_fixed_size_list(DataType::Float32, 10, false),
+                        false,
+                    ),
+                ]),
+            )) as Arc<dyn VectorIndex>),
+        )
+        .expect("could not make 'VectorScanTableProvider'");
+
+        let provider: Arc<dyn TableProvider> = Arc::new(p);
+
+        // Schema-sufficient: every selected column is in the base table. The bare
+        // `LIMIT` (no `ORDER BY`) lets DataFusion fold the limit into the outer
+        // TableScan's `fetch`, so `VectorScanTableProvider::scan` is called with
+        // `limit=Some(5)`. After the fix the inner BaseTable plan must show
+        // `limit=Some(5)`; before the fix it shows `limit=None`.
+        test_explain(
+            Arc::clone(&provider),
+            TableReference::parse_str("my_vectored_table"),
+            "SELECT pk, another_column from my_vectored_table LIMIT 5",
+            "scan_table_limit_pushdown_schema_sufficient",
         )
         .await?;
 


### PR DESCRIPTION
## Summary

Fixes #8368.

When a dataset has both an acceleration and an s3 vector index, queries with a `LIMIT` were not reaching the underlying base table provider (e.g. Iceberg). The outer `TableScan` carried `fetch=N`, but `VectorScanTableProvider::scan`'s schema-sufficient branch built a fresh inner `LogicalPlan` and discarded the `limit` parameter, so the inner `TableScan` was left with `fetch=None` and the base provider scanned the whole table.

## Root cause

In `VectorScanTableProvider::scan` (crates/search/src/index/vector_table.rs):

- The **join branch** already applies `.limit(0, limit)?` on the inner plan.
- The **schema-sufficient branch** (where the requested projection is fully satisfiable by the base table) built `LogicalPlanBuilder::scan(...)` + `apply_proj_and_filter`, then `.build()` — never threading the `limit` through.

Result: the user's reported plan showed `IcebergTableScan ... limit:[]` even though the outer logical `TableScan` had `fetch=1000`.

## Changes

- `crates/search/src/index/vector_table.rs`: apply `.limit(0, limit)?` on the inner plan in the schema-sufficient branch when `limit.is_some()`.
- Add regression test `test_vector_scan_limit_pushdown_schema_sufficient` plus an `insta` snapshot. The test verifies that `SELECT pk, another_column FROM tbl LIMIT 5` produces an inner `BaseTable: ... limit=Some(5)`. Verified to fail before the fix (`limit=None`) and pass after (`limit=Some(5)`).

## Performance impact

Net positive: when LIMIT is present on a vector-indexed dataset, the base table provider (Iceberg, Postgres, etc.) now scans only `N` rows instead of the entire table. Plans without a LIMIT (and join-branch plans) are unchanged.

## Test plan

- [x] `cargo test -p search` — all 42 tests pass, including the new regression test
- [x] `cargo build -p search --all-targets`
- [x] `cargo fmt -p search` — clean
- [ ] `make lint`
- [ ] `make test`

## Checklist

- [x] Regression test that fails on old code and passes on new
- [x] No backwards-compatibility shims
- [x] Comment explains *why*, not what