### PR TITLE
feat(cayenne): expose compaction tuning params on the Cayenne catalog connector

### DIFF
--- a/crates/cayenne/src/catalog_provider.rs
+++ b/crates/cayenne/src/catalog_provider.rs
@@ -75,6 +75,17 @@ pub struct CayenneCatalogProviderConfig {
     pub inline_flush_max_bytes: Option<i64>,
     /// Primary-key conflict detection behavior for inserts.
     pub pk_conflict_detection: Option<PkConflictDetection>,
+    /// New current-snapshot files since the last compaction before a
+    /// post-write compaction pass is scheduled.
+    pub compaction_trigger_files: Option<usize>,
+    /// Protected snapshot count that triggers a fast subset compaction.
+    pub compaction_trigger_protected_snapshots: Option<usize>,
+    /// Maximum input files merged per compaction pass.
+    pub compaction_max_files_per_pick: Option<usize>,
+    /// Byte budget in MB for the in-memory primary-key keyset used for upsert
+    /// conflict detection. Over budget, upsert tables degrade to a bloom
+    /// keyset (and position capture for deletions falls back to the key path).
+    pub pk_keyset_cache_mb: Option<usize>,
 }
 
 /// Errors that can occur when interacting with a Cayenne catalog.
@@ -300,6 +311,18 @@ impl CayenneCatalogProvider {
         }
         if let Some(v) = provider_config.pk_conflict_detection {
             config.pk_conflict_detection = v;
+        }
+        if let Some(v) = provider_config.compaction_trigger_files {
+            config.compaction_trigger_files = v.max(1);
+        }
+        if let Some(v) = provider_config.compaction_trigger_protected_snapshots {
+            config.compaction_trigger_protected_snapshots = v.max(1);
+        }
+        if let Some(v) = provider_config.compaction_max_files_per_pick {
+            config.compaction_max_files_per_pick = v.max(2);
+        }
+        if provider_config.pk_keyset_cache_mb.is_some() {
+            config.pk_keyset_cache_mb = provider_config.pk_keyset_cache_mb;
         }
         config
     }

--- a/crates/runtime/src/catalogconnector/cayenne/mod.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/mod.rs
@@ -77,6 +77,14 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("inline_flush_max_bytes")
         .description("Maximum inline IPC bytes before checkpointing inline data to Vortex. Default: 8388608.")
         .default("8388608"),
+    ParameterSpec::component("compaction_trigger_files")
+        .description("New current-snapshot files since the last compaction before a post-write compaction pass is scheduled. Default: 8."),
+    ParameterSpec::component("compaction_trigger_protected_snapshots")
+        .description("Protected snapshot count that triggers a fast subset compaction. Lower values reduce per-scan protected-snapshot amplification at the cost of more frequent compaction. Default: 8."),
+    ParameterSpec::component("compaction_max_files_per_pick")
+        .description("Maximum input files merged per compaction pass. Default: 32."),
+    ParameterSpec::component("pk_keyset_cache_mb")
+        .description("MB budget for the in-memory primary-key keyset used for upsert conflict detection. Within budget an exact keyset (and position-based deletion capture) is kept; over budget upsert tables degrade to a bloom keyset. Default: 256."),
 ];
 
 /// A catalog connector for Cayenne lakehouse catalogs.
@@ -195,6 +203,34 @@ impl CayenneCatalogConnector {
             .ok()
             .and_then(|v| v.parse::<i64>().ok())
             .map(|v| v.max(0));
+        let compaction_trigger_files = self
+            .params
+            .get("compaction_trigger_files")
+            .expose()
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|v| v.max(1));
+        let compaction_trigger_protected_snapshots = self
+            .params
+            .get("compaction_trigger_protected_snapshots")
+            .expose()
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|v| v.max(1));
+        let compaction_max_files_per_pick = self
+            .params
+            .get("compaction_max_files_per_pick")
+            .expose()
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|v| v.max(2));
+        let pk_keyset_cache_mb = self
+            .params
+            .get("pk_keyset_cache_mb")
+            .expose()
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|v| v.max(1));
 
         CayenneCatalogProviderConfig {
             data_dir,
@@ -213,6 +249,10 @@ impl CayenneCatalogConnector {
             inline_flush_max_rows,
             inline_flush_max_segments,
             inline_flush_max_bytes,
+            compaction_trigger_files,
+            compaction_trigger_protected_snapshots,
+            compaction_max_files_per_pick,
+            pk_keyset_cache_mb,
         }
     }
 }

--- a/tools/cayenne-flightsql/src/main.rs
+++ b/tools/cayenne-flightsql/src/main.rs
@@ -182,6 +182,10 @@ async fn main() -> Result<()> {
                 inline_flush_max_segments: None,
                 inline_flush_max_bytes: None,
                 pk_conflict_detection: None,
+                compaction_trigger_files: None,
+                compaction_trigger_protected_snapshots: None,
+                compaction_max_files_per_pick: None,
+                pk_keyset_cache_mb: None,
             },
             ctx.runtime_env(),
         )


### PR DESCRIPTION
Exposes `cayenne_compaction_trigger_files`, `cayenne_compaction_trigger_protected_snapshots`, and `cayenne_compaction_max_files_per_pick` as Cayenne **catalog** params (parity with the per-dataset accelerator params). Plumbs through `CayenneCatalogProviderConfig` → `VortexConfig` with the same clamping conventions as existing params.

Motivation: #11164 — needed catalog-level compaction tuning for cloud bench experiments (the catalog connector previously accepted only 14 params, none compaction-related). Note: the tuning arm did NOT recover the #11164 regression — these knobs are exposed for operability, not as a fix.