### PR TITLE
feat(connectors): extended schema inference for Postgres & MongoDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,6 +3501,7 @@ dependencies = [
  "hash-index",
  "im",
  "insta",
+ "libc",
  "object_store",
  "parking_lot 0.12.5",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,10 +3646,14 @@ dependencies = [
 name = "chbench-driver"
 version = "2.0.0-unstable"
 dependencies = [
+ "arrow",
  "async-trait",
  "chrono",
+ "datafusion-table-providers",
+ "futures",
  "governor",
  "rand 0.10.1",
+ "secrecy",
  "snafu",
  "tokio",
  "tokio-postgres",
@@ -19298,6 +19302,7 @@ version = "2.0.0-unstable"
 dependencies = [
  "arrow",
  "arrow-json",
+ "arrow_tools",
  "async-trait",
  "aws-config",
  "aws-credential-types",

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -71,6 +71,13 @@ aegis = { version = "0.9.3", default-features = false, features = [
     "pure-rust",
 ] }
 
+# Ordering-tier fsync on the staged-commit hot path (provider/fsync_tier.rs):
+# on macOS both std `sync_all` AND `sync_data` are fcntl(F_FULLFSYNC) (~4-5 ms
+# per call, measured), so the plain-fsync ordering tier needs a direct
+# libc::fsync. See the module docs for the durability rationale.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [features]
 default = []
 turso = ["dep:turso"]
@@ -252,6 +259,21 @@ required-features = ["duckdb-bench"]
 [[bench]]
 harness = false
 name = "vs_duckdb_scaling"
+required-features = ["duckdb-bench"]
+
+[[bench]]
+harness = false
+name = "vs_duckdb_memory_budget"
+required-features = ["duckdb-bench"]
+
+[[bench]]
+harness = false
+name = "vs_duckdb_scan_under_compaction"
+required-features = ["duckdb-bench"]
+
+[[bench]]
+harness = false
+name = "vs_duckdb_cdc_multitable"
 required-features = ["duckdb-bench"]
 
 [[bench]]

--- a/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
+++ b/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
@@ -1,0 +1,313 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Fleet CDC: sustained CDC apply across N tables concurrently.
+//!
+//! `vs_duckdb_scaling_cdc` pumps ONE table with N writers; this bench pumps
+//! N TABLES with one CDC writer each — the real HTAP topology (CH-benCH is
+//! 14 CDC datasets, each its own accelerator with its own metastore). The
+//! distinction matters because per-table write concurrency is sized in
+//! isolation: with T tables the effective encoder demand is the SUM across
+//! tables, which oversubscribes the box in exactly the way a single-table
+//! bench structurally cannot see. This curve is the micro-proxy guarding
+//! the global write-budget work.
+//!
+//! - **Cayenne**: each table is a fully independent fixture (own metastore,
+//!   own data dir — the per-dataset topology spiced creates). One persistent
+//!   writer task per table pumps `write_cdc_append_stream + finish()` (the
+//!   production `refresh_mode: changes` path) with a long-lived per-writer
+//!   `SessionContext`, batches of `WRITE_BATCH_ROWS` appends per tick.
+//! - **DuckDB**: one file-backed database with N tables; one writer thread
+//!   per table, each with its own `Connection`. DuckDB serializes writers
+//!   internally — the single-global-writer architecture Cayenne's
+//!   per-table encoders are traded against.
+//!
+//! Criterion `Throughput::Elements(N × WRITE_BATCH_ROWS)` makes the report
+//! read as aggregate rows/sec; a flat (or falling) elements-per-second curve
+//! as N grows is the oversubscription signal.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::sync::Arc;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use criterion::{
+    BenchmarkId, Criterion, SamplingMode, Throughput, criterion_group, criterion_main,
+};
+use duckdb::Connection;
+use tokio::runtime::Runtime;
+
+use common::{
+    CAYENNE_LANES, CayenneFixture, cayenne_cdc_write, duckdb_insert_rows, make_batch, schema,
+    setup_cayenne_for, setup_duckdb,
+};
+
+/// Table-count sweep. 14 ≈ CH-benCH's table fleet; 16 keeps the axis on a
+/// power-of-two grid while covering it.
+const TABLE_COUNTS: &[usize] = &[1, 2, 4, 8, 16];
+
+/// Rows per CDC batch per table per tick — matches
+/// `vs_duckdb_scaling`'s WRITE_BATCH_ROWS so the N=1 lane of this bench is
+/// directly comparable to that bench's concurrency=1 CDC lane.
+const WRITE_BATCH_ROWS: usize = 1_024;
+
+/// Batches pre-written into every table (both engines) before its lane is
+/// timed. A fresh table's per-batch cost is not stationary — snapshots and
+/// metadata accumulate as batches land, so lanes with cheaper iterations
+/// would silently run MORE iterations and age their tables further than
+/// expensive lanes, corrupting the cross-N comparison (a first cut of this
+/// bench produced a non-monotonic garbage curve exactly this way). The
+/// preload parks every table well past the steep start of that cost curve
+/// so marginal aging during the (bounded, flat-sampled) measurement is
+/// small and comparable across lanes. Preload ids are negative so timed
+/// writes (cursor 0..) never overlap them.
+const PRELOAD_BATCHES: usize = 64;
+
+/// Per-completion wait bound: a stalled writer surfaces as a labeled panic
+/// instead of a hung bench (same rationale as `vs_duckdb_scaling`).
+const COMPLETION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Persistent CDC writer task bound to ONE Cayenne table. Receives a tick,
+/// writes one batch through the production CDC path, signals done.
+struct CayenneTableWriter {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl CayenneTableWriter {
+    fn spawn(
+        rt: &Runtime,
+        fixture: Arc<CayenneFixture>,
+        mut go_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+        done_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    ) -> Self {
+        let handle = rt.spawn(async move {
+            // One long-lived session per writer — the long-running refresh
+            // loop shape (see `cayenne_cdc_write` docs for why per-batch
+            // SessionContext construction would dominate).
+            let ctx = datafusion::prelude::SessionContext::new();
+            let task_ctx = ctx.task_ctx();
+            let mut cursor: i64 = 0;
+            while go_rx.recv().await.is_some() {
+                let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
+                cursor += WRITE_BATCH_ROWS as i64;
+                let rows = cayenne_cdc_write(&fixture.table, &task_ctx, batch).await;
+                assert!(rows > 0, "cdc write acknowledged zero rows");
+                let _ = done_tx.send(());
+            }
+        });
+        Self { handle }
+    }
+}
+
+/// Persistent CDC-analog writer thread bound to ONE DuckDB table in the
+/// shared database file. Own `Connection` (connections are not `Send`).
+struct DuckDbTableWriter {
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl DuckDbTableWriter {
+    fn spawn(
+        db_path: std::path::PathBuf,
+        table_name: String,
+        go_rx: mpsc::Receiver<()>,
+        done_tx: mpsc::Sender<()>,
+    ) -> Self {
+        let handle = std::thread::spawn(move || {
+            let conn = Connection::open(&db_path).expect("duckdb writer connection open");
+            let mut cursor: i64 = 0;
+            while go_rx.recv().is_ok() {
+                let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
+                cursor += WRITE_BATCH_ROWS as i64;
+                duckdb_insert_rows(&conn, &table_name, &batch);
+                let _ = done_tx.send(());
+            }
+        });
+        Self { handle }
+    }
+}
+
+fn bench_cdc_multitable(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_cdc_multitable");
+    // Flat sampling + bounded measurement: every sample runs the same
+    // iteration count and the lane stops aging its tables after a few
+    // hundred batches — see PRELOAD_BATCHES for why this matters.
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(4));
+
+    for &lane in CAYENNE_LANES {
+        let lane_label = format!("{}_cdc", lane.lane());
+
+        for &tables in TABLE_COUNTS {
+            group.throughput(Throughput::Elements((tables * WRITE_BATCH_ROWS) as u64));
+
+            // N independent fixtures: own metastore + data dir each, the
+            // per-dataset topology spiced creates for a CDC fleet.
+            let fixtures: Vec<Arc<CayenneFixture>> = (0..tables)
+                .map(|i| Arc::new(rt.block_on(setup_cayenne_for(&format!("cdc_multi_{i}"), lane))))
+                .collect();
+
+            // Preload: park every table past the steep start of the
+            // per-batch cost curve (negative id range; timed writes use
+            // cursor 0.. and never overlap).
+            rt.block_on(async {
+                let preload_ctx = datafusion::prelude::SessionContext::new();
+                let task_ctx = preload_ctx.task_ctx();
+                let preload_start = -((PRELOAD_BATCHES * WRITE_BATCH_ROWS) as i64);
+                for fixture in &fixtures {
+                    for batch_idx in 0..PRELOAD_BATCHES {
+                        let start = preload_start + (batch_idx * WRITE_BATCH_ROWS) as i64;
+                        let batch = make_batch(schema(), start, WRITE_BATCH_ROWS);
+                        let rows = cayenne_cdc_write(&fixture.table, &task_ctx, batch).await;
+                        assert!(rows > 0, "preload cdc write acknowledged zero rows");
+                    }
+                }
+            });
+
+            let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+            let mut go_txs: Vec<tokio::sync::mpsc::UnboundedSender<()>> =
+                Vec::with_capacity(tables);
+            let mut workers: Vec<CayenneTableWriter> = Vec::with_capacity(tables);
+            for fixture in &fixtures {
+                let (go_tx, go_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+                go_txs.push(go_tx);
+                workers.push(CayenneTableWriter::spawn(
+                    &rt,
+                    Arc::clone(fixture),
+                    go_rx,
+                    done_tx.clone(),
+                ));
+            }
+            drop(done_tx);
+
+            let bench_ctx = format!("vs_duckdb_cdc_multitable/{lane_label}");
+            group.bench_with_input(BenchmarkId::new(&lane_label, tables), &tables, |b, &n| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        for tx in &go_txs {
+                            tx.send(()).expect("cayenne cdc go-tx (worker exited?)");
+                        }
+                        for i in 0..n {
+                            match tokio::time::timeout(COMPLETION_TIMEOUT, done_rx.recv()).await {
+                                Ok(Some(())) => {}
+                                Ok(None) => panic!(
+                                    "{bench_ctx}: done channel closed at completion {}/{n} \
+                                         (worker exited?)",
+                                    i + 1
+                                ),
+                                Err(_) => panic!(
+                                    "{bench_ctx}: stalled waiting for writer completion \
+                                         {}/{n} after {COMPLETION_TIMEOUT:?}",
+                                    i + 1
+                                ),
+                            }
+                        }
+                    });
+                });
+            });
+
+            // Teardown: dropping the go senders ends each worker loop; join
+            // them before the fixtures are torn down. Propagate panics — a
+            // writer that died late would otherwise be swallowed and the
+            // lane would report numbers from a partially failed run.
+            drop(go_txs);
+            for worker in workers {
+                rt.block_on(worker.handle)
+                    .expect("cayenne cdc writer task panicked");
+            }
+            drop(fixtures);
+        }
+    }
+
+    // --- DuckDB: one database file, N tables, one writer thread per table.
+    for &tables in TABLE_COUNTS {
+        group.throughput(Throughput::Elements((tables * WRITE_BATCH_ROWS) as u64));
+
+        let fixture = setup_duckdb("cdc_multi_0");
+        for i in 1..tables {
+            fixture
+                .conn
+                .execute_batch(&format!(
+                    "CREATE TABLE cdc_multi_{i} (id BIGINT, name VARCHAR NOT NULL, \
+                     value BIGINT NOT NULL);"
+                ))
+                .expect("duckdb create table");
+        }
+
+        // Preload to the same per-table batch count as the Cayenne lanes.
+        {
+            let preload_start = -((PRELOAD_BATCHES * WRITE_BATCH_ROWS) as i64);
+            for i in 0..tables {
+                let table_name = format!("cdc_multi_{i}");
+                for batch_idx in 0..PRELOAD_BATCHES {
+                    let start = preload_start + (batch_idx * WRITE_BATCH_ROWS) as i64;
+                    let batch = make_batch(schema(), start, WRITE_BATCH_ROWS);
+                    duckdb_insert_rows(&fixture.conn, &table_name, &batch);
+                }
+            }
+        }
+
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        let mut go_txs: Vec<mpsc::Sender<()>> = Vec::with_capacity(tables);
+        let mut workers: Vec<DuckDbTableWriter> = Vec::with_capacity(tables);
+        for i in 0..tables {
+            let (go_tx, go_rx) = mpsc::channel::<()>();
+            go_txs.push(go_tx);
+            workers.push(DuckDbTableWriter::spawn(
+                fixture.db_path(),
+                format!("cdc_multi_{i}"),
+                go_rx,
+                done_tx.clone(),
+            ));
+        }
+        drop(done_tx);
+
+        let bench_ctx = format!("vs_duckdb_cdc_multitable/duckdb tables={tables}");
+        group.bench_with_input(BenchmarkId::new("duckdb", tables), &tables, |b, &n| {
+            b.iter(|| {
+                for tx in &go_txs {
+                    tx.send(()).expect("duckdb go-tx (worker exited?)");
+                }
+                for i in 0..n {
+                    done_rx
+                        .recv_timeout(COMPLETION_TIMEOUT)
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "{bench_ctx}: stalled waiting for writer completion {}/{n} \
+                             after {COMPLETION_TIMEOUT:?} ({err})",
+                                i + 1
+                            )
+                        });
+                }
+            });
+        });
+
+        drop(go_txs);
+        for worker in workers {
+            // Propagate late panics — same rationale as the Cayenne teardown.
+            worker
+                .handle
+                .join()
+                .expect("duckdb cdc writer thread panicked");
+        }
+        drop(fixture);
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cdc_multitable);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_helpers/common.rs
+++ b/crates/cayenne/benches/vs_duckdb_helpers/common.rs
@@ -240,6 +240,37 @@ async fn setup_cayenne_with(
     on_conflict: Option<OnConflict>,
     table_schema: Arc<Schema>,
 ) -> CayenneFixture {
+    setup_cayenne_custom(
+        table_name,
+        metastore,
+        primary_key,
+        on_conflict,
+        table_schema,
+        cayenne::metadata::VortexConfig::default(),
+        Arc::new(RuntimeEnv::default()),
+    )
+    .await
+}
+
+/// Fully-parameterized Cayenne fixture: callers control the `VortexConfig`
+/// (e.g. compaction triggers, inline-memtable size) and the `RuntimeEnv`
+/// (e.g. a budgeted memory pool). The simpler `setup_cayenne*` wrappers all
+/// route through this with defaults.
+///
+/// Pass the SAME `RuntimeEnv` to [`warm_session_with_runtime`] when queries
+/// must run under the same memory budget as the table's write path — that
+/// mirrors spiced, which shares one `RuntimeEnv` across the accelerator and
+/// the query sessions.
+#[allow(clippy::too_many_arguments)]
+pub async fn setup_cayenne_custom(
+    table_name: &str,
+    metastore: Metastore,
+    primary_key: Vec<String>,
+    on_conflict: Option<OnConflict>,
+    table_schema: Arc<Schema>,
+    vortex_config: cayenne::metadata::VortexConfig,
+    runtime_env: Arc<RuntimeEnv>,
+) -> CayenneFixture {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let data_path = temp_dir.path().join("data");
     tokio::fs::create_dir_all(&data_path)
@@ -260,9 +291,9 @@ async fn setup_cayenne_with(
                 on_conflict,
                 base_path: data_path.to_string_lossy().to_string(),
                 partition_column: None,
-                vortex_config: cayenne::metadata::VortexConfig::default(),
+                vortex_config,
             },
-            Arc::new(RuntimeEnv::default()),
+            runtime_env,
         )
         .await
         .expect("cayenne create_table"),
@@ -273,6 +304,24 @@ async fn setup_cayenne_with(
         table,
         catalog: Arc::clone(&catalog) as Arc<dyn MetadataCatalog>,
     }
+}
+
+/// Like [`warm_session_for`] but builds the session on a caller-provided
+/// [`RuntimeEnv`] — required when the query must execute under a budgeted
+/// memory pool. A plain `SessionContext::new()` would silently run queries
+/// against an UNLIMITED default pool, making any memory-budget comparison
+/// measure nothing (the fixture's budget would gate only the write path).
+pub fn warm_session_with_runtime(
+    table: &Arc<CayenneTableProvider>,
+    runtime_env: Arc<RuntimeEnv>,
+) -> datafusion::prelude::SessionContext {
+    use datafusion::datasource::TableProvider;
+    use datafusion::prelude::{SessionConfig, SessionContext};
+
+    let ctx = SessionContext::new_with_config_rt(SessionConfig::new(), runtime_env);
+    ctx.register_table("t", Arc::clone(table) as Arc<dyn TableProvider>)
+        .expect("register table");
+    ctx
 }
 
 /// A clean DuckDB file-mode database with the same schema.

