### PR TITLE
Fix #11137: localpod child not tracking parent refreshes with in-memory (arrow) parent accelerator

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2631,20 +2631,36 @@ impl DataFusion {
             );
             return;
         };
-        let Some(parent_table_federation_adaptor) = parent_table
+
+        // The parent's registered provider takes one of two shapes depending on its
+        // acceleration engine:
+        // - Engines backed by a `PolyTableProvider` (duckdb/sqlite/postgres/cayenne) expose a
+        //   federated source, so `AcceleratedTable::table_provider()` wraps the table in a
+        //   `FederatedTableProviderAdaptor`.
+        // - The in-memory Arrow accelerator has no federated source, so
+        //   `create_federated_table_source()` returns `None` and `table_provider()` hands back the
+        //   bare `AcceleratedTable`.
+        // Unwrap the adaptor when present so we can find the parent `AcceleratedTable` in either
+        // case; otherwise a child of an Arrow-accelerated parent would never synchronize. The
+        // downcast borrows `parent_table`, so clone out the inner provider first to release the
+        // borrow before falling back to `parent_table` itself.
+        let adaptor_inner = parent_table
             .as_any()
-            .downcast_ref::<FederatedTableProviderAdaptor>(
-        ) else {
-            tracing::debug!(
-                "Could not synchronize refreshes with parent table {parent_table_reference}. Parent table is not a federated table."
-            );
-            return;
-        };
-        let Some(parent_table) = parent_table_federation_adaptor.table_provider.clone() else {
-            tracing::debug!(
-                "Could not synchronize refreshes with parent table {parent_table_reference}. Parent federated table doesn't contain a table provider."
-            );
-            return;
+            .downcast_ref::<FederatedTableProviderAdaptor>()
+            .map(|adaptor| adaptor.table_provider.clone());
+        let parent_table = match adaptor_inner {
+            // FederatedTableProviderAdaptor wrapping an inner provider.
+            Some(Some(inner)) => inner,
+            // FederatedTableProviderAdaptor with no inner provider — nothing to synchronize with.
+            Some(None) => {
+                tracing::debug!(
+                    "Could not synchronize refreshes with parent table {parent_table_reference}. Parent federated table doesn't contain a table provider."
+                );
+                return;
+            }
+            // Not a FederatedTableProviderAdaptor (e.g. a bare AcceleratedTable from the in-memory
+            // Arrow accelerator).
+            None => parent_table,
         };
         let Some(parent_table) = parent_table.as_any().downcast_ref::<AcceleratedTable>() else {
             tracing::debug!(

--- a/crates/runtime/tests/acceleration/localpod_sync.rs
+++ b/crates/runtime/tests/acceleration/localpod_sync.rs
@@ -1,0 +1,223 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::expect_used)]
+
+//! Regression tests for localpod full-refresh synchronization.
+//!
+//! A `localpod:` child dataset has no refresh interval of its own; it stays current by
+//! subscribing to its parent's refreshes. Setting that subscription up requires resolving the
+//! parent's registered provider back to its [`AcceleratedTable`]. The parent's provider takes one
+//! of two shapes depending on its acceleration engine:
+//!
+//! - Engines backed by a `PolyTableProvider` (duckdb/sqlite/postgres/cayenne) expose a federated
+//!   source, so the parent is wrapped in a `FederatedTableProviderAdaptor`.
+//! - The default in-memory Arrow accelerator has no federated source, so the parent is registered
+//!   as a bare `AcceleratedTable`.
+//!
+//! Regression test for <https://github.com/spiceai/spiceai/issues/11137>: a child of an
+//! Arrow-accelerated parent used to bail out of synchronization (only the
+//! `FederatedTableProviderAdaptor` shape was handled), so the child loaded once at startup and then
+//! stayed frozen while the parent kept refreshing.
+
+use std::fmt::Write as _;
+use std::sync::Arc;
+use std::time::Duration;
+
+use app::AppBuilder;
+use arrow::array::Int64Array;
+use runtime::Runtime;
+use spicepod::{
+    acceleration::{Acceleration, RefreshMode},
+    component::dataset::Dataset,
+    param::Params,
+};
+use tempfile::TempDir;
+use tokio::fs;
+
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{runtime_ready_check, test_request_context},
+};
+
+const CSV_HEADER: &str = "id,name\n";
+
+fn rows(start: usize, end: usize) -> String {
+    (start..end).fold(String::new(), |mut acc, i| {
+        let _ = writeln!(acc, "{i},name_{i}");
+        acc
+    })
+}
+
+async fn count_rows(rt: &Runtime, table: &str) -> usize {
+    let batches = rt
+        .datafusion()
+        .ctx
+        .sql(&format!("SELECT COUNT(*) AS c FROM {table}"))
+        .await
+        .expect("count query should plan")
+        .collect()
+        .await
+        .expect("count query should execute");
+    let count = batches
+        .first()
+        .expect("count query should return a batch")
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("COUNT(*) should be an Int64Array")
+        .value(0);
+    usize::try_from(count).expect("count should be non-negative")
+}
+
+/// Poll `table`'s row count until it reaches `expected` or the timeout elapses, returning the last
+/// observed count.
+async fn wait_for_count(rt: &Runtime, table: &str, expected: usize, timeout: Duration) -> usize {
+    let deadline = timeout.as_millis() / 100;
+    let mut last = count_rows(rt, table).await;
+    for _ in 0..deadline {
+        if last == expected {
+            return last;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        last = count_rows(rt, table).await;
+    }
+    last
+}
+
+/// A localpod child whose parent uses the default in-memory (Arrow) accelerator must keep tracking
+/// the parent's full refreshes at runtime, not just load once at startup.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_localpod_full_refresh_synchronization_with_arrow_parent() -> Result<(), anyhow::Error>
+{
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,runtime::accelerated_table=trace",
+    ));
+
+    test_request_context()
+        .scope(async {
+            // Start with the header plus two rows so the CSV schema is well-defined and the
+            // initial load is non-empty (initial sync is known to work; runtime sync is the bug).
+            let temp_dir = TempDir::new().expect("create temp dir");
+            let csv_path = temp_dir.path().join("data.csv");
+            fs::write(&csv_path, format!("{CSV_HEADER}{}", rows(0, 2)))
+                .await
+                .expect("write initial csv");
+
+            // Parent: file connector, full refresh, default (Arrow / in-memory) accelerator.
+            // No refresh_check_interval, so the parent only refreshes when triggered manually,
+            // keeping the test deterministic.
+            let mut parent = Dataset::new(format!("file://{}", csv_path.display()), "time_series");
+            parent.params = Some(Params::from_string_map(
+                vec![
+                    ("file_format".to_string(), "csv".to_string()),
+                    ("csv_has_header".to_string(), "true".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+            parent.acceleration = Some(Acceleration {
+                enabled: true,
+                refresh_mode: Some(RefreshMode::Full),
+                ..Acceleration::default()
+            });
+
+            // Child: localpod over the parent, also Arrow + full refresh, with no refresh interval
+            // of its own — it must rely on synchronization with the parent.
+            let mut child = Dataset::new("localpod:time_series", "local_time_series");
+            child.acceleration = Some(Acceleration {
+                enabled: true,
+                refresh_mode: Some(RefreshMode::Full),
+                ..Acceleration::default()
+            });
+
+            let app = AppBuilder::new("test_localpod_full_refresh_sync")
+                .with_dataset(parent)
+                .with_dataset(child)
+                .build();
+
+            configure_test_datafusion();
+            let runtime = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&runtime).load_components() => {}
+            }
+            runtime_ready_check(&runtime).await;
+
+            // Initial load: both parent and child see the two startup rows.
+            assert_eq!(
+                count_rows(&runtime, "time_series").await,
+                2,
+                "parent should load the two startup rows"
+            );
+            assert_eq!(
+                count_rows(&runtime, "local_time_series").await,
+                2,
+                "localpod child should load the two startup rows"
+            );
+
+            // Append three more rows, for a total of five.
+            fs::write(&csv_path, format!("{CSV_HEADER}{}", rows(0, 5)))
+                .await
+                .expect("append rows to csv");
+
+            // Drive parent refreshes until the child catches up. The child subscribes to the
+            // parent's refreshes only once its own startup load completes; retrying keeps the test
+            // robust against that subscription landing slightly after readiness, without depending
+            // on a fixed sleep. With the fix the child tracks the very first refresh; before it,
+            // the child never moves off its startup count and this loop exhausts its retries.
+            let mut child_count = count_rows(&runtime, "local_time_series").await;
+            for _ in 0..15 {
+                let notify = runtime
+                    .datafusion()
+                    .refresh_table(&"time_series".into(), None)
+                    .await
+                    .expect("trigger parent refresh");
+                if let Some(notify) = notify {
+                    tokio::select! {
+                        () = notify.notified() => {}
+                        () = tokio::time::sleep(Duration::from_secs(5)) => {}
+                    }
+                }
+                child_count =
+                    wait_for_count(&runtime, "local_time_series", 5, Duration::from_secs(3)).await;
+                if child_count == 5 {
+                    break;
+                }
+            }
+
+            // The parent tracks the new rows on refresh.
+            assert_eq!(
+                count_rows(&runtime, "time_series").await,
+                5,
+                "parent should track the appended rows after a refresh"
+            );
+
+            // The child must follow the parent's refresh via synchronization. Before the fix it
+            // stayed frozen at its startup count of 2.
+            assert_eq!(
+                child_count, 5,
+                "localpod child should synchronize with the parent's refresh (was frozen at \
+                 startup count before #11137 fix)"
+            );
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -38,6 +38,7 @@ mod cron;
 #[cfg(feature = "sqlite")]
 mod file_watcher;
 mod hash_index;
+mod localpod_sync;
 #[cfg(all(feature = "postgres-accel", feature = "duckdb", feature = "sqlite"))]
 mod on_conflict;
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary

A `localpod:` child dataset only loaded **once at startup** and then never re-synced when its parent refreshed new data at runtime — but only when the parent used the **default in-memory (Arrow) accelerator**. Children of parents accelerated by DuckDB/SQLite/Postgres/Cayenne synchronized correctly.

Fixes #11137.

## Root cause

A localpod child has no refresh interval of its own; it stays current by subscribing to its parent's refreshes. Setting that subscription up (`attempt_to_synchronize_accelerated_table`) requires resolving the parent's registered provider back to its `AcceleratedTable`. The parent's provider takes one of two shapes depending on its acceleration engine:

- Engines backed by a `PolyTableProvider` (DuckDB/SQLite/Postgres/Cayenne) expose a federated source, so `AcceleratedTable::table_provider()` wraps the table in a `FederatedTableProviderAdaptor`.
- The default in-memory **Arrow** accelerator has no federated source, so `create_federated_table_source()` returns `None` and `table_provider()` hands back the **bare `AcceleratedTable`**.

The sync code only handled the `FederatedTableProviderAdaptor` shape and bailed out (at `debug` level) for an Arrow parent. The child then ran a single startup load and, having no `refresh_check_interval`, stayed frozen while the parent kept refreshing — exactly the symptom in the issue (missing `synchronizing refreshes with parent` log line; child registered with no refresh interval).

## Changes

- `crates/runtime/src/datafusion/mod.rs`: in `attempt_to_synchronize_accelerated_table`, resolve the parent's `AcceleratedTable` from **either** a `FederatedTableProviderAdaptor`-wrapped provider **or** a bare `AcceleratedTable` (the Arrow case), so synchronization is wired up regardless of the parent's acceleration engine.
- `crates/runtime/tests/acceleration/localpod_sync.rs`: regression test — an Arrow-accelerated parent (file connector, full refresh) with a localpod child; appends rows, refreshes the parent, and asserts the child tracks the new row count. Fails before the fix (child frozen at startup count), passes after.

## Testing

- New integration test `test_localpod_full_refresh_synchronization_with_arrow_parent` (in `acceleration::localpod_sync`).
- Existing localpod synchronization coverage (`acceleration::caching_mode::test_localpod_caching_synchronization`) continues to exercise the `FederatedTableProviderAdaptor` (DuckDB) path.
