### PR TITLE
fix(test-framework): alias reference-schema tables so parameterized federated reference queries resolve

### DIFF
--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -241,7 +241,10 @@ impl Query {
     /// For example, if `reference_schema` is \"arrow\", the query:
     ///   `SELECT * FROM customer WHERE c_custkey = 1`
     /// becomes:
-    ///   `SELECT * FROM arrow.customer WHERE c_custkey = 1`
+    ///   `SELECT * FROM arrow.customer AS customer WHERE c_custkey = 1`
+    ///
+    /// Each bare table is aliased back to its original name so that column
+    /// qualifications resolve exactly as in the original query.
     ///
     /// Uses `DataFusion`'s SQL parser to parse the query, rewrite all table references,
     /// and unparse back to SQL. This works with any valid SQL query.
@@ -251,25 +254,70 @@ impl Query {
     /// - The SQL query cannot be parsed
     /// - The query contains multiple statements (only single statements are supported)
     pub fn rewrite_with_reference_schema(&self, reference_schema: &str) -> anyhow::Result<Self> {
-        use datafusion::sql::sqlparser::ast::{Ident, ObjectNamePart, visit_relations_mut};
+        use datafusion::sql::sqlparser::ast::{
+            Ident, ObjectNamePart, TableAlias, TableFactor, VisitMut, VisitorMut,
+        };
         use std::ops::ControlFlow;
+
+        // Rewrite every bare (single-part, non-CTE) table reference to live under the
+        // reference schema *and* alias it back to its original name, e.g.
+        // `orders` -> `__test_reference.orders AS orders`. The alias keeps column
+        // qualifications (e.g. `orders.o_orderpriority`) resolving exactly as in the
+        // original query. Without it, qualifying a bare table leaks the reference
+        // schema into the derived names of aggregate output columns on the federated +
+        // prepared-statement (parameterized) planning path, which breaks field
+        // resolution for tpch[parameterized] q12/q14. See spiceai/spiceai#11142.
+        struct ReferenceSchemaRewriter<'a> {
+            reference_schema: &'a str,
+            cte_names: &'a BTreeSet<String>,
+        }
+
+        impl VisitorMut for ReferenceSchemaRewriter<'_> {
+            type Break = ();
+
+            fn pre_visit_table_factor(
+                &mut self,
+                table_factor: &mut TableFactor,
+            ) -> ControlFlow<Self::Break> {
+                if let TableFactor::Table { name, alias, .. } = table_factor
+                    && name.0.len() == 1
+                {
+                    // Clone the original identifier (and end the borrow of `name`)
+                    // before mutating, but only for plain, non-CTE table names.
+                    let original = match &name.0[0] {
+                        ObjectNamePart::Identifier(ident)
+                            if !self.cte_names.contains(ident.value.as_str()) =>
+                        {
+                            Some(ident.clone())
+                        }
+                        _ => None,
+                    };
+
+                    if let Some(original) = original {
+                        name.0.insert(
+                            0,
+                            ObjectNamePart::Identifier(Ident::new(self.reference_schema)),
+                        );
+                        // Preserve any explicit alias the query already has; only add
+                        // one for tables that were referenced bare.
+                        if alias.is_none() {
+                            *alias = Some(TableAlias {
+                                name: original,
+                                columns: Vec::new(),
+                            });
+                        }
+                    }
+                }
+                ControlFlow::Continue(())
+            }
+        }
 
         let mut statement = self.parse_single_statement("reference schema rewrite")?;
         let cte_names = collect_cte_names(&statement);
 
-        // Visit and rewrite all table references in the statement
-        let _ = visit_relations_mut(&mut statement, |table_name| {
-            // Only rewrite if the table doesn't already have a schema prefix (single-part name)
-            if table_name.0.len() == 1
-                && let ObjectNamePart::Identifier(ident) = &table_name.0[0]
-                && !cte_names.contains(ident.value.as_str())
-            {
-                // Prepend the reference schema to the table name
-                table_name
-                    .0
-                    .insert(0, ObjectNamePart::Identifier(Ident::new(reference_schema)));
-            }
-            ControlFlow::<()>::Continue(())
+        let _ = statement.visit(&mut ReferenceSchemaRewriter {
+            reference_schema,
+            cte_names: &cte_names,
         });
 
         // Unparse the modified statement back to SQL
@@ -1397,7 +1445,7 @@ mod tests {
 
         assert_eq!(
             rewritten.sql.as_ref(),
-            "SELECT * FROM arrow.customer WHERE c_custkey = 1"
+            "SELECT * FROM arrow.customer AS customer WHERE c_custkey = 1"
         );
         assert_eq!(rewritten.name.as_ref(), "test_query");
         assert!(!rewritten.overridden);
@@ -1418,6 +1466,35 @@ mod tests {
         assert_eq!(
             rewritten.sql.as_ref(),
             "SELECT * FROM ref_schema.customer AS c JOIN ref_schema.orders AS o ON c.c_custkey = o.o_custkey"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_aliases_bare_join_tables() {
+        // Regression for spiceai/spiceai#11142: bare tables in a join (no explicit
+        // alias) must be aliased back to their original name so column references
+        // such as `orders.o_orderpriority` keep resolving against the unqualified
+        // relation, exactly as in the original query. Without the alias, qualifying
+        // `orders` as `ref.orders` leaks the schema into derived aggregate column
+        // names and breaks field resolution on the parameterized/federated path.
+        let query = Query::new(
+            "test_bare_join".into(),
+            "SELECT l_shipmode FROM lineitem JOIN orders ON l_orderkey = o_orderkey".into(),
+            false,
+        );
+
+        let rewritten = query
+            .rewrite_with_reference_schema("ref")
+            .expect("Failed to rewrite bare-join query");
+
+        let sql = rewritten.sql.as_ref();
+        assert!(
+            sql.contains("ref.lineitem AS lineitem"),
+            "bare table `lineitem` should be aliased back to `lineitem`, got: {sql}"
+        );
+        assert!(
+            sql.contains("ref.orders AS orders"),
+            "bare table `orders` should be aliased back to `orders`, got: {sql}"
         );
     }
 
@@ -1565,7 +1642,7 @@ mod tests {
 
         assert_eq!(
             rewritten.sql.as_ref(),
-            "SELECT * FROM arrow.customer WHERE c_custkey = $1"
+            "SELECT * FROM arrow.customer AS customer WHERE c_custkey = $1"
         );
         assert!(rewritten.parameters.is_some());
     }
@@ -1582,7 +1659,10 @@ mod tests {
             .rewrite_with_reference_schema("arrow")
             .expect("Failed to rewrite query with overridden flag");
 
-        assert_eq!(rewritten.sql.as_ref(), "SELECT * FROM arrow.customer");
+        assert_eq!(
+            rewritten.sql.as_ref(),
+            "SELECT * FROM arrow.customer AS customer"
+        );
         assert!(rewritten.overridden);
     }
 


### PR DESCRIPTION
## What

`rewrite_with_reference_schema` (the benchmark **reference-validation** path) now aliases each qualified table back to its original name, e.g. `orders` → `__test_reference.orders AS orders`, via a `pre_visit_table_factor` visitor. Existing explicit aliases are preserved.

## Why

In `--validate` mode the harness runs each query a second time against an auto-generated `__test_reference.*` schema to compute known-good results. It rewrote bare table refs to `__test_reference.<table>` **without an alias**. For parameterized queries (which take the Flight SQL prepared-statement CAST-rewrite + re-plan path), the federation unparse then produced an aggregate output column whose auto-generated name embedded the **qualified** column refs (`__test_reference.orders.o_orderpriority`) while an outer plan stage looked it up **unqualified** (`orders.o_orderpriority`), so field resolution failed:

```
tpch[parameterized]_q12: ... InvalidArgument, message: "No field named \"sum(CASE WHEN orders.o_orderpriority = $1 OR orders.o_orderpriority = $2 THEN Int64(1) ELSE Int64(0) END)\". Did you mean 'sum(CASE WHEN __test_reference.orders...'?."
tpch[parameterized]_q14: ... "No field named \"sum(CASE WHEN part.p_type LIKE $1 THEN lineitem.l_extendedprice * $2 - lineitem.l_discount ELSE $3 END)\". Did you mean '... __test_reference.part...'?."
```

Aliasing the relation back to its original name keeps column qualifications resolving exactly as in the original query (in SQL, `FROM schema.orders` already has implicit name `orders`, so `AS orders` is a results-preserving no-op) — but it stops the reference schema from leaking into the derived aggregate column names. Root-cause analysis in #11142.

This is a **test-harness-only** change: it does not touch `spiced`, any query plan, or the benchmark query measured against the system-under-test — only the reference-validation copy of the query.

## Changes

- `crates/test-framework/src/queries/mod.rs`: `rewrite_with_reference_schema` qualifies **and** aliases bare (single-part, non-CTE) table references; explicit aliases are left intact. Updated 3 unit-test expectations and added `test_rewrite_aliases_bare_join_tables` covering the bare-join shape.

## Validation

- `cargo test -p test-framework --lib queries::tests` — 22/22 pass.
- `tpch[parameterized] federated/duckdb` bench with `--validate=true` (run [26918837839](https://github.com/spiceai/spiceai/actions/runs/26918837839)): **success** — q12 and q14 execute 5/5 with reference validation enabled, zero `No field named` errors, zero failed queries.

Fixes #11142