--- a/crates/cayenne/benches/vs_duckdb_memory_budget.rs
+++ b/crates/cayenne/benches/vs_duckdb_memory_budget.rs
@@ -1,0 +1,485 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Peak memory under a fixed budget: Cayenne vs DuckDB.
+//!
+//! Every other `vs_duckdb_*` bench runs Cayenne on `RuntimeEnv::default()` —
+//! an UNLIMITED memory pool — so none of them can see whether Cayenne lives
+//! within the budget an operator configures via `runtime.query.memory_limit`.
+//! This bench closes that gap: each lane runs the same workload at the same
+//! configured budget on both engines —
+//!
+//! - **Cayenne**: a `TrackConsumersPool<GreedyMemoryPool>` sized to the
+//!   budget (exactly how spiced builds the production pool — see
+//!   `crates/runtime/src/datafusion/builder.rs`), wrapped in a high-water
+//!   tracker, wired into BOTH the table's `RuntimeEnv` (write path) and the
+//!   query `SessionContext` (scan path), mirroring spiced's single shared
+//!   `RuntimeEnv`.
+//! - **DuckDB**: `SET memory_limit='<budget>'` on the same file-backed DB.
+//!
+//! Three workloads per budget: a filtered scan-aggregate, a GROUP BY with
+//! 16Ki groups, and a PK upsert from parquet (the CDC replace shape).
+//!
+//! Reported signals, per (engine, workload, budget):
+//! - criterion wall-clock (latency at the budget);
+//! - `pool high-water` lines on stderr — the maximum bytes the DataFusion
+//!   pool had reserved at any point during the lane (Cayenne), best-effort
+//!   `duckdb_memory()` usage (DuckDB);
+//! - a hard assert that Cayenne's pool high-water never exceeds the budget
+//!   (the operator contract — exceeding it is a bug, not a slow lane);
+//! - a lane that cannot complete at a budget (ResourcesExhausted) is
+//!   SKIPPED with an explanatory stderr line rather than panicking — "needs
+//!   more than 256 MiB for this workload" is a finding, not a crash.
+//!
+//! Pool high-water ≈ 0 while the workload clearly allocates (e.g. the upsert
+//! lane) is itself a signal: that work is running OFF-pool, invisible to the
+//! operator's budget — the known "ingest caches sized off total RAM" class
+//! of findings. For process-level peak RSS, wrap the bench invocation in
+//! `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux).
+//!
+//! READING THE NUMBERS: budgets run sequentially (256MiB → 2GiB → 16GiB), so
+//! slow systemic drift (thermal, page cache) accumulates toward the later
+//! budgets — compare ENGINES WITHIN a budget, not one engine across budgets.
+//! The high-water lines are order-robust; the wall-clock lanes are the
+//! within-budget pairing.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use arrow::array::RecordBatch;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion::common::Result as DataFusionResult;
+use datafusion::execution::memory_pool::{
+    GreedyMemoryPool, MemoryLimit, MemoryPool, MemoryReservation, TrackConsumersPool,
+};
+use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+use datafusion::prelude::SessionContext;
+use duckdb::Connection;
+use tokio::runtime::Runtime;
+
+use common::{
+    CayenneFixture, Metastore, cayenne_insert, make_batch, make_batch_grouped, schema,
+    setup_cayenne_custom, warm_session_with_runtime, write_parquet,
+};
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+
+/// Budgets from the audit skill's three reference points: embedded /
+/// dev-laptop / production-server.
+const MEMORY_BUDGETS: &[(&str, usize)] = &[
+    ("256MiB", 256 * 1024 * 1024),
+    ("2GiB", 2 * 1024 * 1024 * 1024),
+    ("16GiB", 16 * 1024 * 1024 * 1024),
+];
+
+/// Rows in the pre-loaded fixture. Matches `vs_duckdb_scaling`'s READ_ROWS
+/// so latency lanes are comparable across benches.
+const BASE_ROWS: usize = 1_048_576;
+
+/// Distinct GROUP BY keys — the existing `vs_duckdb_groupby` high-cardinality
+/// lane, here re-run under a budgeted pool.
+const GROUPS: usize = 16_384;
+
+/// Rows per upsert batch (CDC replace shape: same ids re-written).
+const UPSERT_ROWS: usize = 16_384;
+
+const SCAN_SQL: &str = "SELECT SUM(value) FROM t WHERE id BETWEEN 1000 AND 11000";
+const GROUPBY_SQL: &str = "SELECT name, SUM(value) FROM t GROUP BY name";
+
+// ---------------------------------------------------------------------------
+// High-water memory pool
+// ---------------------------------------------------------------------------
+
+/// Wraps the production pool shape (`TrackConsumersPool<GreedyMemoryPool>`)
+/// and records the maximum total reservation ever observed. DataFusion's
+/// `MemoryPool::reserved()` only reports the CURRENT reservation; the budget
+/// question is about the peak.
+#[derive(Debug)]
+struct HighWaterPool {
+    inner: TrackConsumersPool<GreedyMemoryPool>,
+    high_water: AtomicUsize,
+}
+
+impl HighWaterPool {
+    fn new(budget_bytes: usize) -> Self {
+        let topn = NonZeroUsize::new(5).expect("non-zero top-n");
+        Self {
+            inner: TrackConsumersPool::new(GreedyMemoryPool::new(budget_bytes), topn),
+            high_water: AtomicUsize::new(0),
+        }
+    }
+
+    fn record_high_water(&self) {
+        let reserved = self.inner.reserved();
+        self.high_water.fetch_max(reserved, Ordering::Relaxed);
+    }
+
+    fn high_water_bytes(&self) -> usize {
+        self.high_water.load(Ordering::Relaxed)
+    }
+
+    fn reset_high_water(&self) {
+        // Seed with the CURRENT reservation, not 0: the high-water only
+        // advances on grow/try_grow, so a pool holding steady-state
+        // reservations that don't grow further during the measured window
+        // would otherwise read 0 — hiding held memory (e.g. table-side
+        // caches sized during a pre-flight upsert and retained across the
+        // timed iterations).
+        self.high_water
+            .store(self.inner.reserved(), Ordering::Relaxed);
+    }
+}
+
+impl MemoryPool for HighWaterPool {
+    fn register(&self, consumer: &datafusion::execution::memory_pool::MemoryConsumer) {
+        self.inner.register(consumer);
+    }
+
+    fn unregister(&self, consumer: &datafusion::execution::memory_pool::MemoryConsumer) {
+        self.inner.unregister(consumer);
+    }
+
+    fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+        self.inner.grow(reservation, additional);
+        self.record_high_water();
+    }
+
+    fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+        self.inner.shrink(reservation, shrink);
+    }
+
+    fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> DataFusionResult<()> {
+        self.inner.try_grow(reservation, additional)?;
+        self.record_high_water();
+        Ok(())
+    }
+
+    fn reserved(&self) -> usize {
+        self.inner.reserved()
+    }
+
+    fn memory_limit(&self) -> MemoryLimit {
+        self.inner.memory_limit()
+    }
+}
+
+/// A budgeted Cayenne fixture: the table AND the warm query session share one
+/// `RuntimeEnv` built on a [`HighWaterPool`] — the spiced topology.
+struct BudgetedCayenne {
+    fixture: CayenneFixture,
+    warm_ctx: SessionContext,
+    pool: Arc<HighWaterPool>,
+}
+
+async fn setup_budgeted_cayenne(
+    table_name: &str,
+    metastore: Metastore,
+    budget_bytes: usize,
+    with_pk: bool,
+) -> BudgetedCayenne {
+    let pool = Arc::new(HighWaterPool::new(budget_bytes));
+    let runtime_env: Arc<RuntimeEnv> = RuntimeEnvBuilder::default()
+        .with_memory_pool(Arc::clone(&pool) as Arc<dyn MemoryPool>)
+        .build_arc()
+        .expect("budgeted runtime env");
+
+    let (primary_key, on_conflict) = if with_pk {
+        (
+            vec!["id".to_string()],
+            Some(OnConflict::Upsert(ColumnReference::new(vec![
+                "id".to_string(),
+            ]))),
+        )
+    } else {
+        (vec![], None)
+    };
+
+    let fixture = setup_cayenne_custom(
+        table_name,
+        metastore,
+        primary_key,
+        on_conflict,
+        schema(),
+        cayenne::metadata::VortexConfig::default(),
+        Arc::clone(&runtime_env),
+    )
+    .await;
+    let warm_ctx = warm_session_with_runtime(&fixture.table, runtime_env);
+    BudgetedCayenne {
+        fixture,
+        warm_ctx,
+        pool,
+    }
+}
+
+/// Run a query, returning the engine error instead of panicking — a budget
+/// too small for the workload is a reportable outcome, not a bench crash.
+async fn try_query(ctx: &SessionContext, sql: &str) -> DataFusionResult<Vec<RecordBatch>> {
+    ctx.sql(sql).await?.collect().await
+}
+
+/// Upsert from parquet through the BUDGETED session. The shared
+/// `cayenne_insert_from_parquet` helper builds its own
+/// `SessionContext::new()` — an unbudgeted pool — and
+/// `CayenneTableProvider::insert_into` draws execution memory from the
+/// SESSION's runtime env, so routing this lane through the helper would
+/// bypass the budget the bench exists to enforce (only the table-internal
+/// reservations would land on the budgeted pool). Errors are returned, not
+/// panicked, so a too-small budget can be reported as a skip.
+async fn try_upsert_from_parquet(
+    ctx: &SessionContext,
+    table: &Arc<cayenne::CayenneTableProvider>,
+    parquet_path: &std::path::Path,
+) -> DataFusionResult<u64> {
+    use datafusion::datasource::TableProvider;
+    use datafusion::prelude::ParquetReadOptions;
+    use datafusion_expr::dml::InsertOp;
+
+    let parquet_path = parquet_path.to_string_lossy().into_owned();
+    let df = ctx
+        .read_parquet::<&str>(parquet_path.as_str(), ParquetReadOptions::default())
+        .await?;
+    let input_exec = df.create_physical_plan().await?;
+    let insert_plan = table
+        .insert_into(&ctx.state(), input_exec, InsertOp::Append)
+        .await?;
+    let results = datafusion::physical_plan::collect(insert_plan, ctx.task_ctx()).await?;
+    Ok(results
+        .first()
+        .and_then(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .map_or(0, |rows| rows.value(0)))
+}
+
+fn eprintln_lane_memory(engine: &str, workload: &str, budget_label: &str, bytes: u64) {
+    eprintln!(
+        "memory_budget: {engine}/{workload}@{budget_label} pool high-water = {bytes} bytes \
+         ({:.1} MiB)",
+        bytes as f64 / (1024.0 * 1024.0)
+    );
+}
+
+/// Best-effort DuckDB memory usage via `duckdb_memory()` (sum of
+/// `memory_usage_bytes` across its internal allocators).
+fn duckdb_memory_bytes(conn: &Connection) -> Option<i64> {
+    conn.prepare("SELECT COALESCE(SUM(memory_usage_bytes), 0) FROM duckdb_memory()")
+        .ok()?
+        .query_row([], |row| row.get::<_, i64>(0))
+        .ok()
+}
+
+// ---------------------------------------------------------------------------
+// Bench
+// ---------------------------------------------------------------------------
+
+fn bench_memory_budget(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_memory_budget");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    let base_batch = make_batch_grouped(schema(), 0, BASE_ROWS, GROUPS);
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+    let base_parquet = parquet_dir.path().join("base.parquet");
+    write_parquet(&base_batch, &base_parquet);
+    // Upsert source: re-writes ids 0..UPSERT_ROWS (CDC replace shape).
+    let upsert_parquet = parquet_dir.path().join("upsert.parquet");
+    write_parquet(&make_batch(schema(), 0, UPSERT_ROWS), &upsert_parquet);
+
+    for &(budget_label, budget_bytes) in MEMORY_BUDGETS {
+        // All Cayenne metastore lanes (Sqlite, plus Turso when compiled in) —
+        // consistent with every other vs_duckdb_* bench, so memory-budget
+        // numbers stay directly comparable across the paired suite.
+        for &cay_lane in common::CAYENNE_LANES {
+            let lane_prefix = cay_lane.lane();
+
+            // --- Cayenne read lanes (scan + groupby) on one budgeted fixture.
+            {
+                let lane = rt.block_on(setup_budgeted_cayenne(
+                    "memory_budget",
+                    cay_lane,
+                    budget_bytes,
+                    false,
+                ));
+                let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
+                assert!(preload > 0, "cayenne preload must insert rows");
+                lane.pool.reset_high_water();
+
+                for (workload, sql) in [("scan_filter_sum", SCAN_SQL), ("groupby_16k", GROUPBY_SQL)]
+                {
+                    // Pre-flight once: a budget the workload cannot fit is a
+                    // finding to report, not a panic.
+                    if let Err(e) = rt.block_on(try_query(&lane.warm_ctx, sql)) {
+                        eprintln!(
+                            "memory_budget: {lane_prefix}/{workload}@{budget_label} SKIPPED — {e}"
+                        );
+                        continue;
+                    }
+                    lane.pool.reset_high_water();
+                    group.bench_function(
+                        BenchmarkId::new(format!("{lane_prefix}_{workload}"), budget_label),
+                        |b| {
+                            b.iter(|| {
+                                rt.block_on(async {
+                                    let batches = try_query(&lane.warm_ctx, sql)
+                                        .await
+                                        .expect("pre-flighted query failed mid-bench");
+                                    black_box(batches);
+                                });
+                            });
+                        },
+                    );
+                    let high_water = lane.pool.high_water_bytes() as u64;
+                    eprintln_lane_memory(lane_prefix, workload, budget_label, high_water);
+                    assert!(
+                        high_water <= budget_bytes as u64,
+                        "{lane_prefix}/{workload}@{budget_label}: pool high-water {high_water} \
+                         bytes exceeds the configured budget {budget_bytes} — operator contract \
+                         violated"
+                    );
+                }
+            }
+
+            // --- Cayenne upsert lane on a budgeted PK fixture. The upsert
+            //     runs through the lane's BUDGETED warm session (see
+            //     `try_upsert_from_parquet`) so both the query-side decode and
+            //     the table-side write reservations draw on the same budgeted
+            //     pool — the spiced topology.
+            {
+                let lane = rt.block_on(setup_budgeted_cayenne(
+                    "memory_budget_upsert",
+                    cay_lane,
+                    budget_bytes,
+                    true,
+                ));
+                let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
+                assert!(preload > 0, "cayenne upsert preload must insert rows");
+                // Pre-flight once: a budget the upsert cannot fit is a finding
+                // to report, not a panic.
+                if let Err(e) = rt.block_on(try_upsert_from_parquet(
+                    &lane.warm_ctx,
+                    &lane.fixture.table,
+                    &upsert_parquet,
+                )) {
+                    eprintln!(
+                        "memory_budget: {lane_prefix}/upsert_16k@{budget_label} SKIPPED — {e}"
+                    );
+                } else {
+                    lane.pool.reset_high_water();
+                    group.bench_function(
+                        BenchmarkId::new(format!("{lane_prefix}_upsert_16k"), budget_label),
+                        |b| {
+                            b.iter(|| {
+                                rt.block_on(async {
+                                    let rows = try_upsert_from_parquet(
+                                        &lane.warm_ctx,
+                                        &lane.fixture.table,
+                                        &upsert_parquet,
+                                    )
+                                    .await
+                                    .expect("pre-flighted upsert failed mid-bench");
+                                    black_box(rows);
+                                });
+                            });
+                        },
+                    );
+                    let high_water = lane.pool.high_water_bytes() as u64;
+                    eprintln_lane_memory(lane_prefix, "upsert_16k", budget_label, high_water);
+                    assert!(
+                        high_water <= budget_bytes as u64,
+                        "{lane_prefix}/upsert_16k@{budget_label}: pool high-water {high_water} \
+                         bytes exceeds the configured budget {budget_bytes} — operator contract \
+                         violated"
+                    );
+                }
+            }
+        }
+
+        // --- DuckDB lanes at the same budget.
+        {
+            let fixture = common::setup_duckdb("memory_budget");
+            fixture
+                .conn
+                .execute_batch(&format!("SET memory_limit='{budget_label}';"))
+                .expect("duckdb SET memory_limit");
+            common::duckdb_insert_parquet(&fixture.conn, "memory_budget", &base_parquet);
+
+            for (workload, sql) in [
+                (
+                    "scan_filter_sum",
+                    "SELECT SUM(value) FROM memory_budget WHERE id BETWEEN 1000 AND 11000",
+                ),
+                (
+                    "groupby_16k",
+                    "SELECT name, SUM(value) FROM memory_budget GROUP BY name",
+                ),
+            ] {
+                group.bench_function(
+                    BenchmarkId::new(format!("duckdb_{workload}"), budget_label),
+                    |b| {
+                        b.iter(|| {
+                            let mut stmt = fixture.conn.prepare(sql).expect("duckdb prepare");
+                            let mut rows = stmt.query([]).expect("duckdb query");
+                            let mut n: i64 = 0;
+                            while let Some(_row) = rows.next().expect("duckdb row") {
+                                n += 1;
+                            }
+                            black_box(n);
+                        });
+                    },
+                );
+                if let Some(bytes) = duckdb_memory_bytes(&fixture.conn) {
+                    eprintln_lane_memory("duckdb", workload, budget_label, bytes.max(0) as u64);
+                }
+            }
+        }
+
+        // --- DuckDB upsert lane at the same budget (PK table).
+        {
+            let fixture = common::setup_duckdb_pk("memory_budget_upsert");
+            fixture
+                .conn
+                .execute_batch(&format!("SET memory_limit='{budget_label}';"))
+                .expect("duckdb SET memory_limit");
+            common::duckdb_insert_parquet(&fixture.conn, "memory_budget_upsert", &base_parquet);
+
+            group.bench_function(BenchmarkId::new("duckdb_upsert_16k", budget_label), |b| {
+                b.iter(|| {
+                    common::duckdb_upsert_parquet(
+                        &fixture.conn,
+                        "memory_budget_upsert",
+                        &upsert_parquet,
+                    );
+                });
+            });
+            if let Some(bytes) = duckdb_memory_bytes(&fixture.conn) {
+                eprintln_lane_memory("duckdb", "upsert_16k", budget_label, bytes.max(0) as u64);
+            }
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_memory_budget);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
@@ -1,0 +1,319 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Scan latency under background COMPACTION: Cayenne vs DuckDB.
+//!
+//! Sibling of `vs_duckdb_concurrent` (scan-under-*write*). Compaction is the
+//! heavier background writer: it re-reads and re-encodes whole snapshot
+//! subsets and contends with readers on the listing-refresh / snapshot-publish
+//! fence — a different (and worse) interference profile than small appends.
+//! The CH-benCH system runs measured exactly this state for hours at a time;
+//! no paired micro-bench covered it.
+//!
+//! Lane shape (RAII background worker, foreground timed scans — the
+//! `vs_duckdb_concurrent` pattern):
+//!
+//! - **Cayenne**: a PK upsert fixture (protected snapshots — the
+//!   compactor's input — are a conflict-resolution construct; an append-only
+//!   table never produces any) pinning `inline_max_rows: 0` and a small
+//!   compaction trigger so every insert lands as a protected snapshot. The
+//!   background task loops: append a burst (creates a fresh snapshot), then
+//!   drive `compact_protected_snapshots_subset(usize::MAX)` — the same
+//!   entry point the background maintenance loop calls — counting merges
+//!   that actually happened.
+//! - **DuckDB**: the background thread loops: insert a burst, then force a
+//!   `CHECKPOINT` — DuckDB's analogous reader-contending maintenance write.
+//!
+//! VALIDITY: after the timed region each lane asserts its background
+//! maintenance actually ran (merge count / checkpoint count > 0) — a bench
+//! whose compactor never fired would just re-measure scan-under-append.
+//! The counts are printed to stderr so a run can also be sanity-checked for
+//! *how much* compaction the scans overlapped.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion::execution::runtime_env::RuntimeEnv;
+use duckdb::Connection;
+use tokio::runtime::Runtime;
+
+use common::{
+    CAYENNE_LANES, CayenneFixture, DuckDbFixture, Metastore, cayenne_insert, cayenne_query,
+    duckdb_insert_parquet, duckdb_insert_rows, duckdb_query_scalar, make_batch, schema,
+    setup_cayenne_custom, setup_duckdb_pk, write_parquet,
+};
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+
+/// Total preloaded rows, written as PRELOAD_SNAPSHOTS separate inserts so the
+/// table starts with a populated protected-snapshot tier for the compactor.
+const BASE_ROWS: usize = 49_152;
+const PRELOAD_SNAPSHOTS: usize = 12;
+
+/// Rows appended per background cycle (each append = one new snapshot).
+const BG_BURST_ROWS: usize = 2_048;
+
+/// Merge as soon as a tier holds this many runs — keeps the compactor busy.
+const COMPACTION_TRIGGER: usize = 4;
+
+/// Same scan as `vs_duckdb_concurrent`, so "scan under compaction" reads
+/// directly against "scan under write" and idle-scan numbers.
+const CAYENNE_SCAN_SQL: &str = "SELECT SUM(value) FROM t WHERE id BETWEEN 1000 AND 11000";
+const DUCKDB_SCAN_SQL: &str =
+    "SELECT SUM(value) FROM compaction_bench WHERE id BETWEEN 1000 AND 11000";
+
+async fn load_cayenne(lane: Metastore) -> CayenneFixture {
+    let vortex_config = cayenne::metadata::VortexConfig {
+        // Everything lands in Vortex files immediately — protected snapshots
+        // are what the compactor consumes.
+        inline_max_rows: 0,
+        compaction_trigger_protected_snapshots: COMPACTION_TRIGGER,
+        // Effectively disable the interval loop: the background task below
+        // drives compaction deterministically instead.
+        compaction_background_interval_ms: 3_600_000,
+        ..cayenne::metadata::VortexConfig::default()
+    };
+    // PK + upsert table: protected snapshots — the compactor's input — are
+    // a conflict-resolution construct, so a plain append-only table never
+    // produces any and `compact_protected_snapshots_subset` is a no-op
+    // (the validity gate below caught exactly that on a non-PK draft of
+    // this bench: merges = 0).
+    let fixture = setup_cayenne_custom(
+        "compaction_bench",
+        lane,
+        vec!["id".to_string()],
+        Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "id".to_string(),
+        ]))),
+        schema(),
+        vortex_config,
+        Arc::new(RuntimeEnv::default()),
+    )
+    .await;
+    let rows_per_snapshot = BASE_ROWS / PRELOAD_SNAPSHOTS;
+    for snapshot in 0..PRELOAD_SNAPSHOTS {
+        let start = (snapshot * rows_per_snapshot) as i64;
+        let _ = cayenne_insert(
+            &fixture.table,
+            make_batch(schema(), start, rows_per_snapshot),
+        )
+        .await;
+    }
+    fixture
+}
+
+/// Background compactor for the Cayenne lane: append a burst (new snapshot),
+/// then drive a subset-compaction pass. Drop to stop + join.
+struct CayenneBgCompactor {
+    stop: Arc<AtomicBool>,
+    merges: Arc<AtomicUsize>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+    rt_handle: tokio::runtime::Handle,
+}
+
+impl CayenneBgCompactor {
+    fn spawn(rt: &Runtime, fixture: &CayenneFixture) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let merges = Arc::new(AtomicUsize::new(0));
+        let stop_clone = Arc::clone(&stop);
+        let merges_clone = Arc::clone(&merges);
+        let table = Arc::clone(&fixture.table);
+        let handle = rt.spawn(async move {
+            let mut cursor = BASE_ROWS as i64;
+            while !stop_clone.load(Ordering::Relaxed) {
+                let batch = make_batch(schema(), cursor, BG_BURST_ROWS);
+                cursor += BG_BURST_ROWS as i64;
+                let _ = cayenne_insert(&table, batch).await;
+                match table.compact_protected_snapshots_subset(usize::MAX).await {
+                    Ok(true) => {
+                        merges_clone.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Ok(false) => {}
+                    Err(e) => panic!("background compaction failed: {e}"),
+                }
+            }
+        });
+        Self {
+            stop,
+            merges,
+            handle: Some(handle),
+            rt_handle: rt.handle().clone(),
+        }
+    }
+
+    /// Clone of the merge counter. Read it AFTER dropping the compactor —
+    /// the background task can complete one more in-flight pass during the
+    /// stop+join, so a pre-drop read can under-report (or, read as 0, fail
+    /// the validity gate spuriously).
+    fn merges_counter(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.merges)
+    }
+}
+
+impl Drop for CayenneBgCompactor {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            if let Err(join_err) = self.rt_handle.block_on(handle) {
+                // Propagate a background-compactor panic at the source —
+                // swallowed, it would resurface later as a misleading
+                // `merges = 0` validity failure (or as silently invalid
+                // numbers). Skip while already unwinding: panicking inside
+                // a panic-triggered drop aborts the process and eats the
+                // original message.
+                if join_err.is_panic() && !std::thread::panicking() {
+                    std::panic::resume_unwind(join_err.into_panic());
+                }
+            }
+        }
+    }
+}
+
+/// Background checkpointer for the DuckDB lane: insert a burst, then force a
+/// `CHECKPOINT` — the closest DuckDB analog to a maintenance rewrite that
+/// contends with readers. Drop to stop + join.
+struct DuckDbBgCheckpointer {
+    stop: Arc<AtomicBool>,
+    checkpoints: Arc<AtomicUsize>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl DuckDbBgCheckpointer {
+    fn spawn(fixture: &DuckDbFixture) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let checkpoints = Arc::new(AtomicUsize::new(0));
+        let stop_clone = Arc::clone(&stop);
+        let checkpoints_clone = Arc::clone(&checkpoints);
+        let db_path = fixture.db_path();
+        let handle = std::thread::spawn(move || {
+            let conn = Connection::open(&db_path).expect("bg duckdb open");
+            let mut cursor = BASE_ROWS as i64;
+            while !stop_clone.load(Ordering::Relaxed) {
+                let batch = make_batch(schema(), cursor, BG_BURST_ROWS);
+                cursor += BG_BURST_ROWS as i64;
+                duckdb_insert_rows(&conn, "compaction_bench", &batch);
+                // FORCE CHECKPOINT would abort concurrent transactions;
+                // plain CHECKPOINT contends with (but doesn't kill) readers —
+                // the apples-to-apples maintenance pressure.
+                conn.execute_batch("CHECKPOINT;")
+                    .expect("duckdb checkpoint");
+                checkpoints_clone.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        Self {
+            stop,
+            checkpoints,
+            handle: Some(handle),
+        }
+    }
+
+    /// Clone of the checkpoint counter — read after drop+join, see
+    /// [`CayenneBgCompactor::merges_counter`].
+    fn checkpoints_counter(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.checkpoints)
+    }
+}
+
+impl Drop for DuckDbBgCheckpointer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            if let Err(panic_payload) = handle.join() {
+                // Same rationale as CayenneBgCompactor::drop — surface the
+                // background panic at the source instead of as a misleading
+                // checkpoint-validity failure later.
+                if !std::thread::panicking() {
+                    std::panic::resume_unwind(panic_payload);
+                }
+            }
+        }
+    }
+}
+
+fn bench_scan_under_compaction(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_scan_under_compaction");
+    // Like vs_duckdb_concurrent: the table is moving (background writer +
+    // compactor), so the signal is the delta vs the idle-scan bench, not
+    // absolute precision.
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(15));
+
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+    let parquet_path = parquet_dir.path().join("base.parquet");
+    write_parquet(&make_batch(schema(), 0, BASE_ROWS), &parquet_path);
+
+    for &lane in CAYENNE_LANES {
+        let lane_label = lane.lane();
+        let fixture = rt.block_on(load_cayenne(lane));
+        let bg = CayenneBgCompactor::spawn(&rt, &fixture);
+
+        let table = Arc::clone(&fixture.table);
+        group.bench_function(BenchmarkId::new(lane_label, "scan_under_compaction"), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let batches = cayenne_query(&table, CAYENNE_SCAN_SQL).await;
+                    black_box(batches);
+                });
+            });
+        });
+
+        // VALIDITY GATE: if no merge ever fired, the bench measured
+        // scan-under-append, not scan-under-compaction. Read the counter
+        // only after drop(bg) joins the task — an in-flight pass can still
+        // complete (and increment) during the stop+join.
+        let merges_counter = bg.merges_counter();
+        drop(bg);
+        drop(fixture);
+        let merges = merges_counter.load(Ordering::Relaxed);
+        eprintln!("scan_under_compaction: {lane_label} background subset merges = {merges}");
+        assert!(
+            merges > 0,
+            "{lane_label}: background compactor never merged — the bench did not \
+             measure scan-under-compaction (check trigger/threshold config)"
+        );
+    }
+
+    // PK table for parity with the Cayenne upsert fixture.
+    let duckdb_fixture = setup_duckdb_pk("compaction_bench");
+    duckdb_insert_parquet(&duckdb_fixture.conn, "compaction_bench", &parquet_path);
+    let bg = DuckDbBgCheckpointer::spawn(&duckdb_fixture);
+    group.bench_function(BenchmarkId::new("duckdb", "scan_under_compaction"), |b| {
+        b.iter(|| {
+            let v = duckdb_query_scalar(&duckdb_fixture.conn, DUCKDB_SCAN_SQL);
+            black_box(v);
+        });
+    });
+    // Same post-join read discipline as the Cayenne lane above.
+    let checkpoints_counter = bg.checkpoints_counter();
+    drop(bg);
+    drop(duckdb_fixture);
+    let checkpoints = checkpoints_counter.load(Ordering::Relaxed);
+    eprintln!("scan_under_compaction: duckdb background checkpoints = {checkpoints}");
+    assert!(
+        checkpoints > 0,
+        "duckdb: background checkpointer never ran — the bench did not measure \
+         scan-under-checkpoint"
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan_under_compaction);
+criterion_main!(benches);

