### PR TITLE
ci: remove workflow cancellation on job failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -145,12 +145,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
           RUST_PROFILE: ${{ env.RUST_PROFILE }}
 
-      - name: Cancel workflow on failure
-        if: failure()
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       - name: Show sccache stats
         if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
         run: sccache --show-stats
@@ -247,12 +241,6 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
           INSTA_UPDATE: ${{ github.event.inputs.update_snapshots || 'no' }}
-
-      - name: Cancel workflow on failure
-        if: failure()
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Build testoperator
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -368,12 +356,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
         run: make install-spiced
-
-      - name: Cancel workflow on failure
-        if: failure()
-        run: gh run cancel ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Show sccache stats
         if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}


### PR DESCRIPTION
## Summary

Remove the "Cancel workflow on failure" steps that ran `gh run cancel ${{ github.run_id }}` on `failure()` in the `pr` workflow.

These steps were present in the `lint-rust`, `build-test`, and `build-install-release` jobs (after their primary steps).

## Rationale

- We can now restart individual jobs via the GitHub UI ("Re-run failed jobs" / "Re-run this job").
- Canceling the entire run when one job fails prevents other parallel jobs from completing and makes selective restarts less useful.
- The jobs are largely independent (all depend only on `check_changes`), so one failing shouldn't block the others from reporting results.
- `cancel-in-progress: true` (for new pushes) is retained as it serves a different purpose.

The change allows failed jobs to be fixed and re-run in isolation without discarding progress from sibling jobs.

## Changes

* Removed 3 identical "Cancel workflow on failure" steps from `.github/workflows/pr.yml`.
* No other workflows used this pattern.