### PR TITLE
fix(duckdb): normalize timestamp columns to microsecond precision (fixes #10627)

### DIFF
--- a/crates/arrow_tools/src/type_rewrite.rs
+++ b/crates/arrow_tools/src/type_rewrite.rs
@@ -64,28 +64,34 @@ impl TypeRewriteRule for IntervalToMonthDayNano {
     }
 }
 
-/// Rewrites `DataType::Timestamp(unit, tz)` with a non-microsecond `unit` →
-/// `DataType::Timestamp(Microsecond, tz)`, preserving the timezone.
+/// Rewrites a timezone-aware `DataType::Timestamp(unit, Some(tz))` with a
+/// non-microsecond `unit` → `DataType::Timestamp(Microsecond, Some(tz))`,
+/// preserving the timezone. Timezone-naive timestamps (`tz = None`) are left
+/// unchanged.
 ///
-/// `DuckDB`'s `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` types are always
-/// microsecond-precision. The Arrow→`DuckDB` column-type mapping in
-/// `datafusion-table-providers` collapses every `Timestamp` to `TIMESTAMP` /
-/// `TIMESTAMPTZ` regardless of the source `TimeUnit`, so a column registered as
-/// `Timestamp(Nanosecond, "UTC")` (e.g. a Postgres `timestamptz` source) is
-/// physically stored — and read back — as `Timestamp(Microsecond, "UTC")`. When
-/// the registered schema keeps the original non-µs unit, `DataFusion` plans
-/// against nanoseconds while `DuckDB` returns microseconds and queries that sort
-/// or range-join on the column panic with
+/// `DuckDB`'s `TIMESTAMP WITH TIME ZONE` (`TIMESTAMPTZ`) type is always
+/// microsecond-precision — `DuckDB` has no nanosecond-with-timezone type. So a
+/// column registered as `Timestamp(Nanosecond, "UTC")` (e.g. a Postgres
+/// `timestamptz` source) is physically stored — and read back — as
+/// `Timestamp(Microsecond, "UTC")`. When the registered schema keeps the
+/// original non-µs unit, `DataFusion` plans against nanoseconds while `DuckDB`
+/// returns microseconds and queries that sort or range-join on the column panic
+/// with
 /// `RowConverter column schema mismatch, expected Timestamp(ns, "UTC") got Timestamp(µs, "UTC")`.
 /// Normalizing the unit to microsecond keeps the registered schema in lockstep
 /// with what `DuckDB` stores and returns.
-pub struct TimestampToMicrosecond;
-impl TypeRewriteRule for TimestampToMicrosecond {
+///
+/// Timezone-naive timestamps are deliberately excluded: `DuckDB` has a native
+/// nanosecond `TIMESTAMP_NS` type and preserves the precision of `TIMESTAMP`
+/// columns without a zone (the runtime's internal `_fetched_at` caching column
+/// relies on this), so normalizing them would instead *introduce* a mismatch.
+pub struct TimestampTzToMicrosecond;
+impl TypeRewriteRule for TimestampTzToMicrosecond {
     fn rewrite(&self, dt: &DataType) -> Option<DataType> {
         match dt {
-            DataType::Timestamp(unit, tz) if *unit != TimeUnit::Microsecond => {
-                Some(DataType::Timestamp(TimeUnit::Microsecond, tz.clone()))
-            }
+            DataType::Timestamp(unit, Some(tz)) if *unit != TimeUnit::Microsecond => Some(
+                DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::clone(tz))),
+            ),
             _ => None,
         }
     }
@@ -301,7 +307,7 @@ mod tests {
             DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
             true,
         )]);
