### PR TITLE
fix(spiceai): keep correlated subqueries out of JOIN ON for Spice Cloud federation

### DIFF
--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -234,7 +234,7 @@ impl Dialect for SpiceCloudPlatformDialect {
         PostgreSqlDialect {}.identifier_quote_style(identifier)
     }
 
-    /// Spice Cloud re-plans the SQL we push down with DataFusion's analyzer,
+    /// Spice Cloud re-plans the SQL we push down with `DataFusion`'s analyzer,
     /// which rejects a correlated scalar subquery whose parent plan node is a
     /// `Join` (only `Projection`/`Filter`/`Aggregate` are permitted). The
     /// unparser only emits subqueries inside `JOIN ... ON` predicates when this

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -233,6 +233,16 @@ impl Dialect for SpiceCloudPlatformDialect {
     fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
         PostgreSqlDialect {}.identifier_quote_style(identifier)
     }
+
+    /// Spice Cloud re-plans the SQL we push down with DataFusion's analyzer,
+    /// which rejects a correlated scalar subquery whose parent plan node is a
+    /// `Join` (only `Projection`/`Filter`/`Aggregate` are permitted). The
+    /// unparser only emits subqueries inside `JOIN ... ON` predicates when this
+    /// returns `true`, so returning `false` keeps them in the `WHERE` clause
+    /// where the remote can decorrelate them. See spiceai/spiceai#11141.
+    fn supports_subquery_in_join_predicate(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Default, Copy, Clone)]


### PR DESCRIPTION
## What

`SpiceCloudPlatformDialect` now overrides `supports_subquery_in_join_predicate()` to return `false`, so the SQL unparser emits federated subqueries in the `WHERE` clause instead of inside a `JOIN ... ON` predicate.

## Why

When all tables are federated to a Spice Cloud provider, datafusion-federation unparses the plan back to SQL and pushes it down. The unparser was placing scalar subqueries into `JOIN ... ON` predicates (the dialect inherited the default `true`). Spice Cloud re-plans that SQL, and DataFusion's analyzer rejects a **correlated scalar subquery whose parent plan node is a `Join`** (only `Projection`/`Filter`/`Aggregate` are permitted), so the query fails remotely:

```
DoGet recv error: rpc error: code = InvalidArgument desc = Correlated scalar subquery can only be used in Projection, Filter, Aggregate plan nodes
```

This made `tpcds q6` fail deterministically on the `federated/spicecloud` benchmark (and is the likely cause of the `q17`/`q2` correlated-subquery failures on `spicecloud-arrow`). Full root-cause analysis in #11141.

With the flag `false`, the unparser's relocation logic moves subquery-bearing table-scan filters from the `JOIN ON` to `WHERE` for inner joins (semantically equivalent), where the remote can decorrelate them. q6's correlated predicate (`i.i_current_price > 1.2 * (select avg(j.i_current_price) from item j where j.i_category = i.i_category)`) is a single-table filter on `item`, so it qualifies for relocation.

## Changes

- `crates/runtime/src/dataconnector/spiceai.rs`: add `supports_subquery_in_join_predicate() -> false` to `SpiceCloudPlatformDialect`.

## Validation

- `cargo check -p runtime` — green.
- Pending: `build_and_release` (Linux x64) on this branch, then the `federated/spicecloud` tpcds benchmark to confirm q6 executes end-to-end. The testoperator will also regenerate the affected `spicecloud*` q6 explain snapshots (the relocated subquery shows up in `WHERE` instead of `JOIN ON`).

## Caveat

If any affected query keeps the subquery in a join's own `filter` (rather than a table-scan filter), the dialect flag alone won't relocate it; the more complete fix would run scalar-subquery decorrelation on the federated sub-plan before unparsing. q6's structure does not hit that path, but the bench run will confirm coverage across the suite.

Fixes #11141
