### PR TITLE
fix(cluster): prevent partitioned datasets from staying Refreshing

### DIFF
--- a/crates/runtime-cluster/src/outbound_broadcaster.rs
+++ b/crates/runtime-cluster/src/outbound_broadcaster.rs
@@ -141,30 +141,47 @@ impl ExecutorOutboundBroadcaster {
         }
 
         let executor_id = self.inner.executor_id.read().await.clone();
+        let total = cached.len();
         let mut replayed = 0usize;
         for (table_name, partition_expr_bytes) in cached {
             let payload =
                 partitions_loaded_message(executor_id.clone(), table_name, partition_expr_bytes);
+            // Fail fast on a closed channel or a timed-out send: both mean
+            // this connection is gone or wedged, so the remaining sends are
+            // guaranteed to fail too — without the break, a large cache would
+            // keep the replay task spinning for `tables * SEND_TIMEOUT`. The
+            // cache is retained; the next (re)connect replays everything.
             match tokio::time::timeout(SEND_TIMEOUT, tx.send(payload)).await {
                 Ok(Ok(())) => replayed += 1,
                 Ok(Err(err)) => {
                     tracing::debug!(
-                        "PartitionsLoaded replay to {scheduler_address} failed (channel closed): {err}"
+                        "PartitionsLoaded replay to {scheduler_address} aborted (channel closed): {err}"
                     );
+                    break;
                 }
                 Err(_) => {
                     tracing::warn!(
                         scheduler = %scheduler_address,
-                        "Timed out replaying PartitionsLoaded; scheduler may miss this ack until next refresh"
+                        "Timed out replaying PartitionsLoaded; aborting replay, will retry on next reconnect"
                     );
+                    break;
                 }
             }
         }
-        tracing::info!(
-            scheduler = %scheduler_address,
-            count = replayed,
-            "Replayed cached PartitionsLoaded acks to connected scheduler"
-        );
+        if replayed == total {
+            tracing::info!(
+                scheduler = %scheduler_address,
+                count = replayed,
+                "Replayed cached PartitionsLoaded acks to connected scheduler"
+            );
+        } else {
+            tracing::warn!(
+                scheduler = %scheduler_address,
+                replayed,
+                total,
+                "Replayed only part of the cached PartitionsLoaded acks; will retry on next reconnect"
+            );
+        }
         replayed
     }
 
@@ -398,7 +415,8 @@ mod tests {
                 .await,
             0
         );
-        assert!(rx1.try_recv().is_err());
+        rx1.try_recv()
+            .expect_err("nothing should be emitted when the cache is empty");
 
         let sent = broadcaster
             .broadcast_partitions_loaded("spice.public.lineitem".to_string(), vec![vec![7]])
@@ -429,12 +447,16 @@ mod tests {
     }
 
     /// Replaying onto a torn-down stream (receiver dropped) fails fast and
-    /// reports zero queued acks — the next reconnect replays.
+    /// reports zero queued acks — even with multiple cached tables, the
+    /// replay aborts on the first failed send. The next reconnect replays.
     #[tokio::test]
     async fn replay_on_closed_channel_queues_nothing() {
         let broadcaster = ExecutorOutboundBroadcaster::new("exec-1".to_string());
         broadcaster
             .broadcast_partitions_loaded("spice.public.region".to_string(), vec![vec![1]])
+            .await;
+        broadcaster
+            .broadcast_partitions_loaded("spice.public.orders".to_string(), vec![vec![2]])
             .await;
         let (tx, rx) = mpsc::channel(8);
         drop(rx);

--- a/crates/runtime-cluster/src/outbound_broadcaster.rs
+++ b/crates/runtime-cluster/src/outbound_broadcaster.rs
@@ -20,6 +20,12 @@ limitations under the License.
 //! single `PartitionsLoaded` ack out to every scheduler it's currently
 //! connected to, without the runtime needing a handle on the control-stream
 //! manager.
+//!
+//! Also caches the latest `PartitionsLoaded` payload per table and replays
+//! the cache to each scheduler when its control stream (re)connects, so
+//! readiness acks emitted before any scheduler was connected (e.g. small
+//! datasets that finish loading faster than the control stream is
+//! established) are not lost.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -30,6 +36,10 @@ use runtime_proto::{
     executor_control_message::Message as ExecutorMessage,
 };
 use tokio::sync::{RwLock, mpsc};
+
+/// Per-scheduler timeout for queueing an outbound message. Keeps a stuck/slow
+/// scheduler from blocking sends to its peers.
+const SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Per-scheduler outbound senders, shared between the control-stream manager
 /// and the executor runtime. The manager populates this map on each