-        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        let result = apply_rules(&schema, &[&TimestampTzToMicrosecond]);
         assert_eq!(
             result.field(0).data_type(),
             &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
@@ -310,35 +316,41 @@ mod tests {
     }
 
     #[test]
-    fn timestamp_nanosecond_without_tz_normalized_to_microsecond() {
-        // DuckDB maps `Timestamp(_, None)` to its microsecond `TIMESTAMP` type
-        // regardless of the source unit, so the no-timezone case must normalize too.
+    fn timestamp_nanosecond_without_tz_unchanged() {
+        // DuckDB has a native nanosecond TIMESTAMP_NS type and preserves the
+        // precision of timezone-naive timestamps, so the no-timezone case must
+        // NOT be normalized — doing so would introduce a mismatch.
         let schema = Schema::new(vec![Field::new(
             "ts",
             DataType::Timestamp(TimeUnit::Nanosecond, None),
             true,
         )]);
-        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        let result = apply_rules(&schema, &[&TimestampTzToMicrosecond]);
         assert_eq!(
             result.field(0).data_type(),
-            &DataType::Timestamp(TimeUnit::Microsecond, None)
+            &DataType::Timestamp(TimeUnit::Nanosecond, None),
+            "timezone-naive timestamps must be left untouched"
         );
     }
 
     #[test]
-    fn timestamp_second_and_millisecond_normalized_to_microsecond() {
+    fn timestamp_tz_second_and_millisecond_normalized_to_microsecond() {
         let schema = Schema::new(vec![
-            Field::new("s", DataType::Timestamp(TimeUnit::Second, None), true),
+            Field::new(
+                "s",
+                DataType::Timestamp(TimeUnit::Second, Some("UTC".into())),
+                true,
+            ),
             Field::new(
                 "ms",
                 DataType::Timestamp(TimeUnit::Millisecond, Some("+05:00".into())),
                 true,
             ),
         ]);
-        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        let result = apply_rules(&schema, &[&TimestampTzToMicrosecond]);
         assert_eq!(
             result.field(0).data_type(),
-            &DataType::Timestamp(TimeUnit::Microsecond, None)
+            &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
         );
         assert_eq!(
             result.field(1).data_type(),
@@ -347,7 +359,7 @@ mod tests {
     }
 
     #[test]
-    fn timestamp_microsecond_unchanged() {
+    fn timestamp_microsecond_with_tz_unchanged() {
         let schema = Schema::new(vec![
             Field::new(
                 "ts",
@@ -356,12 +368,13 @@ mod tests {
             ),
             Field::new("id", DataType::Int64, false),
         ]);
-        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        let result = apply_rules(&schema, &[&TimestampTzToMicrosecond]);
         assert_eq!(result, schema, "already-microsecond schema must be a no-op");
     }
 
     #[test]
-    fn timestamp_nanosecond_nested_in_list_and_struct_normalized() {
+    fn timestamp_nanosecond_nested_in_list_and_struct() {
+        // tz-aware nested timestamp normalizes; tz-naive nested timestamp does not.
         let schema = Schema::new(vec![
             Field::new(
                 "events",
@@ -385,25 +398,27 @@ mod tests {
                 false,
             ),
         ]);
-        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        let result = apply_rules(&schema, &[&TimestampTzToMicrosecond]);
         assert_eq!(
             result.field(0).data_type(),
             &DataType::List(Arc::new(Field::new(
                 "item",
                 DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
                 true,
-            )))
+            ))),
+            "tz-aware nested timestamp must normalize to microsecond"
         );
         assert_eq!(
             result.field(1).data_type(),
             &DataType::Struct(
                 vec![Field::new(
                     "at",
-                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
                     true,
                 )]
                 .into(),
-            )
+            ),
+            "tz-naive nested timestamp must be left untouched"
         );
     }
 

--- a/crates/arrow_tools/src/type_rewrite.rs
+++ b/crates/arrow_tools/src/type_rewrite.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::sync::Arc;
 
-use arrow_schema::{DataType, Field, IntervalUnit, Schema};
+use arrow_schema::{DataType, Field, IntervalUnit, Schema, TimeUnit};
 
 /// A rewrite rule applied by [`apply_rules`] to every [`DataType`] node in a schema.
 ///
@@ -58,6 +58,33 @@ impl TypeRewriteRule for IntervalToMonthDayNano {
         match dt {
             DataType::Interval(IntervalUnit::YearMonth | IntervalUnit::DayTime) => {
                 Some(DataType::Interval(IntervalUnit::MonthDayNano))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Rewrites `DataType::Timestamp(unit, tz)` with a non-microsecond `unit` →
+/// `DataType::Timestamp(Microsecond, tz)`, preserving the timezone.
+///
+/// `DuckDB`'s `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` types are always
+/// microsecond-precision. The Arrow→`DuckDB` column-type mapping in
+/// `datafusion-table-providers` collapses every `Timestamp` to `TIMESTAMP` /
+/// `TIMESTAMPTZ` regardless of the source `TimeUnit`, so a column registered as
+/// `Timestamp(Nanosecond, "UTC")` (e.g. a Postgres `timestamptz` source) is
+/// physically stored — and read back — as `Timestamp(Microsecond, "UTC")`. When
+/// the registered schema keeps the original non-µs unit, `DataFusion` plans
+/// against nanoseconds while `DuckDB` returns microseconds and queries that sort
+/// or range-join on the column panic with
+/// `RowConverter column schema mismatch, expected Timestamp(ns, "UTC") got Timestamp(µs, "UTC")`.
+/// Normalizing the unit to microsecond keeps the registered schema in lockstep
+/// with what `DuckDB` stores and returns.
+pub struct TimestampToMicrosecond;
+impl TypeRewriteRule for TimestampToMicrosecond {
+    fn rewrite(&self, dt: &DataType) -> Option<DataType> {
+        match dt {
+            DataType::Timestamp(unit, tz) if *unit != TimeUnit::Microsecond => {
+                Some(DataType::Timestamp(TimeUnit::Microsecond, tz.clone()))
             }
             _ => None,
         }
@@ -264,6 +291,119 @@ mod tests {
         assert_eq!(
             result.field(0).data_type(),
             &DataType::Interval(IntervalUnit::MonthDayNano)
+        );
+    }
+
+    #[test]
+    fn timestamp_nanosecond_with_tz_normalized_to_microsecond() {
+        let schema = Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+            true,
+        )]);
+        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            "timezone must be preserved while the unit is normalized to microsecond"
+        );
+    }
+
+    #[test]
+    fn timestamp_nanosecond_without_tz_normalized_to_microsecond() {
+        // DuckDB maps `Timestamp(_, None)` to its microsecond `TIMESTAMP` type
+        // regardless of the source unit, so the no-timezone case must normalize too.
+        let schema = Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        )]);
+        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+    }
+
+    #[test]
+    fn timestamp_second_and_millisecond_normalized_to_microsecond() {
+        let schema = Schema::new(vec![
+            Field::new("s", DataType::Timestamp(TimeUnit::Second, None), true),
+            Field::new(
+                "ms",
+                DataType::Timestamp(TimeUnit::Millisecond, Some("+05:00".into())),
+                true,
+            ),
+        ]);
+        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        assert_eq!(
+            result.field(1).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, Some("+05:00".into()))
+        );
+    }
+
+    #[test]
+    fn timestamp_microsecond_unchanged() {
+        let schema = Schema::new(vec![
+            Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                true,
+            ),
+            Field::new("id", DataType::Int64, false),
+        ]);
+        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        assert_eq!(result, schema, "already-microsecond schema must be a no-op");
+    }
+
+    #[test]
+    fn timestamp_nanosecond_nested_in_list_and_struct_normalized() {
+        let schema = Schema::new(vec![
+            Field::new(
+                "events",
+                DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                    true,
+                ))),
+                false,
+            ),
+            Field::new(
+                "rec",
+                DataType::Struct(
+                    vec![Field::new(
+                        "at",
+                        DataType::Timestamp(TimeUnit::Nanosecond, None),
+                        true,
+                    )]
+                    .into(),
+                ),
+                false,
+            ),
+        ]);
+        let result = apply_rules(&schema, &[&TimestampToMicrosecond]);
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                true,
+            )))
+        );
+        assert_eq!(
+            result.field(1).data_type(),
+            &DataType::Struct(
+                vec![Field::new(
+                    "at",
+                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    true,
+                )]
+                .into(),
+            )
         );
     }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -396,7 +396,7 @@ static DUCKDB_TYPE_REWRITE_RULES: &[&dyn arrow_tools::type_rewrite::TypeRewriteR
     &arrow_tools::type_rewrite::DictionaryUnwrap,
     &arrow_tools::type_rewrite::IntervalToMonthDayNano,
     &arrow_tools::type_rewrite::NullToInt32,
-    &arrow_tools::type_rewrite::TimestampToMicrosecond,
+    &arrow_tools::type_rewrite::TimestampTzToMicrosecond,
 ];
 
 #[async_trait]
