### PR TITLE
perf(cayenne): fused tombstone index, split-block bloom, XXH3-128 key identity

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -100,6 +100,10 @@ name = "deletion_index_probe"
 
 [[bench]]
 harness = false
+name = "deletion_index_probe_large"
+
+[[bench]]
+harness = false
 name = "position_vs_key_deletion_scan"
 
 [[bench]]

--- a/crates/cayenne/benches/apply_on_conflict_keys_double_clone.rs
+++ b/crates/cayenne/benches/apply_on_conflict_keys_double_clone.rs
@@ -76,8 +76,8 @@ fn build_deleted_row_keys(n: usize) -> Vec<Box<[u8]>> {
 
 fn historical_two_indexes(written_keys: &[Box<[u8]>]) -> (KeyDeletionIndex, KeyDeletionIndex) {
     let empty_deleted = KeyDeletionIndex::empty();
-    let deleted_row_keys = empty_deleted
-        .extend_max_deletes(written_keys.iter().map(|key| (key, DELETE_SEQUENCE)));
+    let deleted_row_keys =
+        empty_deleted.extend_max_deletes(written_keys.iter().map(|key| (key, DELETE_SEQUENCE)));
 
     let empty_inserts = KeyDeletionIndex::empty();
     let insert_records =
@@ -97,16 +97,12 @@ fn bench_double_clone(c: &mut Criterion) {
         let written_keys = build_deleted_row_keys(n);
         group.throughput(Throughput::Elements(throughput_elements(n)));
 
-        group.bench_with_input(
-            BenchmarkId::new("historical_two_indexes", n),
-            &n,
-            |b, _| {
-                b.iter(|| {
-                    let pair = historical_two_indexes(black_box(&written_keys));
-                    black_box(pair);
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("historical_two_indexes", n), &n, |b, _| {
+            b.iter(|| {
+                let pair = historical_two_indexes(black_box(&written_keys));
+                black_box(pair);
+            });
+        });
 
         group.bench_with_input(
             BenchmarkId::new("current_fused_single_pass", n),

--- a/crates/cayenne/benches/apply_on_conflict_keys_double_clone.rs
+++ b/crates/cayenne/benches/apply_on_conflict_keys_double_clone.rs
@@ -17,30 +17,25 @@ limitations under the License.
 //! Regression bench for the composite-PK on-conflict cache update in
 //! `CayenneTableProvider::apply_on_conflict_deletions`.
 //!
-//! The production path writes key-based deletion records, takes the owned
-//! `Vec<Box<[u8]>>` back from the catalog write result, and extends two
-//! immutable cache indexes:
-//!
-//! - `deleted_row_keys`: clones each key because the same key set is still
-//!   needed by the second cache update.
-//! - `insert_records`: consumes the owned key vector with `into_iter()`, so
-//!   the second update moves keys instead of cloning them again.
-//!
-//! A future edit that changes the second update back to `.iter().cloned()`
-//! pays one extra `Box<[u8]>` allocation per conflict. With ~8 K conflicts
-//! and ~32-byte composite keys, that is ~8 K avoidable heap allocations and
-//! ~256 KB of redundant key copies per upsert.
+//! The production path historically extended TWO immutable cache indexes per
+//! conflict batch — `deleted_row_keys` (cloning each key) and
+//! `insert_records` (moving the keys) — i.e. two full passes and two maps.
+//! The fused tombstone index records the deletion and the re-insertion in a
+//! single `extend_max_conflicts` pass over borrowed keys (the index stores
+//! XXH3-128 identities, never the key bytes), so the second pass and every
+//! per-key `Box<[u8]>` clone disappear.
 //!
 //! ## What this bench measures
 //!
 //! Pure CPU shape. Two lanes per conflict-count:
 //!
-//! - `regression_clone_both_indices`: clones keys into both cache indexes.
-//! - `current_move_second_index`: mirrors the current code by cloning into
-//!   the first index and moving the owned keys into the second.
+//! - `historical_two_indexes`: the pre-fusion shape — two extend passes
+//!   building two indexes from the same key set.
+//! - `current_fused_single_pass`: one `extend_max_conflicts` pass building
+//!   the fused index.
 //!
-//! Both end up with equivalent cache indexes. The difference is one fewer
-//! `Box<[u8]>` clone per conflict in the current path.
+//! A future edit that re-splits the indexes (or re-introduces per-key key
+//! cloning) shows up as the `current` lane regressing toward `historical`.
 //!
 //! `cargo bench --bench apply_on_conflict_keys_double_clone -p cayenne`.
 
@@ -79,39 +74,21 @@ fn build_deleted_row_keys(n: usize) -> Vec<Box<[u8]>> {
         .collect()
 }
 
-fn regression_clone_both_indices(
-    written_keys: &[Box<[u8]>],
-) -> (KeyDeletionIndex, KeyDeletionIndex) {
+fn historical_two_indexes(written_keys: &[Box<[u8]>]) -> (KeyDeletionIndex, KeyDeletionIndex) {
     let empty_deleted = KeyDeletionIndex::empty();
-    let deleted_row_keys = empty_deleted.extend_max(
-        written_keys
-            .iter()
-            .map(|key| (key.clone(), DELETE_SEQUENCE)),
-    );
+    let deleted_row_keys = empty_deleted
+        .extend_max_deletes(written_keys.iter().map(|key| (key, DELETE_SEQUENCE)));
 
     let empty_inserts = KeyDeletionIndex::empty();
-    let insert_records = empty_inserts.extend_max(
-        written_keys
-            .iter()
-            .map(|key| (key.clone(), INSERT_SEQUENCE)),
-    );
+    let insert_records =
+        empty_inserts.extend_max_deletes(written_keys.iter().map(|key| (key, INSERT_SEQUENCE)));
 
     (deleted_row_keys, insert_records)
 }
 
-fn current_move_second_index(written_keys: Vec<Box<[u8]>>) -> (KeyDeletionIndex, KeyDeletionIndex) {
-    let empty_deleted = KeyDeletionIndex::empty();
-    let deleted_row_keys = empty_deleted.extend_max(
-        written_keys
-            .iter()
-            .map(|key| (key.clone(), DELETE_SEQUENCE)),
-    );
-
-    let empty_inserts = KeyDeletionIndex::empty();
-    let insert_records =
-        empty_inserts.extend_max(written_keys.into_iter().map(|key| (key, INSERT_SEQUENCE)));
-
-    (deleted_row_keys, insert_records)
+fn current_fused_single_pass(written_keys: &[Box<[u8]>]) -> KeyDeletionIndex {
+    let empty = KeyDeletionIndex::empty();
+    empty.extend_max_conflicts(written_keys.iter(), DELETE_SEQUENCE, INSERT_SEQUENCE)
 }
 
 fn bench_double_clone(c: &mut Criterion) {
@@ -121,31 +98,24 @@ fn bench_double_clone(c: &mut Criterion) {
         group.throughput(Throughput::Elements(throughput_elements(n)));
 
         group.bench_with_input(
-            BenchmarkId::new("regression_clone_both_indices", n),
+            BenchmarkId::new("historical_two_indexes", n),
             &n,
             |b, _| {
                 b.iter(|| {
-                    let pair = regression_clone_both_indices(black_box(&written_keys));
+                    let pair = historical_two_indexes(black_box(&written_keys));
                     black_box(pair);
                 });
             },
         );
 
         group.bench_with_input(
-            BenchmarkId::new("current_move_second_index", n),
+            BenchmarkId::new("current_fused_single_pass", n),
             &n,
             |b, _| {
-                // `iter_batched` hands the measured function an owned vector
-                // each iteration so the in-tree move is real while input setup
-                // remains outside the measured body.
-                b.iter_batched(
-                    || written_keys.clone(),
-                    |owned| {
-                        let pair = current_move_second_index(owned);
-                        black_box(pair);
-                    },
-                    criterion::BatchSize::SmallInput,
-                );
+                b.iter(|| {
+                    let index = current_fused_single_pass(black_box(&written_keys));
+                    black_box(index);
+                });
             },
         );
     }

--- a/crates/cayenne/benches/apply_partial_deletion_filter_per_scan.rs
+++ b/crates/cayenne/benches/apply_partial_deletion_filter_per_scan.rs
@@ -95,8 +95,12 @@ fn run_full_rebuild(cache: &Arc<DeletionIndex>, snapshot_count: usize, min_seq: 
         let filtered: HashMap<i64, i64> = cache
             .entries()
             .iter()
-            .filter(|(_, seq)| **seq > min_seq)
-            .map(|(&pk, &seq)| (pk, seq))
+            .filter_map(|(&pk, entry)| {
+                entry
+                    .delete_sequence()
+                    .filter(|seq| *seq > min_seq)
+                    .map(|seq| (pk, seq))
+            })
             .collect();
         let index = DeletionIndex::from_map(filtered);
         black_box(index);

--- a/crates/cayenne/benches/apply_partial_deletion_filter_per_scan.rs
+++ b/crates/cayenne/benches/apply_partial_deletion_filter_per_scan.rs
@@ -93,9 +93,8 @@ fn build_deletion_cache(size: usize) -> Arc<DeletionIndex> {
 fn run_full_rebuild(cache: &Arc<DeletionIndex>, snapshot_count: usize, min_seq: i64) {
     for _ in 0..snapshot_count {
         let filtered: HashMap<i64, i64> = cache
-            .entries()
-            .iter()
-            .filter_map(|(&pk, entry)| {
+            .iter_entries()
+            .filter_map(|(pk, entry)| {
                 entry
                     .delete_sequence()
                     .filter(|seq| *seq > min_seq)

--- a/crates/cayenne/benches/deletion_index_probe.rs
+++ b/crates/cayenne/benches/deletion_index_probe.rs
@@ -70,7 +70,6 @@ fn bench_int64_probe(c: &mut Criterion) {
 
     let pk_array = build_int64_pk_column(ROWS_PER_BATCH);
     let pk_slice = pk_array.values();
-    let empty_inserts = DeletionIndex::empty();
 
     for ratio in DELETION_RATIOS {
         let index = build_int64_index(ROWS_PER_BATCH, ratio);
@@ -84,9 +83,9 @@ fn bench_int64_probe(c: &mut Criterion) {
                     for &pk in pk_slice.iter() {
                         let visible = match index.get(pk) {
                             None => true,
-                            Some(del_seq) => empty_inserts
-                                .get(pk)
-                                .is_some_and(|ins_seq| ins_seq > del_seq),
+                            Some(t) => t
+                                .insert_sequence
+                                .is_some_and(|ins_seq| ins_seq > t.delete_sequence),
                         };
                         keep += usize::from(visible);
                     }
@@ -124,7 +123,6 @@ fn bench_row_keys_probe(c: &mut Criterion) {
     group.throughput(Throughput::Elements(ROWS_PER_BATCH as u64));
 
     let row_keys = build_row_keys(ROWS_PER_BATCH);
-    let empty_inserts = KeyDeletionIndex::empty();
 
     for ratio in DELETION_RATIOS {
         let index = build_key_index(ROWS_PER_BATCH, ratio);
@@ -137,9 +135,9 @@ fn bench_row_keys_probe(c: &mut Criterion) {
                     for key in &row_keys {
                         let visible = match index.get(key.as_ref()) {
                             None => true,
-                            Some(del_seq) => empty_inserts
-                                .get(key.as_ref())
-                                .is_some_and(|ins_seq| ins_seq > del_seq),
+                            Some(t) => t
+                                .insert_sequence
+                                .is_some_and(|ins_seq| ins_seq > t.delete_sequence),
                         };
                         keep += usize::from(visible);
                     }
@@ -236,7 +234,7 @@ fn bench_extend_max_at_growing_cache_sizes(c: &mut Criterion) {
                 // every iteration takes the Vacant branch. (If we extended
                 // with an existing key, the Occupied branch would short-
                 // circuit and obscure the new-key bloom-insert work.)
-                let next = base.extend_max([((n as i64) + 1, 2)]);
+                let next = base.extend_max_deletes([((n as i64) + 1, 2)]);
                 black_box(next);
             });
         });
@@ -267,7 +265,7 @@ fn bench_extend_max_cumulative_from_empty(c: &mut Criterion) {
                 // stays roughly flat.
                 let mut idx = DeletionIndex::empty();
                 for i in 0..total as i64 {
-                    idx = idx.extend_max([(i, 1)]);
+                    idx = idx.extend_max_deletes([(i, 1)]);
                 }
                 black_box(idx);
             });

--- a/crates/cayenne/benches/deletion_index_probe_large.rs
+++ b/crates/cayenne/benches/deletion_index_probe_large.rs
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Out-of-cache probe bench for the deletion index.
+//!
+//! The companion `deletion_index_probe` bench builds indexes of at most one
+//! probe batch (8192 entries), so every tier is cache-resident and the numbers
+//! mostly measure the hash pipeline. This bench builds indexes of millions of
+//! entries — the SF10 changes-mode regime where per-row deletion probes were
+//! profiled as the dominant executor cost — so present-key probes pay the real
+//! memory-hierarchy price of the backing map.
+//!
+//! Lanes per index size:
+//! - `hit`: every probed key is present (the upsert-churn scan shape, where
+//!   superseded rows genuinely populate the index). This is the lane that the
+//!   layered frozen-base design targets: a flat-table lookup instead of a
+//!   multi-level HAMT pointer chase.
+//! - `miss`: no probed key is present (append-mostly scan shape) — dominated
+//!   by the bloom filter's rejection path.
+//!
+//! Probed keys are spread with a large odd multiplier so consecutive probes
+//! touch unrelated cache lines (no streaming-prefetch flattery).
+//!
+//! `cargo bench --bench deletion_index_probe_large -p cayenne`.
+
+use std::collections::HashMap;
+use std::hint::black_box;
+
+use cayenne::provider::deletion_index::{DeletionIndex, KeyDeletionIndex};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+/// Probed keys per iteration (one Arrow batch worth).
+const PROBES_PER_BATCH: usize = 8_192;
+
+/// Index entry counts. 1M ≈ tens of MB resident (out of L2), 4M ≈ out of L3
+/// on most parts.
+const INDEX_SIZES: &[usize] = &[1_000_000, 4_000_000];
+
+/// Large odd stride so probe i touches an unpredictable slot of the key space.
+const SPREAD: u64 = 0x9E37_79B9_7F4A_7C15;
+
+fn spread_key(i: usize, modulus: usize) -> i64 {
+    let mixed = (i as u64).wrapping_mul(SPREAD);
+    i64::try_from(mixed % (modulus as u64)).unwrap_or(0)
+}
+
+fn bench_int64_large(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deletion_index_int64_probe_large");
+    group.throughput(Throughput::Elements(PROBES_PER_BATCH as u64));
+    group.sample_size(50);
+
+    for &n in INDEX_SIZES {
+        let index = DeletionIndex::from_map(
+            (0..n)
+                .map(|pk| (i64::try_from(pk).unwrap_or(0), 1_i64))
+                .collect::<HashMap<i64, i64>>(),
+        );
+
+        // Present keys, spread across the whole index.
+        let hit_keys: Vec<i64> = (0..PROBES_PER_BATCH).map(|i| spread_key(i, n)).collect();
+        // Absent keys, beyond the populated range.
+        let miss_keys: Vec<i64> = (0..PROBES_PER_BATCH)
+            .map(|i| spread_key(i, n) + i64::try_from(2 * n).unwrap_or(i64::MAX / 2))
+            .collect();
+
+        group.bench_with_input(BenchmarkId::new("hit", n), &n, |b, _| {
+            b.iter(|| {
+                let mut found = 0_usize;
+                for &pk in &hit_keys {
+                    found += usize::from(index.get(black_box(pk)).is_some());
+                }
+                black_box(found);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("miss", n), &n, |b, _| {
+            b.iter(|| {
+                let mut found = 0_usize;
+                for &pk in &miss_keys {
+                    found += usize::from(index.get(black_box(pk)).is_some());
+                }
+                black_box(found);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_row_keys_large(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deletion_index_row_keys_probe_large");
+    group.throughput(Throughput::Elements(PROBES_PER_BATCH as u64));
+    group.sample_size(50);
+
+    for &n in INDEX_SIZES {
+        let index = KeyDeletionIndex::from_map(
+            (0..n)
+                .map(|key| {
+                    (
+                        (key as u64).to_be_bytes().to_vec().into_boxed_slice(),
+                        1_i64,
+                    )
+                })
+                .collect::<HashMap<Box<[u8]>, i64>>(),
+        );
+
+        let hit_keys: Vec<[u8; 8]> = (0..PROBES_PER_BATCH)
+            .map(|i| (spread_key(i, n) as u64).to_be_bytes())
+            .collect();
+        let miss_keys: Vec<[u8; 8]> = (0..PROBES_PER_BATCH)
+            .map(|i| ((spread_key(i, n) as u64) + 2 * (n as u64)).to_be_bytes())
+            .collect();
+
+        group.bench_with_input(BenchmarkId::new("hit", n), &n, |b, _| {
+            b.iter(|| {
+                let mut found = 0_usize;
+                for key in &hit_keys {
+                    found += usize::from(index.get(black_box(key)).is_some());
+                }
+                black_box(found);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("miss", n), &n, |b, _| {
+            b.iter(|| {
+                let mut found = 0_usize;
+                for key in &miss_keys {
+                    found += usize::from(index.get(black_box(key)).is_some());
+                }
+                black_box(found);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_int64_large, bench_row_keys_large);
+criterion_main!(benches);

--- a/crates/cayenne/benches/get_max_delete_sequence_walk.rs
+++ b/crates/cayenne/benches/get_max_delete_sequence_walk.rs
@@ -95,7 +95,12 @@ fn build_index(size: usize) -> DeletionIndex {
 
 /// Mirror of the historical O(N) walk (pre-`max_sequence_number` cache).
 fn o_n_walk(index: &DeletionIndex) -> i64 {
-    index.entries().values().max().copied().unwrap_or(0)
+    index
+        .entries()
+        .values()
+        .filter_map(cayenne::provider::deletion_index::TombstoneEntry::delete_sequence)
+        .max()
+        .unwrap_or(0)
 }
 
 /// Proposed: read the cached max directly.

--- a/crates/cayenne/benches/get_max_delete_sequence_walk.rs
+++ b/crates/cayenne/benches/get_max_delete_sequence_walk.rs
@@ -96,9 +96,8 @@ fn build_index(size: usize) -> DeletionIndex {
 /// Mirror of the historical O(N) walk (pre-`max_sequence_number` cache).
 fn o_n_walk(index: &DeletionIndex) -> i64 {
     index
-        .entries()
-        .values()
-        .filter_map(cayenne::provider::deletion_index::TombstoneEntry::delete_sequence)
+        .iter_entries()
+        .filter_map(|(_, entry)| entry.delete_sequence())
         .max()
         .unwrap_or(0)
 }

--- a/crates/cayenne/benches/int64_pk_filter_keep_mask_alloc.rs
+++ b/crates/cayenne/benches/int64_pk_filter_keep_mask_alloc.rs
@@ -118,8 +118,7 @@ fn build_index(rows: usize, ratio: f64) -> DeletionIndex {
 fn keep_mask_vec_bool(
     batch: &RecordBatch,
     pk_column_index: usize,
-    deleted_pk_values: &DeletionIndex,
-    insert_records: &DeletionIndex,
+    tombstones: &DeletionIndex,
 ) -> RecordBatch {
     let batch_size = batch.num_rows();
     let pk_column = batch.column(pk_column_index);
@@ -131,11 +130,11 @@ fn keep_mask_vec_bool(
     let mut keep_mask: Vec<bool> = Vec::with_capacity(batch_size);
     let mut keep_count: usize = 0;
     for &pk in pk_slice {
-        let visible = match deleted_pk_values.get(pk) {
+        let visible = match tombstones.get(pk) {
             None => true,
-            Some(delete_seq) => insert_records
-                .get(pk)
-                .is_some_and(|insert_seq| insert_seq > delete_seq),
+            Some(t) => t
+                .insert_sequence
+                .is_some_and(|insert_seq| insert_seq > t.delete_sequence),
         };
         keep_mask.push(visible);
         keep_count += usize::from(visible);
@@ -158,8 +157,7 @@ fn keep_mask_vec_bool(
 fn keep_mask_boolean_buffer(
     batch: &RecordBatch,
     pk_column_index: usize,
-    deleted_pk_values: &DeletionIndex,
-    insert_records: &DeletionIndex,
+    tombstones: &DeletionIndex,
 ) -> RecordBatch {
     let batch_size = batch.num_rows();
     let pk_column = batch.column(pk_column_index);
@@ -171,11 +169,11 @@ fn keep_mask_boolean_buffer(
     let mut builder = BooleanBufferBuilder::new(batch_size);
     let mut keep_count: usize = 0;
     for &pk in pk_slice {
-        let visible = match deleted_pk_values.get(pk) {
+        let visible = match tombstones.get(pk) {
             None => true,
-            Some(delete_seq) => insert_records
-                .get(pk)
-                .is_some_and(|insert_seq| insert_seq > delete_seq),
+            Some(t) => t
+                .insert_sequence
+                .is_some_and(|insert_seq| insert_seq > t.delete_sequence),
         };
         builder.append(visible);
         keep_count += usize::from(visible);
@@ -195,7 +193,6 @@ fn bench_keep_mask(c: &mut Criterion) {
     group.throughput(Throughput::Elements(ROWS_PER_BATCH as u64));
 
     let batch = make_batch(ROWS_PER_BATCH);
-    let empty_inserts = DeletionIndex::empty();
 
     for (shape_name, ratio) in SHAPES {
         let index = build_index(ROWS_PER_BATCH, *ratio);
@@ -209,7 +206,6 @@ fn bench_keep_mask(c: &mut Criterion) {
                         black_box(&batch),
                         black_box(0),
                         black_box(&index),
-                        black_box(&empty_inserts),
                     );
                     black_box(out);
                 });
@@ -225,7 +221,6 @@ fn bench_keep_mask(c: &mut Criterion) {
                         black_box(&batch),
                         black_box(0),
                         black_box(&index),
-                        black_box(&empty_inserts),
                     );
                     black_box(out);
                 });

--- a/crates/cayenne/benches/int64_pk_filter_keep_mask_alloc.rs
+++ b/crates/cayenne/benches/int64_pk_filter_keep_mask_alloc.rs
@@ -202,11 +202,8 @@ fn bench_keep_mask(c: &mut Criterion) {
             shape_name,
             |b, _| {
                 b.iter(|| {
-                    let out = keep_mask_vec_bool(
-                        black_box(&batch),
-                        black_box(0),
-                        black_box(&index),
-                    );
+                    let out =
+                        keep_mask_vec_bool(black_box(&batch), black_box(0), black_box(&index));
                     black_box(out);
                 });
             },

--- a/crates/cayenne/src/provider/delete.rs
+++ b/crates/cayenne/src/provider/delete.rs
@@ -48,7 +48,9 @@ pub use sink::CayenneDeletionSink;
 pub(crate) use sink::file_based::FileBasedDeletionSink;
 
 // Crate-internal types used by table.rs
-pub(crate) use filter_exec::{Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec};
+pub(crate) use filter_exec::{
+    InsertRecordHandling, Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
+};
 pub(crate) use vector_io::{
     DeletionIdentifier, DeletionVectorWriteResult, DeletionVectorWriteSpec, DeletionVectorWriter,
     detect_deletion_type_and_read,

--- a/crates/cayenne/src/provider/delete/filter_exec.rs
+++ b/crates/cayenne/src/provider/delete/filter_exec.rs
@@ -46,7 +46,7 @@ limitations under the License.
 //!    bloom-filter prefilter that early-rejects keys that are definitely not deleted.
 //! 2. Apply the mask in one shot via [`arrow::compute::filter_record_batch`].
 
-use crate::provider::deletion_index::{DeletionIndex, KeyDeletionIndex};
+use crate::provider::deletion_index::{DeletionIndex, KeyDeletionIndex, Tombstone};
 use arrow::array::{ArrayRef, BooleanArray, BooleanBufferBuilder};
 use arrow_row::RowConverter;
 use datafusion_execution::SendableRecordBatchStream;
@@ -61,72 +61,75 @@ use std::sync::Arc;
 // ============================================================================
 //
 // A row is visible (kept) if either:
-// - Its PK is not in the deletion index, OR
-// - Its PK is in the deletion index but was re-inserted with a higher sequence
-//   number (upsert).
+// - Its PK has no tombstone in the deletion index, OR
+// - Its tombstone's deletion pre-dates the protected-snapshot cutoff, OR
+// - Insert records are honored and the PK was re-inserted with a higher
+//   sequence number (upsert).
 //
-// Both helpers run inside the per-row loop, so they avoid second probes when
-// the bloom filter on the deletion index already rejects the key.
+// The fused index answers all of this with ONE bloom-prefiltered probe per
+// row; the previous two-index design paid a second bloom + HAMT walk on every
+// confirmed deletion (the dominant per-row cost in changes-mode profiles).
+
+/// Whether the visibility check honors insert records (upsert re-insertions).
+///
+/// The main scan path applies them. Protected-snapshot paths ignore them: a
+/// re-inserted row is scanned from the snapshot's own newer files, so honoring
+/// the re-insert in the base scan would resurrect the old row version.
+/// (Previously expressed by passing the shared-static empty index as
+/// `insert_records`; the fused index makes the mode explicit.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertRecordHandling {
+    /// A deleted PK is visible again if re-inserted after the delete.
+    Apply,
+    /// Re-inserts never override a deletion.
+    Ignore,
+}
+
+/// Shared visibility verdict for a probed tombstone.
+#[inline]
+fn tombstone_visible(
+    tombstone: Tombstone,
+    insert_record_handling: InsertRecordHandling,
+    min_delete_seq_to_apply: Option<i64>,
+) -> bool {
+    if min_delete_seq_to_apply
+        .is_some_and(|min_delete_seq| tombstone.delete_sequence <= min_delete_seq)
+    {
+        // Deletion pre-dates the protected snapshot's creation — skip it. The
+        // full deletion index is reused here instead of being rebuilt with
+        // these entries filtered out.
+        return true;
+    }
+    match insert_record_handling {
+        InsertRecordHandling::Apply => tombstone
+            .insert_sequence
+            .is_some_and(|insert_seq| insert_seq > tombstone.delete_sequence),
+        InsertRecordHandling::Ignore => false,
+    }
+}
 
 /// Check if a row with the given Int64 PK is visible (not deleted, or re-inserted after deletion).
 ///
 /// `min_delete_seq_to_apply` is the protected-snapshot cutoff: when `Some(min)`,
 /// only deletions whose `delete_seq > min` apply. This lets the protected
-/// snapshot scan path share the full `deleted_pks` index across snapshots
+/// snapshot scan path share the full deletion index across snapshots
 /// instead of rebuilding a filtered [`DeletionIndex`] per snapshot — the
 /// `min_seq` is a single integer compared against the deletion sequence
-/// number returned by the existing bloom-prefiltered `HashMap` probe, so it
+/// number returned by the existing bloom-prefiltered probe, so it
 /// adds at most one comparison per confirmed match (which the bloom
 /// rejects most non-matching probes from reaching). `None` means apply every
-/// deletion in `deleted_pks` (main scan path).
+/// deletion in the index (main scan path).
 #[inline]
 pub(crate) fn is_pk_visible_i64(
     pk: i64,
-    deleted_pks: &DeletionIndex,
-    insert_records: &DeletionIndex,
+    tombstones: &DeletionIndex,
+    insert_record_handling: InsertRecordHandling,
     min_delete_seq_to_apply: Option<i64>,
 ) -> bool {
-    match min_delete_seq_to_apply {
-        Some(min_delete_seq_to_apply) => {
-            is_pk_visible_i64_after_min(pk, deleted_pks, insert_records, min_delete_seq_to_apply)
-        }
-        None => is_pk_visible_i64_without_min(pk, deleted_pks, insert_records),
-    }
-}
-
-#[inline]
-fn is_pk_visible_i64_without_min(
-    pk: i64,
-    deleted_pks: &DeletionIndex,
-    insert_records: &DeletionIndex,
-) -> bool {
-    match deleted_pks.get(pk) {
+    match tombstones.get(pk) {
         None => true,
-        Some(delete_seq) => insert_records
-            .get(pk)
-            .is_some_and(|insert_seq| insert_seq > delete_seq),
-    }
-}
-
-#[inline]
-fn is_pk_visible_i64_after_min(
-    pk: i64,
-    deleted_pks: &DeletionIndex,
-    insert_records: &DeletionIndex,
-    min_delete_seq_to_apply: i64,
-) -> bool {
-    match deleted_pks.get(pk) {
-        None => true,
-        Some(delete_seq) => {
-            if delete_seq <= min_delete_seq_to_apply {
-                // Deletion pre-dates the protected snapshot's creation —
-                // skip it. The full deletion index is reused here instead
-                // of being rebuilt with these entries filtered out.
-                return true;
-            }
-            insert_records
-                .get(pk)
-                .is_some_and(|insert_seq| insert_seq > delete_seq)
+        Some(tombstone) => {
+            tombstone_visible(tombstone, insert_record_handling, min_delete_seq_to_apply)
         }
     }
 }
@@ -138,51 +141,14 @@ fn is_pk_visible_i64_after_min(
 #[inline]
 pub(crate) fn is_pk_visible_row_key(
     key: &[u8],
-    deleted_keys: &KeyDeletionIndex,
-    insert_records: &KeyDeletionIndex,
+    tombstones: &KeyDeletionIndex,
+    insert_record_handling: InsertRecordHandling,
     min_delete_seq_to_apply: Option<i64>,
 ) -> bool {
-    match min_delete_seq_to_apply {
-        Some(min_delete_seq_to_apply) => is_pk_visible_row_key_after_min(
-            key,
-            deleted_keys,
-            insert_records,
-            min_delete_seq_to_apply,
-        ),
-        None => is_pk_visible_row_key_without_min(key, deleted_keys, insert_records),
-    }
-}
-
-#[inline]
-fn is_pk_visible_row_key_without_min(
-    key: &[u8],
-    deleted_keys: &KeyDeletionIndex,
-    insert_records: &KeyDeletionIndex,
-) -> bool {
-    match deleted_keys.get(key) {
+    match tombstones.get(key) {
         None => true,
-        Some(delete_seq) => insert_records
-            .get(key)
-            .is_some_and(|insert_seq| insert_seq > delete_seq),
-    }
-}
-
-#[inline]
-fn is_pk_visible_row_key_after_min(
-    key: &[u8],
-    deleted_keys: &KeyDeletionIndex,
-    insert_records: &KeyDeletionIndex,
-    min_delete_seq_to_apply: i64,
-) -> bool {
-    match deleted_keys.get(key) {
-        None => true,
-        Some(delete_seq) => {
-            if delete_seq <= min_delete_seq_to_apply {
-                return true;
-            }
-            insert_records
-                .get(key)
-                .is_some_and(|insert_seq| insert_seq > delete_seq)
+        Some(tombstone) => {
+            tombstone_visible(tombstone, insert_record_handling, min_delete_seq_to_apply)
         }
     }
 }
@@ -216,10 +182,11 @@ fn is_pk_visible_row_key_after_min(
 /// This allows upsert semantics without full table compaction.
 pub struct KeyBasedDeletionFilterExec {
     input: Arc<dyn ExecutionPlan>,
-    /// Deletion index of PK bytes -> delete sequence number.
-    deleted_row_keys: Arc<KeyDeletionIndex>,
-    /// Deletion index of PK bytes -> insert sequence number for upserted PKs.
-    insert_records: Arc<KeyDeletionIndex>,
+    /// Fused tombstone index of PK bytes -> (delete, insert) sequence numbers.
+    tombstones: Arc<KeyDeletionIndex>,
+    /// Whether re-inserted PKs override their deletion (main scan) or not
+    /// (protected-snapshot paths).
+    insert_record_handling: InsertRecordHandling,
     /// Indices of primary key columns in the schema
     pk_column_indices: Vec<usize>,
     /// `RowConverter` for converting PK columns to bytes
@@ -235,15 +202,15 @@ impl KeyBasedDeletionFilterExec {
     ///
     /// # Arguments
     /// * `input` - The input execution plan to filter
-    /// * `deleted_row_keys` - Bloom-prefiltered index of deleted PK byte keys
-    /// * `insert_records` - Bloom-prefiltered index of upserted PK byte keys
+    /// * `tombstones` - Bloom-prefiltered fused index of deleted/upserted PK byte keys
+    /// * `insert_record_handling` - Whether upsert re-insertions override deletions
     /// * `pk_column_indices` - Indices of primary key columns in the schema
     /// * `row_converter` - `RowConverter` configured for the PK columns
     /// * `min_delete_seq_to_apply` - Optional protected-snapshot cutoff
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
-        deleted_row_keys: Arc<KeyDeletionIndex>,
-        insert_records: Arc<KeyDeletionIndex>,
+        tombstones: Arc<KeyDeletionIndex>,
+        insert_record_handling: InsertRecordHandling,
         pk_column_indices: Vec<usize>,
         row_converter: Arc<RowConverter>,
         min_delete_seq_to_apply: Option<i64>,
@@ -251,8 +218,8 @@ impl KeyBasedDeletionFilterExec {
         let properties = input.properties().clone();
         Self {
             input,
-            deleted_row_keys,
-            insert_records,
+            tombstones,
+            insert_record_handling,
             pk_column_indices,
             row_converter,
             min_delete_seq_to_apply,
@@ -272,7 +239,7 @@ impl DisplayAs for KeyBasedDeletionFilterExec {
         write!(
             f,
             "KeyBasedDeletionFilterExec: filtered_keys={}",
-            self.deleted_row_keys.len()
+            self.tombstones.delete_len()
         )
     }
 }
@@ -305,8 +272,8 @@ impl ExecutionPlan for KeyBasedDeletionFilterExec {
         }
         Ok(Arc::new(Self::new(
             Arc::clone(&children[0]),
-            Arc::clone(&self.deleted_row_keys),
-            Arc::clone(&self.insert_records),
+            Arc::clone(&self.tombstones),
+            self.insert_record_handling,
             self.pk_column_indices.clone(),
             Arc::clone(&self.row_converter),
             self.min_delete_seq_to_apply,
@@ -319,8 +286,8 @@ impl ExecutionPlan for KeyBasedDeletionFilterExec {
         context: Arc<datafusion_execution::TaskContext>,
     ) -> datafusion_common::Result<SendableRecordBatchStream> {
         let input_stream = self.input.execute(partition, context)?;
-        let deleted_row_keys = Arc::clone(&self.deleted_row_keys);
-        let insert_records = Arc::clone(&self.insert_records);
+        let tombstones = Arc::clone(&self.tombstones);
+        let insert_record_handling = self.insert_record_handling;
         let pk_column_indices = self.pk_column_indices.clone();
         let row_converter = Arc::clone(&self.row_converter);
         let min_delete_seq_to_apply = self.min_delete_seq_to_apply;
@@ -328,8 +295,8 @@ impl ExecutionPlan for KeyBasedDeletionFilterExec {
 
         Ok(Box::pin(KeyBasedDeletionFilterStream {
             input: input_stream,
-            deleted_row_keys,
-            insert_records,
+            tombstones,
+            insert_record_handling,
             pk_column_indices,
             row_converter,
             min_delete_seq_to_apply,
@@ -341,8 +308,8 @@ impl ExecutionPlan for KeyBasedDeletionFilterExec {
 /// Stream that filters out deleted rows based on primary key matching.
 pub struct KeyBasedDeletionFilterStream {
     input: SendableRecordBatchStream,
-    deleted_row_keys: Arc<KeyDeletionIndex>,
-    insert_records: Arc<KeyDeletionIndex>,
+    tombstones: Arc<KeyDeletionIndex>,
+    insert_record_handling: InsertRecordHandling,
     pk_column_indices: Vec<usize>,
     row_converter: Arc<RowConverter>,
     /// See [`Int64PkDeletionFilterStream::min_delete_seq_to_apply`].
@@ -366,8 +333,9 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                         return std::task::Poll::Ready(Some(Ok(batch)));
                     }
 
-                    // Fast path: empty deleted keys index
-                    if self.deleted_row_keys.is_empty() {
+                    // Fast path: no deletions to apply (insert-only entries
+                    // never affect visibility)
+                    if !self.tombstones.has_deletions() {
                         return std::task::Poll::Ready(Some(Ok(batch)));
                     }
 
@@ -414,8 +382,8 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                         let key: &[u8] = row.as_ref();
                         let visible = is_pk_visible_row_key(
                             key,
-                            &self.deleted_row_keys,
-                            &self.insert_records,
+                            &self.tombstones,
+                            self.insert_record_handling,
                             self.min_delete_seq_to_apply,
                         );
                         keep_mask.append(visible);
@@ -486,17 +454,18 @@ impl datafusion_execution::RecordBatchStream for KeyBasedDeletionFilterStream {
 /// `HashMap<i64, i64>`) directly with native i64 comparisons.
 pub struct Int64PkDeletionFilterExec {
     input: Arc<dyn ExecutionPlan>,
-    /// Bloom-prefiltered index of deleted PK -> delete sequence number.
-    deleted_pk_values: Arc<DeletionIndex>,
-    /// Bloom-prefiltered index of upserted PK -> insert sequence number.
-    insert_records: Arc<DeletionIndex>,
+    /// Bloom-prefiltered fused index of PK -> (delete, insert) sequence numbers.
+    tombstones: Arc<DeletionIndex>,
+    /// Whether re-inserted PKs override their deletion (main scan) or not
+    /// (protected-snapshot paths).
+    insert_record_handling: InsertRecordHandling,
     /// Index of the primary key column in the schema
     pk_column_index: usize,
     /// Optional minimum sequence number — only deletions with
     /// `delete_seq > min_delete_seq_to_apply` are honoured. Used by the
     /// protected-snapshot scan path to skip deletions that pre-date the
     /// protected snapshot's creation without rebuilding the deletion
-    /// index. `None` means apply every deletion in `deleted_pk_values`.
+    /// index. `None` means apply every deletion in the index.
     min_delete_seq_to_apply: Option<i64>,
     properties: datafusion_physical_plan::PlanProperties,
 }
@@ -506,22 +475,22 @@ impl Int64PkDeletionFilterExec {
     ///
     /// # Arguments
     /// * `input` - The input execution plan to filter
-    /// * `deleted_pk_values` - Bloom-prefiltered index of deleted PK values
-    /// * `insert_records` - Bloom-prefiltered index of upserted PK values
+    /// * `tombstones` - Bloom-prefiltered fused index of deleted/upserted PK values
+    /// * `insert_record_handling` - Whether upsert re-insertions override deletions
     /// * `pk_column_index` - Index of the primary key column in the schema
     /// * `min_delete_seq_to_apply` - Optional protected-snapshot cutoff
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
-        deleted_pk_values: Arc<DeletionIndex>,
-        insert_records: Arc<DeletionIndex>,
+        tombstones: Arc<DeletionIndex>,
+        insert_record_handling: InsertRecordHandling,
         pk_column_index: usize,
         min_delete_seq_to_apply: Option<i64>,
     ) -> Self {
         let properties = input.properties().clone();
         Self {
             input,
-            deleted_pk_values,
-            insert_records,
+            tombstones,
+            insert_record_handling,
             pk_column_index,
             min_delete_seq_to_apply,
             properties,
@@ -540,7 +509,7 @@ impl DisplayAs for Int64PkDeletionFilterExec {
         write!(
             f,
             "Int64PkDeletionFilterExec: filtered_keys={}, pk_col_idx={}",
-            self.deleted_pk_values.len(),
+            self.tombstones.delete_len(),
             self.pk_column_index
         )
     }
@@ -574,8 +543,8 @@ impl ExecutionPlan for Int64PkDeletionFilterExec {
         }
         Ok(Arc::new(Self::new(
             Arc::clone(&children[0]),
-            Arc::clone(&self.deleted_pk_values),
-            Arc::clone(&self.insert_records),
+            Arc::clone(&self.tombstones),
+            self.insert_record_handling,
             self.pk_column_index,
             self.min_delete_seq_to_apply,
         )))
@@ -587,16 +556,16 @@ impl ExecutionPlan for Int64PkDeletionFilterExec {
         context: Arc<datafusion_execution::TaskContext>,
     ) -> datafusion_common::Result<SendableRecordBatchStream> {
         let input_stream = self.input.execute(partition, context)?;
-        let deleted_pk_values = Arc::clone(&self.deleted_pk_values);
-        let insert_records = Arc::clone(&self.insert_records);
+        let tombstones = Arc::clone(&self.tombstones);
+        let insert_record_handling = self.insert_record_handling;
         let pk_column_index = self.pk_column_index;
         let min_delete_seq_to_apply = self.min_delete_seq_to_apply;
         let schema = input_stream.schema();
 
         Ok(Box::pin(Int64PkDeletionFilterStream {
             input: input_stream,
-            deleted_pk_values,
-            insert_records,
+            tombstones,
+            insert_record_handling,
             pk_column_index,
             min_delete_seq_to_apply,
             schema,
@@ -607,11 +576,11 @@ impl ExecutionPlan for Int64PkDeletionFilterExec {
 /// Stream that filters out deleted rows based on Int64 primary key matching.
 struct Int64PkDeletionFilterStream {
     input: SendableRecordBatchStream,
-    deleted_pk_values: Arc<DeletionIndex>,
-    insert_records: Arc<DeletionIndex>,
+    tombstones: Arc<DeletionIndex>,
+    insert_record_handling: InsertRecordHandling,
     pk_column_index: usize,
     /// If `Some(min)`, only deletions with `delete_seq > min` apply. Lets
-    /// protected snapshots share one `deleted_pk_values` index instead of
+    /// protected snapshots share one tombstone index instead of
     /// each snapshot owning a per-snapshot rebuilt copy.
     min_delete_seq_to_apply: Option<i64>,
     schema: arrow_schema::SchemaRef,
@@ -635,8 +604,9 @@ impl futures::Stream for Int64PkDeletionFilterStream {
                         return std::task::Poll::Ready(Some(Ok(batch)));
                     }
 
-                    // Fast path: empty deletion index
-                    if self.deleted_pk_values.is_empty() {
+                    // Fast path: no deletions to apply (insert-only entries
+                    // never affect visibility)
+                    if !self.tombstones.has_deletions() {
                         return std::task::Poll::Ready(Some(Ok(batch)));
                     }
 
@@ -674,8 +644,8 @@ impl futures::Stream for Int64PkDeletionFilterStream {
                     for &pk_value in pk_slice {
                         let visible = is_pk_visible_i64(
                             pk_value,
-                            &self.deleted_pk_values,
-                            &self.insert_records,
+                            &self.tombstones,
+                            self.insert_record_handling,
                             self.min_delete_seq_to_apply,
                         );
                         keep_mask.append(visible);
@@ -768,13 +738,19 @@ mod tests {
             .map(|(&pk, &seq)| (pk, seq))
             .collect();
         let filtered_index = DeletionIndex::from_map(filtered_entries);
-        let empty_inserts = DeletionIndex::empty();
 
-        // Probe every key, including some that aren't in either index.
+        // Probe every key, including some that aren't in either index. The
+        // protected-snapshot paths ignore insert records (see
+        // `InsertRecordHandling::Ignore`).
         for pk in -2..12_i64 {
-            let probe_time_filter =
-                is_pk_visible_i64(pk, &full_index, &empty_inserts, Some(min_seq));
-            let rebuilt_filter = is_pk_visible_i64(pk, &filtered_index, &empty_inserts, None);
+            let probe_time_filter = is_pk_visible_i64(
+                pk,
+                &full_index,
+                InsertRecordHandling::Ignore,
+                Some(min_seq),
+            );
+            let rebuilt_filter =
+                is_pk_visible_i64(pk, &filtered_index, InsertRecordHandling::Ignore, None);
             assert_eq!(
                 probe_time_filter, rebuilt_filter,
                 "pk={pk}: probe-time min_seq filter must match a rebuilt index"
@@ -793,19 +769,87 @@ mod tests {
             .map(|(k, &seq)| (k.clone(), seq))
             .collect();
         let filtered_key_index = KeyDeletionIndex::from_map(filtered_key_entries);
-        let empty_key_inserts = KeyDeletionIndex::empty();
 
         for pk in -2..12_i64 {
             let key = pk.to_be_bytes();
-            let probe_time =
-                is_pk_visible_row_key(&key, &full_key_index, &empty_key_inserts, Some(min_seq));
-            let rebuilt =
-                is_pk_visible_row_key(&key, &filtered_key_index, &empty_key_inserts, None);
+            let probe_time = is_pk_visible_row_key(
+                &key,
+                &full_key_index,
+                InsertRecordHandling::Ignore,
+                Some(min_seq),
+            );
+            let rebuilt = is_pk_visible_row_key(
+                &key,
+                &filtered_key_index,
+                InsertRecordHandling::Ignore,
+                None,
+            );
             assert_eq!(
                 probe_time, rebuilt,
                 "byte-key pk={pk}: probe-time min_seq filter must match a rebuilt KeyDeletionIndex"
             );
         }
+    }
+
+    /// Upsert semantics through the fused index: a deleted PK re-inserted at a
+    /// higher sequence is visible on the main scan path (`Apply`) and stays
+    /// hidden on protected-snapshot paths (`Ignore`).
+    #[test]
+    fn fused_tombstone_visibility_honors_handling_mode() {
+        let deleted: HashMap<i64, i64> = HashMap::from([(1, 10), (2, 20)]);
+        let inserts: HashMap<i64, i64> = HashMap::from([(1, 11), (2, 5)]);
+        let index = DeletionIndex::from_maps(deleted, inserts);
+
+        // pk=1: re-inserted after delete (11 > 10) — visible only under Apply.
+        assert!(is_pk_visible_i64(
+            1,
+            &index,
+            InsertRecordHandling::Apply,
+            None
+        ));
+        assert!(!is_pk_visible_i64(
+            1,
+            &index,
+            InsertRecordHandling::Ignore,
+            None
+        ));
+
+        // pk=2: stale insert record (5 < 20) — deleted under both modes.
+        assert!(!is_pk_visible_i64(
+            2,
+            &index,
+            InsertRecordHandling::Apply,
+            None
+        ));
+        assert!(!is_pk_visible_i64(
+            2,
+            &index,
+            InsertRecordHandling::Ignore,
+            None
+        ));
+
+        // pk=3: never deleted — visible under both modes.
+        assert!(is_pk_visible_i64(
+            3,
+            &index,
+            InsertRecordHandling::Apply,
+            None
+        ));
+        assert!(is_pk_visible_i64(
+            3,
+            &index,
+            InsertRecordHandling::Ignore,
+            None
+        ));
+
+        // The min-seq cutoff overrides everything: deletions at or below the
+        // protected snapshot's creation sequence are skipped.
+        assert!(is_pk_visible_i64(
+            2,
+            &index,
+            InsertRecordHandling::Ignore,
+            Some(20)
+        ));
     }
 
     #[tokio::test]
@@ -829,8 +873,8 @@ mod tests {
 
         let mut stream = KeyBasedDeletionFilterStream {
             input,
-            deleted_row_keys,
-            insert_records: Arc::new(KeyDeletionIndex::empty()),
+            tombstones: deleted_row_keys,
+            insert_record_handling: InsertRecordHandling::Apply,
             pk_column_indices: Vec::new(),
             row_converter,
             min_delete_seq_to_apply: None,

--- a/crates/cayenne/src/provider/delete/filter_exec.rs
+++ b/crates/cayenne/src/provider/delete/filter_exec.rs
@@ -743,12 +743,8 @@ mod tests {
         // protected-snapshot paths ignore insert records (see
         // `InsertRecordHandling::Ignore`).
         for pk in -2..12_i64 {
-            let probe_time_filter = is_pk_visible_i64(
-                pk,
-                &full_index,
-                InsertRecordHandling::Ignore,
-                Some(min_seq),
-            );
+            let probe_time_filter =
+                is_pk_visible_i64(pk, &full_index, InsertRecordHandling::Ignore, Some(min_seq));
             let rebuilt_filter =
                 is_pk_visible_i64(pk, &filtered_index, InsertRecordHandling::Ignore, None);
             assert_eq!(

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -694,7 +694,7 @@ impl CayenneDeletionSink {
         let current = deletion_snapshot.load_full();
         let new_deletion_count = row_keys
             .iter()
-            .filter(|key| current.deleted_row_keys.get(key.as_ref()).is_none())
+            .filter(|key| current.tombstones.get(key.as_ref()).is_none())
             .count();
 
         // Create a temporary metadata with the delete sequence number
@@ -726,15 +726,10 @@ impl CayenneDeletionSink {
         // Build a fresh snapshot with the new deletions and publish via ArcSwap.
         // Writes are serialised by the per-table write lock so the load+rebuild+store
         // sequence is race-free.
-        let updated = current.deleted_row_keys.extend_max(
-            written_row_keys
-                .iter()
-                .map(|key| (key.clone(), delete_sequence)),
-        );
-        deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_arcs(
-            Arc::new(updated),
-            Arc::clone(&current.insert_records),
-        )));
+        let updated = current
+            .tombstones
+            .extend_max_deletes(written_row_keys.iter().map(|key| (key, delete_sequence)));
+        deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_index(updated)));
         self.refresh_deletion_memory_accounting();
 
         let deleted_count =
@@ -816,7 +811,7 @@ impl CayenneDeletionSink {
         let current = deletion_snapshot.load_full();
         let new_deletion_count = pk_values
             .iter()
-            .filter(|pk| current.deleted_pk.get(**pk).is_none())
+            .filter(|pk| current.tombstones.get(**pk).is_none())
             .count();
 
         // For Int64 PK deletions, we store them as key-based deletions
@@ -846,12 +841,9 @@ impl CayenneDeletionSink {
         // Writes are serialised by the per-table write lock so the load+rebuild+store
         // sequence is race-free.
         let updated = current
-            .deleted_pk
-            .extend_max(pk_values.iter().map(|&pk| (pk, delete_sequence)));
-        deletion_snapshot.store(Arc::new(Int64PkDeletionSnapshot::from_arcs(
-            Arc::new(updated),
-            Arc::clone(&current.insert_records),
-        )));
+            .tombstones
+            .extend_max_deletes(pk_values.iter().map(|&pk| (pk, delete_sequence)));
+        deletion_snapshot.store(Arc::new(Int64PkDeletionSnapshot::from_index(updated)));
         self.refresh_deletion_memory_accounting();
 
         let deleted_count =

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -261,19 +261,18 @@ impl DeletionIndex {
         let delete_count = deleted.len();
         let insert_count = insert_records.len();
 
-        let mut entries: PersistentHashMap<i64, TombstoneEntry, DeletionIndexHasher> =
-            deleted
-                .into_iter()
-                .map(|(pk, delete_seq)| {
-                    (
-                        pk,
-                        TombstoneEntry {
-                            delete_seq,
-                            insert_seq: SEQUENCE_ABSENT,
-                        },
-                    )
-                })
-                .collect();
+        let mut entries: PersistentHashMap<i64, TombstoneEntry, DeletionIndexHasher> = deleted
+            .into_iter()
+            .map(|(pk, delete_seq)| {
+                (
+                    pk,
+                    TombstoneEntry {
+                        delete_seq,
+                        insert_seq: SEQUENCE_ABSENT,
+                    },
+                )
+            })
+            .collect();
         for (pk, insert_seq) in insert_records {
             merge_max(
                 entries.entry(pk).or_insert(TombstoneEntry {
@@ -416,9 +415,11 @@ impl DeletionIndex {
     /// regression that prompted this fix.
     #[must_use]
     pub fn extend_max_deletes(&self, additions: impl IntoIterator<Item = (i64, i64)>) -> Self {
-        self.extend_with(additions.into_iter().map(|(pk, delete_seq)| {
-            (pk, delete_seq, SEQUENCE_ABSENT)
-        }))
+        self.extend_with(
+            additions
+                .into_iter()
+                .map(|(pk, delete_seq)| (pk, delete_seq, SEQUENCE_ABSENT)),
+        )
     }
 
     /// Build a new index recording an upsert-conflict batch: every key in
@@ -450,7 +451,10 @@ impl DeletionIndex {
         // from the iterator's hint to skip Vec growth reallocations.
         let mut new_delete_keys: Vec<i64> = Vec::with_capacity(additions.size_hint().0);
         for (pk, delete_seq, insert_seq) in additions {
-            debug_assert_ne!(delete_seq, SEQUENCE_ABSENT, "real sequences are non-negative");
+            debug_assert_ne!(
+                delete_seq, SEQUENCE_ABSENT,
+                "real sequences are non-negative"
+            );
             let entry = entries.entry(pk).or_insert(TombstoneEntry {
                 delete_seq: SEQUENCE_ABSENT,
                 insert_seq: SEQUENCE_ABSENT,
@@ -608,21 +612,20 @@ impl KeyDeletionIndex {
         let delete_count = deleted.len();
         let insert_count = insert_records.len();
 
-        let mut entries: PersistentHashMap<u128, TombstoneEntry, PrehashedBuildHasher> =
-            deleted
-                .into_iter()
-                .map(|(key, delete_seq)| {
-                    let key_hash = hash_key_128(&key);
-                    bloom.insert(bloom_half(key_hash));
-                    (
-                        key_hash,
-                        TombstoneEntry {
-                            delete_seq,
-                            insert_seq: SEQUENCE_ABSENT,
-                        },
-                    )
-                })
-                .collect();
+        let mut entries: PersistentHashMap<u128, TombstoneEntry, PrehashedBuildHasher> = deleted
+            .into_iter()
+            .map(|(key, delete_seq)| {
+                let key_hash = hash_key_128(&key);
+                bloom.insert(bloom_half(key_hash));
+                (
+                    key_hash,
+                    TombstoneEntry {
+                        delete_seq,
+                        insert_seq: SEQUENCE_ABSENT,
+                    },
+                )
+            })
+            .collect();
         for (key, insert_seq) in insert_records {
             let key_hash = hash_key_128(&key);
             merge_max(
@@ -747,9 +750,11 @@ impl KeyDeletionIndex {
         &self,
         additions: impl IntoIterator<Item = (K, i64)>,
     ) -> Self {
-        self.extend_with(additions.into_iter().map(|(key, delete_seq)| {
-            (hash_key_128(key.as_ref()), delete_seq, SEQUENCE_ABSENT)
-        }))
+        self.extend_with(
+            additions
+                .into_iter()
+                .map(|(key, delete_seq)| (hash_key_128(key.as_ref()), delete_seq, SEQUENCE_ABSENT)),
+        )
     }
 
     /// Build a new index recording an upsert-conflict batch; see
@@ -761,13 +766,10 @@ impl KeyDeletionIndex {
         delete_sequence: i64,
         insert_sequence: i64,
     ) -> Self {
-        self.extend_with(keys.into_iter().map(|key| {
-            (
-                hash_key_128(key.as_ref()),
-                delete_sequence,
-                insert_sequence,
-            )
-        }))
+        self.extend_with(
+            keys.into_iter()
+                .map(|key| (hash_key_128(key.as_ref()), delete_sequence, insert_sequence)),
+        )
     }
 
     /// Shared merge core for the extend methods, operating on pre-hashed key
@@ -783,7 +785,10 @@ impl KeyDeletionIndex {
         // from the iterator's hint to skip Vec growth reallocations.
         let mut new_delete_hashes: Vec<u64> = Vec::with_capacity(additions.size_hint().0);
         for (key_hash, delete_seq, insert_seq) in additions {
-            debug_assert_ne!(delete_seq, SEQUENCE_ABSENT, "real sequences are non-negative");
+            debug_assert_ne!(
+                delete_seq, SEQUENCE_ABSENT,
+                "real sequences are non-negative"
+            );
             let entry = entries.entry(key_hash).or_insert(TombstoneEntry {
                 delete_seq: SEQUENCE_ABSENT,
                 insert_seq: SEQUENCE_ABSENT,
@@ -907,7 +912,11 @@ mod tests {
         assert_eq!(next.len(), 3);
         assert_eq!(next.delete_len(), 3);
         assert_eq!(next.insert_len(), 3);
-        assert_eq!(next.max_sequence_number(), Some(10), "insert seqs must not raise the delete max");
+        assert_eq!(
+            next.max_sequence_number(),
+            Some(10),
+            "insert seqs must not raise the delete max"
+        );
         for pk in [1, 2, 3] {
             let tombstone = next.get(pk).expect("conflict key must have a tombstone");
             assert_eq!(tombstone.delete_sequence, 10);
@@ -947,7 +956,11 @@ mod tests {
         assert!(!idx.has_deletions());
         assert_eq!(idx.max_sequence_number(), None);
         for pk in 0..10 {
-            assert_eq!(idx.get(pk), None, "insert-only pk={pk} must probe as absent");
+            assert_eq!(
+                idx.get(pk),
+                None,
+                "insert-only pk={pk} must probe as absent"
+            );
         }
     }
 
@@ -986,7 +999,11 @@ mod tests {
         assert_eq!(tombstone.delete_sequence, 80);
         assert_eq!(tombstone.insert_sequence, Some(70));
         assert_eq!(next.delete_len(), 1);
-        assert_eq!(next.len(), 1, "delete of an insert-only key must not add an entry");
+        assert_eq!(
+            next.len(),
+            1,
+            "delete of an insert-only key must not add an entry"
+        );
     }
 
     #[test]
@@ -1052,10 +1069,8 @@ mod tests {
         assert_eq!(tombstone.insert_sequence, Some(11));
 
         // Insert-only entries from the catalog load path probe as absent until deleted.
-        let loaded = KeyDeletionIndex::from_maps(
-            HashMap::new(),
-            HashMap::from([(byte_key(9), 90_i64)]),
-        );
+        let loaded =
+            KeyDeletionIndex::from_maps(HashMap::new(), HashMap::from([(byte_key(9), 90_i64)]));
         assert_eq!(loaded.get(&byte_key(9)), None);
         assert!(!loaded.has_deletions());
         let deleted = loaded.extend_max_deletes([(byte_key(9), 95)]);
@@ -1091,10 +1106,7 @@ mod tests {
             Some(0)
         );
         assert_eq!(key_delete_seq_of(&next, &0_u16.to_be_bytes()), Some(0));
-        assert_eq!(
-            key_delete_seq_of(&next, &999_u16.to_be_bytes()),
-            Some(999)
-        );
+        assert_eq!(key_delete_seq_of(&next, &999_u16.to_be_bytes()), Some(999));
     }
 
     #[test]
@@ -1193,7 +1205,11 @@ mod tests {
 
         // Every inserted key probes positive.
         for pk in 0..200 {
-            assert_eq!(delete_seq_of(&idx, pk), Some(1), "missing pk={pk} after rebuilds");
+            assert_eq!(
+                delete_seq_of(&idx, pk),
+                Some(1),
+                "missing pk={pk} after rebuilds"
+            );
         }
     }
 

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -56,7 +56,7 @@ limitations under the License.
 //! for the rebuild policy.
 
 use hash_index::{
-    PrehashedBuildHasher, SplitBlockBloomFilter, XxHash3BuildHasher, hash_key, hash_key_128,
+    PrehashedBuildHasher, SplitBlockBloomFilter, XxHash3BuildHasher, hash_key_128, hash_key_i64,
 };
 use im::HashMap as PersistentHashMap;
 use std::collections::HashMap;
@@ -70,8 +70,8 @@ const MIN_BLOOM_CAPACITY: usize = 64;
 /// (SipHash-1-3), which showed up as `im::nodes::hamt::hash_key` in executor
 /// profiles of changes-mode ingest — every probe was paying a SipHash walk on
 /// top of the seeded-XXH3 bloom hash. [`XxHash3BuildHasher`] uses the same
-/// seeded XXH3-64 as [`hash_key`], so map and bloom hashing now agree at a
-/// fraction of SipHash's per-key cost.
+/// seeded XXH3-64 as [`hash_key_i64`], so map and bloom hashing now agree at
+/// a fraction of SipHash's per-key cost.
 pub type DeletionIndexHasher = XxHash3BuildHasher;
 
 /// Bloom capacity for a deletion set of `len` keys: sized with 2x headroom so the
@@ -255,7 +255,7 @@ impl DeletionIndex {
         let capacity = bloom_capacity_for(deleted.len());
         let bloom = SplitBlockBloomFilter::new(capacity);
         for &pk in deleted.keys() {
-            bloom.insert(hash_key(&pk));
+            bloom.insert(hash_key_i64(pk));
         }
         let max_sequence_number = deleted.values().copied().max();
         let delete_count = deleted.len();
@@ -356,7 +356,7 @@ impl DeletionIndex {
     #[inline]
     #[must_use]
     pub fn might_contain(&self, pk: i64) -> bool {
-        self.bloom.might_contain(hash_key(&pk))
+        self.bloom.might_contain(hash_key_i64(pk))
     }
 
     /// Bloom-prefiltered lookup. Returns the key's [`Tombstone`] if `pk` has a
@@ -369,7 +369,7 @@ impl DeletionIndex {
     #[inline]
     #[must_use]
     pub fn get(&self, pk: i64) -> Option<Tombstone> {
-        if !self.bloom.might_contain(hash_key(&pk)) {
+        if !self.bloom.might_contain(hash_key_i64(pk)) {
             return None;
         }
         self.entries.get(&pk).and_then(Tombstone::from_entry)
@@ -486,7 +486,7 @@ impl DeletionIndex {
             let bloom = SplitBlockBloomFilter::new(new_capacity);
             for (pk, entry) in &entries {
                 if entry.delete_seq != SEQUENCE_ABSENT {
-                    bloom.insert(hash_key(pk));
+                    bloom.insert(hash_key_i64(*pk));
                 }
             }
             return Self {
@@ -502,7 +502,7 @@ impl DeletionIndex {
         // Common path: insert only the newly-deleted keys into the shared
         // filter (O(K) relaxed atomic stores; see the safety argument above).
         for pk in &new_delete_keys {
-            self.bloom.insert(hash_key(pk));
+            self.bloom.insert(hash_key_i64(*pk));
         }
         Self {
             entries,

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -17,23 +17,47 @@ limitations under the License.
 //! Immutable deletion index with bloom-filter prefilter.
 //!
 //! [`DeletionIndex`] (Int64 PK) and [`KeyDeletionIndex`] (composite-key PK) are the
-//! frozen snapshots that scans probe at query time. They hold a persistent
-//! [`im::HashMap`] plus a [`BloomFilter`] sized for the deletion set, and expose only
-//! read-only methods: a probe goes through the bloom filter first, and falls through to
-//! the hash map only on a possible hit.
+//! frozen snapshots that scans probe at query time. Each entry fuses the two
+//! sequence numbers visibility needs — the highest *delete* sequence and, for keys
+//! re-inserted by an upsert, the highest *insert* sequence — into one
+//! [`TombstoneEntry`], so the scan hot path answers "is this row deleted, and was
+//! it re-inserted after that?" with a **single** map probe. (These were previously
+//! two separate indexes, costing two bloom checks and two HAMT walks per deleted
+//! row — the dominant per-row cost in changes-mode profiles.)
+//!
+//! The index holds a persistent [`im::HashMap`] plus a [`SplitBlockBloomFilter`]
+//! keyed on *deletion* membership (a single cache line per probe): a probe goes
+//! through the bloom filter first, and falls through to the hash map only on a
+//! possible hit. Entries holding only an insert record (which occur after
+//! compaction purges delete files while insert records remain in the catalog) are
+//! not represented in the bloom and are reported as absent by [`get`] — exactly
+//! the visibility semantics of the previous two-index design.
+//!
+//! [`get`]: DeletionIndex::get
 //!
 //! # Build then publish
 //!
-//! All mutation happens before the index is wrapped in an `Arc`/`ArcSwap`. Construct
-//! via [`DeletionIndex::from_map`] / [`DeletionIndex::empty`] (and the matching
-//! [`KeyDeletionIndex`] constructors), publish through `ArcSwap`, and treat the
-//! published index as immutable. To apply a write, build a new index with
-//! [`DeletionIndex::extend_max`] (or [`KeyDeletionIndex::extend_max`]) and store the
+//! All map mutation happens before the index is wrapped in an `Arc`/`ArcSwap`.
+//! Construct via [`DeletionIndex::from_maps`] / [`DeletionIndex::empty`] (and the
+//! matching [`KeyDeletionIndex`] constructors), publish through `ArcSwap`, and treat
+//! the published index as immutable. To apply a write, build a new index with
+//! [`extend_max_deletes`](DeletionIndex::extend_max_deletes) (delete-only writes) or
+//! [`extend_max_conflicts`](DeletionIndex::extend_max_conflicts) (upsert conflicts,
+//! which record a delete and a re-insert in one pass) and store the
 //! `Arc<DeletionIndex>` back into the swap cell. Readers always see a fully-built
 //! snapshot and never block.
+//!
+//! The bloom filter is the one deliberate exception to "frozen": it is shared
+//! across generations behind an `Arc` and extended in place with relaxed atomic
+//! stores. Older pinned generations may observe bits for keys added after they
+//! were published — a safe superset that can only add false positives (caught by
+//! the map probe), never false negatives. See [`SplitBlockBloomFilter`] for the
+//! memory-ordering contract and [`extend_max_deletes`](DeletionIndex::extend_max_deletes)
+//! for the rebuild policy.
 
-use bytes::Bytes;
-use hash_index::{BloomFilter, hash_key};
+use hash_index::{
+    PrehashedBuildHasher, SplitBlockBloomFilter, XxHash3BuildHasher, hash_key, hash_key_128,
+};
 use im::HashMap as PersistentHashMap;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
@@ -42,29 +66,145 @@ use std::sync::{Arc, LazyLock};
 /// "probably-not-present" path stays useful when a fresh index is constructed.
 const MIN_BLOOM_CAPACITY: usize = 64;
 
+/// Hasher for the persistent HAMT. `im::HashMap` defaults to `RandomState`
+/// (SipHash-1-3), which showed up as `im::nodes::hamt::hash_key` in executor
+/// profiles of changes-mode ingest — every probe was paying a SipHash walk on
+/// top of the seeded-XXH3 bloom hash. [`XxHash3BuildHasher`] uses the same
+/// seeded XXH3-64 as [`hash_key`], so map and bloom hashing now agree at a
+/// fraction of SipHash's per-key cost.
+pub type DeletionIndexHasher = XxHash3BuildHasher;
+
+/// Bloom capacity for a deletion set of `len` keys: sized with 2x headroom so the
+/// filter stays at or below its design false-positive rate for the whole window
+/// between rebuilds. The previous policy sized the filter exactly and rebuilt
+/// only when the entry count crossed `2x` capacity, which let the effective
+/// bits-per-key halve before each rebuild — at millions of deletions the filter
+/// spent long windows saturated, sending most not-deleted probes through to the
+/// hash map.
+fn bloom_capacity_for(len: usize) -> usize {
+    len.saturating_mul(2).max(MIN_BLOOM_CAPACITY)
+}
+
+/// Sentinel for "no sequence recorded" inside [`TombstoneEntry`]. Catalog
+/// sequence numbers are non-negative, so `i64::MIN` can never collide with a
+/// real sequence; packing both fields as raw `i64` keeps the per-entry payload
+/// at 16 bytes (an `Option<i64>` pair would double it — at tens of millions of
+/// entries that is hundreds of MiB).
+const SEQUENCE_ABSENT: i64 = i64::MIN;
+
+/// Raw fused map value: the highest delete and insert sequence numbers recorded
+/// for one primary key, with [`SEQUENCE_ABSENT`] marking an unset side. Exposed
+/// (read-only) so callers iterating [`entries`](DeletionIndex::entries) can
+/// project the side they need.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TombstoneEntry {
+    delete_seq: i64,
+    insert_seq: i64,
+}
+
+impl TombstoneEntry {
+    /// Highest delete sequence recorded for this key, if any.
+    #[inline]
+    #[must_use]
+    pub fn delete_sequence(&self) -> Option<i64> {
+        (self.delete_seq != SEQUENCE_ABSENT).then_some(self.delete_seq)
+    }
+
+    /// Highest insert (upsert re-insertion) sequence recorded for this key, if any.
+    #[inline]
+    #[must_use]
+    pub fn insert_sequence(&self) -> Option<i64> {
+        (self.insert_seq != SEQUENCE_ABSENT).then_some(self.insert_seq)
+    }
+}
+
+/// Deletion state returned by a successful probe: the key **has** a recorded
+/// deletion, plus the re-insertion sequence if an upsert wrote the key back.
+///
+/// Visibility under upsert semantics: the row is visible iff
+/// `insert_sequence > delete_sequence` (re-inserted after the delete).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Tombstone {
+    /// Highest delete sequence recorded for the key.
+    pub delete_sequence: i64,
+    /// Highest insert (upsert re-insertion) sequence for the key, if any.
+    pub insert_sequence: Option<i64>,
+}
+
+impl Tombstone {
+    #[inline]
+    fn from_entry(entry: &TombstoneEntry) -> Option<Self> {
+        entry.delete_sequence().map(|delete_sequence| Self {
+            delete_sequence,
+            insert_sequence: entry.insert_sequence(),
+        })
+    }
+}
+
+/// Outcome of merging one addition into the fused map: which sides newly
+/// transitioned from absent to present. Drives the bloom update (delete side
+/// only) and the `delete_len`/`insert_len` counters.
+#[derive(Clone, Copy, Default)]
+struct MergeTransitions {
+    new_delete: bool,
+    new_insert: bool,
+}
+
+/// Merge `delete_seq`/`insert_seq` (either possibly [`SEQUENCE_ABSENT`]) into
+/// `entry`, taking the per-side max, and report absent→present transitions.
+#[inline]
+fn merge_max(entry: &mut TombstoneEntry, delete_seq: i64, insert_seq: i64) -> MergeTransitions {
+    let mut transitions = MergeTransitions::default();
+    if delete_seq != SEQUENCE_ABSENT {
+        if entry.delete_seq == SEQUENCE_ABSENT {
+            transitions.new_delete = true;
+            entry.delete_seq = delete_seq;
+        } else if delete_seq > entry.delete_seq {
+            entry.delete_seq = delete_seq;
+        }
+    }
+    if insert_seq != SEQUENCE_ABSENT {
+        if entry.insert_seq == SEQUENCE_ABSENT {
+            transitions.new_insert = true;
+            entry.insert_seq = insert_seq;
+        } else if insert_seq > entry.insert_seq {
+            entry.insert_seq = insert_seq;
+        }
+    }
+    transitions
+}
+
 /// Frozen deletion index for tables with a single-column Int64 primary key.
 ///
-/// Holds the (pk → `delete_sequence`) map and an accompanying bloom filter. The bloom
-/// filter's bit array is sized for `bloom_capacity` items; the writer tracks that
-/// capacity so `extend_max` can update the bloom incrementally for the common case
-/// where the index grows slowly, only paying a full O(N) rebuild when the entry count
-/// crosses the next doubling boundary. This keeps amortized writer cost at O(K) per
+/// Holds the fused (pk → [`TombstoneEntry`]) map and an accompanying bloom filter
+/// keyed on deletion membership. The bloom filter's bit array is sized for
+/// `bloom_capacity` deletion keys; the writer tracks that capacity so the extend
+/// methods can update the shared bloom in place for the common case where the
+/// index grows slowly, only paying a full O(N) rebuild when the deletion count
+/// outgrows the sized capacity. This keeps amortized writer cost at O(K) per
 /// call (K = number of additions) instead of the O(N) it would otherwise be — see
-/// [`extend_max`](Self::extend_max) for the full argument.
+/// [`extend_max_deletes`](Self::extend_max_deletes) for the full argument.
 #[derive(Debug, Clone)]
 pub struct DeletionIndex {
-    entries: PersistentHashMap<i64, i64>,
-    bloom: BloomFilter,
-    /// Monotonic upper bound for the current immutable entries. This stays
-    /// exact because indexes are build-once / extend-only; any future removal
-    /// API must recompute it instead of carrying a stale high-water mark.
+    entries: PersistentHashMap<i64, TombstoneEntry, DeletionIndexHasher>,
+    bloom: Arc<SplitBlockBloomFilter>,
+    /// Monotonic upper bound over the **delete** sequences in the current
+    /// immutable entries. This stays exact because indexes are build-once /
+    /// extend-only; any future removal API must recompute it instead of
+    /// carrying a stale high-water mark.
     /// `CayenneTableProvider::apply_partial_deletion_filter` relies on this
     /// exact value to decide whether a protected snapshot can skip deletion
     /// filtering without letting deleted rows through.
     max_sequence_number: Option<i64>,
-    /// Item count the current `bloom` was sized for. When `entries.len()` exceeds
-    /// `2 * bloom_capacity`, `extend_max` rebuilds the bloom from scratch to keep the
-    /// false-positive rate bounded; otherwise it inserts incrementally.
+    /// Number of entries with a recorded deletion (= bloom population).
+    delete_count: usize,
+    /// Number of entries with a recorded insert (upsert re-insertion).
+    insert_count: usize,
+    /// Deletion-key count the current `bloom` was sized for
+    /// ([`bloom_capacity_for`]: 2x the deletion count at build time). When
+    /// `delete_count` exceeds it, the extend methods rebuild the bloom from
+    /// scratch into a fresh `Arc`; otherwise they insert newly-deleted keys
+    /// into the shared filter in place.
     bloom_capacity: usize,
 }
 
@@ -76,13 +216,15 @@ impl Default for DeletionIndex {
 
 impl DeletionIndex {
     /// An empty deletion index. Probes always miss; bloom filter still allocated at the
-    /// minimum capacity so size-0 indexes don't degrade once `extend_max` is called.
+    /// minimum capacity so size-0 indexes don't degrade once the index is extended.
     #[must_use]
     pub fn empty() -> Self {
         Self {
-            entries: PersistentHashMap::new(),
-            bloom: BloomFilter::new(MIN_BLOOM_CAPACITY),
+            entries: PersistentHashMap::default(),
+            bloom: Arc::new(SplitBlockBloomFilter::new(MIN_BLOOM_CAPACITY)),
             max_sequence_number: None,
+            delete_count: 0,
+            insert_count: 0,
             bloom_capacity: MIN_BLOOM_CAPACITY,
         }
     }
@@ -98,195 +240,320 @@ impl DeletionIndex {
         Arc::clone(&EMPTY)
     }
 
-    /// Build a frozen index from an owned `HashMap` of `pk -> delete_sequence`.
+    /// Build a frozen index from an owned `HashMap` of `pk -> delete_sequence`
+    /// with no insert records.
     #[must_use]
-    pub fn from_map(entries: HashMap<i64, i64>) -> Self {
-        let capacity = entries.len().max(MIN_BLOOM_CAPACITY);
-        let mut bloom = BloomFilter::new(capacity);
-        for &pk in entries.keys() {
+    pub fn from_map(deleted: HashMap<i64, i64>) -> Self {
+        Self::from_maps(deleted, HashMap::new())
+    }
+
+    /// Build a frozen index from `pk -> delete_sequence` plus
+    /// `pk -> insert_sequence` maps (the catalog load path persists the two
+    /// sides separately).
+    #[must_use]
+    pub fn from_maps(deleted: HashMap<i64, i64>, insert_records: HashMap<i64, i64>) -> Self {
+        let capacity = bloom_capacity_for(deleted.len());
+        let bloom = SplitBlockBloomFilter::new(capacity);
+        for &pk in deleted.keys() {
             bloom.insert(hash_key(&pk));
         }
-        let max_sequence_number = entries.values().copied().max();
+        let max_sequence_number = deleted.values().copied().max();
+        let delete_count = deleted.len();
+        let insert_count = insert_records.len();
+
+        let mut entries: PersistentHashMap<i64, TombstoneEntry, DeletionIndexHasher> =
+            deleted
+                .into_iter()
+                .map(|(pk, delete_seq)| {
+                    (
+                        pk,
+                        TombstoneEntry {
+                            delete_seq,
+                            insert_seq: SEQUENCE_ABSENT,
+                        },
+                    )
+                })
+                .collect();
+        for (pk, insert_seq) in insert_records {
+            merge_max(
+                entries.entry(pk).or_insert(TombstoneEntry {
+                    delete_seq: SEQUENCE_ABSENT,
+                    insert_seq: SEQUENCE_ABSENT,
+                }),
+                SEQUENCE_ABSENT,
+                insert_seq,
+            );
+        }
+
         Self {
-            entries: entries.into_iter().collect(),
-            bloom,
+            entries,
+            bloom: Arc::new(bloom),
             max_sequence_number,
+            delete_count,
+            insert_count,
             bloom_capacity: capacity,
         }
     }
 
-    /// Build a frozen index from an `Arc<HashMap>` (clones the map).
+    /// Build a frozen index from an `Arc<HashMap>` of deletions (clones the map).
     #[must_use]
     pub fn from_arc_map(map: &Arc<HashMap<i64, i64>>) -> Self {
         Self::from_map((**map).clone())
     }
 
-    /// Number of deletion entries in the index.
+    /// Total number of fused entries (keys with a deletion, an insert record,
+    /// or both).
     #[must_use]
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
-    /// Whether the index has any deletions.
+    /// Whether the index has no entries at all.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 
-    /// Approximate resident bytes for memory accounting: each `i64 -> i64` entry
-    /// includes the key/value payload plus HAMT node/bitmap/Arc overhead. Shared
-    /// nodes retained by older reader-pinned generations are intentionally not
-    /// charged to the latest snapshot again.
+    /// Number of keys with a recorded deletion.
+    #[must_use]
+    pub fn delete_len(&self) -> usize {
+        self.delete_count
+    }
+
+    /// Number of keys with a recorded insert (upsert re-insertion).
+    #[must_use]
+    pub fn insert_len(&self) -> usize {
+        self.insert_count
+    }
+
+    /// Whether any key has a recorded deletion. Scan fast paths skip the
+    /// filter entirely when this is `false` (insert-only entries never affect
+    /// visibility).
+    #[must_use]
+    pub fn has_deletions(&self) -> bool {
+        self.delete_count > 0
+    }
+
+    /// Approximate resident bytes for memory accounting: each `i64 ->
+    /// (i64, i64)` entry includes the key/value payload plus HAMT
+    /// node/bitmap/Arc overhead. Shared nodes retained by older reader-pinned
+    /// generations are intentionally not charged to the latest snapshot again.
     #[must_use]
     pub fn approx_bytes(&self) -> usize {
-        const APPROX_I64_ENTRY_BYTES: usize = 72;
+        const APPROX_I64_ENTRY_BYTES: usize = 80;
         self.entries.len().saturating_mul(APPROX_I64_ENTRY_BYTES)
     }
 
-    /// Highest delete sequence number in this index, if any.
+    /// Highest **delete** sequence number in this index, if any.
     #[must_use]
     pub fn max_sequence_number(&self) -> Option<i64> {
         self.max_sequence_number
     }
 
-    /// Bloom-filter check. Returns `false` if the key is definitely not in the index;
-    /// `true` if it might be (and a [`get`](Self::get) is required to confirm).
+    /// Bloom-filter check against deletion membership. Returns `false` if the key
+    /// definitely has no recorded deletion; `true` if it might (and a
+    /// [`get`](Self::get) is required to confirm).
     #[inline]
     #[must_use]
     pub fn might_contain(&self, pk: i64) -> bool {
         self.bloom.might_contain(hash_key(&pk))
     }
 
-    /// Bloom-prefiltered lookup. Returns the delete sequence number if `pk` is in the
-    /// index, `None` otherwise.
+    /// Bloom-prefiltered lookup. Returns the key's [`Tombstone`] if `pk` has a
+    /// recorded deletion, `None` otherwise.
+    ///
+    /// Keys holding only an insert record are reported as `None`: the bloom is
+    /// keyed on deletion membership, and visibility treats "no deletion" and
+    /// "insert-only" identically. One probe answers both the deletion and the
+    /// re-insertion question — previously two separate index walks.
     #[inline]
     #[must_use]
-    pub fn get(&self, pk: i64) -> Option<i64> {
+    pub fn get(&self, pk: i64) -> Option<Tombstone> {
         if !self.bloom.might_contain(hash_key(&pk)) {
             return None;
         }
-        self.entries.get(&pk).copied()
+        self.entries.get(&pk).and_then(Tombstone::from_entry)
     }
 
-    /// Direct read-only access to the underlying entries (for callers that need to
-    /// rebuild a filtered index, e.g. partial-deletion filters).
+    /// Direct read-only access to the underlying fused entries (for callers
+    /// that need to iterate, e.g. benches; project sides via
+    /// [`TombstoneEntry::delete_sequence`] / [`TombstoneEntry::insert_sequence`]).
     #[must_use]
-    pub fn entries(&self) -> &PersistentHashMap<i64, i64> {
+    pub fn entries(&self) -> &PersistentHashMap<i64, TombstoneEntry, DeletionIndexHasher> {
         &self.entries
     }
 
-    /// Build a new index from `self`'s entries plus `additions`, taking the max sequence
-    /// number on conflict. Used by writers to publish a new snapshot via `ArcSwap::store`.
+    /// Build a new index from `self`'s entries plus delete-only `additions`
+    /// (`pk -> delete_sequence`), taking the per-key max sequence on conflict.
+    /// Used by writers to publish a new snapshot via `ArcSwap::store`.
     ///
     /// # Performance
     ///
     /// `entries` is a persistent HAMT, so cloning the current map for a write
     /// shares unchanged nodes with any reader-pinned generation. Inserts update
     /// only the path to the touched key (O(log N)) instead of cloning every
-    /// entry. The bloom filter is updated incrementally (O(K) inserts for K new
-    /// keys) instead of being rebuilt from scratch every call. A full O(N)
-    /// rebuild only happens when the entry count crosses `2 * bloom_capacity`,
-    /// giving amortized O(K) bloom cost per call.
+    /// entry. The bloom filter is *shared* with the parent index behind an
+    /// `Arc`: keys gaining their first deletion are inserted into it in place
+    /// (relaxed atomic stores, O(K), no copy of the bit array — at millions of
+    /// entries a per-call copy would be a multi-megabyte memcpy on every CDC
+    /// batch). A full O(N) rebuild into a fresh filter only happens when the
+    /// deletion count outgrows the capacity the filter was sized for — 2x the
+    /// deletion count at build time ([`bloom_capacity_for`]) — so the rebuild
+    /// cadence is geometric and the amortized bloom cost stays O(K) per call.
+    ///
+    /// Sharing the filter means older pinned generations observe bits for keys
+    /// added after they were published. That is a safe superset: extra bits can
+    /// only add false positives (caught by the map probe), never false
+    /// negatives. Writers are serialized by the per-table write lock, which
+    /// keeps the `bloom_capacity` bookkeeping consistent across generations.
     ///
     /// **Why this matters**: a previous revision rebuilt the bloom from scratch on
-    /// every `extend_max` call, which is the dominant cost (10K entries ≈ 10K hash
+    /// every extend call, which is the dominant cost (10K entries ≈ 10K hash
     /// ops ≈ ~1 ms per call before any map update work is counted).
     /// On high-rate upsert/delete workloads (each producing a small `additions`
     /// batch but operating on a deletion cache that grows over time), the wasted
     /// bloom rebuild work compounds — and is the root cause of the ingestion
     /// regression that prompted this fix.
     #[must_use]
-    pub fn extend_max(&self, additions: impl IntoIterator<Item = (i64, i64)>) -> Self {
+    pub fn extend_max_deletes(&self, additions: impl IntoIterator<Item = (i64, i64)>) -> Self {
+        self.extend_with(additions.into_iter().map(|(pk, delete_seq)| {
+            (pk, delete_seq, SEQUENCE_ABSENT)
+        }))
+    }
+
+    /// Build a new index recording an upsert-conflict batch: every key in
+    /// `keys` gains a deletion at `delete_sequence` **and** a re-insertion at
+    /// `insert_sequence`, each merged with per-key max. One pass over the map
+    /// replaces the previous two-index double `extend_max`.
+    #[must_use]
+    pub fn extend_max_conflicts(
+        &self,
+        keys: impl IntoIterator<Item = i64>,
+        delete_sequence: i64,
+        insert_sequence: i64,
+    ) -> Self {
+        self.extend_with(
+            keys.into_iter()
+                .map(|pk| (pk, delete_sequence, insert_sequence)),
+        )
+    }
+
+    /// Shared merge core for the extend methods. `delete_seq`/`insert_seq` use
+    /// [`SEQUENCE_ABSENT`] for "leave this side unchanged".
+    fn extend_with(&self, additions: impl Iterator<Item = (i64, i64, i64)>) -> Self {
         let mut entries = self.entries.clone();
         let mut max_sequence_number = self.max_sequence_number;
-        let additions = additions.into_iter();
-        // Track newly-inserted keys so the bloom can be updated incrementally
-        // without re-iterating the entire entry set. Pre-size from the
-        // iterator's hint to skip Vec growth reallocations.
-        let mut new_keys: Vec<i64> = Vec::with_capacity(additions.size_hint().0);
-        for (pk, seq) in additions {
-            // Use explicit `Entry::Occupied` / `Entry::Vacant` matching so the bloom-update path only sees newly-inserted keys; the Occupied
-            // branch must not push to `new_keys`, otherwise repeat updates of existing keys would re-insert their hashes and bloat the bloom.
-            let stored_sequence = match entries.entry(pk) {
-                im::hashmap::Entry::Occupied(mut occ) => {
-                    let existing = *occ.get();
-                    if seq > existing {
-                        occ.insert(seq);
-                        seq
-                    } else {
-                        existing
-                    }
-                }
-                im::hashmap::Entry::Vacant(vac) => {
-                    vac.insert(seq);
-                    new_keys.push(pk);
-                    seq
-                }
-            };
-            if max_sequence_number.is_none_or(|max| stored_sequence > max) {
-                max_sequence_number = Some(stored_sequence);
+        let mut delete_count = self.delete_count;
+        let mut insert_count = self.insert_count;
+        // Track keys gaining their first deletion so the bloom can be updated
+        // incrementally without re-iterating the entire entry set. Pre-size
+        // from the iterator's hint to skip Vec growth reallocations.
+        let mut new_delete_keys: Vec<i64> = Vec::with_capacity(additions.size_hint().0);
+        for (pk, delete_seq, insert_seq) in additions {
+            debug_assert_ne!(delete_seq, SEQUENCE_ABSENT, "real sequences are non-negative");
+            let entry = entries.entry(pk).or_insert(TombstoneEntry {
+                delete_seq: SEQUENCE_ABSENT,
+                insert_seq: SEQUENCE_ABSENT,
+            });
+            let transitions = merge_max(entry, delete_seq, insert_seq);
+            let stored_delete = entry.delete_seq;
+            if transitions.new_delete {
+                delete_count += 1;
+                new_delete_keys.push(pk);
+            }
+            if transitions.new_insert {
+                insert_count += 1;
+            }
+            if stored_delete != SEQUENCE_ABSENT
+                && max_sequence_number.is_none_or(|max| stored_delete > max)
+            {
+                max_sequence_number = Some(stored_delete);
             }
         }
 
-        let new_len = entries.len();
-        // `max_sequence_number` is maintained incrementally above; the inline
-        // `is_none_or` check covers every mutation site, so we do not
-        // re-scan `entries` here (a full scan would make `extend_max` O(N)
-        // in debug builds and noticeably slow the test suite as the index
-        // grows). `from_map` is the single rebuild path and recomputes the
-        // exact max from scratch.
-        // Rebuild from scratch when growth has outpaced bloom capacity by 2×.
-        // The doubling threshold keeps amortized cost at O(K) per call:
-        // between rebuilds we pay O(K) for incremental inserts; on a rebuild
-        // we pay O(N), but at the next rebuild N has doubled again, so the
-        // total work across one doubling cycle is geometric and amortizes
-        // to O(N).
-        if new_len > self.bloom_capacity.saturating_mul(2) {
-            let new_capacity = new_len.max(MIN_BLOOM_CAPACITY);
-            let mut bloom = BloomFilter::new(new_capacity);
-            for &pk in entries.keys() {
-                bloom.insert(hash_key(&pk));
+        // `max_sequence_number` is maintained incrementally above; we do not
+        // re-scan `entries` here (a full scan would make extends O(N) in debug
+        // builds and noticeably slow the test suite as the index grows).
+        // `from_maps` is the single rebuild path and recomputes the exact max
+        // from scratch.
+        // Rebuild from scratch when deletion growth has outpaced the sized
+        // capacity. The new filter takes 2x headroom, so the rebuild cadence
+        // is geometric: between rebuilds we pay O(K) for in-place inserts; on
+        // a rebuild we pay O(N), but the next rebuild is another doubling
+        // away, so the total work across one doubling cycle amortizes to O(N).
+        if delete_count > self.bloom_capacity {
+            let new_capacity = bloom_capacity_for(delete_count);
+            let bloom = SplitBlockBloomFilter::new(new_capacity);
+            for (pk, entry) in &entries {
+                if entry.delete_seq != SEQUENCE_ABSENT {
+                    bloom.insert(hash_key(pk));
+                }
             }
             return Self {
                 entries,
-                bloom,
+                bloom: Arc::new(bloom),
                 max_sequence_number,
+                delete_count,
+                insert_count,
                 bloom_capacity: new_capacity,
             };
         }
 
-        // Common path: clone the existing bloom (cheap — Vec<u64> memcpy of a
-        // few KB) and insert only the new keys. O(K) work for K new keys.
-        let mut bloom = self.bloom.clone();
-        for pk in &new_keys {
-            bloom.insert(hash_key(pk));
+        // Common path: insert only the newly-deleted keys into the shared
+        // filter (O(K) relaxed atomic stores; see the safety argument above).
+        for pk in &new_delete_keys {
+            self.bloom.insert(hash_key(pk));
         }
         Self {
             entries,
-            bloom,
+            bloom: Arc::clone(&self.bloom),
             max_sequence_number,
+            delete_count,
+            insert_count,
             bloom_capacity: self.bloom_capacity,
         }
     }
 }
 
-/// Frozen deletion index for tables with a composite or non-integer primary key. Keys
-/// are the byte-encoded form produced by `arrow_row::RowConverter`.
+/// Splits a 128-bit key hash into its map identity and the (independent)
+/// 64 bits fed to the bloom filter. Using disjoint halves keeps the bloom's
+/// block/bit selection uncorrelated with the map's bucket selection (the map
+/// consumes the low half via [`PrehashedBuildHasher`]).
+#[inline]
+fn bloom_half(hash: u128) -> u64 {
+    (hash >> 64) as u64
+}
+
+/// Frozen deletion index for tables with a composite or non-integer primary key.
+/// Probe keys are the byte-encoded form produced by `arrow_row::RowConverter`.
 ///
-/// See [`DeletionIndex`] for the bloom-capacity / incremental-rebuild contract;
-/// `KeyDeletionIndex` applies the same strategy to byte-keyed entries.
+/// Entries are keyed by the **seeded XXH3-128 hash of the key bytes**
+/// ([`hash_key_128`]) rather than the bytes themselves: the hash is the key's
+/// identity and the bytes are not retained. This fixes the per-entry footprint
+/// at 32 bytes regardless of composite-key width, removes byte comparisons
+/// from probes, and (via [`PrehashedBuildHasher`]) lets the map reuse the
+/// hash's own entropy instead of re-hashing per probe — one hash computation
+/// serves the bloom filter and the map together.
+///
+/// Two distinct keys colliding under XXH3-128 would share a tombstone; at one
+/// billion keys the birthday bound puts that below ~1e-20 — orders of
+/// magnitude under hardware error rates. (A 64-bit hash would NOT be safe as
+/// identity at these cardinalities: ~0.3% collision odds at the same scale.)
+///
+/// See [`DeletionIndex`] for the fused-entry, bloom-capacity, and shared-filter
+/// contracts.
 #[derive(Debug, Clone)]
 pub struct KeyDeletionIndex {
-    entries: PersistentHashMap<Bytes, i64>,
-    bloom: BloomFilter,
-    /// Monotonic upper bound for the current immutable entries. This stays
-    /// exact because indexes are build-once / extend-only; any future removal
-    /// API must recompute it instead of carrying a stale high-water mark.
-    /// `CayenneTableProvider::apply_partial_deletion_filter` relies on this
-    /// exact value to decide whether a protected snapshot can skip deletion
-    /// filtering without letting deleted rows through.
+    entries: PersistentHashMap<u128, TombstoneEntry, PrehashedBuildHasher>,
+    bloom: Arc<SplitBlockBloomFilter>,
+    /// Monotonic upper bound over the **delete** sequences in the current
+    /// immutable entries. See [`DeletionIndex::max_sequence_number`].
     max_sequence_number: Option<i64>,
-    /// Item count the current `bloom` was sized for. Mirrors
+    /// Number of entries with a recorded deletion (= bloom population).
+    delete_count: usize,
+    /// Number of entries with a recorded insert (upsert re-insertion).
+    insert_count: usize,
+    /// Deletion-key count the current `bloom` was sized for. Mirrors
     /// [`DeletionIndex::bloom_capacity`] to amortize bloom rebuilds.
     bloom_capacity: usize,
 }
@@ -302,9 +569,11 @@ impl KeyDeletionIndex {
     #[must_use]
     pub fn empty() -> Self {
         Self {
-            entries: PersistentHashMap::new(),
-            bloom: BloomFilter::new(MIN_BLOOM_CAPACITY),
+            entries: PersistentHashMap::default(),
+            bloom: Arc::new(SplitBlockBloomFilter::new(MIN_BLOOM_CAPACITY)),
             max_sequence_number: None,
+            delete_count: 0,
+            insert_count: 0,
             bloom_capacity: MIN_BLOOM_CAPACITY,
         }
     }
@@ -318,146 +587,253 @@ impl KeyDeletionIndex {
         Arc::clone(&EMPTY)
     }
 
-    /// Build a frozen index from an owned `HashMap` of `pk_bytes -> delete_sequence`.
+    /// Build a frozen index from an owned `HashMap` of `pk_bytes ->
+    /// delete_sequence` with no insert records.
     #[must_use]
-    pub fn from_map(entries: HashMap<Box<[u8]>, i64>) -> Self {
-        let capacity = entries.len().max(MIN_BLOOM_CAPACITY);
-        let mut bloom = BloomFilter::new(capacity);
-        for key in entries.keys() {
-            bloom.insert(hash_key(&key.as_ref()));
-        }
-        let max_sequence_number = entries.values().copied().max();
-        Self {
-            entries: entries
+    pub fn from_map(deleted: HashMap<Box<[u8]>, i64>) -> Self {
+        Self::from_maps(deleted, HashMap::new())
+    }
+
+    /// Build a frozen index from `pk_bytes -> delete_sequence` plus
+    /// `pk_bytes -> insert_sequence` maps (the catalog load path persists the
+    /// two sides separately).
+    #[must_use]
+    pub fn from_maps(
+        deleted: HashMap<Box<[u8]>, i64>,
+        insert_records: HashMap<Box<[u8]>, i64>,
+    ) -> Self {
+        let capacity = bloom_capacity_for(deleted.len());
+        let bloom = SplitBlockBloomFilter::new(capacity);
+        let max_sequence_number = deleted.values().copied().max();
+        let delete_count = deleted.len();
+        let insert_count = insert_records.len();
+
+        let mut entries: PersistentHashMap<u128, TombstoneEntry, PrehashedBuildHasher> =
+            deleted
                 .into_iter()
-                .map(|(key, sequence)| (Bytes::from(key), sequence))
-                .collect(),
-            bloom,
+                .map(|(key, delete_seq)| {
+                    let key_hash = hash_key_128(&key);
+                    bloom.insert(bloom_half(key_hash));
+                    (
+                        key_hash,
+                        TombstoneEntry {
+                            delete_seq,
+                            insert_seq: SEQUENCE_ABSENT,
+                        },
+                    )
+                })
+                .collect();
+        for (key, insert_seq) in insert_records {
+            let key_hash = hash_key_128(&key);
+            merge_max(
+                entries.entry(key_hash).or_insert(TombstoneEntry {
+                    delete_seq: SEQUENCE_ABSENT,
+                    insert_seq: SEQUENCE_ABSENT,
+                }),
+                SEQUENCE_ABSENT,
+                insert_seq,
+            );
+        }
+
+        Self {
+            entries,
+            bloom: Arc::new(bloom),
             max_sequence_number,
+            delete_count,
+            insert_count,
             bloom_capacity: capacity,
         }
     }
 
-    /// Build a frozen index from an `Arc<HashMap>` (clones the map).
+    /// Build a frozen index from an `Arc<HashMap>` of deletions (clones the map).
     #[must_use]
     pub fn from_arc_map(map: &Arc<HashMap<Box<[u8]>, i64>>) -> Self {
         Self::from_map((**map).clone())
     }
 
-    /// Number of deletion entries.
+    /// Total number of fused entries (keys with a deletion, an insert record,
+    /// or both).
     #[must_use]
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
-    /// Approximate resident bytes for memory accounting. Uses a per-entry
-    /// estimate (a typical row-encoded composite key plus the `Box`, value, and
-    /// HAMT node overhead) rather than summing every key length, so the call stays
-    /// O(1) on the hot CDC path instead of O(total deletions). Shared nodes
-    /// retained by older reader-pinned generations are intentionally not charged
-    /// to the latest snapshot again.
+    /// Number of keys with a recorded deletion.
+    #[must_use]
+    pub fn delete_len(&self) -> usize {
+        self.delete_count
+    }
+
+    /// Number of keys with a recorded insert (upsert re-insertion).
+    #[must_use]
+    pub fn insert_len(&self) -> usize {
+        self.insert_count
+    }
+
+    /// Whether any key has a recorded deletion. See
+    /// [`DeletionIndex::has_deletions`].
+    #[must_use]
+    pub fn has_deletions(&self) -> bool {
+        self.delete_count > 0
+    }
+
+    /// Approximate resident bytes for memory accounting: each `u128 ->
+    /// (i64, i64)` entry is a fixed 32-byte payload plus HAMT node/bitmap/Arc
+    /// overhead — key bytes are not retained (hash-keyed identity), so the
+    /// estimate no longer depends on composite-key width. Shared nodes
+    /// retained by older reader-pinned generations are intentionally not
+    /// charged to the latest snapshot again.
     #[must_use]
     pub fn approx_bytes(&self) -> usize {
-        const APPROX_KEY_ENTRY_BYTES: usize = 112;
+        const APPROX_KEY_ENTRY_BYTES: usize = 88;
         self.entries.len().saturating_mul(APPROX_KEY_ENTRY_BYTES)
     }
 
-    /// Whether the index has any deletions.
+    /// Whether the index has no entries at all.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 
-    /// Highest delete sequence number in this index, if any.
+    /// Highest **delete** sequence number in this index, if any.
     #[must_use]
     pub fn max_sequence_number(&self) -> Option<i64> {
         self.max_sequence_number
     }
 
-    /// Bloom-filter check; see [`DeletionIndex::might_contain`].
+    /// Bloom-filter check against deletion membership; see
+    /// [`DeletionIndex::might_contain`].
     #[inline]
     #[must_use]
     pub fn might_contain(&self, key: &[u8]) -> bool {
-        self.bloom.might_contain(hash_key(&key))
+        self.bloom.might_contain(bloom_half(hash_key_128(key)))
     }
 
-    /// Bloom-prefiltered lookup. Returns the delete sequence number if `key` is in the
-    /// index, `None` otherwise.
+    /// Bloom-prefiltered lookup. Returns the key's [`Tombstone`] if it has a
+    /// recorded deletion, `None` otherwise. See [`DeletionIndex::get`] for the
+    /// insert-only-entry contract.
+    ///
+    /// One XXH3-128 computation serves both the bloom check (high half) and
+    /// the map probe (full hash as identity, low half as bucket entropy via
+    /// [`PrehashedBuildHasher`]) — the key bytes are never re-hashed or
+    /// compared.
     #[inline]
     #[must_use]
-    pub fn get(&self, key: &[u8]) -> Option<i64> {
-        if !self.bloom.might_contain(hash_key(&key)) {
+    pub fn get(&self, key: &[u8]) -> Option<Tombstone> {
+        let key_hash = hash_key_128(key);
+        if !self.bloom.might_contain(bloom_half(key_hash)) {
             return None;
         }
-        self.entries.get(key).copied()
+        self.entries.get(&key_hash).and_then(Tombstone::from_entry)
     }
 
-    /// Direct read-only access to the underlying entries.
+    /// Direct read-only access to the underlying fused entries, keyed by the
+    /// XXH3-128 hash of the original key bytes.
     #[must_use]
-    pub fn entries(&self) -> &PersistentHashMap<Bytes, i64> {
+    pub fn entries(&self) -> &PersistentHashMap<u128, TombstoneEntry, PrehashedBuildHasher> {
         &self.entries
     }
 
-    /// Build a new index from `self`'s entries plus `additions`, taking the max sequence
-    /// number on conflict.
+    /// Build a new index from `self`'s entries plus delete-only `additions`,
+    /// taking the per-key max sequence on conflict. Keys are borrowed — the
+    /// index stores their XXH3-128 hash, never the bytes.
     ///
-    /// See [`DeletionIndex::extend_max`] for the amortization argument. Bloom rebuilds
-    /// only happen when the entry count crosses `2 * bloom_capacity`; otherwise only
-    /// the new keys are inserted into a clone of the existing bloom.
+    /// See [`DeletionIndex::extend_max_deletes`] for the amortization and
+    /// shared-filter safety argument. Bloom rebuilds only happen when the
+    /// deletion count outgrows the sized capacity; otherwise only the
+    /// newly-deleted keys are inserted into the shared filter in place.
     #[must_use]
-    pub fn extend_max(&self, additions: impl IntoIterator<Item = (Box<[u8]>, i64)>) -> Self {
+    pub fn extend_max_deletes<K: AsRef<[u8]>>(
+        &self,
+        additions: impl IntoIterator<Item = (K, i64)>,
+    ) -> Self {
+        self.extend_with(additions.into_iter().map(|(key, delete_seq)| {
+            (hash_key_128(key.as_ref()), delete_seq, SEQUENCE_ABSENT)
+        }))
+    }
+
+    /// Build a new index recording an upsert-conflict batch; see
+    /// [`DeletionIndex::extend_max_conflicts`].
+    #[must_use]
+    pub fn extend_max_conflicts<K: AsRef<[u8]>>(
+        &self,
+        keys: impl IntoIterator<Item = K>,
+        delete_sequence: i64,
+        insert_sequence: i64,
+    ) -> Self {
+        self.extend_with(keys.into_iter().map(|key| {
+            (
+                hash_key_128(key.as_ref()),
+                delete_sequence,
+                insert_sequence,
+            )
+        }))
+    }
+
+    /// Shared merge core for the extend methods, operating on pre-hashed key
+    /// identities. `insert_seq` uses [`SEQUENCE_ABSENT`] for "leave this side
+    /// unchanged".
+    fn extend_with(&self, additions: impl Iterator<Item = (u128, i64, i64)>) -> Self {
         let mut entries = self.entries.clone();
         let mut max_sequence_number = self.max_sequence_number;
-        let additions = additions.into_iter();
-        // Hash newly-inserted keys inline so the bloom can be updated
-        // incrementally without cloning key bytes (the bloom only needs the
-        // hash, not the byte slice). Pre-size from the
-        // iterator's hint to skip Vec growth reallocations.
-        let mut new_hashes: Vec<u64> = Vec::with_capacity(additions.size_hint().0);
-        for (key, seq) in additions {
-            let stored_sequence = if let Some(existing) = entries.get_mut(key.as_ref()) {
-                if seq > *existing {
-                    *existing = seq;
-                    seq
-                } else {
-                    *existing
-                }
-            } else {
-                let key_hash = hash_key(&key.as_ref());
-                entries.insert(Bytes::from(key), seq);
-                new_hashes.push(key_hash);
-                seq
-            };
-            if max_sequence_number.is_none_or(|max| stored_sequence > max) {
-                max_sequence_number = Some(stored_sequence);
+        let mut delete_count = self.delete_count;
+        let mut insert_count = self.insert_count;
+        // Track keys gaining their first deletion so the bloom can be updated
+        // incrementally without re-iterating the entire entry set. Pre-size
+        // from the iterator's hint to skip Vec growth reallocations.
+        let mut new_delete_hashes: Vec<u64> = Vec::with_capacity(additions.size_hint().0);
+        for (key_hash, delete_seq, insert_seq) in additions {
+            debug_assert_ne!(delete_seq, SEQUENCE_ABSENT, "real sequences are non-negative");
+            let entry = entries.entry(key_hash).or_insert(TombstoneEntry {
+                delete_seq: SEQUENCE_ABSENT,
+                insert_seq: SEQUENCE_ABSENT,
+            });
+            let transitions = merge_max(entry, delete_seq, insert_seq);
+            let stored_delete = entry.delete_seq;
+            if transitions.new_delete {
+                delete_count += 1;
+                new_delete_hashes.push(bloom_half(key_hash));
+            }
+            if transitions.new_insert {
+                insert_count += 1;
+            }
+            if max_sequence_number.is_none_or(|max| stored_delete > max) {
+                max_sequence_number = Some(stored_delete);
             }
         }
 
-        let new_len = entries.len();
-        // See `DeletionIndex::extend_max` for the rationale behind not
+        // See `DeletionIndex::extend_with` for the rationale behind not
         // re-scanning `entries` to validate `max_sequence_number` here.
-        if new_len > self.bloom_capacity.saturating_mul(2) {
-            let new_capacity = new_len.max(MIN_BLOOM_CAPACITY);
-            let mut bloom = BloomFilter::new(new_capacity);
-            for key in entries.keys() {
-                bloom.insert(hash_key(&key.as_ref()));
+        if delete_count > self.bloom_capacity {
+            let new_capacity = bloom_capacity_for(delete_count);
+            let bloom = SplitBlockBloomFilter::new(new_capacity);
+            for (key_hash, entry) in &entries {
+                if entry.delete_seq != SEQUENCE_ABSENT {
+                    bloom.insert(bloom_half(*key_hash));
+                }
             }
             return Self {
                 entries,
-                bloom,
+                bloom: Arc::new(bloom),
                 max_sequence_number,
+                delete_count,
+                insert_count,
                 bloom_capacity: new_capacity,
             };
         }
 
-        let mut bloom = self.bloom.clone();
-        for h in new_hashes {
-            bloom.insert(h);
+        // Common path: insert only the newly-deleted keys into the shared
+        // filter (O(K) relaxed atomic stores; see the safety argument in
+        // `DeletionIndex::extend_max_deletes`).
+        for h in new_delete_hashes {
+            self.bloom.insert(h);
         }
         Self {
             entries,
-            bloom,
+            bloom: Arc::clone(&self.bloom),
             max_sequence_number,
+            delete_count,
+            insert_count,
             bloom_capacity: self.bloom_capacity,
         }
     }
@@ -466,6 +842,18 @@ impl KeyDeletionIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn byte_key(value: u64) -> Box<[u8]> {
+        value.to_be_bytes().to_vec().into_boxed_slice()
+    }
+
+    fn delete_seq_of(idx: &DeletionIndex, pk: i64) -> Option<i64> {
+        idx.get(pk).map(|t| t.delete_sequence)
+    }
+
+    fn key_delete_seq_of(idx: &KeyDeletionIndex, key: &[u8]) -> Option<i64> {
+        idx.get(key).map(|t| t.delete_sequence)
+    }
 
     #[test]
     fn from_map_then_get() {
@@ -476,10 +864,13 @@ mod tests {
         let idx = DeletionIndex::from_map(map);
 
         assert_eq!(idx.len(), 3);
+        assert_eq!(idx.delete_len(), 3);
+        assert_eq!(idx.insert_len(), 0);
         assert_eq!(idx.max_sequence_number(), Some(3));
-        assert_eq!(idx.get(100), Some(1));
-        assert_eq!(idx.get(200), Some(2));
-        assert_eq!(idx.get(300), Some(3));
+        assert_eq!(delete_seq_of(&idx, 100), Some(1));
+        assert_eq!(delete_seq_of(&idx, 200), Some(2));
+        assert_eq!(delete_seq_of(&idx, 300), Some(3));
+        assert_eq!(idx.get(100).and_then(|t| t.insert_sequence), None);
         assert_eq!(idx.get(400), None);
     }
 
@@ -487,24 +878,115 @@ mod tests {
     fn empty_index_probes_to_none() {
         let idx = DeletionIndex::empty();
         assert!(idx.is_empty());
+        assert!(!idx.has_deletions());
         assert_eq!(idx.max_sequence_number(), None);
         assert_eq!(idx.get(42), None);
     }
 
     #[test]
-    fn extend_max_takes_higher_sequence() {
+    fn extend_max_deletes_takes_higher_sequence() {
         let mut map = HashMap::new();
         map.insert(100, 5);
         let idx = DeletionIndex::from_map(map);
 
-        let next = idx.extend_max([(100, 3), (200, 7)]);
+        let next = idx.extend_max_deletes([(100, 3), (200, 7)]);
         assert_eq!(next.max_sequence_number(), Some(7));
-        assert_eq!(next.get(100), Some(5));
-        assert_eq!(next.get(200), Some(7));
+        assert_eq!(delete_seq_of(&next, 100), Some(5));
+        assert_eq!(delete_seq_of(&next, 200), Some(7));
 
-        let after = next.extend_max([(100, 10)]);
+        let after = next.extend_max_deletes([(100, 10)]);
         assert_eq!(after.max_sequence_number(), Some(10));
-        assert_eq!(after.get(100), Some(10));
+        assert_eq!(delete_seq_of(&after, 100), Some(10));
+    }
+
+    #[test]
+    fn conflicts_record_delete_and_insert() {
+        let idx = DeletionIndex::empty();
+        let next = idx.extend_max_conflicts([1, 2, 3], 10, 11);
+
+        assert_eq!(next.len(), 3);
+        assert_eq!(next.delete_len(), 3);
+        assert_eq!(next.insert_len(), 3);
+        assert_eq!(next.max_sequence_number(), Some(10), "insert seqs must not raise the delete max");
+        for pk in [1, 2, 3] {
+            let tombstone = next.get(pk).expect("conflict key must have a tombstone");
+            assert_eq!(tombstone.delete_sequence, 10);
+            assert_eq!(tombstone.insert_sequence, Some(11));
+        }
+    }
+
+    #[test]
+    fn conflicts_merge_max_per_side() {
+        let idx = DeletionIndex::empty();
+        let first = idx.extend_max_conflicts([42], 10, 11);
+        // An older conflict must not lower either side.
+        let second = first.extend_max_conflicts([42], 5, 6);
+        let tombstone = second.get(42).expect("tombstone");
+        assert_eq!(tombstone.delete_sequence, 10);
+        assert_eq!(tombstone.insert_sequence, Some(11));
+        assert_eq!(second.len(), 1);
+        assert_eq!(second.delete_len(), 1);
+        assert_eq!(second.insert_len(), 1);
+
+        // A newer conflict raises both sides.
+        let third = second.extend_max_conflicts([42], 20, 21);
+        let tombstone = third.get(42).expect("tombstone");
+        assert_eq!(tombstone.delete_sequence, 20);
+        assert_eq!(tombstone.insert_sequence, Some(21));
+    }
+
+    #[test]
+    fn insert_only_entries_are_invisible_to_get() {
+        // Post-compaction state: delete files purged, insert records remain.
+        let inserts: HashMap<i64, i64> = (0..10).map(|pk| (pk, pk + 100)).collect();
+        let idx = DeletionIndex::from_maps(HashMap::new(), inserts);
+
+        assert_eq!(idx.len(), 10);
+        assert_eq!(idx.delete_len(), 0);
+        assert_eq!(idx.insert_len(), 10);
+        assert!(!idx.has_deletions());
+        assert_eq!(idx.max_sequence_number(), None);
+        for pk in 0..10 {
+            assert_eq!(idx.get(pk), None, "insert-only pk={pk} must probe as absent");
+        }
+    }
+
+    #[test]
+    fn from_maps_fuses_overlapping_keys() {
+        let deleted: HashMap<i64, i64> = HashMap::from([(1, 10), (2, 20)]);
+        let inserts: HashMap<i64, i64> = HashMap::from([(2, 21), (3, 30)]);
+        let idx = DeletionIndex::from_maps(deleted, inserts);
+
+        assert_eq!(idx.len(), 3);
+        assert_eq!(idx.delete_len(), 2);
+        assert_eq!(idx.insert_len(), 2);
+        assert_eq!(idx.max_sequence_number(), Some(20));
+
+        let lone_delete = idx.get(1).expect("tombstone");
+        assert_eq!(lone_delete.delete_sequence, 10);
+        assert_eq!(lone_delete.insert_sequence, None);
+
+        let fused = idx.get(2).expect("tombstone");
+        assert_eq!(fused.delete_sequence, 20);
+        assert_eq!(fused.insert_sequence, Some(21));
+
+        assert_eq!(idx.get(3), None, "insert-only key must probe as absent");
+    }
+
+    #[test]
+    fn delete_after_insert_only_enters_bloom() {
+        // An existing insert-only entry gaining its first deletion must become
+        // probeable (exercises the bloom insert on the occupied-entry path).
+        let inserts: HashMap<i64, i64> = HashMap::from([(7, 70)]);
+        let idx = DeletionIndex::from_maps(HashMap::new(), inserts);
+        assert_eq!(idx.get(7), None);
+
+        let next = idx.extend_max_deletes([(7, 80)]);
+        let tombstone = next.get(7).expect("tombstone after delete");
+        assert_eq!(tombstone.delete_sequence, 80);
+        assert_eq!(tombstone.insert_sequence, Some(70));
+        assert_eq!(next.delete_len(), 1);
+        assert_eq!(next.len(), 1, "delete of an insert-only key must not add an entry");
     }
 
     #[test]
@@ -538,29 +1020,52 @@ mod tests {
 
         let idx = KeyDeletionIndex::from_map(map);
         assert_eq!(idx.max_sequence_number(), Some(2));
-        assert_eq!(idx.get(&key1), Some(1));
-        assert_eq!(idx.get(&key2), Some(2));
+        assert_eq!(key_delete_seq_of(&idx, &key1), Some(1));
+        assert_eq!(key_delete_seq_of(&idx, &key2), Some(2));
         assert_eq!(idx.get(&[7, 8, 9]), None);
     }
 
     #[test]
-    fn key_index_extend_max() {
+    fn key_index_extend_max_deletes() {
         let key1: Box<[u8]> = vec![1, 2].into_boxed_slice();
         let mut map: HashMap<Box<[u8]>, i64> = HashMap::new();
         map.insert(key1.clone(), 5);
         let idx = KeyDeletionIndex::from_map(map);
 
-        let next = idx.extend_max([(key1.clone(), 3)]);
+        let next = idx.extend_max_deletes([(key1.clone(), 3)]);
         assert_eq!(next.max_sequence_number(), Some(5));
-        assert_eq!(next.get(&key1), Some(5));
+        assert_eq!(key_delete_seq_of(&next, &key1), Some(5));
 
-        let after = next.extend_max([(key1.clone(), 10)]);
+        let after = next.extend_max_deletes([(key1.clone(), 10)]);
         assert_eq!(after.max_sequence_number(), Some(10));
-        assert_eq!(after.get(&key1), Some(10));
+        assert_eq!(key_delete_seq_of(&after, &key1), Some(10));
     }
 
     #[test]
-    fn key_index_extend_max_keeps_existing_key_allocations_shared() {
+    fn key_index_conflicts_and_insert_only_fusion() {
+        let idx = KeyDeletionIndex::empty();
+        let next = idx.extend_max_conflicts([byte_key(1), byte_key(2)], 10, 11);
+        assert_eq!(next.delete_len(), 2);
+        assert_eq!(next.insert_len(), 2);
+        let tombstone = next.get(&byte_key(1)).expect("tombstone");
+        assert_eq!(tombstone.delete_sequence, 10);
+        assert_eq!(tombstone.insert_sequence, Some(11));
+
+        // Insert-only entries from the catalog load path probe as absent until deleted.
+        let loaded = KeyDeletionIndex::from_maps(
+            HashMap::new(),
+            HashMap::from([(byte_key(9), 90_i64)]),
+        );
+        assert_eq!(loaded.get(&byte_key(9)), None);
+        assert!(!loaded.has_deletions());
+        let deleted = loaded.extend_max_deletes([(byte_key(9), 95)]);
+        let tombstone = deleted.get(&byte_key(9)).expect("tombstone");
+        assert_eq!(tombstone.delete_sequence, 95);
+        assert_eq!(tombstone.insert_sequence, Some(90));
+    }
+
+    #[test]
+    fn key_index_pinned_generation_is_unaffected_by_extends() {
         let mut map: HashMap<Box<[u8]>, i64> = HashMap::new();
         for value in 0_u16..512 {
             map.insert(
@@ -569,86 +1074,77 @@ mod tests {
             );
         }
         let idx = KeyDeletionIndex::from_map(map);
-        let original_ptrs: HashMap<Vec<u8>, *const u8> = idx
-            .entries
-            .keys()
-            .map(|key| (key.as_ref().to_vec(), key.as_ptr()))
-            .collect();
 
         let pinned_reader_generation = idx.clone();
-        let next = idx.extend_max([(999_u16.to_be_bytes().to_vec().into_boxed_slice(), 999)]);
-        let shared_existing_keys = next
-            .entries
-            .keys()
-            .filter(|key| {
-                original_ptrs
-                    .get(key.as_ref())
-                    .is_some_and(|original_ptr| *original_ptr == key.as_ptr())
-            })
-            .count();
+        let next =
+            idx.extend_max_deletes([(999_u16.to_be_bytes().to_vec().into_boxed_slice(), 999)]);
 
-        assert!(
-            shared_existing_keys > 400,
-            "expected the HAMT update to share most existing key allocations, shared {shared_existing_keys} of {}",
-            original_ptrs.len(),
+        // The pinned generation never sees the new key's entry; the new
+        // generation sees both old and new entries.
+        assert_eq!(
+            pinned_reader_generation.get(&999_u16.to_be_bytes()),
+            None,
+            "pinned generation must not observe later extends"
         );
-        assert_eq!(pinned_reader_generation.get(&0_u16.to_be_bytes()), Some(0));
-        assert_eq!(next.get(&0_u16.to_be_bytes()), Some(0));
+        assert_eq!(
+            key_delete_seq_of(&pinned_reader_generation, &0_u16.to_be_bytes()),
+            Some(0)
+        );
+        assert_eq!(key_delete_seq_of(&next, &0_u16.to_be_bytes()), Some(0));
+        assert_eq!(
+            key_delete_seq_of(&next, &999_u16.to_be_bytes()),
+            Some(999)
+        );
     }
 
     #[test]
-    fn key_index_extend_max_preserves_updated_key_allocation() {
+    fn key_index_identity_is_content_based_not_allocation_based() {
+        // Hash-keyed identity: equal key bytes from different allocations
+        // resolve to the same entry.
         let key: Box<[u8]> = vec![9, 9].into_boxed_slice();
-        let original_ptr = key.as_ptr();
         let mut map: HashMap<Box<[u8]>, i64> = HashMap::new();
         map.insert(key, 1);
         let idx = KeyDeletionIndex::from_map(map);
 
         let replacement_key: Box<[u8]> = vec![9, 9].into_boxed_slice();
-        assert_ne!(replacement_key.as_ptr(), original_ptr);
-        let next = idx.extend_max([(replacement_key, 5)]);
+        let next = idx.extend_max_deletes([(replacement_key, 5)]);
 
-        let stored_ptr = next
-            .entries
-            .keys()
-            .find(|stored_key| stored_key.as_ref() == [9, 9])
-            .expect("updated key should still exist")
-            .as_ptr();
-        assert_eq!(stored_ptr, original_ptr);
-        assert_eq!(idx.get(&[9, 9]), Some(1));
-        assert_eq!(next.get(&[9, 9]), Some(5));
+        assert_eq!(next.len(), 1, "equal bytes must merge into one entry");
+        assert_eq!(key_delete_seq_of(&idx, &[9, 9]), Some(1));
+        assert_eq!(key_delete_seq_of(&next, &[9, 9]), Some(5));
     }
 
     // -------------------------------------------------------------------------
     // Regression tests for the incremental bloom-update path.
     //
     // A previous revision rebuilt the bloom filter from scratch on every
-    // `extend_max` call (iterating ALL entries and re-hashing them). On
-    // high-rate upsert/delete workloads this turned every per-row cache
-    // update into O(N) work, where N is the cumulative deletion-cache size.
-    // The cumulative effect across M writes is O(M*N), which is the root
-    // cause of the ingestion regression the user reported (~200% on
-    // upsert-heavy workloads with growing deletion sets).
+    // extend call (iterating ALL entries and re-hashing them). On high-rate
+    // upsert/delete workloads this turned every per-row cache update into
+    // O(N) work, where N is the cumulative deletion-cache size. The
+    // cumulative effect across M writes is O(M*N), which is the root cause
+    // of the ingestion regression the user reported (~200% on upsert-heavy
+    // workloads with growing deletion sets).
     //
-    // The fix rebuilds the bloom only when entries cross `2 * bloom_capacity`
-    // (amortized O(K)) and inserts incrementally in between. These tests
-    // exercise both code paths and verify correctness across many extend
-    // cycles.
+    // The fix rebuilds the bloom only when the deletion count outgrows the
+    // sized capacity (which carries 2x headroom, so the cadence is geometric
+    // / amortized O(K)) and inserts into the shared filter in place in
+    // between. These tests exercise both code paths and verify correctness
+    // across many extend cycles.
     // -------------------------------------------------------------------------
 
     #[test]
-    fn extend_max_many_small_batches_preserves_all_entries() {
+    fn extend_many_small_batches_preserves_all_entries() {
         // Simulates many small upserts each adding a single new PK to the
         // cache — the exact pattern that exposed the O(N²) regression.
         let mut idx = DeletionIndex::empty();
         let n = 1024;
         for pk in 0_i64..n {
-            idx = idx.extend_max([(pk, pk + 1)]);
+            idx = idx.extend_max_deletes([(pk, pk + 1)]);
         }
         assert_eq!(i64::try_from(idx.len()).expect("len fits in i64"), n);
         for pk in 0_i64..n {
             assert_eq!(
-                idx.get(pk),
+                delete_seq_of(&idx, pk),
                 Some(pk + 1),
                 "missing entry for pk={pk} after {n} incremental extends",
             );
@@ -658,68 +1154,94 @@ mod tests {
     }
 
     #[test]
-    fn extend_max_rebuilds_bloom_at_doubling_boundaries() {
-        // Verify the bloom_capacity grows in doublings (geometric amortization).
-        // The first `from_map`/`empty` builds at MIN_BLOOM_CAPACITY=64;
-        // crossing 128 triggers a rebuild to ≥128; crossing 256 to ≥256; etc.
+    fn extend_rebuilds_bloom_with_headroom() {
+        // Verify the bloom is rebuilt when the deletion count crosses the
+        // sized capacity, and that the new filter takes 2x headroom so it
+        // never runs past its design FPR between rebuilds (geometric
+        // amortization).
         let mut idx = DeletionIndex::empty();
         assert_eq!(idx.bloom_capacity, MIN_BLOOM_CAPACITY);
 
-        // Add 64 items — still within original capacity (64 ≤ 128 = 2*64).
+        // 64 deletions fit the minimum capacity exactly: no rebuild.
         for pk in 0..64 {
-            idx = idx.extend_max([(pk, 1)]);
+            idx = idx.extend_max_deletes([(pk, 1)]);
         }
         assert_eq!(idx.len(), 64);
         assert_eq!(
             idx.bloom_capacity, MIN_BLOOM_CAPACITY,
-            "no rebuild expected before crossing 2x capacity"
+            "no rebuild expected before exceeding the sized capacity"
         );
 
-        // Add 65 more — cross 2*64=128. Rebuild expected.
-        for pk in 64..129 {
-            idx = idx.extend_max([(pk, 1)]);
+        // The 65th deletion crosses the sized capacity: rebuild with headroom.
+        idx = idx.extend_max_deletes([(64, 1)]);
+        assert_eq!(idx.len(), 65);
+        assert_eq!(
+            idx.bloom_capacity, 130,
+            "rebuild must size the new bloom for 2x the deletion count"
+        );
+
+        // Keep growing to force another rebuild cycle at the next boundary.
+        for pk in 65..200 {
+            idx = idx.extend_max_deletes([(pk, 1)]);
         }
-        assert_eq!(idx.len(), 129);
         assert!(
-            idx.bloom_capacity >= 129,
-            "bloom_capacity must grow to fit {} entries after rebuild, got {}",
-            idx.len(),
+            idx.bloom_capacity >= 200,
+            "bloom_capacity must stay ahead of {} deletions, got {}",
+            idx.delete_len(),
             idx.bloom_capacity,
         );
 
         // Every inserted key probes positive.
-        for pk in 0..129 {
-            assert_eq!(idx.get(pk), Some(1), "missing pk={pk} after rebuild");
+        for pk in 0..200 {
+            assert_eq!(delete_seq_of(&idx, pk), Some(1), "missing pk={pk} after rebuilds");
         }
     }
 
     #[test]
-    fn extend_max_preserves_max_sequence_under_repeated_updates() {
+    fn bloom_rebuild_sizes_by_deletion_count_not_total_entries() {
+        // Insert-only entries must not count against the bloom capacity: the
+        // filter is keyed on deletion membership.
+        let inserts: HashMap<i64, i64> = (0..1000).map(|pk| (pk, 1)).collect();
+        let idx = DeletionIndex::from_maps(HashMap::new(), inserts);
+        assert_eq!(idx.bloom_capacity, MIN_BLOOM_CAPACITY);
+
+        // 64 deletions still fit the minimum capacity despite 1000 entries.
+        let mut grown = idx;
+        for pk in 0..64 {
+            grown = grown.extend_max_deletes([(pk, 2)]);
+        }
+        assert_eq!(grown.bloom_capacity, MIN_BLOOM_CAPACITY);
+        assert_eq!(grown.delete_len(), 64);
+        assert_eq!(grown.len(), 1000);
+    }
+
+    #[test]
+    fn extend_preserves_max_sequence_under_repeated_updates() {
         // Same PK updated many times — every extend should preserve the max
-        // sequence seen so far. Tests the Occupied entry path.
+        // sequence seen so far. Tests the occupied-entry path.
         let mut idx = DeletionIndex::empty();
-        idx = idx.extend_max([(42, 100)]);
-        idx = idx.extend_max([(42, 50)]); // older write, should not override
-        idx = idx.extend_max([(42, 200)]); // newer write, takes max
-        idx = idx.extend_max([(42, 150)]); // older write, should not override
-        assert_eq!(idx.get(42), Some(200));
+        idx = idx.extend_max_deletes([(42, 100)]);
+        idx = idx.extend_max_deletes([(42, 50)]); // older write, should not override
+        idx = idx.extend_max_deletes([(42, 200)]); // newer write, takes max
+        idx = idx.extend_max_deletes([(42, 150)]); // older write, should not override
+        assert_eq!(delete_seq_of(&idx, 42), Some(200));
         assert_eq!(idx.len(), 1, "no new entry should have been added");
     }
 
     #[test]
-    fn key_index_extend_max_many_small_batches_preserves_all_entries() {
+    fn key_index_extend_many_small_batches_preserves_all_entries() {
         // Same regression case for byte-keyed (composite-PK) tables.
         let mut idx = KeyDeletionIndex::empty();
         let n = 256_usize;
         for i in 0..n {
-            let key: Box<[u8]> = (i as u64).to_le_bytes().to_vec().into_boxed_slice();
-            idx = idx.extend_max([(key, i64::try_from(i).expect("i fits in i64") + 1)]);
+            let key = byte_key(i as u64);
+            idx = idx.extend_max_deletes([(key, i64::try_from(i).expect("i fits in i64") + 1)]);
         }
         assert_eq!(idx.len(), n);
         for i in 0..n {
-            let key: Box<[u8]> = (i as u64).to_le_bytes().to_vec().into_boxed_slice();
+            let key = byte_key(i as u64);
             assert_eq!(
-                idx.get(&key),
+                key_delete_seq_of(&idx, &key),
                 Some(i64::try_from(i).expect("i fits in i64") + 1),
                 "missing entry for key i={i} after {n} incremental extends",
             );
@@ -727,7 +1249,7 @@ mod tests {
     }
 
     #[test]
-    fn extend_max_batch_only_pays_for_new_keys() {
+    fn extend_batch_only_pays_for_new_keys() {
         // When all additions are duplicates (already present), no new bloom
         // inserts should happen — verified indirectly by checking the
         // bloom_capacity is unchanged and queries still work.
@@ -738,16 +1260,48 @@ mod tests {
         let idx = DeletionIndex::from_map(map);
         let initial_cap = idx.bloom_capacity;
 
-        // Extend with all-duplicate keys (different seq, but Occupied path).
-        let next = idx.extend_max((0..32).map(|pk| (pk, 2_i64)));
+        // Extend with all-duplicate keys (different seq, but occupied path).
+        let next = idx.extend_max_deletes((0..32).map(|pk| (pk, 2_i64)));
         assert_eq!(next.bloom_capacity, initial_cap);
         assert_eq!(next.len(), 32);
         for pk in 0..32 {
             assert_eq!(
-                next.get(pk),
+                delete_seq_of(&next, pk),
                 Some(2),
                 "max-sequence update lost for pk={pk}"
             );
         }
+    }
+
+    #[test]
+    fn extend_shares_bloom_until_rebuild() {
+        // The common path must share the parent's filter (no per-call copy of
+        // the bit array); a rebuild must allocate a fresh one.
+        let idx = DeletionIndex::from_map((0..32).map(|pk| (pk, 1_i64)).collect());
+
+        let extended = idx.extend_max_deletes([(100, 2)]);
+        assert!(
+            Arc::ptr_eq(&idx.bloom, &extended.bloom),
+            "in-capacity extend must share the parent's bloom filter"
+        );
+
+        // Old generation sees a superset: the new key's bits are visible, but
+        // a map probe correctly reports it absent from the old generation.
+        assert!(idx.might_contain(100));
+        assert_eq!(idx.get(100), None);
+        assert_eq!(delete_seq_of(&extended, 100), Some(2));
+
+        // Grow past the sized capacity (64): the rebuild must not alias the
+        // shared filter.
+        let mut grown = extended;
+        for pk in 200..280 {
+            grown = grown.extend_max_deletes([(pk, 3)]);
+        }
+        assert!(
+            !Arc::ptr_eq(&idx.bloom, &grown.bloom),
+            "rebuild must allocate a fresh filter"
+        );
+        assert_eq!(delete_seq_of(&grown, 100), Some(2));
+        assert_eq!(delete_seq_of(&grown, 250), Some(3));
     }
 }

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -21,17 +21,37 @@ limitations under the License.
 //! sequence numbers visibility needs — the highest *delete* sequence and, for keys
 //! re-inserted by an upsert, the highest *insert* sequence — into one
 //! [`TombstoneEntry`], so the scan hot path answers "is this row deleted, and was
-//! it re-inserted after that?" with a **single** map probe. (These were previously
-//! two separate indexes, costing two bloom checks and two HAMT walks per deleted
-//! row — the dominant per-row cost in changes-mode profiles.)
+//! it re-inserted after that?" with a **single** probe.
 //!
-//! The index holds a persistent [`im::HashMap`] plus a [`SplitBlockBloomFilter`]
-//! keyed on *deletion* membership (a single cache line per probe): a probe goes
-//! through the bloom filter first, and falls through to the hash map only on a
-//! possible hit. Entries holding only an insert record (which occur after
-//! compaction purges delete files while insert records remain in the catalog) are
-//! not represented in the bloom and are reported as absent by [`get`] — exactly
-//! the visibility semantics of the previous two-index design.
+//! # Layered storage: frozen flat base + small delta
+//!
+//! Entries live in two tiers (the in-memory analogue of an LSM memtable over a
+//! frozen run):
+//!
+//! - **base**: an `Arc<std::collections::HashMap>` (SwissTable). Frozen — never
+//!   mutated after construction — so publishing a new index generation shares it
+//!   with an `Arc` clone, and probing it costs 1–2 cache lines regardless of
+//!   size. This tier holds the overwhelming majority of entries at scale.
+//! - **delta**: a small persistent [`im::HashMap`] holding writes since the last
+//!   merge. `O(1)` to snapshot per publish (structural sharing), and because the
+//!   merge policy caps it at `max(`[`DELTA_MERGE_MIN`]`, base/4)` entries it
+//!   stays a shallow, cache-resident HAMT — the pointer-chasing that made a
+//!   *large* HAMT the dominant scan cost (per-row `get` walks of 5+ levels at
+//!   millions of entries) never develops.
+//!
+//! A probe checks the bloom filter, then delta, then base — at most one small
+//! in-cache lookup plus one flat-table lookup. A write goes to delta only; when
+//! delta outgrows the threshold it is folded into a fresh base (`O(base+delta)`
+//! copy). The `base/4` ladder keeps total copy work per key logarithmic in the
+//! final index size, and old generations pinned by long scans share the previous
+//! base `Arc`, so a merge costs one transient extra base — not one per
+//! generation.
+//!
+//! The bloom filter is keyed on *deletion* membership (a single cache line per
+//! probe). Entries holding only an insert record (which occur after compaction
+//! purges delete files while insert records remain in the catalog) are not
+//! represented in the bloom and are reported as absent by [`get`] — exactly the
+//! visibility semantics of the original two-index design.
 //!
 //! [`get`]: DeletionIndex::get
 //!
@@ -60,18 +80,38 @@ use hash_index::{
 };
 use im::HashMap as PersistentHashMap;
 use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
 use std::sync::{Arc, LazyLock};
 
 /// Bloom filter capacity floor: keep some signal even for empty / tiny sets so that the
 /// "probably-not-present" path stays useful when a fresh index is constructed.
 const MIN_BLOOM_CAPACITY: usize = 64;
 
-/// Hasher for the persistent HAMT. `im::HashMap` defaults to `RandomState`
-/// (SipHash-1-3), which showed up as `im::nodes::hamt::hash_key` in executor
-/// profiles of changes-mode ingest — every probe was paying a SipHash walk on
-/// top of the seeded-XXH3 bloom hash. [`XxHash3BuildHasher`] uses the same
-/// seeded XXH3-64 as [`hash_key_i64`], so map and bloom hashing now agree at
-/// a fraction of SipHash's per-key cost.
+/// Delta-size floor below which a merge into the base is never triggered.
+/// Small in tests so layering (merge, pinned-generation, and counter behavior
+/// across merges) is exercised by ordinary unit tests without inserting tens of
+/// thousands of keys.
+#[cfg(not(test))]
+const DELTA_MERGE_MIN: usize = 16_384;
+#[cfg(test)]
+const DELTA_MERGE_MIN: usize = 64;
+
+/// Delta size at which the delta is folded into a fresh frozen base.
+///
+/// `max(DELTA_MERGE_MIN, base/4)`: the floor avoids re-copying tiny bases on
+/// every publish, and the `base/4` ladder makes merge cadence geometric — each
+/// key is copied `O(log N)` times over the index's lifetime — while capping the
+/// delta at a quarter of the base so it stays a shallow, cache-resident HAMT.
+fn delta_merge_threshold(base_len: usize) -> usize {
+    (base_len / 4).max(DELTA_MERGE_MIN)
+}
+
+/// Hasher for the Int64 index maps. `im::HashMap`/`std::collections::HashMap`
+/// default to `RandomState` (SipHash-1-3), which showed up as
+/// `im::nodes::hamt::hash_key` in executor profiles of changes-mode ingest —
+/// every probe was paying a SipHash walk on top of the seeded-XXH3 bloom hash.
+/// [`XxHash3BuildHasher`] uses the same seeded XXH3-64 as [`hash_key_i64`], so
+/// map and bloom hashing now agree at a fraction of SipHash's per-key cost.
 pub type DeletionIndexHasher = XxHash3BuildHasher;
 
 /// Bloom capacity for a deletion set of `len` keys: sized with 2x headroom so the
@@ -94,8 +134,8 @@ const SEQUENCE_ABSENT: i64 = i64::MIN;
 
 /// Raw fused map value: the highest delete and insert sequence numbers recorded
 /// for one primary key, with [`SEQUENCE_ABSENT`] marking an unset side. Exposed
-/// (read-only) so callers iterating [`entries`](DeletionIndex::entries) can
-/// project the side they need.
+/// (read-only) so callers iterating [`iter_entries`](DeletionIndex::iter_entries)
+/// can project the side they need.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TombstoneEntry {
     delete_seq: i64,
@@ -103,6 +143,11 @@ pub struct TombstoneEntry {
 }
 
 impl TombstoneEntry {
+    const EMPTY: Self = Self {
+        delete_seq: SEQUENCE_ABSENT,
+        insert_seq: SEQUENCE_ABSENT,
+    };
+
     /// Highest delete sequence recorded for this key, if any.
     #[inline]
     #[must_use]
@@ -141,23 +186,31 @@ impl Tombstone {
     }
 }
 
-/// Outcome of merging one addition into the fused map: which sides newly
-/// transitioned from absent to present. Drives the bloom update (delete side
-/// only) and the `delete_len`/`insert_len` counters.
-#[derive(Clone, Copy, Default)]
-struct MergeTransitions {
+/// Outcome of merging one addition against a key's current effective entry.
+#[derive(Clone, Copy)]
+struct MergeOutcome {
+    /// The merged entry to store.
+    entry: TombstoneEntry,
+    /// The key had no entry in either tier before this addition.
+    new_key: bool,
+    /// The delete side transitioned from absent to present (drives the bloom
+    /// update and `delete_len`).
     new_delete: bool,
+    /// The insert side transitioned from absent to present (drives `insert_len`).
     new_insert: bool,
 }
 
 /// Merge `delete_seq`/`insert_seq` (either possibly [`SEQUENCE_ABSENT`]) into
-/// `entry`, taking the per-side max, and report absent→present transitions.
+/// `current`, taking the per-side max.
 #[inline]
-fn merge_max(entry: &mut TombstoneEntry, delete_seq: i64, insert_seq: i64) -> MergeTransitions {
-    let mut transitions = MergeTransitions::default();
+fn merged_entry(current: Option<TombstoneEntry>, delete_seq: i64, insert_seq: i64) -> MergeOutcome {
+    let new_key = current.is_none();
+    let mut entry = current.unwrap_or(TombstoneEntry::EMPTY);
+    let mut new_delete = false;
+    let mut new_insert = false;
     if delete_seq != SEQUENCE_ABSENT {
         if entry.delete_seq == SEQUENCE_ABSENT {
-            transitions.new_delete = true;
+            new_delete = true;
             entry.delete_seq = delete_seq;
         } else if delete_seq > entry.delete_seq {
             entry.delete_seq = delete_seq;
@@ -165,47 +218,291 @@ fn merge_max(entry: &mut TombstoneEntry, delete_seq: i64, insert_seq: i64) -> Me
     }
     if insert_seq != SEQUENCE_ABSENT {
         if entry.insert_seq == SEQUENCE_ABSENT {
-            transitions.new_insert = true;
+            new_insert = true;
             entry.insert_seq = insert_seq;
         } else if insert_seq > entry.insert_seq {
             entry.insert_seq = insert_seq;
         }
     }
-    transitions
+    MergeOutcome {
+        entry,
+        new_key,
+        new_delete,
+        new_insert,
+    }
 }
 
-/// Frozen deletion index for tables with a single-column Int64 primary key.
-///
-/// Holds the fused (pk → [`TombstoneEntry`]) map and an accompanying bloom filter
-/// keyed on deletion membership. The bloom filter's bit array is sized for
-/// `bloom_capacity` deletion keys; the writer tracks that capacity so the extend
-/// methods can update the shared bloom in place for the common case where the
-/// index grows slowly, only paying a full O(N) rebuild when the deletion count
-/// outgrows the sized capacity. This keeps amortized writer cost at O(K) per
-/// call (K = number of additions) instead of the O(N) it would otherwise be — see
-/// [`extend_max_deletes`](Self::extend_max_deletes) for the full argument.
+// =============================================================================
+// Layered core
+// =============================================================================
+
+/// Shared layered-storage core for [`DeletionIndex`] (`K = i64`) and
+/// [`KeyDeletionIndex`] (`K = u128` hash identity). See the [module docs](self)
+/// for the tiering design. Key-specific concerns (how a key maps to its bloom
+/// hash) stay in the wrappers and are passed in as functions.
 #[derive(Debug, Clone)]
-pub struct DeletionIndex {
-    entries: PersistentHashMap<i64, TombstoneEntry, DeletionIndexHasher>,
+struct LayeredTombstones<K, S>
+where
+    K: Copy + Eq + Hash,
+    S: BuildHasher + Default + Clone,
+{
+    /// Frozen flat tier: never mutated after construction, shared across
+    /// generations via `Arc`.
+    base: Arc<HashMap<K, TombstoneEntry, S>>,
+    /// Mutable tier holding writes since the last merge; `O(1)` to snapshot.
+    /// Values here are pre-merged with any base entry for the same key, so a
+    /// delta hit never needs a second base lookup.
+    delta: PersistentHashMap<K, TombstoneEntry, S>,
     bloom: Arc<SplitBlockBloomFilter>,
     /// Monotonic upper bound over the **delete** sequences in the current
-    /// immutable entries. This stays exact because indexes are build-once /
+    /// immutable entries. Stays exact because indexes are build-once /
     /// extend-only; any future removal API must recompute it instead of
     /// carrying a stale high-water mark.
     /// `CayenneTableProvider::apply_partial_deletion_filter` relies on this
     /// exact value to decide whether a protected snapshot can skip deletion
     /// filtering without letting deleted rows through.
     max_sequence_number: Option<i64>,
-    /// Number of entries with a recorded deletion (= bloom population).
+    /// Number of distinct keys across both tiers.
+    entry_count: usize,
+    /// Number of keys with a recorded deletion (= bloom population).
     delete_count: usize,
-    /// Number of entries with a recorded insert (upsert re-insertion).
+    /// Number of keys with a recorded insert (upsert re-insertion).
     insert_count: usize,
     /// Deletion-key count the current `bloom` was sized for
     /// ([`bloom_capacity_for`]: 2x the deletion count at build time). When
-    /// `delete_count` exceeds it, the extend methods rebuild the bloom from
-    /// scratch into a fresh `Arc`; otherwise they insert newly-deleted keys
+    /// `delete_count` exceeds it, the extend path rebuilds the bloom from
+    /// scratch into a fresh `Arc`; otherwise it inserts newly-deleted keys
     /// into the shared filter in place.
     bloom_capacity: usize,
+}
+
+impl<K, S> LayeredTombstones<K, S>
+where
+    K: Copy + Eq + Hash,
+    S: BuildHasher + Default + Clone,
+{
+    fn empty() -> Self {
+        Self {
+            base: Arc::new(HashMap::default()),
+            delta: PersistentHashMap::default(),
+            bloom: Arc::new(SplitBlockBloomFilter::new(MIN_BLOOM_CAPACITY)),
+            max_sequence_number: None,
+            entry_count: 0,
+            delete_count: 0,
+            insert_count: 0,
+            bloom_capacity: MIN_BLOOM_CAPACITY,
+        }
+    }
+
+    /// Bulk-build: deletions land directly in the frozen base (no delta, no
+    /// merges); insert records fold into the same entries.
+    fn from_iters(
+        deleted: impl ExactSizeIterator<Item = (K, i64)>,
+        insert_records: impl Iterator<Item = (K, i64)>,
+        bloom_hash_of: impl Fn(&K) -> u64,
+    ) -> Self {
+        let capacity = bloom_capacity_for(deleted.len());
+        let bloom = SplitBlockBloomFilter::new(capacity);
+        let delete_count = deleted.len();
+        let mut max_sequence_number = None;
+        let mut base: HashMap<K, TombstoneEntry, S> =
+            HashMap::with_capacity_and_hasher(delete_count, S::default());
+        for (key, delete_seq) in deleted {
+            bloom.insert(bloom_hash_of(&key));
+            if max_sequence_number.is_none_or(|max| delete_seq > max) {
+                max_sequence_number = Some(delete_seq);
+            }
+            base.insert(
+                key,
+                TombstoneEntry {
+                    delete_seq,
+                    insert_seq: SEQUENCE_ABSENT,
+                },
+            );
+        }
+        let mut insert_count = 0;
+        for (key, insert_seq) in insert_records {
+            insert_count += 1;
+            let outcome = merged_entry(base.get(&key).copied(), SEQUENCE_ABSENT, insert_seq);
+            base.insert(key, outcome.entry);
+        }
+
+        Self {
+            entry_count: base.len(),
+            base: Arc::new(base),
+            delta: PersistentHashMap::default(),
+            bloom: Arc::new(bloom),
+            max_sequence_number,
+            delete_count,
+            insert_count,
+            bloom_capacity: capacity,
+        }
+    }
+
+    /// Effective entry for `key`: delta overrides base (delta values are
+    /// pre-merged, so the first hit is authoritative).
+    #[inline]
+    fn entry(&self, key: &K) -> Option<&TombstoneEntry> {
+        self.delta.get(key).or_else(|| self.base.get(key))
+    }
+
+    /// Tombstone for `key`, bypassing the bloom filter. Callers must perform
+    /// the bloom check first (the wrappers keep it in their thin `get` bodies
+    /// so the bloom-reject fast path — the overwhelmingly common outcome on
+    /// append-mostly scans — inlines into the per-row probe loop without
+    /// dragging the tier-walk code with it).
+    #[inline]
+    fn tombstone_of(&self, key: &K) -> Option<Tombstone> {
+        self.entry(key).and_then(Tombstone::from_entry)
+    }
+
+    /// Iterate all effective entries (delta first, then base entries the delta
+    /// does not override). Each key yields exactly once with its newest value.
+    fn iter_entries(&self) -> impl Iterator<Item = (K, TombstoneEntry)> + '_ {
+        self.delta.iter().map(|(key, entry)| (*key, *entry)).chain(
+            self.base
+                .iter()
+                .filter(|(key, _)| !self.delta.contains_key(key))
+                .map(|(key, entry)| (*key, *entry)),
+        )
+    }
+
+    /// Core of the extend methods: apply `additions` to a delta snapshot, run
+    /// the bloom policy, then the merge policy. `insert_seq` uses
+    /// [`SEQUENCE_ABSENT`] for "leave this side unchanged".
+    fn extend(
+        &self,
+        additions: impl Iterator<Item = (K, i64, i64)>,
+        bloom_hash_of: impl Fn(&K) -> u64,
+    ) -> Self {
+        let mut delta = self.delta.clone();
+        let mut max_sequence_number = self.max_sequence_number;
+        let mut entry_count = self.entry_count;
+        let mut delete_count = self.delete_count;
+        let mut insert_count = self.insert_count;
+        // Track keys gaining their first deletion so the bloom can be updated
+        // incrementally without re-iterating the entire entry set. Pre-size
+        // from the iterator's hint to skip Vec growth reallocations.
+        let mut new_delete_hashes: Vec<u64> = Vec::with_capacity(additions.size_hint().0);
+        for (key, delete_seq, insert_seq) in additions {
+            debug_assert_ne!(
+                delete_seq, SEQUENCE_ABSENT,
+                "real sequences are non-negative"
+            );
+            let current = self.entry_in(&delta, &key);
+            let outcome = merged_entry(current, delete_seq, insert_seq);
+            if outcome.new_key {
+                entry_count += 1;
+            }
+            if outcome.new_delete {
+                delete_count += 1;
+                new_delete_hashes.push(bloom_hash_of(&key));
+            }
+            if outcome.new_insert {
+                insert_count += 1;
+            }
+            if max_sequence_number.is_none_or(|max| outcome.entry.delete_seq > max) {
+                max_sequence_number = Some(outcome.entry.delete_seq);
+            }
+            // Skip the delta write when the addition was a no-op (stale
+            // sequences for an existing key): keeps the delta minimal and the
+            // merge cadence honest.
+            if current != Some(outcome.entry) {
+                delta.insert(key, outcome.entry);
+            }
+        }
+
+        // `max_sequence_number` is maintained incrementally above; we do not
+        // re-scan entries here (a full scan would make extends O(N) in debug
+        // builds and noticeably slow the test suite as the index grows).
+        // `from_iters` is the single bulk-build path and recomputes the exact
+        // max from scratch.
+        //
+        // Bloom policy: rebuild from scratch when deletion growth has outpaced
+        // the sized capacity; the new filter takes 2x headroom so the rebuild
+        // cadence is geometric. Otherwise insert only the newly-deleted keys
+        // into the shared filter in place (O(K) relaxed atomic stores; older
+        // pinned generations observe a safe superset — see the module docs).
+        let (bloom, bloom_capacity) = if delete_count > self.bloom_capacity {
+            let new_capacity = bloom_capacity_for(delete_count);
+            let fresh = SplitBlockBloomFilter::new(new_capacity);
+            // A key present in both tiers is inserted twice; bloom inserts are
+            // idempotent, so that is harmless.
+            for (key, entry) in self.base.iter().chain(delta.iter()) {
+                if entry.delete_seq != SEQUENCE_ABSENT {
+                    fresh.insert(bloom_hash_of(key));
+                }
+            }
+            (Arc::new(fresh), new_capacity)
+        } else {
+            for hash in new_delete_hashes {
+                self.bloom.insert(hash);
+            }
+            (Arc::clone(&self.bloom), self.bloom_capacity)
+        };
+
+        // Merge policy: fold the delta into a fresh frozen base once it
+        // crosses the threshold. Old generations keep the previous base Arc,
+        // so the transient cost is one extra base — not one per generation.
+        let (base, delta) = if delta.len() >= delta_merge_threshold(self.base.len()) {
+            let mut merged = HashMap::clone(&self.base);
+            merged.reserve(delta.len());
+            for (key, entry) in &delta {
+                merged.insert(*key, *entry);
+            }
+            (Arc::new(merged), PersistentHashMap::default())
+        } else {
+            (Arc::clone(&self.base), delta)
+        };
+
+        Self {
+            base,
+            delta,
+            bloom,
+            max_sequence_number,
+            entry_count,
+            delete_count,
+            insert_count,
+            bloom_capacity,
+        }
+    }
+
+    /// Effective-entry lookup against an in-progress delta (plus the frozen
+    /// base), used while applying an additions batch.
+    #[inline]
+    fn entry_in(
+        &self,
+        delta: &PersistentHashMap<K, TombstoneEntry, S>,
+        key: &K,
+    ) -> Option<TombstoneEntry> {
+        delta.get(key).or_else(|| self.base.get(key)).copied()
+    }
+
+    fn approx_bytes(&self, base_entry_bytes: usize, delta_entry_bytes: usize) -> usize {
+        self.base
+            .len()
+            .saturating_mul(base_entry_bytes)
+            .saturating_add(self.delta.len().saturating_mul(delta_entry_bytes))
+    }
+}
+
+// =============================================================================
+// Int64 primary keys
+// =============================================================================
+
+/// Frozen deletion index for tables with a single-column Int64 primary key.
+///
+/// Entries are layered across a frozen flat base and a small delta (see the
+/// [module docs](self)), fronted by a bloom filter keyed on deletion
+/// membership. The bloom filter's bit array is sized for `bloom_capacity`
+/// deletion keys with 2x headroom; in-capacity extends update the shared
+/// filter in place and a full O(N) rebuild only happens when the deletion
+/// count outgrows the sized capacity, keeping amortized writer cost at O(K)
+/// per call (K = number of additions) — see
+/// [`extend_max_deletes`](Self::extend_max_deletes) for the full argument.
+#[derive(Debug, Clone)]
+pub struct DeletionIndex {
+    core: LayeredTombstones<i64, DeletionIndexHasher>,
 }
 
 impl Default for DeletionIndex {
@@ -220,12 +517,7 @@ impl DeletionIndex {
     #[must_use]
     pub fn empty() -> Self {
         Self {
-            entries: PersistentHashMap::default(),
-            bloom: Arc::new(SplitBlockBloomFilter::new(MIN_BLOOM_CAPACITY)),
-            max_sequence_number: None,
-            delete_count: 0,
-            insert_count: 0,
-            bloom_capacity: MIN_BLOOM_CAPACITY,
+            core: LayeredTombstones::empty(),
         }
     }
 
@@ -252,45 +544,12 @@ impl DeletionIndex {
     /// sides separately).
     #[must_use]
     pub fn from_maps(deleted: HashMap<i64, i64>, insert_records: HashMap<i64, i64>) -> Self {
-        let capacity = bloom_capacity_for(deleted.len());
-        let bloom = SplitBlockBloomFilter::new(capacity);
-        for &pk in deleted.keys() {
-            bloom.insert(hash_key_i64(pk));
-        }
-        let max_sequence_number = deleted.values().copied().max();
-        let delete_count = deleted.len();
-        let insert_count = insert_records.len();
-
-        let mut entries: PersistentHashMap<i64, TombstoneEntry, DeletionIndexHasher> = deleted
-            .into_iter()
-            .map(|(pk, delete_seq)| {
-                (
-                    pk,
-                    TombstoneEntry {
-                        delete_seq,
-                        insert_seq: SEQUENCE_ABSENT,
-                    },
-                )
-            })
-            .collect();
-        for (pk, insert_seq) in insert_records {
-            merge_max(
-                entries.entry(pk).or_insert(TombstoneEntry {
-                    delete_seq: SEQUENCE_ABSENT,
-                    insert_seq: SEQUENCE_ABSENT,
-                }),
-                SEQUENCE_ABSENT,
-                insert_seq,
-            );
-        }
-
         Self {
-            entries,
-            bloom: Arc::new(bloom),
-            max_sequence_number,
-            delete_count,
-            insert_count,
-            bloom_capacity: capacity,
+            core: LayeredTombstones::from_iters(
+                deleted.into_iter(),
+                insert_records.into_iter(),
+                |pk| hash_key_i64(*pk),
+            ),
         }
     }
 
@@ -304,25 +563,25 @@ impl DeletionIndex {
     /// or both).
     #[must_use]
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.core.entry_count
     }
 
     /// Whether the index has no entries at all.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.core.entry_count == 0
     }
 
     /// Number of keys with a recorded deletion.
     #[must_use]
     pub fn delete_len(&self) -> usize {
-        self.delete_count
+        self.core.delete_count
     }
 
     /// Number of keys with a recorded insert (upsert re-insertion).
     #[must_use]
     pub fn insert_len(&self) -> usize {
-        self.insert_count
+        self.core.insert_count
     }
 
     /// Whether any key has a recorded deletion. Scan fast paths skip the
@@ -330,23 +589,26 @@ impl DeletionIndex {
     /// visibility).
     #[must_use]
     pub fn has_deletions(&self) -> bool {
-        self.delete_count > 0
+        self.core.delete_count > 0
     }
 
-    /// Approximate resident bytes for memory accounting: each `i64 ->
-    /// (i64, i64)` entry includes the key/value payload plus HAMT
-    /// node/bitmap/Arc overhead. Shared nodes retained by older reader-pinned
-    /// generations are intentionally not charged to the latest snapshot again.
+    /// Approximate resident bytes for memory accounting. Base entries are
+    /// flat-table slots (`i64 -> (i64, i64)` payload plus SwissTable load
+    /// factor and control bytes); delta entries carry HAMT node/bitmap/Arc
+    /// overhead. Shared structure retained by older reader-pinned generations
+    /// is intentionally not charged to the latest snapshot again.
     #[must_use]
     pub fn approx_bytes(&self) -> usize {
-        const APPROX_I64_ENTRY_BYTES: usize = 80;
-        self.entries.len().saturating_mul(APPROX_I64_ENTRY_BYTES)
+        const APPROX_I64_BASE_ENTRY_BYTES: usize = 32;
+        const APPROX_I64_DELTA_ENTRY_BYTES: usize = 80;
+        self.core
+            .approx_bytes(APPROX_I64_BASE_ENTRY_BYTES, APPROX_I64_DELTA_ENTRY_BYTES)
     }
 
     /// Highest **delete** sequence number in this index, if any.
     #[must_use]
     pub fn max_sequence_number(&self) -> Option<i64> {
-        self.max_sequence_number
+        self.core.max_sequence_number
     }
 
     /// Bloom-filter check against deletion membership. Returns `false` if the key
@@ -355,7 +617,7 @@ impl DeletionIndex {
     #[inline]
     #[must_use]
     pub fn might_contain(&self, pk: i64) -> bool {
-        self.bloom.might_contain(hash_key_i64(pk))
+        self.core.bloom.might_contain(hash_key_i64(pk))
     }
 
     /// Bloom-prefiltered lookup. Returns the key's [`Tombstone`] if `pk` has a
@@ -364,22 +626,22 @@ impl DeletionIndex {
     /// Keys holding only an insert record are reported as `None`: the bloom is
     /// keyed on deletion membership, and visibility treats "no deletion" and
     /// "insert-only" identically. One probe answers both the deletion and the
-    /// re-insertion question — previously two separate index walks.
+    /// re-insertion question.
     #[inline]
     #[must_use]
     pub fn get(&self, pk: i64) -> Option<Tombstone> {
-        if !self.bloom.might_contain(hash_key_i64(pk)) {
+        if !self.core.bloom.might_contain(hash_key_i64(pk)) {
             return None;
         }
-        self.entries.get(&pk).and_then(Tombstone::from_entry)
+        self.core.tombstone_of(&pk)
     }
 
-    /// Direct read-only access to the underlying fused entries (for callers
-    /// that need to iterate, e.g. benches; project sides via
-    /// [`TombstoneEntry::delete_sequence`] / [`TombstoneEntry::insert_sequence`]).
-    #[must_use]
-    pub fn entries(&self) -> &PersistentHashMap<i64, TombstoneEntry, DeletionIndexHasher> {
-        &self.entries
+    /// Iterate all effective entries (for callers that need a full walk, e.g.
+    /// benches; project sides via [`TombstoneEntry::delete_sequence`] /
+    /// [`TombstoneEntry::insert_sequence`]). Each key yields exactly once with
+    /// its newest value.
+    pub fn iter_entries(&self) -> impl Iterator<Item = (i64, TombstoneEntry)> + '_ {
+        self.core.iter_entries()
     }
 
     /// Build a new index from `self`'s entries plus delete-only `additions`
@@ -388,17 +650,19 @@ impl DeletionIndex {
     ///
     /// # Performance
     ///
-    /// `entries` is a persistent HAMT, so cloning the current map for a write
-    /// shares unchanged nodes with any reader-pinned generation. Inserts update
-    /// only the path to the touched key (O(log N)) instead of cloning every
-    /// entry. The bloom filter is *shared* with the parent index behind an
-    /// `Arc`: keys gaining their first deletion are inserted into it in place
-    /// (relaxed atomic stores, O(K), no copy of the bit array — at millions of
-    /// entries a per-call copy would be a multi-megabyte memcpy on every CDC
-    /// batch). A full O(N) rebuild into a fresh filter only happens when the
-    /// deletion count outgrows the capacity the filter was sized for — 2x the
-    /// deletion count at build time ([`bloom_capacity_for`]) — so the rebuild
-    /// cadence is geometric and the amortized bloom cost stays O(K) per call.
+    /// Additions land in the small delta tier (`O(log delta)` persistent-map
+    /// inserts that share structure with reader-pinned generations); the
+    /// frozen base is shared by `Arc` and only re-copied when the delta
+    /// crosses [`delta_merge_threshold`] — a geometric cadence that amortizes
+    /// to `O(log N)` total copy work per key. The bloom filter is *shared*
+    /// with the parent index behind an `Arc`: keys gaining their first
+    /// deletion are inserted into it in place (relaxed atomic stores, O(K), no
+    /// copy of the bit array — at millions of entries a per-call copy would be
+    /// a multi-megabyte memcpy on every CDC batch). A full O(N) bloom rebuild
+    /// only happens when the deletion count outgrows the capacity the filter
+    /// was sized for — 2x the deletion count at build time
+    /// ([`bloom_capacity_for`]) — so the rebuild cadence is geometric and the
+    /// amortized bloom cost stays O(K) per call.
     ///
     /// Sharing the filter means older pinned generations observe bits for keys
     /// added after they were published. That is a safe superset: extra bits can
@@ -415,17 +679,20 @@ impl DeletionIndex {
     /// regression that prompted this fix.
     #[must_use]
     pub fn extend_max_deletes(&self, additions: impl IntoIterator<Item = (i64, i64)>) -> Self {
-        self.extend_with(
-            additions
-                .into_iter()
-                .map(|(pk, delete_seq)| (pk, delete_seq, SEQUENCE_ABSENT)),
-        )
+        Self {
+            core: self.core.extend(
+                additions
+                    .into_iter()
+                    .map(|(pk, delete_seq)| (pk, delete_seq, SEQUENCE_ABSENT)),
+                |pk| hash_key_i64(*pk),
+            ),
+        }
     }
 
     /// Build a new index recording an upsert-conflict batch: every key in
     /// `keys` gains a deletion at `delete_sequence` **and** a re-insertion at
     /// `insert_sequence`, each merged with per-key max. One pass over the map
-    /// replaces the previous two-index double `extend_max`.
+    /// replaces the previous two-index double extend.
     #[must_use]
     pub fn extend_max_conflicts(
         &self,
@@ -433,96 +700,24 @@ impl DeletionIndex {
         delete_sequence: i64,
         insert_sequence: i64,
     ) -> Self {
-        self.extend_with(
-            keys.into_iter()
-                .map(|pk| (pk, delete_sequence, insert_sequence)),
-        )
-    }
-
-    /// Shared merge core for the extend methods. `delete_seq`/`insert_seq` use
-    /// [`SEQUENCE_ABSENT`] for "leave this side unchanged".
-    fn extend_with(&self, additions: impl Iterator<Item = (i64, i64, i64)>) -> Self {
-        let mut entries = self.entries.clone();
-        let mut max_sequence_number = self.max_sequence_number;
-        let mut delete_count = self.delete_count;
-        let mut insert_count = self.insert_count;
-        // Track keys gaining their first deletion so the bloom can be updated
-        // incrementally without re-iterating the entire entry set. Pre-size
-        // from the iterator's hint to skip Vec growth reallocations.
-        let mut new_delete_keys: Vec<i64> = Vec::with_capacity(additions.size_hint().0);
-        for (pk, delete_seq, insert_seq) in additions {
-            debug_assert_ne!(
-                delete_seq, SEQUENCE_ABSENT,
-                "real sequences are non-negative"
-            );
-            let entry = entries.entry(pk).or_insert(TombstoneEntry {
-                delete_seq: SEQUENCE_ABSENT,
-                insert_seq: SEQUENCE_ABSENT,
-            });
-            let transitions = merge_max(entry, delete_seq, insert_seq);
-            let stored_delete = entry.delete_seq;
-            if transitions.new_delete {
-                delete_count += 1;
-                new_delete_keys.push(pk);
-            }
-            if transitions.new_insert {
-                insert_count += 1;
-            }
-            if stored_delete != SEQUENCE_ABSENT
-                && max_sequence_number.is_none_or(|max| stored_delete > max)
-            {
-                max_sequence_number = Some(stored_delete);
-            }
-        }
-
-        // `max_sequence_number` is maintained incrementally above; we do not
-        // re-scan `entries` here (a full scan would make extends O(N) in debug
-        // builds and noticeably slow the test suite as the index grows).
-        // `from_maps` is the single rebuild path and recomputes the exact max
-        // from scratch.
-        // Rebuild from scratch when deletion growth has outpaced the sized
-        // capacity. The new filter takes 2x headroom, so the rebuild cadence
-        // is geometric: between rebuilds we pay O(K) for in-place inserts; on
-        // a rebuild we pay O(N), but the next rebuild is another doubling
-        // away, so the total work across one doubling cycle amortizes to O(N).
-        if delete_count > self.bloom_capacity {
-            let new_capacity = bloom_capacity_for(delete_count);
-            let bloom = SplitBlockBloomFilter::new(new_capacity);
-            for (pk, entry) in &entries {
-                if entry.delete_seq != SEQUENCE_ABSENT {
-                    bloom.insert(hash_key_i64(*pk));
-                }
-            }
-            return Self {
-                entries,
-                bloom: Arc::new(bloom),
-                max_sequence_number,
-                delete_count,
-                insert_count,
-                bloom_capacity: new_capacity,
-            };
-        }
-
-        // Common path: insert only the newly-deleted keys into the shared
-        // filter (O(K) relaxed atomic stores; see the safety argument above).
-        for pk in &new_delete_keys {
-            self.bloom.insert(hash_key_i64(*pk));
-        }
         Self {
-            entries,
-            bloom: Arc::clone(&self.bloom),
-            max_sequence_number,
-            delete_count,
-            insert_count,
-            bloom_capacity: self.bloom_capacity,
+            core: self.core.extend(
+                keys.into_iter()
+                    .map(|pk| (pk, delete_sequence, insert_sequence)),
+                |pk| hash_key_i64(*pk),
+            ),
         }
     }
 }
 
+// =============================================================================
+// Composite / non-integer primary keys
+// =============================================================================
+
 /// Splits a 128-bit key hash into its map identity and the (independent)
 /// 64 bits fed to the bloom filter. Using disjoint halves keeps the bloom's
-/// block/bit selection uncorrelated with the map's bucket selection (the map
-/// consumes the low half via [`PrehashedBuildHasher`]).
+/// block/bit selection uncorrelated with the map's bucket selection (the maps
+/// consume the low half via [`PrehashedBuildHasher`]).
 #[inline]
 fn bloom_half(hash: u128) -> u64 {
     (hash >> 64) as u64
@@ -535,31 +730,20 @@ fn bloom_half(hash: u128) -> u64 {
 /// ([`hash_key_128`]) rather than the bytes themselves: the hash is the key's
 /// identity and the bytes are not retained. This fixes the per-entry footprint
 /// at 32 bytes regardless of composite-key width, removes byte comparisons
-/// from probes, and (via [`PrehashedBuildHasher`]) lets the map reuse the
+/// from probes, and (via [`PrehashedBuildHasher`]) lets the maps reuse the
 /// hash's own entropy instead of re-hashing per probe — one hash computation
-/// serves the bloom filter and the map together.
+/// serves the bloom filter and the maps together.
 ///
 /// Two distinct keys colliding under XXH3-128 would share a tombstone; at one
 /// billion keys the birthday bound puts that below ~1e-20 — orders of
 /// magnitude under hardware error rates. (A 64-bit hash would NOT be safe as
 /// identity at these cardinalities: ~0.3% collision odds at the same scale.)
 ///
-/// See [`DeletionIndex`] for the fused-entry, bloom-capacity, and shared-filter
-/// contracts.
+/// See [`DeletionIndex`] for the fused-entry, layered-storage, bloom-capacity,
+/// and shared-filter contracts.
 #[derive(Debug, Clone)]
 pub struct KeyDeletionIndex {
-    entries: PersistentHashMap<u128, TombstoneEntry, PrehashedBuildHasher>,
-    bloom: Arc<SplitBlockBloomFilter>,
-    /// Monotonic upper bound over the **delete** sequences in the current
-    /// immutable entries. See [`DeletionIndex::max_sequence_number`].
-    max_sequence_number: Option<i64>,
-    /// Number of entries with a recorded deletion (= bloom population).
-    delete_count: usize,
-    /// Number of entries with a recorded insert (upsert re-insertion).
-    insert_count: usize,
-    /// Deletion-key count the current `bloom` was sized for. Mirrors
-    /// [`DeletionIndex::bloom_capacity`] to amortize bloom rebuilds.
-    bloom_capacity: usize,
+    core: LayeredTombstones<u128, PrehashedBuildHasher>,
 }
 
 impl Default for KeyDeletionIndex {
@@ -573,12 +757,7 @@ impl KeyDeletionIndex {
     #[must_use]
     pub fn empty() -> Self {
         Self {
-            entries: PersistentHashMap::default(),
-            bloom: Arc::new(SplitBlockBloomFilter::new(MIN_BLOOM_CAPACITY)),
-            max_sequence_number: None,
-            delete_count: 0,
-            insert_count: 0,
-            bloom_capacity: MIN_BLOOM_CAPACITY,
+            core: LayeredTombstones::empty(),
         }
     }
 
@@ -606,45 +785,16 @@ impl KeyDeletionIndex {
         deleted: HashMap<Box<[u8]>, i64>,
         insert_records: HashMap<Box<[u8]>, i64>,
     ) -> Self {
-        let capacity = bloom_capacity_for(deleted.len());
-        let bloom = SplitBlockBloomFilter::new(capacity);
-        let max_sequence_number = deleted.values().copied().max();
-        let delete_count = deleted.len();
-        let insert_count = insert_records.len();
-
-        let mut entries: PersistentHashMap<u128, TombstoneEntry, PrehashedBuildHasher> = deleted
-            .into_iter()
-            .map(|(key, delete_seq)| {
-                let key_hash = hash_key_128(&key);
-                bloom.insert(bloom_half(key_hash));
-                (
-                    key_hash,
-                    TombstoneEntry {
-                        delete_seq,
-                        insert_seq: SEQUENCE_ABSENT,
-                    },
-                )
-            })
-            .collect();
-        for (key, insert_seq) in insert_records {
-            let key_hash = hash_key_128(&key);
-            merge_max(
-                entries.entry(key_hash).or_insert(TombstoneEntry {
-                    delete_seq: SEQUENCE_ABSENT,
-                    insert_seq: SEQUENCE_ABSENT,
-                }),
-                SEQUENCE_ABSENT,
-                insert_seq,
-            );
-        }
-
         Self {
-            entries,
-            bloom: Arc::new(bloom),
-            max_sequence_number,
-            delete_count,
-            insert_count,
-            bloom_capacity: capacity,
+            core: LayeredTombstones::from_iters(
+                deleted
+                    .into_iter()
+                    .map(|(key, seq)| (hash_key_128(&key), seq)),
+                insert_records
+                    .into_iter()
+                    .map(|(key, seq)| (hash_key_128(&key), seq)),
+                |key_hash| bloom_half(*key_hash),
+            ),
         }
     }
 
@@ -658,50 +808,53 @@ impl KeyDeletionIndex {
     /// or both).
     #[must_use]
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.core.entry_count
     }
 
     /// Number of keys with a recorded deletion.
     #[must_use]
     pub fn delete_len(&self) -> usize {
-        self.delete_count
+        self.core.delete_count
     }
 
     /// Number of keys with a recorded insert (upsert re-insertion).
     #[must_use]
     pub fn insert_len(&self) -> usize {
-        self.insert_count
+        self.core.insert_count
     }
 
     /// Whether any key has a recorded deletion. See
     /// [`DeletionIndex::has_deletions`].
     #[must_use]
     pub fn has_deletions(&self) -> bool {
-        self.delete_count > 0
+        self.core.delete_count > 0
     }
 
-    /// Approximate resident bytes for memory accounting: each `u128 ->
-    /// (i64, i64)` entry is a fixed 32-byte payload plus HAMT node/bitmap/Arc
-    /// overhead — key bytes are not retained (hash-keyed identity), so the
-    /// estimate no longer depends on composite-key width. Shared nodes
-    /// retained by older reader-pinned generations are intentionally not
+    /// Approximate resident bytes for memory accounting. Base entries are
+    /// flat-table slots (`u128 -> (i64, i64)` payload plus SwissTable load
+    /// factor and control bytes); delta entries carry HAMT node/bitmap/Arc
+    /// overhead. Key bytes are not retained (hash-keyed identity), so the
+    /// estimate no longer depends on composite-key width. Shared structure
+    /// retained by older reader-pinned generations is intentionally not
     /// charged to the latest snapshot again.
     #[must_use]
     pub fn approx_bytes(&self) -> usize {
-        const APPROX_KEY_ENTRY_BYTES: usize = 88;
-        self.entries.len().saturating_mul(APPROX_KEY_ENTRY_BYTES)
+        const APPROX_KEY_BASE_ENTRY_BYTES: usize = 40;
+        const APPROX_KEY_DELTA_ENTRY_BYTES: usize = 88;
+        self.core
+            .approx_bytes(APPROX_KEY_BASE_ENTRY_BYTES, APPROX_KEY_DELTA_ENTRY_BYTES)
     }
 
     /// Whether the index has no entries at all.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.core.entry_count == 0
     }
 
     /// Highest **delete** sequence number in this index, if any.
     #[must_use]
     pub fn max_sequence_number(&self) -> Option<i64> {
-        self.max_sequence_number
+        self.core.max_sequence_number
     }
 
     /// Bloom-filter check against deletion membership; see
@@ -709,7 +862,7 @@ impl KeyDeletionIndex {
     #[inline]
     #[must_use]
     pub fn might_contain(&self, key: &[u8]) -> bool {
-        self.bloom.might_contain(bloom_half(hash_key_128(key)))
+        self.core.bloom.might_contain(bloom_half(hash_key_128(key)))
     }
 
     /// Bloom-prefiltered lookup. Returns the key's [`Tombstone`] if it has a
@@ -717,44 +870,44 @@ impl KeyDeletionIndex {
     /// insert-only-entry contract.
     ///
     /// One XXH3-128 computation serves both the bloom check (high half) and
-    /// the map probe (full hash as identity, low half as bucket entropy via
+    /// the map probes (full hash as identity, low half as bucket entropy via
     /// [`PrehashedBuildHasher`]) — the key bytes are never re-hashed or
     /// compared.
     #[inline]
     #[must_use]
     pub fn get(&self, key: &[u8]) -> Option<Tombstone> {
         let key_hash = hash_key_128(key);
-        if !self.bloom.might_contain(bloom_half(key_hash)) {
+        if !self.core.bloom.might_contain(bloom_half(key_hash)) {
             return None;
         }
-        self.entries.get(&key_hash).and_then(Tombstone::from_entry)
+        self.core.tombstone_of(&key_hash)
     }
 
-    /// Direct read-only access to the underlying fused entries, keyed by the
-    /// XXH3-128 hash of the original key bytes.
-    #[must_use]
-    pub fn entries(&self) -> &PersistentHashMap<u128, TombstoneEntry, PrehashedBuildHasher> {
-        &self.entries
+    /// Iterate all effective entries, keyed by the XXH3-128 hash of the
+    /// original key bytes. Each key yields exactly once with its newest value.
+    pub fn iter_entries(&self) -> impl Iterator<Item = (u128, TombstoneEntry)> + '_ {
+        self.core.iter_entries()
     }
 
     /// Build a new index from `self`'s entries plus delete-only `additions`,
     /// taking the per-key max sequence on conflict. Keys are borrowed — the
     /// index stores their XXH3-128 hash, never the bytes.
     ///
-    /// See [`DeletionIndex::extend_max_deletes`] for the amortization and
-    /// shared-filter safety argument. Bloom rebuilds only happen when the
-    /// deletion count outgrows the sized capacity; otherwise only the
-    /// newly-deleted keys are inserted into the shared filter in place.
+    /// See [`DeletionIndex::extend_max_deletes`] for the layering,
+    /// amortization, and shared-filter safety argument.
     #[must_use]
     pub fn extend_max_deletes<K: AsRef<[u8]>>(
         &self,
         additions: impl IntoIterator<Item = (K, i64)>,
     ) -> Self {
-        self.extend_with(
-            additions
-                .into_iter()
-                .map(|(key, delete_seq)| (hash_key_128(key.as_ref()), delete_seq, SEQUENCE_ABSENT)),
-        )
+        Self {
+            core: self.core.extend(
+                additions.into_iter().map(|(key, delete_seq)| {
+                    (hash_key_128(key.as_ref()), delete_seq, SEQUENCE_ABSENT)
+                }),
+                |key_hash| bloom_half(*key_hash),
+            ),
+        }
     }
 
     /// Build a new index recording an upsert-conflict batch; see
@@ -766,80 +919,12 @@ impl KeyDeletionIndex {
         delete_sequence: i64,
         insert_sequence: i64,
     ) -> Self {
-        self.extend_with(
-            keys.into_iter()
-                .map(|key| (hash_key_128(key.as_ref()), delete_sequence, insert_sequence)),
-        )
-    }
-
-    /// Shared merge core for the extend methods, operating on pre-hashed key
-    /// identities. `insert_seq` uses [`SEQUENCE_ABSENT`] for "leave this side
-    /// unchanged".
-    fn extend_with(&self, additions: impl Iterator<Item = (u128, i64, i64)>) -> Self {
-        let mut entries = self.entries.clone();
-        let mut max_sequence_number = self.max_sequence_number;
-        let mut delete_count = self.delete_count;
-        let mut insert_count = self.insert_count;
-        // Track keys gaining their first deletion so the bloom can be updated
-        // incrementally without re-iterating the entire entry set. Pre-size
-        // from the iterator's hint to skip Vec growth reallocations.
-        let mut new_delete_hashes: Vec<u64> = Vec::with_capacity(additions.size_hint().0);
-        for (key_hash, delete_seq, insert_seq) in additions {
-            debug_assert_ne!(
-                delete_seq, SEQUENCE_ABSENT,
-                "real sequences are non-negative"
-            );
-            let entry = entries.entry(key_hash).or_insert(TombstoneEntry {
-                delete_seq: SEQUENCE_ABSENT,
-                insert_seq: SEQUENCE_ABSENT,
-            });
-            let transitions = merge_max(entry, delete_seq, insert_seq);
-            let stored_delete = entry.delete_seq;
-            if transitions.new_delete {
-                delete_count += 1;
-                new_delete_hashes.push(bloom_half(key_hash));
-            }
-            if transitions.new_insert {
-                insert_count += 1;
-            }
-            if max_sequence_number.is_none_or(|max| stored_delete > max) {
-                max_sequence_number = Some(stored_delete);
-            }
-        }
-
-        // See `DeletionIndex::extend_with` for the rationale behind not
-        // re-scanning `entries` to validate `max_sequence_number` here.
-        if delete_count > self.bloom_capacity {
-            let new_capacity = bloom_capacity_for(delete_count);
-            let bloom = SplitBlockBloomFilter::new(new_capacity);
-            for (key_hash, entry) in &entries {
-                if entry.delete_seq != SEQUENCE_ABSENT {
-                    bloom.insert(bloom_half(*key_hash));
-                }
-            }
-            return Self {
-                entries,
-                bloom: Arc::new(bloom),
-                max_sequence_number,
-                delete_count,
-                insert_count,
-                bloom_capacity: new_capacity,
-            };
-        }
-
-        // Common path: insert only the newly-deleted keys into the shared
-        // filter (O(K) relaxed atomic stores; see the safety argument in
-        // `DeletionIndex::extend_max_deletes`).
-        for h in new_delete_hashes {
-            self.bloom.insert(h);
-        }
         Self {
-            entries,
-            bloom: Arc::clone(&self.bloom),
-            max_sequence_number,
-            delete_count,
-            insert_count,
-            bloom_capacity: self.bloom_capacity,
+            core: self.core.extend(
+                keys.into_iter()
+                    .map(|key| (hash_key_128(key.as_ref()), delete_sequence, insert_sequence)),
+                |key_hash| bloom_half(*key_hash),
+            ),
         }
     }
 }
@@ -1147,7 +1232,9 @@ mod tests {
     #[test]
     fn extend_many_small_batches_preserves_all_entries() {
         // Simulates many small upserts each adding a single new PK to the
-        // cache — the exact pattern that exposed the O(N²) regression.
+        // cache — the exact pattern that exposed the O(N²) regression. With
+        // the test-sized DELTA_MERGE_MIN this also crosses several base
+        // merges, covering the layered path end to end.
         let mut idx = DeletionIndex::empty();
         let n = 1024;
         for pk in 0_i64..n {
@@ -1172,7 +1259,7 @@ mod tests {
         // never runs past its design FPR between rebuilds (geometric
         // amortization).
         let mut idx = DeletionIndex::empty();
-        assert_eq!(idx.bloom_capacity, MIN_BLOOM_CAPACITY);
+        assert_eq!(idx.core.bloom_capacity, MIN_BLOOM_CAPACITY);
 
         // 64 deletions fit the minimum capacity exactly: no rebuild.
         for pk in 0..64 {
@@ -1180,7 +1267,7 @@ mod tests {
         }
         assert_eq!(idx.len(), 64);
         assert_eq!(
-            idx.bloom_capacity, MIN_BLOOM_CAPACITY,
+            idx.core.bloom_capacity, MIN_BLOOM_CAPACITY,
             "no rebuild expected before exceeding the sized capacity"
         );
 
@@ -1188,7 +1275,7 @@ mod tests {
         idx = idx.extend_max_deletes([(64, 1)]);
         assert_eq!(idx.len(), 65);
         assert_eq!(
-            idx.bloom_capacity, 130,
+            idx.core.bloom_capacity, 130,
             "rebuild must size the new bloom for 2x the deletion count"
         );
 
@@ -1197,10 +1284,10 @@ mod tests {
             idx = idx.extend_max_deletes([(pk, 1)]);
         }
         assert!(
-            idx.bloom_capacity >= 200,
+            idx.core.bloom_capacity >= 200,
             "bloom_capacity must stay ahead of {} deletions, got {}",
             idx.delete_len(),
-            idx.bloom_capacity,
+            idx.core.bloom_capacity,
         );
 
         // Every inserted key probes positive.
@@ -1219,14 +1306,14 @@ mod tests {
         // filter is keyed on deletion membership.
         let inserts: HashMap<i64, i64> = (0..1000).map(|pk| (pk, 1)).collect();
         let idx = DeletionIndex::from_maps(HashMap::new(), inserts);
-        assert_eq!(idx.bloom_capacity, MIN_BLOOM_CAPACITY);
+        assert_eq!(idx.core.bloom_capacity, MIN_BLOOM_CAPACITY);
 
         // 64 deletions still fit the minimum capacity despite 1000 entries.
         let mut grown = idx;
         for pk in 0..64 {
             grown = grown.extend_max_deletes([(pk, 2)]);
         }
-        assert_eq!(grown.bloom_capacity, MIN_BLOOM_CAPACITY);
+        assert_eq!(grown.core.bloom_capacity, MIN_BLOOM_CAPACITY);
         assert_eq!(grown.delete_len(), 64);
         assert_eq!(grown.len(), 1000);
     }
@@ -1274,11 +1361,11 @@ mod tests {
             map.insert(pk, 1_i64);
         }
         let idx = DeletionIndex::from_map(map);
-        let initial_cap = idx.bloom_capacity;
+        let initial_cap = idx.core.bloom_capacity;
 
         // Extend with all-duplicate keys (different seq, but occupied path).
         let next = idx.extend_max_deletes((0..32).map(|pk| (pk, 2_i64)));
-        assert_eq!(next.bloom_capacity, initial_cap);
+        assert_eq!(next.core.bloom_capacity, initial_cap);
         assert_eq!(next.len(), 32);
         for pk in 0..32 {
             assert_eq!(
@@ -1297,7 +1384,7 @@ mod tests {
 
         let extended = idx.extend_max_deletes([(100, 2)]);
         assert!(
-            Arc::ptr_eq(&idx.bloom, &extended.bloom),
+            Arc::ptr_eq(&idx.core.bloom, &extended.core.bloom),
             "in-capacity extend must share the parent's bloom filter"
         );
 
@@ -1314,10 +1401,154 @@ mod tests {
             grown = grown.extend_max_deletes([(pk, 3)]);
         }
         assert!(
-            !Arc::ptr_eq(&idx.bloom, &grown.bloom),
+            !Arc::ptr_eq(&idx.core.bloom, &grown.core.bloom),
             "rebuild must allocate a fresh filter"
         );
         assert_eq!(delete_seq_of(&grown, 100), Some(2));
         assert_eq!(delete_seq_of(&grown, 250), Some(3));
+    }
+
+    // -------------------------------------------------------------------------
+    // Layered-storage tests (frozen base + delta). DELTA_MERGE_MIN is 64 under
+    // cfg(test), so ordinary insert counts cross merge boundaries.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn delta_merges_into_base_at_threshold() {
+        // Single-key extends accumulate in the delta until the threshold, then
+        // fold into the frozen base.
+        let mut idx = DeletionIndex::empty();
+        for pk in 0..63_i64 {
+            idx = idx.extend_max_deletes([(pk, 1)]);
+        }
+        assert_eq!(idx.core.delta.len(), 63, "delta below threshold");
+        assert_eq!(idx.core.base.len(), 0);
+
+        idx = idx.extend_max_deletes([(63, 1)]);
+        assert_eq!(idx.core.delta.len(), 0, "delta folded into base");
+        assert_eq!(idx.core.base.len(), 64);
+
+        // Everything probeable through both tiers' lifetimes.
+        for pk in 0..64 {
+            assert_eq!(delete_seq_of(&idx, pk), Some(1), "missing pk={pk}");
+        }
+        assert_eq!(idx.len(), 64);
+    }
+
+    #[test]
+    fn base_key_update_lands_in_delta_and_wins() {
+        // Force keys into the frozen base, then update one: the merged entry
+        // lives in the delta and overrides the base on probes, without
+        // changing entry counts.
+        let idx = DeletionIndex::from_map((0..100).map(|pk| (pk, 10_i64)).collect());
+        assert_eq!(idx.core.base.len(), 100);
+        assert_eq!(idx.core.delta.len(), 0);
+
+        let updated = idx.extend_max_conflicts([5], 20, 21);
+        assert_eq!(updated.core.base.len(), 100, "base stays frozen");
+        assert_eq!(updated.core.delta.len(), 1, "update lands in delta");
+        assert_eq!(updated.len(), 100, "no new entry for an existing key");
+        assert_eq!(updated.delete_len(), 100);
+        assert_eq!(updated.insert_len(), 1);
+
+        let tombstone = updated.get(5).expect("tombstone");
+        assert_eq!(tombstone.delete_sequence, 20, "delta overrides base");
+        assert_eq!(tombstone.insert_sequence, Some(21));
+
+        // A stale update is a no-op and must not grow the delta.
+        let stale = updated.extend_max_deletes([(5, 15)]);
+        assert_eq!(stale.core.delta.len(), 1, "no-op update must not re-insert");
+        assert_eq!(stale.get(5).expect("tombstone").delete_sequence, 20);
+    }
+
+    #[test]
+    fn pinned_generation_survives_base_merge() {
+        // A reader pinning a pre-merge generation must keep its exact view
+        // while the writer merges the delta into a new base.
+        let mut idx = DeletionIndex::empty();
+        for pk in 0..50_i64 {
+            idx = idx.extend_max_deletes([(pk, 1)]);
+        }
+        let pinned = idx.clone();
+        let pinned_base = Arc::clone(&pinned.core.base);
+
+        // Cross the merge threshold.
+        for pk in 50..130_i64 {
+            idx = idx.extend_max_deletes([(pk, 2)]);
+        }
+        assert!(
+            !Arc::ptr_eq(&pinned_base, &idx.core.base),
+            "merge must produce a fresh base"
+        );
+
+        // Pinned view: first 50 keys only.
+        for pk in 0..50 {
+            assert_eq!(delete_seq_of(&pinned, pk), Some(1));
+        }
+        assert_eq!(pinned.get(75), None, "pinned view must not see later keys");
+        assert_eq!(pinned.len(), 50);
+
+        // New view: everything.
+        for pk in 0..50 {
+            assert_eq!(delete_seq_of(&idx, pk), Some(1));
+        }
+        for pk in 50..130 {
+            assert_eq!(delete_seq_of(&idx, pk), Some(2));
+        }
+        assert_eq!(idx.len(), 130);
+    }
+
+    #[test]
+    fn counters_consistent_across_merges() {
+        // Interleave fresh keys, repeat updates, and conflicts across several
+        // merge boundaries; counters must match a straightforward model.
+        let mut idx = DeletionIndex::empty();
+        let mut model: HashMap<i64, (i64, Option<i64>)> = HashMap::new();
+
+        for round in 0..6_i64 {
+            for slot in 0..40_i64 {
+                let pk = round * 30 + slot; // overlapping ranges → repeat keys
+                let delete_seq = round + 1;
+                let insert_seq = round + 2;
+                idx = idx.extend_max_conflicts([pk], delete_seq, insert_seq);
+                let entry = model.entry(pk).or_insert((SEQUENCE_ABSENT, None));
+                entry.0 = entry.0.max(delete_seq);
+                entry.1 = Some(
+                    entry
+                        .1
+                        .map_or(insert_seq, |existing: i64| existing.max(insert_seq)),
+                );
+            }
+        }
+
+        assert_eq!(idx.len(), model.len());
+        assert_eq!(idx.delete_len(), model.len());
+        assert_eq!(idx.insert_len(), model.len());
+        for (pk, (delete_seq, insert_seq)) in &model {
+            let tombstone = idx.get(*pk).expect("tombstone");
+            assert_eq!(tombstone.delete_sequence, *delete_seq, "pk={pk}");
+            assert_eq!(tombstone.insert_sequence, *insert_seq, "pk={pk}");
+        }
+    }
+
+    #[test]
+    fn iter_entries_yields_latest_values_without_duplicates() {
+        // Keys split across base (merged) and delta (recent update of a base
+        // key + a brand-new key): iteration must yield each key once with its
+        // newest value.
+        let idx = DeletionIndex::from_map((0..100).map(|pk| (pk, 1_i64)).collect());
+        let idx = idx.extend_max_deletes([(5, 50), (200, 60)]);
+        assert!(idx.core.delta.len() >= 2, "updates must be delta-resident");
+
+        let collected: HashMap<i64, TombstoneEntry> = idx.iter_entries().collect();
+        assert_eq!(collected.len(), 101);
+        assert_eq!(
+            idx.iter_entries().count(),
+            101,
+            "no duplicate keys in iteration"
+        );
+        assert_eq!(collected[&5].delete_sequence(), Some(50), "delta wins");
+        assert_eq!(collected[&200].delete_sequence(), Some(60));
+        assert_eq!(collected[&6].delete_sequence(), Some(1), "base preserved");
     }
 }

--- a/crates/cayenne/src/provider/deletion_strategy.rs
+++ b/crates/cayenne/src/provider/deletion_strategy.rs
@@ -138,76 +138,53 @@ fn approx_position_bitmap_bytes(bitmap: &PositionBitmap) -> usize {
 }
 
 /// Atomically-published deletion state for single-column `Int64` primary keys.
+///
+/// Holds one fused [`DeletionIndex`] whose entries carry both the delete and
+/// (for upsert conflicts) re-insert sequence numbers, so the scan hot path
+/// resolves visibility with a single probe. Previously a (deleted,
+/// insert-records) index pair published together; the fused index preserves
+/// the same atomicity with one cell.
 #[derive(Debug, Clone)]
 pub struct Int64PkDeletionSnapshot {
-    pub(crate) deleted_pk: Arc<DeletionIndex>,
-    pub(crate) insert_records: Arc<DeletionIndex>,
+    pub(crate) tombstones: Arc<DeletionIndex>,
 }
 
 impl Int64PkDeletionSnapshot {
     #[must_use]
     pub(crate) fn empty() -> Self {
         Self {
-            deleted_pk: Arc::new(DeletionIndex::empty()),
-            insert_records: Arc::new(DeletionIndex::empty()),
+            tombstones: Arc::new(DeletionIndex::empty()),
         }
     }
 
     #[must_use]
-    pub(crate) const fn from_arcs(
-        deleted_pk: Arc<DeletionIndex>,
-        insert_records: Arc<DeletionIndex>,
-    ) -> Self {
+    pub(crate) fn from_index(tombstones: DeletionIndex) -> Self {
         Self {
-            deleted_pk,
-            insert_records,
-        }
-    }
-
-    #[must_use]
-    pub(crate) fn from_indices(deleted_pk: DeletionIndex, insert_records: DeletionIndex) -> Self {
-        Self {
-            deleted_pk: Arc::new(deleted_pk),
-            insert_records: Arc::new(insert_records),
+            tombstones: Arc::new(tombstones),
         }
     }
 }
 
 /// Atomically-published deletion state for row-converter primary keys.
+///
+/// See [`Int64PkDeletionSnapshot`] for the fused-index rationale.
 #[derive(Debug, Clone)]
 pub struct RowConverterDeletionSnapshot {
-    pub(crate) deleted_row_keys: Arc<KeyDeletionIndex>,
-    pub(crate) insert_records: Arc<KeyDeletionIndex>,
+    pub(crate) tombstones: Arc<KeyDeletionIndex>,
 }
 
 impl RowConverterDeletionSnapshot {
     #[must_use]
     pub(crate) fn empty() -> Self {
         Self {
-            deleted_row_keys: Arc::new(KeyDeletionIndex::empty()),
-            insert_records: Arc::new(KeyDeletionIndex::empty()),
+            tombstones: Arc::new(KeyDeletionIndex::empty()),
         }
     }
 
     #[must_use]
-    pub(crate) const fn from_arcs(
-        deleted_row_keys: Arc<KeyDeletionIndex>,
-        insert_records: Arc<KeyDeletionIndex>,
-    ) -> Self {
+    pub(crate) fn from_index(tombstones: KeyDeletionIndex) -> Self {
         Self {
-            deleted_row_keys,
-            insert_records,
-        }
-    }
-
-    #[must_use]
-    pub(crate) fn from_indices(
-        deleted_row_keys: KeyDeletionIndex,
-        insert_records: KeyDeletionIndex,
-    ) -> Self {
-        Self {
-            deleted_row_keys: Arc::new(deleted_row_keys),
-            insert_records: Arc::new(insert_records),
+            tombstones: Arc::new(tombstones),
         }
     }
 }
@@ -398,9 +375,8 @@ impl PkDeletionStrategyWithCache {
                 let snapshot = deletion_snapshot.load();
                 let position_snapshot = position_deletions.load_full();
                 snapshot
-                    .deleted_pk
+                    .tombstones
                     .approx_bytes()
-                    .saturating_add(snapshot.insert_records.approx_bytes())
                     .saturating_add(approx_position_bitmap_bytes(&position_snapshot))
             }
             Self::RowConverterBased {
@@ -410,9 +386,8 @@ impl PkDeletionStrategyWithCache {
                 let snapshot = deletion_snapshot.load();
                 let position_snapshot = position_deletions.load_full();
                 snapshot
-                    .deleted_row_keys
+                    .tombstones
                     .approx_bytes()
-                    .saturating_add(snapshot.insert_records.approx_bytes())
                     .saturating_add(approx_position_bitmap_bytes(&position_snapshot))
             }
         }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2130,12 +2130,8 @@ enum OnConflictDeletionUpdate {
 #[derive(Clone)]
 enum PkDeletionSnapshot {
     PositionBased,
-    Int64Pk {
-        tombstones: Arc<DeletionIndex>,
-    },
-    RowConverterBased {
-        tombstones: Arc<KeyDeletionIndex>,
-    },
+    Int64Pk { tombstones: Arc<DeletionIndex> },
+    RowConverterBased { tombstones: Arc<KeyDeletionIndex> },
 }
 
 impl PkDeletionSnapshot {

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -20,7 +20,7 @@ limitations under the License.
 use super::constants::{STAGING_DIR_NAME, STAGING_WAL_FILENAME, STAGING_WAL_TMP_FILENAME};
 use super::delete::{
     CayenneDeletionSink, DeletionIdentifier, DeletionVectorWriteResult, DeletionVectorWriteSpec,
-    DeletionVectorWriter, FileBasedDeletionSink, Int64PkDeletionFilterExec,
+    DeletionVectorWriter, FileBasedDeletionSink, InsertRecordHandling, Int64PkDeletionFilterExec,
     KeyBasedDeletionFilterExec,
 };
 use super::mutation_writer::AppendMutationWriter;
@@ -2131,12 +2131,10 @@ enum OnConflictDeletionUpdate {
 enum PkDeletionSnapshot {
     PositionBased,
     Int64Pk {
-        deleted_pk_values: Arc<DeletionIndex>,
-        insert_records: Arc<DeletionIndex>,
+        tombstones: Arc<DeletionIndex>,
     },
     RowConverterBased {
-        deleted_row_keys: Arc<KeyDeletionIndex>,
-        insert_records: Arc<KeyDeletionIndex>,
+        tombstones: Arc<KeyDeletionIndex>,
     },
 }
 
@@ -2144,18 +2142,14 @@ impl PkDeletionSnapshot {
     fn has_deletions(&self) -> bool {
         match self {
             Self::PositionBased => false,
-            Self::Int64Pk {
-                deleted_pk_values, ..
-            } => !deleted_pk_values.is_empty(),
-            Self::RowConverterBased {
-                deleted_row_keys, ..
-            } => !deleted_row_keys.is_empty(),
+            Self::Int64Pk { tombstones } => tombstones.has_deletions(),
+            Self::RowConverterBased { tombstones } => tombstones.has_deletions(),
         }
     }
 
     /// The highest delete sequence reflected in THIS coherent snapshot.
     ///
-    /// Because every deletion update does `extend_max(...)` followed by a single
+    /// Because every deletion update builds an extended index followed by a single
     /// atomic `deletion_snapshot.store(...)`, a snapshot obtained from one load
     /// reflects all deletions up to this value. Deriving the compaction fence
     /// from the same snapshot (rather than a second, independent
@@ -2164,12 +2158,8 @@ impl PkDeletionSnapshot {
     fn max_sequence_number(&self) -> Option<i64> {
         match self {
             Self::PositionBased => None,
-            Self::Int64Pk {
-                deleted_pk_values, ..
-            } => deleted_pk_values.max_sequence_number(),
-            Self::RowConverterBased {
-                deleted_row_keys, ..
-            } => deleted_row_keys.max_sequence_number(),
+            Self::Int64Pk { tombstones } => tombstones.max_sequence_number(),
+            Self::RowConverterBased { tombstones } => tombstones.max_sequence_number(),
         }
     }
 }
@@ -2182,8 +2172,7 @@ fn pk_deletion_snapshot_for_strategy(strategy: &PkDeletionStrategyWithCache) -> 
         } => {
             let snapshot = deletion_snapshot.load_full();
             PkDeletionSnapshot::Int64Pk {
-                deleted_pk_values: Arc::clone(&snapshot.deleted_pk),
-                insert_records: Arc::clone(&snapshot.insert_records),
+                tombstones: Arc::clone(&snapshot.tombstones),
             }
         }
         PkDeletionStrategyWithCache::RowConverterBased {
@@ -2191,8 +2180,7 @@ fn pk_deletion_snapshot_for_strategy(strategy: &PkDeletionStrategyWithCache) -> 
         } => {
             let snapshot = deletion_snapshot.load_full();
             PkDeletionSnapshot::RowConverterBased {
-                deleted_row_keys: Arc::clone(&snapshot.deleted_row_keys),
-                insert_records: Arc::clone(&snapshot.insert_records),
+                tombstones: Arc::clone(&snapshot.tombstones),
             }
         }
     }
@@ -5015,14 +5003,14 @@ impl CayenneTableProvider {
         let deleted_pk_i64: Option<Arc<DeletionIndex>> = match &self.pk_deletion_strategy {
             PkDeletionStrategyWithCache::Int64Pk {
                 deletion_snapshot, ..
-            } => Some(Arc::clone(&deletion_snapshot.load_full().deleted_pk)),
+            } => Some(Arc::clone(&deletion_snapshot.load_full().tombstones)),
             _ => None,
         };
 
         let deleted_row_keys: Option<Arc<KeyDeletionIndex>> = match &self.pk_deletion_strategy {
             PkDeletionStrategyWithCache::RowConverterBased {
                 deletion_snapshot, ..
-            } => Some(Arc::clone(&deletion_snapshot.load_full().deleted_row_keys)),
+            } => Some(Arc::clone(&deletion_snapshot.load_full().tombstones)),
             _ => None,
         };
 
@@ -5432,9 +5420,9 @@ impl CayenneTableProvider {
                             let pk_value = pk_array.value(row_idx);
                             match deleted_pks.get(pk_value) {
                                 None => false, // not deleted (bloom-prefiltered)
-                                Some(del_seq) => match min_delete_seq_threshold {
+                                Some(tombstone) => match min_delete_seq_threshold {
                                     None => true, // all deletions apply
-                                    Some(threshold) => del_seq > threshold,
+                                    Some(threshold) => tombstone.delete_sequence > threshold,
                                 },
                             }
                         } else {
@@ -5446,9 +5434,9 @@ impl CayenneTableProvider {
                             let key = rows.row(row_idx);
                             match deleted_keys.get(key.as_ref()) {
                                 None => false, // not deleted (bloom-prefiltered)
-                                Some(del_seq) => match min_delete_seq_threshold {
+                                Some(tombstone) => match min_delete_seq_threshold {
                                     None => true, // all deletions apply
-                                    Some(threshold) => del_seq > threshold,
+                                    Some(threshold) => tombstone.delete_sequence > threshold,
                                 },
                             }
                         } else {
@@ -6017,13 +6005,10 @@ impl CayenneTableProvider {
                     return;
                 }
                 let current = deletion_snapshot.load_full();
-                let updated_deleted = current
-                    .deleted_pk
-                    .extend_max(deleted_pk_i64.iter().map(|&pk| (pk, delete_sequence)));
-                deletion_snapshot.store(Arc::new(Int64PkDeletionSnapshot::from_arcs(
-                    Arc::new(updated_deleted),
-                    Arc::clone(&current.insert_records),
-                )));
+                let updated = current
+                    .tombstones
+                    .extend_max_deletes(deleted_pk_i64.iter().map(|&pk| (pk, delete_sequence)));
+                deletion_snapshot.store(Arc::new(Int64PkDeletionSnapshot::from_index(updated)));
                 self.refresh_deletion_memory_accounting();
             }
             PkDeletionStrategyWithCache::RowConverterBased {
@@ -6033,15 +6018,11 @@ impl CayenneTableProvider {
                     return;
                 }
                 let current = deletion_snapshot.load_full();
-                let updated_deleted = current.deleted_row_keys.extend_max(
-                    deleted_row_keys
-                        .iter()
-                        .map(|key| (key.clone(), delete_sequence)),
-                );
-                deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_arcs(
-                    Arc::new(updated_deleted),
-                    Arc::clone(&current.insert_records),
-                )));
+                let updated = current
+                    .tombstones
+                    .extend_max_deletes(deleted_row_keys.iter().map(|key| (key, delete_sequence)));
+                deletion_snapshot
+                    .store(Arc::new(RowConverterDeletionSnapshot::from_index(updated)));
                 self.refresh_deletion_memory_accounting();
             }
             PkDeletionStrategyWithCache::PositionBased { .. } => {
@@ -6443,36 +6424,25 @@ impl CayenneTableProvider {
                 deletion_snapshot, ..
             } => {
                 let current = deletion_snapshot.load_full();
-                let updated_deleted = current
-                    .deleted_pk
-                    .extend_max(deleted_pk_i64.iter().map(|&pk| (pk, delete_sequence)));
-                let updated_inserts = current
-                    .insert_records
-                    .extend_max(deleted_pk_i64.iter().map(|&pk| (pk, insert_sequence)));
-                deletion_snapshot.store(Arc::new(Int64PkDeletionSnapshot::from_indices(
-                    updated_deleted,
-                    updated_inserts,
-                )));
+                let updated = current.tombstones.extend_max_conflicts(
+                    deleted_pk_i64.iter().copied(),
+                    delete_sequence,
+                    insert_sequence,
+                );
+                deletion_snapshot.store(Arc::new(Int64PkDeletionSnapshot::from_index(updated)));
                 self.refresh_deletion_memory_accounting();
             }
             PkDeletionStrategyWithCache::RowConverterBased {
                 deletion_snapshot, ..
             } => {
                 let current = deletion_snapshot.load_full();
-                let updated_deleted = current.deleted_row_keys.extend_max(
-                    deleted_row_keys
-                        .iter()
-                        .map(|key| (key.clone(), delete_sequence)),
+                let updated = current.tombstones.extend_max_conflicts(
+                    deleted_row_keys,
+                    delete_sequence,
+                    insert_sequence,
                 );
-                let updated_inserts = current.insert_records.extend_max(
-                    deleted_row_keys
-                        .into_iter()
-                        .map(|key| (key, insert_sequence)),
-                );
-                deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_indices(
-                    updated_deleted,
-                    updated_inserts,
-                )));
+                deletion_snapshot
+                    .store(Arc::new(RowConverterDeletionSnapshot::from_index(updated)));
                 self.refresh_deletion_memory_accounting();
             }
             PkDeletionStrategyWithCache::PositionBased { .. } => {
@@ -6643,38 +6613,34 @@ impl CayenneTableProvider {
             PkDeletionStrategyWithCache::Int64Pk {
                 deletion_snapshot, ..
             } => {
-                // Build new deletion + insert snapshots and publish both in one
-                // ArcSwap store so readers never observe mismatched generations.
-                // Writers are serialised by the per-table write lock so the load+rebuild+store
-                // sequence is race-free.
+                // Record the deletion and the re-insertion in ONE fused-index
+                // pass and one ArcSwap store, so readers never observe
+                // mismatched generations. Writers are serialised by the
+                // per-table write lock so the load+rebuild+store sequence is
+                // race-free.
                 let current = deletion_snapshot.load_full();
-                let updated_deleted = current
-                    .deleted_pk
-                    .extend_max(deleted_pk_i64.iter().map(|&pk| (pk, delete_sequence)));
-                let deleted_count = updated_deleted.len();
-                let updated_inserts = current
-                    .insert_records
-                    .extend_max(deleted_pk_i64.iter().map(|&pk| (pk, insert_sequence)));
-                let insert_count = updated_inserts.len();
+                let updated = current.tombstones.extend_max_conflicts(
+                    deleted_pk_i64.iter().copied(),
+                    delete_sequence,
+                    insert_sequence,
+                );
                 tracing::debug!(
                     "Prepared Int64 PK deletion cache update with {} deleted keys (seq={}) and {} insert records (seq={}) for table {}",
-                    deleted_count,
+                    updated.delete_len(),
                     delete_sequence,
-                    insert_count,
+                    updated.insert_len(),
                     insert_sequence,
                     self.table_metadata.table_name
                 );
 
-                OnConflictDeletionUpdate::Int64Pk(Arc::new(Int64PkDeletionSnapshot::from_indices(
-                    updated_deleted,
-                    updated_inserts,
+                OnConflictDeletionUpdate::Int64Pk(Arc::new(Int64PkDeletionSnapshot::from_index(
+                    updated,
                 )))
             }
             PkDeletionStrategyWithCache::RowConverterBased {
                 deletion_snapshot, ..
             } => {
-                // Consume `results` to take owned `Box<[u8]>` keys; the second
-                // extend_max then MOVES them in instead of cloning. The branch
+                // Consume `results` to take owned `Box<[u8]>` keys. The branch
                 // is invariantly the sole `KeyBased` producer (one spec built
                 // above, results non-empty by the early-return at 4669).
                 let written_keys: Vec<Box<[u8]>> = results
@@ -6687,27 +6653,22 @@ impl CayenneTableProvider {
                         message: "RowConverterBased on-conflict deletion did not produce a key-based write result".to_string(),
                     })?;
                 let current = deletion_snapshot.load_full();
-                let updated_deleted = current.deleted_row_keys.extend_max(
-                    written_keys
-                        .iter()
-                        .map(|key| (key.clone(), delete_sequence)),
+                let updated = current.tombstones.extend_max_conflicts(
+                    written_keys,
+                    delete_sequence,
+                    insert_sequence,
                 );
-                let deleted_count = updated_deleted.len();
-                let updated_inserts = current
-                    .insert_records
-                    .extend_max(written_keys.into_iter().map(|key| (key, insert_sequence)));
-                let insert_count = updated_inserts.len();
                 tracing::debug!(
                     "Prepared RowConverter deletion cache update with {} deleted keys (seq={}) and {} insert records (seq={}) for table {}",
-                    deleted_count,
+                    updated.delete_len(),
                     delete_sequence,
-                    insert_count,
+                    updated.insert_len(),
                     insert_sequence,
                     self.table_metadata.table_name
                 );
 
                 OnConflictDeletionUpdate::RowConverter(Arc::new(
-                    RowConverterDeletionSnapshot::from_indices(updated_deleted, updated_inserts),
+                    RowConverterDeletionSnapshot::from_index(updated),
                 ))
             }
             PkDeletionStrategyWithCache::PositionBased { .. } => {
@@ -8489,10 +8450,10 @@ impl CayenneTableProvider {
             } => !cached_deleted_row_ids.load().is_empty(),
             PkDeletionStrategyWithCache::Int64Pk {
                 deletion_snapshot, ..
-            } => !deletion_snapshot.load().deleted_pk.is_empty(),
+            } => deletion_snapshot.load().tombstones.has_deletions(),
             PkDeletionStrategyWithCache::RowConverterBased {
                 deletion_snapshot, ..
-            } => !deletion_snapshot.load().deleted_row_keys.is_empty(),
+            } => deletion_snapshot.load().tombstones.has_deletions(),
         }
     }
 
@@ -9391,7 +9352,7 @@ impl CayenneTableProvider {
                             batch.column(pk_index).data_type()
                         ),
                     })?;
-                let deleted_pk = Arc::clone(&deletion_snapshot.load_full().deleted_pk);
+                let deleted_pk = Arc::clone(&deletion_snapshot.load_full().tombstones);
 
                 for row_index in 0..batch.num_rows() {
                     if pk_array.is_null(row_index) {
@@ -9403,6 +9364,7 @@ impl CayenneTableProvider {
                     let pk = pk_array.value(row_index);
                     let max_delete_sequence = deleted_pk
                         .get(pk)
+                        .map(|tombstone| tombstone.delete_sequence)
                         .into_iter()
                         .chain(inlined_deletions.int64_pk.get(&pk).copied())
                         .max();
@@ -9421,7 +9383,7 @@ impl CayenneTableProvider {
                     .map(|idx| Arc::clone(batch.column(*idx)))
                     .collect();
                 let rows = converter.convert_columns(&pk_columns)?;
-                let deleted_row_keys = Arc::clone(&deletion_snapshot.load_full().deleted_row_keys);
+                let deleted_row_keys = Arc::clone(&deletion_snapshot.load_full().tombstones);
 
                 for row_index in 0..batch.num_rows() {
                     if pk_columns.iter().any(|column| column.is_null(row_index)) {
@@ -9433,6 +9395,7 @@ impl CayenneTableProvider {
                     let row_key = rows.row(row_index);
                     let max_delete_sequence = deleted_row_keys
                         .get(row_key.as_ref())
+                        .map(|tombstone| tombstone.delete_sequence)
                         .into_iter()
                         .chain(inlined_deletions.row_keys.get(row_key.as_ref()).copied())
                         .max();
@@ -10026,10 +9989,10 @@ impl CayenneTableProvider {
                 }
                 PkDeletionStrategy::Int64Pk => PkDeletionStrategyWithCache::Int64Pk {
                     deletion_snapshot: Arc::new(ArcSwap::from_pointee(
-                        Int64PkDeletionSnapshot::from_indices(
-                            DeletionIndex::empty(),
-                            DeletionIndex::from_map(insert_records_pk_i64),
-                        ),
+                        Int64PkDeletionSnapshot::from_index(DeletionIndex::from_maps(
+                            HashMap::new(),
+                            insert_records_pk_i64,
+                        )),
                     )),
                     // No delete files => no position deletes either.
                     position_deletions: Arc::new(ArcSwap::from_pointee(PositionBitmap::new())),
@@ -10037,10 +10000,10 @@ impl CayenneTableProvider {
                 PkDeletionStrategy::RowConverterBased => {
                     PkDeletionStrategyWithCache::RowConverterBased {
                         deletion_snapshot: Arc::new(ArcSwap::from_pointee(
-                            RowConverterDeletionSnapshot::from_indices(
-                                KeyDeletionIndex::empty(),
-                                KeyDeletionIndex::from_map(insert_records_row_keys),
-                            ),
+                            RowConverterDeletionSnapshot::from_index(KeyDeletionIndex::from_maps(
+                                HashMap::new(),
+                                insert_records_row_keys,
+                            )),
                         )),
                         position_deletions: Arc::new(ArcSwap::from_pointee(PositionBitmap::new())),
                     }
@@ -10114,10 +10077,10 @@ impl CayenneTableProvider {
                 );
                 PkDeletionStrategyWithCache::Int64Pk {
                     deletion_snapshot: Arc::new(ArcSwap::from_pointee(
-                        Int64PkDeletionSnapshot::from_indices(
-                            DeletionIndex::from_map(int64_pks),
-                            DeletionIndex::from_map(insert_records_pk_i64),
-                        ),
+                        Int64PkDeletionSnapshot::from_index(DeletionIndex::from_maps(
+                            int64_pks,
+                            insert_records_pk_i64,
+                        )),
                     )),
                     // Position-delete files (written under `deletion_mode: position`
                     // for located rows) load here; empty for key-mode tables.
@@ -10139,10 +10102,10 @@ impl CayenneTableProvider {
                 );
                 PkDeletionStrategyWithCache::RowConverterBased {
                     deletion_snapshot: Arc::new(ArcSwap::from_pointee(
-                        RowConverterDeletionSnapshot::from_indices(
-                            KeyDeletionIndex::from_map(deleted_row_keys),
-                            KeyDeletionIndex::from_map(insert_records_row_keys),
-                        ),
+                        RowConverterDeletionSnapshot::from_index(KeyDeletionIndex::from_maps(
+                            deleted_row_keys,
+                            insert_records_row_keys,
+                        )),
                     )),
                     // Position-delete files (written under `deletion_mode: position`
                     // for located rows) load here; empty for key-mode tables.
@@ -10695,10 +10658,8 @@ impl CayenneTableProvider {
         // `crates/cayenne/benches/apply_partial_deletion_filter_per_scan.rs`
         // for the before-numbers.
         match deletion_snapshot {
-            PkDeletionSnapshot::Int64Pk {
-                deleted_pk_values, ..
-            } => {
-                if deleted_pk_values
+            PkDeletionSnapshot::Int64Pk { tombstones } => {
+                if tombstones
                     .max_sequence_number()
                     .is_none_or(|max_sequence| max_sequence <= min_delete_seq_to_apply)
                 {
@@ -10714,17 +10675,15 @@ impl CayenneTableProvider {
 
                 Ok(Arc::new(Int64PkDeletionFilterExec::new(
                     plan,
-                    Arc::clone(deleted_pk_values),
-                    DeletionIndex::shared_empty(),
+                    Arc::clone(tombstones),
+                    InsertRecordHandling::Ignore,
                     pk_column_index,
                     Some(min_delete_seq_to_apply),
                 )))
             }
-            PkDeletionSnapshot::RowConverterBased {
-                deleted_row_keys, ..
-            } => {
+            PkDeletionSnapshot::RowConverterBased { tombstones } => {
                 if let Some(ref row_converter) = self.pk_row_converter {
-                    if deleted_row_keys
+                    if tombstones
                         .max_sequence_number()
                         .is_none_or(|max_sequence| max_sequence <= min_delete_seq_to_apply)
                     {
@@ -10733,8 +10692,8 @@ impl CayenneTableProvider {
 
                     Ok(Arc::new(KeyBasedDeletionFilterExec::new(
                         plan,
-                        Arc::clone(deleted_row_keys),
-                        KeyDeletionIndex::shared_empty(),
+                        Arc::clone(tombstones),
+                        InsertRecordHandling::Ignore,
                         pk_indices_in_projection.to_vec(),
                         Arc::clone(row_converter),
                         Some(min_delete_seq_to_apply),
@@ -10758,12 +10717,10 @@ impl CayenneTableProvider {
         deletion_snapshot: &PkDeletionSnapshot,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
         match deletion_snapshot {
-            PkDeletionSnapshot::Int64Pk {
-                deleted_pk_values, ..
-            } => {
+            PkDeletionSnapshot::Int64Pk { tombstones } => {
                 // Protected snapshots already handle new data without filtering,
-                // so insert_records is the shared-static empty index.
-                if !deleted_pk_values.is_empty() {
+                // so insert records are ignored here.
+                if tombstones.has_deletions() {
                     let pk_column_index =
                         pk_indices_in_projection.first().copied().ok_or_else(|| {
                             datafusion_common::DataFusionError::Internal(
@@ -10774,23 +10731,21 @@ impl CayenneTableProvider {
 
                     return Ok(Arc::new(Int64PkDeletionFilterExec::new(
                         plan,
-                        Arc::clone(deleted_pk_values),
-                        DeletionIndex::shared_empty(),
+                        Arc::clone(tombstones),
+                        InsertRecordHandling::Ignore,
                         pk_column_index,
                         None,
                     )));
                 }
             }
-            PkDeletionSnapshot::RowConverterBased {
-                deleted_row_keys, ..
-            } => {
+            PkDeletionSnapshot::RowConverterBased { tombstones } => {
                 if let Some(ref row_converter) = self.pk_row_converter
-                    && !deleted_row_keys.is_empty()
+                    && tombstones.has_deletions()
                 {
                     return Ok(Arc::new(KeyBasedDeletionFilterExec::new(
                         plan,
-                        Arc::clone(deleted_row_keys),
-                        KeyDeletionIndex::shared_empty(),
+                        Arc::clone(tombstones),
+                        InsertRecordHandling::Ignore,
                         pk_indices_in_projection.to_vec(),
                         Arc::clone(row_converter),
                         None,
@@ -10816,15 +10771,12 @@ impl CayenneTableProvider {
         deletion_snapshot: &PkDeletionSnapshot,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
         match deletion_snapshot {
-            PkDeletionSnapshot::Int64Pk {
-                deleted_pk_values,
-                insert_records,
-            } => {
-                if !deleted_pk_values.is_empty() {
+            PkDeletionSnapshot::Int64Pk { tombstones } => {
+                if tombstones.has_deletions() {
                     tracing::debug!(
                         "Applying Int64 PK deletion filter ({} deleted keys, {} insert records) to scan of table {}",
-                        deleted_pk_values.len(),
-                        insert_records.len(),
+                        tombstones.delete_len(),
+                        tombstones.insert_len(),
                         self.table_metadata.table_name
                     );
 
@@ -10838,31 +10790,28 @@ impl CayenneTableProvider {
 
                     return Ok(Arc::new(Int64PkDeletionFilterExec::new(
                         plan,
-                        Arc::clone(deleted_pk_values),
-                        Arc::clone(insert_records),
+                        Arc::clone(tombstones),
+                        InsertRecordHandling::Apply,
                         pk_column_index,
                         None,
                     )));
                 }
             }
-            PkDeletionSnapshot::RowConverterBased {
-                deleted_row_keys,
-                insert_records,
-            } => {
+            PkDeletionSnapshot::RowConverterBased { tombstones } => {
                 if let Some(ref row_converter) = self.pk_row_converter
-                    && !deleted_row_keys.is_empty()
+                    && tombstones.has_deletions()
                 {
                     tracing::debug!(
                         "Applying RowConverter-based deletion filter ({} deleted keys, {} insert records) to scan of table {}",
-                        deleted_row_keys.len(),
-                        insert_records.len(),
+                        tombstones.delete_len(),
+                        tombstones.insert_len(),
                         self.table_metadata.table_name
                     );
 
                     return Ok(Arc::new(KeyBasedDeletionFilterExec::new(
                         plan,
-                        Arc::clone(deleted_row_keys),
-                        Arc::clone(insert_records),
+                        Arc::clone(tombstones),
+                        InsertRecordHandling::Apply,
                         pk_indices_in_projection.to_vec(),
                         Arc::clone(row_converter),
                         None,
@@ -12286,39 +12235,38 @@ mod tests {
             position_deletions: Arc::new(ArcSwap::from_pointee(PositionBitmap::new())),
         };
 
-        deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_indices(
+        deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_index(
             KeyDeletionIndex::from_map(HashMap::from([(
                 Box::<[u8]>::from([42_u8].as_slice()),
                 1_i64,
             )])),
-            KeyDeletionIndex::empty(),
         )));
 
         let scan_snapshot = pk_deletion_snapshot_for_strategy(&strategy);
         assert!(scan_snapshot.has_deletions());
 
-        deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_indices(
+        deletion_snapshot.store(Arc::new(RowConverterDeletionSnapshot::from_index(
             KeyDeletionIndex::from_map(HashMap::from([(
                 Box::<[u8]>::from([99_u8].as_slice()),
                 2_i64,
             )])),
-            KeyDeletionIndex::empty(),
         )));
 
-        let PkDeletionSnapshot::RowConverterBased {
-            deleted_row_keys, ..
-        } = scan_snapshot
-        else {
+        let PkDeletionSnapshot::RowConverterBased { tombstones } = scan_snapshot else {
             panic!("expected row-converter deletion snapshot");
         };
-        assert_eq!(deleted_row_keys.get(&[42_u8]), Some(1_i64));
-        assert_eq!(deleted_row_keys.get(&[99_u8]), None);
         assert_eq!(
-            deletion_snapshot.load().deleted_row_keys.get(&[42_u8]),
-            None
+            tombstones.get(&[42_u8]).map(|t| t.delete_sequence),
+            Some(1_i64)
         );
+        assert_eq!(tombstones.get(&[99_u8]), None);
+        assert_eq!(deletion_snapshot.load().tombstones.get(&[42_u8]), None);
         assert_eq!(
-            deletion_snapshot.load().deleted_row_keys.get(&[99_u8]),
+            deletion_snapshot
+                .load()
+                .tombstones
+                .get(&[99_u8])
+                .map(|t| t.delete_sequence),
             Some(2_i64)
         );
     }
@@ -12742,10 +12690,7 @@ mod tests {
         let deleted_index = DeletionIndex::from_map(HashMap::from([(2_i64, 1_i64)]));
         let strategy = PkDeletionStrategyWithCache::Int64Pk {
             deletion_snapshot: Arc::new(ArcSwap::from_pointee(
-                Int64PkDeletionSnapshot::from_indices(
-                    deleted_index.clone(),
-                    DeletionIndex::empty(),
-                ),
+                Int64PkDeletionSnapshot::from_index(deleted_index.clone()),
             )),
             position_deletions: Arc::new(ArcSwap::from_pointee(PositionBitmap::new())),
         };
@@ -12782,10 +12727,7 @@ mod tests {
             DeletionIndex::from_map(HashMap::from([(1_i64, 5_i64), (2_i64, 15_i64)]));
         let strategy = PkDeletionStrategyWithCache::Int64Pk {
             deletion_snapshot: Arc::new(ArcSwap::from_pointee(
-                Int64PkDeletionSnapshot::from_indices(
-                    deleted_index.clone(),
-                    DeletionIndex::empty(),
-                ),
+                Int64PkDeletionSnapshot::from_index(deleted_index.clone()),
             )),
             position_deletions: Arc::new(ArcSwap::from_pointee(PositionBitmap::new())),
         };

--- a/crates/hash-index/src/index.rs
+++ b/crates/hash-index/src/index.rs
@@ -129,10 +129,27 @@ pub fn hash_key_128(key: &[u8]) -> u128 {
     XxHash3_128::oneshot_with_seed(HASH_SEED, key)
 }
 
-/// [`BuildHasher`](std::hash::BuildHasher) producing the same seeded XXH3-64
-/// hashers as [`hash_key`], for keyed containers (e.g. `HashMap`/`im::HashMap`)
-/// that should share this crate's hashing instead of the standard library's
-/// SipHash default.
+/// One-shot XXH3-64 of an `i64` key. Produces the same value as
+/// [`hash_key`]`(&key)` — both hash the value's native-endian bytes with the
+/// crate seed — but skips the streaming hasher construction, which dominates
+/// per-probe cost when the entire input is 8 bytes. The equality is pinned by
+/// the `hash_key_i64_matches_streaming_hash_key` test.
+#[inline]
+#[must_use]
+pub fn hash_key_i64(key: i64) -> u64 {
+    XxHash3_64::oneshot_with_seed(HASH_SEED, &key.to_ne_bytes())
+}
+
+/// [`BuildHasher`](std::hash::BuildHasher) producing seeded XXH3-64 hashers
+/// that agree with [`hash_key`], for keyed containers (e.g.
+/// `HashMap`/`im::HashMap`) that should share this crate's hashing instead of
+/// the standard library's SipHash default.
+///
+/// The produced [`XxHash3Hasher`] buffers short inputs and hashes them with
+/// the **one-shot** XXH3-64 at `finish()`, skipping the streaming hasher's
+/// per-probe setup cost — the dominant term for 8-byte integer keys. Values
+/// are identical to streaming XXH3 over the same byte sequence, so containers
+/// using this hasher agree with [`hash_key`] / [`hash_key_i64`].
 ///
 /// The seed is fixed (not per-process random), matching [`hash_key`]: keys
 /// hashed here are internal primary-key values already fronted by fixed-seed
@@ -142,11 +159,66 @@ pub fn hash_key_128(key: &[u8]) -> u128 {
 pub struct XxHash3BuildHasher;
 
 impl std::hash::BuildHasher for XxHash3BuildHasher {
-    type Hasher = XxHash3_64;
+    type Hasher = XxHash3Hasher;
 
     #[inline]
-    fn build_hasher(&self) -> XxHash3_64 {
-        XxHash3_64::with_seed(HASH_SEED)
+    fn build_hasher(&self) -> XxHash3Hasher {
+        XxHash3Hasher {
+            buf: [0; XXH3_HASHER_INLINE_BUF],
+            len: 0,
+            spill: None,
+        }
+    }
+}
+
+/// Inline buffer size for [`XxHash3Hasher`]. Covers integer keys and small
+/// composites; longer inputs spill to the streaming implementation.
+const XXH3_HASHER_INLINE_BUF: usize = 32;
+
+/// Hasher produced by [`XxHash3BuildHasher`]. Buffers written bytes (up to
+/// [`XXH3_HASHER_INLINE_BUF`] inline) and hashes them one-shot at `finish()`;
+/// longer inputs spill to streaming XXH3-64, producing identical values.
+pub struct XxHash3Hasher {
+    buf: [u8; XXH3_HASHER_INLINE_BUF],
+    len: usize,
+    spill: Option<XxHash3_64>,
+}
+
+impl std::fmt::Debug for XxHash3Hasher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `XxHash3_64` has no `Debug` impl; report the mode instead.
+        f.debug_struct("XxHash3Hasher")
+            .field("buffered_len", &self.len)
+            .field("spilled", &self.spill.is_some())
+            .finish()
+    }
+}
+
+impl std::hash::Hasher for XxHash3Hasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        match &self.spill {
+            Some(streaming) => std::hash::Hasher::finish(streaming),
+            None => XxHash3_64::oneshot_with_seed(HASH_SEED, &self.buf[..self.len]),
+        }
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        if let Some(streaming) = &mut self.spill {
+            std::hash::Hasher::write(streaming, bytes);
+            return;
+        }
+        let new_len = self.len + bytes.len();
+        if new_len <= XXH3_HASHER_INLINE_BUF {
+            self.buf[self.len..new_len].copy_from_slice(bytes);
+            self.len = new_len;
+        } else {
+            let mut streaming = XxHash3_64::with_seed(HASH_SEED);
+            std::hash::Hasher::write(&mut streaming, &self.buf[..self.len]);
+            std::hash::Hasher::write(&mut streaming, bytes);
+            self.spill = Some(streaming);
+        }
     }
 }
 
@@ -204,6 +276,59 @@ impl std::hash::Hasher for PrehashedHasher {
     #[inline]
     fn write_u64(&mut self, value: u64) {
         self.state = value;
+    }
+}
+
+#[cfg(test)]
+mod hashing_tests {
+    use super::*;
+    use std::hash::{BuildHasher, Hasher};
+
+    /// Pins the one-shot/streaming equality that bloom filters and maps rely
+    /// on to agree: `hash_key_i64` must equal `hash_key(&i64)` forever.
+    #[test]
+    fn hash_key_i64_matches_streaming_hash_key() {
+        for key in [0_i64, 1, -1, 42, i64::MIN, i64::MAX, 0x5370_6963] {
+            assert_eq!(hash_key_i64(key), hash_key(&key), "mismatch for {key}");
+        }
+    }
+
+    /// The buffered one-shot hasher must agree with [`hash_key`] for hashed
+    /// integer keys (a container keyed with `XxHash3BuildHasher` and a filter
+    /// fed by `hash_key`/`hash_key_i64` see the same values).
+    #[test]
+    fn build_hasher_matches_hash_key_for_i64() {
+        for key in [0_i64, 7, -7, i64::MIN, i64::MAX] {
+            let mut hasher = XxHash3BuildHasher.build_hasher();
+            std::hash::Hash::hash(&key, &mut hasher);
+            assert_eq!(hasher.finish(), hash_key(&key), "mismatch for {key}");
+        }
+    }
+
+    /// Split writes must hash like one contiguous write, and inputs past the
+    /// inline buffer must spill to streaming with identical results.
+    #[test]
+    fn buffered_hasher_is_write_boundary_invariant() {
+        let payload: Vec<u8> = (0_u8..=63).collect(); // 64 bytes: forces spill
+        for split in [1_usize, 8, 31, 32, 33, 63] {
+            let mut split_hasher = XxHash3BuildHasher.build_hasher();
+            split_hasher.write(&payload[..split]);
+            split_hasher.write(&payload[split..]);
+
+            let mut whole_hasher = XxHash3BuildHasher.build_hasher();
+            whole_hasher.write(&payload);
+
+            assert_eq!(
+                split_hasher.finish(),
+                whole_hasher.finish(),
+                "mismatch at split {split}"
+            );
+            assert_eq!(
+                whole_hasher.finish(),
+                XxHash3_64::oneshot_with_seed(HASH_SEED, &payload),
+                "spill path must match one-shot at split {split}"
+            );
+        }
     }
 }
 

--- a/crates/hash-index/src/index.rs
+++ b/crates/hash-index/src/index.rs
@@ -143,7 +143,7 @@ pub fn hash_key_i64(key: i64) -> u64 {
 /// [`BuildHasher`](std::hash::BuildHasher) producing seeded XXH3-64 hashers
 /// that agree with [`hash_key`], for keyed containers (e.g.
 /// `HashMap`/`im::HashMap`) that should share this crate's hashing instead of
-/// the standard library's SipHash default.
+/// the standard library's `SipHash` default.
 ///
 /// The produced [`XxHash3Hasher`] buffers short inputs and hashes them with
 /// the **one-shot** XXH3-64 at `finish()`, skipping the streaming hasher's
@@ -186,11 +186,12 @@ pub struct XxHash3Hasher {
 
 impl std::fmt::Debug for XxHash3Hasher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // `XxHash3_64` has no `Debug` impl; report the mode instead.
+        // `XxHash3_64` has no `Debug` impl; report the mode instead of the
+        // raw buffer/spill fields.
         f.debug_struct("XxHash3Hasher")
             .field("buffered_len", &self.len)
             .field("spilled", &self.spill.is_some())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/hash-index/src/index.rs
+++ b/crates/hash-index/src/index.rs
@@ -54,7 +54,7 @@ use std::time::Instant;
 use arrow::array::RecordBatch;
 use parking_lot::RwLock;
 use snafu::OptionExt;
-use twox_hash::XxHash3_64;
+use twox_hash::{XxHash3_64, XxHash3_128};
 
 use crate::bloom::BloomFilter;
 use crate::extract::create_key_extractor;
@@ -114,6 +114,97 @@ pub fn hash_key_bytes(parts: &[&[u8]]) -> u64 {
         hasher.write(part);
     }
     hasher.finish()
+}
+
+/// Computes a 128-bit XXH3 hash for a byte key, using the same fixed seed as
+/// [`hash_key`].
+///
+/// Use this where a hash value serves as the key's *identity* (the key bytes
+/// are not retained for comparison): a 64-bit hash reaches ~0.3% collision
+/// probability at one billion keys (birthday bound), while 128 bits stays
+/// below ~1e-20 at the same scale — far under hardware error rates.
+#[inline]
+#[must_use]
+pub fn hash_key_128(key: &[u8]) -> u128 {
+    XxHash3_128::oneshot_with_seed(HASH_SEED, key)
+}
+
+/// [`BuildHasher`](std::hash::BuildHasher) producing the same seeded XXH3-64
+/// hashers as [`hash_key`], for keyed containers (e.g. `HashMap`/`im::HashMap`)
+/// that should share this crate's hashing instead of the standard library's
+/// SipHash default.
+///
+/// The seed is fixed (not per-process random), matching [`hash_key`]: keys
+/// hashed here are internal primary-key values already fronted by fixed-seed
+/// bloom filters, so per-process seeding would add cost without changing the
+/// trust model.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct XxHash3BuildHasher;
+
+impl std::hash::BuildHasher for XxHash3BuildHasher {
+    type Hasher = XxHash3_64;
+
+    #[inline]
+    fn build_hasher(&self) -> XxHash3_64 {
+        XxHash3_64::with_seed(HASH_SEED)
+    }
+}
+
+/// [`BuildHasher`](std::hash::BuildHasher) for maps whose keys are *already*
+/// uniform hash values (e.g. a `u128` from [`hash_key_128`]): passes the key's
+/// own entropy through instead of re-hashing it. `u128` keys contribute their
+/// low 64 bits; `u64` keys pass through unchanged.
+///
+/// Only meaningful for pre-hashed keys — using it with structured keys would
+/// forfeit hashing entirely (non-integer writes fall back to seeded XXH3-64 to
+/// stay correct, at normal hashing cost).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PrehashedBuildHasher;
+
+impl std::hash::BuildHasher for PrehashedBuildHasher {
+    type Hasher = PrehashedHasher;
+
+    #[inline]
+    fn build_hasher(&self) -> PrehashedHasher {
+        PrehashedHasher { state: 0 }
+    }
+}
+
+/// Hasher produced by [`PrehashedBuildHasher`]. See its docs for the contract.
+#[derive(Debug)]
+pub struct PrehashedHasher {
+    state: u64,
+}
+
+impl std::hash::Hasher for PrehashedHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.state
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        // Fallback for non-integer keys: real hashing so correctness never
+        // depends on callers honoring the pre-hashed contract.
+        let mut hasher = XxHash3_64::with_seed(HASH_SEED);
+        std::hash::Hasher::write(&mut hasher, &self.state.to_le_bytes());
+        std::hash::Hasher::write(&mut hasher, bytes);
+        self.state = std::hash::Hasher::finish(&hasher);
+    }
+
+    #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "low 64 bits of a uniform 128-bit hash are themselves uniform"
+    )]
+    fn write_u128(&mut self, value: u128) {
+        self.state = value as u64;
+    }
+
+    #[inline]
+    fn write_u64(&mut self, value: u64) {
+        self.state = value;
+    }
 }
 
 /// Location of a row in the accelerator's storage.

--- a/crates/hash-index/src/lib.rs
+++ b/crates/hash-index/src/lib.rs
@@ -55,7 +55,6 @@ mod sbbf;
 mod tests;
 
 pub use bloom::{BatchBloomFilter, BloomFilter};
-pub use sbbf::SplitBlockBloomFilter;
 pub use extract::{
     KeyExtractor, PrimitiveKeyExtractor, RowConverterKeyExtractor, Utf8KeyExtractor,
 };
@@ -64,6 +63,7 @@ pub use index::{
     RowLocation, XxHash3BuildHasher, XxHash3Hasher, hash_key, hash_key_128, hash_key_bytes,
     hash_key_i64, index_threshold,
 };
+pub use sbbf::SplitBlockBloomFilter;
 
 use snafu::prelude::*;
 

--- a/crates/hash-index/src/lib.rs
+++ b/crates/hash-index/src/lib.rs
@@ -61,7 +61,8 @@ pub use extract::{
 };
 pub use index::{
     HashIndex, HashIndexBuilder, InsertResult, NUM_SHARDS, PrehashedBuildHasher, PrehashedHasher,
-    RowLocation, XxHash3BuildHasher, hash_key, hash_key_128, hash_key_bytes, index_threshold,
+    RowLocation, XxHash3BuildHasher, XxHash3Hasher, hash_key, hash_key_128, hash_key_bytes,
+    hash_key_i64, index_threshold,
 };
 
 use snafu::prelude::*;

--- a/crates/hash-index/src/lib.rs
+++ b/crates/hash-index/src/lib.rs
@@ -49,17 +49,19 @@ limitations under the License.
 mod bloom;
 mod extract;
 mod index;
+mod sbbf;
 
 #[cfg(test)]
 mod tests;
 
 pub use bloom::{BatchBloomFilter, BloomFilter};
+pub use sbbf::SplitBlockBloomFilter;
 pub use extract::{
     KeyExtractor, PrimitiveKeyExtractor, RowConverterKeyExtractor, Utf8KeyExtractor,
 };
 pub use index::{
-    HashIndex, HashIndexBuilder, InsertResult, NUM_SHARDS, RowLocation, hash_key, hash_key_bytes,
-    index_threshold,
+    HashIndex, HashIndexBuilder, InsertResult, NUM_SHARDS, PrehashedBuildHasher, PrehashedHasher,
+    RowLocation, XxHash3BuildHasher, hash_key, hash_key_128, hash_key_bytes, index_threshold,
 };
 
 use snafu::prelude::*;

--- a/crates/hash-index/src/sbbf.rs
+++ b/crates/hash-index/src/sbbf.rs
@@ -1,0 +1,287 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Split-block bloom filter for cache-efficient negative lookups.
+//!
+//! A split-block bloom filter (SBBF — the design used by Apache Parquet and
+//! Impala) confines every key to a single 256-bit block: the high 32 bits of
+//! the key's hash select the block and the low 32 bits derive eight bit
+//! positions inside it, one per 32-bit word. A probe therefore touches exactly
+//! one 32-byte, cache-line-aligned block — at most a single cache miss — where
+//! a classic bloom filter with `k` hash functions ([`BloomFilter`]) takes up to
+//! `k` dependent cache misses per probe.
+//!
+//! [`BloomFilter`]: crate::BloomFilter
+//!
+//! # Concurrency
+//!
+//! [`insert`](SplitBlockBloomFilter::insert) takes `&self`: words are
+//! [`AtomicU32`] and bits are set with relaxed `fetch_or`. This lets a writer
+//! extend a filter that is concurrently probed by readers pinning older
+//! snapshots of the indexed data. A reader that observes bits from a newer
+//! generation sees a superset of its own generation's keys, which can only add
+//! false positives — never false negatives — so probes stay correct without
+//! locking or copy-on-write of the bit array. Relaxed atomic loads compile to
+//! plain loads on x86-64 and aarch64, so the probe path costs the same as a
+//! non-atomic implementation.
+//!
+//! # False positive rate
+//!
+//! Sized at 16 bits per item ([`SplitBlockBloomFilter::new`]), the FPR at
+//! design capacity is ≈0.04%. Unlike a classic bloom filter the FPR degrades
+//! steeply once fill exceeds capacity, so callers should size for projected
+//! growth and rebuild before the item count crosses the sized capacity.
+
+use std::array;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Per-word salt constants from the Parquet split-block bloom filter spec.
+/// Each odd constant maps the low 32 hash bits to an independent bit position
+/// within one 32-bit word of the block.
+const SALT: [u32; 8] = [
+    0x47b6_137b,
+    0x4497_4d91,
+    0x8824_ad5b,
+    0xa2b7_289d,
+    0x7054_95c7,
+    0x2df1_424b,
+    0x9efc_4947,
+    0x5c6b_fb31,
+];
+
+/// Bits allocated per expected item. 16 bits/item gives ≈0.04% FPR at design
+/// capacity — comfortably below the classic filter's 0.82% at 10 bits/item —
+/// while keeping the filter ~2 bytes per key, negligible next to the indexes
+/// it fronts.
+const BITS_PER_ITEM: usize = 16;
+
+/// One 256-bit filter block. `align(32)` keeps a block from straddling two
+/// cache lines, preserving the one-miss-per-probe property.
+#[derive(Debug, Default)]
+#[repr(align(32))]
+struct Block([AtomicU32; 8]);
+
+/// A cache-efficient split-block bloom filter with lock-free concurrent
+/// inserts.
+///
+/// If [`might_contain`](Self::might_contain) returns `false`, the item is
+/// definitely not in the set. If it returns `true`, the item might be (check
+/// the backing structure). See the [module docs](self) for the block layout
+/// and concurrency contract.
+#[derive(Debug)]
+pub struct SplitBlockBloomFilter {
+    blocks: Vec<Block>,
+}
+
+impl SplitBlockBloomFilter {
+    /// Creates a filter sized for `expected_items` at 16 bits per item.
+    ///
+    /// Always allocates at least one block, so the filter is usable (and
+    /// rejects misses) even when sized for zero items.
+    #[must_use]
+    pub fn new(expected_items: usize) -> Self {
+        let num_blocks = expected_items
+            .saturating_mul(BITS_PER_ITEM)
+            .div_ceil(256)
+            .max(1);
+        Self {
+            blocks: (0..num_blocks).map(|_| Block::default()).collect(),
+        }
+    }
+
+    /// Number of items this filter was sized for at the design FPR.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.blocks.len() * 256 / BITS_PER_ITEM
+    }
+
+    /// Memory used by the bit array, in bytes.
+    #[must_use]
+    pub fn memory_usage_bytes(&self) -> usize {
+        self.blocks.len() * size_of::<Block>()
+    }
+
+    /// Selects the block for `hash` via multiply-shift range reduction over
+    /// the high 32 bits, leaving the low 32 bits independent for the in-block
+    /// bit positions. The double shift keeps the product within block range,
+    /// so the final cast cannot truncate.
+    #[inline]
+    fn block_index(&self, hash: u64) -> usize {
+        (((hash >> 32) * (self.blocks.len() as u64)) >> 32) as usize
+    }
+
+    /// Computes the eight per-word bit masks for `hash` from its low 32 bits.
+    #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "intentional truncation to the low 32 bits"
+    )]
+    fn masks(hash: u64) -> [u32; 8] {
+        let h = hash as u32;
+        array::from_fn(|i| 1_u32 << (h.wrapping_mul(SALT[i]) >> 27))
+    }
+
+    /// Inserts a hash into the filter.
+    ///
+    /// Takes `&self`: bits are set with relaxed atomic `fetch_or`, so a writer
+    /// may insert while readers probe concurrently (readers observe a safe
+    /// superset; see the [module docs](self)). Callers that require a reader
+    /// to see the bits for a specific key must publish the surrounding
+    /// structure with release/acquire ordering (e.g. `ArcSwap::store`), as the
+    /// deletion index does.
+    #[inline]
+    pub fn insert(&self, hash: u64) {
+        let block = &self.blocks[self.block_index(hash)];
+        let masks = Self::masks(hash);
+        for (word, mask) in block.0.iter().zip(masks) {
+            word.fetch_or(mask, Ordering::Relaxed);
+        }
+    }
+
+    /// Checks whether a hash might be in the filter.
+    ///
+    /// Returns `false` if the item is definitely not present; `true` if it
+    /// might be (possible false positive). Touches exactly one 32-byte block.
+    #[inline]
+    #[must_use]
+    pub fn might_contain(&self, hash: u64) -> bool {
+        let block = &self.blocks[self.block_index(hash)];
+        let masks = Self::masks(hash);
+        block
+            .0
+            .iter()
+            .zip(masks)
+            .all(|(word, mask)| word.load(Ordering::Relaxed) & mask == mask)
+    }
+}
+
+impl Clone for SplitBlockBloomFilter {
+    /// Snapshots the bit array with relaxed loads. Cloning concurrently with
+    /// inserts yields some consistent superset/subset of in-flight bits, which
+    /// is safe for bloom semantics (per-bit monotonicity); clones intended to
+    /// capture specific keys must be taken after those inserts are published.
+    fn clone(&self) -> Self {
+        Self {
+            blocks: self
+                .blocks
+                .iter()
+                .map(|block| {
+                    Block(array::from_fn(|i| {
+                        AtomicU32::new(block.0[i].load(Ordering::Relaxed))
+                    }))
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash_key;
+
+    #[test]
+    fn insert_then_contains() {
+        let filter = SplitBlockBloomFilter::new(100);
+        for key in [12345_i64, 67890, 11111, -1, 0, i64::MAX] {
+            filter.insert(hash_key(&key));
+        }
+        for key in [12345_i64, 67890, 11111, -1, 0, i64::MAX] {
+            assert!(filter.might_contain(hash_key(&key)), "missing key {key}");
+        }
+    }
+
+    #[test]
+    fn no_false_negatives_even_when_overfilled() {
+        // 4x over design capacity: FPR degrades but false negatives must not occur.
+        let filter = SplitBlockBloomFilter::new(1_000);
+        for key in 0_i64..4_000 {
+            filter.insert(hash_key(&key));
+        }
+        for key in 0_i64..4_000 {
+            assert!(filter.might_contain(hash_key(&key)), "missing key {key}");
+        }
+    }
+
+    #[test]
+    fn false_positive_rate_at_capacity() {
+        let n = 100_000_i64;
+        #[expect(clippy::cast_sign_loss, reason = "n is positive")]
+        let filter = SplitBlockBloomFilter::new(n as usize);
+        for key in 0..n {
+            filter.insert(hash_key(&key));
+        }
+
+        let mut false_positives = 0_u32;
+        for key in n..(2 * n) {
+            if filter.might_contain(hash_key(&key)) {
+                false_positives += 1;
+            }
+        }
+        // Design FPR at 16 bits/item is ≈0.04%; allow generous margin.
+        let fpr = f64::from(false_positives) / 1_000.0; // percent of 100k probes
+        assert!(fpr < 0.5, "FPR too high at design capacity: {fpr:.3}%");
+    }
+
+    #[test]
+    fn zero_capacity_is_usable() {
+        let filter = SplitBlockBloomFilter::new(0);
+        assert!(filter.capacity() >= 1);
+        filter.insert(hash_key(&42_i64));
+        assert!(filter.might_contain(hash_key(&42_i64)));
+        assert!(!filter.might_contain(hash_key(&43_i64)));
+    }
+
+    #[test]
+    fn clone_snapshots_bits() {
+        let filter = SplitBlockBloomFilter::new(100);
+        filter.insert(hash_key(&1_i64));
+        let snapshot = filter.clone();
+        filter.insert(hash_key(&2_i64));
+
+        assert!(snapshot.might_contain(hash_key(&1_i64)));
+        assert!(filter.might_contain(hash_key(&2_i64)));
+        assert!(!snapshot.might_contain(hash_key(&2_i64)));
+    }
+
+    #[test]
+    fn shared_insert_is_a_superset_for_old_readers() {
+        // Simulates the deletion-index generation model: an old reader keeps
+        // probing the same filter while a writer inserts new keys. Old keys
+        // stay present (no false negatives ever).
+        let filter = std::sync::Arc::new(SplitBlockBloomFilter::new(1_000));
+        for key in 0_i64..500 {
+            filter.insert(hash_key(&key));
+        }
+        let reader = std::sync::Arc::clone(&filter);
+        for key in 500_i64..1_000 {
+            filter.insert(hash_key(&key));
+        }
+        for key in 0_i64..500 {
+            assert!(reader.might_contain(hash_key(&key)), "missing key {key}");
+        }
+    }
+
+    #[test]
+    fn memory_usage_matches_sizing() {
+        let filter = SplitBlockBloomFilter::new(1_000);
+        // 1000 items * 16 bits = 16,000 bits = 2,000 bytes, rounded up to
+        // 32-byte blocks.
+        let usage = filter.memory_usage_bytes();
+        assert!(usage >= 2_000, "memory usage too low: {usage}");
+        assert!(usage <= 2_048, "memory usage too high: {usage}");
+    }
+}

--- a/crates/hash-index/src/sbbf.rs
+++ b/crates/hash-index/src/sbbf.rs
@@ -120,10 +120,6 @@ impl SplitBlockBloomFilter {
     /// `2^32` (a >128 GiB filter) cannot overflow the product; the double
     /// shift keeps the result within block range, so the cast cannot truncate.
     #[inline]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "range reduction bounds the result to the block count"
-    )]
     fn block_index(&self, hash: u64) -> usize {
         ((u128::from(hash >> 32) * self.blocks.len() as u128) >> 32) as usize
     }

--- a/crates/hash-index/src/sbbf.rs
+++ b/crates/hash-index/src/sbbf.rs
@@ -116,11 +116,16 @@ impl SplitBlockBloomFilter {
 
     /// Selects the block for `hash` via multiply-shift range reduction over
     /// the high 32 bits, leaving the low 32 bits independent for the in-block
-    /// bit positions. The double shift keeps the product within block range,
-    /// so the final cast cannot truncate.
+    /// bit positions. The multiply widens to `u128` so block counts beyond
+    /// `2^32` (a >128 GiB filter) cannot overflow the product; the double
+    /// shift keeps the result within block range, so the cast cannot truncate.
     #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "range reduction bounds the result to the block count"
+    )]
     fn block_index(&self, hash: u64) -> usize {
-        (((hash >> 32) * (self.blocks.len() as u64)) >> 32) as usize
+        ((u128::from(hash >> 32) * self.blocks.len() as u128) >> 32) as usize
     }
 
     /// Computes the eight per-word bit masks for `hash` from its low 32 bits.

--- a/docs/release_notes/v2.0.0.md
+++ b/docs/release_notes/v2.0.0.md
@@ -1,0 +1,1108 @@
+# Spice v2.0.0 (June 4, 2026)
+
+Spice v2.0.0 is the next major release of Spice and a major milestone in the project's development, advancing Spice from a single-node engine into a distributed data and query platform built for enterprise AI agents. These agents need low-latency, governed access to data spread across many production systems, and because they generate their own queries autonomously, that access has to be sandboxed, observable, and able to absorb occasional heavy analytical queries without overwhelming the underlying systems. The release is headlined by **multi-node distributed query**, now generally available — multi-active, highly-available, and object-store-native, built on Apache Ballista — distributing both query execution and ingestion across executors with data-local routing and per-executor statistics for distributed join planning. Alongside it, the **Spice Cayenne data accelerator is generally available**, built on the Vortex compressed columnar format, with a high-throughput CDC write path, MERGE INTO, SQL-defined partitioning, inline writes, a dedicated compaction runtime, and write-path statistics for distributed join sizing. The engine also moves to **DataFusion v52** with sort pushdown, a rewritten merge join, and dynamic filters, and the **Spice CLI is rewritten in Rust** as a single self-contained binary.
+
+v2.0 also expands real-time and write-path capabilities across the platform: native **CDC from MongoDB Change Streams and PostgreSQL WAL logical replication**, durable **Kafka CDC offsets**, **DML write-back** for PostgreSQL, Snowflake, DynamoDB, Arrow, and DuckLake, **DDL and MERGE INTO** for Iceberg catalogs, **mutual TLS** across server endpoints and outbound connectors, **HashiCorp Vault and Azure Key Vault secret stores**, **user-defined functions**, hybrid **search with Elasticsearch and DuckDB HNSW vector indexes**, provider-aware **LLM prompt caching**, and the **Responses API across all model providers**.
+
+Highlights in v2.0.0 include:
+
+- **[Spice Cayenne (GA)](#spice-cayenne-reaches-general-availability)** — generally available on the Vortex compressed columnar format, with WAL-staged writes, inline low-latency writes, fast-path CDC deletes, merge-on-read position deletes, composite & SQL-defined partitioning, MERGE INTO, dedicated compaction runtime, and join-sizing statistics maintained on the write path
+- **[Multi-Active HA Distributed Query (GA)](#multi-active-ha-distributed-query-ga)** — multi-node distributed query built on Apache Ballista, with object-store-native clustering, dynamic cluster sizing, distributed ingestion, data-local query routing, per-executor table statistics for distributed join planning, and async queries via `/v1/queries`
+- **[Mutual TLS (mTLS)](#security-mutual-tls-secret-stores-and-hardening)** — public mTLS for HTTP and Flight, TLS cert hot-reload, and mTLS client certificates for FlightSQL and Spice.ai connectors
+- **[Enterprise Authentication & Authorization](#security-mutual-tls-secret-stores-and-hardening)** — OIDC bearer-token verification and Cedar-based authorization policy with per-principal row- and column-level filtering
+- **[New Secret Stores](#security-mutual-tls-secret-stores-and-hardening)** — HashiCorp Vault and Azure Key Vault
+- **[CDC Sources](#change-data-capture-cdc-sources)** — native MongoDB Change Streams, PostgreSQL WAL logical replication, and durable Kafka CDC offsets — no Debezium or Kafka middleware required
+- **[DML & DDL](#dml-ddl-and-write-back)** — INSERT/UPDATE/DELETE write-back for PostgreSQL, Snowflake, DynamoDB, and Arrow; `CREATE TABLE`/`DROP TABLE` and `MERGE INTO` for Iceberg catalogs
+- **[User-Defined Functions](#sql--user-defined-functions)** — SQL UDFs in spicepods, remote UDFs over HTTP, and optional geospatial `ST_*` UDFs
+- **[On-Demand Dataset Loading & Unified Query Cancellation](#runtime-features)** — faster startup and end-to-end cancellation across HTTP, Flight, FlightSQL, and MCP
+- **[Dynamic HTTP Connector](#data-connectors--catalogs)** — OAuth2 refresh tokens, pagination, dynamic headers, subquery-driven parameters, and rate-control state persisted across restarts
+- **[Storage-Profile Accelerator Tuning & `refresh_mode: snapshot`](#runtime-features)** — storage-aware acceleration defaults and point-in-time snapshot acceleration
+- **[Search & Vectors](#search--vectors)** — Elasticsearch data connector with native hybrid search, DuckDB HNSW vector engine with a statically linked VSS extension, multi-vector MaxSim embeddings, and a `rerank()` UDTF
+- **[AI & LLM](#ai--llm)** — provider-aware prompt caching, Responses API across all providers, MCP Streamable HTTP transport, and a searchable LLM tool registry
+- **[New Data Connectors](#data-connectors--catalogs)** — Elasticsearch (Alpha), GCS (Alpha), Azure Cosmos DB (Alpha), Git (RC), ADBC, DuckLake (Beta), and catalog connectors for PostgreSQL, MySQL, MSSQL, and Snowflake
+- **[Rust CLI](#rust-cli)** — single-binary `spice` CLI with `spice query` async REPL, shell completions, and `--output=json`
+- **[Dependency upgrades](#dependency-updates)** including **DataFusion v52.5**, **DuckDB v1.5.3**, **Arrow v57.2**, **iceberg-rust v0.9.1**, **Turso v0.6.1**, and **Vortex v0.69**
+
+Spice v2.0 includes several [breaking changes](#breaking-changes). Review the breaking changes section before upgrading.
+
+## Distribution Changes
+
+AI/ML support including local LLM/ML model and hosted LLM inference is now included in the default Spice build and image. The separate `models` build variant has been removed.
+
+With models now included by default, the data-only distribution (without AI/ML support) is only published in nightly builds. Official production-ready data-only distributions are available exclusively through [Spice Cloud](https://spice.ai/pricing) and the Enterprise release.
+
+A new Network Attached Storage (NAS) distribution with built-in SMB and NFS data connector support is also available in nightly builds and with [Spice.ai Enterprise](https://spice.ai/pricing).
+
+| Distribution / Variant | Open Source      | Spice Cloud | Enterprise |
+| ---------------------- | ---------------- | ----------- | ---------- |
+| Default                | ✅                | ✅           | ✅          |
+| Data                   | Nightly only     | ✅           | ✅          |
+| NAS (SMB + NFS)        | Nightly only     | ❌           | ✅          |
+| Metal (macOS)          | ✅                | ✅           | ✅          |
+| CUDA (Linux)           | Nightly only     | ✅           | ✅          |
+| Allocator variants     | Nightly only     | ✅           | ✅          |
+| ODBC connector         | Local build only | ✅           | ✅          |
+
+Native Windows builds are no longer provided; use [WSL](https://learn.microsoft.com/en-us/windows/wsl/) for local development. For more details, see the [Distributions documentation](../DISTRIBUTIONS.md).
+
+## What's New in v2.0.0
+
+### Spice Cayenne Reaches General Availability
+
+The [Spice Cayenne data accelerator](https://spiceai.org/docs/components/data-accelerators/cayenne) is generally available in v2.0, with a major focus across the release candidates on write-path throughput, correctness, and distributed operation.
+
+**Write path & ingest**:
+
+- **Staged Append Writes**: WAL-based staged append writes prevent partial writes and data loss on stream errors — batches commit atomically.
+- **Inline Writes**: Small writes are serialized as Arrow IPC and committed directly into the Cayenne metastore, bypassing the staged Vortex write path for low-latency ingest. Inline upserts atomically rewrite existing inline rows, inline data stays query-visible via an in-memory union scan, and rows are checkpointed to Vortex when thresholds are reached. Inline writes now also proceed with pending deletions in flight, and inline flush caps scale with available memory and storage class.
+- **Fast-Path CDC Deletes**: `DELETE` statements whose filters identify primary keys directly — including composite keys expressed as `(k1, k2) IN ((...), (...))` — skip the table scan entirely.
+- **Merge-On-Read Position Deletes**: Primary-key upsert tables use position deletes with memory-pool accounting, avoiding full-table rewrites on update-heavy workloads.
+- **Resident Upsert Keysets**: CDC upsert primary-key keysets stay resident between batches, avoiding per-batch full-table rebuilds.
+- **CDC Sub-Batch Efficiency**: Interleaved upsert/delete workloads produce fewer sub-batch splits, with last-write-wins deduplication applied within batches.
+- **Dedicated Compaction Runtime**: Background compaction runs on a dedicated thread pool with CDC pipelining and protected snapshots, isolating compaction work from query and ingest paths.
+
+**Query & planning**:
+
+- **Join Filter Propagation**: Filters propagate across equi-join keys, with range fallback for large join filters and IN-list rewrites.
+- **Write-Path Join-Sizing Statistics**: Cayenne maintains live row counts and HyperLogLog-based distinct-value estimates on the write path, so distributed `JoinSelection` can correctly size joins without rescans.
+- **Scan-Result Cache**: A new scan-result cache accelerates hot reads, with parallel Vortex partition writes and lock-free deletion caches with bloom-prefiltered probes.
+
+**SQL & catalog**:
+
+- **MERGE INTO**: Upsert-style `MERGE INTO` for Cayenne catalog tables, distributed across executors in cluster mode.
+- **`PARTITION BY` in SQL**: Define partitioning directly in `CREATE TABLE ... PARTITION BY (...)`; metadata is persisted in the catalog and survives restarts.
+- **Composite Partitioning**: `partition_by: [col1, col2]` with hierarchical path-like keys.
+- **File-Based Retention Deletes**: Time-based retention uses file-level deletes for both position-based and primary-key tables.
+
+**Correctness**: Synchronized partition commits, correct `NULL`-sentinel handling for nullable partition expressions, tombstoned inline-checkpointed rows on upsert (preventing duplicate primary keys), and live reads through expired protected snapshots.
+
+### Multi-Active HA Distributed Query (GA)
+
+> [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise) feature. See [High Availability](https://docs.spice.ai/docs/enterprise/production/high-availability).
+
+[Distributed Query](https://spiceai.org/docs/features/distributed-query) is generally available. Built on Apache Ballista, it distributes query execution across multiple active executor nodes with no single point of failure, reading directly from object storage rather than relying on a central cluster.
+
+Distributed query supports two execution modes:
+
+- **Synchronous**: Queries for accelerated datasets are distributed across executors and results stream back in real-time — best for interactive, latency-sensitive queries.
+- **Asynchronous**: Queries submitted via the HTTP `/v1/queries` API materialize results to object storage for later retrieval — best for long-running analytical and batch workloads.
+
+**Key capabilities**:
+
+- **Dynamic Cluster Sizing**: The planner adjusts parallelism to the number of active executors as nodes join or leave.
+- **Distributed Ingestion**: Ingestion for partitioned accelerated tables is distributed across executors, with partition-aware write-through splitting scheduler-side Flight `DoPut` writes to the responsible executors.
+- **Data-Local Query Routing**: Cayenne catalog queries route to the executors holding the relevant partitions.
+- **Per-Executor Table Statistics**: Executors report table statistics — including NDV-aware estimates — so distributed `JoinSelection` can size joins correctly, fixing out-of-memory conditions on large semi-joins.
+- **Readiness & Failure Detection**: `/v1/ready` gates on a configurable executor quorum for safe rolling deployments; scheduler readiness additionally waits for executor partition loads; executor heartbeat timeout reduced from 180s to 30s.
+- **Distributed DML & DDL**: UPDATE/DELETE forwarding to all executors, executor DDL sync for late joiners, and distributed `MERGE INTO`.
+- **Cluster Observability**: New cluster metrics (including `scheduler_active_executors_count`), distributed `runtime.task_history` replication, and a Grafana dashboard.
+- **Ballista S3 Shuffle**: Async queries with `runtime.params.shuffle_location: s3://...` complete reliably with executor-environment-derived S3 clients.
+
+### Security: Mutual TLS, Secret Stores, and Hardening
+
+> Several capabilities in this section are [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise) features. See [Enterprise Security](https://docs.spice.ai/docs/enterprise/production/security).
+
+**Mutual TLS** across the platform:
+
+- **Public mTLS for HTTP and Flight**: `client_auth_mode: request` (optional, for migration windows) or `required` (strict) client-certificate verification.
+- **TLS Cert Hot-Reload**: The runtime reloads TLS certificates on `SIGHUP` for zero-downtime rotation.
+- **Outbound mTLS Client Certificates**: FlightSQL and Spice.ai data connectors present client certificates to upstream services; the `spice sql` REPL supports mTLS client auth.
+
+```yaml
+runtime:
+  tls:
+    enabled: true
+    certificate_file: /etc/spice/tls/server.crt
+    key_file: /etc/spice/tls/server.key
+    client_auth_mode: required
+    client_auth_ca_file: /etc/spice/tls/client-ca.crt
+```
+
+**Authentication & Authorization** (Spice.ai Enterprise):
+
+- **OIDC Authentication**: Validate [OIDC](https://docs.spice.ai/docs/enterprise/features/authentication) bearer tokens (JWTs) issued by enterprise identity providers — Microsoft Entra ID, Okta, Auth0, AWS Cognito, and Google — for secure access to runtime endpoints, standalone or combined with API keys.
+- **Principal-Based Policy Enforcement**: Fine-grained, Cedar-based [authorization policy](https://docs.spice.ai/docs/enterprise/features/policy) configured under `runtime.authorization` governs allow/deny access across datasets, models, tools, and endpoints. Combined with identity SQL functions (`current_principal()`, `current_principal_email()`, `current_principal_groups()`), policies enforce per-principal row-level filtering and column masking.
+
+**New Secret Stores**: [HashiCorp Vault](https://spiceai.org/docs/components/secret-stores/hashicorp-vault) (KV v1/v2; `token`, `approle`, `kubernetes`, and `jwt` auth with automatic lease renewal) and [Azure Key Vault](https://spiceai.org/docs/components/secret-stores/azure-keyvault) (service principal, managed identity, workload identity, Azure CLI, or auto-detect; sovereign cloud support).
+
+**Hardening**:
+
+- **Read-only API Key Enforcement** on the Flight `DoGet` path and async query endpoints.
+- **Per-Principal Cache Namespacing**: SQL, search, and caching-accelerator caches are namespaced per authenticated principal so cached results never cross identity boundaries.
+- **API Key Timing Leak & Remote-UDF SSRF**: Closed a timing-based position-disclosure leak in API key comparison and blocked SSRF via remote UDF endpoints.
+- **Snowflake Function Deny-List**: A function deny-list is enforced in Snowflake federation pushdown, and Snowflake account identifiers and auth configuration are validated at startup.
+- **MCP `allowed_hosts`**: MCP servers can be restricted to an explicit allowlist of upstream hosts.
+
+### Change Data Capture (CDC) Sources
+
+See [Change Data Capture (CDC)](https://spiceai.org/docs/features/cdc) for an overview of CDC in Spice.
+
+- **MongoDB Change Streams**: [MongoDB](https://spiceai.org/docs/components/data-connectors/mongodb) datasets with `refresh_mode: changes` stream changes natively into any local accelerator — no Debezium or Kafka required.
+- **PostgreSQL Native Replication (WAL)**: [PostgreSQL](https://spiceai.org/docs/components/data-connectors/postgres) datasets stream INSERT/UPDATE/DELETE directly from logical replication using `pgoutput` decoding, with automatic per-replica slot management, an initial `REPEATABLE READ` bootstrap snapshot, and durable LSN acknowledgement.
+- **Kafka CDC Offset Persistence**: [Kafka](https://spiceai.org/docs/components/data-connectors/kafka) CDC offsets persist in sidecar tables for durable, resumable streams across restarts and failovers.
+- **Pipelined CDC Ingestion**: Source reads overlap with batch apply, with envelope coalescing and improved nullability propagation.
+- **Debezium Schema Evolution**: Schema changes in [Debezium](https://spiceai.org/docs/components/data-connectors/debezium)-sourced datasets no longer break dataset initialization on reload.
+
+```yaml
+datasets:
+  - from: postgres:my_table
+    name: my_table
+    params:
+      pg_host: localhost
+      pg_db: mydb
+    acceleration:
+      enabled: true
+      engine: duckdb
+      refresh_mode: changes
+```
+
+### DML, DDL, and Write-Back
+
+Spice v2.0 turns more connectors and catalogs into full read/write tables:
+
+- **PostgreSQL DML**: `INSERT`, `UPDATE`, and `DELETE` write-back on [PostgreSQL](https://spiceai.org/docs/components/data-connectors/postgres) datasets, with foreign-key metadata exposed via the PostgreSQL catalog connector.
+- **Snowflake DML**: `INSERT`, `UPDATE`, and `DELETE` write-back on [Snowflake](https://spiceai.org/docs/components/data-connectors/snowflake) datasets.
+- **DynamoDB DML**: `INSERT`, `UPDATE`, and `DELETE` for [DynamoDB](https://spiceai.org/docs/components/data-connectors/dynamodb), complementing read and CDC streaming.
+- **Arrow Primary Key Upserts**: Native update-or-insert semantics for in-memory [Arrow](https://spiceai.org/docs/components/data-accelerators/arrow)-accelerated tables.
+- **DDL for Iceberg**: `CREATE TABLE` and `DROP TABLE` via FlightSQL and `/v1/sql` for [Iceberg](https://iceberg.apache.org/), with `catalog.access: read_write_create`.
+- **DuckLake INSERT**: DuckLake catalog tables with `read_write` access support `INSERT`.
+
+### SQL & User-Defined Functions
+
+See the [SQL Reference](https://spiceai.org/docs/reference/sql) for the full SQL surface area.
+
+- **User-Defined Functions**: Define reusable SQL UDFs as first-class spicepod components, or invoke remote functions over HTTP (Spice.ai Enterprise), plus table user functions.
+- **Spatial SQL UDFs**: Optional geospatial `ST_*` UDFs for geometry workloads.
+- **JSON UDTFs**: `flatten_json`, `json_tree`, and `flatten_json_properties` table-valued functions for JSON transformation and schema decomposition (with options such as `expand_maps`). See [JSON Functions and Operators](https://spiceai.org/docs/reference/sql/json).
+- **PostgreSQL Metadata UDFs**: Dataset and column descriptions are exposed via PostgreSQL-compatible UDFs (`obj_description`, `col_description`), so BI tools and `psql` surface Spice metadata.
+- **FlightSQL Substrait Plans**: `CommandStatementSubstraitPlan` support for clients submitting Substrait-encoded plans.
+- **SQL REPL Expanded View**: Toggle `\x` for a vertical key-value layout on wide result sets.
+- **Prepared statement, federation, and unparsing fixes** across the engine, including keeping correlated subqueries out of `JOIN ON` conditions for Spice Cloud federation and correct `EXISTS`/`NOT EXISTS` subquery handling in the federation analyzer.
+
+### Runtime Features
+
+- **On-Demand Dataset Loading**: Datasets can be deferred — registered with a declared schema at startup (`columns[].type`, `columns[].nullable`) and fully resolved on first reference, reducing startup time and memory for large spicepods.
+- **Unified Query Cancellation**: HTTP, Flight, FlightSQL, MCP, and internal execution paths honour a unified cancellation signal — disconnects, REPL `Ctrl-C`, and cancelled HTTP requests cancel the query end-to-end.
+- **Storage-Profile Accelerator Tuning**: `acceleration.storage_profile` (`auto`, `local_ssd`, `ebs`, `tmpfs`) applies storage-aware defaults across DuckDB, SQLite, Turso, and Cayenne file-mode accelerators; `auto` detects the backing storage.
+- **`refresh_mode: snapshot`** (Spice.ai Enterprise): Point-in-time snapshot acceleration with SQLite/Turso WAL flushing and Cayenne metastore slice integration, now reporting accurate readiness when no snapshot exists yet.
+- **Structured Component Errors**: `/v1/datasets?status=true` and `/v1/models?status=true` return structured `error` objects (`category`, `type`, `code`) and human-readable `error_message` fields; the CLI shows an `ERROR` column.
+- **Actionable Config Errors**: Parameter typos, missing secret references, and unknown engine names produce specific, actionable errors with suggestions.
+
+### Spicepod v2
+
+Spicepods now support `version: v2`, the default for `spice init`, while `v1` spicepods continue to work with automatic migration of deprecated fields.
+
+| Version   | Status                                     |
+| --------- | ------------------------------------------ |
+| `v2`      | Default. Used by `spice init`.             |
+| `v1`      | Supported. Deprecated fields auto-migrate. |
+| `v1beta1` | Removed. No longer accepted.               |
+
+| v1 (deprecated)               | v2 (preferred)                    | Notes                                                             |
+| ----------------------------- | --------------------------------- | ----------------------------------------------------------------- |
+| `runtime.results_cache`       | `runtime.caching.sql_results`     | All fields migrate automatically. `cache_max_size` → `max_size`.  |
+| `runtime.memory_limit`        | `runtime.query.memory_limit`      | Auto-migrated. `query.memory_limit` takes priority if both set.   |
+| `runtime.temp_directory`      | `runtime.query.temp_directory`    | Auto-migrated. `query.temp_directory` takes priority if both set. |
+| `dataset.invalid_type_action` | `dataset.unsupported_type_action` | Auto-migrated. v2 adds a new `string` variant.                    |
+
+New v2 fields include `runtime.ready_state`, `runtime.query.spill_compression`, `runtime.caching.sql_results.stale_while_revalidate_ttl`, `runtime.caching.sql_results.encoding`, scheduler partition-assignment configuration, and `catalog.access: read_write_create`.
+
+### Data Connectors & Catalogs
+
+**New connectors**:
+
+- **Elasticsearch (Alpha, Spice.ai Enterprise)**: Query Elasticsearch indexes as SQL tables with native hybrid search — `vector_search()` kNN, `text_search()` BM25, and `rrf()` fusion — plus Elasticsearch as a backing vector engine, direct FTS engine configuration, and index lifecycle controls.
+- **GCS (Alpha)**: Federated queries against Google Cloud Storage, with Iceberg table support.
+- **Azure Cosmos DB (Alpha)**: Read-only NoSQL / Core SQL API connector with cross-partition scans and schema inference.
+- **Git (RC)**: HTTPS/SSH auth, Git LFS support, and per-repo connection resilience.
+- **ADBC**: Data connector and catalog with full query federation, BigQuery support, and schema/table discovery.
+- **DuckLake (Beta)**: Lakehouse-style data management with DuckDB as the metadata catalog and object storage for data — ACID transactions, time travel, and schema evolution on Parquet.
+- **Self-Hosted Spice Connector**: Connect Spice to another self-hosted Spice runtime as a federated source.
+
+**New catalog connectors** for [PostgreSQL](https://spiceai.org/docs/components/catalogs/postgres), [MySQL](https://spiceai.org/docs/components/catalogs/mysql), [MSSQL](https://spiceai.org/docs/components/catalogs/mssql), and [Snowflake](https://spiceai.org/docs/components/catalogs/snowflake), using native metadata catalogs for schema and table discovery. [Unity Catalog](https://spiceai.org/docs/components/catalogs/unity-catalog) compatibility extends to OSS Unity Catalog deployments, and DDL-defined catalogs can expose and query views.
+
+**HTTP connector**: OAuth2 refresh-token authentication, query-parameter and no-limit pagination, dynamic request headers parameterised from query predicates, subquery-driven request parameters for fan-out queries, response metadata as queryable columns, map-to-array conversion, shared and persistent rate-control state across restarts and replicas, no caching of transient `429`/`5xx` errors, and a correctly populated `fetched_at` column.
+
+**JSON ingestion**: Single-object documents, JSONL, BOM-prefixed input, Socrata SODA responses, format auto-detection, and RFC 6901 `json_pointer` extraction of nested payloads.
+
+**Databricks**: Resilience controls, Unity Catalog-aware permission prechecks with structured advisory errors, Classic SQL Warehouse foreign-table compatibility, `connect_timeout`/`client_timeout` parameters, a Databricks SQL dialect for federation, and [Delta Lake column mapping](https://spiceai.org/docs/components/data-connectors/delta-lake) (Name and Id modes).
+
+**Other connector improvements**: MongoDB SRV support; MySQL `mysql_zero_date_behavior`; Snowflake `OBJECT`, `MAP`, `GEOGRAPHY`, `GEOMETRY`, `VECTOR`, and `TIMESTAMP_LTZ` types plus key-pair auth; ClickHouse `Date32`; S3 `s3_url_style` for path-style addressing and faster Parquet reads; GraphQL custom auth headers; Oracle and MSSQL sort/limit pushdown; GitHub GraphQL resilience; and improved Kafka reliability.
+
+### AI & LLM
+
+- **Provider-Aware Prompt Caching**: [LLM](https://spiceai.org/docs/features/large-language-models) calls automatically use provider-side prompt caching (e.g., Anthropic, OpenAI) for system prompts and tool descriptions, reducing latency and cost.
+- **Responses API Across All Providers**: The Responses API works with every configured model provider, including streaming `response.output_text.delta` events and `Authorization: Bearer` header support.
+- **Multi-Vector Embeddings with MaxSim**: List-of-string columns produce one embedding per element with MaxSim/mean/sum scoring for ColBERT-style late-interaction retrieval, plus a `_match` column identifying the best-matching element.
+- **`rerank()` UDTF**: Reorder results from `vector_search`, `text_search`, or `rrf` using any registered chat model as a reranker, with automatic query propagation and pushdown support.
+- **Searchable LLM Tool Registry**: Agents discover tools via semantic search instead of enumerating every tool in the system prompt.
+- **MCP Improvements**: Streamable HTTP transport (`/v1/mcp`) on rmcp v1.5.0, native auth for streamable HTTP tools (`mcp_auth_token`, `mcp_headers`), external MCP server tool calls traced in task history, and configurable `allowed_hosts`.
+- **Per-Model Rate-Limited AI UDF Execution** for controlling concurrent AI function invocations.
+
+### Search & Vectors
+
+- **DuckDB Vector Engine**: `vector_engine: duckdb` uses DuckDB's HNSW index for fast approximate nearest-neighbor search without an external vector store. In v2.0.0, the DuckDB VSS extension is **statically linked** into the bundled DuckDB, so HNSW vector search works out-of-the-box on clean machines with no extension download. HNSW indexes are preserved across data refresh, and `cosine_distance` pushes down via `array_cosine_distance`.
+- **Hybrid Search**: Combine kNN vector search and BM25 full-text search with reciprocal rank fusion (`rrf()`), backed by Tantivy, Elasticsearch, or DuckDB.
+- **Full-Text Search Performance**: Significantly faster Tantivy ingestion with rollback-on-error, and search metadata is correctly preserved on indexing and in Vortex physical schema calculation.
+- **Embedding Validation**: `row_id` columns are validated during dataset initialization.
+
+### Caching
+
+Improvements across [Caching](https://spiceai.org/docs/features/caching):
+
+- **Stale-While-Revalidate**: `runtime.caching.sql_results.stale_while_revalidate_ttl` serves stale results while revalidating in the background.
+- **Cache Encoding**: Optional compression (e.g., `zstd`) for SQL results cache entries.
+- **Retention Policies** for cached query results, and improved CDC-driven cache invalidation (including view plan invalidation on updates).
+- **Idle Cache Maintenance**: Periodic maintenance drains invalidation predicates on idle caches, fixing unbounded memory growth in rarely-read caches.
+
+### Performance & Query Engine
+
+[Apache DataFusion](https://datafusion.apache.org/) is upgraded to **v52.5** over the course of the release cycle, bringing:
+
+- **Sort Pushdown to Scans**: ~30x faster top-K queries on pre-sorted data; Parquet scans reverse row-group order for `DESC` on `ASC`-sorted files.
+- **Rewritten Sort-Merge Join**: Up to three orders of magnitude faster in pathological cases (e.g., TPC-H Q21: minutes → milliseconds).
+- **Dynamic Filters**: `MIN`/`MAX` aggregates and hash-join build sides prune files, row groups, and rows during execution.
+- **Faster `CASE` Expressions, statistics caching, and prefix-aware list-files caching** for faster planning.
+- **`TableProvider` DELETE/UPDATE hooks and the `RelationPlanner` API** for extensible SQL planning.
+- **Strict Overflow Handling**: `try_cast_to` errors on overflow instead of silently producing NULLs.
+
+Additional engine work: default query memory limit raised from 70% to 90% with `GreedyMemoryPool`, partial aggregation optimization for `FlightSQLExec`, improved partitioned query planning, and metastore transaction support to prevent concurrent conflicts.
+
+### Rust CLI
+
+The Spice CLI is completely rewritten from Go to Rust — a single `spice` binary built from the same codebase as `spiced`, with full feature parity across 27+ commands.
+
+- **`spice query`**: Interactive REPL for [async queries](https://spiceai.org/docs/features/query-federation/async-queries) with multi-line SQL, progress indication, and cancellation.
+- **`spice dataset configure`**: Non-interactive flag-based configuration (`--from`, `--description`, `--param KEY=VALUE`, `--set`) alongside interactive prompts.
+- **`spice completions`**: Shell completion script generation.
+- **`--output=json`**: Machine-readable output for scripting; `spice login --output` adds `env`, `json`, and `keychain` modes.
+- **`spice init`** writes a `yaml-language-server` schema directive for IDE completions.
+
+### Observability
+
+- **OpenTelemetry**: Exporter fixes, authenticated metrics export, configurable metric name prefix (`runtime.telemetry.metric_prefix`), delta temporality by default, and OTLP resource attributes via `runtime.telemetry.properties`.
+- **Query Metrics**: The `query_executions` metric gains a `datasets` dimension for per-dataset query attribution.
+- **Ingestion Metrics**: `rows_written`, `bytes_written`, and `dataset_acceleration_size_bytes` for acceleration refresh and Flight `DoPut`/ADBC ingestion, and `EXPLAIN ANALYZE` metrics in `FlightSQLExec`.
+- **Task History**: Distributed task history in cluster mode and tracing for external MCP server tool calls.
+
+### Notable Bug Fixes
+
+- **localpod synchronization**: `localpod` child datasets correctly track parent refreshes when the parent uses the in-memory Arrow accelerator.
+- **Spice Cloud federation**: Correlated subqueries are kept out of `JOIN ON` conditions, fixing rejected federated queries.
+- **`refresh_mode: snapshot`**: No longer reports Ready with empty data when no snapshot exists.
+- **Search metadata**: Field and schema metadata preserved on search indexing and in Vortex physical schema calculation.
+- **HTTP connector**: `fetched_at` column is correctly populated.
+- **Connector correctness**: DynamoDB Streams transient-error retries and typed-NULL DML handling; ScyllaDB physical filter pushdown disabled to fix incorrect results; MSSQL `TOP N` pushdown; DuckDB DELETE/UPDATE on `full` and `caching` refresh modes; Turso checked arithmetic for timestamp conversions; ODBC queries no longer silently return 0 rows on failure; Flight `GetFlightInfo`/`DoGet` schema parity.
+
+### Dependency Updates
+
+| Dependency / Component | Version                             |
+| ---------------------- | ----------------------------------- |
+| **DataFusion**         | v52.5                               |
+| **Ballista**           | v52                                 |
+| **Arrow (arrow-rs)**   | v57.2                               |
+| **DuckDB**             | v1.5.3 (with statically linked VSS) |
+| **iceberg-rust**       | v0.9.1                              |
+| **Turso (libsql)**     | v0.6.1                              |
+| **Vortex**             | v0.69.0                             |
+| **delta_kernel**       | v0.18.2                             |
+| **rmcp (MCP)**         | v1.5.0                              |
+| **mistral.rs**         | v0.8.x (candle v0.10.1)             |
+| **ADBC Core**          | v0.23                               |
+| **Rust toolchain**     | v1.94.1                             |
+
+## Contributors
+
+- [@cluster2600](https://github.com/cluster2600)
+- [@ewgenius](https://github.com/ewgenius)
+- [@Jeadie](https://github.com/Jeadie)
+- [@krinart](https://github.com/krinart)
+- [@lukekim](https://github.com/lukekim)
+- [@peasee](https://github.com/peasee)
+- [@penberg](https://github.com/penberg)
+- [@phillipleblanc](https://github.com/phillipleblanc)
+- [@sgrebnov](https://github.com/sgrebnov)
+
+## Breaking Changes
+
+- **Models included by default**: The separate `models` build variant has been removed. Local LLM inference is always included in the default build and image.
+- **Windows native builds removed**: Use [WSL](https://learn.microsoft.com/en-us/windows/wsl/) for local development.
+- **Spicepod version defaults to `v2`**: `spice init` creates `version: v2` spicepods. `v1` remains supported with auto-migration; `v1beta1` is no longer accepted.
+- **Flattened `runtime.scheduler` configuration**: The nested `runtime.scheduler.partition_management` block is flattened and renamed:
+
+  ```yaml
+  # Before
+  runtime:
+    scheduler:
+      partition_management:
+        interval: 30s
+        max_assignments_per_cycle: 16
+        discovery_timeout: 10s
+
+  # After
+  runtime:
+    scheduler:
+      partition_assignment_interval: 30s
+      max_assignments_per_interval: 16
+      partition_discovery_timeout: 10s
+  ```
+
+- **S3 metadata columns renamed**: `location`, `last_modified`, `size` → `_location`, `_last_modified`, `_size`.
+- **Default query memory limit changed**: Increased from 70% to 90%.
+- **Metric renames**: `accelerated_refresh` metrics renamed to `acceleration_refresh`; `last_refresh_time` gauge renamed to include the milliseconds unit.
+- **DuckDB parameter rename**: `partitioned_write_flush_threshold` → `partitioned_write_flush_threshold_rows`.
+- **`/v1/search` API**: Always returns an array in `matches`, even for single results.
+- **`/v1/evals` API removed**.
+- **Perplexity model provider removed**.
+- **x.ai model endpoint**: x.ai models exclusively use the `/v1/responses` endpoint.
+
+## Upgrade Guide from v1.x
+
+Most v1 spicepods continue to work on v2.0 — `v1` remains supported and deprecated fields auto-migrate at load time — so many deployments can upgrade by updating the binary or image alone. The steps below cover the [breaking changes](#breaking-changes) that may require manual action. Review each before upgrading a production deployment.
+
+### 1. Build, image, and platform changes
+
+- **Models are now included by default.** The separate `models` build variant (and the corresponding `-models` image tags) has been removed; local LLM inference is always included in the default build and image. If your deployment pinned a `models` build or `-models`-tagged image, switch to the default build/image.
+- **Native Windows builds are removed.** Use [WSL](https://learn.microsoft.com/en-us/windows/wsl/) for local Windows development.
+
+### 2. Adopt Spicepod `v2` (recommended)
+
+`spice init` now creates `version: v2` spicepods. `v1` spicepods remain supported with automatic migration, but `v1beta1` is no longer accepted. To move to `v2`, set `version: v2` and update the following fields — each auto-migrates from `v1`, but updating now clears the deprecation:
+
+| v1 (deprecated)               | v2 (preferred)                                                |
+| ----------------------------- | ------------------------------------------------------------- |
+| `runtime.results_cache`       | `runtime.caching.sql_results` (`cache_max_size` → `max_size`) |
+| `runtime.memory_limit`        | `runtime.query.memory_limit`                                  |
+| `runtime.temp_directory`      | `runtime.query.temp_directory`                                |
+| `dataset.invalid_type_action` | `dataset.unsupported_type_action`                             |
+
+### 3. Update changed configuration
+
+- **DuckDB parameter rename:** `partitioned_write_flush_threshold` → `partitioned_write_flush_threshold_rows`.
+- **Default query memory limit raised from 70% to 90%.** If you relied on the previous default to leave headroom for other processes on the host, set it explicitly via `runtime.query.memory_limit`.
+
+### 4. Update queries and API clients
+
+- **S3 metadata columns renamed:** `location`, `last_modified`, `size` → `_location`, `_last_modified`, `_size`. Update any queries that reference these columns.
+- **`/v1/search` always returns an array** in `matches`, even for a single result. Update clients that assumed a scalar value.
+- **`/v1/evals` API removed.** Remove integrations that depend on it.
+
+### 5. Update model providers
+
+- **Perplexity model provider removed.** Re-point affected models to another provider.
+- **x.ai models use the `/v1/responses` endpoint exclusively.** Ensure x.ai integrations target the Responses API.
+
+### 6. Update observability
+
+- **Metric renames:** `accelerated_refresh` → `acceleration_refresh`, and the `last_refresh_time` gauge is renamed to include the milliseconds unit. Update dashboards and alerts that reference these metric names.
+
+After updating, restart the runtime and verify datasets and models report ready via `/v1/datasets?status=true` and `/v1/models?status=true` (the CLI shows a `Ready`/`ERROR` column).
+
+## Cookbook Updates
+
+New [Spice Cookbook](https://spiceai.org/cookbook) recipes added during the v2.0 release cycle:
+
+- **[Async Queries](https://github.com/spiceai/cookbook/blob/trunk/async-queries)**: Submit long-running queries asynchronously and retrieve results later.
+- **[DuckLake Catalog](https://github.com/spiceai/cookbook/blob/trunk/catalogs/ducklake)**: Lakehouse-style data management with ACID transactions and time travel.
+- **[Distributed Query](https://github.com/spiceai/cookbook/blob/trunk/distributed)**: Run Spice in multi-active distributed cluster mode.
+- **[mTLS](https://github.com/spiceai/cookbook/blob/trunk/mtls)**: Mutual TLS for HTTP and Flight endpoints.
+- **[Elasticsearch Connector](https://github.com/spiceai/cookbook/blob/trunk/elasticsearch/connector)**: Query Elasticsearch indexes as SQL tables.
+- **[MCP Server](https://github.com/spiceai/cookbook/blob/trunk/mcp-server)**: Use Spice as an MCP server over Streamable HTTP.
+- **[Snowflake DML](https://github.com/spiceai/cookbook/blob/trunk/snowflake/dml)**: Write-back to Snowflake with INSERT/UPDATE/DELETE.
+- **[PostgreSQL](https://github.com/spiceai/cookbook/blob/trunk/catalogs/postgres), [MySQL](https://github.com/spiceai/cookbook/blob/trunk/catalogs/mysql), and [MSSQL](https://github.com/spiceai/cookbook/blob/trunk/catalogs/mssql) Catalogs**: Schema and table discovery for external databases.
+- **[Full-Text Search](https://github.com/spiceai/cookbook/blob/trunk/full-text-search)**: BM25 full-text search over accelerated datasets.
+
+The [Spice Cookbook](https://spiceai.org/cookbook) includes more than 100 recipes to help you get started with Spice quickly and easily.
+
+## Upgrading
+
+To upgrade to v2.0.0, use one of the following methods:
+
+**CLI**:
+
+```console
+spice upgrade
+```
+
+**Homebrew**:
+
+```console
+brew upgrade spiceai/spiceai/spice
+```
+
+**Docker**:
+
+Pull the `spiceai/spiceai:2.0.0` image:
+
+```console
+docker pull spiceai/spiceai:2.0.0
+```
+
+For available tags, see [DockerHub](https://hub.docker.com/r/spiceai/spiceai/tags).
+
+**Helm**:
+
+```console
+helm repo update
+helm upgrade spiceai spiceai/spiceai --version 2.0.0
+```
+
+**AWS Marketplace**:
+
+Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-jmf6jskjvnq7i).
+
+## What's Changed
+
+### Changelog
+
+- Add TPC-DS integration tests with S3 source and PostgreSQL acceleration by [@phillipleblanc](https://github.com/phillipleblanc) in [#9006](https://github.com/spiceai/spiceai/pull/9006)
+- fix(tests): fix flaky/slow/failing unit tests by [@phillipleblanc](https://github.com/phillipleblanc) in [#9009](https://github.com/spiceai/spiceai/pull/9009)
+- fix: Update benchmark snapshots for DF51 upgrade by [@app/github-actions](https://github.com/app/github-actions) in [#9008](https://github.com/spiceai/spiceai/pull/9008)
+- fix: add feature gate to rrf TEST_EMBEDDING_MODEL by [@phillipleblanc](https://github.com/phillipleblanc) in [#9017](https://github.com/spiceai/spiceai/pull/9017)
+- fix: features check by [@phillipleblanc](https://github.com/phillipleblanc) in [#9014](https://github.com/spiceai/spiceai/pull/9014)
+- fix: Enable Cayenne acceleration snapshots by [@lukekim](https://github.com/lukekim) in [#9020](https://github.com/spiceai/spiceai/pull/9020)
+- URL table support by [@lukekim](https://github.com/lukekim) in [#9018](https://github.com/spiceai/spiceai/pull/9018)
+- ScyllaDB key filter by [@lukekim](https://github.com/lukekim) in [#8997](https://github.com/spiceai/spiceai/pull/8997)
+- fix: Schema mismatch when using column projection with HTTP caching by [@phillipleblanc](https://github.com/phillipleblanc) in [#9021](https://github.com/spiceai/spiceai/pull/9021)
+- Add more tests for HTTP caching with columns selection by [@sgrebnov](https://github.com/sgrebnov) in [#9025](https://github.com/spiceai/spiceai/pull/9025)
+- HTTP cache snapshots: default to `time_interval` and fix `snapshots_creation_policy: on_change` by [@sgrebnov](https://github.com/sgrebnov) in [#9026](https://github.com/spiceai/spiceai/pull/9026)
+- Fix duplicate snapshot creation on startup by [@sgrebnov](https://github.com/sgrebnov) in [#9029](https://github.com/spiceai/spiceai/pull/9029)
+- Add ScyllaDB and SMB to the README table by [@krinart](https://github.com/krinart) in [#9034](https://github.com/spiceai/spiceai/pull/9034)
+- Remove waiting for runtime to be ready before creating snapshot by [@krinart](https://github.com/krinart) in [#9033](https://github.com/spiceai/spiceai/pull/9033)
+- Fix snapshot on_change policy to skip when no writes occurred by [@sgrebnov](https://github.com/sgrebnov) in [#9028](https://github.com/spiceai/spiceai/pull/9028)
+- Release notes for release `release/1.11.0-rc.2` by [@krinart](https://github.com/krinart) in [#9016](https://github.com/spiceai/spiceai/pull/9016)
+- ci: use arduino/setup-protoc for official protobuf compiler by [@phillipleblanc](https://github.com/phillipleblanc) in [#9036](https://github.com/spiceai/spiceai/pull/9036)
+- ci: install unzip on aarch64 runner for arduino/setup-protoc by [@phillipleblanc](https://github.com/phillipleblanc) in [#9038](https://github.com/spiceai/spiceai/pull/9038)
+- fix: don't fail release if upload to minio fails by [@phillipleblanc](https://github.com/phillipleblanc) in [#9039](https://github.com/spiceai/spiceai/pull/9039)
+- Add missing protoc step to setup-cc action by [@krinart](https://github.com/krinart) in [#9041](https://github.com/spiceai/spiceai/pull/9041)
+- fix: Update Search integration test snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9013](https://github.com/spiceai/spiceai/pull/9013)
+- Fix `formula_1` and `codebase_community` in `bird-bench` by [@Jeadie](https://github.com/Jeadie) in [#9000](https://github.com/spiceai/spiceai/pull/9000)
+- Cayenne S3 Express One Zone improvements by [@lukekim](https://github.com/lukekim) in [#9015](https://github.com/spiceai/spiceai/pull/9015)
+- Add zlib1g-dev to CI by [@lukekim](https://github.com/lukekim) in [#9052](https://github.com/spiceai/spiceai/pull/9052)
+- Improve validation and logging for hash indexes by [@lukekim](https://github.com/lukekim) in [#9047](https://github.com/spiceai/spiceai/pull/9047)
+- Upgrade Vortex with CASE-WHEN by [@lukekim](https://github.com/lukekim) in [#9051](https://github.com/spiceai/spiceai/pull/9051)
+- x.ai models now exclusively use /v1/responses endpoint by [@lukekim](https://github.com/lukekim) in [#9400](https://github.com/spiceai/spiceai/pull/9400)
+- Improvements for snapshot schema comparison by [@krinart](https://github.com/krinart) in [#9401](https://github.com/spiceai/spiceai/pull/9401)
+- v2.0 breaking changes by [@lukekim](https://github.com/lukekim) in [#9233](https://github.com/spiceai/spiceai/pull/9233)
+- Create `PartitionManagementTask` for scheduler to update accelerated table partition assignments by [@Jeadie](https://github.com/Jeadie) in [#9378](https://github.com/spiceai/spiceai/pull/9378)
+- refactor(Cayenne): route all write orchestration through `CayenneDataSink` by [@sgrebnov](https://github.com/sgrebnov) in [#9402](https://github.com/spiceai/spiceai/pull/9402)
+- Refactor benchmark to use QueryExecutor trait by [@Jeadie](https://github.com/Jeadie) in [#9418](https://github.com/spiceai/spiceai/pull/9418)
+- feat: Add spidapter build and release workflow by [@peasee](https://github.com/peasee) in [#9427](https://github.com/spiceai/spiceai/pull/9427)
+- Testoperator: add support for api-key when connecting to external spice instance by [@sgrebnov](https://github.com/sgrebnov) in [#9421](https://github.com/spiceai/spiceai/pull/9421)
+- Initial implementation of Ducklake catalog & data connectors by [@lukekim](https://github.com/lukekim) in [#9083](https://github.com/spiceai/spiceai/pull/9083)
+- Require `aws_lc_rs` since jsonwebtoken upgrade by [@Jeadie](https://github.com/Jeadie) in [#9426](https://github.com/spiceai/spiceai/pull/9426)
+- feat: Add spidapter tool by [@peasee](https://github.com/peasee) in [#9425](https://github.com/spiceai/spiceai/pull/9425)
+- Add release notes for 1.11.2 patch release by [@sgrebnov](https://github.com/sgrebnov) in [#9430](https://github.com/spiceai/spiceai/pull/9430)
+- feat(spidapter): integrate system-adapter-protocol with SCP provisioning by [@phillipleblanc](https://github.com/phillipleblanc) in [#9434](https://github.com/spiceai/spiceai/pull/9434)
+- Add DuckLake TPCH E2E workflow and federated Spicepod configuration by [@lukekim](https://github.com/lukekim) in [#9431](https://github.com/spiceai/spiceai/pull/9431)
+- fix(spidapter): use Flight handshake auth instead of x-api-key header by [@phillipleblanc](https://github.com/phillipleblanc) in [#9435](https://github.com/spiceai/spiceai/pull/9435)
+- [spidapter] Keep only what sparks joy by [@Jeadie](https://github.com/Jeadie) in [#9439](https://github.com/spiceai/spiceai/pull/9439)
+- Refactor binary operator balancing by [@Jeadie](https://github.com/Jeadie) in [#9424](https://github.com/spiceai/spiceai/pull/9424)
+- feat: Add Iceberg DDL support (CREATE TABLE / DROP TABLE) for default catalog override by [@phillipleblanc](https://github.com/phillipleblanc) in [#9440](https://github.com/spiceai/spiceai/pull/9440)
+- Fix Flight SQL schema consistency: expand view types and verify field names by [@sgrebnov](https://github.com/sgrebnov) in [#9438](https://github.com/spiceai/spiceai/pull/9438)
+- Update spidapter for new system-adapter-protocol by [@sgrebnov](https://github.com/sgrebnov) in [#9442](https://github.com/spiceai/spiceai/pull/9442)
+- docs: fix typos and syntax errors in style guide and error handling docs by [@cluster2600](https://github.com/cluster2600) in [#9445](https://github.com/spiceai/spiceai/pull/9445)
+- Add acceleration refresh ingestion metrics (rows_written, bytes_written) by [@phillipleblanc](https://github.com/phillipleblanc) in [#9461](https://github.com/spiceai/spiceai/pull/9461)
+- Refactor(Cayenne): Replace CatalogError and string based errors with Snafu errors by [@sgrebnov](https://github.com/sgrebnov) in [#9403](https://github.com/spiceai/spiceai/pull/9403)
+- Replace deprecated claude-3-5-haiku-latest with claude-haiku-4-5 by [@Jeadie](https://github.com/Jeadie) in [#9492](https://github.com/spiceai/spiceai/pull/9492)
+- Fix #9481: Preserve schema in results cache for empty query results by [@phillipleblanc](https://github.com/phillipleblanc) in [#9485](https://github.com/spiceai/spiceai/pull/9485)
+- Fix partition by serializing by [@Jeadie](https://github.com/Jeadie) in [#9474](https://github.com/spiceai/spiceai/pull/9474)
+- query: reconcile execution stream nullability with logical plan schema by [@phillipleblanc](https://github.com/phillipleblanc) in [#9486](https://github.com/spiceai/spiceai/pull/9486)
+- initial `spice-cloud-client` crate and `spice cloud metrics --app <app-name>`. by [@Jeadie](https://github.com/Jeadie) in [#9480](https://github.com/spiceai/spiceai/pull/9480)
+- feat: Return dataset error message in datasets API by [@peasee](https://github.com/peasee) in [#9487](https://github.com/spiceai/spiceai/pull/9487)
+- Spicebench by [@lukekim](https://github.com/lukekim) in [#9447](https://github.com/spiceai/spiceai/pull/9447)
+- build(deps): consolidate dependabot dependency updates by [@phillipleblanc](https://github.com/phillipleblanc) in [#9504](https://github.com/spiceai/spiceai/pull/9504)
+- fix(cluster): route non-partitioned accelerated tables in distributed mode by [@phillipleblanc](https://github.com/phillipleblanc) in [#9508](https://github.com/spiceai/spiceai/pull/9508)
+- Enable core scalar UDFs in refresh SQL by [@sgrebnov](https://github.com/sgrebnov) in [#9502](https://github.com/spiceai/spiceai/pull/9502)
+- Fix metrics in Spidapter again by [@Jeadie](https://github.com/Jeadie) in [#9497](https://github.com/spiceai/spiceai/pull/9497)
+- fix(cluster): tolerate Completed->status propagation race in distributed query handle by [@phillipleblanc](https://github.com/phillipleblanc) in [#9510](https://github.com/spiceai/spiceai/pull/9510)
+- feat: Support distributed ingestion in cayenne catalog by [@peasee](https://github.com/peasee) in [#9506](https://github.com/spiceai/spiceai/pull/9506)
+- Fix Cayenne duplicate primary keys after DELETE + UPSERT CDC sequences by [@krinart](https://github.com/krinart) in [#9494](https://github.com/spiceai/spiceai/pull/9494)
+- fix(cluster): rewrite table scans inside subqueries for distributed execution by [@phillipleblanc](https://github.com/phillipleblanc) in [#9518](https://github.com/spiceai/spiceai/pull/9518)
+- fix: Set catalog mode to readwritecreate in spidapter by [@peasee](https://github.com/peasee) in [#9519](https://github.com/spiceai/spiceai/pull/9519)
+- Upgrade AWS SDK crates & set APN user-agent in AWS SDK credential bridge by [@lukekim](https://github.com/lukekim) in [#8328](https://github.com/spiceai/spiceai/pull/8328)
+- feat(runtime): add runtime ready_state on_registration semantics by [@lukekim](https://github.com/lukekim) in [#9522](https://github.com/spiceai/spiceai/pull/9522)
+- fix: Add spidapter post-setup retries by [@peasee](https://github.com/peasee) in [#9526](https://github.com/spiceai/spiceai/pull/9526)
+- Make partition discovery more robust and make initialization non-blocking by [@sgrebnov](https://github.com/sgrebnov) in [#9499](https://github.com/spiceai/spiceai/pull/9499)
+- Make `lint-rust-fix` support targeted packages and features by [@Jeadie](https://github.com/Jeadie) in [#9511](https://github.com/spiceai/spiceai/pull/9511)
+- Handle new Cloud SCP API by [@Jeadie](https://github.com/Jeadie) in [#9532](https://github.com/spiceai/spiceai/pull/9532)
+- Refactor and simplify streaming benchmarks by [@krinart](https://github.com/krinart) in [#9405](https://github.com/spiceai/spiceai/pull/9405)
+- fix: ensure spidapter only increments attempts on failures by [@peasee](https://github.com/peasee) in [#9534](https://github.com/spiceai/spiceai/pull/9534)
+- feat: Support specifying app resources in spidapter by [@peasee](https://github.com/peasee) in [#9536](https://github.com/spiceai/spiceai/pull/9536)
+- test(runtime): Spice Cayenne DDL integration test by [@lukekim](https://github.com/lukekim) in [#9535](https://github.com/spiceai/spiceai/pull/9535)
+- fix: Handle schema evolution mismatch errors during data refresh by [@lukekim](https://github.com/lukekim) in [#9527](https://github.com/spiceai/spiceai/pull/9527)
+- fix: resolve clippy lint warnings by [@phillipleblanc](https://github.com/phillipleblanc) in [#9547](https://github.com/spiceai/spiceai/pull/9547)
+- 'pr-builds --tag <TAG>' for build_and_release.yml by [@Jeadie](https://github.com/Jeadie) in [#9507](https://github.com/spiceai/spiceai/pull/9507)
+- Add `--output` flag to `spice login` with env/json/keychain modes by [@Jeadie](https://github.com/Jeadie) in [#9541](https://github.com/spiceai/spiceai/pull/9541)
+- Don't use 'PartitionedTableScanRewrite' in async distributed query by [@Jeadie](https://github.com/Jeadie) in [#9548](https://github.com/spiceai/spiceai/pull/9548)
+- feat(spidapter): add local backend mode with single executor by [@phillipleblanc](https://github.com/phillipleblanc) in [#9531](https://github.com/spiceai/spiceai/pull/9531)
+- support chat template in HF by [@Jeadie](https://github.com/Jeadie) in [#9543](https://github.com/spiceai/spiceai/pull/9543)
+- fix(cayenne): stream PK retention deletes and run OOM regression in CI by [@phillipleblanc](https://github.com/phillipleblanc) in [#9533](https://github.com/spiceai/spiceai/pull/9533)
+- cayenne: Staged append writes to prevent partial writes and data loss on stream error by [@sgrebnov](https://github.com/sgrebnov) in [#9491](https://github.com/spiceai/spiceai/pull/9491)
+- `AcceleratedTable::scan` use `FederatedTable::scan` when `ClusterRole::Scheduler` by [@Jeadie](https://github.com/Jeadie) in [#9550](https://github.com/spiceai/spiceai/pull/9550)
+- Upgrade to delta-kernel-rs v0.18.2 by [@lukekim](https://github.com/lukekim) in [#9528](https://github.com/spiceai/spiceai/pull/9528)
+- Run cayenne tests as part of PR CI by [@sgrebnov](https://github.com/sgrebnov) in [#9554](https://github.com/spiceai/spiceai/pull/9554)
+- Upgrade to DataFusion v52.2.0 by [@lukekim](https://github.com/lukekim) in [#9419](https://github.com/spiceai/spiceai/pull/9419)
+- Remove Snapshot Compaction + Add snapshot existence check by [@krinart](https://github.com/krinart) in [#9523](https://github.com/spiceai/spiceai/pull/9523)
+- Update dependencies by [@lukekim](https://github.com/lukekim) in [#9566](https://github.com/spiceai/spiceai/pull/9566)
+- fix: Update benchmark snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9565](https://github.com/spiceai/spiceai/pull/9565)
+- fix: Compare Cayenne table configuration on startup by [@peasee](https://github.com/peasee) in [#9529](https://github.com/spiceai/spiceai/pull/9529)
+- Make `Refresh::refresh_sql` more robust to alterations over time. by [@Jeadie](https://github.com/Jeadie) in [#9549](https://github.com/spiceai/spiceai/pull/9549)
+- fix: Update datafusion-table-providers dependency to latest revision by [@lukekim](https://github.com/lukekim) in [#9574](https://github.com/spiceai/spiceai/pull/9574)
+- Unset `AWS_ENDPOINT_URL` when empty by [@krinart](https://github.com/krinart) in [#9575](https://github.com/spiceai/spiceai/pull/9575)
+- fix: allow BytesProcessedExec repartitioning for unordered input by [@lukekim](https://github.com/lukekim) in [#9540](https://github.com/spiceai/spiceai/pull/9540)
+- Sanitize DataFusion errors by [@lukekim](https://github.com/lukekim) in [#9530](https://github.com/spiceai/spiceai/pull/9530)
+- Add conditional logging for partition assignments by [@Jeadie](https://github.com/Jeadie) in [#9577](https://github.com/spiceai/spiceai/pull/9577)
+- use 'properly early exit on SIGTERM' by [@Jeadie](https://github.com/Jeadie) in [#9573](https://github.com/spiceai/spiceai/pull/9573)
+- Update datafusion to 52.2.0 by [@phillipleblanc](https://github.com/phillipleblanc) in [#9582](https://github.com/spiceai/spiceai/pull/9582)
+- Ensure we query one and only one partition per request by [@Jeadie](https://github.com/Jeadie) in [#9416](https://github.com/spiceai/spiceai/pull/9416)
+- feat: Add support for Spicepod version v2 by [@lukekim](https://github.com/lukekim) in [#9583](https://github.com/spiceai/spiceai/pull/9583)
+- [SpiceDQ] Improve error messages; Avoid race condition on allocate_initial_partitions. by [@Jeadie](https://github.com/Jeadie) in [#9579](https://github.com/spiceai/spiceai/pull/9579)
+- Update ballista dependencies to latest 52.0.0 revision by [@lukekim](https://github.com/lukekim) in [#9581](https://github.com/spiceai/spiceai/pull/9581)
+- Fix Databricks spark_connect mode always disabled by [@phillipleblanc](https://github.com/phillipleblanc) in [#9586](https://github.com/spiceai/spiceai/pull/9586)
+- Support partitioning in Arrow accelerator by [@Jeadie](https://github.com/Jeadie) in [#9571](https://github.com/spiceai/spiceai/pull/9571)
+- Fix `spice query` CLI response deserialization by [@phillipleblanc](https://github.com/phillipleblanc) in [#9588](https://github.com/spiceai/spiceai/pull/9588)
+- fix: Update benchmark snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#9584](https://github.com/spiceai/spiceai/pull/9584)
+- fix: Share RuntimeEnv across Cayenne read/write/delete paths for targeted list_files_cache invalidation by [@sgrebnov](https://github.com/sgrebnov) in [#9589](https://github.com/spiceai/spiceai/pull/9589)
+- feat: Add file:// state_location support for async queries scheduler by [@phillipleblanc](https://github.com/phillipleblanc) in [#9590](https://github.com/spiceai/spiceai/pull/9590)
+- Update endgame links by [@krinart](https://github.com/krinart) in [#9598](https://github.com/spiceai/spiceai/pull/9598)
+- ci: fix E2E CLI upgrade test to use latest release for spiced download by [@phillipleblanc](https://github.com/phillipleblanc) in [#9613](https://github.com/spiceai/spiceai/pull/9613)
+- fix(DF): Lazily initialize BatchCoalescer in RepartitionExec to avoid schema type mismatch by [@sgrebnov](https://github.com/sgrebnov) in [#9623](https://github.com/spiceai/spiceai/pull/9623)
+- feat: Implement catalog connectors for various databases by [@lukekim](https://github.com/lukekim) in [#9509](https://github.com/spiceai/spiceai/pull/9509)
+- Refactor and clean up code across multiple crates by [@lukekim](https://github.com/lukekim) in [#9620](https://github.com/spiceai/spiceai/pull/9620)
+- fix: Improve error handling for distributed mode and state_location configuration by [@lukekim](https://github.com/lukekim) in [#9611](https://github.com/spiceai/spiceai/pull/9611)
+- Properly install postgres in `install-postgres` action by [@krinart](https://github.com/krinart) in [#9629](https://github.com/spiceai/spiceai/pull/9629)
+- fix: Use Python venv for schema validation in CI by [@phillipleblanc](https://github.com/phillipleblanc) in [#9637](https://github.com/spiceai/spiceai/pull/9637)
+- Update spicepod.schema.json by [@app/github-actions](https://github.com/app/github-actions) in [#9640](https://github.com/spiceai/spiceai/pull/9640)
+- Update testoperator dispatch to use release/2.0 branch by [@phillipleblanc](https://github.com/phillipleblanc) in [#9641](https://github.com/spiceai/spiceai/pull/9641)
+- fix: Align CUDA asset names in Dockerfile and install tests with build output by [@phillipleblanc](https://github.com/phillipleblanc) in [#9639](https://github.com/spiceai/spiceai/pull/9639)
+- Fix expect test scripts in E2E Installation AI test by [@sgrebnov](https://github.com/sgrebnov) in [#9643](https://github.com/spiceai/spiceai/pull/9643)
+- testoperator for partitioned arrow accelerator by [@Jeadie](https://github.com/Jeadie) in [#9635](https://github.com/spiceai/spiceai/pull/9635)
+- Remove default 1s refresh_check_interval from spidapter for hive datasets by [@phillipleblanc](https://github.com/phillipleblanc) in [#9645](https://github.com/spiceai/spiceai/pull/9645)
+- Fix scheduler panic and cancel race condition by [@phillipleblanc](https://github.com/phillipleblanc) in [#9644](https://github.com/spiceai/spiceai/pull/9644)
+- Align Spice.ai connector parameter names across catalog/data connectors by [@lukekim](https://github.com/lukekim) in [#9632](https://github.com/spiceai/spiceai/pull/9632)
+- docs: update distribution details and add NAS support in release notes by [@lukekim](https://github.com/lukekim) in [#9650](https://github.com/spiceai/spiceai/pull/9650)
+- Enable `postgres-accel` in CI builds for benchmarks by [@sgrebnov](https://github.com/sgrebnov) in [#9649](https://github.com/spiceai/spiceai/pull/9649)
+- perf: Cache Turso metastore connection across operations by [@penberg](https://github.com/penberg) in [#9646](https://github.com/spiceai/spiceai/pull/9646)
+- Add 'scheduler_state_location' to spidapter by [@Jeadie](https://github.com/Jeadie) in [#9655](https://github.com/spiceai/spiceai/pull/9655)
+- Implement Cayenne S3 Express multi-zone live test with data validation by [@lukekim](https://github.com/lukekim) in [#9631](https://github.com/spiceai/spiceai/pull/9631)
+- chore(spidapter): bump default memory limit from 8Gi to 32Gi by [@phillipleblanc](https://github.com/phillipleblanc) in [#9661](https://github.com/spiceai/spiceai/pull/9661)
+- perf: Use prepare_cached() in Turso and SQLite metastore backends by [@penberg](https://github.com/penberg) in [#9662](https://github.com/spiceai/spiceai/pull/9662)
+- Improve CDC cache invalidation by [@krinart](https://github.com/krinart) in [#9651](https://github.com/spiceai/spiceai/pull/9651)
+- Refactor Cayenne IDs to use UUIDv7 strings by [@lukekim](https://github.com/lukekim) in [#9667](https://github.com/spiceai/spiceai/pull/9667)
+- fix: add liveness check for dead executors in partition routing by [@Jeadie](https://github.com/Jeadie) in [#9657](https://github.com/spiceai/spiceai/pull/9657)
+- fix(s3): Fix metadata column schema mismatches in projected queries by [@sgrebnov](https://github.com/sgrebnov) in [#9664](https://github.com/spiceai/spiceai/pull/9664)
+- s3_metadata_columns tests: include test for location outside table prefix by [@sgrebnov](https://github.com/sgrebnov) in [#9676](https://github.com/spiceai/spiceai/pull/9676)
+- docs: Update DuckDB, GCS, Git connector and Cayenne documentation by [@lukekim](https://github.com/lukekim) in [#9671](https://github.com/spiceai/spiceai/pull/9671)
+- Add s3_url_style support for S3 connector URL addressing by [@phillipleblanc](https://github.com/phillipleblanc) in [#9642](https://github.com/spiceai/spiceai/pull/9642)
+- Consolidate E2E workflows and require WSL for Windows runtime by [@lukekim](https://github.com/lukekim) in [#9660](https://github.com/spiceai/spiceai/pull/9660)
+- Upgrade to Rust v1.93.1 by [@lukekim](https://github.com/lukekim) in [#9669](https://github.com/spiceai/spiceai/pull/9669)
+- Security fixes and improvements by [@lukekim](https://github.com/lukekim) in [#9666](https://github.com/spiceai/spiceai/pull/9666)
+- feat(flight): add DoPut rows/bytes written metrics for DoPut ETL ingestion tracking by [@phillipleblanc](https://github.com/phillipleblanc) in [#9663](https://github.com/spiceai/spiceai/pull/9663)
+- Skip caching http error response + add `response_headers` by [@krinart](https://github.com/krinart) in [#9670](https://github.com/spiceai/spiceai/pull/9670)
+- refactor: Remove `v1/evals` functionality by [@Jeadie](https://github.com/Jeadie) in [#9420](https://github.com/spiceai/spiceai/pull/9420)
+- Make a test harness for Distributed Spice integration tests by [@Jeadie](https://github.com/Jeadie) in [#9615](https://github.com/spiceai/spiceai/pull/9615)
+- Enable `on_zero_results: use_source` for views by [@krinart](https://github.com/krinart) in [#9699](https://github.com/spiceai/spiceai/pull/9699)
+- fix(spidapter): Lower memory limit, passthrough AWS secrets, override flight URL by [@peasee](https://github.com/peasee) in [#9704](https://github.com/spiceai/spiceai/pull/9704)
+- Show an error on a shared acceleration file with snapshots enabled by [@krinart](https://github.com/krinart) in [#9698](https://github.com/spiceai/spiceai/pull/9698)
+- Fixes for anthropic by [@Jeadie](https://github.com/Jeadie) in [#9707](https://github.com/spiceai/spiceai/pull/9707)
+- Use `max_partitions_per_executor` in `allocate_initial_partitions` by [@Jeadie](https://github.com/Jeadie) in [#9659](https://github.com/spiceai/spiceai/pull/9659)
+- [SpiceDQ] Accelerations must have partition key by [@Jeadie](https://github.com/Jeadie) in [#9711](https://github.com/spiceai/spiceai/pull/9711)
+- Upgrade to Turso v0.5 by [@lukekim](https://github.com/lukekim) in [#9628](https://github.com/spiceai/spiceai/pull/9628)
+- feat: Rename metadata columns to _location, _last_modified, _size by [@phillipleblanc](https://github.com/phillipleblanc) in [#9712](https://github.com/spiceai/spiceai/pull/9712)
+- fix: bump datafusion-ballista to fix BatchCoalescer schema mismatch panic by [@phillipleblanc](https://github.com/phillipleblanc) in [#9716](https://github.com/spiceai/spiceai/pull/9716)
+- fix: Ensure Cayenne respects target file size by [@peasee](https://github.com/peasee) in [#9730](https://github.com/spiceai/spiceai/pull/9730)
+- refactor: Make DDL preprocessing generic from Iceberg DDL processing by [@peasee](https://github.com/peasee) in [#9731](https://github.com/spiceai/spiceai/pull/9731)
+- [SpiceDQ] Distribute query of Cayenne Catalog to executors with data by [@Jeadie](https://github.com/Jeadie) in [#9727](https://github.com/spiceai/spiceai/pull/9727)
+- Properly set `primary_keys`/`on_conflict` for Cayenne tables by [@krinart](https://github.com/krinart) in [#9739](https://github.com/spiceai/spiceai/pull/9739)
+- Add executor resource and replica support to cloud app config by [@ewgenius](https://github.com/ewgenius) in [#9734](https://github.com/spiceai/spiceai/pull/9734)
+- feat: Support PARTITION BY in Cayenne Catalog table creation by [@peasee](https://github.com/peasee) in [#9741](https://github.com/spiceai/spiceai/pull/9741)
+- Update datafusion and related packages to version 52.3.0 by [@lukekim](https://github.com/lukekim) in [#9708](https://github.com/spiceai/spiceai/pull/9708)
+- Route FlightSQL statement updates through QueryBuilder by [@phillipleblanc](https://github.com/phillipleblanc) in [#9754](https://github.com/spiceai/spiceai/pull/9754)
+- JSON file format improvements by [@lukekim](https://github.com/lukekim) in [#9743](https://github.com/spiceai/spiceai/pull/9743)
+- [SpiceDQ] Partition Cayenne catalogs writes through to executors by [@Jeadie](https://github.com/Jeadie) in [#9737](https://github.com/spiceai/spiceai/pull/9737)
+- Update to DF v52.3.0 versions of datafusion & datafusion-tableproviders by [@lukekim](https://github.com/lukekim) in [#9756](https://github.com/spiceai/spiceai/pull/9756)
+- Make S3 metadata column handling more robust by [@sgrebnov](https://github.com/sgrebnov) in [#9762](https://github.com/spiceai/spiceai/pull/9762)
+- Fetch API keys from dedicated endpoint instead of apps response by [@phillipleblanc](https://github.com/phillipleblanc) in [#9767](https://github.com/spiceai/spiceai/pull/9767)
+- Update arrow-rs, datafusion-federation, and datafusion-table-providers dependencies by [@phillipleblanc](https://github.com/phillipleblanc) in [#9769](https://github.com/spiceai/spiceai/pull/9769)
+- Chunk metastore batch inserts to respect SQLite parameter limits by [@phillipleblanc](https://github.com/phillipleblanc) in [#9770](https://github.com/spiceai/spiceai/pull/9770)
+- Improve JSON SODA support by [@lukekim](https://github.com/lukekim) in [#9795](https://github.com/spiceai/spiceai/pull/9795)
+- Add ADBC Data Connector by [@lukekim](https://github.com/lukekim) in [#9723](https://github.com/spiceai/spiceai/pull/9723)
+- docs: Release Cayenne as RC by [@peasee](https://github.com/peasee) in [#9766](https://github.com/spiceai/spiceai/pull/9766)
+- cli[feat]: cloud mode to use region-specific endpoints by [@lukekim](https://github.com/lukekim) in [#9803](https://github.com/spiceai/spiceai/pull/9803)
+- Include updated JSON formats in HTTPS connector by [@lukekim](https://github.com/lukekim) in [#9800](https://github.com/spiceai/spiceai/pull/9800)
+- Flight DoPut: Partition-aware write-through forwarding by [@Jeadie](https://github.com/Jeadie) in [#9759](https://github.com/spiceai/spiceai/pull/9759)
+- Pass through authentication to ADBC connector by [@lukekim](https://github.com/lukekim) in [#9801](https://github.com/spiceai/spiceai/pull/9801)
+- Move scheduler_state_location from adapter metadata to env var by [@phillipleblanc](https://github.com/phillipleblanc) in [#9802](https://github.com/spiceai/spiceai/pull/9802)
+- Fix Cayenne DoPut upsert returning stale data after 3+ writes by [@phillipleblanc](https://github.com/phillipleblanc) in [#9806](https://github.com/spiceai/spiceai/pull/9806)
+- Fix JSON column projection producing schema mismatch by [@sgrebnov](https://github.com/sgrebnov) in [#9811](https://github.com/spiceai/spiceai/pull/9811)
+- Fix http connector by [@krinart](https://github.com/krinart) in [#9818](https://github.com/spiceai/spiceai/pull/9818)
+- Fix ADBC Connector build and test by [@lukekim](https://github.com/lukekim) in [#9813](https://github.com/spiceai/spiceai/pull/9813)
+- Support update & delete DML for distributed cayenne catalog by [@Jeadie](https://github.com/Jeadie) in [#9805](https://github.com/spiceai/spiceai/pull/9805)
+- Set allow_http param when S3 endpoint uses http scheme by [@phillipleblanc](https://github.com/phillipleblanc) in [#9834](https://github.com/spiceai/spiceai/pull/9834)
+- fix: Cayenne Catalog DDL requires a connected executor in distributed mode by [@Jeadie](https://github.com/Jeadie) in [#9838](https://github.com/spiceai/spiceai/pull/9838)
+- fix: Add conditional put support for file:// scheduler state location by [@Jeadie](https://github.com/Jeadie) in [#9842](https://github.com/spiceai/spiceai/pull/9842)
+- fix: Require the DDL primary key contain the partition key by [@Jeadie](https://github.com/Jeadie) in [#9844](https://github.com/spiceai/spiceai/pull/9844)
+- fix: Databricks SQL Warehouse schema retrieval with INLINE disposition and async retry by [@lukekim](https://github.com/lukekim) in [#9846](https://github.com/spiceai/spiceai/pull/9846)
+- Filter pushdown improvements for SqlTable by [@lukekim](https://github.com/lukekim) in [#9852](https://github.com/spiceai/spiceai/pull/9852)
+- feat: add iam_role_source parameter for AWS credential configuration by [@lukekim](https://github.com/lukekim) in [#9854](https://github.com/spiceai/spiceai/pull/9854)
+- Fix ODBC queries silently returning 0 rows on query failure by [@lukekim](https://github.com/lukekim) in [#9864](https://github.com/spiceai/spiceai/pull/9864)
+- feat(adbc): Add ADBC catalog connector with schema/table discovery by [@lukekim](https://github.com/lukekim) in [#9865](https://github.com/spiceai/spiceai/pull/9865)
+- Make Turso SQL unparsing more robust and fix date comparisons by [@lukekim](https://github.com/lukekim) in [#9871](https://github.com/spiceai/spiceai/pull/9871)
+- Fix Flight/FlightSQL filter precedence and mutable query consistency by [@lukekim](https://github.com/lukekim) in [#9876](https://github.com/spiceai/spiceai/pull/9876)
+- Partial Aggregation optimisation for `FlightSQLExec` by [@lukekim](https://github.com/lukekim) in [#9882](https://github.com/spiceai/spiceai/pull/9882)
+- fix: v1/responses API preserves client instructions when system_prompt is set by [@Jeadie](https://github.com/Jeadie) in [#9884](https://github.com/spiceai/spiceai/pull/9884)
+- feat: emit `scheduler_active_executors_count` and use it in spidapter by [@Jeadie](https://github.com/Jeadie) in [#9885](https://github.com/spiceai/spiceai/pull/9885)
+- feat: Add custom auth header support for GraphQL connector by [@krinart](https://github.com/krinart) in [#9899](https://github.com/spiceai/spiceai/pull/9899)
+- Add --endpoint flag to spice run with scheme-based routing by [@lukekim](https://github.com/lukekim) in [#9903](https://github.com/spiceai/spiceai/pull/9903)
+- When executor connects, send DDL for existing tables by [@Jeadie](https://github.com/Jeadie) in [#9904](https://github.com/spiceai/spiceai/pull/9904)
+- fix: Improve ADBC driver shutdown handling and error classification by [@lukekim](https://github.com/lukekim) in [#9905](https://github.com/spiceai/spiceai/pull/9905)
+- fix: require all executors to succeed for distributed DML (DELETE/UPDATE) forwarding by [@Jeadie](https://github.com/Jeadie) in [#9908](https://github.com/spiceai/spiceai/pull/9908)
+- fix(cayenne catalog): fix catalog refresh race condition causing duplicate primary keys by [@Jeadie](https://github.com/Jeadie) in [#9909](https://github.com/spiceai/spiceai/pull/9909)
+- Remove Perplexity support by [@Jeadie](https://github.com/Jeadie) in [#9910](https://github.com/spiceai/spiceai/pull/9910)
+- Fix refresh_sql support for debezium constraints by [@krinart](https://github.com/krinart) in [#9912](https://github.com/spiceai/spiceai/pull/9912)
+- Implement DML for DynamoDBTableProvider by [@lukekim](https://github.com/lukekim) in [#9915](https://github.com/spiceai/spiceai/pull/9915)
+- chore: Update iceberg-rust fork to v0.9 by [@lukekim](https://github.com/lukekim) in [#9917](https://github.com/spiceai/spiceai/pull/9917)
+- Run physical optimizer on `FallbackOnZeroResultsScanExec` fallback plan by [@sgrebnov](https://github.com/sgrebnov) in [#9927](https://github.com/spiceai/spiceai/pull/9927)
+- Improve Databricks error message when dataset has no columns by [@sgrebnov](https://github.com/sgrebnov) in [#9928](https://github.com/spiceai/spiceai/pull/9928)
+- Delta Lake: fix data skipping for >= timestamp predicates by [@sgrebnov](https://github.com/sgrebnov) in [#9932](https://github.com/spiceai/spiceai/pull/9932)
+- fix: Ensure distributed Cayenne DML inserts are forwarded to executors by [@Jeadie](https://github.com/Jeadie) in [#9948](https://github.com/spiceai/spiceai/pull/9948)
+- Add full query federation support for ADBC data connector by [@lukekim](https://github.com/lukekim) in [#9953](https://github.com/spiceai/spiceai/pull/9953)
+- Make time_format deserialization case-insensitive by [@claudespice](https://github.com/claudespice) in [#9955](https://github.com/spiceai/spiceai/pull/9955)
+- Hash ADBC join-pushdown context to prevent credential leaks in EXPLAIN plans by [@lukekim](https://github.com/lukekim) in [#9956](https://github.com/spiceai/spiceai/pull/9956)
+- fix: Normalize Arrow Dictionary types for DuckDB and SQLite acceleration by [@sgrebnov](https://github.com/sgrebnov) in [#9959](https://github.com/spiceai/spiceai/pull/9959)
+- ADBC BigQuery: Improve BigQuery dialect date/time and interval SQL generation by [@lukekim](https://github.com/lukekim) in [#9967](https://github.com/spiceai/spiceai/pull/9967)
+- Make `BigQueryDialect` more robust and add BigQuery TPC-H benchmark support by [@lukekim](https://github.com/lukekim) in [#9969](https://github.com/spiceai/spiceai/pull/9969)
+- fix: Show proper unauthorized error instead of misleading runtime unavailable by [@lukekim](https://github.com/lukekim) in [#9972](https://github.com/spiceai/spiceai/pull/9972)
+- fix: Enforce target_chunk_size as hard maximum in chunking by [@lukekim](https://github.com/lukekim) in [#9973](https://github.com/spiceai/spiceai/pull/9973)
+- Add caching retention by [@krinart](https://github.com/krinart) in [#9984](https://github.com/spiceai/spiceai/pull/9984)
+- fix: improve Databricks schema error detection and messages by [@lukekim](https://github.com/lukekim) in [#9987](https://github.com/spiceai/spiceai/pull/9987)
+- fix: Set default S3 region for opendal operator and fix cayenne nextest by [@phillipleblanc](https://github.com/phillipleblanc) in [#9995](https://github.com/spiceai/spiceai/pull/9995)
+- fix(PostgreSQL): fix schema discovery for PostgreSQL partitioned tables by [@sgrebnov](https://github.com/sgrebnov) in [#9997](https://github.com/spiceai/spiceai/pull/9997)
+- fix: Defer cache size check until after encoding for compressed results by [@krinart](https://github.com/krinart) in [#10001](https://github.com/spiceai/spiceai/pull/10001)
+- fix: Rewrite numeric BETWEEN to CAST(AS REAL) for Turso by [@lukekim](https://github.com/lukekim) in [#10003](https://github.com/spiceai/spiceai/pull/10003)
+- fix: Handle integer time columns in append refresh for all accelerators by [@sgrebnov](https://github.com/sgrebnov) in [#10004](https://github.com/spiceai/spiceai/pull/10004)
+- fix: preserve s3a:// scheme when building OpenDalStorageFactory with custom endpoint by [@phillipleblanc](https://github.com/phillipleblanc) in [#10006](https://github.com/spiceai/spiceai/pull/10006)
+- Fix ISO8601 time_format with Vortex/Cayenne append refresh by [@sgrebnov](https://github.com/sgrebnov) in [#10009](https://github.com/spiceai/spiceai/pull/10009)
+- fix: Address data correctness bugs found in audit by [@sgrebnov](https://github.com/sgrebnov) in [#10015](https://github.com/spiceai/spiceai/pull/10015)
+- fix(federation): fix SQL unparsing for Inexact filter pushdown with alias by [@lukekim](https://github.com/lukekim) in [#10017](https://github.com/spiceai/spiceai/pull/10017)
+- Improve GitHub connector ref handling and resilience by [@lukekim](https://github.com/lukekim) in [#10023](https://github.com/spiceai/spiceai/pull/10023)
+- feat: Add spice completions command for shell completion generation by [@lukekim](https://github.com/lukekim) in [#10024](https://github.com/spiceai/spiceai/pull/10024)
+- fix: Fix data correctness bugs in DynamoDB decimal conversion and GraphQL pagination by [@sgrebnov](https://github.com/sgrebnov) in [#10054](https://github.com/spiceai/spiceai/pull/10054)
+- Implement RefreshDataset for distributed control stream by [@Jeadie](https://github.com/Jeadie) in [#10055](https://github.com/spiceai/spiceai/pull/10055)
+- perf: Improve S3 parquet read performance by [@sgrebnov](https://github.com/sgrebnov) in [#10064](https://github.com/spiceai/spiceai/pull/10064)
+- fix: Prevent write-through stalls and preserve PartitionTableProvider during catalog refresh by [@Jeadie](https://github.com/Jeadie) in [#10066](https://github.com/spiceai/spiceai/pull/10066)
+- feat: `spice completions` auto-detects shell directory and writes file by [@lukekim](https://github.com/lukekim) in [#10068](https://github.com/spiceai/spiceai/pull/10068)
+- fix: Bug in DynamoDB, GraphQL, and ISO8601 refresh data handling by [@sgrebnov](https://github.com/sgrebnov) in [#10063](https://github.com/spiceai/spiceai/pull/10063)
+- fix partial aggregation deduplication on string checking by [@lukekim](https://github.com/lukekim) in [#10078](https://github.com/spiceai/spiceai/pull/10078)
+- fix: add MetastoreTransaction support to prevent concurrent transaction conflicts by [@phillipleblanc](https://github.com/phillipleblanc) in [#10080](https://github.com/spiceai/spiceai/pull/10080)
+- fix: Use GreedyMemoryPool, add spidapter query memory limit arg by [@phillipleblanc](https://github.com/phillipleblanc) in [#10082](https://github.com/spiceai/spiceai/pull/10082)
+- feat: Add metrics for EXPLAIN ANALYZE in FlightSQLExec by [@lukekim](https://github.com/lukekim) in [#10084](https://github.com/spiceai/spiceai/pull/10084)
+- Use strict cast in `try_cast_to` to error on overflow instead of silent NULL by [@sgrebnov](https://github.com/sgrebnov) in [#10104](https://github.com/spiceai/spiceai/pull/10104)
+- feat: Implement MERGE INTO for Cayenne catalog tables by [@peasee](https://github.com/peasee) in [#10105](https://github.com/spiceai/spiceai/pull/10105)
+- feat: Add distributed MERGE INTO support for Cayenne catalog tables by [@peasee](https://github.com/peasee) in [#10106](https://github.com/spiceai/spiceai/pull/10106)
+- Improve JSON format auto-detection for single multi-line objects by [@lukekim](https://github.com/lukekim) in [#10107](https://github.com/spiceai/spiceai/pull/10107)
+- Add mode: file_update acceleration mode by [@krinart](https://github.com/krinart) in [#10108](https://github.com/spiceai/spiceai/pull/10108)
+- Coerce unsupported Arrow types to Iceberg v2 equivalents in REST catalog API by [@peasee](https://github.com/peasee) in [#10109](https://github.com/spiceai/spiceai/pull/10109)
+- fix: Update default query memory limit to 90% from 70% by [@phillipleblanc](https://github.com/phillipleblanc) in [#10112](https://github.com/spiceai/spiceai/pull/10112)
+- feat: Add mTLS client auth support to spice sql REPL by [@lukekim](https://github.com/lukekim) in [#10113](https://github.com/spiceai/spiceai/pull/10113)
+- fix(datafusion-federation): report error on overflow instead of silent NULL by [@sgrebnov](https://github.com/sgrebnov) in [#10124](https://github.com/spiceai/spiceai/pull/10124)
+- fix: Prevent data loss in MERGE when source has duplicate keys by [@peasee](https://github.com/peasee) in [#10126](https://github.com/spiceai/spiceai/pull/10126)
+- feat: Add ClickHouse Date32 type support by [@sgrebnov](https://github.com/sgrebnov) in [#10132](https://github.com/spiceai/spiceai/pull/10132)
+- Add Delta Lake column mapping support (Name/Id modes) by [@sgrebnov](https://github.com/sgrebnov) in [#10134](https://github.com/spiceai/spiceai/pull/10134)
+- fix: Restore Turso numeric BETWEEN rewrite lost in DML revert by [@lukekim](https://github.com/lukekim) in [#10139](https://github.com/spiceai/spiceai/pull/10139)
+- fix: Enable arm64 Linux builds with fp16 and lld workarounds by [@lukekim](https://github.com/lukekim) in [#10142](https://github.com/spiceai/spiceai/pull/10142)
+- fix: remove double trailing slash in Unity Catalog storage locations by [@sgrebnov](https://github.com/sgrebnov) in [#10147](https://github.com/spiceai/spiceai/pull/10147)
+- fix: Improve GitHub GraphQL client resilience and performance by [@lukekim](https://github.com/lukekim) in [#10151](https://github.com/spiceai/spiceai/pull/10151)
+- Enable reqwest compression and optimize HTTP client settings by [@lukekim](https://github.com/lukekim) in [#10154](https://github.com/spiceai/spiceai/pull/10154)
+- fix: executor startup failures by [@Jeadie](https://github.com/Jeadie) in [#10155](https://github.com/spiceai/spiceai/pull/10155)
+- feat: Distributed runtime.task_history support by [@Jeadie](https://github.com/Jeadie) in [#10156](https://github.com/spiceai/spiceai/pull/10156)
+- fix: Preserve timestamp timezone in DDL forwarding to executors by [@peasee](https://github.com/peasee) in [#10159](https://github.com/spiceai/spiceai/pull/10159)
+- feat: Per-model rate-limited concurrent AI UDF execution by [@Jeadie](https://github.com/Jeadie) in [#10160](https://github.com/spiceai/spiceai/pull/10160)
+- fix(Turso): Reject subquery/outer-ref filter pushdown in Turso provider by [@lukekim](https://github.com/lukekim) in [#10174](https://github.com/spiceai/spiceai/pull/10174)
+- Fix linux/macos `spice upgrade` by [@phillipleblanc](https://github.com/phillipleblanc) in [#10194](https://github.com/spiceai/spiceai/pull/10194)
+- Improve CREATE TABLE LIKE error messages, success output, EXPLAIN, and validation by [@peasee](https://github.com/peasee) in [#10203](https://github.com/spiceai/spiceai/pull/10203)
+- fix: chunk MERGE delete filters and update Vortex for stack-safe IN-lists by [@peasee](https://github.com/peasee) in [#10207](https://github.com/spiceai/spiceai/pull/10207)
+- Propagate `runtime.params.parquet_page_index` to Delta Lake connector by [@sgrebnov](https://github.com/sgrebnov) in [#10209](https://github.com/spiceai/spiceai/pull/10209)
+- Properly mark dataset as Ready on Scheduler by [@Jeadie](https://github.com/Jeadie) in [#10215](https://github.com/spiceai/spiceai/pull/10215)
+- fix: handle Utf8View/LargeUtf8 in GitHub connector ref filters by [@lukekim](https://github.com/lukekim) in [#10217](https://github.com/spiceai/spiceai/pull/10217)
+- fix(databricks): Fix schema introspection and timestamp overflow by [@lukekim](https://github.com/lukekim) in [#10226](https://github.com/spiceai/spiceai/pull/10226)
+- fix(databricks): Fix schema introspection failures for non-Unity-Catalog environments by [@lukekim](https://github.com/lukekim) in [#10227](https://github.com/spiceai/spiceai/pull/10227)
+- feat: Add pagination support to HTTP data connector by [@lukekim](https://github.com/lukekim) in [#10228](https://github.com/spiceai/spiceai/pull/10228)
+- feat(databricks): DESCRIBE TABLE fallback and source-native type parsing for Lakehouse Federation by [@lukekim](https://github.com/lukekim) in [#10229](https://github.com/spiceai/spiceai/pull/10229)
+- fix(databricks): harden HTTP retries, compression, and token refresh by [@lukekim](https://github.com/lukekim) in [#10232](https://github.com/spiceai/spiceai/pull/10232)
+- feat[helm chart]: Add support for ServiceAccount annotations and AWS IRSA example by [@peasee](https://github.com/peasee) in [#9833](https://github.com/spiceai/spiceai/pull/9833)
+- fix: Log warning and fall back gracefully on Cayenne config change by [@krinart](https://github.com/krinart) in [#9092](https://github.com/spiceai/spiceai/pull/9092)
+- fix: Handle engine mismatch gracefully in snapshot fallback loop by [@krinart](https://github.com/krinart) in [#9187](https://github.com/spiceai/spiceai/pull/9187)
+- fix: Full Text Search schema mismatch with ADBC connector by [@lukekim](https://github.com/lukekim) in [#10235](https://github.com/spiceai/spiceai/pull/10235)
+- docs: Update v2.0.0-rc.2 release notes with latest changes by [@lukekim](https://github.com/lukekim) in [#10238](https://github.com/spiceai/spiceai/pull/10238)
+- Fix append refresh dedup failure when refresh_sql selects column subset by [@sgrebnov](https://github.com/sgrebnov) in [#10225](https://github.com/spiceai/spiceai/pull/10225)
+- Revert "Properly mark dataset as Ready on Scheduler (#10215)" by [@sgrebnov](https://github.com/sgrebnov) in [#10242](https://github.com/spiceai/spiceai/pull/10242)
+- Fix failing merge conflicts for benchmarks by [@krinart](https://github.com/krinart) in [#10247](https://github.com/spiceai/spiceai/pull/10247)
+- fix(github): fetch commits for dynamic and slash refs by [@lukekim](https://github.com/lukekim) in [#10233](https://github.com/spiceai/spiceai/pull/10233)
+- Upgrade DataFusion to v52.5.0-rc1 by [@lukekim](https://github.com/lukekim) in [#10249](https://github.com/spiceai/spiceai/pull/10249)
+- Merge develop to trunk (2026-04-09) by [@claudespice](https://github.com/claudespice) in [#10248](https://github.com/spiceai/spiceai/pull/10248)
+- fix: Validate embedding row_id columns during dataset init (fixes #8226) by [@claudespice](https://github.com/claudespice) in [#10208](https://github.com/spiceai/spiceai/pull/10208)
+- fix: Update tpch benchmark snapshots for federated/glue[csv].yaml by [@app/github-actions](https://github.com/app/github-actions) in [#10244](https://github.com/spiceai/spiceai/pull/10244)
+- feat(databricks): add resilience controls, UC awareness, and task history instrumentation by [@lukekim](https://github.com/lukekim) in [#10246](https://github.com/spiceai/spiceai/pull/10246)
+- fix: Make PartitionManager resilient to bare vs fully qualified table references by [@sgrebnov](https://github.com/sgrebnov) in [#10257](https://github.com/spiceai/spiceai/pull/10257)
+- fix: Update tpch benchmark snapshots for accelerated/s3[parquet]-cayenne[file].yaml by [@app/github-actions](https://github.com/app/github-actions) in [#10256](https://github.com/spiceai/spiceai/pull/10256)
+- Merge develop to trunk (2026-04-10) by [@claudespice](https://github.com/claudespice) in [#10251](https://github.com/spiceai/spiceai/pull/10251)
+- Improve Snowflake/ADBC dataset registration performance and observability by [@lukekim](https://github.com/lukekim) in [#10266](https://github.com/spiceai/spiceai/pull/10266)
+- Fixes for kafka connector by [@krinart](https://github.com/krinart) in [#10263](https://github.com/spiceai/spiceai/pull/10263)
+- fix(runtime): gate otel code tags, suppress aws sdk noise, and unblock connector init by [@lukekim](https://github.com/lukekim) in [#10260](https://github.com/spiceai/spiceai/pull/10260)
+- fix(runtime): avoid regionless AWS SDK loads by [@lukekim](https://github.com/lukekim) in [#10271](https://github.com/spiceai/spiceai/pull/10271)
+- Add versioned release install workflow coverage by [@lukekim](https://github.com/lukekim) in [#10276](https://github.com/spiceai/spiceai/pull/10276)
+- fix(runtime): handle HTTP JSON unions and spicepod reloads by [@lukekim](https://github.com/lukekim) in [#10277](https://github.com/spiceai/spiceai/pull/10277)
+- Databricks UC permission prechecks: explicit denial as permanent error, ambiguous cases advisory by [@lukekim](https://github.com/lukekim) in [#10274](https://github.com/spiceai/spiceai/pull/10274)
+- Revert component status changes re-introduced by develop merge (#10248) by [@sgrebnov](https://github.com/sgrebnov) in [#10293](https://github.com/spiceai/spiceai/pull/10293)
+- Fix broken CI workflows by [@ewgenius](https://github.com/ewgenius) in [#10294](https://github.com/spiceai/spiceai/pull/10294)
+- Group dependabot updates by ecosystem by [@lukekim](https://github.com/lukekim) in [#10296](https://github.com/spiceai/spiceai/pull/10296)
+- fix(tests): Replace flaky S3 Vectors snapshot tests with structural validation by [@lukekim](https://github.com/lukekim) in [#10301](https://github.com/spiceai/spiceai/pull/10301)
+- Update test_github_workflows snapshot by [@lukekim](https://github.com/lukekim) in [#10304](https://github.com/spiceai/spiceai/pull/10304)
+- fix(ci): fix Bedrock runner mismatch and snapshot auto-merge failure by [@ewgenius](https://github.com/ewgenius) in [#10306](https://github.com/spiceai/spiceai/pull/10306)
+- feat(http): Add map-to-array conversion and query-parameter pagination by [@lukekim](https://github.com/lukekim) in [#10295](https://github.com/spiceai/spiceai/pull/10295)
+- New crate: `datafusion-ddl` by [@Jeadie](https://github.com/Jeadie) in [#10205](https://github.com/spiceai/spiceai/pull/10205)
+- Make Databricks UC permission checks advisory with structured error reporting by [@lukekim](https://github.com/lukekim) in [#10283](https://github.com/spiceai/spiceai/pull/10283)
+- build(deps): bump the github-actions-dependencies group with 4 updates by [@app/dependabot](https://github.com/app/dependabot) in [#10298](https://github.com/spiceai/spiceai/pull/10298)
+- fix: Clear cached plans on view updates by [@peasee](https://github.com/peasee) in [#10312](https://github.com/spiceai/spiceai/pull/10312)
+- build(deps): bump the aws-sdk group with 7 updates by [@app/dependabot](https://github.com/app/dependabot) in [#10299](https://github.com/spiceai/spiceai/pull/10299)
+- Code out of runtime. by [@Jeadie](https://github.com/Jeadie) in [#10178](https://github.com/spiceai/spiceai/pull/10178)
+- fix: Respect function registry denies for accelerated table filter pushdown by [@peasee](https://github.com/peasee) in [#10311](https://github.com/spiceai/spiceai/pull/10311)
+- fix: Don't block heartbeat when all slots acquired by [@peasee](https://github.com/peasee) in [#10322](https://github.com/spiceai/spiceai/pull/10322)
+- fix: strip only outer parens in `get_table_partition_expr_from_ctx` by [@Jeadie](https://github.com/Jeadie) in [#10323](https://github.com/spiceai/spiceai/pull/10323)
+- Upgrade datafusion-table-providers with MongoDB SRV support by [@lukekim](https://github.com/lukekim) in [#10317](https://github.com/spiceai/spiceai/pull/10317)
+- fix: Avoid pushing down bucketing partition expressions into executors by [@peasee](https://github.com/peasee) in [#10324](https://github.com/spiceai/spiceai/pull/10324)
+- Upgrade datafusion-table-providers to d1b911a5 and bump adbc to 0.23 by [@lukekim](https://github.com/lukekim) in [#10329](https://github.com/spiceai/spiceai/pull/10329)
+- fix: Update Search integration test snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#10308](https://github.com/spiceai/spiceai/pull/10308)
+- Handle foreign table + Classic sql warehouse combination gracefully by [@krinart](https://github.com/krinart) in [#10318](https://github.com/spiceai/spiceai/pull/10318)
+- New crate `datafusion-flightsql` by [@Jeadie](https://github.com/Jeadie) in [#10201](https://github.com/spiceai/spiceai/pull/10201)
+- Set `tantivy=warn` unless very verbose logging by [@Jeadie](https://github.com/Jeadie) in [#10338](https://github.com/spiceai/spiceai/pull/10338)
+- Remove image registry and image name options from spidapter by [@ewgenius](https://github.com/ewgenius) in [#10241](https://github.com/spiceai/spiceai/pull/10241)
+- build(deps): bump sysinfo from 0.37.2 to 0.38.4 by [@app/dependabot](https://github.com/app/dependabot) in [#10291](https://github.com/spiceai/spiceai/pull/10291)
+- build(deps): bump futures from 0.3.31 to 0.3.32 by [@app/dependabot](https://github.com/app/dependabot) in [#10289](https://github.com/spiceai/spiceai/pull/10289)
+- New crate 'datafusion-dml' by [@Jeadie](https://github.com/Jeadie) in [#10334](https://github.com/spiceai/spiceai/pull/10334)
+- Jeadie/26 04 16/spice sql by [@Jeadie](https://github.com/Jeadie) in [#10343](https://github.com/spiceai/spiceai/pull/10343)
+- Add Teraswitch/Pittsburgh apt mirrors + retry config for CI runners by [@lukekim](https://github.com/lukekim) in [#10349](https://github.com/spiceai/spiceai/pull/10349)
+- Implement sort pushdown and fix pushdown gaps across providers by [@lukekim](https://github.com/lukekim) in [#10337](https://github.com/spiceai/spiceai/pull/10337)
+- Merge develop to trunk (2026-04-16) by [@claudespice](https://github.com/claudespice) in [#10345](https://github.com/spiceai/spiceai/pull/10345)
+- Update candle and mistral.rs lock-step pins by [@lukekim](https://github.com/lukekim) in [#10278](https://github.com/spiceai/spiceai/pull/10278)
+- docs: fix status badges in README by [@lukekim](https://github.com/lukekim) in [#10350](https://github.com/spiceai/spiceai/pull/10350)
+- Migrate secrets to vars by [@krinart](https://github.com/krinart) in [#10354](https://github.com/spiceai/spiceai/pull/10354)
+- Add limit pushdown and improve sort pushdown for Oracle and MSSQL by [@sgrebnov](https://github.com/sgrebnov) in [#10351](https://github.com/spiceai/spiceai/pull/10351)
+- Fix ubuntu mirror configuration by [@ewgenius](https://github.com/ewgenius) in [#10359](https://github.com/spiceai/spiceai/pull/10359)
+- fix: Increase throughput test default ready_wait from 30s to 300s (fixes #8207) by [@claudespice](https://github.com/claudespice) in [#10344](https://github.com/spiceai/spiceai/pull/10344)
+- Add auth headers support to OTEL metrics exporter by [@lukekim](https://github.com/lukekim) in [#10347](https://github.com/spiceai/spiceai/pull/10347)
+- fix(github): shrink GraphQL page size on gateway errors; lower comment defaults by [@lukekim](https://github.com/lukekim) in [#10355](https://github.com/spiceai/spiceai/pull/10355)
+- Relax apt mirror substitution failure to warning in CI action by [@ewgenius](https://github.com/ewgenius) in [#10361](https://github.com/spiceai/spiceai/pull/10361)
+- feat(http): Add OAuth2 refresh-token auth to HTTP connector by [@lukekim](https://github.com/lukekim) in [#10348](https://github.com/spiceai/spiceai/pull/10348)
+- Upgrade Rust toolchain to 1.94.1 by [@lukekim](https://github.com/lukekim) in [#10353](https://github.com/spiceai/spiceai/pull/10353)
+- Handle order by and sort in PartitionedTableScanRewrite by [@Jeadie](https://github.com/Jeadie) in [#9656](https://github.com/spiceai/spiceai/pull/9656)
+- Fix OTEL Exporter by [@krinart](https://github.com/krinart) in [#10363](https://github.com/spiceai/spiceai/pull/10363)
+- Pin spiceai candle / TEI forks to merged revs; drop local [patch] overrides by [@lukekim](https://github.com/lukekim) in [#10362](https://github.com/spiceai/spiceai/pull/10362)
+- Integrate spiceio and makefile_targets into pr.yml by [@lukekim](https://github.com/lukekim) in [#10357](https://github.com/spiceai/spiceai/pull/10357)
+- ci: skip artifact compression for test binaries/archives by [@lukekim](https://github.com/lukekim) in [#10381](https://github.com/spiceai/spiceai/pull/10381)
+- chore(deps): bump spiceai/candle, spiceai/mistral.rs, aws-lc-rs, tantivy, rand by [@lukekim](https://github.com/lukekim) in [#10379](https://github.com/spiceai/spiceai/pull/10379)
+- Bump datafusion-table-providers (#10375) by [@lukekim](https://github.com/lukekim) in [#10384](https://github.com/spiceai/spiceai/pull/10384)
+- fix: Update Search integration test snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#10376](https://github.com/spiceai/spiceai/pull/10376)
+- v2.0.0-rc.3 preparation by [@ewgenius](https://github.com/ewgenius) in [#10382](https://github.com/spiceai/spiceai/pull/10382)
+- fix(spicepod): JSON schema accepts string or {name: expr} for `partition_by` by [@lukekim](https://github.com/lukekim) in [#10352](https://github.com/spiceai/spiceai/pull/10352)
+- fix: Use ROUND for Turso decimal BETWEEN comparisons (fixes #9872) by [@claudespice](https://github.com/claudespice) in [#10360](https://github.com/spiceai/spiceai/pull/10360)
+- Revert "v2.0.0-rc.3 preparation" from trunk by [@ewgenius](https://github.com/ewgenius) in [#10386](https://github.com/spiceai/spiceai/pull/10386)
+- Add `on_schema_resolved` dataset ready state by [@lukekim](https://github.com/lukekim) in [#10368](https://github.com/spiceai/spiceai/pull/10368)
+- feat: Add Elasticsearch data connector with hybrid search support by [@lukekim](https://github.com/lukekim) in [#10258](https://github.com/spiceai/spiceai/pull/10258)
+- ci: bump test archive upload compression-level to 1 by [@lukekim](https://github.com/lukekim) in [#10388](https://github.com/spiceai/spiceai/pull/10388)
+- feat(git-connector): promote Git connector to RC status by [@lukekim](https://github.com/lukekim) in [#10385](https://github.com/spiceai/spiceai/pull/10385)
+- feat(postgres): stream WAL directly to Spice accelerators by [@lukekim](https://github.com/lukekim) in [#10364](https://github.com/spiceai/spiceai/pull/10364)
+- Add schema decomposition to the HTTP connector by [@lukekim](https://github.com/lukekim) in [#10393](https://github.com/spiceai/spiceai/pull/10393)
+- fix(cayenne): Skip catalog refresh state reload for existing providers by [@sgrebnov](https://github.com/sgrebnov) in [#10396](https://github.com/spiceai/spiceai/pull/10396)
+- Make `cayenne-flightsql` tool by [@Jeadie](https://github.com/Jeadie) in [#10356](https://github.com/spiceai/spiceai/pull/10356)
+- build(deps): bump the github-actions-dependencies group with 2 updates by [@app/dependabot](https://github.com/app/dependabot) in [#10398](https://github.com/spiceai/spiceai/pull/10398)
+- Update openapi.json by [@app/github-actions](https://github.com/app/github-actions) in [#10272](https://github.com/spiceai/spiceai/pull/10272)
+- Merge develop to trunk — 2026-04-19 by [@claudespice](https://github.com/claudespice) in [#10407](https://github.com/spiceai/spiceai/pull/10407)
+- feat(otel): default OTLP push exporter to delta temporality by [@phillipleblanc](https://github.com/phillipleblanc) in [#10412](https://github.com/spiceai/spiceai/pull/10412)
+- fix: Restore analyzer rule ordering to run federation before type coercion by [@sgrebnov](https://github.com/sgrebnov) in [#10415](https://github.com/spiceai/spiceai/pull/10415)
+- fix: Map Utf8/LargeUtf8 to STRING in Databricks/Spark SQL dialects by [@sgrebnov](https://github.com/sgrebnov) in [#10420](https://github.com/spiceai/spiceai/pull/10420)
+- feat(otel): add metric name prefix at runtime.telemetry.metric_prefix by [@phillipleblanc](https://github.com/phillipleblanc) in [#10418](https://github.com/spiceai/spiceai/pull/10418)
+- fix: Map LargeUtf8 to VARCHAR in Athena ODBC dialect by [@sgrebnov](https://github.com/sgrebnov) in [#10419](https://github.com/spiceai/spiceai/pull/10419)
+- feat(cluster): connector-driven object store registration on executors by [@phillipleblanc](https://github.com/phillipleblanc) in [#10414](https://github.com/spiceai/spiceai/pull/10414)
+- build(deps): bump ubuntu from 22.04 to 24.04 in the docker-dependencies group by [@app/dependabot](https://github.com/app/dependabot) in [#10397](https://github.com/spiceai/spiceai/pull/10397)
+- fix: Update benchmark snapshots Apr 20 by [@app/github-actions](https://github.com/app/github-actions) in [#10417](https://github.com/spiceai/spiceai/pull/10417)
+- feat(otel): apply runtime.telemetry.properties as resource attributes on exported metrics by [@phillipleblanc](https://github.com/phillipleblanc) in [#10416](https://github.com/spiceai/spiceai/pull/10416)
+- Publish RC releases to DockerHub; upgrade runners to ubuntu-24.04 by [@lukekim](https://github.com/lukekim) in [#10428](https://github.com/spiceai/spiceai/pull/10428)
+- feat: Add Azure Cosmos DB (NoSQL) data connector (RC) by [@lukekim](https://github.com/lukekim) in [#10392](https://github.com/spiceai/spiceai/pull/10392)
+- feat(datafusion): flatten_json_properties + json_tree UDTFs by [@lukekim](https://github.com/lukekim) in [#10406](https://github.com/spiceai/spiceai/pull/10406)
+- Harden /v1/tools and /v1/nsql against unauthenticated / LLM-driven SQL by [@lukekim](https://github.com/lukekim) in [#10365](https://github.com/spiceai/spiceai/pull/10365)
+- feat(embeddings): multi-vector embeddings with MaxSim + late-interaction by [@lukekim](https://github.com/lukekim) in [#10408](https://github.com/spiceai/spiceai/pull/10408)
+- Update GH runners for CUDA builds by [@ewgenius](https://github.com/ewgenius) in [#10432](https://github.com/spiceai/spiceai/pull/10432)
+- fix(delta_lake): register object stores on cluster executors by [@phillipleblanc](https://github.com/phillipleblanc) in [#10436](https://github.com/spiceai/spiceai/pull/10436)
+- DF-native DML by [@krinart](https://github.com/krinart) in [#10327](https://github.com/spiceai/spiceai/pull/10327)
+- ci: run Build and Test on spiceai-macos; split install jobs by profile by [@lukekim](https://github.com/lukekim) in [#10434](https://github.com/spiceai/spiceai/pull/10434)
+- Improve search UDTFs: text_search, vector_search, rrf by [@lukekim](https://github.com/lukekim) in [#10387](https://github.com/spiceai/spiceai/pull/10387)
+- fix(model2vec): Improve robustness of model loading for sentence-transformers layouts by [@sgrebnov](https://github.com/sgrebnov) in [#10444](https://github.com/spiceai/spiceai/pull/10444)
+- Merge develop to trunk — 2026-04-21 by [@claudespice](https://github.com/claudespice) in [#10448](https://github.com/spiceai/spiceai/pull/10448)
+- Enable filter pushdown for `vector_search` UDTF by [@sgrebnov](https://github.com/sgrebnov) in [#10447](https://github.com/spiceai/spiceai/pull/10447)
+- Support Snowflake OBJECT, MAP, GEOGRAPHY, GEOMETRY, VECTOR, TIMESTAMP_LTZ types by [@lukekim](https://github.com/lukekim) in [#10451](https://github.com/spiceai/spiceai/pull/10451)
+- Fix Databricks tests by [@krinart](https://github.com/krinart) in [#10449](https://github.com/spiceai/spiceai/pull/10449)
+- fix(cluster): forward register_object_stores through connector wrappers by [@phillipleblanc](https://github.com/phillipleblanc) in [#10460](https://github.com/spiceai/spiceai/pull/10460)
+- Fixes for vector-search by [@krinart](https://github.com/krinart) in [#10455](https://github.com/spiceai/spiceai/pull/10455)
+- Add expand_maps option and flatten_json UDTF by [@lukekim](https://github.com/lukekim) in [#10452](https://github.com/spiceai/spiceai/pull/10452)
+- fix: Update Search integration test snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#10458](https://github.com/spiceai/spiceai/pull/10458)
+- Fix physical codec decode ambiguity for empty protobuf messages by [@sgrebnov](https://github.com/sgrebnov) in [#10466](https://github.com/spiceai/spiceai/pull/10466)
+- chore(logging): demote s3_single_file_cached skip refresh log to debug by [@phillipleblanc](https://github.com/phillipleblanc) in [#10467](https://github.com/spiceai/spiceai/pull/10467)
+- Enable filter pushdown for `rrf` UDTF by [@sgrebnov](https://github.com/sgrebnov) in [#10465](https://github.com/spiceai/spiceai/pull/10465)
+- feat(cluster): consolidate distributed state into cluster.json by [@phillipleblanc](https://github.com/phillipleblanc) in [#10463](https://github.com/spiceai/spiceai/pull/10463)
+- feat(cayenne): Add column statistics and data inlining by [@lukekim](https://github.com/lukekim) in [#10314](https://github.com/spiceai/spiceai/pull/10314)
+- docs(copilot): flag missing wrapper delegation when adding default trait methods by [@phillipleblanc](https://github.com/phillipleblanc) in [#10461](https://github.com/spiceai/spiceai/pull/10461)
+- Wire Elasticsearch vector engine write path through acceleration by [@lukekim](https://github.com/lukekim) in [#10453](https://github.com/spiceai/spiceai/pull/10453)
+- Add helm lint CI by [@ewgenius](https://github.com/ewgenius) in [#10468](https://github.com/spiceai/spiceai/pull/10468)
+- Fix Azure and GCS acceleration snapshot object store credential handling by [@phillipleblanc](https://github.com/phillipleblanc) in [#10486](https://github.com/spiceai/spiceai/pull/10486)
+- Update spicepod.schema.json by [@app/github-actions](https://github.com/app/github-actions) in [#10485](https://github.com/spiceai/spiceai/pull/10485)
+- fix(secrets): harden AWS Secrets Manager secret store by [@lukekim](https://github.com/lukekim) in [#10478](https://github.com/spiceai/spiceai/pull/10478)
+- Update `datafusion-ballista` crate by [@sgrebnov](https://github.com/sgrebnov) in [#10488](https://github.com/spiceai/spiceai/pull/10488)
+- feat(secrets): add ParameterSpec and more params for AWS secrets manager by [@phillipleblanc](https://github.com/phillipleblanc) in [#10487](https://github.com/spiceai/spiceai/pull/10487)
+- Add rerank UDTF for hybrid search with query auto-propagation by [@lukekim](https://github.com/lukekim) in [#10469](https://github.com/spiceai/spiceai/pull/10469)
+- Fix flatten_json_properties by [@krinart](https://github.com/krinart) in [#10475](https://github.com/spiceai/spiceai/pull/10475)
+- fix: preserve field and schema metadata in expand_views_schema by [@claudespice](https://github.com/claudespice) in [#10494](https://github.com/spiceai/spiceai/pull/10494)
+- Upgrade rmcp to upstream 1.5.0; switch MCP server to Streamable HTTP by [@lukekim](https://github.com/lukekim) in [#10491](https://github.com/spiceai/spiceai/pull/10491)
+- fix: handle Snowflake TIMESTAMP_LTZ wire format and prevent nanosecond overflow by [@claudespice](https://github.com/claudespice) in [#10493](https://github.com/spiceai/spiceai/pull/10493)
+- Lint parity in Makefile by [@krinart](https://github.com/krinart) in [#10492](https://github.com/spiceai/spiceai/pull/10492)
+- Add connect_timeout/client_timeout params to Databricks sql_warehouse mode by [@lukekim](https://github.com/lukekim) in [#10495](https://github.com/spiceai/spiceai/pull/10495)
+- fix(tracing): suppress opentelemetry INFO logs at all verbosity levels by [@lukekim](https://github.com/lukekim) in [#10497](https://github.com/spiceai/spiceai/pull/10497)
+- DynamoDB DML by [@krinart](https://github.com/krinart) in [#10470](https://github.com/spiceai/spiceai/pull/10470)
+- feat(cayenne): native vector search via SIMD similarity UDFs by [@lukekim](https://github.com/lukekim) in [#10456](https://github.com/spiceai/spiceai/pull/10456)
+- fix(cli): suppress banner for all JSON-producing cloud subcommands (fixes #10498) by [@claudespice](https://github.com/claudespice) in [#10510](https://github.com/spiceai/spiceai/pull/10510)
+- fix(deps): bump openssl to 0.10.78 by [@phillipleblanc](https://github.com/phillipleblanc) in [#10509](https://github.com/spiceai/spiceai/pull/10509)
+- fix(s3): quiet AWS SDK credential probe when no region is configured by [@phillipleblanc](https://github.com/phillipleblanc) in [#10506](https://github.com/spiceai/spiceai/pull/10506)
+- fix(cdc): emit ready signal on caught-up Kafka/Debezium streams (#5201) by [@phillipleblanc](https://github.com/phillipleblanc) in [#10504](https://github.com/spiceai/spiceai/pull/10504)
+- `runtime-cluster` crate + Run partition discovery before forwarding refresh to executors by [@krinart](https://github.com/krinart) in [#10490](https://github.com/spiceai/spiceai/pull/10490)
+- Update lint-rust target to use `--keep-going` by [@Jeadie](https://github.com/Jeadie) in [#10508](https://github.com/spiceai/spiceai/pull/10508)
+- Add TPC-H SF100 s3[parquet]-duckdb[file] benchmark spicepod by [@lukekim](https://github.com/lukekim) in [#10524](https://github.com/spiceai/spiceai/pull/10524)
+- Remove dev-profile install steps from pr.yml by [@Jeadie](https://github.com/Jeadie) in [#10507](https://github.com/spiceai/spiceai/pull/10507)
+- fix: add missing NULL check on Timestamp path in append refresh by [@claudespice](https://github.com/claudespice) in [#10518](https://github.com/spiceai/spiceai/pull/10518)
+- fix: return error on Decimal128/256 overflow instead of silently dropping scale by [@claudespice](https://github.com/claudespice) in [#10519](https://github.com/spiceai/spiceai/pull/10519)
+- fix: delegate update and delete_from in IndexedTableProvider and EmbeddingTable by [@claudespice](https://github.com/claudespice) in [#10520](https://github.com/spiceai/spiceai/pull/10520)
+- feat(devx): make config errors, CLI, and REPL lead users to success by [@lukekim](https://github.com/lukekim) in [#10489](https://github.com/spiceai/spiceai/pull/10489)
+- fix(rerank): defer execution to RerankExec, enable filters and projection pushdown by [@sgrebnov](https://github.com/sgrebnov) in [#10514](https://github.com/spiceai/spiceai/pull/10514)
+- fix(llms): support Gemma models with missing attention_bias config field by [@lukekim](https://github.com/lukekim) in [#10523](https://github.com/spiceai/spiceai/pull/10523)
+- Fix vector_search silently ignoring named limit/column/include_score args by [@sgrebnov](https://github.com/sgrebnov) in [#10527](https://github.com/spiceai/spiceai/pull/10527)
+- fix: split unsupported filters locally in scan() for UseSource mode by [@ewgenius](https://github.com/ewgenius) in [#10528](https://github.com/spiceai/spiceai/pull/10528)
+- feat(secrets): add Azure Key Vault secret store by [@lukekim](https://github.com/lukekim) in [#10496](https://github.com/spiceai/spiceai/pull/10496)
+- Bump mistralrs by [@krinart](https://github.com/krinart) in [#10532](https://github.com/spiceai/spiceai/pull/10532)
+- Fix benchmark configurations and CI build issues by [@sgrebnov](https://github.com/sgrebnov) in [#10535](https://github.com/spiceai/spiceai/pull/10535)
+- Fix catalog query overrides for MySQL and MSSQL benchmarks by [@sgrebnov](https://github.com/sgrebnov) in [#10543](https://github.com/spiceai/spiceai/pull/10543)
+- For Cayenne, preserve matched columns for `MERGE ... ON <cols>` by [@Jeadie](https://github.com/Jeadie) in [#10340](https://github.com/spiceai/spiceai/pull/10340)
+- build(deps): bump the aws-sdk group across 1 directory with 5 updates by [@app/dependabot](https://github.com/app/dependabot) in [#10538](https://github.com/spiceai/spiceai/pull/10538)
+- docs: update AI agent instructions (git workflow + Rust 1.94) by [@lukekim](https://github.com/lukekim) in [#10544](https://github.com/spiceai/spiceai/pull/10544)
+- fix: Update tpch benchmark snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#10529](https://github.com/spiceai/spiceai/pull/10529)
+- fix: Update tpch benchmark snapshots for accelerated/s3[parquet]-duckdb[file].yaml by [@app/github-actions](https://github.com/app/github-actions) in [#10525](https://github.com/spiceai/spiceai/pull/10525)
+- Extract `runtime-datafusion` from `runtime` by [@krinart](https://github.com/krinart) in [#10545](https://github.com/spiceai/spiceai/pull/10545)
+- Use generic DML extension planner for Cayenne by [@Jeadie](https://github.com/Jeadie) in [#10437](https://github.com/spiceai/spiceai/pull/10437)
+- fix: Update Search integration test snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#10552](https://github.com/spiceai/spiceai/pull/10552)
+- Fix security and correctness audit issues by [@lukekim](https://github.com/lukekim) in [#10526](https://github.com/spiceai/spiceai/pull/10526)
+- fix(MySQL): revert MySQL result column reorder to fix federated query failures by [@sgrebnov](https://github.com/sgrebnov) in [#10557](https://github.com/spiceai/spiceai/pull/10557)
+- Fix `protoc` installation by [@krinart](https://github.com/krinart) in [#10566](https://github.com/spiceai/spiceai/pull/10566)
+- fix: Disable Ballista dynamic filters on HashJoinExec by [@peasee](https://github.com/peasee) in [#10548](https://github.com/spiceai/spiceai/pull/10548)
+- Support views on DDL catalogs by [@Jeadie](https://github.com/Jeadie) in [#10554](https://github.com/spiceai/spiceai/pull/10554)
+- Update datafusion by [@Jeadie](https://github.com/Jeadie) in [#10422](https://github.com/spiceai/spiceai/pull/10422)
+- Improve full-text search indexing performance by [@sgrebnov](https://github.com/sgrebnov) in [#10464](https://github.com/spiceai/spiceai/pull/10464)
+- feat(mysql): add mysql_zero_date_behavior parameter (null|error) by [@phillipleblanc](https://github.com/phillipleblanc) in [#10573](https://github.com/spiceai/spiceai/pull/10573)
+- fix(snowflake): declare `private_key` in connector PARAMETERS (fixes #10517) by [@claudespice](https://github.com/claudespice) in [#10559](https://github.com/spiceai/spiceai/pull/10559)
+- Honour `CARGO_TARGET_DIR` in Makefiles by [@Jeadie](https://github.com/Jeadie) in [#10569](https://github.com/spiceai/spiceai/pull/10569)
+- Enable `cosine_distance` pushdown to DuckDB accelerator via `array_cosine_distance` by [@sgrebnov](https://github.com/sgrebnov) in [#10564](https://github.com/spiceai/spiceai/pull/10564)
+- fix: Update test snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#10570](https://github.com/spiceai/spiceai/pull/10570)
+- fix: Update tpch benchmark snapshots by [@app/github-actions](https://github.com/app/github-actions) in [#10560](https://github.com/spiceai/spiceai/pull/10560)
+- feat(snapshots): make snapshots an optional feature by [@phillipleblanc](https://github.com/phillipleblanc) in [#10574](https://github.com/spiceai/spiceai/pull/10574)
+- Enforce read-only API key restrictions on Flight DoGet and async query paths by [@Jeadie](https://github.com/Jeadie) in [#10551](https://github.com/spiceai/spiceai/pull/10551)
+- Improved security posture on Github workflows by [@Jeadie](https://github.com/Jeadie) in [#10556](https://github.com/spiceai/spiceai/pull/10556)
+- fix: Update datafusion-table-providers to improve SqlTable filter pushdown by [@sgrebnov](https://github.com/sgrebnov) in [#10595](https://github.com/spiceai/spiceai/pull/10595)
+- feat(secrets): add HashiCorp Vault secret store by [@phillipleblanc](https://github.com/phillipleblanc) in [#10561](https://github.com/spiceai/spiceai/pull/10561)
+- fix: delegate update() in UpsertDedupTableProvider to inner provider by [@claudespice](https://github.com/claudespice) in [#10593](https://github.com/spiceai/spiceai/pull/10593)
+- Add DuckDB vector engine support by [@lukekim](https://github.com/lukekim) in [#10562](https://github.com/spiceai/spiceai/pull/10562)
+- Sharepoint - add object-store listing connector with expanded auth and write support by [@lukekim](https://github.com/lukekim) in [#10473](https://github.com/spiceai/spiceai/pull/10473)
+- fix: Install protoc from source by [@peasee](https://github.com/peasee) in [#10597](https://github.com/spiceai/spiceai/pull/10597)
+- Enable DML support for PostgreSQL data connector by [@phillipleblanc](https://github.com/phillipleblanc) in [#10446](https://github.com/spiceai/spiceai/pull/10446)
+- feat(postgres): support inline PEM sslrootcert by [@claudespice](https://github.com/claudespice) in [#10578](https://github.com/spiceai/spiceai/pull/10578)
+- Add foreign key metadata discovery to PostgreSQL Catalog by [@sgrebnov](https://github.com/sgrebnov) in [#10849](https://github.com/spiceai/spiceai/pull/10849)
+- Add Snowflake DML support by [@lukekim](https://github.com/lukekim) in [#10747](https://github.com/spiceai/spiceai/pull/10747)
+- Add MongoDB Change Streams support by [@lukekim](https://github.com/lukekim) in [#10813](https://github.com/spiceai/spiceai/pull/10813)
+- Add user-defined functions by [@lukekim](https://github.com/lukekim) in [#10571](https://github.com/spiceai/spiceai/pull/10571)
+- Add table user functions and gate HTTP servers by [@lukekim](https://github.com/lukekim) in [#10675](https://github.com/spiceai/spiceai/pull/10675)
+- feat: add on-demand dataset loading by [@phillipleblanc](https://github.com/phillipleblanc) in [#10629](https://github.com/spiceai/spiceai/pull/10629)
+- feat(runtime): declared-schema deferred datasets by [@phillipleblanc](https://github.com/phillipleblanc) in [#10669](https://github.com/spiceai/spiceai/pull/10669)
+- feat(spicepod, runtime): add columns[].type / nullable + lenient type parser by [@phillipleblanc](https://github.com/phillipleblanc) in [#10661](https://github.com/spiceai/spiceai/pull/10661)
+- Replace external smb crate with internal SMB 3.1.1 client by [@phillipleblanc](https://github.com/phillipleblanc) in [#10516](https://github.com/spiceai/spiceai/pull/10516)
+- Add unified query cancellation across all paths by [@lukekim](https://github.com/lukekim) in [#10390](https://github.com/spiceai/spiceai/pull/10390)
+- Add dynamic HTTP request headers by [@lukekim](https://github.com/lukekim) in [#10604](https://github.com/spiceai/spiceai/pull/10604)
+- feat(http): Support dynamic HTTP connector request params from subqueries by [@lukekim](https://github.com/lukekim) in [#10636](https://github.com/spiceai/spiceai/pull/10636)
+- feat(http): pass through HTTP metadata columns with JSON schema decomposition by [@lukekim](https://github.com/lukekim) in [#10679](https://github.com/spiceai/spiceai/pull/10679)
+- Add nolimit HTTP pagination max pages by [@lukekim](https://github.com/lukekim) in [#10673](https://github.com/spiceai/spiceai/pull/10673)
+- Add shared HTTP rate control for connectors by [@lukekim](https://github.com/lukekim) in [#10648](https://github.com/spiceai/spiceai/pull/10648)
+- Use origin label instead of name for HTTP rate control metrics by [@lukekim](https://github.com/lukekim) in [#10689](https://github.com/spiceai/spiceai/pull/10689)
+- fix(http): reject OR across different HTTP filter columns by [@lukekim](https://github.com/lukekim) in [#10625](https://github.com/spiceai/spiceai/pull/10625)
+- Add provider-aware LLM prompt caching by [@lukekim](https://github.com/lukekim) in [#10645](https://github.com/spiceai/spiceai/pull/10645)
+- Add searchable registry mode for LLM tools by [@lukekim](https://github.com/lukekim) in [#10647](https://github.com/spiceai/spiceai/pull/10647)
+- feat: refresh_mode: snapshot + SQLite/Turso WAL flush + Cayenne metastore slice by [@phillipleblanc](https://github.com/phillipleblanc) in [#10651](https://github.com/spiceai/spiceai/pull/10651)
+- feat: per-principal cache namespacing for SQL/search/caching-accelerator by [@lukekim](https://github.com/lukekim) in [#10702](https://github.com/spiceai/spiceai/pull/10702)
+- Add self-hosted Spice connector support by [@phillipleblanc](https://github.com/phillipleblanc) in [#10546](https://github.com/spiceai/spiceai/pull/10546)
+- Add Delta Lake Azure tenant parameter by [@phillipleblanc](https://github.com/phillipleblanc) in [#10671](https://github.com/spiceai/spiceai/pull/10671)
+- Support OAuth2 client credentials in 'spice cloud login' by [@ewgenius](https://github.com/ewgenius) in [#10586](https://github.com/spiceai/spiceai/pull/10586)
+- Add configurable allowed_hosts for MCP by [@lukekim](https://github.com/lukekim) in [#10638](https://github.com/spiceai/spiceai/pull/10638)
+- fix: make Helm chart probes configurable by [@peasee](https://github.com/peasee) in [#10696](https://github.com/spiceai/spiceai/pull/10696)
+- Strip high-cardinality datasets dim from anonymous telemetry by [@lukekim](https://github.com/lukekim) in [#10711](https://github.com/spiceai/spiceai/pull/10711)
+- feat(elasticsearch): direct FTS engine config + index lifecycle and ingestion controls by [@lukekim](https://github.com/lukekim) in [#10672](https://github.com/spiceai/spiceai/pull/10672)
+- Add DuckDB HNSW vector index support for accelerated views by [@sgrebnov](https://github.com/sgrebnov) in [#10695](https://github.com/spiceai/spiceai/pull/10695)
+- Rewrite DuckDB vector search SQL to activate HNSW_INDEX_SCAN by [@sgrebnov](https://github.com/sgrebnov) in [#10674](https://github.com/spiceai/spiceai/pull/10674)
+- Fix DuckDB HNSW vector indexes lost after data refresh by [@sgrebnov](https://github.com/sgrebnov) in [#10668](https://github.com/spiceai/spiceai/pull/10668)
+- Fix DuckDB DELETE/UPDATE on `full` and `caching` refresh mode datasets by [@phillipleblanc](https://github.com/phillipleblanc) in [#10632](https://github.com/spiceai/spiceai/pull/10632)
+- Fix DuckLake connector: downcast, module registration, schema discovery, and S3 credentials by [@sgrebnov](https://github.com/sgrebnov) in [#10650](https://github.com/spiceai/spiceai/pull/10650)
+- Fix federation pushing denied functions inside subqueries to remote engines by [@phillipleblanc](https://github.com/phillipleblanc) in [#10692](https://github.com/spiceai/spiceai/pull/10692)
+- fix(caching): honour refresh_on_startup: always in caching mode by [@phillipleblanc](https://github.com/phillipleblanc) in [#10594](https://github.com/spiceai/spiceai/pull/10594)
+- fix(iceberg): rebuild storage factory when Hadoop catalog scheme is inferred by [@sgrebnov](https://github.com/sgrebnov) in [#10601](https://github.com/spiceai/spiceai/pull/10601)
+- Pipeline CDC ingestion: overlap source reads with batch apply by [@lukekim](https://github.com/lukekim) in [#10676](https://github.com/spiceai/spiceai/pull/10676)
+- fix: add NULL check to CDC primary key extraction by [@lukekim](https://github.com/lukekim) in [#10684](https://github.com/spiceai/spiceai/pull/10684)
+- Properly handle nullability during CDC processing by [@krinart](https://github.com/krinart) in [#10803](https://github.com/spiceai/spiceai/pull/10803)
+- Flatten scheduler config and rename partition management → partition assignment by [@lukekim](https://github.com/lukekim) in [#10450](https://github.com/spiceai/spiceai/pull/10450)
+- Improve NSQL UX and harden internal LLM tools by [@lukekim](https://github.com/lukekim) in [#10715](https://github.com/spiceai/spiceai/pull/10715)
+- Support Responses API across model providers by [@lukekim](https://github.com/lukekim) in [#10724](https://github.com/spiceai/spiceai/pull/10724)
+- Update xAI default model and handle Grok model retirements by [@Jeadie](https://github.com/Jeadie) in [#10723](https://github.com/spiceai/spiceai/pull/10723)
+- Improve cli table layout by [@krinart](https://github.com/krinart) in [#10725](https://github.com/spiceai/spiceai/pull/10725)
+- TLS cert hot-reload (mTLS plan M1) by [@phillipleblanc](https://github.com/phillipleblanc) in [#10727](https://github.com/spiceai/spiceai/pull/10727)
+- Fix DuckLake catalog `include` filter being ignored by [@phillipleblanc](https://github.com/phillipleblanc) in [#10738](https://github.com/spiceai/spiceai/pull/10738)
+- Promote DuckLake Catalog and Data Connector to Beta quality by [@sgrebnov](https://github.com/sgrebnov) in [#10743](https://github.com/spiceai/spiceai/pull/10743)
+- feat(ducklake): Support INSERT on catalog tables with read_write access by [@sgrebnov](https://github.com/sgrebnov) in [#10744](https://github.com/spiceai/spiceai/pull/10744)
+- perf(cdc): coalesce envelopes and overlap commits in apply pipeline by [@lukekim](https://github.com/lukekim) in [#10745](https://github.com/spiceai/spiceai/pull/10745)
+- feat: Allow full version tags in spicepod version by [@peasee](https://github.com/peasee) in [#10748](https://github.com/spiceai/spiceai/pull/10748)
+- Add Arrow primary key upserts by [@lukekim](https://github.com/lukekim) in [#10749](https://github.com/spiceai/spiceai/pull/10749)
+- fix(snapshot): keep refresh_mode snapshot read-only by [@phillipleblanc](https://github.com/phillipleblanc) in [#10752](https://github.com/spiceai/spiceai/pull/10752)
+- feat(tls): public mTLS for HTTP and Flight (channel + identity modes) by [@phillipleblanc](https://github.com/phillipleblanc) in [#10753](https://github.com/spiceai/spiceai/pull/10753)
+- perf(cayenne): lock-free deletion caches with bloom-prefiltered probe by [@lukekim](https://github.com/lukekim) in [#10756](https://github.com/spiceai/spiceai/pull/10756)
+- fix(security): close API key timing-position leak and remote-UDF SSRF by [@lukekim](https://github.com/lukekim) in [#10757](https://github.com/spiceai/spiceai/pull/10757)
+- Fix 'wait_until_dependent_tables_are_ready' for catalogs by [@phillipleblanc](https://github.com/phillipleblanc) in [#10758](https://github.com/spiceai/spiceai/pull/10758)
+- Fixes for views and resolved tables on 'spice refresh' CLI by [@phillipleblanc](https://github.com/phillipleblanc) in [#10759](https://github.com/spiceai/spiceai/pull/10759)
+- Implement FlightSQL CommandStatementSubstraitPlan support by [@lukekim](https://github.com/lukekim) in [#10761](https://github.com/spiceai/spiceai/pull/10761)
+- feat(connectors): mTLS client cert support for flightsql and spiceai connectors by [@phillipleblanc](https://github.com/phillipleblanc) in [#10764](https://github.com/spiceai/spiceai/pull/10764)
+- Allow arbitrary filenames when specifying spicepod path + `kind` validation by [@krinart](https://github.com/krinart) in [#10777](https://github.com/spiceai/spiceai/pull/10777)
+- fix: ignore field metadata in schema compatibility check in index_table_scan by [@Jeadie](https://github.com/Jeadie) in [#10778](https://github.com/spiceai/spiceai/pull/10778)
+- Display pushed-down limits in EXPLAIN TREE output by [@lukekim](https://github.com/lukekim) in [#10779](https://github.com/spiceai/spiceai/pull/10779)
+- fix: enable streaming append for Kafka with Cayenne accelerator by [@lukekim](https://github.com/lukekim) in [#10780](https://github.com/spiceai/spiceai/pull/10780)
+- fix: bound chunked-index intermediate batch size to prevent OOM by [@phillipleblanc](https://github.com/phillipleblanc) in [#10783](https://github.com/spiceai/spiceai/pull/10783)
+- fix: label all columns in `spice cloud metrics` table output by [@claudespice](https://github.com/claudespice) in [#10784](https://github.com/spiceai/spiceai/pull/10784)
+- fix: use checked arithmetic for Turso integer-millis timestamp read path by [@claudespice](https://github.com/claudespice) in [#10786](https://github.com/spiceai/spiceai/pull/10786)
+- fix: use checked arithmetic in timestamp-to-nanosecond conversions by [@claudespice](https://github.com/claudespice) in [#10666](https://github.com/spiceai/spiceai/pull/10666)
+- Upgrade to DuckDB v1.5.2 by [@sgrebnov](https://github.com/sgrebnov) in [#10788](https://github.com/spiceai/spiceai/pull/10788)
+- Improve CDC ingestion performance by [@lukekim](https://github.com/lukekim) in [#10789](https://github.com/spiceai/spiceai/pull/10789)
+- Fix `tool_search`/`tool_invoke` spans by [@lukekim](https://github.com/lukekim) in [#10791](https://github.com/spiceai/spiceai/pull/10791)
+- Add Cayenne inline mutations and benchmark coverage by [@lukekim](https://github.com/lukekim) in [#10792](https://github.com/spiceai/spiceai/pull/10792)
+- Ensure we always resolve table names in distributed mode/metadata by [@Jeadie](https://github.com/Jeadie) in [#10793](https://github.com/spiceai/spiceai/pull/10793)
+- Remove permanent errors from DynamoDB Streams by [@krinart](https://github.com/krinart) in [#10794](https://github.com/spiceai/spiceai/pull/10794)
+- Add expanded view mode for wide table display in SQL REPL by [@lukekim](https://github.com/lukekim) in [#10797](https://github.com/spiceai/spiceai/pull/10797)
+- Fix Cayenne CDC schema mismatch error by [@sgrebnov](https://github.com/sgrebnov) in [#10800](https://github.com/spiceai/spiceai/pull/10800)
+- Executors should create catalog tables on join by [@Jeadie](https://github.com/Jeadie) in [#10807](https://github.com/spiceai/spiceai/pull/10807)
+- Add compressed file support for listing connectors by [@lukekim](https://github.com/lukekim) in [#10809](https://github.com/spiceai/spiceai/pull/10809)
+- Improve Cayenne mutation, scan, and inline memtable scaling by [@lukekim](https://github.com/lukekim) in [#10811](https://github.com/spiceai/spiceai/pull/10811)
+- Add range fallback for large join filters by [@lukekim](https://github.com/lukekim) in [#10816](https://github.com/spiceai/spiceai/pull/10816)
+- Improve Cayenne join filter pushdown by [@lukekim](https://github.com/lukekim) in [#10818](https://github.com/spiceai/spiceai/pull/10818)
+- Synchronize Cayenne partition commits across partitions by [@phillipleblanc](https://github.com/phillipleblanc) in [#10819](https://github.com/spiceai/spiceai/pull/10819)
+- fix: Deny nondistributed cayenne catalog by [@peasee](https://github.com/peasee) in [#10821](https://github.com/spiceai/spiceai/pull/10821)
+- Enable parallel Cayenne Vortex writes by [@lukekim](https://github.com/lukekim) in [#10822](https://github.com/spiceai/spiceai/pull/10822)
+- Expand Arrow type handling in formatting and Elasticsearch by [@lukekim](https://github.com/lukekim) in [#10825](https://github.com/spiceai/spiceai/pull/10825)
+- Add `response.output_text.delta` to responses API by [@krinart](https://github.com/krinart) in [#10828](https://github.com/spiceai/spiceai/pull/10828)
+- feat(cayenne): add join filter propagation and no-spill Q21 planning by [@lukekim](https://github.com/lukekim) in [#10840](https://github.com/spiceai/spiceai/pull/10840)
+- Upgrade Turso to v0.6.0 by [@sgrebnov](https://github.com/sgrebnov) in [#10843](https://github.com/spiceai/spiceai/pull/10843)
+- feat(cli): add `spice feedback` command to open community Slack by [@lukekim](https://github.com/lukekim) in [#10856](https://github.com/spiceai/spiceai/pull/10856)
+- Upgrade iceberg to v0.9.1 by [@sgrebnov](https://github.com/sgrebnov) in [#10859](https://github.com/spiceai/spiceai/pull/10859)
+- feat(cluster): per-request executor readiness gate on /v1/ready by [@phillipleblanc](https://github.com/phillipleblanc) in [#10860](https://github.com/spiceai/spiceai/pull/10860)
+- fix: Require dim-side statistics for `CayennePropagateFilterAcrossEquiJoinKeys` by [@sgrebnov](https://github.com/sgrebnov) in [#10863](https://github.com/spiceai/spiceai/pull/10863)
+- fix: Debezium schema evolution breaks dataset init on reload by [@claudespice](https://github.com/claudespice) in [#10144](https://github.com/spiceai/spiceai/pull/10144)
+- fix(mssql): Push topK limit to SQL Server for non-nullable sort columns by [@Jeadie](https://github.com/Jeadie) in [#10621](https://github.com/spiceai/spiceai/pull/10621)
+- fix(ScyllaDB): disable physical filter pushdown by [@sgrebnov](https://github.com/sgrebnov) in [#10772](https://github.com/spiceai/spiceai/pull/10772)
+- fix: handle typed NULLs and prevent overflow in DynamoDB DML type conversions by [@krinart](https://github.com/krinart) in [#10511](https://github.com/spiceai/spiceai/pull/10511)
+- fix: use InsertOp::Overwrite in DynamoDB bootstrap scan_and_overwrite_accelerator by [@krinart](https://github.com/krinart) in [#10639](https://github.com/spiceai/spiceai/pull/10639)
+- Improve DynamoDB Bootstrap performance by [@krinart](https://github.com/krinart) in [#10616](https://github.com/spiceai/spiceai/pull/10616)
+- fix: preserve field and schema metadata in Vortex type transformation by [@lukekim](https://github.com/lukekim) in [#10628](https://github.com/spiceai/spiceai/pull/10628)
+- fix: GH connector - explicitly use AWS LC RS crypto provider for jwt by [@phillipleblanc](https://github.com/phillipleblanc) in [#10619](https://github.com/spiceai/spiceai/pull/10619)
+- fix: add snapshot mode guards to delete_from/update and delegate DML in SwappableTableProvider by [@phillipleblanc](https://github.com/phillipleblanc) in [#10685](https://github.com/spiceai/spiceai/pull/10685)
+- Persist HTTP rate-control state in object storage by [@lukekim](https://github.com/lukekim) in [#10697](https://github.com/spiceai/spiceai/pull/10697)
+- Rate limit metrics HTTP endpoint by [@lukekim](https://github.com/lukekim) in [#10162](https://github.com/spiceai/spiceai/pull/10162)
+- feat(geo): add optional spatial SQL UDF support by [@lukekim](https://github.com/lukekim) in [#10833](https://github.com/spiceai/spiceai/pull/10833)
+- feat(cayenne): CDC throughput, compaction, scan caching, and benchmarks by [@lukekim](https://github.com/lukekim) in [#10852](https://github.com/spiceai/spiceai/pull/10852)
+- fix(cayenne): fix Vortex panic on highly compressible data by [@sgrebnov](https://github.com/sgrebnov) in [#10855](https://github.com/spiceai/spiceai/pull/10855)
+- fix(cayenne): Read live protected snapshots after cleanup grace period by [@sgrebnov](https://github.com/sgrebnov) in [#10901](https://github.com/spiceai/spiceai/pull/10901)
+- fix: Disable Cayenne HashJoin rewriter optimizer by [@sgrebnov](https://github.com/sgrebnov) in [#10882](https://github.com/spiceai/spiceai/pull/10882)
+- Fix GetFlightInfo vs DoGet Flight Schema by [@krinart](https://github.com/krinart) in [#10864](https://github.com/spiceai/spiceai/pull/10864)
+- fix(search): preserve column casing in /v1/search primary key plumbing by [@claudespice](https://github.com/claudespice) in [#10909](https://github.com/spiceai/spiceai/pull/10909)
+- fix(object-store): dedupe s3 url style auto-detection log by [@phillipleblanc](https://github.com/phillipleblanc) in [#10898](https://github.com/spiceai/spiceai/pull/10898)
+- Improve Spice CLI manifest editing and direct command modes by [@lukekim](https://github.com/lukekim) in [#10815](https://github.com/spiceai/spiceai/pull/10815)
+- Persist Kafka CDC offsets in sidecar tables by [@lukekim](https://github.com/lukekim) in [#10823](https://github.com/spiceai/spiceai/pull/10823)
+- feat(task-history): record Ballista stages for distributed queries by [@phillipleblanc](https://github.com/phillipleblanc) in [#10831](https://github.com/spiceai/spiceai/pull/10831)
+- Add '#[deny(clippy::missing_trait_methods)]' to wrapper/delegation trait impls by [@Jeadie](https://github.com/Jeadie) in [#10795](https://github.com/spiceai/spiceai/pull/10795)
+- Optimize Cayenne catalog maintenance paths by [@lukekim](https://github.com/lukekim) in [#10904](https://github.com/spiceai/spiceai/pull/10904)
+- Centralize DuckDB settings for accelerator by [@ewgenius](https://github.com/ewgenius) in [#10895](https://github.com/spiceai/spiceai/pull/10895)
+- deps(ballista): bump to 47e2b494 to fix S3 shuffle reads under cluster mode by [@phillipleblanc](https://github.com/phillipleblanc) in [#10910](https://github.com/spiceai/spiceai/pull/10910)
+- Authorization header + Bump async-openai + `responses_adapter` fix by [@krinart](https://github.com/krinart) in [#10911](https://github.com/spiceai/spiceai/pull/10911)
+- Tune accelerators by storage profile by [@lukekim](https://github.com/lukekim) in [#10913](https://github.com/spiceai/spiceai/pull/10913)
+- feat: add dataset-level on_schema_change config by [@lukekim](https://github.com/lukekim) in [#10908](https://github.com/spiceai/spiceai/pull/10908)
+- Handle `NULL` sentinel for nullable partition expressions by [@Jeadie](https://github.com/Jeadie) in [#10880](https://github.com/spiceai/spiceai/pull/10880)
+- fix: Remove Cayenne Catalog from catalog registration by [@peasee](https://github.com/peasee) in [#10914](https://github.com/spiceai/spiceai/pull/10914)
+- Add catalog name to foreign key metadata in postgres catalog by [@Jeadie](https://github.com/Jeadie) in [#10917](https://github.com/spiceai/spiceai/pull/10917)
+- Cayenne perf: eliminate redundant clones, PK point-lookup fanout fix, IN-list rewrite + microbench coverage by [@lukekim](https://github.com/lukekim) in [#10916](https://github.com/spiceai/spiceai/pull/10916)
+- fix(turso-shared): retry on Turso BEGIN CONCURRENT "Write-write conflict" by [@lukekim](https://github.com/lukekim) in [#10946](https://github.com/spiceai/spiceai/pull/10946)
+- Vendor Vortex DataFusion for Cayenne by [@lukekim](https://github.com/lukekim) in [#10933](https://github.com/spiceai/spiceai/pull/10933)
+- perf(cayenne): background retention + enable CDC pipelining for retention-configured tables by [@lukekim](https://github.com/lukekim) in [#10936](https://github.com/spiceai/spiceai/pull/10936)
+- feat(cayenne): scale metastore pool to 32 + vs_duckdb_scaling benches (1→128 concurrency, sqlite + turso lanes) by [@lukekim](https://github.com/lukekim) in [#10943](https://github.com/spiceai/spiceai/pull/10943)
+- feat(mcp): support auth for streamable HTTP tools by [@phillipleblanc](https://github.com/phillipleblanc) in [#10927](https://github.com/spiceai/spiceai/pull/10927)
+- Explicit error if v1/search requests a table without search index by [@Jeadie](https://github.com/Jeadie) in [#10968](https://github.com/spiceai/spiceai/pull/10968)
+- Fix spicepod loading failure when directory name contains dots by [@sgrebnov](https://github.com/sgrebnov) in [#10958](https://github.com/spiceai/spiceai/pull/10958)
+- Extend append tests with arrow engine configurations by [@sgrebnov](https://github.com/sgrebnov) in [#10959](https://github.com/spiceai/spiceai/pull/10959)
+- Remove dataset on_schema_change Policy from rc.5 release notes by [@sgrebnov](https://github.com/sgrebnov) in [#10964](https://github.com/spiceai/spiceai/pull/10964)
+- Skip tpcds_q78 for Cayenne engine at SF100 by [@sgrebnov](https://github.com/sgrebnov) in [#10966](https://github.com/spiceai/spiceai/pull/10966)
+- fix: Update benchmark snapshots May-20 by [@app/github-actions](https://github.com/apps/github-actions) in [#10952](https://github.com/spiceai/spiceai/pull/10952)
+- Fix #10951: UdtfExec invariant Vec lengths must match children count by [@phillipleblanc](https://github.com/phillipleblanc) in [#10953](https://github.com/spiceai/spiceai/pull/10953)
+- docs(release): update v2.0.0-rc.5 notes with latest trunk PRs by [@lukekim](https://github.com/lukekim) in [#10949](https://github.com/spiceai/spiceai/pull/10949)
+- Remove eval related things for v2.0.0 by [@Jeadie](https://github.com/Jeadie) in [#10945](https://github.com/spiceai/spiceai/pull/10945)
+- build(deps): bump ubuntu from 24.04 to 26.04 in the docker-dependencies group by [@app/dependabot](https://github.com/apps/dependabot) in [#10883](https://github.com/spiceai/spiceai/pull/10883)
+- fix: Add publish = false to chbench-driver by [@sgrebnov](https://github.com/sgrebnov) in [#10939](https://github.com/spiceai/spiceai/pull/10939)
+- [Bug] Timing between reconnect and AllocateInitialPartitions leaves connection without flight_sql_client by [@Jeadie](https://github.com/Jeadie) in [#10805](https://github.com/spiceai/spiceai/pull/10805)
+- Fix: `refresh_mode: snapshot` reports Ready with empty data when no snapshot exists by [@sgrebnov](https://github.com/sgrebnov) in [#10979](https://github.com/spiceai/spiceai/pull/10979)
+- fix(cluster): gate scheduler readiness on executor partition loads by [@phillipleblanc](https://github.com/phillipleblanc) in [#10992](https://github.com/spiceai/spiceai/pull/10992)
+- fix: handle EXISTS/NOT EXISTS subqueries in federation analyzer by [@sgrebnov](https://github.com/sgrebnov) in [#10996](https://github.com/spiceai/spiceai/pull/10996)
+- Refactor spice dataset configuration command by [@Jeadie](https://github.com/Jeadie) in [#10999](https://github.com/spiceai/spiceai/pull/10999)
+- fix: preserve field and schema metadata in Vortex physical schema calculation by [@claudespice](https://github.com/claudespice) in [#11013](https://github.com/spiceai/spiceai/pull/11013)
+- fix: validate Snowflake account identifiers and auth config by [@Jeadie](https://github.com/Jeadie) in [#11024](https://github.com/spiceai/spiceai/pull/11024)
+- Fix Unity Catalog connector deserialization failure with OSS Unity Catalog by [@ewgenius](https://github.com/ewgenius) in [#11026](https://github.com/spiceai/spiceai/pull/11026)
+- feat(cayenne): allow inline writes with pending deletions (deletes/upserts) by [@sgrebnov](https://github.com/sgrebnov) in [#11031](https://github.com/spiceai/spiceai/pull/11031)
+- Expose metadata descriptions via PostgreSQL UDFs by [@lukekim](https://github.com/lukekim) in [#11032](https://github.com/spiceai/spiceai/pull/11032)
+- Remove default runtime features - enable explicitly in spiced by [@phillipleblanc](https://github.com/phillipleblanc) in [#11037](https://github.com/spiceai/spiceai/pull/11037)
+- feat(cayenne): fast-path CDC deletes by extracting PK values from filters by [@sgrebnov](https://github.com/sgrebnov) in [#11049](https://github.com/spiceai/spiceai/pull/11049)
+- Cayenne optimizer rules: auto relevance test for q21-shape (all-Cayenne CH-Bench) and runtime rule selection by [@lukekim](https://github.com/lukekim) in [#11050](https://github.com/spiceai/spiceai/pull/11050)
+- refactor(cdc): reduce CDC sub-batch splits for interleaved upsert/delete workloads by [@sgrebnov](https://github.com/sgrebnov) in [#11051](https://github.com/spiceai/spiceai/pull/11051)
+- fix(snowflake): enforce function deny-list in federation pushdown by [@claudespice](https://github.com/claudespice) in [#11057](https://github.com/spiceai/spiceai/pull/11057)
+- fix(mcp): trace external server tool calls in task history by [@ewgenius](https://github.com/ewgenius) in [#11058](https://github.com/spiceai/spiceai/pull/11058)
+- perf(cdc): Last-write-wins dedup in `group_into_sub_batches` to reduce sub-batch splits by [@sgrebnov](https://github.com/sgrebnov) in [#11059](https://github.com/spiceai/spiceai/pull/11059)
+- PM edits to v2.0.0-rc5 by [@lukekim](https://github.com/lukekim) in [#11067](https://github.com/spiceai/spiceai/pull/11067)
+- fix(snowflake): wire deny-list in extracted connector crate (#10703) by [@claudespice](https://github.com/claudespice) in [#11071](https://github.com/spiceai/spiceai/pull/11071)
+- perf(cayenne): keep CDC upsert PK keysets resident to avoid per-batch full-table rebuilds by [@lukekim](https://github.com/lukekim) in [#11074](https://github.com/spiceai/spiceai/pull/11074)
+- Fix metadata on search indexing by [@Jeadie](https://github.com/Jeadie) in [#11080](https://github.com/spiceai/spiceai/pull/11080)
+- feat(cayenne): merge-on-read position deletes for PK upsert tables + memory-pool accounting by [@lukekim](https://github.com/lukekim) in [#11085](https://github.com/spiceai/spiceai/pull/11085)
+- perf(cayenne): scale CDC inline flush caps with memory + storage class by [@lukekim](https://github.com/lukekim) in [#11087](https://github.com/spiceai/spiceai/pull/11087)
+- feat(cluster): report per-executor table statistics so distributed JoinSelection can size joins by [@phillipleblanc](https://github.com/phillipleblanc) in [#11089](https://github.com/spiceai/spiceai/pull/11089)
+- Improve Cayenne CDC write and compaction path tracing by [@sgrebnov](https://github.com/sgrebnov) in [#11091](https://github.com/spiceai/spiceai/pull/11091)
+- Support tuple-IN composite PK extraction in Cayenne delete fast-path by [@sgrebnov](https://github.com/sgrebnov) in [#11093](https://github.com/spiceai/spiceai/pull/11093)
+- feat(cluster): NDV-aware executor stats so CDC q18 join swap fires by [@phillipleblanc](https://github.com/phillipleblanc) in [#11098](https://github.com/spiceai/spiceai/pull/11098)
+- feat(cayenne): maintain join-sizing stats on the write path by [@phillipleblanc](https://github.com/phillipleblanc) in [#11104](https://github.com/spiceai/spiceai/pull/11104)
+- fix(cache): run periodic moka maintenance for idle caches by [@phillipleblanc](https://github.com/phillipleblanc) in [#11106](https://github.com/spiceai/spiceai/pull/11106)
+- Upgrade to DuckDB 1.5.3 + statically link the VSS (HNSW) extension by [@sgrebnov](https://github.com/sgrebnov) in [#11107](https://github.com/spiceai/spiceai/pull/11107)
+- Fix fetched_at for HTTP connector by [@Jeadie](https://github.com/Jeadie) in [#11116](https://github.com/spiceai/spiceai/pull/11116)
+- fix(cayenne): tombstone inline-checkpointed rows on upsert to prevent duplicate PKs by [@sgrebnov](https://github.com/sgrebnov) in [#11129](https://github.com/spiceai/spiceai/pull/11129)
+- feat: dedicated compaction runtime for Cayenne + CDC pipelining, protected snapshots, and test coverage by [@lukekim](https://github.com/lukekim) in [#11130](https://github.com/spiceai/spiceai/pull/11130)
+- Add `datasets` dimension to the `query_executions` metric by [@phillipleblanc](https://github.com/phillipleblanc) in [#11138](https://github.com/spiceai/spiceai/pull/11138)
+- Fix #11137: localpod child not tracking parent refreshes with in-memory (arrow) parent accelerator by [@phillipleblanc](https://github.com/phillipleblanc) in [#11139](https://github.com/spiceai/spiceai/pull/11139)
+- Fix Windows build: vendor the VSS extension (drop nested submodule) by [@phillipleblanc](https://github.com/phillipleblanc) in [#11140](https://github.com/spiceai/spiceai/pull/11140)
+- fix(spiceai): keep correlated subqueries out of JOIN ON for Spice Cloud federation by [@phillipleblanc](https://github.com/phillipleblanc) in [#11143](https://github.com/spiceai/spiceai/pull/11143)
+- Refactor spice dataset configuration command by [@Jeadie](https://github.com/Jeadie) in [#10999](https://github.com/spiceai/spiceai/pull/10999)
+- feat(cayenne): sharded parallel Vortex encode with key/time clustering by [@lukekim](https://github.com/lukekim) in [#11144](https://github.com/spiceai/spiceai/pull/11144)
+- fix(cluster): prevent DoPut write pipeline self-deadlock under ingest backpressure by [@phillipleblanc](https://github.com/phillipleblanc) in [#11160](https://github.com/spiceai/spiceai/pull/11160)
+- fix(cayenne): only warn on genuine protected-snapshot amplification by [@lukekim](https://github.com/lukekim) in [#11158](https://github.com/spiceai/spiceai/pull/11158)
+
+**Full Changelog**: <https://github.com/spiceai/spiceai/compare/v1.11.6...v2.0.0>


### PR DESCRIPTION
## Summary

Phases 0 **and 1** of the deletion-index hot-path rework for #11164: executor profiles of changes-mode ingest showed per-row `KeyDeletionIndex::get` dominating all three executors (~3–10x the next hottest frame) — two bloom checks + two `im::HashMap` (HAMT) walks per deleted row, a saturating classic bloom, double hashing (XXH3 + SipHash), and at millions of entries a cache-hostile multi-level HAMT pointer chase per probe.

Phase 0 removes the constant-factor overheads; Phase 1 replaces the large-N HAMT walk itself with layered storage (frozen flat base + small delta) behind the same public API.

## Phase 0 — constant factors

- **Fused tombstone index**: `deleted` + `insert_records` were two parallel indexes probed back-to-back on every deleted-row hit. They now fuse into one index whose 16-byte entry carries both max-merged sequences (`pk → (delete_seq, insert_seq)`): one bloom check + one map walk per probed row. Upsert conflicts publish in a single `extend_max_conflicts` pass.
- **Split-block bloom filter** (`hash-index::SplitBlockBloomFilter`, Parquet-style): exactly one 32-byte aligned block per probe vs up to 7 dependent cache-line touches (classic k=7). Inserts are `&self` with relaxed `AtomicU32` stores, so the filter is **shared across index generations** behind an `Arc` — older pinned readers observe a safe superset (false positives only, never false negatives) — eliminating the per-CDC-batch bloom memcpy.
- **Bloom sizing headroom**: sized for 2x the deletion count, rebuilt at capacity (the old exact-size/rebuild-at-2x policy let FPR degrade to ~13% at SF10 scale — the "bloom isn't rejecting" observation in the issue).
- **One-shot XXH3 everywhere**: `im`'s SipHash default replaced by `hash-index::XxHash3BuildHasher` (buffers ≤32-byte inputs, hashes one-shot at `finish()`, spills to streaming above — value-identical); the i64 bloom path uses the matching `hash_key_i64` one-shot. Bloom↔map equality is pinned by unit tests. The streaming-hasher setup this removes was the dominant per-probe cost at cache-resident sizes.
- **XXH3-128 hash-keyed identity for composite PKs**: `KeyDeletionIndex` entries keyed by the seeded XXH3-128 of the `RowConverter` bytes; bytes not retained. Fixed 32-byte payload regardless of key width, no byte compares, and a pass-through hasher (`hash-index::PrehashedBuildHasher`) reuses the hash's entropy — one hash per probe serves bloom (high 64 bits) and map (low 64). Collision odds at 1e9 keys ≈ 1e-20 (64-bit would be ~0.3% — not safe as identity).

## Phase 1 — layered storage (frozen flat base + small delta)

A generic `LayeredTombstones<K, S>` core (shared by both index types) holds entries in two tiers:

- **base**: `Arc<std::collections::HashMap>` (SwissTable). Frozen after construction; generations share it by `Arc` clone; probes cost 1–2 cache lines at any size.
- **delta**: small persistent `im::HashMap` holding writes since the last merge. O(1) to snapshot per publish; the merge policy caps it at `max(16K, base/4)` entries so it stays a shallow **cache-resident** HAMT — the pointer-chasing that dominated at millions of entries never develops. At the threshold the delta folds into a fresh base (geometric cadence ⇒ O(log N) total copy work per key); pinned old generations keep the previous base `Arc`, so a merge costs one transient extra base, not one per generation.

Probe order: bloom → delta → base. Writes touch only the delta. `entries()` became `iter_entries()` (bench-only callers); every other signature is unchanged.

## Semantics preserved

- Insert-only entries (post-compaction: delete files purged, insert records remain) probe as absent; bloom is keyed on deletion membership only.
- Protected-snapshot paths ignore re-inserts via explicit `InsertRecordHandling::{Apply, Ignore}` (previously expressed by passing a shared-empty insert index).
- `max_sequence_number()` remains the **delete-side** high-water mark (partial-filter / compaction-fence invariant).
- Single-writer publish discipline unchanged: extends under the per-table write lock, one `ArcSwap::store` per batch.

## Benchmarks

Criterion medians, Apple M-series, 8192-row probe batches.

**Out-of-cache (`deletion_index_probe_large`, NEW: 1M / 4M-entry indexes) — Phase 1 vs Phase 0:**

| lane | Phase 0 | Phase 1 | speedup |
|---|---|---|---|
| int64 hit 1M / 4M | 152µs / 178µs | 92µs / 103µs | **1.65x / 1.73x** |
| row-keys hit 1M / 4M | 230µs / 239µs | 71µs / 78µs | **3.2x / 3.1x** |
| row-keys miss 1M / 4M | 70µs / 75µs | 68µs / 70µs | ~1.05x |

(hit = probed keys present, the changes-mode upsert-churn shape; miss = bloom-rejection path)

**Cache-resident (`deletion_index_probe`) — Phase 0 vs trunk:**

| | trunk | Phase 0 | speedup |
|---|---|---|---|
| row-keys, ratio 0 → 0.5 | 283–591µs | 19.5–62.9µs | **7.7–14.5x** |
| int64, ratio 0 → 0.5 | 227–466µs | 9.2–44.0µs | **10.6–24.7x** |

End-to-end validation against the changes-mode spicebench arms from #11164 is the real gate; these isolate the index.

## Validation

- `cargo test -p cayenne --lib` (378 passed, incl. new layering tests: merge thresholds, pinned generations across base merges, delta-wins probes, counter consistency, duplicate-free iteration) and `-p hash-index` (134 passed, incl. one-shot↔streaming hash equality pinning)
- CI-grade pedantic clippy run locally on both crates
- Base branch merged (`lukim/olap`), conflicts in `filter_exec.rs` resolved preserving the new EXPLAIN ANALYZE metrics alongside the fused-index fast paths

## Follow-ups (not in this PR)

- Keyset-budget bench arm to test whether SF10 changes-mode can stay in `deletion_mode: position` (separate from this index work)
- Optional: per-tier filters / batch-probe prefetching if profiles justify (Phase 2)

Relates to #11164.