### PR TITLE
feat(spidapter): SPIDAPTER_CAYENNE_PARAMS passthrough + safe custom image tag for branch builds

### DIFF
--- a/.github/workflows/spidapter_build_and_release.yml
+++ b/.github/workflows/spidapter_build_and_release.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: boolean
         default: false
+      tag:
+        description: 'Custom image tag for branch builds (replaces latest; trunk pushes still tag latest)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -103,6 +107,6 @@ jobs:
           push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/spidapter:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/spidapter:latest
+            ghcr.io/${{ github.repository_owner }}/spidapter:${{ inputs.tag || 'latest' }}
           cache-from: type=gha,scope=spidapter
           cache-to: type=gha,scope=spidapter,mode=max

--- a/tools/spidapter/src/args/mod.rs
+++ b/tools/spidapter/src/args/mod.rs
@@ -149,6 +149,13 @@ pub struct StdioArgs {
     /// Query memory limit to apply to `runtime.query.memory_limit` spicepod configuration (e.g. `150Gi`).
     #[arg(long, env = "SPIDAPTER_QUERY_MEMORY_LIMIT")]
     pub query_memory_limit: Option<String>,
+
+    /// Extra params for the generated Cayenne catalog as comma-separated
+    /// `key=value` pairs, e.g.
+    /// `cayenne_write_concurrency=1,cayenne_compaction_max_files_per_pick=512`.
+    /// Applied on top of (and overriding) the params spidapter sets itself.
+    #[arg(long, env = "SPIDAPTER_CAYENNE_PARAMS")]
+    pub cayenne_params: Option<String>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -181,6 +188,11 @@ pub struct LocalSpicedArgs {
     /// Query memory limit to apply to `runtime.query.memory_limit` spicepod configuration (e.g. `150Gi`).
     #[arg(long, env = "SPIDAPTER_QUERY_MEMORY_LIMIT")]
     pub query_memory_limit: Option<String>,
+
+    /// Extra params for the generated Cayenne catalog as comma-separated
+    /// `key=value` pairs (see `StdioArgs::cayenne_params`).
+    #[arg(long, env = "SPIDAPTER_CAYENNE_PARAMS")]
+    pub cayenne_params: Option<String>,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/tools/spidapter/src/local_spiced_server.rs
+++ b/tools/spidapter/src/local_spiced_server.rs
@@ -32,6 +32,7 @@ fn to_stdio_args(args: &LocalSpicedArgs) -> StdioArgs {
         cayenne_metadata_dir: args.cayenne_metadata_dir.clone(),
         scheduler_state_location: args.scheduler_state_location.clone(),
         query_memory_limit: args.query_memory_limit.clone(),
+        cayenne_params: args.cayenne_params.clone(),
         // SCP-only fields — unused in local mode
         spice_cloud_api_url: String::new(),
         channel: None,

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -1666,6 +1666,28 @@ fn generate_adbc_spicepod(
         );
     }
 
+    // Extra catalog params passed through verbatim (e.g.
+    // `cayenne_write_concurrency=1,cayenne_compaction_max_files_per_pick=512`).
+    // Applied last so they override the params spidapter sets itself.
+    if let Some(raw) = &args.cayenne_params {
+        for pair in raw.split(',') {
+            let pair = pair.trim();
+            if pair.is_empty() {
+                continue;
+            }
+            match pair.split_once('=') {
+                Some((key, value)) if !key.trim().is_empty() && !value.trim().is_empty() => {
+                    params_map.insert(key.trim().to_string(), value.trim().to_string());
+                }
+                _ => {
+                    eprintln!(
+                        "[stdio] ignoring malformed SPIDAPTER_CAYENNE_PARAMS entry: {pair:?} (expected key=value)"
+                    );
+                }
+            }
+        }
+    }
+
     if !params_map.is_empty() {
         cayenne_catalog.params = Some(Params::from_string_map(params_map));
     }
@@ -1785,7 +1807,55 @@ mod tests {
             ephemeral_storage_limit_gb: None,
             organization_tag: None,
             query_memory_limit: None,
+            cayenne_params: None,
         }
+    }
+
+    #[test]
+    fn adbc_spicepod_applies_cayenne_params_passthrough() {
+        let mut args = test_stdio_args();
+        args.cayenne_data_dir = Some("/data/cayenne".to_string());
+        args.cayenne_params = Some(
+            " cayenne_write_concurrency=1, cayenne_compaction_max_files_per_pick = 512 ,, bogus , also=  "
+                .to_string(),
+        );
+
+        let run_id = Uuid::new_v4();
+        let spicepod = generate_adbc_spicepod(&run_id, None, &args);
+
+        let catalog = spicepod
+            .catalogs
+            .iter()
+            .find_map(|c| match c {
+                ComponentOrReference::Component(c) if c.name == "spicebench" => Some(c),
+                _ => None,
+            })
+            .expect("generated spicepod should contain the spicebench catalog");
+        let params = catalog
+            .params
+            .as_ref()
+            .expect("catalog params should be set")
+            .as_string_map();
+
+        // Well-formed entries are applied (trimmed)...
+        assert_eq!(
+            params.get("cayenne_write_concurrency").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            params
+                .get("cayenne_compaction_max_files_per_pick")
+                .map(String::as_str),
+            Some("512")
+        );
+        // ...existing spidapter-set params are preserved...
+        assert_eq!(
+            params.get("cayenne_data_dir").map(String::as_str),
+            Some("/data/cayenne")
+        );
+        // ...and malformed entries (no '=', empty value) are ignored.
+        assert!(!params.contains_key("bogus"));
+        assert!(!params.contains_key("also"));
     }
 
     #[test]


### PR DESCRIPTION
Adds a generic `SPIDAPTER_CAYENNE_PARAMS` env/arg (comma-separated `key=value`) that spidapter applies to the generated Cayenne catalog params — enables per-run tuning of any catalog param (e.g. `cayenne_write_concurrency`) from spicebench without code changes. Includes unit test, and a `tag` input for `spidapter_build_and_release.yml` so branch builds publish a custom tag instead of overwriting `:latest`.

Used (and proven) in the #11164 bisection: cloud arms verified the param reaches the spicepod catalog.

Companion: spicebench workflow input PR (spiceai/spicebench).