@@ -2396,7 +2396,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_schema_for_duckdb_timestamp_to_microsecond() {
+    fn normalize_schema_for_duckdb_timestamptz_to_microsecond() {
         use arrow::datatypes::TimeUnit;
         let mut cmd = cmd_with_schema(Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
@@ -2413,8 +2413,8 @@ mod tests {
         ])));
         super::normalize_schema_for_duckdb(&mut cmd).expect("normalize succeeds");
         let arrow = cmd.schema.as_arrow();
-        // DuckDB stores all TIMESTAMP/TIMESTAMPTZ at microsecond precision; the
-        // registered schema must match to avoid a RowConverter mismatch (#10627).
+        // DuckDB's TIMESTAMPTZ is always microsecond; the registered schema for a
+        // timezone-aware column must match to avoid a RowConverter mismatch (#10627).
         assert_eq!(
             arrow
                 .field_with_name("created_at")
@@ -2422,12 +2422,14 @@ mod tests {
                 .data_type(),
             &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
         );
+        // Timezone-naive timestamps keep nanosecond precision — DuckDB has a
+        // native TIMESTAMP_NS type and the runtime's _fetched_at column relies on it.
         assert_eq!(
             arrow
                 .field_with_name("local_at")
                 .expect("local_at field")
                 .data_type(),
-            &DataType::Timestamp(TimeUnit::Microsecond, None),
+            &DataType::Timestamp(TimeUnit::Nanosecond, None),
         );
     }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -396,6 +396,7 @@ static DUCKDB_TYPE_REWRITE_RULES: &[&dyn arrow_tools::type_rewrite::TypeRewriteR
     &arrow_tools::type_rewrite::DictionaryUnwrap,
     &arrow_tools::type_rewrite::IntervalToMonthDayNano,
     &arrow_tools::type_rewrite::NullToInt32,
+    &arrow_tools::type_rewrite::TimestampToMicrosecond,
 ];
 
 #[async_trait]
