### PR TITLE
Add `datasets` dimension to the `query_executions` metric

### DIFF
--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -345,8 +345,6 @@ impl Query {
         request_context: Arc<RequestContext>,
         span: Span,
     ) -> Result<QueryHandle> {
-        crate::metrics::telemetry::track_query_count(&request_context.to_dimensions());
-
         // Get the scheduler server
         let scheduler = Self::get_scheduler_server(&self.df)?;
         let tracker = self.tracker;
@@ -586,8 +584,6 @@ impl Query {
     }
 
     async fn run_internal(self, request_context: Arc<RequestContext>) -> Result<QueryResult> {
-        crate::metrics::telemetry::track_query_count(&request_context.to_dimensions());
-
         let span = tracing::span!(target: "task_history", tracing::Level::INFO, "sql_query", input = %self.sql, runtime_query = false);
 
         if let Some(traceparent) = request_context.trace_parent() {

--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -95,6 +95,12 @@ impl QueryTracker {
 
         labels.extend(request_context.to_dimensions());
 
+        // Record the execution count here (rather than at query submission) so it
+        // shares the same `datasets`/`tags` dimensions as the duration metrics
+        // below. `finish` is the single terminal step for every tracked query
+        // (normal completion, cache hit, and error paths all route through it),
+        // so this counts each execution exactly once.
+        crate::metrics::telemetry::track_query_count(&labels);
         crate::metrics::telemetry::track_query_duration(query_duration, &labels);
         crate::metrics::telemetry::track_query_execution_duration(
             query_execution_duration,

--- a/crates/runtime/src/metrics/telemetry/mod.rs
+++ b/crates/runtime/src/metrics/telemetry/mod.rs
@@ -30,7 +30,7 @@ static QUERY_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
 });
 
 pub fn track_query_count(dimensions: &[KeyValue]) {
-    telemetry::track_query_count(dimensions);
+    telemetry::track_query_count(&without_anonymous_excluded(dimensions));
     QUERY_COUNT.add(1, dimensions);
 }
 


### PR DESCRIPTION
## Summary

Adds the `datasets` dimension to the `query_executions` counter, mirroring how it already exists on `query_duration_ms`.

Previously `query_executions` was recorded at query **submission** (start of `run_internal` / `submit_distributed_internal`) with only the request-context dimensions. The referenced datasets aren't known until after planning, so the count is now recorded in `QueryTracker::finish` using the **same `labels` vector** as the duration metrics — giving `query_executions` both the `datasets` (sorted, comma-joined dataset names) and `tags` (cache-hit / cache-miss / error) dimensions, and making it directly joinable with `query_duration_ms`.

## Changes

- **`crates/runtime/src/datafusion/query/tracker.rs`**: record `query_executions` in `finish()` with the shared `labels` vector.
- **`crates/runtime/src/datafusion/query.rs`**: remove the two early `track_query_count` calls.
- **`crates/runtime/src/metrics/telemetry/mod.rs`**: strip the `datasets` key from the anonymous-telemetry pipeline in `track_query_count`, mirroring `track_query_duration`. The operator-facing instrument keeps the full dimensions.

## Behavior notes

- **Counting moves from submission → completion.** `finish` consumes the tracker and is the single terminal step for normal completion, cache hits (via `attach_query_tracker_to_stream`), and errors (via `finish_with_error`), so each tracked query is still counted exactly once.
- **Internal plan-based queries** (built via `Query::from_logical_plan`: cached-query background revalidation and the search engine) have no tracker and never reach `finish`, so they are no longer counted. They were already absent from `query_duration_ms`, so `query_executions` now matches that metric's population.

## Testing

- `cargo check -p runtime` — clean
- `make lint-rust` — clean