### PR TITLE
fix(runtime): don't list `postgres` as a valid accelerator engine when `postgres-accel` is disabled

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -312,8 +312,15 @@ pub enum Error {
     #[snafu(display("Expected acceleration settings for {name}, found None"))]
     ExpectedAccelerationSettings { name: String },
 
+    #[cfg(feature = "postgres-accel")]
     #[snafu(display(
         "The accelerator engine {name} is not available. Valid engines are arrow, cayenne, duckdb, sqlite, and postgres."
+    ))]
+    AcceleratorEngineNotAvailable { name: String },
+
+    #[cfg(not(feature = "postgres-accel"))]
+    #[snafu(display(
+        "The accelerator engine {name} is not available. Valid engines are arrow, cayenne, duckdb, and sqlite."
     ))]
     AcceleratorEngineNotAvailable { name: String },
 


### PR DESCRIPTION
## 📝 Summary

`postgres-accel` is not enabled by default, this fixes the following misleading message when `postgres` or another unsupported accelerator is specified

>2026-06-04T19:45:31.321970Z  WARN runtime::init::dataset: supplier The accelerator engine postgres is not available. Valid engines are arrow, cayenne, duckdb, sqlite, and postgres.

->

>2026-06-04T19:45:31.321970Z  WARN runtime::init::dataset: supplier The accelerator engine postgres is not available. Valid engines are arrow, cayenne, duckdb, and sqlite.


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

We might want to add dedicated message specifically for postgres that it requires feature flag, current approach selected for simplicity