@@ -1188,6 +1189,109 @@ mod tests {
         }
 
         assert_eq!(values, vec![5, 7]);
+    }
+
+    #[tokio::test]
+    async fn duckdb_timestamptz_roundtrip_sorts_without_rowconverter_panic() {
+        use arrow::array::TimestampMicrosecondArray;
+        use arrow::datatypes::TimeUnit;
+
+        // Register the column as Timestamp(Nanosecond, "UTC") — the type Spice
+        // assigns to a Postgres `timestamptz` source (see declared_type.rs).
+        // DuckDB physically stores and returns microsecond precision, so without
+        // schema normalization an ORDER BY on this column panics with a
+        // RowConverter "expected Timestamp(ns) got Timestamp(µs)" mismatch (#10627).
+        let source_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "created_at",
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                true,
+            ),
+        ]));
+
+        let cmd = cmd_with_schema(Arc::clone(&source_schema));
+        let duckdb_accelerator = DuckDBAccelerator::new();
+        let table = duckdb_accelerator
+            .create_external_table(cmd, None, vec![], None)
+            .await
+            .expect("table should be created");
+
+        // The accelerator must register the column at microsecond precision so the
+        // registered schema matches what DuckDB returns.
+        let microsecond_tz = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+        assert_eq!(
+            table
+                .schema()
+                .field_with_name("created_at")
+                .expect("created_at field")
+                .data_type(),
+            &microsecond_tz,
+            "DuckDB-accelerated timestamptz column must be registered as microsecond",
+        );
+
+        // Insert rows out of timestamp order. Values are microsecond-precision to
+        // match the normalized table schema (the refresh path casts source batches
+        // to this schema via arrow_tools::record_batch::try_cast_to before writing).
+        let insert_schema = table.schema();
+        let input = RecordBatch::try_new(
+            Arc::clone(&insert_schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(
+                    TimestampMicrosecondArray::from(vec![
+                        1_730_194_427_511_278, // latest
+                        1_730_108_530_123_456,
+                        1_730_022_333_789_012, // earliest
+                    ])
+                    .with_timezone("UTC"),
+                ),
+            ],
+        )
+        .expect("to create RecordBatch");
+
+        let exec = Arc::new(MockExec::new(vec![Ok(input)], insert_schema));
+        let write_ctx = SessionContext::new();
+        let insert_plan = table
+            .insert_into(
+                &write_ctx.state(),
+                Arc::<MockExec>::clone(&exec),
+                InsertOp::Append,
+            )
+            .await
+            .expect("to create insert plan");
+        collect(insert_plan, write_ctx.task_ctx())
+            .await
+            .expect("to execute insert");
+
+        // ORDER BY on the timestamptz column exercises DataFusion's RowConverter,
+        // which is where the schema mismatch previously panicked.
+        let read_ctx = SessionContext::new();
+        read_ctx
+            .register_table(TableReference::bare("events"), Arc::clone(&table))
+            .expect("to register table");
+        let batches = read_ctx
+            .sql("SELECT id FROM events ORDER BY created_at DESC")
+            .await
+            .expect("to plan query")
+            .collect()
+            .await
+            .expect("ORDER BY on timestamptz column must not panic in RowConverter");
+
+        let mut ids = Vec::new();
+        for batch in &batches {
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id column is Int64");
+            ids.extend((0..col.len()).map(|i| col.value(i)));
+        }
+        assert_eq!(
+            ids,
+            vec![1, 2, 3],
+            "rows must be ordered by descending timestamp"
+        );
     }
 
     #[tokio::test]