--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -194,115 +194,152 @@ impl<'a> DeletionVectorWriter<'a> {
         &self,
         specs: Vec<DeletionVectorWriteSpec>,
     ) -> Result<Vec<DeletionVectorWriteResult>> {
-        let mut results = Vec::with_capacity(specs.len());
+        let specs: Vec<DeletionVectorWriteSpec> =
+            specs.into_iter().filter(|spec| !spec.is_empty()).collect();
+        if specs.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        for spec in specs {
-            if spec.is_empty() {
-                continue;
+        let deletion_dir = self.table_snapshot_deletion_dir();
+        let snapshot_dir = deletion_dir
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| Error::Internal {
+                table: self.table.path.clone(),
+                message: format!(
+                    "Deletion vector directory '{}' has no snapshot parent",
+                    deletion_dir.display()
+                ),
+            })?;
+
+        // Ensure the deletions/ subdirectory exists (once per call — it was
+        // previously re-checked per spec, a no-op after the first).
+        // If we just created it, sync its parent (the snapshot directory)
+        // so the subdir entry is durable on local FS.
+        //
+        // This is required for the same contract we now enforce for
+        // snapshot directories themselves (ensure_snapshot_dir_exists)
+        // and for the _partitioned_wal/ coordination directory:
+        // on POSIX, mkdir in a directory updates the parent's metadata.
+        // A crash immediately after this create_dir_all but before the
+        // subsequent file write + file fsync + catalog record could
+        // otherwise leave a catalog entry pointing at a deletions/
+        // directory whose creation was lost.
+        //
+        // The sync is one-time per snapshot (first deletion vector
+        // written to it). Subsequent deletions reuse the directory.
+        let sync_snapshot_parent = match tokio::fs::create_dir(&deletion_dir).await {
+            Ok(()) => true,
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => false,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                tokio::fs::create_dir_all(&deletion_dir).await?;
+                true
             }
+            Err(source) => return Err(Error::IoError { source }),
+        };
+        if sync_snapshot_parent {
+            let table = self.table.path.clone();
+            // Directory ordering tier (plain fsync on macOS, full fsync
+            // on other platforms) — see `provider/fsync_tier.rs`.
+            tokio::task::spawn_blocking(move || {
+                let dir = std::fs::File::open(&snapshot_dir)?;
+                crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+            })
+            .await
+            .map_err(|source| Error::TaskPanicked { table, source })??;
+        }
 
-            let deletion_dir = self.table_snapshot_deletion_dir();
-            let snapshot_dir = deletion_dir
-                .parent()
-                .map(Path::to_path_buf)
-                .ok_or_else(|| Error::Internal {
-                    table: self.table.path.clone(),
-                    message: format!(
-                        "Deletion vector directory '{}' has no snapshot parent",
-                        deletion_dir.display()
-                    ),
-                })?;
-
-            // Ensure the deletions/ subdirectory exists.
-            // If we just created it, sync its parent (the snapshot directory)
-            // so the subdir entry is durable on local FS.
-            //
-            // This is required for the same contract we now enforce for
-            // snapshot directories themselves (ensure_snapshot_dir_exists)
-            // and for the _partitioned_wal/ coordination directory:
-            // on POSIX, mkdir in a directory updates the parent's metadata.
-            // A crash immediately after this create_dir_all but before the
-            // subsequent file write + file fsync + catalog record could
-            // otherwise leave a catalog entry pointing at a deletions/
-            // directory whose creation was lost.
-            //
-            // The sync is one-time per snapshot (first deletion vector
-            // written to it). Subsequent deletions reuse the directory.
-            let sync_snapshot_parent = match tokio::fs::create_dir(&deletion_dir).await {
-                Ok(()) => true,
-                Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => false,
-                Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                    tokio::fs::create_dir_all(&deletion_dir).await?;
-                    true
-                }
-                Err(source) => return Err(Error::IoError { source }),
-            };
-            if sync_snapshot_parent {
-                let table = self.table.path.clone();
-                tokio::task::spawn_blocking(move || std::fs::File::open(&snapshot_dir)?.sync_all())
-                    .await
-                    .map_err(|source| Error::TaskPanicked { table, source })??;
-            }
-
+        // Write every spec's deletion-vector file CONCURRENTLY. The files are
+        // independent (one per spec, UUIDv7 filenames), so their writes + file
+        // fsyncs overlap on the blocking pool — on network-attached storage
+        // (EBS) this turns N serialized ~1 ms fsync round-trips into ~1 round
+        // of in-flight barriers. `try_join_all` preserves spec order in the
+        // returned results.
+        let write_futures = specs.into_iter().map(|spec| {
             let file_path = Self::deletion_file_path(&deletion_dir);
-
-            let (batch, schema, count, identifiers, source_data_file_path) = match spec.identifiers
-            {
-                DeletionIdentifier::PositionBased {
-                    file_path: source_file,
-                    mut row_ids,
-                    pre_sorted,
-                } => {
-                    if pre_sorted {
-                        debug_assert!(
-                            row_ids.windows(2).all(|w| w[0] < w[1]),
-                            "pre_sorted=true but row_ids is not strictly increasing",
-                        );
-                    } else {
-                        row_ids.sort_unstable();
-                        row_ids.dedup();
-                    }
-                    let count = row_ids.len();
-                    let schema = position_based_deletion_schema();
-                    let batch = build_position_based_batch(&schema, &row_ids)?;
-                    (
-                        batch,
-                        schema,
-                        count,
+            let table_name = self.table.table_name.clone();
+            async move {
+                let (batch, schema, count, identifiers, source_data_file_path) =
+                    match spec.identifiers {
                         DeletionIdentifier::PositionBased {
-                            file_path: source_file.clone(),
-                            row_ids,
+                            file_path: source_file,
+                            mut row_ids,
                             pre_sorted,
-                        },
-                        Some(source_file),
-                    )
-                }
-                DeletionIdentifier::KeyBased(mut row_keys) => {
-                    // Sort and deduplicate keys
-                    row_keys.sort();
-                    row_keys.dedup();
-                    let count = row_keys.len();
-                    let schema = key_based_deletion_schema();
-                    let batch = build_key_based_batch(&schema, &row_keys)?;
-                    (
-                        batch,
-                        schema,
-                        count,
-                        DeletionIdentifier::KeyBased(row_keys),
-                        None,
-                    )
-                }
-            };
+                        } => {
+                            if pre_sorted {
+                                debug_assert!(
+                                    row_ids.windows(2).all(|w| w[0] < w[1]),
+                                    "pre_sorted=true but row_ids is not strictly increasing",
+                                );
+                            } else {
+                                row_ids.sort_unstable();
+                                row_ids.dedup();
+                            }
+                            let count = row_ids.len();
+                            let schema = position_based_deletion_schema();
+                            let batch = build_position_based_batch(&schema, &row_ids)?;
+                            (
+                                batch,
+                                schema,
+                                count,
+                                DeletionIdentifier::PositionBased {
+                                    file_path: source_file.clone(),
+                                    row_ids,
+                                    pre_sorted,
+                                },
+                                Some(source_file),
+                            )
+                        }
+                        DeletionIdentifier::KeyBased(mut row_keys) => {
+                            // Sort and deduplicate keys
+                            row_keys.sort();
+                            row_keys.dedup();
+                            let count = row_keys.len();
+                            let schema = key_based_deletion_schema();
+                            let batch = build_key_based_batch(&schema, &row_keys)?;
+                            (
+                                batch,
+                                schema,
+                                count,
+                                DeletionIdentifier::KeyBased(row_keys),
+                                None,
+                            )
+                        }
+                    };
 
-            let file_size_bytes = write_deletion_file(
-                &file_path,
-                Arc::clone(&schema),
-                batch,
-                &self.table.table_name,
-            )
-            .await?;
+                let file_size_bytes =
+                    write_deletion_file(&file_path, Arc::clone(&schema), batch, &table_name)
+                        .await?;
 
-            // Determine deletion type from identifiers
+                Ok::<_, Error>((
+                    file_path,
+                    count,
+                    file_size_bytes,
+                    identifiers,
+                    source_data_file_path,
+                ))
+            }
+        });
+        let written = futures::future::try_join_all(write_futures).await?;
+
+        // ONE coalesced deletions/-dir sync for the whole batch of files
+        // (replaces the previous per-file parent-dir fsync): a directory fsync
+        // flushes ALL of its pending entries, so syncing once after every file
+        // exists provides the same dirent durability at 1/N the barrier count.
+        // Must complete before the catalog records any of the paths.
+        {
+            let table = self.table.path.clone();
+            let deletion_dir_for_sync = deletion_dir.clone();
+            tokio::task::spawn_blocking(move || {
+                let dir = std::fs::File::open(&deletion_dir_for_sync)?;
+                crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+            })
+            .await
+            .map_err(|source| Error::TaskPanicked { table, source })??;
+        }
+
+        let mut results = Vec::with_capacity(written.len());
+        for (file_path, count, file_size_bytes, identifiers, source_data_file_path) in written {
             let deletion_type = match &identifiers {
                 DeletionIdentifier::PositionBased { .. } => DeletionType::PositionBased,
                 DeletionIdentifier::KeyBased(_) => DeletionType::KeyBased,
@@ -559,33 +596,30 @@ async fn write_deletion_file(
         //
         // 1. Stream Arrow IPC into the file.
         // 2. Recover the underlying std::fs::File from the writer and fsync
-        //    its data (sync_all flushes data + metadata). A previous revision
-        //    also re-opened the file to fsync it a second time — that
-        //    reopen+fsync was redundant work on every delete and has been
-        //    removed.
-        // 3. fsync the parent directory so the new directory entry is durable
-        //    across a power-loss restart — without this, the catalog can
-        //    record a delete file path that fails to resolve after a crash
-        //    because the file's inode is on disk but the dirent isn't.
+        //    its data with the ordering tier (`fsync_tier::ordering_sync_std`:
+        //    plain fsync on macOS, fdatasync on Linux — on macOS both std
+        //    `sync_all` AND `sync_data` are F_FULLFSYNC ~4-5 ms, while the
+        //    catalog commit referencing this file is SQLite
+        //    synchronous=NORMAL, so a full drive-cache flush here cannot
+        //    raise end-to-end durability; see `provider/fsync_tier.rs`). A
+        //    previous revision also re-opened the file to fsync it a second
+        //    time — that reopen+fsync was redundant work on every delete and
+        //    has been removed.
+        //
+        // The parent-directory fsync (so the new dirent is written through
+        // before the catalog records the path) is NOT done here: the caller
+        // (`DeletionVectorWriter::write`) writes all of a batch's deletion
+        // files concurrently and issues ONE coalesced deletions/-dir sync
+        // after they complete — same dirent durability, 1/N the barriers.
         let file = std::fs::File::create(&output_path)?;
         let mut writer = FileWriter::try_new(file, &schema)?;
         writer.write(&batch)?;
         writer.finish()?;
         let inner = writer.into_inner()?;
-        inner.sync_all()?;
+        crate::provider::fsync_tier::ordering_sync_std(&inner)?;
         drop(inner);
 
         let metadata = std::fs::metadata(&output_path)?;
-
-        // Best-effort parent-dir fsync. Matches the partitioned_wal /
-        // staging_wal write patterns: a failure here is unusual and logged
-        // by the caller; the deletion file's content is already durable
-        // regardless.
-        if let Some(parent) = output_path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
 
         Ok(metadata.len())
     })

--- a/crates/cayenne/src/provider/fsync_tier.rs
+++ b/crates/cayenne/src/provider/fsync_tier.rs
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Ordering-tier fsync for the staged-commit hot path.
+//!
+//! ## Why this module exists (measured, not assumed)
+//!
+//! On macOS, **both** `File::sync_all` *and* `File::sync_data` map to
+//! `fcntl(F_FULLFSYNC)` — a full drive-cache flush. Measured on an Apple
+//! Silicon laptop (64 KiB file, 20 iterations): `sync_all` ≈ 4.5 ms,
+//! `sync_data` ≈ 5.0 ms, raw `fcntl(F_BARRIERFSYNC)` ≈ 0.46 ms, and plain
+//! `fsync(2)` ≈ 66 µs. A staged CDC batch pays 5-7 such barriers (data dir,
+//! staging WAL file + dir, deletion-vector file + dir, move-target dir), so
+//! the full tier put a ~25-30 ms fixed floor under every staged commit on
+//! macOS — the dominant cost of small upserts (`vs_duckdb_upsert_scaling`).
+//!
+//! ## Why plain `fsync(2)` is the right tier on macOS
+//!
+//! Durability here can't exceed the weakest link, and the weakest link is the
+//! metastore: `SQLite` runs `journal_mode=WAL, synchronous=NORMAL` with no
+//! `fullfsync` pragma, so the catalog transaction that makes staged files
+//! *visible* uses plain `fsync(2)` semantics on macOS (NORMAL does not even
+//! fsync on every commit). A power-loss window that loses fsync-tier data
+//! necessarily also loses the catalog rows referencing it. Plain `fsync(2)`
+//! is likewise the macOS default for `DuckDB` and `PostgreSQL` — it is the
+//! durability bar the rest of the storage industry sets on this platform.
+//! Crash-consistency (process crash, not power loss) is unaffected: the page
+//! cache survives a process crash, and the staging-WAL recovery protocol
+//! (`ensure_no_incomplete_write`) heals interrupted commits either way.
+//!
+//! On non-macOS platforms the REGULAR-FILE helpers ([`ordering_sync_std`] /
+//! [`ordering_sync_tokio_file`]) are `File::sync_data` — on Linux that is
+//! `fdatasync(2)`, which still issues a device flush and skips only metadata
+//! journaling irrelevant to reading the bytes back. The DIRECTORY variants
+//! ([`ordering_sync_dir_std`] / [`ordering_sync_dir_tokio_file`]) are the
+//! deliberate exception: they keep full `sync_all` on non-macOS, because
+//! `fdatasync`'s "metadata required to retrieve the data" wording leaves
+//! directory-entry durability implementation-defined, and a dirent that
+//! vanishes after power loss un-publishes the file it referenced. On macOS
+//! both file and directory variants are plain `fsync(2)` (the metastore
+//! weakest-link argument above applies to either handle kind there).
+//!
+//! Cold paths (table create/drop, metastore initialization, partition
+//! creation) intentionally do NOT use this module and keep `sync_all`.
+
+use std::io;
+
+/// Ordering-tier sync for a regular-file [`std::fs::File`].
+///
+/// For directory handles use [`ordering_sync_dir_std`] — on non-macOS
+/// platforms `sync_data` is only guaranteed to flush "metadata required to
+/// retrieve the data", and whether that wording covers directory entries is
+/// implementation-defined.
+///
+/// Call from a blocking context (`spawn_blocking`) — on macOS this issues a
+/// blocking `fsync(2)` (~tens of µs); elsewhere `sync_data` may block on a
+/// device flush.
+pub(crate) fn ordering_sync_std(file: &std::fs::File) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::fd::AsRawFd;
+        // SAFETY: `fsync` is async-signal-safe and takes a valid open fd; the
+        // borrow of `file` keeps the fd alive for the duration of the call.
+        if unsafe { libc::fsync(file.as_raw_fd()) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        file.sync_data()
+    }
+}
+
+/// Ordering-tier sync for a **directory** handle.
+///
+/// Directories get full `fsync` on non-macOS: POSIX only guarantees
+/// `fdatasync` flushes "metadata required to retrieve the data", and whether
+/// that covers directory entries is implementation-defined (Linux treats
+/// them as the directory's data; other platforms may not). `PostgreSQL` and
+/// `SQLite` both use full `fsync` on directories for the same reason. On
+/// Linux `fsync` and `fdatasync` are equivalent for directories (same
+/// journal commit + device flush), so this costs nothing. On macOS the
+/// ordering tier is plain `fsync(2)` either way.
+pub(crate) fn ordering_sync_dir_std(dir: &std::fs::File) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        ordering_sync_std(dir)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        dir.sync_all()
+    }
+}
+
+/// Ordering-tier sync for a regular-file [`tokio::fs::File`].
+///
+/// For directory handles use [`ordering_sync_dir_tokio_file`] (see
+/// [`ordering_sync_dir_std`] for why directories need full `fsync` on
+/// non-macOS platforms).
+///
+/// On macOS the `fsync(2)` runs on the blocking pool (mirroring what tokio's
+/// own `sync_data` does internally); elsewhere this delegates to
+/// `tokio::fs::File::sync_data`.
+pub(crate) async fn ordering_sync_tokio_file(file: &tokio::fs::File) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        // Cancellation safety: `spawn_blocking` tasks are detached — if this
+        // future is dropped at the `.await`, the blocking closure keeps
+        // running. A raw fd captured from `file` could then outlive the
+        // caller's `File` (closed/reused fd under a live `libc::fsync` —
+        // unsound). Move an OWNED duplicate of the fd into the closure
+        // instead: the dup stays open for exactly as long as the fsync needs
+        // it, regardless of caller cancellation. One `dup(2)` (~µs) per sync.
+        let owned_dup = file.try_clone().await?.into_std().await;
+        tokio::task::spawn_blocking(move || ordering_sync_std(&owned_dup))
+            .await
+            .map_err(io::Error::other)?
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        file.sync_data().await
+    }
+}
+
+/// Ordering-tier sync for a **directory** [`tokio::fs::File`] handle.
+///
+/// See [`ordering_sync_dir_std`] for why directories use full `fsync` on
+/// non-macOS platforms.
+pub(crate) async fn ordering_sync_dir_tokio_file(dir: &tokio::fs::File) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        ordering_sync_tokio_file(dir).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        dir.sync_all().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn ordering_sync_std_succeeds_on_file_and_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("probe.bin");
+        let mut file = std::fs::File::create(&file_path).expect("create probe file");
+        file.write_all(b"ordering-tier probe").expect("write");
+        ordering_sync_std(&file).expect("file ordering sync");
+
+        let dir_handle = std::fs::File::open(dir.path()).expect("open dir");
+        ordering_sync_dir_std(&dir_handle).expect("dir ordering sync");
+    }
+
+    #[tokio::test]
+    async fn ordering_sync_dir_tokio_file_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dir_handle = tokio::fs::File::open(dir.path())
+            .await
+            .expect("open dir handle");
+        ordering_sync_dir_tokio_file(&dir_handle)
+            .await
+            .expect("tokio dir ordering sync");
+    }
+
+    #[tokio::test]
+    async fn ordering_sync_tokio_file_succeeds() {
+        use tokio::io::AsyncWriteExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("probe_tokio.bin");
+        let mut file = tokio::fs::File::create(&file_path)
+            .await
+            .expect("create probe file");
+        file.write_all(b"ordering-tier probe").await.expect("write");
+        ordering_sync_tokio_file(&file)
+            .await
+            .expect("tokio ordering sync");
+    }
+}

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -76,6 +76,7 @@ pub(crate) mod delete;
 pub mod deletion_index;
 pub(crate) mod deletion_strategy;
 pub(crate) mod delta_encoding;
