### PR TITLE
fix(http): preserve non-JSON HTTP response rows in nested column decomposition (fixes #11155)

### DIFF
--- a/crates/data_components/src/http/json_nest.rs
+++ b/crates/data_components/src/http/json_nest.rs
@@ -52,9 +52,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to parse HTTP response row as JSON: {source}"))]
-    JsonParse { source: serde_json::Error },
-
     #[snafu(display("Failed to serialize catch-all JSON column: {source}"))]
     JsonSerialize { source: serde_json::Error },
 }
@@ -126,10 +123,42 @@ pub type DecomposedRow = HashMap<String, Option<String>>;
 /// row is placed into the catch-all column and every declared static
 /// field resolves to `NULL`. This preserves data without silently
 /// dropping values.
+///
+/// Behavior for rows that are *not valid JSON at all* (empty bodies,
+/// HTML error pages, plain text): the row is preserved losslessly
+/// rather than failing the query — every declared static field resolves
+/// to `NULL`, and the catch-all column receives the raw row text encoded
+/// as a JSON string (or `NULL` when the body is empty/whitespace-only).
+/// This mirrors the non-nested code path ([`HttpExec::parse_content`]),
+/// which already returns a non-JSON body as a single raw `content` row.
+/// Hard-erroring here previously crashed any `SELECT` against an HTTP
+/// dataset that declared `columns:` whenever the endpoint returned a
+/// non-JSON body (e.g. fetching a base URL with no path) — see
+/// <https://github.com/spiceai/spiceai/issues/11155>.
+///
+/// [`HttpExec::parse_content`]: super::provider::HttpExec
 pub fn decompose_json_row(json_row: &str, nesting: &HttpJsonNesting) -> Result<DecomposedRow> {
-    let value: serde_json::Value = serde_json::from_str(json_row).context(JsonParseSnafu)?;
-
     let mut out: DecomposedRow = HashMap::new();
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json_row) else {
+        // Not valid JSON: preserve the raw row instead of failing the
+        // whole query. All declared static fields are NULL; the
+        // catch-all keeps the raw text as a JSON string (NULL when the
+        // body is empty/whitespace).
+        for name in &nesting.static_fields {
+            out.insert(name.clone(), None);
+        }
+        let catchall = if json_row.trim().is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::to_string(&serde_json::Value::String(json_row.to_string()))
+                    .context(JsonSerializeSnafu)?,
+            )
+        };
+        out.insert(nesting.json_field_name.clone(), catchall);
+        return Ok(out);
+    };
 
     match value {
         serde_json::Value::Object(map) => {
@@ -279,6 +308,62 @@ mod tests {
         let catchall = d.get("data").expect("data").as_deref().expect("val");
         // BTreeMap ordering => keys alphabetical
         assert_eq!(catchall, r#"{"alpha":2,"mu":3,"zeta":1}"#);
+    }
+
+    #[test]
+    fn non_json_row_is_preserved_in_catchall() {
+        // Regression for https://github.com/spiceai/spiceai/issues/11155:
+        // a non-JSON HTTP body (e.g. an HTML error page returned when the
+        // base URL is fetched with no path) must not crash the query.
+        let n = nesting(&["id", "title", "data"], "data");
+        let row = "<!DOCTYPE html><html><body>not json</body></html>";
+        let d = decompose_json_row(row, &n).expect("non-JSON row must not error");
+        assert!(d.get("id").expect("id present").is_none());
+        assert!(d.get("title").expect("title present").is_none());
+        let catchall = d
+            .get("data")
+            .expect("data present")
+            .as_deref()
+            .expect("catchall not null");
+        // The raw text is preserved as a JSON string, so the catch-all
+        // column always contains valid JSON.
+        let parsed: serde_json::Value =
+            serde_json::from_str(catchall).expect("catchall is valid JSON");
+        assert_eq!(parsed, serde_json::Value::String(row.to_string()));
+    }
+
+    #[test]
+    fn empty_row_yields_all_null() {
+        // An empty HTTP body (e.g. a 5xx with no content) decomposes to a
+        // single all-NULL row rather than erroring.
+        let n = nesting(&["id", "data"], "data");
+        for row in ["", "   ", "\n\t "] {
+            let d = decompose_json_row(row, &n).expect("empty row must not error");
+            assert!(d.get("id").expect("id present").is_none());
+            assert!(
+                d.get("data").expect("data present").is_none(),
+                "empty body => catch-all NULL, got {:?}",
+                d.get("data")
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_json_is_preserved_not_dropped() {
+        // Truncated/garbage JSON is preserved verbatim, not silently
+        // discarded.
+        let n = nesting(&["id", "data"], "data");
+        let row = r#"{"id": "abc", "#; // truncated, invalid JSON
+        let d = decompose_json_row(row, &n).expect("malformed JSON must not error");
+        assert!(d.get("id").expect("id present").is_none());
+        let catchall = d
+            .get("data")
+            .expect("data present")
+            .as_deref()
+            .expect("catchall not null");
+        let parsed: serde_json::Value =
+            serde_json::from_str(catchall).expect("catchall is valid JSON");
+        assert_eq!(parsed, serde_json::Value::String(row.to_string()));
     }
 
     #[test]

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -6855,6 +6855,47 @@ mod tests {
     }
 
     #[test]
+    fn create_batch_from_rows_nested_non_json_rows_are_preserved() {
+        // Regression for https://github.com/spiceai/spiceai/issues/11155.
+        // A `SELECT *` against an HTTP dataset that declares `columns:`
+        // used to crash with "Internal Error" when the endpoint returned a
+        // non-JSON body (e.g. fetching the base URL with no path). The
+        // batch builder must instead preserve the raw row and produce
+        // NULL static fields.
+        let (exec, nesting) = nested_exec(&["id", "details"], "details");
+        let rows = vec![
+            "<!DOCTYPE html><html>not json</html>".to_string(),
+            String::new(),                   // empty body (e.g. 5xx)
+            r#"{"id": "abc", "#.to_string(), // truncated/malformed JSON
+        ];
+        let batch = exec
+            .create_batch_from_rows_nested(
+                None,
+                None,
+                None,
+                None,
+                &rows,
+                &empty_fetch_result(),
+                &nesting,
+            )
+            .expect("non-JSON rows must not crash batch construction");
+        assert_eq!(batch.num_rows(), 3);
+        for v in string_col(&batch, "id") {
+            assert!(v.is_none(), "non-JSON rows must have NULL static fields");
+        }
+        let details = string_col(&batch, "details");
+        // Raw HTML preserved as a JSON string in the catch-all column.
+        assert_eq!(
+            details[0].as_deref(),
+            Some(r#""<!DOCTYPE html><html>not json</html>""#)
+        );
+        // Empty body => catch-all NULL.
+        assert!(details[1].is_none(), "empty body => catch-all NULL");
+        // Malformed JSON preserved verbatim as a JSON string.
+        assert_eq!(details[2].as_deref(), Some(r#""{\"id\": \"abc\", ""#));
+    }
+
+    #[test]
     fn create_batch_from_rows_nested_empty_catchall_is_null_when_all_keys_declared() {
         let (exec, nesting) = nested_exec(&["id", "name", "details"], "details");
         let rows = vec![r#"{"id":"1","name":"alpha"}"#.to_string()];


### PR DESCRIPTION
## Summary

Querying an HTTP/HTTPS dataset that declares `columns:` with a `json_object: "*"` catch-all crashed with an internal error whenever the endpoint returned a non-JSON body:

```
Internal Error: Unexpected internal error.
Failed to decompose HTTP response row into declared columns: Failed to parse HTTP response row as JSON: expected value at line 1 column 1
```

This reproduces by querying without filters (e.g. `select * from tvmaze`), which fetches the base URL with no path and commonly returns an empty body or a non-JSON page.

## Root cause

`crates/data_components/src/http/json_nest.rs::decompose_json_row` called `serde_json::from_str(json_row)?` and hard-errored on any row that was not valid JSON. The non-nested code path (`HttpExec::parse_content`) already tolerates non-JSON bodies — it returns the raw body as a single `content` row — so a dataset *without* `columns:` returned one row while the *same* endpoint *with* `columns:` aborted the entire query.

## Changes

- `decompose_json_row` now treats a parse failure as a non-fatal, lossless case (consistent with its existing handling of non-object valid JSON): every declared static field resolves to `NULL`, and the catch-all column receives the raw row text encoded as a JSON string (`NULL` when the body is empty/whitespace). This mirrors the non-nested path and the function's documented "preserves data without silently dropping values" contract.
- Removed the now-unused `Error::JsonParse` variant.

Scope: limited to the HTTP connector's nested-column decomposition. No behavior change for datasets that return valid JSON, and no change to the non-nested path.

## Test plan
- [x] Added regression test for non-JSON / empty / malformed-JSON rows at the `decompose_json_row` unit level (`non_json_row_is_preserved_in_catchall`, `empty_row_yields_all_null`, `malformed_json_is_preserved_not_dropped`)
- [x] Added regression test at the batch-builder level (`create_batch_from_rows_nested_non_json_rows_are_preserved`) exercising the actual failure mode through `create_batch_from_rows_nested`
- [x] `make lint` passes (workspace-wide fmt check + full clippy)
- [x] `make test` passes

Fixes #11155