@@ -2288,6 +2392,42 @@ mod tests {
         assert_eq!(
             arrow.field_with_name("dur").expect("dur field").data_type(),
             &DataType::Interval(IntervalUnit::MonthDayNano)
+        );
+    }
+
+    #[test]
+    fn normalize_schema_for_duckdb_timestamp_to_microsecond() {
+        use arrow::datatypes::TimeUnit;
+        let mut cmd = cmd_with_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "created_at",
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                true,
+            ),
+            Field::new(
+                "local_at",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+        ])));
+        super::normalize_schema_for_duckdb(&mut cmd).expect("normalize succeeds");
+        let arrow = cmd.schema.as_arrow();
+        // DuckDB stores all TIMESTAMP/TIMESTAMPTZ at microsecond precision; the
+        // registered schema must match to avoid a RowConverter mismatch (#10627).
+        assert_eq!(
+            arrow
+                .field_with_name("created_at")
+                .expect("created_at field")
+                .data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+        );
+        assert_eq!(
+            arrow
+                .field_with_name("local_at")
+                .expect("local_at field")
+                .data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, None),
         );
     }
 

--- a/crates/runtime/tests/retention/mod.rs
+++ b/crates/runtime/tests/retention/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow::array::{BooleanArray, RecordBatch, StringArray, TimestampNanosecondArray};
+use arrow::array::{BooleanArray, RecordBatch, StringArray, TimestampMicrosecondArray};
 use arrow::datatypes::{DataType, TimeUnit};
 use datafusion::common::TableReference;
 use futures::{StreamExt, TryStreamExt};
@@ -90,8 +90,8 @@ fn rows_from_batches(batches: &[RecordBatch]) -> Result<Vec<(String, i64, bool)>
         let updated_at = batch
             .column(1)
             .as_any()
-            .downcast_ref::<TimestampNanosecondArray>()
-            .ok_or_else(|| anyhow::anyhow!("Expected TimestampNanosecondArray in column 1"))?;
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .ok_or_else(|| anyhow::anyhow!("Expected TimestampMicrosecondArray in column 1"))?;
         let deleted = batch
             .column(2)
             .as_any()
@@ -353,7 +353,7 @@ SET
             let pg_initial_ts: i64 = db_conn
                 .conn
                 .query_one(
-                    "SELECT (EXTRACT(EPOCH FROM updated_at) * 1000000000)::BIGINT FROM widgets WHERE name = 'Sample widget';",
+                    "SELECT (EXTRACT(EPOCH FROM updated_at) * 1000000)::BIGINT FROM widgets WHERE name = 'Sample widget';",
                     &[],
                 )
                 .await?