@@ -47,6 +57,12 @@ pub struct ExecutorOutboundBroadcaster {
 struct ExecutorOutboundBroadcasterInner {
     streams: RwLock<HashMap<String, mpsc::Sender<ExecutorControlMessage>>>,
     executor_id: RwLock<String>,
+    /// Latest `PartitionsLoaded` payload per table, replayed to schedulers on
+    /// (re)connect. Small/fast datasets can finish their initial load before
+    /// any scheduler control stream is established; without this replay the
+    /// readiness ack would be broadcast to zero schedulers and lost, leaving
+    /// the dataset (and the cluster) stuck in `Refreshing` forever.
+    latest_partitions_loaded: RwLock<HashMap<String, Vec<Vec<u8>>>>,
 }
 
 impl ExecutorOutboundBroadcaster {
@@ -56,6 +72,7 @@ impl ExecutorOutboundBroadcaster {
             inner: Arc::new(ExecutorOutboundBroadcasterInner {
                 streams: RwLock::new(HashMap::new()),
                 executor_id: RwLock::new(executor_id),
+                latest_partitions_loaded: RwLock::new(HashMap::new()),
             }),
         }
     }
@@ -78,12 +95,90 @@ impl ExecutorOutboundBroadcaster {
             .insert(scheduler_address, tx);
     }
 
+    /// Replays the latest cached `PartitionsLoaded` ack for every table to a
+    /// single scheduler over `tx`, that scheduler's just-established control
+    /// stream sender. The control-stream client calls this right after the
+    /// bidirectional stream is established. Datasets that finished their
+    /// initial load before the control stream existed (fast initial loads of
+    /// small datasets), or before a restarted scheduler reconnected (losing
+    /// its in-memory load tracker), would otherwise never deliver their
+    /// readiness ack and stay `Refreshing` forever.
+    ///
+    /// Takes the sender explicitly (rather than looking it up by address) so
+    /// the replay is pinned to the connection that triggered it — on a fast
+    /// disconnect/reconnect it fails fast on the dead channel instead of
+    /// filling the successor connection's bounded channel before that
+    /// stream is established and draining it.
+    ///
+    /// Must only be called once the stream is established — the channel is
+    /// bounded, so replaying more tables than its capacity before anything
+    /// consumes it would wedge the connection setup.
+    ///
+    /// Ordering: `broadcast_partitions_loaded` writes the cache *before*
+    /// snapshotting `streams`, the sender is registered before the stream is
+    /// established, and this replay reads the cache after both. A concurrent
+    /// broadcast therefore always reaches a connecting scheduler — via the
+    /// replay (cache write happened before the replay read), the live
+    /// broadcast (snapshot saw the registered sender), or both. Duplicates
+    /// are fine: the scheduler-side `PartitionLoadTracker` treats acks as
+    /// idempotent replacements.
+    ///
+    /// Returns the number of acks queued for the scheduler.
+    pub async fn replay_partitions_loaded(
+        &self,
+        scheduler_address: &str,
+        tx: &mpsc::Sender<ExecutorControlMessage>,
+    ) -> usize {
+        let cached: Vec<(String, Vec<Vec<u8>>)> = {
+            let cache = self.inner.latest_partitions_loaded.read().await;
+            cache
+                .iter()
+                .map(|(table, bytes)| (table.clone(), bytes.clone()))
+                .collect()
+        };
+        if cached.is_empty() {
+            return 0;
+        }
+
+        let executor_id = self.inner.executor_id.read().await.clone();
+        let mut replayed = 0usize;
+        for (table_name, partition_expr_bytes) in cached {
+            let payload =
+                partitions_loaded_message(executor_id.clone(), table_name, partition_expr_bytes);
+            match tokio::time::timeout(SEND_TIMEOUT, tx.send(payload)).await {
+                Ok(Ok(())) => replayed += 1,
+                Ok(Err(err)) => {
+                    tracing::debug!(
+                        "PartitionsLoaded replay to {scheduler_address} failed (channel closed): {err}"
+                    );
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        scheduler = %scheduler_address,
+                        "Timed out replaying PartitionsLoaded; scheduler may miss this ack until next refresh"
+                    );
+                }
+            }
+        }
+        tracing::info!(
+            scheduler = %scheduler_address,
+            count = replayed,
+            "Replayed cached PartitionsLoaded acks to connected scheduler"
+        );
+        replayed
+    }
+
     pub async fn unregister(&self, scheduler_address: &str) {
         self.inner.streams.write().await.remove(scheduler_address);
     }
 
     /// Broadcasts a `PartitionsLoaded` message to every connected scheduler.
     /// Returns the number of schedulers the message was queued for.
