### PR TITLE
Fix Windows build: vendor the VSS extension (drop nested submodule)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=be0837e39a8c02ad76e3885a94c66aa83fe8e8a2#be0837e39a8c02ad76e3885a94c66aa83fe8e8a2"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=4af854228e9f503bbaf6858fb76a9f4fcdcf091c#4af854228e9f503bbaf6858fb76a9f4fcdcf091c"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -6850,7 +6850,7 @@ checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
 [[package]]
 name = "duckdb"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b1cf1723252204caf6262865255cd47e7435cbbe#b1cf1723252204caf6262865255cd47e7435cbbe"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=7648ff8c7d1ff06576478d518415e1ba0eac659c#7648ff8c7d1ff06576478d518415e1ba0eac659c"
 dependencies = [
  "arrow",
  "calamine",
@@ -10532,7 +10532,7 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 [[package]]
 name = "libduckdb-sys"
 version = "1.10503.1"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b1cf1723252204caf6262865255cd47e7435cbbe#b1cf1723252204caf6262865255cd47e7435cbbe"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=7648ff8c7d1ff06576478d518415e1ba0eac659c#7648ff8c7d1ff06576478d518415e1ba0eac659c"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,7 +428,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "be0837e39a8c02ad76e3885a94c66aa83fe8e8a2" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4af854228e9f503bbaf6858fb76a9f4fcdcf091c" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" } # spiceai-52.5
@@ -437,7 +437,7 @@ ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "47034733a0477f72e4f6abbbf6a27d0da069860a" } # spiceai-0.18.2
 
 # Patch duckdb for direct dependencies and spiceai_duckdb_fork for datafusion-table-providers
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b1cf1723252204caf6262865255cd47e7435cbbe" } # spiceai-1.5.3 + static VSS (DuckDB version pinned to v1.5.3)
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "7648ff8c7d1ff06576478d518415e1ba0eac659c" } # spiceai-1.5.3 + static VSS (vendored, DuckDB version pinned to v1.5.3)
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6d062676210d095df45eafa6e19fd8" }
 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113

--- a/crates/data_components/src/mongodb.rs
+++ b/crates/data_components/src/mongodb.rs
@@ -29,6 +29,8 @@ impl Read for MongoDBTableFactory {
         &self,
         table_reference: TableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
-        self.table_provider(table_reference).await
+        // table-providers MongoDBTableFactory::table_provider now takes an optional declared
+        // schema (schema-merging support, #657); none is declared at this layer, so pass None.
+        self.table_provider(table_reference, None).await
     }
 }


### PR DESCRIPTION
## Summary

Fixes the **Windows build break** on trunk introduced by the static-VSS work (#11107). Bumps:
- `duckdb` (duckdb-rs fork): `b1cf1723` → **`7648ff8c`** ([spiceai/duckdb-rs#39](https://github.com/spiceai/duckdb-rs/pull/39))
- `datafusion-table-providers`: `be0837e3` → **`4af85422`** ([#660](https://github.com/datafusion-contrib/datafusion-table-providers/pull/660))

Both vendor the VSS extension as **committed files** instead of a git submodule.

## Root cause

Cargo recursively checks out **all** submodules of the `duckdb-rs` git dependency. The VSS extension was vendored as a submodule (`duckdb-sources/extension/vss/upstream → duckdb-vss`), and duckdb-vss has its *own* nested `duckdb` submodule. Cargo therefore cloned a full nested duckdb, whose deeply-nested Swift example path exceeds Windows' `MAX_PATH` (260 chars):

```
failed to update submodule extension/vss/upstream -> failed to update submodule duckdb
  path too long: '.../extension/vss/upstream/duckdb/tools/swift/.../IDEWorkspaceChecks.plist'; class=Filesystem
```

Linux/macOS were unaffected (no path-length limit), so it only failed on the Windows CLI build.

## Fix

The vss source is now committed directly (`duckdb-sources/extension/vss/src`) — no submodule, so nothing for Cargo to recurse into. Same ABI-matched duckdb-vss commit (`b833341c`), same statically-linked behavior, same `v1.5.3` version pin. No functional change to the bundled DuckDB; this is purely how the vss source is stored. SKILLs in both forks updated to document that vss must stay vendored (with the Windows reason).

## Validation

`cargo metadata --locked` resolves cleanly (single `libduckdb-sys`). The Windows CI build on this PR is the real confirmation — it exercises both the (now-fixed) submodule checkout and the MSVC compile of vss/usearch.