@@ -417,8 +417,8 @@ SET
                 .expect("updated_at column present");
             assert_eq!(
                 updated_field.data_type(),
-                &DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
-                "accelerator should expose updated_at as UTC"
+                &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                "accelerator should expose timestamptz updated_at as microsecond UTC (DuckDB's TIMESTAMPTZ precision, #10627)"
             );
 
             let initial_rows = rows_from_batches(&initial_batches)?;


### PR DESCRIPTION
## Summary

A DuckDB-accelerated column sourced from a `timestamptz` (e.g. a Postgres source) is registered by Spice as `Timestamp(Nanosecond, "UTC")`, but DuckDB's `TIMESTAMP WITH TIME ZONE` (`TIMESTAMPTZ`) type is always **microsecond** precision — DuckDB has no nanosecond-with-timezone type. The registered schema therefore disagrees with what DuckDB physically stores and returns, and any query that sorts or range-joins on the column panics in DataFusion's `RowConverter`:

```
Arrow error: Invalid argument error: RowConverter column schema mismatch, expected Timestamp(ns, "UTC") got Timestamp(µs, "UTC")
```

Fixes #10627

## Root cause

The DuckDB accelerator normalizes its registered schema through `DUCKDB_TYPE_REWRITE_RULES` (Dictionary→value, Interval→MonthDayNano, Null→Int32) to keep the schema in lockstep with what DuckDB physically stores. There was no rule for timezone-aware timestamp precision, so a non-µs `Timestamp(_, Some(tz))` survived into the registered schema while DuckDB stored/returned µs.

## Changes

- Add a `TimestampTzToMicrosecond` rewrite rule in `arrow_tools::type_rewrite` that rewrites a **timezone-aware** `Timestamp(unit, Some(tz))` with a non-microsecond `unit` to `Timestamp(Microsecond, Some(tz))`, preserving the timezone and recursing into nested container types.
- Register the rule in `DUCKDB_TYPE_REWRITE_RULES` so the DuckDB-accelerated table schema for timezone-aware columns is normalized to microsecond precision. Incoming refresh batches are already cast to the accelerator schema via `arrow_tools::record_batch::try_cast_to` (which handles timestamp-unit casts), so no separate data-path change is needed.

### Scope: timezone-aware only

Timezone-**naive** timestamps (`Timestamp(_, None)`) are deliberately left untouched. DuckDB has a native nanosecond `TIMESTAMP_NS` type and preserves the precision of timezone-naive columns — the runtime's own caching-mode `_fetched_at` column is explicitly stored as `TIMESTAMP_NS` (`crates/runtime/src/dataaccelerator/spice_sys/caching_engine/duckdb.rs`). Normalizing those to microsecond would *introduce* a mismatch rather than fix one. Only `TIMESTAMPTZ` lacks a nanosecond variant in DuckDB, so the fix is scoped to timezone-aware timestamps — the exact class the bug affects. Other accelerator engines are unaffected (Cayenne already normalizes timestamps to microsecond in its own schema path).

## Test plan
- [x] Added regression test `duckdb_timestamptz_roundtrip_sorts_without_rowconverter_panic` that registers a `Timestamp(Nanosecond, "UTC")` column, accelerates it with DuckDB, inserts rows, and runs `ORDER BY` (the operation that triggered the RowConverter panic) — asserts the registered schema is microsecond and rows come back in the correct order
- [x] Added `normalize_schema_for_duckdb_timestamptz_to_microsecond` unit test asserting the tz-aware column normalizes to µs and the tz-naive column stays nanosecond
- [x] Added `arrow_tools` unit tests for the rule: tz-aware ns/second/millisecond→µs, tz-aware µs no-op, **tz-naive left unchanged**, nested in List/Struct (tz-aware normalizes, tz-naive does not)
- [x] Updated the existing `retention::test_duckdb_append_refresh_preserves_timestamptz` integration test (Postgres→DuckDB append refresh of a `TIMESTAMPTZ` column) to expect microsecond precision and compare microsecond-aligned values
- [x] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy)
- [x] `make test` passes

## Checklist
- [x] `make lint` clean (Rust Lint CI green)
- [x] `make test` / integration tests pass (incl. retention timestamptz test)
- [x] Regression test exercises the actual `RowConverter` failure mode (ORDER BY on the timestamptz column)