### PR TITLE
Release 2.0: cherry-pick #10999 — fix E2E quickstart (spiceai_region param)

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -464,7 +464,7 @@ jobs:
       - name: Spice dataset configure
         working-directory: test_app
         run: |
-          echo -e "taxi_trips\nnew york taxi trips\nspice.ai/spiceai/quickstart/datasets/taxi_trips\ny" | spice dataset configure
+          spice dataset configure taxi_trips --description "new york taxi trips" --from spice.ai/spiceai/quickstart/datasets/taxi_trips --param spiceai_region=us-east-1
           cat spicepod.yaml
 
       - name: Start spice runtime


### PR DESCRIPTION
## Summary

Cherry-picks **#10999** (`Refactor spice dataset configuration command`, trunk `6aca0deece`) into `release/2.0` to fix the failing **E2E Test CI → Test Spice.ai quickstart** job ([failing run](https://github.com/spiceai/spiceai/actions/runs/26921893556)).

**Root cause:** the `spiceai` data connector requires the `region` parameter, but release/2.0's workflow still used the old interactive `spice dataset configure` flow, which can't set it. `taxi_trips` repeatedly failed with `Missing required parameter: region` and the *Wait for dataset to be ready* step timed out; the darwin job was cancelled by fail-fast.

**The cherry-pick** switches the workflow to the flag-based command (`--param spiceai_region=us-east-1`). #10999 only touches `.github/workflows/e2e_test_ci.yml` (+1/−1) — the CLI flag support itself landed earlier via #10815, which is already in release/2.0. With this, `e2e_test_ci.yml` is byte-identical to trunk's, where the quickstart jobs are green.