+    ///
+    /// The payload is also cached (latest per table) so it can be replayed to
+    /// schedulers that connect later — see [`Self::replay_partitions_loaded`].
+    /// A return value of `0` therefore no longer means the ack is lost, only
+    /// deferred.
     ///
     /// Uses `send().await` with a short timeout rather than `try_send`. The
     /// scheduler's readiness gate depends on this ack arriving, so silently
@@ -95,16 +190,17 @@ impl ExecutorOutboundBroadcaster {
         table_name: String,
         partition_expr_bytes: Vec<Vec<u8>>,
     ) -> usize {
+        // Cache before snapshotting streams — see the ordering note on
+        // `replay_partitions_loaded` for why this guarantees a concurrently
+        // connecting scheduler can't miss the ack.
+        self.inner
+            .latest_partitions_loaded
+            .write()
+            .await
+            .insert(table_name.clone(), partition_expr_bytes.clone());
+
         let executor_id = self.inner.executor_id.read().await.clone();
-        let payload = ExecutorControlMessage {
-            executor_id,
-            message: Some(ExecutorMessage::PartitionsLoaded(PartitionsLoaded {
-                table_name,
-                partition_expr_bytes: Some(BytesArray {
-                    items: partition_expr_bytes,
-                }),
-            })),
-        };
+        let payload = partitions_loaded_message(executor_id, table_name, partition_expr_bytes);
 
         // Snapshot the (address, sender) pairs so we don't hold the read lock
         // across awaits — a slow scheduler shouldn't block register/unregister.
@@ -118,7 +214,7 @@ impl ExecutorOutboundBroadcaster {
 
         let mut sent = 0usize;
         for (scheduler_address, tx) in targets {
-            match tokio::time::timeout(Duration::from_secs(5), tx.send(payload.clone())).await {
+            match tokio::time::timeout(SEND_TIMEOUT, tx.send(payload.clone())).await {
                 Ok(Ok(())) => sent += 1,
                 Ok(Err(err)) => {
                     tracing::debug!(
@@ -166,7 +262,7 @@ impl ExecutorOutboundBroadcaster {
 
         let mut sent = 0usize;
         for (scheduler_address, tx) in targets {
-            match tokio::time::timeout(Duration::from_secs(5), tx.send(payload.clone())).await {
+            match tokio::time::timeout(SEND_TIMEOUT, tx.send(payload.clone())).await {
                 Ok(Ok(())) => sent += 1,
                 Ok(Err(err)) => {
                     tracing::debug!(
@@ -182,5 +278,171 @@ impl ExecutorOutboundBroadcaster {
             }
         }
         sent
+    }
+}
+
+fn partitions_loaded_message(
+    executor_id: String,
+    table_name: String,
+    partition_expr_bytes: Vec<Vec<u8>>,
+) -> ExecutorControlMessage {
+    ExecutorControlMessage {
+        executor_id,
+        message: Some(ExecutorMessage::PartitionsLoaded(PartitionsLoaded {
+            table_name,
+            partition_expr_bytes: Some(BytesArray {
+                items: partition_expr_bytes,
+            }),
+        })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_partitions_loaded(msg: ExecutorControlMessage) -> PartitionsLoaded {
+        match msg.message {
+            Some(ExecutorMessage::PartitionsLoaded(loaded)) => loaded,
+            other => panic!("expected PartitionsLoaded, got {other:?}"),
+        }
+    }
+
+    /// Regression test for the small-dataset readiness race (#11152): a
+    /// dataset that finishes loading before any scheduler control stream is
+    /// connected broadcasts to zero schedulers; the cached ack must be
+    /// replayed when a scheduler connects afterwards.
+    #[tokio::test]
+    async fn replay_delivers_ack_broadcast_before_any_scheduler_connected() {
+        let broadcaster = ExecutorOutboundBroadcaster::new("exec-1".to_string());
+
+        let sent = broadcaster
+            .broadcast_partitions_loaded("spice.public.region".to_string(), vec![vec![1, 2]])
+            .await;
+        assert_eq!(sent, 0, "no scheduler is connected yet");
+
+        let (tx, mut rx) = mpsc::channel(8);
+        broadcaster
+            .register("scheduler-1".to_string(), tx.clone())
+            .await;
+        let replayed = broadcaster
+            .replay_partitions_loaded("scheduler-1", &tx)
+            .await;
+        assert_eq!(replayed, 1);
+
+        let msg = rx.recv().await.expect("replayed ack");
+        assert_eq!(msg.executor_id, "exec-1");
+        let loaded = expect_partitions_loaded(msg);
+        assert_eq!(loaded.table_name, "spice.public.region");
+        assert_eq!(
+            loaded
+                .partition_expr_bytes
+                .expect("partition bytes present")
+                .items,
+            vec![vec![1, 2]]
+        );
+    }
+
+    /// Re-broadcasting for the same table must overwrite the cached payload
+    /// so a later-connecting scheduler sees only the latest assignment set.
+    #[tokio::test]
+    async fn replay_sends_latest_payload_per_table() {
+        let broadcaster = ExecutorOutboundBroadcaster::new("exec-1".to_string());
+
+        broadcaster
+            .broadcast_partitions_loaded("spice.public.orders".to_string(), vec![vec![1]])
+            .await;
+        broadcaster
+            .broadcast_partitions_loaded("spice.public.orders".to_string(), vec![vec![2], vec![3]])
+            .await;
+
+        let (tx, mut rx) = mpsc::channel(8);
+        // Only the latest payload is cached — exactly one replay per table.
+        assert_eq!(
+            broadcaster
+                .replay_partitions_loaded("scheduler-1", &tx)
+                .await,
+            1
+        );
+
+        let loaded = expect_partitions_loaded(rx.recv().await.expect("replayed ack"));
+        assert_eq!(loaded.table_name, "spice.public.orders");
+        assert_eq!(
+            loaded
+                .partition_expr_bytes
+                .expect("partition bytes present")
+                .items,
+            vec![vec![2], vec![3]]
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "expected a single replayed ack for the table"
+        );
+    }
+
+    /// A live broadcast to a connected scheduler still works, and a second
+    /// scheduler connecting later gets the same ack via replay (covers
+    /// scheduler restart/reconnect, which loses the in-memory load tracker).
+    #[tokio::test]
+    async fn live_broadcast_delivered_and_replayed_to_late_scheduler() {
+        let broadcaster = ExecutorOutboundBroadcaster::new("exec-1".to_string());
+
+        let (tx1, mut rx1) = mpsc::channel(8);
+        broadcaster
+            .register("scheduler-1".to_string(), tx1.clone())
+            .await;
+        // Nothing cached yet — connecting must not emit anything.
+        assert_eq!(
+            broadcaster
+                .replay_partitions_loaded("scheduler-1", &tx1)
+                .await,
+            0
+        );
+        assert!(rx1.try_recv().is_err());
+
+        let sent = broadcaster
+            .broadcast_partitions_loaded("spice.public.lineitem".to_string(), vec![vec![7]])
+            .await;
+        assert_eq!(sent, 1);
+        let loaded = expect_partitions_loaded(rx1.recv().await.expect("live ack"));
+        assert_eq!(loaded.table_name, "spice.public.lineitem");
+
+        let (tx2, mut rx2) = mpsc::channel(8);
+        broadcaster
+            .register("scheduler-2".to_string(), tx2.clone())
+            .await;
+        assert_eq!(
+            broadcaster
+                .replay_partitions_loaded("scheduler-2", &tx2)
+                .await,
+            1
+        );
+        let loaded = expect_partitions_loaded(rx2.recv().await.expect("replayed ack"));
+        assert_eq!(loaded.table_name, "spice.public.lineitem");
+        assert_eq!(
+            loaded
+                .partition_expr_bytes
+                .expect("partition bytes present")
+                .items,
+            vec![vec![7]]
+        );
+    }
+
+    /// Replaying onto a torn-down stream (receiver dropped) fails fast and
+    /// reports zero queued acks — the next reconnect replays.
+    #[tokio::test]
+    async fn replay_on_closed_channel_queues_nothing() {
+        let broadcaster = ExecutorOutboundBroadcaster::new("exec-1".to_string());
+        broadcaster
+            .broadcast_partitions_loaded("spice.public.region".to_string(), vec![vec![1]])
+            .await;
+        let (tx, rx) = mpsc::channel(8);
+        drop(rx);
+        assert_eq!(
+            broadcaster
+                .replay_partitions_loaded("scheduler-1", &tx)
+                .await,
+            0
+        );
     }
 }

--- a/crates/runtime-cluster/src/partition_load_tracker.rs
+++ b/crates/runtime-cluster/src/partition_load_tracker.rs
@@ -79,6 +79,19 @@ impl PartitionLoadTracker {
         }
     }
 
+    /// Returns the tables that have at least one executor ack recorded.
+    /// Used by the scheduler's periodic readiness sweep to re-evaluate acks
+    /// that arrived before the table's partition metadata was seeded (e.g.
+    /// acks replayed by executors that connected during scheduler startup).
+    pub async fn acked_tables(&self) -> Vec<TableReference> {
+        let guard = self.loaded.read().await;
+        guard
+            .iter()
+            .filter(|(_, executors)| !executors.is_empty())
+            .map(|(table, _)| table.clone())
+            .collect()
+    }
+
     /// Returns true when every partition in `metadata` has at least one
     /// of its `assigned_executors` reporting the partition's bytes as
     /// loaded. Returns false on any unassigned partition or encoding
@@ -224,6 +237,23 @@ mod tests {
             .get(&table_b)
             .expect("table_b entry should exist after replace()");
         assert!(acks_other.get("exec-1").is_none());
+    }
+
+    #[tokio::test]
+    async fn acked_tables_lists_tables_with_recorded_acks() {
+        let tracker = PartitionLoadTracker::new();
+        assert!(tracker.acked_tables().await.is_empty());
+
+        let table = TableReference::parse_str("t");
+        // An empty ack (zero-partition dataset) still counts as an ack.
+        tracker
+            .replace(table.clone(), "exec-1".to_string(), HashSet::new())
+            .await;
+        assert_eq!(tracker.acked_tables().await, vec![table.clone()]);
+
+        // Dropping the only acking executor leaves the table without acks.
+        tracker.drop_executor("exec-1").await;
+        assert!(tracker.acked_tables().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/runtime-cluster/src/service.rs
+++ b/crates/runtime-cluster/src/service.rs
@@ -499,6 +499,23 @@ impl PartitionService {
 
         let diff = PartitionDiff { new, removed };
 
+        // Ensure the table has a metadata entry (with `updated_at > 0`) even
+        // when the source currently has no partitions — readiness for
+        // zero-partition tables is gated on the `updated_at > 0` shortcut in
+        // `PartitionLoadTracker::is_table_loaded`, which could never trip if
+        // the entry were only created once partitions are added. Also lets
+        // `add_partitions_with_retry` find the entry below.
+        // No-op if already initialized.
+        let partition_expressions: Vec<String> =
+            partition_by.iter().map(|p| p.expression.clone()).collect();
+        if let Err(e) = self
+            .partition_store
+            .initialize_metadata(table, partition_expressions)
+            .await
+        {
+            tracing::warn!(table = %table, error = %e, "Failed to initialize partition metadata");
+        }
+
         if diff.is_empty() {
             return Ok(diff);
         }
@@ -509,17 +526,6 @@ impl PartitionService {
                 count = diff.new.len(),
                 "Adding new partitions"
             );
-            // Initialize metadata so add_partitions_with_retry can find it.
-            // No-op if already initialized.
-            let partition_expressions: Vec<String> =
-                partition_by.iter().map(|p| p.expression.clone()).collect();
-            if let Err(e) = self
-                .partition_store
-                .initialize_metadata(table, partition_expressions)
-                .await
-            {
-                tracing::warn!(table = %table, error = %e, "Failed to initialize partition metadata");
-            }
             add_partitions_with_retry(&self.partition_store, table, diff.new.clone()).await?;
             if let Some(node_id) = self.executor_registry.node_id() {
                 metrics::record_partition_state_operation(
@@ -1371,6 +1377,74 @@ mod tests {
 
     fn unassigned_partition(key: &str, val: &str) -> PartitionMetadata {
         PartitionMetadata::new(pv(key, val))
+    }
+
+    /// `PartitionOperations` stub whose discovery always returns zero
+    /// partition values, modelling an empty source table.
+    struct EmptySourceOps;
+
+    #[async_trait::async_trait]
+    impl crate::context::PartitionExprResolver for EmptySourceOps {
+        async fn try_parse_expr(
+            &self,
+            _tbl: &TableReference,
+            expr: &str,
+        ) -> std::result::Result<::datafusion_expr::Expr, datafusion::error::DataFusionError>
+        {
+            Ok(::datafusion_expr::col(expr))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::context::PartitionDiscoverer for EmptySourceOps {
+        async fn table_partition_values(
+            &self,
+            _table: &TableReference,
+            _partition_by: &[PartitionedBy],
+        ) -> std::result::Result<Vec<PartitionValue>, Box<dyn std::error::Error + Send + Sync>>
+        {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Seeding a table whose source has zero partitions must still create a
+    /// metadata entry with `updated_at > 0` — readiness for zero-partition
+    /// tables is gated on the `updated_at > 0` shortcut in
+    /// `PartitionLoadTracker::is_table_loaded`, which can never trip if the
+    /// entry is only written once partitions are discovered (#11152).
+    #[tokio::test]
+    async fn seed_table_with_empty_source_writes_metadata_entry() {
+        let store = make_store().await;
+        let registry = Arc::new(ExecutorRegistry::new(
+            Arc::clone(&store),
+            make_store().await,
+        ));
+        let service = PartitionService::new(
+            Arc::clone(&store),
+            registry,
+            Arc::new(tokio::sync::RwLock::new(None)),
+        );
+
+        let table = TableReference::parse_str("empty_table");
+        let partition_by = vec![PartitionedBy {
+            name: "r_regionkey".to_string(),
+            expression: "r_regionkey".to_string(),
+        }];
+
+        service
+            .seed_table(&table, &partition_by, &EmptySourceOps)
+            .await
+            .expect("seed_table");
+
+        store.refresh().await.expect("refresh");
+        let metadata = store
+            .get_cached_table_metadata(&table)
+            .expect("metadata entry must exist for zero-partition table");
+        assert!(metadata.partitions.is_empty());
+        assert!(
+            metadata.updated_at > 0,
+            "updated_at must be stamped so the readiness shortcut can trip"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -289,6 +289,22 @@ fn spawn_control_stream(
             tracing::debug!("Control stream established to scheduler {scheduler_address}");
             backoff.reset();
 
+            // Replay cached PartitionsLoaded acks now that the stream is
+            // established and draining the outbound channel. Datasets that
+            // finished loading before this stream existed (fast initial loads
+            // of small datasets) or before a restarted scheduler reconnected
+            // would otherwise never deliver their readiness ack, leaving them
+            // stuck in `Refreshing`. Spawned so a slow scheduler can't delay
+            // inbound message processing.
+            if let Some(b) = broadcaster.as_ref() {
+                let b = b.clone();
+                let address = scheduler_address.clone();
+                let replay_tx = outbound_tx.clone();
+                tokio::spawn(async move {
+                    b.replay_partitions_loaded(&address, &replay_tx).await;
+                });
+            }
+
             runtime_cluster::metrics::set_executor_scheduler_active_connection(
                 &executor_id,
                 &scheduler_address,

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -94,6 +94,11 @@ impl PartitionAssignmentTask {
                 match result {
                     Ok(()) => {
                         self.status.update_component_status("partition_metadata", ComponentStatus::Ready);
+                        // Pick up executor acks that arrived before metadata
+                        // seeding completed (e.g. replayed on control-stream
+                        // connect during scheduler startup) — they couldn't
+                        // flip their dataset to `Ready` at arrival time.
+                        crate::cluster::service::evaluate_acked_tables_readiness(&self.df).await;
                     }
                     Err(err) => {
                         tracing::warn!("Failed to initialize partition metadata: {err}");
@@ -133,6 +138,13 @@ impl PartitionAssignmentTask {
                             );
                         }
                     }
+
+                    // Re-evaluate acks recorded before their table's partition
+                    // metadata existed; no-op for tables already `Ready`. Runs
+                    // regardless of the cycle's outcome — readiness depends on
+                    // recorded acks + stored metadata, not on this cycle
+                    // having succeeded.
+                    crate::cluster::service::evaluate_acked_tables_readiness(&self.df).await;
 
                     let cycle_duration = cycle_start.elapsed();
                     if cycle_duration > self.interval {

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -1018,7 +1018,7 @@ async fn handle_partitions_loaded(
     // Fail closed: if we can't refresh we may be looking at a stale
     // assignment, which could flip a dataset to `Ready` based on outdated
     // executor membership. Skip this evaluation and let the next ack or
-    // reconcile cycle retry.
+    // readiness sweep retry.
     if let Err(err) = partition_store.refresh().await {
         tracing::warn!(
             table = %loaded.table_name,
@@ -1026,36 +1026,103 @@ async fn handle_partitions_loaded(
         );
         return;
     }
-    let Some(metadata) = partition_store.get_cached_table_metadata(&table) else {
-        // No partition metadata yet — likely raced with first discovery
-        // cycle; the next reconcile will re-evaluate.
+
+    evaluate_table_readiness(datafusion, &table).await;
+}
+
+/// Evaluates whether every assigned partition for `table` is covered by an
+/// executor ack and, if so, flips the dataset's status to `Ready`. Reads the
+/// partition store's *cached* metadata — callers must refresh the store
+/// first. No-op when the dataset is already `Ready`, when partition metadata
+/// hasn't been seeded yet, or when ack coverage is incomplete.
+///
+/// `table` must be the canonical (fully resolved) reference — the same form
+/// `handle_partitions_loaded` uses as the tracker key.
+pub(crate) async fn evaluate_table_readiness(datafusion: &DataFusion, table: &TableReference) {
+    let Some(tracker) = datafusion.partition_load_tracker.as_ref() else {
+        return;
+    };
+    let Some(partition_store) = datafusion
+        .partition_service
+        .as_ref()
+        .map(|s| Arc::clone(&s.partition_store))
+    else {
         return;
     };
 
-    if tracker.is_table_loaded(&table, &metadata, datafusion).await {
-        // Find the dataset key that was registered as `Refreshing` at init
-        // time. The original key may be bare/partial (`foo`) while the
-        // canonical form is full (`spice.public.foo`); calling
-        // `update_dataset(&canonical)` would create a *new* status entry and
-        // leave the original stuck in `Refreshing`, keeping `/v1/ready` at
-        // 503. Match by resolve-equality to update the existing entry.
-        let target = datafusion
-            .runtime_status
-            .get_dataset_statuses()
-            .into_keys()
-            .find(|key| {
-                key.clone()
-                    .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
-                    == resolved
-            })
-            .unwrap_or_else(|| table.clone());
+    let resolved = table
+        .clone()
+        .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
+
+    // Find the dataset key that was registered as `Refreshing` at init
+    // time. The original key may be bare/partial (`foo`) while the
+    // canonical form is full (`spice.public.foo`); calling
+    // `update_dataset(&canonical)` would create a *new* status entry and
+    // leave the original stuck in `Refreshing`, keeping `/v1/ready` at
+    // 503. Match by resolve-equality to update the existing entry.
+    let target = datafusion
+        .runtime_status
+        .get_dataset_statuses()
+        .into_iter()
+        .find(|(key, _)| {
+            key.clone()
+                .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
+                == resolved
+        });
+
+    // Already `Ready` — skip so re-acks and periodic readiness sweeps don't
+    // re-emit the status-change log/metric every time.
+    if matches!(&target, Some((_, crate::status::ComponentStatus::Ready))) {
+        return;
+    }
+
+    let Some(metadata) = partition_store.get_cached_table_metadata(table) else {
+        // No partition metadata yet — the ack raced the first discovery
+        // cycle; the readiness sweep after the next reconcile re-evaluates.
+        return;
+    };
+
+    if tracker.is_table_loaded(table, &metadata, datafusion).await {
+        let target = target.map_or_else(|| table.clone(), |(key, _)| key);
         tracing::info!(
-            table = %loaded.table_name,
+            table = %table,
             "All assigned partitions loaded; marking dataset Ready"
         );
         datafusion
             .runtime_status
             .update_dataset(&target, crate::status::ComponentStatus::Ready);
+    }
+}
+
+/// Re-evaluates readiness for every table with at least one recorded executor
+/// ack. Called from the partition-assignment task after metadata seeding and
+/// after each reconcile cycle: an ack that arrives *before* the table's
+/// partition metadata is seeded (e.g. replayed by an executor that connected
+/// while the scheduler was still starting up) is recorded in the tracker but
+/// can't flip the dataset to `Ready` at arrival time — this sweep picks it up
+/// once metadata exists.
+pub(crate) async fn evaluate_acked_tables_readiness(datafusion: &DataFusion) {
+    let Some(tracker) = datafusion.partition_load_tracker.as_ref() else {
+        return;
+    };
+    let Some(partition_store) = datafusion
+        .partition_service
+        .as_ref()
+        .map(|s| Arc::clone(&s.partition_store))
+    else {
+        return;
+    };
+
+    let acked = tracker.acked_tables().await;
+    if acked.is_empty() {
+        return;
+    }
+    if let Err(err) = partition_store.refresh().await {
+        tracing::warn!("Skipping readiness sweep: partition store refresh failed: {err}");
+        return;
+    }
+    for table in acked {
+        evaluate_table_readiness(datafusion, &table).await;
     }
 }
 

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -1054,25 +1054,37 @@ pub(crate) async fn evaluate_table_readiness(datafusion: &DataFusion, table: &Ta
         .clone()
         .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
 
-    // Find the dataset key that was registered as `Refreshing` at init
-    // time. The original key may be bare/partial (`foo`) while the
-    // canonical form is full (`spice.public.foo`); calling
-    // `update_dataset(&canonical)` would create a *new* status entry and
-    // leave the original stuck in `Refreshing`, keeping `/v1/ready` at
-    // 503. Match by resolve-equality to update the existing entry.
-    let target = datafusion
+    // Find the dataset keys registered at init time. The original key may be
+    // bare/partial (`foo`) while the canonical form is full
+    // (`spice.public.foo`); calling `update_dataset(&canonical)` would create
+    // a *new* status entry and leave the original stuck in `Refreshing`,
+    // keeping `/v1/ready` at 503. Match by resolve-equality to update the
+    // existing entries. Collect *all* matches: an ack that arrived before
+    // dataset registration can have created a canonical-key entry alongside
+    // the registered bare key, and every resolve-equal entry must reach
+    // `Ready` for `/v1/ready` to flip.
+    let matching: Vec<(TableReference, crate::status::ComponentStatus)> = datafusion
         .runtime_status
         .get_dataset_statuses()
         .into_iter()
-        .find(|(key, _)| {
+        .filter(|(key, _)| {
             key.clone()
                 .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
                 == resolved
-        });
+        })
+        .collect();
+    let pending: Vec<TableReference> = matching
+        .iter()
+        .filter(|(_, status)| !matches!(status, crate::status::ComponentStatus::Ready))
+        .map(|(key, _)| key.clone())
+        .collect();
 
-    // Already `Ready` — skip so re-acks and periodic readiness sweeps don't
-    // re-emit the status-change log/metric every time.
-    if matches!(&target, Some((_, crate::status::ComponentStatus::Ready))) {
+    // Every matching entry is already `Ready` — skip so re-acks and periodic
+    // readiness sweeps don't re-emit the status-change log/metric every time.
+    // (No matching entry at all still proceeds: the ack may have arrived
+    // before the dataset registered its status, in which case the canonical
+    // entry is created below.)
+    if pending.is_empty() && !matching.is_empty() {
         return;
     }
 
@@ -1083,14 +1095,21 @@ pub(crate) async fn evaluate_table_readiness(datafusion: &DataFusion, table: &Ta
     };
 
     if tracker.is_table_loaded(table, &metadata, datafusion).await {
-        let target = target.map_or_else(|| table.clone(), |(key, _)| key);
         tracing::info!(
             table = %table,
             "All assigned partitions loaded; marking dataset Ready"
         );
-        datafusion
-            .runtime_status
-            .update_dataset(&target, crate::status::ComponentStatus::Ready);
+        if pending.is_empty() {
+            datafusion
+                .runtime_status
+                .update_dataset(table, crate::status::ComponentStatus::Ready);
+        } else {
+            for key in pending {
+                datafusion
+                    .runtime_status
+                    .update_dataset(&key, crate::status::ComponentStatus::Ready);
+            }
+        }
     }
 }
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -1271,9 +1271,18 @@ impl Runtime {
                     let sent = b
                         .broadcast_partitions_loaded(table_name.clone(), bytes)
                         .await;
-                    tracing::info!(
-                        "Broadcast initial PartitionsLoaded for {table_name} to {sent} scheduler(s)"
-                    );
+                    if sent == 0 {
+                        // Fast initial loads can finish before any scheduler
+                        // control stream is connected; the broadcaster caches
+                        // the ack and replays it on scheduler connect.
+                        tracing::info!(
+                            "Initial PartitionsLoaded for {table_name} cached; no scheduler connected yet, will replay on connect"
+                        );
+                    } else {
+                        tracing::info!(
+                            "Broadcast initial PartitionsLoaded for {table_name} to {sent} scheduler(s)"
+                        );
+                    }
                 }
                 if let Err(e) = runtime.create_dataset_or_view_schedule(ds).await {
                     tracing::error!("Failed to create dataset schedule for '{dataset_name}': {e}");


### PR DESCRIPTION
## Summary

Fixes #11152, where a partitioned dataset could finish its initial executor load before the scheduler control stream was ready. The executor sent `PartitionsLoaded` to zero schedulers, the one-shot readiness ack was lost, and the dataset stayed `Refreshing`; `/v1/ready` stayed at 503.

This PR makes partition readiness resilient to that startup race, scheduler reconnects, and empty partitioned sources. Executors cache and replay the latest load ack, while schedulers re-check recorded acks after partition metadata is available.

## Flow

```text
Before
------
executor loads dataset -> broadcasts PartitionsLoaded -> no scheduler connected
                                                   |
                                                   v
                                      ack is lost; dataset stays Refreshing

After
-----
executor loads dataset -> caches latest PartitionsLoaded
                       -> scheduler control stream connects
                       -> executor replays cached ack
                       -> scheduler evaluates metadata + ack coverage
                       -> dataset Ready
```

## Changes

- Cache the latest `PartitionsLoaded` ack per table in `ExecutorOutboundBroadcaster` and replay it after each scheduler control stream is established.
- Re-evaluate readiness for all acked tables after partition metadata seeding and after each partition-assignment cycle.
- Initialize partition metadata even when a source has zero partitions, so empty partitioned datasets can become `Ready`.
- Skip datasets already marked `Ready` during sweeps to avoid duplicate status logs and metrics.

## Notes

- Replays run only after the stream is established so the bounded outbound channel is being drained.
- Partition assignment semantics are unchanged; this only makes readiness ack delivery and evaluation reliable.

## Test plan

- [x] `cargo test -p runtime-cluster`
- [x] `cargo fmt --check`
- [x] Clippy for the touched crates with the lint-rust flags
- [x] Manual 2-node cluster covering fresh boot, scheduler restart, and a 0-row partitioned dataset
- [ ] CI

Fixes #11152