+pub(crate) mod fsync_tier;
 pub(crate) mod memory_account;
 pub(crate) mod mutation_writer;
 pub(crate) mod overwrite;

--- a/crates/cayenne/src/provider/partitioned_wal.rs
+++ b/crates/cayenne/src/provider/partitioned_wal.rs
@@ -140,10 +140,15 @@ impl PartitionedWal {
                 let parent = table_root.to_path_buf(); // the table root
                 let table = table_root.display().to_string();
 
-                // Sync the table root so the _partitioned_wal/ subdir entry is durable.
-                tokio::task::spawn_blocking(move || std::fs::File::open(&parent)?.sync_all())
-                    .await
-                    .map_err(|source| Error::TaskPanicked { table, source })??;
+                // Sync the table root so the _partitioned_wal/ subdir entry is
+                // written through (directory ordering tier: plain fsync on
+                // macOS, full fsync elsewhere — see `provider/fsync_tier.rs`).
+                tokio::task::spawn_blocking(move || {
+                    let dir = std::fs::File::open(&parent)?;
+                    crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+                })
+                .await
+                .map_err(|source| Error::TaskPanicked { table, source })??;
             }
             Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {}
             Err(source) => return Err(Error::IoError { source }),
@@ -215,7 +220,10 @@ impl PartitionedWal {
             .open(&tmp_path)
             .await?;
         tmp_file.write_all(content.as_bytes()).await?;
-        tmp_file.sync_all().await?;
+        // Ordering tier: see `provider/fsync_tier.rs` — losing this
+        // coordination record in a power-loss window is healed by recovery,
+        // and the metastore's visibility commits are no stronger.
+        super::fsync_tier::ordering_sync_tokio_file(&tmp_file).await?;
         drop(tmp_file);
 
         // Step 2: atomic rename. POSIX rename within the same directory is
@@ -226,10 +234,10 @@ impl PartitionedWal {
             return Err(Error::IoError { source: e });
         }
 
-        // Step 3: fsync the parent dir so the rename is durable across a
-        // power-loss restart.
+        // Step 3: fsync the parent dir (ordering tier) so the rename is
+        // written through before dependent work proceeds.
         if let Ok(dir) = tokio::fs::File::open(&wal_dir).await
-            && let Err(e) = dir.sync_all().await
+            && let Err(e) = super::fsync_tier::ordering_sync_dir_tokio_file(&dir).await
         {
             // Directory fsync is best-effort: on some filesystems / OSes it
             // is a no-op anyway. Log the failure but don't abort — the WAL
@@ -343,7 +351,8 @@ impl PartitionedWal {
                 let wal_dir = table_root.join(PARTITIONED_WAL_DIR);
                 let wal_dir_display = wal_dir.display().to_string();
                 match tokio::task::spawn_blocking(move || {
-                    std::fs::File::open(&wal_dir).and_then(|f| f.sync_all())
+                    std::fs::File::open(&wal_dir)
+                        .and_then(|f| crate::provider::fsync_tier::ordering_sync_dir_std(&f))
                 })
                 .await
                 {

--- a/crates/cayenne/src/provider/staging_wal.rs
+++ b/crates/cayenne/src/provider/staging_wal.rs
@@ -791,12 +791,26 @@ impl CayenneTableProvider {
             message: format!("Failed to serialize staging WAL: {e}"),
         })?;
 
-        // Single open + write + fsync, keeping the fd through to `sync_all`.
+        // Single open + write + fsync, keeping the fd through to the sync.
         // The previous revision called `tokio::fs::write` (which opens,
         // writes, drops the fd) and then re-opened the file to call
         // `sync_all` — paying an extra `open(2)` per WAL write on every
         // staged append. Replacing the two opens with one is a small but
         // real per-ingestion saving on the local-FS hot path.
+        //
+        // Ordering tier (`fsync_tier::ordering_sync_tokio_file`), not
+        // `sync_all`: on macOS BOTH std `sync_all` and `sync_data` are
+        // `fcntl(F_FULLFSYNC)` (~4-5 ms full drive-cache flush, measured),
+        // while plain `fsync(2)` is ~66 µs — and plain fsync is the macOS
+        // tier SQLite/DuckDB/Postgres default to. On Linux the helper is
+        // `fdatasync`, which flushes the WAL bytes + the size metadata needed
+        // to read them. Full-platter durability is not load-bearing here:
+        // losing this WAL record in a power-loss window only orphans staging
+        // files that recovery (`ensure_no_incomplete_write`) audits and
+        // discards — and the metastore's own visibility commits are SQLite
+        // `synchronous=NORMAL` (no fullfsync), so a stronger barrier on this
+        // marker file could not raise end-to-end durability anyway. See
+        // `provider/fsync_tier.rs` for the measurements and rationale.
         let mut file = tokio::fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -804,7 +818,7 @@ impl CayenneTableProvider {
             .open(&tmp_path)
             .await?;
         file.write_all(content.as_bytes()).await?;
-        file.sync_all().await?;
+        super::fsync_tier::ordering_sync_tokio_file(&file).await?;
         drop(file);
 
         if let Err(e) = tokio::fs::rename(&tmp_path, &wal_path).await {

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -3231,17 +3231,22 @@ impl CayenneTableProvider {
             let parent = snapshot_dir.parent().map(std::path::Path::to_path_buf);
             tokio::fs::create_dir_all(snapshot_dir).await?;
 
-            // Make the *creation of the new snapshot directory itself* durable.
-            // On POSIX, creating a subdirectory updates the parent's directory
-            // metadata. Without syncing the parent, a crash can make the new
-            // snapshot directory "disappear" from the filesystem even though
-            // we later write files into it and commit the catalog to point at it.
-            // This is the same durability requirement we enforce for file
-            // creation, renames, and WAL marker removal elsewhere in the code.
+            // Write the *creation of the new snapshot directory itself* through
+            // to the device (ordering tier). On POSIX, creating a subdirectory
+            // updates the parent's directory metadata. Without syncing the
+            // parent, a crash can make the new snapshot directory "disappear"
+            // from the filesystem even though we later write files into it and
+            // commit the catalog to point at it. This is the same requirement
+            // we enforce for file creation, renames, and WAL marker removal
+            // elsewhere in the code. Directory ordering tier (plain fsync on
+            // macOS, full fsync on other platforms — see
+            // `fsync_tier::ordering_sync_dir_std`): this runs once per staged
+            // batch, and the macOS full-drive-flush tier bought nothing — see
+            // `sync_snapshot_dir`.
             if let Some(parent) = parent {
                 tokio::task::spawn_blocking(move || {
                     let f = std::fs::File::open(&parent)?;
-                    f.sync_all()
+                    super::fsync_tier::ordering_sync_dir_std(&f)
                 })
                 .await
                 .map_err(std::io::Error::other)??;
@@ -3606,10 +3611,37 @@ impl CayenneTableProvider {
         let snapshot_dir = snapshot_dir.to_path_buf();
         let dir_display = snapshot_dir.display().to_string();
         tokio::task::spawn_blocking(move || {
-            // Open the directory and call sync_all to flush metadata
+            // Open the directory and flush its entries with the directory
+            // ORDERING tier (`fsync_tier::ordering_sync_dir_std`), not
+            // full-tier `sync_all`.
+            //
+            // Durability-tier rationale (matters on macOS): Rust's `sync_all`
+            // AND `sync_data` both map to `fcntl(F_FULLFSYNC)` on Apple
+            // targets — a full drive-cache flush measured at ~4-5 ms per call
+            // — while plain `fsync(2)` is ~66 µs. Plain fsync is the macOS
+            // durability tier SQLite (synchronous=NORMAL), DuckDB, and
+            // PostgreSQL all default to. On non-macOS platforms the directory
+            // helper issues a full `fsync` (dirent flushing under plain
+            // `fdatasync` is implementation-defined; on Linux the two are
+            // equivalent for directories) — behavior is effectively unchanged
+            // there.
+            //
+            // F_FULLFSYNC here would be strictly stronger than the visibility
+            // commit it protects: the metastore runs SQLite with
+            // `journal_mode=WAL, synchronous=NORMAL` and no `fullfsync`
+            // pragma, so the catalog transaction that makes these files
+            // visible is itself only plain-fsync durable on macOS (NORMAL
+            // doesn't even fsync at every commit). A power-loss window that
+            // loses ordering-tier data files necessarily also loses the
+            // catalog rows referencing them — there is no inconsistent state
+            // a full flush here would prevent. Paying 5-7 F_FULLFSYNCs per
+            // staged CDC batch (~25 ms of pure barrier latency) bought no
+            // additional end-to-end durability; it was the dominant fixed
+            // cost of small staged upserts. Full details + measurements in
+            // `provider/fsync_tier.rs`.
             let dir = std::fs::File::open(&snapshot_dir)
                 .map_err(|source| CatalogError::IoError { source })?;
-            dir.sync_all()
+            super::fsync_tier::ordering_sync_dir_std(&dir)
                 .map_err(|source| CatalogError::IoError { source })?;
             Ok::<(), CatalogError>(())
         })

--- a/crates/cayenne/tests/ingest_fsync_regression_test.rs
+++ b/crates/cayenne/tests/ingest_fsync_regression_test.rs
@@ -146,16 +146,25 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
         .expect("write_deletion_file function not found in delete/vector_io.rs");
 
     // The deletion-vector writer must sync the FileWriter's inner fd
-    // (`inner.sync_all()?`) — this is the cheap path that uses the open fd
-    // we already have. A previous revision additionally re-opened the file
-    // with `OpenOptions::new().write(true).open(...)` to fsync it AGAIN,
+    // (`ordering_sync_std(&inner)`) — this is the cheap path that uses the
+    // open fd we already have. A previous revision additionally re-opened the
+    // file with `OpenOptions::new().write(true).open(...)` to fsync it AGAIN,
     // which doubled the per-deletion fsync cost. The reopen must NOT come
     // back without a documented reason.
+    //
+    // Ordering tier (`fsync_tier::ordering_sync_std`), not `sync_all` or
+    // `sync_data`: on macOS BOTH std calls are `fcntl(F_FULLFSYNC)` (~4-5 ms
+    // full drive-cache flush per call, measured), while the helper issues
+    // plain `fsync(2)` (~66 µs) — the same macOS tier as the SQLite
+    // metastore (`synchronous=NORMAL`, no fullfsync pragma) whose commit
+    // makes this file visible, so a full-tier flush here could not raise
+    // end-to-end durability. See `provider/fsync_tier.rs`.
     assert!(
-        body.contains("inner.sync_all()"),
-        "write_deletion_file must call `inner.sync_all()` on the FileWriter's \
-         inner std::fs::File — this is the fsync that ensures the deletion \
-         vector data is durable before we record the path in the catalog."
+        body.contains("ordering_sync_std(&inner)"),
+        "write_deletion_file must call `fsync_tier::ordering_sync_std(&inner)` \
+         on the FileWriter's inner std::fs::File — this is the fsync that \
+         writes the deletion vector data through before we record the path \
+         in the catalog."
     );
 
     let reopened_fsync_pattern =
@@ -164,47 +173,80 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
         !body.contains(reopened_fsync_pattern),
         "write_deletion_file must NOT re-open the deletion vector file and \
          fsync it a second time. That reopen+fsync pattern is redundant work \
-         after `inner.sync_all()` on the writer's inner fd and was previously \
-         a per-deletion regression."
+         after `ordering_sync_std(&inner)` on the writer's inner fd and was \
+         previously a per-deletion regression."
     );
 
-    // Also assert there is at most one `*.sync_all()` call on any file
-    // descriptor for the deletion vector file in this function. The parent
-    // directory fsync (`dir.sync_all()`) is allowed and distinct.
-    let file_sync_all_count = body
+    // Also assert there is exactly one file-level sync call on the deletion
+    // vector file in this function. The parent directory fsync
+    // (`ordering_sync_dir_std(&dir)`) is allowed and distinct.
+    let file_sync_count = body
         .lines()
         .filter(|line| {
             let line = line.trim();
-            // `inner.sync_all()` or `f.sync_all()` style calls on the data file
-            // itself. Match on the bare `sync_all()` suffix while excluding the
-            // parent-dir `dir.sync_all()` line.
-            line.contains(".sync_all()") && !line.contains("dir.sync_all()")
+            line.contains("ordering_sync_std(&inner)")
         })
         .count();
     assert_eq!(
-        file_sync_all_count, 1,
-        "write_deletion_file must call `sync_all()` on the deletion vector \
-         file exactly once (the writer's inner fd). Found {file_sync_all_count} \
-         occurrence(s). Parent-directory fsync via `dir.sync_all()` is allowed \
-         and is filtered out of this count."
+        file_sync_count, 1,
+        "write_deletion_file must sync the deletion vector file exactly once \
+         (the writer's inner fd, via `ordering_sync_std(&inner)`). Found \
+         {file_sync_count} occurrence(s). Parent-directory fsync via \
+         `ordering_sync_dir_std(&dir)` is distinct and not counted here."
+    );
+
+    // Tier guard: no full-tier `sync_all` — and no direct `sync_data`, which
+    // on macOS is ALSO F_FULLFSYNC — may creep back onto this per-deletion
+    // hot path. The ordering tier (`fsync_tier::ordering_sync_std`) is the
+    // documented contract; a full-tier flush re-introduces ~4-5 ms per
+    // deletion vector on macOS for zero end-to-end durability gain (the
+    // catalog commit it protects is SQLite synchronous=NORMAL).
+    assert!(
+        !body.contains(".sync_all()") && !body.contains(".sync_data()"),
+        "write_deletion_file must not call `.sync_all()`/`.sync_data()` \
+         directly (both are F_FULLFSYNC on macOS) — route through \
+         `fsync_tier::ordering_sync_std` and see provider/fsync_tier.rs."
     );
 }
 
 #[test]
-fn write_deletion_file_still_fsyncs_parent_dir() {
+fn deletion_vector_write_parallelizes_files_and_coalesces_dir_sync() {
     // The companion fsync — the parent directory — must still happen, so the
-    // dirent for the new deletion-vector file is durable before the catalog
-    // is updated. This is the load-bearing half of the ACID-Durability fix
-    // that the removed reopen was *replicating*; we want to keep this one.
-    let body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write_deletion_file")
-        .expect("write_deletion_file function not found in delete/vector_io.rs");
-
+    // dirents for new deletion-vector files are durable before the catalog
+    // is updated. It now lives in `DeletionVectorWriter::write`, ONCE per
+    // batch: the per-spec files are written CONCURRENTLY (`try_join_all`,
+    // overlapping their file fsyncs — on EBS this collapses N serialized
+    // ~1 ms barrier round-trips into ~1), and a single deletions/-dir sync
+    // after they all complete flushes every pending dirent at once. Same
+    // durability contract, 1/N the directory barriers.
+    let write_body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write")
+        .expect("DeletionVectorWriter::write not found in delete/vector_io.rs");
     assert!(
-        body.contains("dir.sync_all()"),
-        "write_deletion_file must still fsync the parent directory of the \
-         deletion vector file. Without this, a crash after the catalog records \
-         the path can leave the directory entry unwritten — the catalog now \
-         references a file that does not exist on restart."
+        write_body.contains("try_join_all"),
+        "DeletionVectorWriter::write must write the batch's deletion-vector \
+         files concurrently (try_join_all) — serializing them re-introduces \
+         N fsync round-trips per batch on network-attached storage."
+    );
+    // Exactly two dir syncs in `write`: the one-time snapshot-parent sync
+    // (first deletion vector for the snapshot) and the per-batch coalesced
+    // deletions/-dir sync. A third occurrence means a per-file dir sync
+    // crept back in.
+    let dir_sync_count = write_body.matches("ordering_sync_dir_std(&dir)").count();
+    assert_eq!(
+        dir_sync_count, 2,
+        "DeletionVectorWriter::write must contain exactly two directory \
+         syncs (one-time snapshot-parent + per-batch coalesced deletions/ \
+         dir). Found {dir_sync_count}."
+    );
+
+    // And write_deletion_file itself must NOT dir-sync — that would undo the
+    // coalescing by re-adding a barrier per file.
+    let file_body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write_deletion_file")
+        .expect("write_deletion_file function not found in delete/vector_io.rs");
+    assert!(
+        !file_body.contains("ordering_sync_dir_std"),
+        "write_deletion_file must not fsync the parent directory per file — \
+         the caller issues one coalesced deletions/-dir sync per batch."
     );
 }
 
@@ -229,8 +271,9 @@ fn write_staging_wal_local_uses_single_open_write_fsync() {
         .lines()
         .filter(|line| {
             let line = line.trim();
-            line.contains(".sync_all()")
-                && !line.contains("dir.sync_all()")
+            (line.contains(".sync_all()")
+                || line.contains(".sync_data()")
+                || line.contains("ordering_sync_tokio_file("))
                 && !line.contains("staging_dir")
                 && !line.contains("parent")
         })
@@ -238,12 +281,84 @@ fn write_staging_wal_local_uses_single_open_write_fsync() {
 
     assert!(
         file_sync_count <= 1,
-        "write_staging_wal_local must perform at most one file-level sync_all \
+        "write_staging_wal_local must perform at most one file-level sync \
          after writing the WAL content (efficient single open+write+fsync). \
          Found {file_sync_count} file syncs. A redundant reopen+fsync was \
          previously present on the hot ingestion path and has been removed."
     );
+
+    // Tier guard: the WAL marker sync must be the ordering tier
+    // (`fsync_tier::ordering_sync_tokio_file` → plain fsync on macOS,
+    // fdatasync on Linux), never `sync_all`/`sync_data` — BOTH are
+    // F_FULLFSYNC (~4-5 ms per call) on macOS. Losing this marker in a
+    // power-loss window only orphans staging files that
+    // `ensure_no_incomplete_write` audits and discards, and the metastore's
+    // visibility commits (SQLite synchronous=NORMAL) are no stronger — so a
+    // full-tier flush here is pure per-batch latency. See
+    // `provider/fsync_tier.rs` for the measurements.
+    assert!(
+        body.contains("ordering_sync_tokio_file(&file)"),
+        "write_staging_wal_local must sync the WAL marker with the ordering \
+         tier (`fsync_tier::ordering_sync_tokio_file(&file)`)."
+    );
+    assert!(
+        !body.contains(".sync_all()") && !body.contains(".sync_data()"),
+        "write_staging_wal_local must not call `.sync_all()`/`.sync_data()` \
+         directly (both are F_FULLFSYNC on macOS) on the staged-append hot \
+         path — route through fsync_tier and see provider/fsync_tier.rs."
+    );
 }
+
+#[test]
+fn staged_commit_hot_path_uses_ordering_tier_syncs() {
+    // The staged-commit hot path pays one barrier per call site per batch.
+    // On macOS, BOTH std `sync_all` AND `sync_data` map to
+    // `fcntl(F_FULLFSYNC)` — a full drive-cache flush measured at ~4-5 ms per
+    // call — while plain `fsync(2)` (what `fsync_tier::ordering_sync_*`
+    // issues there) is ~66 µs. On Linux the helper is `fdatasync`, still a
+    // device flush.
+    //
+    // Full-tier barriers on this path bought no end-to-end durability: the
+    // SQLite metastore runs `journal_mode=WAL, synchronous=NORMAL` with no
+    // `fullfsync` pragma, so the catalog transaction that makes staged files
+    // visible is itself only plain-fsync durable on macOS (NORMAL does not
+    // even fsync at every commit). A power-loss window that loses
+    // ordering-tier data necessarily also loses the catalog rows referencing
+    // it. Before this contract, a single 2,000-row staged upsert paid 5-7
+    // F_FULLFSYNCs ≈ ~25 ms of pure barrier latency — the dominant fixed cost
+    // of small staged batches (vs_duckdb_upsert_scaling).
+    //
+    // `sync_snapshot_dir` is the shared dir-barrier helper used by the write,
+    // staging-WAL, move/publish, and compaction paths; pin its tier here.
+    let body = extract_fn_body(TABLE_SRC, "sync_snapshot_dir")
+        .expect("sync_snapshot_dir function not found in table.rs");
+    assert!(
+        body.contains("ordering_sync_dir_std(&dir)"),
+        "sync_snapshot_dir must flush directory entries with the ordering \
+         tier (`fsync_tier::ordering_sync_dir_std(&dir)`), not `sync_all` or \
+         `sync_data` (both F_FULLFSYNC on macOS). See the durability-tier \
+         rationale in the function body and provider/fsync_tier.rs."
+    );
+    assert!(
+        !body.contains(".sync_all()") && !body.contains(".sync_data()"),
+        "sync_snapshot_dir must not call `.sync_all()`/`.sync_data()` \
+         directly: every staged CDC batch pays this barrier multiple times, \
+         both are F_FULLFSYNC on macOS, and the metastore's visibility \
+         commits (SQLite synchronous=NORMAL) are no stronger — the full \
+         flush is pure latency with no durability gain."
+    );
+
+    // And the helper itself must implement the macOS ordering tier with a
+    // plain `libc::fsync` (std offers no cheaper-than-F_FULLFSYNC call).
+    assert!(
+        FSYNC_TIER_SRC.contains("libc::fsync"),
+        "provider/fsync_tier.rs must issue plain `libc::fsync` on macOS — \
+         std `sync_all`/`sync_data` are both F_FULLFSYNC there (measured \
+         ~4-5 ms vs ~66 µs for plain fsync)."
+    );
+}
+
+const FSYNC_TIER_SRC: &str = include_str!("../src/provider/fsync_tier.rs");
 
 // -----------------------------------------------------------------------------
 // Devil's Advocate / "Be really sure" analysis (for the recurring /loop task)

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -226,3 +226,8 @@ name = "object_filter"
 harness = false
 name = "mongodb_change_stream"
 required-features = ["mongodb"]
+
+[[bench]]
+harness = false
+name = "kafka_decode"
+required-features = ["bench", "kafka"]

--- a/crates/data_components/benches/kafka_decode.rs
+++ b/crates/data_components/benches/kafka_decode.rs
@@ -1,0 +1,75 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Head-to-head decode microbench for the Kafka change-stream JSON path:
+//! `direct` (raw bytes -> Arrow) vs `roundtrip` (bytes -> serde_json::Value ->
+//! to_string() -> Arrow). Run with:
+//!   cargo bench -p data_components --features bench,kafka --bench kafka_decode
+
+#![allow(clippy::expect_used, clippy::redundant_closure_for_method_calls)]
+
+use arrow::datatypes::{DataType, Field, Schema};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use data_components::kafka::bench_wrappers::{decode_direct, decode_roundtrip};
+use std::hint::black_box;
+use std::sync::Arc;
+
+fn record_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Utf8, false),
+        Field::new("category", DataType::Utf8, false),
+        Field::new("amount", DataType::Decimal128(38, 18), false),
+        Field::new("ts", DataType::Utf8, false),
+    ]))
+}
+
+/// Mixed-type messages: a string key, a category, an 18-dp decimal amount, and a
+/// timestamp string. The 18-decimal field exercises the precision-sensitive path.
+fn make_payloads(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|i| {
+            let frac = 123_456_789_012_345_678u64 + (i as u64 % 1000);
+            format!(
+                "{{\"key\":\"item_{i:04}\",\"category\":\"cat_{}\",\"amount\":{}.{frac:018},\"ts\":\"2026-01-01T00:00:{:02}Z\"}}",
+                i % 8,
+                600 + (i % 50),
+                i % 60
+            )
+            .into_bytes()
+        })
+        .collect()
+}
+
+fn bench_decode(c: &mut Criterion) {
+    let schema = record_schema();
+    let mut group = c.benchmark_group("kafka_json_decode");
+    for &n in &[100usize, 1_000, 10_000] {
+        let owned = make_payloads(n);
+        let payloads: Vec<&[u8]> = owned.iter().map(|v| v.as_slice()).collect();
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(BenchmarkId::new("direct", n), &payloads, |b, p| {
+            b.iter(|| black_box(decode_direct(black_box(p), &schema).expect("direct")));
+        });
+        group.bench_with_input(BenchmarkId::new("roundtrip", n), &payloads, |b, p| {
+            b.iter(|| black_box(decode_roundtrip(black_box(p), &schema).expect("roundtrip")));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_decode);
+criterion_main!(benches);

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -1039,21 +1039,29 @@ fn payloads_to_change_batch<'a>(
     payloads: impl Iterator<Item = &'a [u8]>,
     schema: &Arc<Schema>,
 ) -> Result<ChangeBatch, cdc::StreamError> {
-    let values = payloads
-        .map(|payload| {
-            serde_json::from_slice::<Value>(payload).map_err(|e| {
-                cdc::StreamError::Kafka(Error::UnableToDeserializeJsonMessage { source: e })
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    // Fast path (no flatten): feed the raw JSON payload bytes straight to the
+    // Arrow NDJSON reader, skipping the serde_json::Value tree + the
+    // re-serialization round-trip that values_to_change_batch performs.
+    // arrow-json accepts both newline-delimited and whitespace-separated JSON
+    // values, so joining payloads with '\n' is safe even when a producer emits
+    // pretty-printed (multi-line) objects.
+    let mut joined: Vec<u8> = Vec::new();
+    let mut count: usize = 0;
+    for payload in payloads {
+        if !joined.is_empty() {
+            joined.push(b'\n');
+        }
+        joined.extend_from_slice(payload);
+        count += 1;
+    }
 
-    if values.is_empty() {
+    if count == 0 {
         return Err(cdc::StreamError::Arrow(
             "No Kafka message payload found in batch".to_string(),
         ));
     }
 
-    values_to_change_batch(values.iter(), None, schema)
+    json_bytes_to_change_batch(&joined, schema)
 }
 
 fn values_to_change_batch<'a>(
@@ -1099,6 +1107,39 @@ fn json_bytes_to_change_batch(
 
     cdc::wrap_data_as_change_batch(schema, &rb)
         .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))
+}
+
+// Public wrappers for benchmarking the two JSON decode paths head-to-head.
+#[cfg(feature = "bench")]
+pub mod bench_wrappers {
+    use super::{
+        Arc, ChangeBatch, Error, Schema, Value, cdc, payloads_to_change_batch,
+        values_to_change_batch,
+    };
+
+    /// Direct path (production): raw payload bytes -> Arrow NDJSON reader.
+    pub fn decode_direct(
+        payloads: &[&[u8]],
+        schema: &Arc<Schema>,
+    ) -> Result<ChangeBatch, cdc::StreamError> {
+        payloads_to_change_batch(payloads.iter().copied(), schema)
+    }
+
+    /// Legacy round-trip path: bytes -> serde_json::Value -> to_string() -> Arrow.
+    pub fn decode_roundtrip(
+        payloads: &[&[u8]],
+        schema: &Arc<Schema>,
+    ) -> Result<ChangeBatch, cdc::StreamError> {
+        let values = payloads
+            .iter()
+            .map(|p| {
+                serde_json::from_slice::<Value>(p).map_err(|e| {
+                    cdc::StreamError::Kafka(Error::UnableToDeserializeJsonMessage { source: e })
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        values_to_change_batch(values.iter(), None, schema)
+    }
 }
 
 #[async_trait]
@@ -1290,6 +1331,61 @@ mod tests {
             }
             _ => panic!("Expected Arrow error"),
         }
+    }
+
+    #[test]
+    fn decimal_precision_roundtrip_vs_direct() {
+        use arrow::array::Decimal128Array;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("amt", DataType::Decimal128(38, 18), false),
+        ]));
+        // 18 fractional digits → exact scaled i128 = 1234567890123456789
+        let exact: i128 = 1_234_567_890_123_456_789;
+        let raw_num = br#"{"id":1,"amt":1.234567890123456789}"#;
+        let raw_str = br#"{"id":1,"amt":"1.234567890123456789"}"#;
+
+        // ChangeBatch.record is [op, primary_keys, data:Struct{table fields}];
+        // amt is field 1 of the nested data struct (col 2).
+        let amt = |b: &ChangeBatch| -> i128 {
+            b.record
+                .column(2)
+                .as_any()
+                .downcast_ref::<arrow::array::StructArray>()
+                .expect("data struct")
+                .column(1)
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .expect("decimal col")
+                .value(0)
+        };
+
+        // direct (this PR's fast path), number form
+        let direct_num = payloads_to_change_batch([raw_num.as_slice()].into_iter(), &schema)
+            .expect("direct num");
+        // current round-trip path, number form
+        let v_num = serde_json::from_slice::<Value>(raw_num).expect("parse num");
+        let rt_num = values_to_change_batch([v_num].iter(), None, &schema).expect("roundtrip num");
+        // direct, string form (decimal-as-string control)
+        let direct_str = payloads_to_change_batch([raw_str.as_slice()].into_iter(), &schema)
+            .expect("direct str");
+
+        eprintln!("[decimal-precision] exact          = {exact}");
+        eprintln!("[decimal-precision] direct(num)     = {}", amt(&direct_num));
+        eprintln!("[decimal-precision] roundtrip(num)  = {}", amt(&rt_num));
+        eprintln!("[decimal-precision] direct(str)     = {}", amt(&direct_str));
+
+        // The direct byte path preserves full Decimal128 precision for both
+        // number- and string-form JSON.
+        assert_eq!(amt(&direct_num), exact, "direct number-form must be exact");
+        assert_eq!(amt(&direct_str), exact, "direct string-form must be exact");
+        // The old serde_json::Value -> to_string() round-trip widens the number
+        // to f64 first and is therefore lossy beyond ~16 significant digits.
+        assert_ne!(
+            amt(&rt_num),
+            exact,
+            "round-trip via serde_json::Value is lossy through f64"
+        );
     }
 
     #[test]

--- a/crates/runtime-parameters/src/lib.rs
+++ b/crates/runtime-parameters/src/lib.rs
@@ -506,34 +506,21 @@ pub use runtime_parameter_spec::{ParameterSpec, ParameterType};
 
 /// Suggest the closest valid parameter name for a user-typo'd key.
 ///
-/// Compares against the user-facing form of every spec (including prefix where relevant).
-/// Returns `Some(candidate)` only when edit distance is low enough to be useful,
-/// to avoid misleading suggestions for keys that are genuinely unknown.
+/// Compares against the user-facing form of every non-deprecated spec
+/// (including prefix where relevant) using the shared
+/// [`util::levenshtein::closest_match`] helper so the "did you mean" UX is
+/// the same as for runtime tunables and connector names.
 fn closest_param_suggestion(
     all_params: &[ParameterSpec],
     prefix: &str,
     typo: &str,
 ) -> Option<String> {
-    let typo_lower = typo.to_ascii_lowercase();
-    let mut best: Option<(String, usize)> = None;
-    for p in all_params {
-        if p.deprecation_message.is_some() {
-            continue;
-        }
-        let candidate = p.display_name(prefix);
-        let d = util::levenshtein::distance(&typo_lower, &candidate.to_ascii_lowercase());
-        if best.as_ref().is_none_or(|(_, best_d)| d < *best_d) {
-            best = Some((candidate, d));
-        }
-    }
-    let (candidate, distance) = best?;
-    // Bound: at most 1/3 of the longer string (so short typos only match very close names).
-    let max_allowed = (candidate.len().max(typo.len()) / 3).max(1);
-    if distance <= max_allowed {
-        Some(candidate)
-    } else {
-        None
-    }
+    let candidates: Vec<String> = all_params
+        .iter()
+        .filter(|p| p.deprecation_message.is_none())
+        .map(|p| p.display_name(prefix))
+        .collect();
+    util::levenshtein::closest_match(typo, &candidates)
 }
 
 /// Build the suffix appended to "Missing required parameter: <name>" when a required

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -366,6 +366,20 @@ fn resolve_cdc_param_u64(
     parse_env_u64(env_var, default)
 }
 
+/// Every `cdc_*` key [`cdc_config_from_params`] reads from `runtime.params`.
+/// Exposed as the authoritative list for this family; the startup unknown-param
+/// check merges it into the full `runtime.params` vocabulary
+/// (`known_runtime_params`) used to recognize keys and scope "did you mean"
+/// suggestions across the whole section. Keep in sync with the keys read in
+/// [`cdc_config_from_params`].
+pub(crate) const CDC_RUNTIME_PARAMS: &[&str] = &[
+    "cdc_prefetch_buffer",
+    "cdc_max_coalesced_envelopes",
+    "cdc_max_coalesced_bytes",
+    "cdc_max_coalesce_age_ms",
+    "cdc_commit_timeout_ms",
+];
+
 /// Build a [`CdcConfig`] from the spicepod `runtime.params` map, reading
 /// the `cdc_prefetch_buffer`, `cdc_max_coalesced_envelopes`,
 /// `cdc_max_coalesced_bytes`, `cdc_max_coalesce_age_ms`, and

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -57,6 +57,23 @@ use util::{in_tracing_context, in_tracing_context_async};
 type DatafusionConfigurationCallback = fn(&mut DataFusion);
 
 const CAYENNE_FOOTER_CACHE_MB_PARAM: &str = "cayenne_footer_cache_mb";
+const CAYENNE_SORT_MERGE_MIN_ROWS_PARAM: &str = "cayenne_sort_merge_min_rows";
+const CAYENNE_SORT_MERGE_MEMORY_POOL_FRACTION_PARAM: &str =
+    "cayenne_sort_merge_memory_pool_fraction";
+const CAYENNE_FILTER_PROPAGATION_PARAM: &str = "cayenne_filter_propagation";
+const CAYENNE_OPTIMIZER_RULES_PARAM: &str = "cayenne_optimizer_rules";
+
+/// Process-global `SQLite` metastore pragma tuning keys (cache, mmap, busy
+/// timeout, WAL autocheckpoint, `auto_vacuum`). Consumed once at startup in
+/// `build_internal`; declared here so they're part of the recognized
+/// `runtime.params` vocabulary and don't false-warn as unknown.
+const CAYENNE_METASTORE_CACHE_MB_PARAM: &str = "cayenne_metastore_cache_mb";
+const CAYENNE_METASTORE_MMAP_MB_PARAM: &str = "cayenne_metastore_mmap_mb";
+const CAYENNE_METASTORE_BUSY_TIMEOUT_MS_PARAM: &str = "cayenne_metastore_busy_timeout_ms";
+const CAYENNE_METASTORE_WAL_AUTOCHECKPOINT_PAGES_PARAM: &str =
+    "cayenne_metastore_wal_autocheckpoint_pages";
+const CAYENNE_METASTORE_AUTO_VACUUM_PARAM: &str = "cayenne_metastore_auto_vacuum";
+
 /// Runtime param: fraction of `runtime.query.memory_limit` carved into a
 /// dedicated Cayenne compaction memory pool when Cayenne acceleration is
 /// configured on a dataset and dedicated thread pools are enabled.
@@ -66,6 +83,57 @@ const CAYENNE_COMPACTION_MEMORY_FRACTION_PARAM: &str = "cayenne_compaction_memor
 const DEFAULT_COMPACTION_MEMORY_FRACTION: f64 = 0.2;
 const MIN_COMPACTION_MEMORY_FRACTION: f64 = 0.05;
 const MAX_COMPACTION_MEMORY_FRACTION: f64 = 0.9;
+
+/// `runtime.params` keys with a `cayenne_` prefix that the runtime recognizes.
+const KNOWN_CAYENNE_RUNTIME_PARAMS: &[&str] = &[
+    CAYENNE_FOOTER_CACHE_MB_PARAM,
+    CAYENNE_SORT_MERGE_MIN_ROWS_PARAM,
+    CAYENNE_SORT_MERGE_MEMORY_POOL_FRACTION_PARAM,
+    CAYENNE_FILTER_PROPAGATION_PARAM,
+    CAYENNE_OPTIMIZER_RULES_PARAM,
+    CAYENNE_COMPACTION_MEMORY_FRACTION_PARAM,
+    CAYENNE_METASTORE_CACHE_MB_PARAM,
+    CAYENNE_METASTORE_MMAP_MB_PARAM,
+    CAYENNE_METASTORE_BUSY_TIMEOUT_MS_PARAM,
+    CAYENNE_METASTORE_WAL_AUTOCHECKPOINT_PAGES_PARAM,
+    CAYENNE_METASTORE_AUTO_VACUUM_PARAM,
+];
+
+/// Recognized `runtime.params` keys that don't belong to a larger prefix
+/// family (the family lists live next to the code that consumes them:
+/// `KNOWN_CAYENNE_RUNTIME_PARAMS`, `changes::CDC_RUNTIME_PARAMS`,
+/// `http_rate_control::HTTP_RATE_CONTROL_RUNTIME_PARAMS`).
+const MISC_RUNTIME_PARAMS: &[&str] = &[
+    "url_tables",
+    "geo",
+    "parquet_page_index",
+    "dedicated_thread_pool",
+    "shuffle_location",
+    "shuffle_format",
+    "github_max_concurrent_connections",
+];
+
+/// The complete set of `runtime.params` keys the runtime recognizes, gathered
+/// from every consuming subsystem's authoritative list. Used to validate the
+/// `runtime.params` section at startup: any key not in this set is a typo or
+/// unsupported option and gets a "did you mean" warning scoped to this
+/// section's vocabulary. See spiceai/spiceai#10970.
+///
+/// When adding a new `runtime.params` key, extend the owning family's list
+/// (or `MISC_RUNTIME_PARAMS`) so it is recognized here.
+fn known_runtime_params() -> Vec<&'static str> {
+    let mut known = Vec::with_capacity(
+        KNOWN_CAYENNE_RUNTIME_PARAMS.len()
+            + crate::accelerated_table::refresh_task::changes::CDC_RUNTIME_PARAMS.len()
+            + dataconnector::http_rate_control::HTTP_RATE_CONTROL_RUNTIME_PARAMS.len()
+            + MISC_RUNTIME_PARAMS.len(),
+    );
+    known.extend_from_slice(KNOWN_CAYENNE_RUNTIME_PARAMS);
+    known.extend_from_slice(crate::accelerated_table::refresh_task::changes::CDC_RUNTIME_PARAMS);
+    known.extend_from_slice(dataconnector::http_rate_control::HTTP_RATE_CONTROL_RUNTIME_PARAMS);
+    known.extend_from_slice(MISC_RUNTIME_PARAMS);
+    known
+}
 
 pub struct RuntimeBuilder {
     app: Option<Arc<app::App>>,
@@ -252,14 +320,25 @@ impl RuntimeBuilder {
         // URL tables are opt-in via `runtime.params.url_tables=enabled`
         let url_tables_enabled =
             spicepod_rt.params.get("url_tables").map(String::as_str) == Some("enabled");
+        warn_on_unknown_runtime_params(&spicepod_rt.params);
         let cayenne_sort_merge_min_rows =
-            parse_usize_runtime_param(&spicepod_rt.params, "cayenne_sort_merge_min_rows");
+            parse_usize_runtime_param(&spicepod_rt.params, CAYENNE_SORT_MERGE_MIN_ROWS_PARAM);
+        log_applied_cayenne_param(
+            CAYENNE_SORT_MERGE_MIN_ROWS_PARAM,
+            cayenne_sort_merge_min_rows,
+        );
         let cayenne_sort_merge_memory_pool_fraction = parse_f64_runtime_param(
             &spicepod_rt.params,
-            "cayenne_sort_merge_memory_pool_fraction",
+            CAYENNE_SORT_MERGE_MEMORY_POOL_FRACTION_PARAM,
+        );
+        log_applied_cayenne_param(
+            CAYENNE_SORT_MERGE_MEMORY_POOL_FRACTION_PARAM,
+            cayenne_sort_merge_memory_pool_fraction,
         );
         let cayenne_footer_cache_mb =
             parse_usize_runtime_param(&spicepod_rt.params, CAYENNE_FOOTER_CACHE_MB_PARAM);
+        log_applied_cayenne_param(CAYENNE_FOOTER_CACHE_MB_PARAM, cayenne_footer_cache_mb);
+        let cayenne_filter_propagation = parse_cayenne_filter_propagation(&spicepod_rt.params);
 
         // Process-global SQLite metastore pragma tuning (cache, mmap, busy
         // timeout, WAL autocheckpoint, auto_vacuum). Applied once at startup;
@@ -268,30 +347,31 @@ impl RuntimeBuilder {
         {
             let mut metastore_cfg = cayenne::SqliteMetastoreConfig::default();
             if let Some(v) =
-                parse_usize_runtime_param(&spicepod_rt.params, "cayenne_metastore_cache_mb")
+                parse_usize_runtime_param(&spicepod_rt.params, CAYENNE_METASTORE_CACHE_MB_PARAM)
             {
                 metastore_cfg.cache_size_mb = v;
             }
             if let Some(v) =
-                parse_usize_runtime_param(&spicepod_rt.params, "cayenne_metastore_mmap_mb")
+                parse_usize_runtime_param(&spicepod_rt.params, CAYENNE_METASTORE_MMAP_MB_PARAM)
             {
                 metastore_cfg.mmap_size_bytes = i64::try_from(v.saturating_mul(1024 * 1024))
                     .unwrap_or(metastore_cfg.mmap_size_bytes);
             }
-            if let Some(v) =
-                parse_usize_runtime_param(&spicepod_rt.params, "cayenne_metastore_busy_timeout_ms")
-            {
+            if let Some(v) = parse_usize_runtime_param(
+                &spicepod_rt.params,
+                CAYENNE_METASTORE_BUSY_TIMEOUT_MS_PARAM,
+            ) {
                 metastore_cfg.busy_timeout_ms =
                     u64::try_from(v).unwrap_or(metastore_cfg.busy_timeout_ms);
             }
             if let Some(v) = parse_usize_runtime_param(
                 &spicepod_rt.params,
-                "cayenne_metastore_wal_autocheckpoint_pages",
+                CAYENNE_METASTORE_WAL_AUTOCHECKPOINT_PAGES_PARAM,
             ) {
                 metastore_cfg.wal_autocheckpoint_pages =
                     u32::try_from(v).unwrap_or(metastore_cfg.wal_autocheckpoint_pages);
             }
-            if let Some(av) = spicepod_rt.params.get("cayenne_metastore_auto_vacuum") {
+            if let Some(av) = spicepod_rt.params.get(CAYENNE_METASTORE_AUTO_VACUUM_PARAM) {
                 metastore_cfg.auto_vacuum = match av.to_lowercase().as_str() {
                     "none" => cayenne::SqliteAutoVacuum::None,
                     "incremental" => cayenne::SqliteAutoVacuum::Incremental,
@@ -308,7 +388,19 @@ impl RuntimeBuilder {
         }
 
         let cayenne_filter_propagation_enabled =
-            parse_cayenne_filter_propagation(&spicepod_rt.params).is_enabled();
+            cayenne_filter_propagation.is_some_and(CayenneFilterPropagation::is_enabled);
+        // Only log "applied" for a value the user validly set; an unset or
+        // invalid value yields `None` (and an invalid value already warned).
+        log_applied_cayenne_param(
+            CAYENNE_FILTER_PROPAGATION_PARAM,
+            cayenne_filter_propagation.map(|propagation| {
+                if propagation.is_enabled() {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            }),
+        );
         let cayenne_optimizer_rules =
             parse_cayenne_optimizer_rules(&spicepod_rt.params, cayenne_filter_propagation_enabled);
 
@@ -770,6 +862,39 @@ fn parse_memory_limit(memory_limit: Option<String>) -> Option<u64> {
     }
 }
 
+/// Emit an INFO log when a `cayenne_*` runtime tunable parsed successfully so
+/// operators see at startup which override actually took effect. Only logs
+/// when `value` is `Some` (the parser already emits a warning for malformed
+/// values). See spiceai/spiceai#10970.
+fn log_applied_cayenne_param<V: std::fmt::Display>(key: &str, value: Option<V>) {
+    if let Some(value) = value {
+        tracing::info!("Cayenne runtime tunable applied: runtime.params.{key}={value}");
+    }
+}
+
+/// Warn (with a "did you mean" suggestion when close) on any key in the
+/// `runtime.params` section the runtime doesn't recognize, so typos like
+/// `cayenne_footer_cach_mb` or `shuffle_locatin` don't silently leave the
+/// runtime on defaults. Candidates are scoped to the `runtime.params`
+/// section's full vocabulary ([`known_runtime_params`]) so suggestions only
+/// ever point at another valid `runtime.params` key. See
+/// spiceai/spiceai#10970.
+fn warn_on_unknown_runtime_params(params: &HashMap<String, String>) {
+    let known = known_runtime_params();
+    for key in params.keys() {
+        if known.contains(&key.as_str()) {
+            continue;
+        }
+        if let Some(suggestion) = util::levenshtein::closest_match(key, &known) {
+            tracing::warn!(
+                "runtime.params.{key} is not a recognized runtime parameter; did you mean '{suggestion}'? Ignoring."
+            );
+        } else {
+            tracing::warn!("runtime.params.{key} is not a recognized runtime parameter; ignoring.");
+        }
+    }
+}
+
 fn parse_usize_runtime_param(params: &HashMap<String, String>, key: &str) -> Option<usize> {
     let raw = params.get(key)?;
     if raw.eq_ignore_ascii_case("usize::MAX") || raw.eq_ignore_ascii_case("max") {
@@ -819,9 +944,6 @@ fn clamp_cayenne_compaction_memory_fraction(value: f64) -> f64 {
     clamped
 }
 
-const CAYENNE_FILTER_PROPAGATION_PARAM: &str = "cayenne_filter_propagation";
-const CAYENNE_OPTIMIZER_RULES_PARAM: &str = "cayenne_optimizer_rules";
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CayenneFilterPropagation {
     Disabled,
@@ -834,19 +956,24 @@ impl CayenneFilterPropagation {
     }
 }
 
-fn parse_cayenne_filter_propagation(params: &HashMap<String, String>) -> CayenneFilterPropagation {
-    let Some(raw) = params.get(CAYENNE_FILTER_PROPAGATION_PARAM) else {
-        return CayenneFilterPropagation::Disabled;
-    };
+/// Parse the Cayenne filter-propagation tunable. Returns `None` when the key is
+/// unset or holds an invalid value (in which case the effective behavior is
+/// `Disabled` and an invalid value warns) — mirroring [`parse_usize_runtime_param`]
+/// /[`parse_f64_runtime_param`], so callers only log "applied" for a value the
+/// user validly set.
+fn parse_cayenne_filter_propagation(
+    params: &HashMap<String, String>,
+) -> Option<CayenneFilterPropagation> {
+    let raw = params.get(CAYENNE_FILTER_PROPAGATION_PARAM)?;
 
     match raw.trim().to_ascii_lowercase().as_str() {
-        "enabled" => CayenneFilterPropagation::Enabled,
-        "disabled" => CayenneFilterPropagation::Disabled,
+        "enabled" => Some(CayenneFilterPropagation::Enabled),
+        "disabled" => Some(CayenneFilterPropagation::Disabled),
         _ => {
             tracing::warn!(
                 "runtime.params.{CAYENNE_FILTER_PROPAGATION_PARAM}={raw:?} must be 'enabled' or 'disabled'; using disabled"
             );
-            CayenneFilterPropagation::Disabled
+            None
         }
     }
 }
@@ -1021,6 +1148,55 @@ mod test {
     }
 
     #[test]
+    fn known_runtime_params_covers_every_family() {
+        // The section vocabulary must include *every* key from *every* family
+        // that feeds it — not just a representative key — so a future addition
+        // to any family list (e.g. a new `cayenne_*` tunable) can't silently
+        // fall out of the merged vocabulary and false-warn on a valid key.
+        let known = known_runtime_params();
+        let family_keys = KNOWN_CAYENNE_RUNTIME_PARAMS
+            .iter()
+            .chain(crate::accelerated_table::refresh_task::changes::CDC_RUNTIME_PARAMS)
+            .chain(dataconnector::http_rate_control::HTTP_RATE_CONTROL_RUNTIME_PARAMS)
+            .chain(MISC_RUNTIME_PARAMS);
+        for key in family_keys {
+            assert!(
+                known.contains(key),
+                "known_runtime_params() missing `{key}`; a valid runtime param would false-warn"
+            );
+        }
+        // No accidental duplicates across the merged family lists.
+        let mut deduped = known.clone();
+        deduped.sort_unstable();
+        deduped.dedup();
+        assert_eq!(
+            deduped.len(),
+            known.len(),
+            "duplicate keys in known_runtime_params()"
+        );
+    }
+
+    #[test]
+    fn runtime_param_typos_suggest_within_section() {
+        // A typo resolves to the intended key, and the suggestion is drawn from
+        // the whole `runtime.params` section vocabulary — across families.
+        let known = known_runtime_params();
+        assert_eq!(
+            util::levenshtein::closest_match("cayenne_footer_cach_mb", &known).as_deref(),
+            Some("cayenne_footer_cache_mb"),
+        );
+        assert_eq!(
+            util::levenshtein::closest_match("shuffle_locatin", &known).as_deref(),
+            Some("shuffle_location"),
+        );
+        // A wholly unrelated key gets no misleading suggestion.
+        assert_eq!(
+            util::levenshtein::closest_match("totally_unrelated_key", &known),
+            None,
+        );
+    }
+
+    #[test]
     fn test_clamp_cayenne_compaction_memory_fraction() {
         for (input, expected) in [(0.0, 0.05), (0.2, 0.2), (1.0, 0.9)] {
             let actual = clamp_cayenne_compaction_memory_fraction(input);
@@ -1040,26 +1216,26 @@ mod test {
 
         assert_eq!(
             parse_cayenne_filter_propagation(&params),
-            CayenneFilterPropagation::Enabled
+            Some(CayenneFilterPropagation::Enabled)
         );
         assert_eq!(
             parse_cayenne_filter_propagation(&HashMap::from([(
                 CAYENNE_FILTER_PROPAGATION_PARAM.to_string(),
                 "disabled".to_string(),
             )])),
-            CayenneFilterPropagation::Disabled
+            Some(CayenneFilterPropagation::Disabled)
         );
+        // An invalid value warns and yields `None` (effective behavior is
+        // disabled, but nothing was validly applied so callers won't log it).
         assert_eq!(
             parse_cayenne_filter_propagation(&HashMap::from([(
                 CAYENNE_FILTER_PROPAGATION_PARAM.to_string(),
                 "true".to_string(),
             )])),
-            CayenneFilterPropagation::Disabled
+            None
         );
-        assert_eq!(
-            parse_cayenne_filter_propagation(&HashMap::new()),
-            CayenneFilterPropagation::Disabled
-        );
+        // An unset key also yields `None`.
+        assert_eq!(parse_cayenne_filter_propagation(&HashMap::new()), None);
     }
 
     #[test]

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -162,7 +162,7 @@ pub async fn registered_catalog_names() -> Vec<String> {
 /// Closest-match suggestion for an unknown catalog connector name. Reuses the
 /// same scoring/threshold helper as data connectors so behaviour is consistent.
 pub async fn suggest_catalog_connector(name: &str) -> Option<String> {
-    crate::dataconnector::closest_name(name, &registered_catalog_names().await)
+    util::levenshtein::closest_match(name, &registered_catalog_names().await)
 }
 
 pub async fn register_all() {

--- a/crates/runtime/src/component/dataset/schema_inference.rs
+++ b/crates/runtime/src/component/dataset/schema_inference.rs
@@ -442,6 +442,18 @@ mod tests {
     }
 
     #[test]
+    fn does_not_apply_sort_for_changes_refresh_mode() {
+        let mut acc = accel(Engine::DuckDB);
+        acc.refresh_mode = Some(RefreshMode::Changes);
+        let inferred = InferredSchema {
+            sort_columns: vec![sort("created_at", true)],
+            ..InferredSchema::default()
+        };
+        apply_inferred_schema(&mut acc, &inferred, &schema(&["created_at"]), "ds");
+        assert!(acc.params.is_empty());
+    }
+
+    #[test]
     fn empty_inferred_is_noop() {
         let mut acc = accel(Engine::DuckDB);
         apply_inferred_schema(&mut acc, &InferredSchema::default(), &schema(&["id"]), "ds");

--- a/crates/runtime/src/dataconnector/http_rate_control.rs
+++ b/crates/runtime/src/dataconnector/http_rate_control.rs
@@ -41,6 +41,19 @@ const RUNTIME_REQUESTS_PER_SECOND_LIMIT: &str = "http_requests_per_second_limit"
 const RUNTIME_REQUESTS_PER_MINUTE_LIMIT: &str = "http_requests_per_minute_limit";
 const RUNTIME_RATE_CONTROL_JITTER_MIN: &str = "http_rate_control_jitter_min";
 const RUNTIME_RATE_CONTROL_JITTER_MAX: &str = "http_rate_control_jitter_max";
+
+/// Every `http_*` rate-control key this module reads from `runtime.params`.
+/// Exposed as the authoritative list for this family; the startup unknown-param
+/// check merges it into the full `runtime.params` vocabulary
+/// (`known_runtime_params`) used to recognize keys and scope "did you mean"
+/// suggestions across the whole section.
+pub(crate) const HTTP_RATE_CONTROL_RUNTIME_PARAMS: &[&str] = &[
+    RUNTIME_MAX_CONCURRENT_REQUESTS,
+    RUNTIME_REQUESTS_PER_SECOND_LIMIT,
+    RUNTIME_REQUESTS_PER_MINUTE_LIMIT,
+    RUNTIME_RATE_CONTROL_JITTER_MIN,
+    RUNTIME_RATE_CONTROL_JITTER_MAX,
+];
 #[cfg(feature = "rate-control")]
 const MIN_PERSISTED_INSTANCE_TTL: Duration = Duration::from_secs(5);
 

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -496,33 +496,11 @@ pub async fn registered_connector_names() -> Vec<String> {
 }
 
 /// Returns the registered connector name whose Levenshtein distance to `name`
-/// is lowest (bounded so short typos only match very close names).
+/// is lowest (bounded so short typos only match very close names). Routes
+/// through [`util::levenshtein::closest_match`] so the "did you mean" UX is
+/// consistent with runtime tunables and component-level parameters.
 pub async fn suggest_connector(name: &str) -> Option<String> {
-    closest_name(name, &registered_connector_names().await)
-}
-
-/// Pure helper used by [`suggest_connector`]. Kept separate from the registry
-/// lookup so its scoring + threshold can be unit-tested without spinning up
-/// the async registry.
-pub(crate) fn closest_name(typo: &str, candidates: &[String]) -> Option<String> {
-    let input = typo.to_ascii_lowercase();
-    let mut best: Option<(String, usize)> = None;
-    for candidate in candidates {
-        let d = util::levenshtein::distance(&input, &candidate.to_ascii_lowercase());
-        if best.as_ref().is_none_or(|(_, b)| d < *b) {
-            best = Some((candidate.clone(), d));
-        }
-    }
-    let (candidate, distance) = best?;
-    // Bound: allow at most one edit per 3 chars of the longer string. Prevents a
-    // wildly different name ("kafka" vs. "postgres") from being suggested while
-    // still catching connector-name typos like "postgress" → "postgres" (d=1).
-    let max_allowed = (candidate.len().max(typo.len()) / 3).max(1);
-    if distance <= max_allowed {
-        Some(candidate)
-    } else {
-        None
-    }
+    util::levenshtein::closest_match(name, &registered_connector_names().await)
 }
 
 pub async fn unregister_all() {
@@ -871,51 +849,11 @@ mod tests {
 
     use super::*;
 
-    fn names(list: &[&str]) -> Vec<String> {
-        list.iter().map(|s| (*s).to_string()).collect()
-    }
+    // The closest-match algorithm is exercised in
+    // crates/util/src/levenshtein.rs (`test_closest_match_*`). `suggest_connector`
+    // / `suggest_catalog_connector` just plumb the registry's name list through
+    // it, so no per-call wrapper test is needed here.
 
-    #[test]
-    fn closest_name_matches_one_char_typo() {
-        let candidates = names(&["postgres", "mysql", "snowflake", "kafka"]);
-        assert_eq!(
-            closest_name("postgress", &candidates),
-            Some("postgres".to_string())
-        );
-    }
-
-    #[test]
-    fn closest_name_matches_case_insensitive() {
-        let candidates = names(&["postgres", "mysql"]);
-        assert_eq!(
-            closest_name("MYSQL", &candidates),
-            Some("mysql".to_string())
-        );
-    }
-
-    #[test]
-    fn closest_name_distant_returns_none() {
-        let candidates = names(&["postgres", "mysql", "kafka"]);
-        // "xyz" has no close match.
-        assert_eq!(closest_name("xyz", &candidates), None);
-    }
-
-    #[test]
-    fn closest_name_empty_candidates_returns_none() {
-        let candidates: Vec<String> = Vec::new();
-        assert_eq!(closest_name("postgres", &candidates), None);
-    }
-
-    #[test]
-    fn closest_name_short_typo_short_threshold() {
-        // Short names get a max_allowed floor of 1 — a single-char off name matches,
-        // but two chars off does not (protects against wildly different suggestions).
-        let candidates = names(&["pg", "my"]);
-        // "po" vs "pg": distance 1, allowed. vs "my": distance 2, not allowed.
-        assert_eq!(closest_name("po", &candidates), Some("pg".to_string()));
-        // "zz" vs both is distance 2 — no match.
-        assert_eq!(closest_name("zz", &candidates), None);
-    }
     use crate::component::dataset::UnsupportedTypeAction as DatasetUnsupportedTypeAction;
     use crate::component::dataset::builder::DatasetBuilder;
     use crate::dataconnector::parameters::ConnectorParamsBuilder;

--- a/crates/runtime/tests/mongo/mod.rs
+++ b/crates/runtime/tests/mongo/mod.rs
@@ -50,9 +50,9 @@ const MONGODB_PORT1: u16 = 27019;
 #[cfg(feature = "duckdb")]
 const MONGODB_CHANGE_STREAM_PORT: u16 = 27020;
 #[cfg(feature = "duckdb")]
-const MONGODB_CHANGE_STREAM_INFERENCE_PORT: u16 = 27021;
+const MONGODB_CHANGE_STREAM_INFERENCE_PORT: u16 = 27035;
 #[cfg(feature = "duckdb")]
-const MONGODB_INFERENCE_PORT: u16 = 27022;
+const MONGODB_INFERENCE_PORT: u16 = 27036;
 
 #[instrument]
 async fn init_mongodb_db(port: u16) -> Result<(), anyhow::Error> {

--- a/crates/util/src/levenshtein.rs
+++ b/crates/util/src/levenshtein.rs
@@ -90,6 +90,41 @@ pub fn similarity(a: &str, b: &str) -> f64 {
     1.0 - (dist as f64 / max_len as f64)
 }
 
+/// Returns the candidate in `candidates` closest to `typo` by case-insensitive
+/// Levenshtein distance, if the distance is small enough to be a useful
+/// "did you mean" hint.
+///
+/// Bound: at most one edit per 3 chars of the longer string (minimum 1).
+/// Prevents a wildly different name from being suggested while still catching
+/// short typos like `postgress` → `postgres` (d=1).
+///
+/// Accepts `&[String]` or `&[&str]` — pass the candidate set directly without
+/// converting. Used for runtime tunable typos, connector-name typos, and
+/// component-level parameter typos to keep the "did you mean" UX consistent.
+#[must_use]
+pub fn closest_match<S: AsRef<str>>(typo: &str, candidates: &[S]) -> Option<String> {
+    let input = typo.to_ascii_lowercase();
+    let mut best: Option<(usize, usize)> = None;
+    for (i, candidate) in candidates.iter().enumerate() {
+        let d = distance(&input, &candidate.as_ref().to_ascii_lowercase());
+        if best.as_ref().is_none_or(|(_, b)| d < *b) {
+            best = Some((i, d));
+        }
+    }
+    let (i, d) = best?;
+    let candidate = candidates[i].as_ref();
+    // Count chars, not bytes: `distance()` is computed over `.chars()`, so the
+    // "one edit per 3 chars" bound must use char counts too — otherwise a
+    // multi-byte (non-ASCII) candidate gets a looser byte-derived threshold
+    // that disagrees with the char-based distance.
+    let max_allowed = (candidate.chars().count().max(typo.chars().count()) / 3).max(1);
+    if d <= max_allowed {
+        Some(candidate.to_string())
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,6 +382,59 @@ mod tests {
         assert!(
             (sim - expected).abs() < f64::EPSILON,
             "Expected {expected}, got {sim}"
+        );
+    }
+
+    // ==================== closest_match() tests ====================
+
+    #[test]
+    fn test_closest_match_one_char_typo() {
+        let candidates = ["postgres", "mysql", "snowflake", "kafka"];
+        assert_eq!(
+            closest_match("postgress", &candidates),
+            Some("postgres".to_string())
+        );
+    }
+
+    #[test]
+    fn test_closest_match_case_insensitive() {
+        let candidates = ["postgres", "mysql"];
+        assert_eq!(
+            closest_match("MYSQL", &candidates),
+            Some("mysql".to_string())
+        );
+    }
+
+    #[test]
+    fn test_closest_match_distant_returns_none() {
+        // "xyz" has no close match to any candidate.
+        let candidates = ["postgres", "mysql", "kafka"];
+        assert_eq!(closest_match("xyz", &candidates), None);
+    }
+
+    #[test]
+    fn test_closest_match_empty_candidates_returns_none() {
+        let candidates: [&str; 0] = [];
+        assert_eq!(closest_match("postgres", &candidates), None);
+    }
+
+    #[test]
+    fn test_closest_match_short_typo_short_threshold() {
+        // Short names get a max_allowed floor of 1 — single-char-off matches,
+        // two chars off does not (protects against wildly different suggestions).
+        let candidates = ["pg", "my"];
+        assert_eq!(closest_match("po", &candidates), Some("pg".to_string()));
+        assert_eq!(closest_match("zz", &candidates), None);
+    }
+
+    #[test]
+    fn test_closest_match_accepts_string_slice() {
+        // Confirms the AsRef<str> generic accepts &[String] in addition
+        // to &[&str], so existing Vec<String> callers don't have to convert.
+        let candidates: Vec<String> = vec!["postgres".to_string(), "mysql".to_string()];
+        assert_eq!(
+            closest_match("postgress", &candidates),
+            Some("postgres".to_string())
         );
     }
 }

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1.yaml
@@ -17,7 +17,7 @@ runtime:
   params:
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '4000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf10.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf10.yaml
@@ -17,7 +17,7 @@ runtime:
   params:
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '4000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
@@ -15,7 +15,7 @@ runtime:
   params:
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '4000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
@@ -15,7 +15,7 @@ runtime:
   params:
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '4000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'

--- a/tools/chbench-driver/Cargo.toml
+++ b/tools/chbench-driver/Cargo.toml
@@ -7,10 +7,14 @@ license-file.workspace = true
 publish = false
 
 [dependencies]
+arrow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
+datafusion-table-providers = { workspace = true, features = ["postgres"] }
+futures = { workspace = true }
 governor = { workspace = true, features = ["std"] }
 rand = { workspace = true }
+secrecy = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 tokio-postgres = { workspace = true }

--- a/tools/chbench-driver/src/lib.rs
+++ b/tools/chbench-driver/src/lib.rs
@@ -29,19 +29,26 @@ pub use config::{ChBenchConfig, PostgresSourceConfig};
 pub use metrics::OltpReport;
 pub use txn::TxnType;
 
+use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use ::rand::SeedableRng;
 use ::rand::rngs::StdRng;
+use arrow::array::RecordBatch;
 use async_trait::async_trait;
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::AsyncDbConnection;
+use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
+use futures::TryStreamExt;
 use governor::{
     Quota, RateLimiter,
     clock::DefaultClock,
     middleware::NoOpMiddleware,
     state::{InMemoryState, NotKeyed},
 };
+use secrecy::SecretBox;
 use snafu::{Snafu, ensure};
+use tokio::sync::OnceCell;
 use tokio_util::sync::CancellationToken;
 
 /// Shared rate limiter gating the aggregate OLTP transaction rate across all terminals.
@@ -62,6 +69,9 @@ pub enum Error {
 
     #[snafu(display("Invalid OLTP target rate: {rate} (must be > 0)"))]
     InvalidRate { rate: u32 },
+
+    #[snafu(display("Failed to {action}: {message}"))]
+    Arrow { action: String, message: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -95,6 +105,14 @@ pub trait ChBenchDriver: Send + Sync {
 
     /// Read `COUNT(*)` from the *source* for a given table.
     async fn row_count(&self, table: &str) -> Result<i64>;
+
+    /// Execute an arbitrary read-only SQL statement against the source and
+    /// return the results as Arrow `RecordBatch`es.
+    ///
+    /// Used by the analytical-query gate to produce ground-truth results
+    /// for CH-benCH queries that are then compared against the same query run
+    /// through Spice.
+    async fn query_arrow(&self, sql: &str) -> Result<Vec<RecordBatch>>;
 }
 
 /// Postgres-backed CH-benCH driver.
@@ -102,6 +120,10 @@ pub struct PostgresChBenchDriver {
     client: tokio_postgres::Client,
     config: ChBenchConfig,
     source: PostgresSourceConfig,
+    /// Postgres pool that returns query results as Arrow `RecordBatch`es,
+    /// kept separate from `client` because the analytical-query gate
+    /// needs Arrow output to compare against Spice results
+    arrow_client: OnceCell<Arc<PostgresConnectionPool>>,
 }
 
 impl PostgresChBenchDriver {
@@ -129,7 +151,27 @@ impl PostgresChBenchDriver {
             client,
             config,
             source,
+            arrow_client: OnceCell::new(),
         })
+    }
+
+    /// Build the Arrow-returning connection pool from the source config.
+    async fn build_arrow_client(&self) -> Result<Arc<PostgresConnectionPool>> {
+        let mut params: HashMap<String, SecretBox<str>> = HashMap::new();
+        params.insert("host".into(), SecretBox::from(self.source.host.clone()));
+        params.insert("port".into(), SecretBox::from(self.source.port.to_string()));
+        params.insert("db".into(), SecretBox::from(self.source.db.clone()));
+        params.insert("user".into(), SecretBox::from(self.source.user.clone()));
+        params.insert("pass".into(), SecretBox::from(self.source.pass.clone()));
+        params.insert("sslmode".into(), SecretBox::from("disable".to_string()));
+
+        let pool = PostgresConnectionPool::new(params)
+            .await
+            .map_err(|e| Error::Arrow {
+                action: "build PostgresConnectionPool".into(),
+                message: e.to_string(),
+            })?;
+        Ok(Arc::new(pool))
     }
 }
 
@@ -270,6 +312,34 @@ impl ChBenchDriver for PostgresChBenchDriver {
                 source,
             })?;
         Ok(rows.first().map_or(0, |row| row.get::<_, i64>(0)))
+    }
+
+    async fn query_arrow(&self, sql: &str) -> Result<Vec<RecordBatch>> {
+        let client = self
+            .arrow_client
+            .get_or_try_init(|| self.build_arrow_client())
+            .await?;
+
+        let conn = client.connect_direct().await.map_err(|e| Error::Arrow {
+            action: "acquire Postgres connection".into(),
+            message: e.to_string(),
+        })?;
+
+        let stream = conn
+            .query_arrow(sql, &[], None)
+            .await
+            .map_err(|e| Error::Arrow {
+                action: format!("execute arrow query: {sql}"),
+                message: e.to_string(),
+            })?;
+
+        stream
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(|e| Error::Arrow {
+                action: format!("collect arrow query results: {sql}"),
+                message: e.to_string(),
+            })
     }
 }
 

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 [dependencies]
 arrow.workspace = true
 arrow-json.workspace = true
+arrow_tools = { path = "../../crates/arrow_tools" }
 async-trait.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
@@ -6,4 +6,4 @@ tests:
     duration: 600
     ready_wait: 60
     query_overrides: duckdb
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
@@ -5,4 +5,4 @@ tests:
     scale_factor: 10
     duration: 600
     ready_wait: 300
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
@@ -6,4 +6,4 @@ tests:
     duration: 600
     ready_wait: 300
     query_overrides: duckdb
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
@@ -6,4 +6,4 @@ tests:
     terminals: 100
     duration: 600
     ready_wait: 600
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
@@ -7,4 +7,4 @@ tests:
     duration: 600
     ready_wait: 600
     query_overrides: duckdb
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -6,5 +6,4 @@ tests:
     terminals: 100
     duration: 600
     ready_wait: 600
-    # Target 10,000 OLTP txns/s ~= 10,000 CDC changes/s for the m7a (64-core/256 GiB) SF-1000 venue.
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -7,4 +7,4 @@ tests:
     duration: 600
     ready_wait: 600
     query_overrides: duckdb
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/src/commands/htap/correctness/analytical.rs
+++ b/tools/testoperator/src/commands/htap/correctness/analytical.rs
@@ -1,0 +1,323 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Analytical-query gate for HTAP benchmarks.
+//!
+//! Runs after the row-count gate (`correctness::verify_after_drain`) confirms
+//! convergence. Executes each CH-benCH analytical query against both the source
+//! Postgres and Spice, comparing results with the existing
+//! `validate_with_expected_batches` comparator (schema equivalence + 5%
+//! numeric tolerance).
+
+use std::sync::Arc;
+
+use arrow::array::RecordBatch;
+use arrow::compute::{SortColumn, concat_batches, lexsort_to_indices, take};
+use arrow::datatypes::{Field, Schema};
+use arrow_tools::record_batch::try_cast_to;
+use chbench_driver::ChBenchDriver;
+use futures::TryStreamExt;
+use test_framework::anyhow;
+use test_framework::queries::validation::{QueryValidationResult, validate_with_expected_batches};
+use test_framework::queries::{QueryOverrides, get_chbench_test_queries};
+
+/// Outcome for a single analytical query.
+#[derive(Debug)]
+pub enum Outcome {
+    Pass,
+    Fail(String),
+    SourceError(String),
+    SpiceError(String),
+}
+
+impl Outcome {
+    fn label(&self) -> &'static str {
+        match self {
+            Outcome::Pass => "PASS",
+            Outcome::Fail(_) => "FAIL",
+            Outcome::SourceError(_) => "PG_ERROR",
+            Outcome::SpiceError(_) => "SPICE_ERROR",
+        }
+    }
+
+    fn detail(&self) -> Option<&str> {
+        match self {
+            Outcome::Pass => None,
+            Outcome::Fail(m) | Outcome::SourceError(m) | Outcome::SpiceError(m) => Some(m),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AnalyticalQueryResult {
+    pub name: String,
+    pub outcome: Outcome,
+}
+
+#[derive(Debug)]
+pub struct AnalyticalReport {
+    pub results: Vec<AnalyticalQueryResult>,
+}
+
+impl AnalyticalReport {
+    pub fn emit(&self) {
+        println!("\nAnalytical Query Correctness");
+        println!("  {:<14} {:>12}", "query", "outcome");
+
+        let mut passed: u64 = 0;
+        let mut failed: u64 = 0;
+        for r in &self.results {
+            println!("  {:<14} {:>12}", r.name, r.outcome.label());
+            if let Some(detail) = r.outcome.detail() {
+                println!("    └─ {detail}");
+            }
+            if matches!(r.outcome, Outcome::Pass) {
+                passed += 1;
+            } else {
+                failed += 1;
+            }
+        }
+
+        let total = passed + failed;
+        if failed == 0 {
+            println!("  verdict: PASSED — {passed}/{total} queries match");
+        } else {
+            println!("  verdict: FAILED — {failed}/{total} queries diverged");
+        }
+    }
+
+    /// Returns a single joined failure summary, or `None` if every query passed.
+    pub fn failure_message(&self) -> Option<String> {
+        let problems: Vec<String> = self
+            .results
+            .iter()
+            .filter(|r| !matches!(r.outcome, Outcome::Pass))
+            .map(|r| match &r.outcome {
+                Outcome::Pass => unreachable!(),
+                Outcome::Fail(m) => format!("{} mismatch: {m}", r.name),
+                Outcome::SourceError(m) => format!("{} source error: {m}", r.name),
+                Outcome::SpiceError(m) => format!("{} spice error: {m}", r.name),
+            })
+            .collect();
+
+        if problems.is_empty() {
+            None
+        } else {
+            Some(format!(
+                "HTAP analytical-query gate failed:\n  {}",
+                problems.join("\n  ")
+            ))
+        }
+    }
+}
+
+/// Run every CH-benCH analytical query against both the source and Spice,
+/// comparing results.
+pub async fn verify_analytical_results(
+    driver: Arc<dyn ChBenchDriver>,
+    spice_client: &spiceai::Client,
+    query_overrides: Option<QueryOverrides>,
+) -> anyhow::Result<AnalyticalReport> {
+    let queries = get_chbench_test_queries(query_overrides);
+    // q15 compares `total_revenue = (SELECT MAX(total_revenue) ...)` over a SUM
+    // of DOUBLE PRECISION values might return 0 rows: https://github.com/spiceai/spiceai/issues/11212
+    let queries: Vec<_> = queries
+        .into_iter()
+        .filter(|q| q.name.as_ref() != "chbench_q15")
+        .collect();
+    println!(
+        "\nRunning analytical-query gate over {} queries",
+        queries.len()
+    );
+
+    let mut results = Vec::with_capacity(queries.len());
+    for query in &queries {
+        let sql = query.to_sql_with_inlined_params();
+
+        let expected = match driver.query_arrow(sql.as_ref()).await {
+            Ok(batches) => batches,
+            Err(e) => {
+                results.push(AnalyticalQueryResult {
+                    name: query.name.to_string(),
+                    outcome: Outcome::SourceError(e.to_string()),
+                });
+                continue;
+            }
+        };
+
+        let actual = match run_spice_query(spice_client, sql.as_ref()).await {
+            Ok(batches) => batches,
+            Err(e) => {
+                results.push(AnalyticalQueryResult {
+                    name: query.name.to_string(),
+                    outcome: Outcome::SpiceError(e.to_string()),
+                });
+                continue;
+            }
+        };
+
+        // Spice and the source connector emit different physical Arrow types
+        // for the same logical SQL columns (e.g. Cayenne stores timestamps as
+        // Microsecond while PG arrow streams produce Nanosecond; aggregate
+        // expressions return Int32 vs Decimal128(38,0)). Cast Spice columns
+        // to the source's per-column type so the string-based row comparator
+        // sees consistent encodings before comparing values.
+        let actual = match align_to_expected_schema(&actual, &expected) {
+            Ok(batches) => batches,
+            Err(e) => {
+                results.push(AnalyticalQueryResult {
+                    name: query.name.to_string(),
+                    outcome: Outcome::Fail(format!("schema align error: {e}")),
+                });
+                continue;
+            }
+        };
+
+        // Several benchmark queries have non-deterministic row order. Sort both sides by every column so comparison is set-based.
+        let (expected_sorted, actual_sorted) = match sort_for_comparison(&expected, &actual) {
+            Ok(pair) => pair,
+            Err(e) => {
+                results.push(AnalyticalQueryResult {
+                    name: query.name.to_string(),
+                    outcome: Outcome::Fail(format!("sort error: {e}")),
+                });
+                continue;
+            }
+        };
+
+        let outcome = if total_rows(&expected_sorted) == 0 && total_rows(&actual_sorted) == 0 {
+            Outcome::Pass
+        } else {
+            match validate_with_expected_batches(
+                query.name.as_ref(),
+                &actual_sorted,
+                &expected_sorted,
+            ) {
+                Ok(QueryValidationResult::Pass) => Outcome::Pass,
+                Ok(QueryValidationResult::Fail(reason)) => Outcome::Fail(format!(
+                    "{reason:?} (source rows={}, spice rows={})",
+                    total_rows(&expected_sorted),
+                    total_rows(&actual_sorted),
+                )),
+                Err(e) => Outcome::Fail(e.to_string()),
+            }
+        };
+
+        results.push(AnalyticalQueryResult {
+            name: query.name.to_string(),
+            outcome,
+        });
+    }
+
+    Ok(AnalyticalReport { results })
+}
+
+async fn run_spice_query(client: &spiceai::Client, sql: &str) -> anyhow::Result<Vec<RecordBatch>> {
+    let stream = client.sql(sql).await?;
+    let batches: Vec<RecordBatch> = stream.try_collect().await?;
+    Ok(batches)
+}
+
+/// Build a target schema by taking each field from `actual` and replacing its
+/// data type with the same-position field type from `expected`, then cast
+/// `actual`'s batches to that schema. Names and nullability are preserved from
+/// `actual` so the string-based row comparator (which already tolerates name /
+/// nullable differences) keeps its existing tolerance.
+///
+/// If column counts differ or no column needs casting, `actual` is returned
+/// unchanged.
+fn align_to_expected_schema(
+    actual: &[RecordBatch],
+    expected: &[RecordBatch],
+) -> anyhow::Result<Vec<RecordBatch>> {
+    let Some(expected_schema) = expected.first().map(RecordBatch::schema) else {
+        return Ok(actual.to_vec());
+    };
+    let Some(actual_schema) = actual.first().map(RecordBatch::schema) else {
+        return Ok(actual.to_vec());
+    };
+    if expected_schema.fields().len() != actual_schema.fields().len() {
+        return Ok(actual.to_vec());
+    }
+
+    let mut needs_cast = false;
+    let mut target_fields = Vec::with_capacity(actual_schema.fields().len());
+    for (af, ef) in actual_schema
+        .fields()
+        .iter()
+        .zip(expected_schema.fields().iter())
+    {
+        if af.data_type() == ef.data_type() {
+            target_fields.push(af.as_ref().clone());
+        } else {
+            needs_cast = true;
+            target_fields.push(Field::new(
+                af.name(),
+                ef.data_type().clone(),
+                af.is_nullable(),
+            ));
+        }
+    }
+
+    if !needs_cast {
+        return Ok(actual.to_vec());
+    }
+
+    let target_schema = Arc::new(Schema::new(target_fields));
+    actual
+        .iter()
+        .map(|batch| try_cast_to(batch.clone(), Arc::clone(&target_schema)).map_err(Into::into))
+        .collect()
+}
+
+/// Concatenate each side into a single batch and lex-sort both by every projected column.
+fn sort_for_comparison(
+    expected: &[RecordBatch],
+    actual: &[RecordBatch],
+) -> anyhow::Result<(Vec<RecordBatch>, Vec<RecordBatch>)> {
+    Ok((sort_all_columns(expected)?, sort_all_columns(actual)?))
+}
+
+fn total_rows(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(RecordBatch::num_rows).sum()
+}
+
+fn sort_all_columns(batches: &[RecordBatch]) -> anyhow::Result<Vec<RecordBatch>> {
+    let Some(schema) = batches.first().map(RecordBatch::schema) else {
+        return Ok(vec![]);
+    };
+    let combined = concat_batches(&schema, batches)?;
+    if combined.num_rows() < 2 {
+        return Ok(vec![combined]);
+    }
+
+    let sort_columns: Vec<SortColumn> = combined
+        .columns()
+        .iter()
+        .map(|c| SortColumn {
+            values: Arc::clone(c),
+            options: None,
+        })
+        .collect();
+    let indices = lexsort_to_indices(&sort_columns, None)?;
+    let new_columns = combined
+        .columns()
+        .iter()
+        .map(|c| take(c, &indices, None))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(vec![RecordBatch::try_new(schema, new_columns)?])
+}

--- a/tools/testoperator/src/commands/htap/correctness/mod.rs
+++ b/tools/testoperator/src/commands/htap/correctness/mod.rs
@@ -1,0 +1,27 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Correctness gates for HTAP benchmarks. Run sequentially after the OLTP
+//! workload stops: `row_count` waits for replication to drain and verifies
+//! per-table `MAX(_bench_ts)` + `COUNT(*)` parity, then `analytical`
+//! re-runs every CH-benCH analytical query against both source and Spice
+//! and compares the results.
+
+pub mod analytical;
+pub mod row_count;
+
+pub use analytical::verify_analytical_results;
+pub use row_count::verify_after_drain;

--- a/tools/testoperator/src/commands/htap/correctness/row_count.rs
+++ b/tools/testoperator/src/commands/htap/correctness/row_count.rs
@@ -30,7 +30,7 @@ use test_framework::anyhow;
 use test_framework::opentelemetry::KeyValue;
 use tokio::time::sleep;
 
-use super::staleness::query_max_bench_ts_spice;
+use super::super::staleness::query_max_bench_ts_spice;
 
 /// Per-table source-vs-Spice row-count comparison.
 #[derive(Debug, Clone)]

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -217,9 +217,26 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     crate::metrics::PEAK_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
     crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
 
+    // Calculate analytical throughput — QPH (queries per hour).
+    let completed_queries: usize = metrics.metrics.iter().map(|q| q.iterations).sum();
+    let elapsed = Duration::from_millis(
+        u64::try_from(metrics.finished_at.saturating_sub(metrics.started_at)).unwrap_or(0),
+    );
+    let elapsed_secs = elapsed.as_secs_f64();
+    #[expect(clippy::cast_precision_loss)]
+    let qph = if elapsed_secs > 0.0 {
+        completed_queries as f64 / elapsed_secs * 3600.0
+    } else {
+        0.0
+    };
+    crate::metrics::QPH.record(qph, &[]);
+
     let records = metrics.with_memory_usage(max_memory).build_records()?;
     println!("\n=== Analytical Queries ===");
     print_batches(&records)?;
+    println!(
+        "  QPH (analytical queries/hour): {qph:.1} ({completed_queries} queries in {elapsed_secs:.1}s)"
+    );
 
     // 8. Report OLTP results.
     println!("\n=== TPC-C OLTP ===");
@@ -288,8 +305,41 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
                     }
                 }
             }
-            if let Some(message) = report.failure_message() {
+            let row_count_message = report.failure_message();
+            if let Some(message) = row_count_message.clone() {
                 error_messages.push(message);
+            }
+
+            // Analytical-correctness gate runs only when the row-count gate fully passed (replication converged + every table matches).
+            // Otherwise the underlying data is known to diverge, so comparing analytical query results adds no signal.
+            if row_count_message.is_none() {
+                let query_overrides = test_args
+                    .query_overrides
+                    .clone()
+                    .map(test_framework::queries::QueryOverrides::from);
+                let analytical_result = {
+                    let spice_client = spiced_instance.spice_client(None, true).await?;
+                    correctness::verify_analytical_results(
+                        Arc::clone(&driver),
+                        &spice_client,
+                        query_overrides,
+                    )
+                    .await
+                };
+
+                match analytical_result {
+                    Ok(analytical) => {
+                        analytical.emit();
+                        if let Some(message) = analytical.failure_message() {
+                            error_messages.push(message);
+                        }
+                    }
+                    Err(e) => {
+                        error_messages.push(format!("HTAP analytical-query error: {e}"));
+                    }
+                }
+            } else {
+                println!("\nSkipping analytical-query gate — row-count gate did not pass");
             }
         }
         Err(e) => {

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -553,3 +553,11 @@ pub static OLTP_TPMC: LazyLock<Gauge<f64>> = LazyLock::new(|| {
         .with_unit("txn/min")
         .build()
 });
+
+pub static QPH: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("qph")
+        .with_description("Queries completed per hour (QPH).")
+        .with_unit("queries/hour")
+        .build()
+});


### PR DESCRIPTION
## Summary

Adds an opt-in, per-dataset **`schema_inference`** tier that auto-detects and applies a source table's **primary key, secondary indexes, and sort/clustering columns** to acceleration settings the user left unset — for **all refresh modes**.

```yaml
datasets:
  - from: postgres:public.orders
    name: orders
    schema_inference: extended      # default: standard
    acceleration:
      engine: duckdb
      refresh_mode: full
```

- `standard` (default) — only column/type inference, exactly as before (always-on, required).
- `extended` — additionally infer PK / indexes / sort and fill any acceleration settings you didn't specify.

The value is a tier (not `auto`/`disabled`) precisely because base schema inference is always performed; `extended` *adds* a layer. Config shape mirrors the existing dataset-level `on_schema_change` / `check_availability` enums.

## What's inferred

| | PostgreSQL (`pg_catalog`) | MongoDB (`listIndexes` / `listCollections`) |
|---|---|---|
| **Primary key** | `pg_index.indisprimary` → `primary_key` + upsert `on_conflict` | always `_id` |
| **Indexes** | unique & non-unique; **skips** partial & expression | from `listIndexes`; **skips** partial / text / geo / hashed |
| **Sort** | clustered index w/ ASC·DESC (`indoption`), else PK | clustered collection key (5.3+), else `_id` |

Inferred values are emitted by the connector as Arrow schema metadata (`spice.inferred_*`) via a connector-agnostic contract (`data_components::inferred_schema`), gated so there's zero extra catalog cost unless `extended`.

## Makes CDC / MongoDB Streams work without manual keys

Both `refresh_mode: changes` paths hard-require an explicit `primary_key` + matching `on_conflict` upsert (Postgres WAL replication and MongoDB Streams both error otherwise). Inference is applied to the `Dataset` **early — before registration and before the change stream is built** — so `schema_inference: extended` now satisfies both automatically. No more hand-writing `primary_key: _id` / `on_conflict: { _id: upsert }` for MongoDB Streams.

## Design notes

- **Gap-fill only:** explicit `primary_key` / `indexes` / sort config always wins.
- **Early, single application point** (`register_loaded_dataset`) so every refresh mode — incl. CDC — observes it.
- **Safe under `refresh_sql`:** columns projected away are dropped from the inferred set; if the `refresh_sql` can't be parsed, inference is skipped for that dataset.
- Sort routes to the engine's existing param (`on_refresh_sort_columns` for DuckDB, `sort_columns` for Arrow, `cayenne_sort_columns` for Cayenne; Cayenne ignores direction). SQLite/Turso/Postgres accelerators have no sort param and are skipped.

## Testing

- **Unit:** spicepod config parsing (3); `data_components` contract round-trip (5); runtime apply matrix (13) — per-engine sort routing, PK→upsert, PK-duplicate skip, missing-column drop, user-config-wins.
- **Integration (run in CI w/ Docker):** Postgres `extended` load over a table with composite PK + unique/non-unique/partial/expression/clustered-DESC indexes; MongoDB Streams test proving inference alone (no explicit `primary_key`/`on_conflict`) starts the change stream and applies an upsert in place.
- Compiles across `spicepod` / `data_components` / `runtime` / `connector-postgres` / `connector-mongodb` and the `postgres,duckdb,mongodb` integration binary; clippy clean on the new contract/config crates.

## Notes

- DuckDB on-refresh sort is experimental (rebuilds the table) — inferring sort-by-PK there has a cost trade-off worth a look in review.
- `.schema/spicepod.schema.json` is regenerated by the separate schema-bot workflow.

See `docs/features/schema-inference.md` for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)