### PR TITLE
fix(cluster): prevent DoPut write pipeline self-deadlock under ingest backpressure

### DIFF
--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -386,10 +386,65 @@ fn create_response_stream(
                                 }
                             };
 
-                            // Only report errors; a success message is sent as the final step upon successful write completion
-                            if let Err(err) = handle_record_batch(new_batch, &batch_tx, &path.to_string()).await {
-                                yield Err(err);
-                                break;
+                            // Only report errors; a success message is sent as the final step upon successful write completion.
+                            //
+                            // The send must race against polling `write_future`:
+                            // `write_future` is an unspawned future driven solely by
+                            // this loop, and the sink consumes `batch_rx` only while
+                            // it is polled. Awaiting the send directly suspends this
+                            // generator inside the branch when the channel is full,
+                            // so the sink could never be polled again to drain it —
+                            // a permanent lost-wakeup deadlock that froze all writes
+                            // to an executor whenever the sink fell one channel's
+                            // worth of batches behind the wire (e.g. during a slow
+                            // metastore WAL checkpoint under heavy ingest). Keep the
+                            // sink and the idle deadline polled while the send is
+                            // pending so backpressure propagates instead of
+                            // deadlocking.
+                            let path_str = path.to_string();
+                            let batch_send = handle_record_batch(new_batch, &batch_tx, &path_str);
+                            let mut batch_send = std::pin::pin!(batch_send);
+                            tokio::select! {
+                                biased;
+                                () = &mut deadline => {
+                                    tracing::error!(
+                                        dataset = %path,
+                                        "Timeout: write sink did not accept a record batch within {} seconds",
+                                        idle_timeout.as_secs()
+                                    );
+                                    yield Err(Status::deadline_exceeded(format!(
+                                        "Timeout: write sink did not accept a record batch within {} seconds",
+                                        idle_timeout.as_secs()
+                                    )));
+                                    break;
+                                }
+                                write_result = &mut write_future => {
+                                    match write_result {
+                                        Ok(()) => {
+                                            // Sink finished while a batch was still pending —
+                                            // mirror the early-completion arm: drain and succeed.
+                                            tracing::warn!("Write operation completed before stream ended for dataset: {path}");
+                                            while let Some(msg) = streaming_flight.next().await {
+                                                if let Err(e) = msg {
+                                                    tracing::error!("Error reading remaining message after early write completion: {e}");
+                                                }
+                                            }
+                                            yield Ok(PutResult::default());
+                                            break;
+                                        }
+                                        Err(e) => {
+                                            tracing::error!("Write operation failed. Details included in the response.");
+                                            yield Err(Status::internal(format!("Write operation failed: {e}")));
+                                            break;
+                                        }
+                                    }
+                                }
+                                send_res = &mut batch_send => {
+                                    if let Err(err) = send_res {
+                                        yield Err(err);
+                                        break;
+                                    }
+                                }
                             }
                         }
                         None => {
@@ -397,8 +452,23 @@ fn create_response_stream(
                             drop(batch_tx);
                             tracing::trace!("No more messages in the stream, finalizing write operation for path: {path}");
 
-                            // Wait for the write operation to complete
-                            if let Err(e) = write_future.await {
+                            // Wait for the write operation to complete, logging a
+                            // heartbeat while finalization is pending so a stuck
+                            // write is visible instead of hanging silently.
+                            let finalize_start = std::time::Instant::now();
+                            let write_result = loop {
+                                match tokio::time::timeout(std::time::Duration::from_secs(30), &mut write_future).await {
+                                    Ok(res) => break res,
+                                    Err(_) => {
+                                        tracing::warn!(
+                                            dataset = %path,
+                                            waited_s = finalize_start.elapsed().as_secs(),
+                                            "DoPut write finalization still pending",
+                                        );
+                                    }
+                                }
+                            };
+                            if let Err(e) = write_result {
                                 tracing::error!("Write operation failed. Details included in the response.");
                                 yield Err(Status::internal(format!("Write operation failed: {e}")));
                             }


### PR DESCRIPTION
## Problem

Under sustained cluster ingest (observed with spicebench TPC-H SF10 changes-mode, 3 executors, `bulk_ingest_upsert`), executor write pipelines intermittently froze permanently: zero CPU, every thread parked, no errors, no timeouts. In a milder variant the scheduler-side forwarding instead failed with `ADBC stream bulk ingest failed … Deadline expired` after 120s. Once one executor froze, h2 connection-level flow control froze every other table stream to that executor, and the whole cluster's ETL stalled indefinitely.

## Root cause: poll-starvation self-deadlock in `create_response_stream`

The DoPut write pipeline is a single task. `write_future` (`df.write_streaming_data(...)`, driven by DataFusion `collect()` — nothing spawns it) is polled **only** through one `tokio::select!` arm, and the sink consumes `batch_rx` only while that future is polled:

1. The sink hits a transient slow await (e.g. a metastore SQLite WAL checkpoint once the catalog grows to hundreds of MB under changes-mode ingest).
2. The wire keeps delivering; the cap-100 `batch_tx` channel fills.
3. The handler suspends at `handle_record_batch → batch_tx.send().await` **inside the select branch** — the generator is no longer at the `select!`, so `write_future` can never be polled again.
4. The sink's wakeup arrives, polls the generator, which is suspended at the send — still no channel capacity — `Pending`. The sink's readiness is lost forever.

Producer waits on consumer; consumer is only polled by the producer's task. Permanent lost-wakeup deadlock. The idle deadline can't fire either — its select arm is starved by the same suspension, which is why the hang produced no timeout.

## Fix

In the message arm, race the batch send against `&mut write_future` **and** the idle deadline (nested `select!`):

- While a send is pending, the sink keeps being polled and drains the channel — backpressure propagates instead of deadlocking.
- If the sink is genuinely stuck, the idle deadline now fires and fails the stream with `deadline_exceeded` instead of hanging forever.
- Sink completion/error during a pending send is handled identically to the existing early-completion/error arms.

Also adds a 30s heartbeat log while post-stream finalization (`write_future` after stream end) is pending, so a stuck finalization is visible instead of silent (this path previously awaited with no timeout and no logging).

## Validation

Repro: local 3-executor cluster, spicebench TPC-H SF10 `data-gen-mutable` (changes), concurrency 2, `bulk_ingest_upsert`.

- Before: 3/3 runs froze at ETL steps 5–7 (two permanent hangs incl. one 45+ min with all threads parked; one 120s-deadline bulk-ingest failure). Diagnosis confirmed with scheduler-side instrumentation showing forwarding encoders blocked 600s+ with `keepalives=0` while one executor stopped draining all four table streams.
- After: the same workload rides through the previously fatal window with no blocked-encoder events, no timeouts; checkpoint validation converges (run in progress at PR time; will confirm full completion in comments).

## Future work

- Consider spawning `write_future` as a real task so the pipeline is not single-task by construction.
- Scheduler-side `write_through` forwarding cannot send keepalives while blocked on a full channel (starving the executor's idle deadline); with this fix the executor self-recovers, but the encoder loop could be restructured similarly for defense in depth.
