### PR TITLE
feat(chbench): run scheduled benchmarks for both SF1 and SF10

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -212,6 +212,14 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
+      - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF10
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf10 --workflow htap
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.branch }}
+
   dispatch-input:
     name: Dispatch tests - Input
     runs-on: spiceai-dev-runners
@@ -371,16 +379,6 @@ jobs:
       - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - Streaming
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/streaming \
-            --workflow ${{ github.event.inputs.workflow_type }} \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ github.event.ref }}
-
-      - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - CH-BenCHmark - SF1
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf1 \
             --workflow ${{ github.event.inputs.workflow_type }} \
             --update-snapshots ${{ github.event.inputs.update_snapshots }}
         env:

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -378,6 +378,16 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ github.event.ref }}
 
+      - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - CH-BenCHmark - SF1
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf1 \
+            --workflow ${{ github.event.inputs.workflow_type }} \
+            --update-snapshots ${{ github.event.inputs.update_snapshots }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}
+
       - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - CH-BenCHmark - SF10
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/sf10 \

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -2,8 +2,12 @@ name: testoperator dispatch
 
 on:
   schedule:
-    # Every day, at 0900 UTC (0200 PDT)
+    # daily-main, 0900 UTC / 0200 PDT  — full bench suite + HTAP CH-benCHmark SF1
     - cron: '0 9 * * *'
+    # htap-sf10, 1200 UTC / 0500 PDT  — HTAP CH-benCHmark SF10
+    - cron: '0 12 * * *'
+    # htap-sf100, 1600 UTC / 0900 PDT  — HTAP CH-benCHmark SF100
+    - cron: '0 16 * * *'
 
   workflow_dispatch:
     inputs:
@@ -92,7 +96,22 @@ jobs:
       - name: Set spicepod validator path
         run: echo "SPICEPOD_VALIDATOR=${{ steps.build-spicepod-validator.outputs.validator-path }}" >> $GITHUB_ENV
 
+      # Map the cron that fired to a human-readable schedule name. 
+      # Every gated step reads steps.sched.outputs.name.
+      - name: Resolve schedule name
+        id: sched
+        run: |
+          case "${{ github.event.schedule }}" in
+            '0 9 * * *')  NAME=daily-main ;;
+            '0 12 * * *') NAME=htap-sf10   ;;
+            '0 16 * * *') NAME=htap-sf100  ;;
+            *)            NAME=            ;;   # manual / unrecognized cron — match nothing
+          esac
+          echo "Resolved schedule name: $NAME"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
       - name: Validate spicepods - TPCH - SF1
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           shopt -s globstar nullglob
           for file in ./test/spicepods/tpch/sf1/**/*.yaml; do
@@ -101,6 +120,7 @@ jobs:
           done
 
       - name: Validate spicepods - TPCDS - SF1
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           shopt -s globstar nullglob
           for file in ./test/spicepods/tpcds/sf1/**/*.yaml; do
@@ -109,9 +129,28 @@ jobs:
           done
 
       - name: Validate spicepods - ClickBench - SF1
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           shopt -s globstar nullglob
           for file in ./test/spicepods/clickbench/sf1/**/*.yaml; do
+            echo "Validating $file"
+            "$SPICEPOD_VALIDATOR" "$file"
+          done
+
+      - name: Validate spicepods - TPCH - SF100
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
+        run: |
+          shopt -s globstar nullglob
+          for file in ./test/spicepods/tpch/sf100/**/*.yaml; do
+            echo "Validating $file"
+            "$SPICEPOD_VALIDATOR" "$file"
+          done
+
+      - name: Validate spicepods - TPCDS - SF100
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
+        run: |
+          shopt -s globstar nullglob
+          for file in ./test/spicepods/tpcds/sf100/**/*.yaml; do
             echo "Validating $file"
             "$SPICEPOD_VALIDATOR" "$file"
           done
@@ -124,23 +163,8 @@ jobs:
             "$SPICEPOD_VALIDATOR" "$file"
           done
 
-      - name: Validate spicepods - TPCH - SF100
-        run: |
-          shopt -s globstar nullglob
-          for file in ./test/spicepods/tpch/sf100/**/*.yaml; do
-            echo "Validating $file"
-            "$SPICEPOD_VALIDATOR" "$file"
-          done
-
-      - name: Validate spicepods - TPCDS - SF100
-        run: |
-          shopt -s globstar nullglob
-          for file in ./test/spicepods/tpcds/sf100/**/*.yaml; do
-            echo "Validating $file"
-            "$SPICEPOD_VALIDATOR" "$file"
-          done
-
       - name: Dispatch Testoperator - Scheduled Bench - TPCH - SF1
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 --workflow bench
         env:
@@ -149,6 +173,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Bench - TPCDS
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 --workflow bench
         env:
@@ -157,6 +182,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Bench - ClickBench
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 --workflow bench
         env:
@@ -165,6 +191,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Append - TPCH - SF1
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 --workflow append
         env:
@@ -173,6 +200,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Bench - TPCH - SF100
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf100 --workflow bench
         env:
@@ -181,6 +209,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Bench - TPCDS - SF100
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf100 --workflow bench
         env:
@@ -189,6 +218,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Streaming - Bench
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/streaming --workflow streaming-bench
         env:
@@ -197,6 +227,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Streaming - Correctness
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/streaming --workflow streaming-correctness
         env:
@@ -204,7 +235,10 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
+      # HTAP CH-benCHmark — one SF per schedule. SF1 rides with daily-main;
+      # SF10 / SF100 each fire on their own staggered cron (see the schedule block).
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF1
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/sf1 --workflow htap
         env:
@@ -213,8 +247,18 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF10
+        if: ${{ steps.sched.outputs.name == 'htap-sf10' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/sf10 --workflow htap
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.branch }}
+
+      - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF100
+        if: ${{ steps.sched.outputs.name == 'htap-sf100' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf100 --workflow htap
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -236,7 +236,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       # HTAP CH-benCHmark — one SF per schedule. SF1 rides with daily-main;
-      # SF10 / SF100 each fire on their own staggered cron (see the schedule block).
+      # SF10 / SF100 each fire on their own cron.
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF1
         if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |


### PR DESCRIPTION
## 📝 Summary

Spread the scheduled HTAP CH-benCHmark runs across separate cron times by scale factor instead of firing them all on the single 0900 UTC job.

A `Resolve schedule name` step maps the cron that fired to a named schedule, and each step gates on it via `if: steps.sched.outputs.name == '...'`:

| Cron (UTC) | Schedule name | Runs |
|------------|---------------|------|
| `0 9 * * *`  | `daily-main`  | full bench suite + HTAP SF1 |
| `0 12 * * *` | `htap-sf10`   | HTAP SF10 (new) |
| `0 16 * * *` | `htap-sf100`  | HTAP SF100 (new) |

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
