### PR TITLE
feat(unity_catalog): support Unity Catalog credential vending for Delta Lake tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,6 +5431,7 @@ dependencies = [
  "url",
  "util",
  "uuid 1.23.2",
+ "wiremock",
  "zip 8.6.0",
  "zstd",
 ]

--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -29,7 +29,10 @@ use data_components::databricks::DatabricksSparkConnect;
 use data_components::databricks::sql_warehouse::DatabricksMetrics;
 use data_components::databricks::{DatabricksDelta, DatabricksSqlWarehouse, sql_warehouse};
 use data_components::delta_lake::DeltaTableFactory;
-use data_components::unity_catalog::provider::UnityCatalogProvider;
+use data_components::unity_catalog::credential_vending::VendedDeltaTableFactory;
+use data_components::unity_catalog::provider::{
+    ReadTableProviderFactory, UCTableProviderFactory, UnityCatalogProvider,
+};
 use data_components::unity_catalog::{
     CatalogId, Endpoint, UCTable, UnityCatalog as UnityCatalogClient,
 };
@@ -141,6 +144,9 @@ pub const PARAMETERS: &[ParameterSpec] = &[
         .secret()
         .description("The SQL Warehouse ID to use when 'mode' is set to 'sql_warehouse'.")
         .examples(&["862f1d7571f6f3c4"])
+        .help_link(DATABRICKS_DOCS),
+    ParameterSpec::component("credential_vending")
+        .description("When set to 'enabled' (requires 'mode' to be 'delta_lake'), short-lived storage credentials for each table are fetched from the Unity Catalog credential vending API instead of using static storage credentials. Defaults to 'disabled'.")
         .help_link(DATABRICKS_DOCS),
 
     // Connection / resilience tuning (sql_warehouse mode)
@@ -282,6 +288,27 @@ impl Databricks {
             .expose()
             .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?;
 
+        let credential_vending = match params.get("credential_vending").expose().ok() {
+            Some("enabled") => true,
+            None | Some("disabled") => false,
+            Some(other) => {
+                return InvalidConfigurationSnafu {
+                    message: format!(
+                        "invalid value '{other}' for 'databricks_credential_vending'; valid values: 'enabled', 'disabled'"
+                    ),
+                }
+                .fail();
+            }
+        };
+        if credential_vending && mode != "delta_lake" {
+            return InvalidConfigurationSnafu {
+                message:
+                    "'databricks_credential_vending' is only supported when 'mode' is 'delta_lake'"
+                        .to_string(),
+            }
+            .fail();
+        }
+
         let auth_credentials = Self::build_auth_credentials(&params)?;
         let initialization = match auth_credentials {
             AuthCredentials::U2M(_) => ComponentInitialization::OnTrigger,
@@ -392,12 +419,21 @@ impl Databricks {
                     }
                 };
 
-                let read_provider = DatabricksDelta::new(
+                let mut read_provider = DatabricksDelta::new(
                     Endpoint(endpoint.to_string()),
                     storage_options,
                     token_provider,
                     io_runtime,
                 );
+                if credential_vending {
+                    if let Some(uc) = &uc_client {
+                        read_provider = read_provider.with_credential_vending(Arc::clone(uc));
+                    } else {
+                        tracing::warn!(
+                            "Unity Catalog credential vending is enabled, but the Unity Catalog client could not be initialized; falling back to configured storage credentials"
+                        );
+                    }
+                }
                 let delta_provider = Arc::new(read_provider);
 
                 Ok(Self {
@@ -1046,6 +1082,16 @@ impl DataConnector for Databricks {
             return Ok(());
         };
 
+        // Executors build their own object stores from the static storage
+        // params encoded below; vended Unity Catalog credentials live only in
+        // the head node's table provider and do not propagate.
+        if delta.credential_vending_enabled() {
+            tracing::warn!(
+                dataset = %dataset.name,
+                "Unity Catalog credential vending is not supported for distributed query execution; executors will use the configured static storage credentials"
+            );
+        }
+
         // Resolve the underlying storage location via Unity Catalog. This is
         // the bare URL (e.g. `s3://databricks-workspace-stack-bfa88-bucket/...`)
         // that DataFusion will look up in `runtime_env().object_store(url)`
@@ -1383,6 +1429,8 @@ pub const CATALOG_PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("token")
         .secret()
         .description("The personal access token used to authenticate against the DataBricks API."),
+    ParameterSpec::component("credential_vending")
+        .description("When set to 'enabled' (requires 'mode' to be 'delta_lake'), short-lived storage credentials for each table are fetched from the Unity Catalog credential vending API instead of using static storage credentials. Defaults to 'disabled'."),
     ParameterSpec::runtime("mode")
         .description("The execution mode for querying against Databricks.")
         .default("spark_connect"),
@@ -1581,14 +1629,44 @@ impl CatalogConnector for DatabricksCatalog {
         let client = Arc::new(unity_catalog);
 
         let mode = self.params.get("mode").expose().ok();
-        let (table_creator, table_reference_creator) = if mode == Some("delta_lake") {
-            (
-                Arc::new(DeltaTableFactory::new(
+        let credential_vending = match params.get("credential_vending").expose().ok() {
+            Some("enabled") => true,
+            None | Some("disabled") => false,
+            Some(other) => {
+                return Err(CatalogError::InvalidConfigurationNoSource {
+                    connector: "databricks".into(),
+                    message: format!(
+                        "Invalid value '{other}' for 'databricks_credential_vending'. Valid values: 'enabled', 'disabled'."
+                    ),
+                    connector_component: ConnectorComponent::from(catalog),
+                });
+            }
+        };
+        if credential_vending && mode != Some("delta_lake") {
+            return Err(CatalogError::InvalidConfigurationNoSource {
+                connector: "databricks".into(),
+                message:
+                    "'databricks_credential_vending' is only supported when 'mode' is 'delta_lake'."
+                        .into(),
+                connector_component: ConnectorComponent::from(catalog),
+            });
+        }
+        let table_creator: Arc<dyn UCTableProviderFactory> = if mode == Some("delta_lake") {
+            if credential_vending {
+                Arc::new(VendedDeltaTableFactory::new(
+                    Arc::clone(&client),
                     params.to_secret_map(),
                     runtime.tokio_io_runtime(),
-                )) as Arc<dyn Read>,
-                table_reference_creator_delta_lake as fn(&UCTable) -> Option<TableReference>,
-            )
+                ))
+            } else {
+                Arc::new(ReadTableProviderFactory::new(
+                    Arc::new(DeltaTableFactory::new(
+                        params.to_secret_map(),
+                        runtime.tokio_io_runtime(),
+                    )) as Arc<dyn Read>,
+                    table_reference_creator_delta_lake,
+                ))
+            }
         } else {
             let shared_semaphore = if mode == Some("sql_warehouse") {
                 match (
@@ -1635,17 +1713,16 @@ impl CatalogConnector for DatabricksCatalog {
                 connector_component: ConnectorComponent::from(catalog),
             })?;
 
-            (
+            Arc::new(ReadTableProviderFactory::new(
                 dataset_databricks.read_provider(),
-                table_reference_creator_spark as fn(&UCTable) -> Option<TableReference>,
-            )
+                table_reference_creator_spark,
+            ))
         };
 
         let catalog_provider = UnityCatalogProvider::try_new(
             client,
             CatalogId(catalog_id),
             table_creator,
-            table_reference_creator,
             catalog.include.clone(),
         )
         .await

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -205,6 +205,7 @@ object_store = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt", "sync"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+wiremock = "0.6"
 zstd = "0.13.3"
 
 [[bench]]

--- a/crates/data_components/src/databricks/delta.rs
+++ b/crates/data_components/src/databricks/delta.rs
@@ -15,12 +15,13 @@ limitations under the License.
 */
 
 use crate::Read;
-use crate::unity_catalog::UnityCatalog;
+use crate::unity_catalog::credential_vending::vended_delta_table;
+use crate::unity_catalog::{UCTable, UnityCatalog};
 use crate::{delta_lake::DeltaTable, unity_catalog::Endpoint};
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use snafu::prelude::*;
 use std::{collections::HashMap, sync::Arc};
 use token_provider::TokenProvider;
@@ -32,6 +33,7 @@ pub struct DatabricksDelta {
     token_provider: Arc<dyn TokenProvider>,
     storage_options: HashMap<String, SecretString>,
     io_runtime: Handle,
+    credential_vending_client: Option<Arc<UnityCatalog>>,
 }
 
 #[derive(Debug, Snafu)]
@@ -58,14 +60,49 @@ impl DatabricksDelta {
             token_provider,
             storage_options,
             io_runtime,
+            credential_vending_client: None,
         }
+    }
+
+    /// Enables Unity Catalog credential vending: each table's storage
+    /// credentials are vended through `client` instead of taken from the
+    /// configured storage options.
+    #[must_use]
+    pub fn with_credential_vending(mut self, client: Arc<UnityCatalog>) -> Self {
+        self.credential_vending_client = Some(client);
+        self
+    }
+
+    /// Returns `true` when Unity Catalog credential vending is enabled.
+    #[must_use]
+    pub fn credential_vending_enabled(&self) -> bool {
+        self.credential_vending_client.is_some()
     }
 
     async fn get_delta_table(
         &self,
         table_reference: TableReference,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
-        let table_uri = self.resolve_table_uri(table_reference).await?;
+        let table = self.get_uc_table(&table_reference).await?;
+        let Some(table_uri) = table.storage_location.clone() else {
+            return Err(Error::TableDoesNotHaveStorageLocation { table_reference }.into());
+        };
+
+        if let Some(client) = &self.credential_vending_client {
+            let aws_region = self
+                .storage_options
+                .get("aws_region")
+                .map(|s| s.expose_secret().to_string());
+            match vended_delta_table(Arc::clone(client), &table, &table_uri, aws_region).await {
+                Ok(delta) => return Ok(Arc::new(delta) as Arc<dyn TableProvider>),
+                Err(err) => {
+                    tracing::warn!(
+                        table = %table.full_name(),
+                        "Unable to use Unity Catalog credential vending for table; falling back to configured storage credentials: {err}"
+                    );
+                }
+            }
+        }
 
         let mut storage_options = HashMap::new();
         for (key, value) in &self.storage_options {
@@ -85,10 +122,10 @@ impl DatabricksDelta {
         Ok(Arc::new(delta_table) as Arc<dyn TableProvider>)
     }
 
-    pub async fn resolve_table_uri(
+    async fn get_uc_table(
         &self,
-        table_reference: TableReference,
-    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        table_reference: &TableReference,
+    ) -> Result<UCTable, Box<dyn std::error::Error + Send + Sync>> {
         let uc_client = UnityCatalog::new(
             self.endpoint.clone(),
             Some(Arc::clone(&self.token_provider)),
@@ -96,17 +133,24 @@ impl DatabricksDelta {
         )
         .boxed()?;
 
-        let table_opt = uc_client.get_table(&table_reference).await.boxed()?;
+        let table_opt = uc_client.get_table(table_reference).await.boxed()?;
 
-        if let Some(table) = table_opt {
-            if let Some(storage_location) = table.storage_location {
-                Ok(storage_location)
-            } else {
-                Err(Error::TableDoesNotHaveStorageLocation { table_reference }.into())
+        table_opt.ok_or_else(|| {
+            Error::TableDoesNotExist {
+                table_reference: table_reference.clone(),
             }
-        } else {
-            Err(Error::TableDoesNotExist { table_reference }.into())
-        }
+            .into()
+        })
+    }
+
+    pub async fn resolve_table_uri(
+        &self,
+        table_reference: TableReference,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        let table = self.get_uc_table(&table_reference).await?;
+        table
+            .storage_location
+            .ok_or_else(|| Error::TableDoesNotHaveStorageLocation { table_reference }.into())
     }
 }
 

--- a/crates/data_components/src/databricks/delta.rs
+++ b/crates/data_components/src/databricks/delta.rs
@@ -126,14 +126,21 @@ impl DatabricksDelta {
         &self,
         table_reference: &TableReference,
     ) -> Result<UCTable, Box<dyn std::error::Error + Send + Sync>> {
-        let uc_client = UnityCatalog::new(
-            self.endpoint.clone(),
-            Some(Arc::clone(&self.token_provider)),
-            None,
-        )
-        .boxed()?;
-
-        let table_opt = uc_client.get_table(table_reference).await.boxed()?;
+        // Reuse the vending client when present: it carries the connector's
+        // rate-control configuration and avoids rebuilding an HTTP client for
+        // every table lookup.
+        let table_opt = match &self.credential_vending_client {
+            Some(client) => client.get_table(table_reference).await.boxed()?,
+            None => {
+                let uc_client = UnityCatalog::new(
+                    self.endpoint.clone(),
+                    Some(Arc::clone(&self.token_provider)),
+                    None,
+                )
+                .boxed()?;
+                uc_client.get_table(table_reference).await.boxed()?
+            }
+        };
 
         table_opt.ok_or_else(|| {
             Error::TableDoesNotExist {

--- a/crates/data_components/src/databricks/delta.rs
+++ b/crates/data_components/src/databricks/delta.rs
@@ -129,17 +129,16 @@ impl DatabricksDelta {
         // Reuse the vending client when present: it carries the connector's
         // rate-control configuration and avoids rebuilding an HTTP client for
         // every table lookup.
-        let table_opt = match &self.credential_vending_client {
-            Some(client) => client.get_table(table_reference).await.boxed()?,
-            None => {
-                let uc_client = UnityCatalog::new(
-                    self.endpoint.clone(),
-                    Some(Arc::clone(&self.token_provider)),
-                    None,
-                )
-                .boxed()?;
-                uc_client.get_table(table_reference).await.boxed()?
-            }
+        let table_opt = if let Some(client) = &self.credential_vending_client {
+            client.get_table(table_reference).await.boxed()?
+        } else {
+            let uc_client = UnityCatalog::new(
+                self.endpoint.clone(),
+                Some(Arc::clone(&self.token_provider)),
+                None,
+            )
+            .boxed()?;
+            uc_client.get_table(table_reference).await.boxed()?
         };
 
         table_opt.ok_or_else(|| {

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -174,7 +174,7 @@ impl DeltaTable {
         let mut storage_options: HashMap<String, String> = HashMap::new();
         for (key, value) in options {
             match key.as_ref() {
-                "token" | "endpoint" => {}
+                "token" | "endpoint" | "credential_vending" => {}
                 "client_timeout" => {
                     storage_options.insert("timeout".into(), value.expose_secret().to_string());
                 }
@@ -228,6 +228,28 @@ impl DeltaTable {
             )),
         };
 
+        Self::with_engine(table_url, engine)
+    }
+
+    /// Creates a `DeltaTable` backed by a pre-built object store, bypassing
+    /// the credential resolution in [`DeltaTable::from`].
+    ///
+    /// Used by Unity Catalog credential vending, where the store
+    /// authenticates with vended, refresh-aware credentials.
+    pub fn from_object_store(
+        table_location: String,
+        object_store: Arc<dyn object_store::ObjectStore>,
+    ) -> Result<Self> {
+        let table_url = delta_kernel::try_parse_uri(ensure_folder_location(table_location))
+            .map_err(handle_delta_error)?;
+        let engine = Arc::new(DefaultEngine::new(object_store));
+        Self::with_engine(table_url, engine)
+    }
+
+    fn with_engine(
+        table_url: Url,
+        engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
+    ) -> Result<Self> {
         let snapshot = Snapshot::builder_for(table_url.clone())
             .build(engine.as_ref())
             .map_err(handle_delta_error)?;

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -30,6 +30,7 @@ use crate::resilient_http::{
     RetryConfig, configure_client_builder, send_request_with_retry_and_concurrency_limit,
 };
 
+pub mod credential_vending;
 pub mod provider;
 
 #[derive(Debug, Snafu)]
@@ -80,6 +81,15 @@ pub enum Error {
 
     #[snafu(display("Failed to acquire Unity Catalog rate-control permit: {source}"))]
     RateControl { source: runtime_rate_control::Error },
+
+    #[snafu(display(
+        "Unity Catalog denied the temporary credentials request for table ID '{table_id}' (HTTP {status}). Verify credential vending is available: on Databricks, the metastore must have external data access enabled, the calling principal needs the EXTERNAL USE SCHEMA privilege, and the table must support reads by external engines. Response: {message}"
+    ))]
+    CredentialVendingDenied {
+        table_id: String,
+        status: reqwest::StatusCode,
+        message: String,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -371,6 +381,50 @@ impl UnityCatalog {
         .await
     }
 
+    /// Requests short-lived, downscoped storage credentials for a table from
+    /// the Unity Catalog credential vending API.
+    ///
+    /// On Databricks, credential vending requires the metastore to have
+    /// external data access enabled and the calling principal to hold the
+    /// `EXTERNAL USE SCHEMA` privilege on the table's schema.
+    pub async fn temporary_table_credentials(
+        &self,
+        table_id: &str,
+        operation: TableOperation,
+    ) -> Result<TemporaryTableCredentials> {
+        let path = "/api/2.1/unity-catalog/temporary-table-credentials";
+        let body = serde_json::json!({
+            "table_id": table_id,
+            "operation": operation.as_str(),
+        });
+        async {
+            let response = self
+                .send_post_with_retry("generate temporary table credentials", path, &body)
+                .await?;
+
+            let status = response.status();
+            if status.is_success() {
+                response.json().await.context(ConnectionSnafu)
+            } else if matches!(status.as_u16(), 400 | 401 | 403 | 404) {
+                let message = response.text().await.unwrap_or_default();
+                CredentialVendingDeniedSnafu {
+                    table_id: table_id.to_string(),
+                    status,
+                    message,
+                }
+                .fail()
+            } else {
+                UnexpectedStatusCodeSnafu { status }.fail()
+            }
+        }
+        .instrument(tracing::info_span!(
+            target: "task_history",
+            "uc_temporary_table_credentials",
+            input = table_id,
+        ))
+        .await
+    }
+
     fn get_req(&self, path: &str) -> reqwest::RequestBuilder {
         let full_url = format!("{}{path}", self.endpoint);
         tracing::debug!("Sending request to {full_url}");
@@ -387,12 +441,49 @@ impl UnityCatalog {
         builder
     }
 
+    fn post_req(&self, path: &str) -> reqwest::RequestBuilder {
+        let full_url = format!("{}{path}", self.endpoint);
+        tracing::debug!("Sending POST request to {full_url}");
+        let mut builder = self.client.post(full_url);
+
+        if let Some(token_provider) = &self.token_provider {
+            builder = builder.bearer_auth(token_provider.get_token());
+        }
+        if let Some(user_agent) = &self.user_agent {
+            builder = builder.header("User-Agent", user_agent);
+        }
+
+        builder
+    }
+
     async fn send_get_with_retry(&self, operation: &str, path: &str) -> Result<reqwest::Response> {
         let rate_controller_permit = self.acquire_rate_controller_permit().await?;
         let response = send_request_with_retry_and_concurrency_limit(
             "Unity Catalog",
             operation,
             || self.get_req(path),
+            &RetryConfig {
+                concurrency_limit: self.request_semaphore.as_deref(),
+                ..RetryConfig::default()
+            },
+        )
+        .await
+        .context(ConnectionSnafu)?;
+        drop(rate_controller_permit);
+        Ok(response)
+    }
+
+    async fn send_post_with_retry(
+        &self,
+        operation: &str,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<reqwest::Response> {
+        let rate_controller_permit = self.acquire_rate_controller_permit().await?;
+        let response = send_request_with_retry_and_concurrency_limit(
+            "Unity Catalog",
+            operation,
+            || self.post_req(path).json(body),
             &RetryConfig {
                 concurrency_limit: self.request_semaphore.as_deref(),
                 ..RetryConfig::default()
@@ -495,6 +586,9 @@ pub struct UCTable {
     pub columns: Vec<UCColumn>,
     #[serde(default)]
     pub storage_location: Option<String>,
+    /// Unique table identifier, used for credential vending.
+    #[serde(default)]
+    pub table_id: Option<String>,
 }
 
 impl UCTable {
@@ -607,6 +701,96 @@ pub struct UCSchema {
 }
 
 // ============================================================================
+// Credential vending
+// ============================================================================
+
+/// The operation that vended credentials will be used for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableOperation {
+    Read,
+    ReadWrite,
+}
+
+impl TableOperation {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Read => "READ",
+            Self::ReadWrite => "READ_WRITE",
+        }
+    }
+}
+
+/// Response from `POST /api/2.1/unity-catalog/temporary-table-credentials`.
+///
+/// Exactly one of the cloud-specific credential fields is expected to be set,
+/// matching the table's storage location.
+#[derive(Clone, Deserialize)]
+pub struct TemporaryTableCredentials {
+    #[serde(default)]
+    pub aws_temp_credentials: Option<AwsTempCredentials>,
+    #[serde(default)]
+    pub azure_user_delegation_sas: Option<AzureUserDelegationSas>,
+    #[serde(default)]
+    pub gcp_oauth_token: Option<GcpOauthToken>,
+    #[serde(default)]
+    pub r2_temp_credentials: Option<R2TempCredentials>,
+    /// Expiration of the credentials as epoch milliseconds.
+    #[serde(default)]
+    pub expiration_time: i64,
+    /// The storage URL the credentials are scoped to.
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+// Manual `Debug` so credential material can never leak into logs.
+impl std::fmt::Debug for TemporaryTableCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TemporaryTableCredentials")
+            .field("aws_temp_credentials", &self.aws_temp_credentials.is_some())
+            .field(
+                "azure_user_delegation_sas",
+                &self.azure_user_delegation_sas.is_some(),
+            )
+            .field("gcp_oauth_token", &self.gcp_oauth_token.is_some())
+            .field("r2_temp_credentials", &self.r2_temp_credentials.is_some())
+            .field("expiration_time", &self.expiration_time)
+            .field("url", &self.url)
+            .finish()
+    }
+}
+
+/// Temporary AWS STS credentials vended by Unity Catalog.
+#[derive(Clone, Deserialize)]
+pub struct AwsTempCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    #[serde(default)]
+    pub session_token: Option<String>,
+}
+
+/// Azure user-delegation SAS token vended by Unity Catalog.
+#[derive(Clone, Deserialize)]
+pub struct AzureUserDelegationSas {
+    pub sas_token: String,
+}
+
+/// GCP OAuth token vended by Unity Catalog.
+#[derive(Clone, Deserialize)]
+pub struct GcpOauthToken {
+    pub oauth_token: String,
+}
+
+/// Temporary Cloudflare R2 credentials vended by Unity Catalog.
+#[derive(Clone, Deserialize)]
+pub struct R2TempCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    #[serde(default)]
+    pub session_token: Option<String>,
+}
+
+// ============================================================================
 // Permissions
 // ============================================================================
 
@@ -677,7 +861,8 @@ impl UCPermissionsEnvelope {
 #[cfg(test)]
 mod tests {
     use super::{
-        UCColumn, UCPermissionsEnvelope, UCPrivilege, UCPrivilegeAssignment, UCTable, UCTableType,
+        TableOperation, TemporaryTableCredentials, UCColumn, UCPermissionsEnvelope, UCPrivilege,
+        UCPrivilegeAssignment, UCTable, UCTableType,
     };
 
     fn make_table(table_type: &str) -> UCTable {
@@ -689,6 +874,7 @@ mod tests {
             data_source_format: "DELTA".to_string(),
             columns: Vec::<UCColumn>::new(),
             storage_location: None,
+            table_id: None,
         }
     }
 
@@ -922,5 +1108,102 @@ mod tests {
             ],
         };
         assert_eq!(perms.all_privileges(), vec!["SELECT", "MODIFY", "CREATE"]);
+    }
+
+    // ----------------------------------------------------------------
+    // Credential vending
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn test_table_operation_as_str() {
+        assert_eq!(TableOperation::Read.as_str(), "READ");
+        assert_eq!(TableOperation::ReadWrite.as_str(), "READ_WRITE");
+    }
+
+    #[test]
+    fn test_uc_table_deserializes_table_id() {
+        let json = r#"{
+            "name": "my_table",
+            "catalog_name": "my_catalog",
+            "schema_name": "my_schema",
+            "table_type": "MANAGED",
+            "table_id": "1234-abcd"
+        }"#;
+        let table: UCTable = serde_json::from_str(json).expect("valid UCTable JSON");
+        assert_eq!(table.table_id.as_deref(), Some("1234-abcd"));
+    }
+
+    #[test]
+    fn test_temporary_table_credentials_deserialize_aws() {
+        let json = r#"{
+            "aws_temp_credentials": {
+                "access_key_id": "AKIA123",
+                "secret_access_key": "SECRET",
+                "session_token": "TOKEN"
+            },
+            "expiration_time": 1716397620000,
+            "url": "s3://bucket/path"
+        }"#;
+        let creds: TemporaryTableCredentials =
+            serde_json::from_str(json).expect("valid AWS credentials JSON");
+        let aws = creds.aws_temp_credentials.expect("aws credentials present");
+        assert_eq!(aws.access_key_id, "AKIA123");
+        assert_eq!(aws.secret_access_key, "SECRET");
+        assert_eq!(aws.session_token.as_deref(), Some("TOKEN"));
+        assert_eq!(creds.expiration_time, 1_716_397_620_000);
+        assert_eq!(creds.url.as_deref(), Some("s3://bucket/path"));
+        assert!(creds.azure_user_delegation_sas.is_none());
+        assert!(creds.gcp_oauth_token.is_none());
+        assert!(creds.r2_temp_credentials.is_none());
+    }
+
+    #[test]
+    fn test_temporary_table_credentials_deserialize_azure_and_gcp() {
+        let azure: TemporaryTableCredentials = serde_json::from_str(
+            r#"{"azure_user_delegation_sas": {"sas_token": "sv=2024&sig=abc"}, "expiration_time": 1}"#,
+        )
+        .expect("valid Azure credentials JSON");
+        assert_eq!(
+            azure
+                .azure_user_delegation_sas
+                .expect("sas present")
+                .sas_token,
+            "sv=2024&sig=abc"
+        );
+
+        let gcp: TemporaryTableCredentials = serde_json::from_str(
+            r#"{"gcp_oauth_token": {"oauth_token": "ya29.token"}, "expiration_time": 1}"#,
+        )
+        .expect("valid GCP credentials JSON");
+        assert_eq!(
+            gcp.gcp_oauth_token.expect("token present").oauth_token,
+            "ya29.token"
+        );
+    }
+
+    #[test]
+    fn test_temporary_table_credentials_debug_redacts_secrets() {
+        let creds: TemporaryTableCredentials = serde_json::from_str(
+            r#"{
+                "aws_temp_credentials": {
+                    "access_key_id": "AKIA123",
+                    "secret_access_key": "SUPERSECRET",
+                    "session_token": "SESSIONTOKEN"
+                },
+                "expiration_time": 1716397620000
+            }"#,
+        )
+        .expect("valid credentials JSON");
+        let debug = format!("{creds:?}");
+        assert!(!debug.contains("AKIA123"), "debug output leaked key id");
+        assert!(
+            !debug.contains("SUPERSECRET"),
+            "debug output leaked secret key"
+        );
+        assert!(
+            !debug.contains("SESSIONTOKEN"),
+            "debug output leaked session token"
+        );
+        assert!(debug.contains("1716397620000"), "expiration should appear");
     }
 }

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -406,7 +406,8 @@ impl UnityCatalog {
             if status.is_success() {
                 response.json().await.context(ConnectionSnafu)
             } else if matches!(status.as_u16(), 400 | 401 | 403 | 404) {
-                let message = response.text().await.unwrap_or_default();
+                let message =
+                    Self::sanitize_response_body(&response.text().await.unwrap_or_default());
                 CredentialVendingDeniedSnafu {
                     table_id: table_id.to_string(),
                     status,
@@ -505,6 +506,21 @@ impl UnityCatalog {
             .await
             .context(RateControlSnafu)
             .map(Some)
+    }
+
+    /// Collapses whitespace (including newlines) and truncates an HTTP
+    /// response body so it can be embedded in single-line error messages and
+    /// logs without inflating them.
+    fn sanitize_response_body(body: &str) -> String {
+        const MAX_CHARS: usize = 512;
+        let collapsed = body.split_whitespace().collect::<Vec<_>>().join(" ");
+        if collapsed.chars().count() > MAX_CHARS {
+            let mut truncated: String = collapsed.chars().take(MAX_CHARS).collect();
+            truncated.push_str("… (truncated)");
+            truncated
+        } else {
+            collapsed
+        }
     }
 
     /// Percent-encodes each dot-separated segment of a UC name individually.
@@ -1179,6 +1195,23 @@ mod tests {
             gcp.gcp_oauth_token.expect("token present").oauth_token,
             "ya29.token"
         );
+    }
+
+    #[test]
+    fn test_sanitize_response_body_collapses_whitespace() {
+        let body = "{\n  \"error_code\": \"PERMISSION_DENIED\",\n\t\"message\":   \"denied\"\n}";
+        assert_eq!(
+            super::UnityCatalog::sanitize_response_body(body),
+            "{ \"error_code\": \"PERMISSION_DENIED\", \"message\": \"denied\" }"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_response_body_truncates_large_bodies() {
+        let body = "x".repeat(10_000);
+        let sanitized = super::UnityCatalog::sanitize_response_body(&body);
+        assert!(sanitized.ends_with("… (truncated)"));
+        assert!(sanitized.chars().count() < 600);
     }
 
     #[test]

--- a/crates/data_components/src/unity_catalog/credential_vending.rs
+++ b/crates/data_components/src/unity_catalog/credential_vending.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "The storage location '{url}' uses scheme '{scheme}', which is not supported for Unity Catalog credential vending. Supported schemes: s3, abfss, gs. Provide static storage credentials for this table instead."
+        "The storage location '{url}' uses scheme '{scheme}', which is not supported for Unity Catalog credential vending. Supported schemes: s3, s3a, abfss, abfs, az, azure, wasbs, wasb, gs. Provide static storage credentials for this table instead."
     ))]
     UnsupportedScheme { url: String, scheme: String },
 
@@ -310,6 +310,15 @@ impl CredentialProvider for VendedGcpCredentialProvider {
     }
 }
 
+/// The AWS region to use for vended S3 access: the explicit `aws_region`
+/// parameter wins, then the `AWS_REGION`/`AWS_DEFAULT_REGION` environment
+/// variables. `None` means the region must be resolved from the bucket.
+fn configured_aws_region(aws_region: Option<String>) -> Option<String> {
+    aws_region
+        .or_else(|| std::env::var("AWS_REGION").ok())
+        .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
+}
+
 /// Parses an Azure SAS token (with or without a leading `?`) into the
 /// key/value pairs expected by [`AzureCredential::SASToken`].
 fn parse_sas_token(sas: &str) -> Vec<(String, String)> {
@@ -336,10 +345,7 @@ pub async fn vended_object_store(
                 .host_str()
                 .context(MissingBucketSnafu { url: url.clone() })?
                 .to_string();
-            let region = match aws_region
-                .or_else(|| std::env::var("AWS_REGION").ok())
-                .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
-            {
+            let region = match configured_aws_region(aws_region) {
                 Some(region) => region,
                 None => resolve_bucket_region(&bucket, &ClientOptions::new())
                     .await
@@ -581,6 +587,88 @@ mod tests {
         // Synthetic TTL is 15 minutes from fetch.
         assert!(!cached.should_refresh(15 * MINUTE_MS));
         assert!(cached.should_refresh(25 * MINUTE_MS));
+    }
+
+    mod object_store_dispatch {
+        use super::*;
+        use crate::unity_catalog::Endpoint;
+
+        fn dummy_credentials() -> Arc<VendedTableCredentials> {
+            let client = UnityCatalog::new(Endpoint("http://127.0.0.1:9".to_string()), None, None)
+                .expect("client should build");
+            Arc::new(VendedTableCredentials::new(
+                Arc::new(client),
+                "table-uuid".to_string(),
+                TableOperation::Read,
+            ))
+        }
+
+        #[tokio::test]
+        async fn test_s3_scheme_builds_with_explicit_region() {
+            let url = Url::parse("s3://my-bucket/path/to/table").expect("valid url");
+            let store =
+                vended_object_store(&url, dummy_credentials(), Some("us-west-2".to_string())).await;
+            assert!(store.is_ok(), "expected S3 store, got: {:?}", store.err());
+        }
+
+        #[tokio::test]
+        async fn test_s3_scheme_missing_bucket() {
+            let url = Url::parse("s3:///no-bucket").expect("valid url");
+            let err = vended_object_store(&url, dummy_credentials(), Some("us-west-2".to_string()))
+                .await
+                .expect_err("expected missing bucket error");
+            assert!(matches!(err, Error::MissingBucket { .. }), "got: {err}");
+        }
+
+        #[tokio::test]
+        async fn test_azure_scheme_builds() {
+            let url = Url::parse("abfss://container@account.dfs.core.windows.net/path")
+                .expect("valid url");
+            let store = vended_object_store(&url, dummy_credentials(), None).await;
+            assert!(
+                store.is_ok(),
+                "expected Azure store, got: {:?}",
+                store.err()
+            );
+        }
+
+        #[tokio::test]
+        async fn test_gcs_scheme_builds() {
+            let url = Url::parse("gs://bucket/path").expect("valid url");
+            let store = vended_object_store(&url, dummy_credentials(), None).await;
+            assert!(store.is_ok(), "expected GCS store, got: {:?}", store.err());
+        }
+
+        #[tokio::test]
+        async fn test_unsupported_scheme() {
+            let url = Url::parse("file:///tmp/table").expect("valid url");
+            let err = vended_object_store(&url, dummy_credentials(), None)
+                .await
+                .expect_err("expected unsupported scheme error");
+            assert!(
+                matches!(&err, Error::UnsupportedScheme { scheme, .. } if scheme == "file"),
+                "got: {err}"
+            );
+            // The error must list the schemes that are actually supported.
+            for scheme in [
+                "s3", "s3a", "abfss", "abfs", "az", "azure", "wasbs", "wasb", "gs",
+            ] {
+                assert!(
+                    err.to_string().contains(scheme),
+                    "error message missing scheme '{scheme}': {err}"
+                );
+            }
+        }
+
+        #[test]
+        fn test_configured_aws_region_prefers_parameter() {
+            // The explicit parameter takes precedence over any environment
+            // configuration.
+            assert_eq!(
+                configured_aws_region(Some("eu-central-1".to_string())).as_deref(),
+                Some("eu-central-1")
+            );
+        }
     }
 
     mod vending {

--- a/crates/data_components/src/unity_catalog/credential_vending.rs
+++ b/crates/data_components/src/unity_catalog/credential_vending.rs
@@ -1,0 +1,715 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Unity Catalog credential vending.
+//!
+//! Unity Catalog can vend short-lived, downscoped storage credentials for a
+//! table via `POST /api/2.1/unity-catalog/temporary-table-credentials`, so
+//! users don't need to provide their own S3/Azure/GCS credentials.
+//!
+//! [`VendedTableCredentials`] caches one table's vended credentials and
+//! re-vends them before they expire. The per-cloud
+//! [`object_store::CredentialProvider`] implementations wrap that cache, and
+//! because `object_store` consults its credential provider on every request,
+//! refreshed credentials transparently apply mid-query and for the entire
+//! lifetime of a table provider.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use object_store::aws::{AmazonS3Builder, AwsCredential, resolve_bucket_region};
+use object_store::azure::{AzureCredential, MicrosoftAzureBuilder};
+use object_store::gcp::{GcpCredential, GoogleCloudStorageBuilder};
+use object_store::{ClientOptions, CredentialProvider, ObjectStore};
+use snafu::prelude::*;
+use tokio::sync::RwLock;
+use url::Url;
+
+use super::{TableOperation, TemporaryTableCredentials, UnityCatalog};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to vend credentials from Unity Catalog: {source}"))]
+    VendCredentials { source: super::Error },
+
+    #[snafu(display(
+        "Unity Catalog returned no table ID for table '{table}', so its credentials cannot be vended."
+    ))]
+    MissingTableId { table: String },
+
+    #[snafu(display("The storage location '{url}' is not a valid URL: {source}"))]
+    InvalidStorageUrl {
+        url: String,
+        source: url::ParseError,
+    },
+
+    #[snafu(display(
+        "The storage location '{url}' uses scheme '{scheme}', which is not supported for Unity Catalog credential vending. Supported schemes: s3, abfss, gs. Provide static storage credentials for this table instead."
+    ))]
+    UnsupportedScheme { url: String, scheme: String },
+
+    #[snafu(display("The storage location '{url}' is missing a bucket or container name."))]
+    MissingBucket { url: String },
+
+    #[snafu(display(
+        "Failed to determine the AWS region for bucket '{bucket}'. Set the connector's 'aws_region' parameter (or the AWS_REGION environment variable), and try again. Error: {source}"
+    ))]
+    ResolveBucketRegion {
+        bucket: String,
+        source: object_store::Error,
+    },
+
+    #[snafu(display("Failed to build the object store for '{url}': {source}"))]
+    BuildObjectStore {
+        url: String,
+        source: object_store::Error,
+    },
+
+    #[snafu(display(
+        "Unity Catalog vended no {expected} credentials for the storage location '{url}'. Verify the table's storage location matches the credentials returned by the catalog."
+    ))]
+    MissingVendedCredential { expected: &'static str, url: String },
+
+    #[snafu(display("Failed to create the Delta table at '{url}': {source}"))]
+    CreateDeltaTable {
+        url: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Refresh credentials this long before they expire.
+const REFRESH_MARGIN_MS: i64 = 5 * 60 * 1000;
+
+/// Synthetic lifetime used when the vending response carries no expiration.
+const DEFAULT_TTL_MS: i64 = 15 * 60 * 1000;
+
+#[derive(Debug, Clone)]
+struct CachedCredentials {
+    creds: TemporaryTableCredentials,
+    fetched_at_ms: i64,
+}
+
+impl CachedCredentials {
+    /// The expiration to enforce, falling back to a synthetic TTL when the
+    /// vending response carried none.
+    fn effective_expiration_ms(&self) -> i64 {
+        if self.creds.expiration_time > 0 {
+            self.creds.expiration_time
+        } else {
+            self.fetched_at_ms + DEFAULT_TTL_MS
+        }
+    }
+
+    /// Whether the cached credentials should be re-vended at `now_ms`.
+    ///
+    /// Credentials are refreshed [`REFRESH_MARGIN_MS`] before expiry. If the
+    /// credentials were *vended* already inside that margin (a very short
+    /// TTL), they are used until they actually expire instead of re-vending
+    /// on every request.
+    fn should_refresh(&self, now_ms: i64) -> bool {
+        let expiration_ms = self.effective_expiration_ms();
+        if now_ms >= expiration_ms {
+            return true;
+        }
+        let in_margin = now_ms >= expiration_ms - REFRESH_MARGIN_MS;
+        let vended_inside_margin = self.fetched_at_ms >= expiration_ms - REFRESH_MARGIN_MS;
+        in_margin && !vended_inside_margin
+    }
+}
+
+/// A refresh-aware cache of one table's vended credentials.
+#[derive(Debug)]
+pub struct VendedTableCredentials {
+    client: Arc<UnityCatalog>,
+    table_id: String,
+    operation: TableOperation,
+    cached: RwLock<Option<CachedCredentials>>,
+}
+
+impl VendedTableCredentials {
+    #[must_use]
+    pub fn new(client: Arc<UnityCatalog>, table_id: String, operation: TableOperation) -> Self {
+        Self {
+            client,
+            table_id,
+            operation,
+            cached: RwLock::new(None),
+        }
+    }
+
+    /// Returns valid vended credentials, re-vending from Unity Catalog if the
+    /// cached ones are missing or close to expiry.
+    pub async fn get(&self) -> Result<TemporaryTableCredentials> {
+        let now_ms = now_millis();
+        {
+            let cached = self.cached.read().await;
+            if let Some(cached) = cached.as_ref()
+                && !cached.should_refresh(now_ms)
+            {
+                return Ok(cached.creds.clone());
+            }
+        }
+
+        // The write lock single-flights concurrent refreshes: the first caller
+        // re-vends while the rest block here, then hit the re-check below.
+        let mut guard = self.cached.write().await;
+        let now_ms = now_millis();
+        if let Some(cached) = guard.as_ref()
+            && !cached.should_refresh(now_ms)
+        {
+            return Ok(cached.creds.clone());
+        }
+
+        tracing::debug!(table_id = %self.table_id, "Vending temporary table credentials from Unity Catalog");
+        let creds = self
+            .client
+            .temporary_table_credentials(&self.table_id, self.operation)
+            .await
+            .context(VendCredentialsSnafu)?;
+
+        let cached = CachedCredentials {
+            creds: creds.clone(),
+            fetched_at_ms: now_ms,
+        };
+        if cached.effective_expiration_ms() - now_ms < REFRESH_MARGIN_MS {
+            tracing::warn!(
+                table_id = %self.table_id,
+                expiration_time = creds.expiration_time,
+                "Unity Catalog vended credentials with a very short lifetime; they will be re-vended once they expire"
+            );
+        }
+        *guard = Some(cached);
+        Ok(creds)
+    }
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+fn to_object_store_error(store: &'static str, error: Error) -> object_store::Error {
+    object_store::Error::Generic {
+        store,
+        source: Box::new(error),
+    }
+}
+
+/// Vends AWS credentials for an S3 object store.
+#[derive(Debug)]
+pub struct VendedAwsCredentialProvider {
+    credentials: Arc<VendedTableCredentials>,
+    url: String,
+}
+
+#[async_trait::async_trait]
+impl CredentialProvider for VendedAwsCredentialProvider {
+    type Credential = AwsCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<AwsCredential>> {
+        let creds = self
+            .credentials
+            .get()
+            .await
+            .map_err(|e| to_object_store_error("S3", e))?;
+        let aws = creds.aws_temp_credentials.ok_or_else(|| {
+            to_object_store_error(
+                "S3",
+                Error::MissingVendedCredential {
+                    expected: "AWS",
+                    url: self.url.clone(),
+                },
+            )
+        })?;
+        Ok(Arc::new(AwsCredential {
+            key_id: aws.access_key_id,
+            secret_key: aws.secret_access_key,
+            token: aws.session_token,
+        }))
+    }
+}
+
+/// Vends an Azure user-delegation SAS token for an Azure object store.
+#[derive(Debug)]
+pub struct VendedAzureCredentialProvider {
+    credentials: Arc<VendedTableCredentials>,
+    url: String,
+}
+
+#[async_trait::async_trait]
+impl CredentialProvider for VendedAzureCredentialProvider {
+    type Credential = AzureCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<AzureCredential>> {
+        let creds = self
+            .credentials
+            .get()
+            .await
+            .map_err(|e| to_object_store_error("MicrosoftAzure", e))?;
+        let sas = creds.azure_user_delegation_sas.ok_or_else(|| {
+            to_object_store_error(
+                "MicrosoftAzure",
+                Error::MissingVendedCredential {
+                    expected: "Azure SAS",
+                    url: self.url.clone(),
+                },
+            )
+        })?;
+        Ok(Arc::new(AzureCredential::SASToken(parse_sas_token(
+            &sas.sas_token,
+        ))))
+    }
+}
+
+/// Vends a GCP OAuth token for a GCS object store.
+#[derive(Debug)]
+pub struct VendedGcpCredentialProvider {
+    credentials: Arc<VendedTableCredentials>,
+    url: String,
+}
+
+#[async_trait::async_trait]
+impl CredentialProvider for VendedGcpCredentialProvider {
+    type Credential = GcpCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<GcpCredential>> {
+        let creds = self
+            .credentials
+            .get()
+            .await
+            .map_err(|e| to_object_store_error("GCS", e))?;
+        let token = creds.gcp_oauth_token.ok_or_else(|| {
+            to_object_store_error(
+                "GCS",
+                Error::MissingVendedCredential {
+                    expected: "GCP",
+                    url: self.url.clone(),
+                },
+            )
+        })?;
+        Ok(Arc::new(GcpCredential {
+            bearer: token.oauth_token,
+        }))
+    }
+}
+
+/// Parses an Azure SAS token (with or without a leading `?`) into the
+/// key/value pairs expected by [`AzureCredential::SASToken`].
+fn parse_sas_token(sas: &str) -> Vec<(String, String)> {
+    url::form_urlencoded::parse(sas.trim_start_matches('?').as_bytes())
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect()
+}
+
+/// Builds an [`ObjectStore`] for `table_url` that authenticates with vended
+/// Unity Catalog credentials, refreshing them before they expire.
+///
+/// The vending response carries no AWS region, so for S3 the region is taken
+/// from `aws_region`, then the `AWS_REGION`/`AWS_DEFAULT_REGION` environment
+/// variables, then resolved from the bucket itself.
+pub async fn vended_object_store(
+    table_url: &Url,
+    credentials: Arc<VendedTableCredentials>,
+    aws_region: Option<String>,
+) -> Result<Arc<dyn ObjectStore>> {
+    let url = table_url.to_string();
+    match table_url.scheme() {
+        "s3" | "s3a" => {
+            let bucket = table_url
+                .host_str()
+                .context(MissingBucketSnafu { url: url.clone() })?
+                .to_string();
+            let region = match aws_region
+                .or_else(|| std::env::var("AWS_REGION").ok())
+                .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
+            {
+                Some(region) => region,
+                None => resolve_bucket_region(&bucket, &ClientOptions::new())
+                    .await
+                    .context(ResolveBucketRegionSnafu {
+                        bucket: bucket.clone(),
+                    })?,
+            };
+            let store = AmazonS3Builder::new()
+                .with_bucket_name(bucket)
+                .with_region(region)
+                .with_credentials(Arc::new(VendedAwsCredentialProvider {
+                    credentials,
+                    url: url.clone(),
+                }))
+                .build()
+                .context(BuildObjectStoreSnafu { url })?;
+            Ok(Arc::new(store))
+        }
+        "abfss" | "abfs" | "az" | "azure" | "wasbs" | "wasb" => {
+            let store = MicrosoftAzureBuilder::new()
+                .with_url(url.clone())
+                .with_credentials(Arc::new(VendedAzureCredentialProvider {
+                    credentials,
+                    url: url.clone(),
+                }))
+                .build()
+                .context(BuildObjectStoreSnafu { url })?;
+            Ok(Arc::new(store))
+        }
+        "gs" => {
+            let store = GoogleCloudStorageBuilder::new()
+                .with_url(url.clone())
+                .with_credentials(Arc::new(VendedGcpCredentialProvider {
+                    credentials,
+                    url: url.clone(),
+                }))
+                .build()
+                .context(BuildObjectStoreSnafu { url })?;
+            Ok(Arc::new(store))
+        }
+        scheme => {
+            let scheme = scheme.to_string();
+            UnsupportedSchemeSnafu { url, scheme }.fail()
+        }
+    }
+}
+
+#[cfg(feature = "delta_lake")]
+mod delta {
+    use std::collections::HashMap;
+
+    use datafusion::config::TableParquetOptions;
+    use datafusion::datasource::TableProvider;
+    use datafusion::sql::TableReference;
+    use secrecy::{ExposeSecret, SecretString};
+    use snafu::prelude::*;
+    use tokio::runtime::Handle;
+
+    use super::*;
+    use crate::delta_lake::DeltaTable;
+    use crate::unity_catalog::UCTable;
+    use crate::unity_catalog::provider::UCTableProviderFactory;
+
+    /// Creates Delta Lake table providers whose object stores authenticate
+    /// with vended Unity Catalog credentials.
+    ///
+    /// Tables that cannot be vended (no table ID, unsupported storage scheme,
+    /// or the catalog denies vending) fall back to the static storage
+    /// credentials in `params`, with a warning.
+    pub struct VendedDeltaTableFactory {
+        client: Arc<UnityCatalog>,
+        params: HashMap<String, SecretString>,
+        io_runtime: Handle,
+        table_parquet_options: TableParquetOptions,
+    }
+
+    impl VendedDeltaTableFactory {
+        #[must_use]
+        pub fn new(
+            client: Arc<UnityCatalog>,
+            params: HashMap<String, SecretString>,
+            io_runtime: Handle,
+        ) -> Self {
+            Self {
+                client,
+                params,
+                io_runtime,
+                table_parquet_options: TableParquetOptions::default(),
+            }
+        }
+
+        #[must_use]
+        pub fn with_table_parquet_options(mut self, opts: TableParquetOptions) -> Self {
+            self.table_parquet_options = opts;
+            self
+        }
+
+        async fn vended_table_provider(
+            &self,
+            table: &UCTable,
+            delta_path: &str,
+        ) -> Result<Arc<dyn TableProvider>> {
+            let aws_region = self
+                .params
+                .get("aws_region")
+                .map(|s| s.expose_secret().to_string());
+
+            let delta = vended_delta_table(Arc::clone(&self.client), table, delta_path, aws_region)
+                .await?
+                .with_table_parquet_options(self.table_parquet_options.clone());
+
+            Ok(Arc::new(delta))
+        }
+    }
+
+    /// Builds a [`DeltaTable`] for a Unity Catalog table whose object store
+    /// authenticates with vended, refresh-aware credentials.
+    pub async fn vended_delta_table(
+        client: Arc<UnityCatalog>,
+        table: &UCTable,
+        delta_path: &str,
+        aws_region: Option<String>,
+    ) -> Result<DeltaTable> {
+        let table_id = table.table_id.as_deref().context(MissingTableIdSnafu {
+            table: table.full_name(),
+        })?;
+
+        let table_url = Url::parse(delta_path).context(InvalidStorageUrlSnafu {
+            url: delta_path.to_string(),
+        })?;
+
+        let credentials = Arc::new(VendedTableCredentials::new(
+            client,
+            table_id.to_string(),
+            TableOperation::Read,
+        ));
+
+        // Vend eagerly so a denial surfaces as a clear, direct error (and
+        // primes the cache) before any Delta log I/O is attempted.
+        credentials.get().await?;
+
+        let store = vended_object_store(&table_url, credentials, aws_region).await?;
+
+        DeltaTable::from_object_store(delta_path.to_string(), store).map_err(|e| {
+            Error::CreateDeltaTable {
+                url: delta_path.to_string(),
+                source: Box::new(e),
+            }
+        })
+    }
+
+    #[async_trait::async_trait]
+    impl UCTableProviderFactory for VendedDeltaTableFactory {
+        fn table_reference(&self, table: &UCTable) -> Option<TableReference> {
+            let storage_location = table.storage_location.as_deref()?;
+            // Don't append a trailing slash here — `DeltaTable::from` calls
+            // `ensure_folder_location` which already adds one when needed.
+            Some(TableReference::bare(storage_location.to_string()))
+        }
+
+        async fn table_provider(
+            &self,
+            table: &UCTable,
+            table_reference: TableReference,
+        ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+            let delta_path = table_reference.table().to_string();
+            match self.vended_table_provider(table, &delta_path).await {
+                Ok(provider) => Ok(provider),
+                Err(err) => {
+                    tracing::warn!(
+                        table = %table.full_name(),
+                        "Unable to use Unity Catalog credential vending for table; falling back to configured storage credentials: {err}"
+                    );
+                    let delta = DeltaTable::from(delta_path, self.params.clone(), &self.io_runtime)
+                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+                        .with_table_parquet_options(self.table_parquet_options.clone());
+                    Ok(Arc::new(delta))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "delta_lake")]
+pub use delta::{VendedDeltaTableFactory, vended_delta_table};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cached(expiration_time: i64, fetched_at_ms: i64) -> CachedCredentials {
+        CachedCredentials {
+            creds: TemporaryTableCredentials {
+                aws_temp_credentials: None,
+                azure_user_delegation_sas: None,
+                gcp_oauth_token: None,
+                r2_temp_credentials: None,
+                expiration_time,
+                url: None,
+            },
+            fetched_at_ms,
+        }
+    }
+
+    const MINUTE_MS: i64 = 60 * 1000;
+
+    #[test]
+    fn test_should_refresh_fresh_credentials() {
+        // Vended now, expires in 60 minutes: no refresh.
+        let cached = make_cached(60 * MINUTE_MS, 0);
+        assert!(!cached.should_refresh(MINUTE_MS));
+    }
+
+    #[test]
+    fn test_should_refresh_inside_margin() {
+        // Vended now, expires in 60 minutes: refresh once within 5 minutes of expiry.
+        let cached = make_cached(60 * MINUTE_MS, 0);
+        assert!(cached.should_refresh(56 * MINUTE_MS));
+    }
+
+    #[test]
+    fn test_should_refresh_expired() {
+        let cached = make_cached(60 * MINUTE_MS, 0);
+        assert!(cached.should_refresh(61 * MINUTE_MS));
+    }
+
+    #[test]
+    fn test_short_ttl_credentials_used_until_expiry() {
+        // Vended already inside the refresh margin (2-minute TTL): keep using
+        // them until they actually expire, instead of re-vending per request.
+        let cached = make_cached(2 * MINUTE_MS, 0);
+        assert!(!cached.should_refresh(MINUTE_MS));
+        assert!(cached.should_refresh(2 * MINUTE_MS));
+    }
+
+    #[test]
+    fn test_missing_expiration_uses_synthetic_ttl() {
+        let cached = make_cached(0, 10 * MINUTE_MS);
+        // Synthetic TTL is 15 minutes from fetch.
+        assert!(!cached.should_refresh(15 * MINUTE_MS));
+        assert!(cached.should_refresh(25 * MINUTE_MS));
+    }
+
+    mod vending {
+        use wiremock::matchers::{body_partial_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        use super::*;
+        use crate::unity_catalog::Endpoint;
+
+        fn vending_response(expiration_time: i64) -> serde_json::Value {
+            serde_json::json!({
+                "aws_temp_credentials": {
+                    "access_key_id": "AKIA123",
+                    "secret_access_key": "SECRET",
+                    "session_token": "TOKEN"
+                },
+                "expiration_time": expiration_time,
+                "url": "s3://bucket/path"
+            })
+        }
+
+        fn make_credentials(server: &MockServer) -> VendedTableCredentials {
+            let client =
+                UnityCatalog::new(Endpoint(server.uri()), None, None).expect("client should build");
+            VendedTableCredentials::new(
+                Arc::new(client),
+                "table-uuid-1".to_string(),
+                TableOperation::Read,
+            )
+        }
+
+        #[tokio::test]
+        async fn test_concurrent_gets_vend_once() {
+            let server = MockServer::start().await;
+            let expiration = now_millis() + 60 * MINUTE_MS;
+            Mock::given(method("POST"))
+                .and(path("/api/2.1/unity-catalog/temporary-table-credentials"))
+                .and(body_partial_json(serde_json::json!({
+                    "table_id": "table-uuid-1",
+                    "operation": "READ"
+                })))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(vending_response(expiration)),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let credentials = Arc::new(make_credentials(&server));
+
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    let credentials = Arc::clone(&credentials);
+                    tokio::spawn(async move { credentials.get().await })
+                })
+                .collect();
+            for handle in handles {
+                let creds = handle
+                    .await
+                    .expect("task should not panic")
+                    .expect("vending should succeed");
+                assert_eq!(creds.expiration_time, expiration);
+            }
+        }
+
+        #[tokio::test]
+        async fn test_expired_credentials_revend() {
+            let server = MockServer::start().await;
+            // First response is already expired, forcing the second get() to re-vend.
+            Mock::given(method("POST"))
+                .and(path("/api/2.1/unity-catalog/temporary-table-credentials"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(vending_response(now_millis() - MINUTE_MS)),
+                )
+                .expect(2)
+                .mount(&server)
+                .await;
+
+            let credentials = make_credentials(&server);
+            credentials.get().await.expect("first vend should succeed");
+            credentials.get().await.expect("second vend should succeed");
+        }
+
+        #[tokio::test]
+        async fn test_denied_vend_surfaces_remediation_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/api/2.1/unity-catalog/temporary-table-credentials"))
+                .respond_with(
+                    ResponseTemplate::new(403)
+                        .set_body_string("PERMISSION_DENIED: missing EXTERNAL USE SCHEMA"),
+                )
+                .mount(&server)
+                .await;
+
+            let credentials = make_credentials(&server);
+            let err = credentials
+                .get()
+                .await
+                .expect_err("403 should surface an error");
+            let message = err.to_string();
+            assert!(
+                message.contains("EXTERNAL USE SCHEMA"),
+                "error should carry remediation guidance, got: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_sas_token() {
+        let pairs = parse_sas_token("?sv=2024-01-01&sr=c&sig=abc%2Fdef%3D");
+        assert_eq!(
+            pairs,
+            vec![
+                ("sv".to_string(), "2024-01-01".to_string()),
+                ("sr".to_string(), "c".to_string()),
+                ("sig".to_string(), "abc/def=".to_string()),
+            ]
+        );
+
+        // Without leading '?'
+        let pairs = parse_sas_token("sv=2024&sig=xyz");
+        assert_eq!(
+            pairs,
+            vec![
+                ("sv".to_string(), "2024".to_string()),
+                ("sig".to_string(), "xyz".to_string()),
+            ]
+        );
+    }
+}

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -35,6 +35,61 @@ use crate::{Read, RefreshableCatalogProvider};
 
 use super::{CatalogId, Result, UCSchema, UCTable, UnityCatalog};
 
+/// Creates `DataFusion` table providers for Unity Catalog tables.
+///
+/// Unlike [`Read`], implementations receive the full [`UCTable`] so they can
+/// use table metadata beyond the storage location — e.g. the `table_id`
+/// needed for credential vending.
+#[async_trait]
+pub trait UCTableProviderFactory: Send + Sync {
+    /// The reference used to construct and identify the table.
+    ///
+    /// Returns `None` when the table cannot be materialized (e.g. it has no
+    /// storage location); such tables are skipped.
+    fn table_reference(&self, table: &UCTable) -> Option<TableReference>;
+
+    async fn table_provider(
+        &self,
+        table: &UCTable,
+        table_reference: TableReference,
+    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+/// Adapts an `(Arc<dyn Read>, table_reference_creator)` pair to
+/// [`UCTableProviderFactory`] for table creators that only need the table
+/// reference.
+pub struct ReadTableProviderFactory {
+    read: Arc<dyn Read>,
+    table_reference_creator: fn(&UCTable) -> Option<TableReference>,
+}
+
+impl ReadTableProviderFactory {
+    pub fn new(
+        read: Arc<dyn Read>,
+        table_reference_creator: fn(&UCTable) -> Option<TableReference>,
+    ) -> Self {
+        Self {
+            read,
+            table_reference_creator,
+        }
+    }
+}
+
+#[async_trait]
+impl UCTableProviderFactory for ReadTableProviderFactory {
+    fn table_reference(&self, table: &UCTable) -> Option<TableReference> {
+        (self.table_reference_creator)(table)
+    }
+
+    async fn table_provider(
+        &self,
+        _table: &UCTable,
+        table_reference: TableReference,
+    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+        self.read.table_provider(table_reference).await
+    }
+}
+
 #[derive(Debug)]
 pub struct UnityCatalogProvider {
     schemas: HashMap<String, Arc<UnityCatalogSchemaProvider>>,
@@ -44,8 +99,7 @@ impl UnityCatalogProvider {
     pub async fn try_new(
         client: Arc<UnityCatalog>,
         catalog_id: CatalogId,
-        table_creator: Arc<dyn Read>,
-        table_reference_creator: fn(&UCTable) -> Option<TableReference>,
+        table_creator: Arc<dyn UCTableProviderFactory>,
         include: Option<GlobSet>,
     ) -> Result<Self> {
         let schemas =
@@ -67,7 +121,6 @@ impl UnityCatalogProvider {
                 Arc::clone(&client),
                 &schema,
                 Arc::clone(&table_creator),
-                table_reference_creator,
                 include.clone(),
             )
             .await?;
@@ -122,9 +175,8 @@ pub struct UnityCatalogSchemaProvider {
     tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
     client: Arc<UnityCatalog>,
     schema: UCSchema,
-    table_reference_creator: fn(&UCTable) -> Option<TableReference>,
     include: Option<Arc<GlobSet>>,
-    table_creator: Arc<dyn Read>,
+    table_creator: Arc<dyn UCTableProviderFactory>,
 }
 
 impl std::fmt::Debug for UnityCatalogSchemaProvider {
@@ -145,8 +197,7 @@ impl UnityCatalogSchemaProvider {
     pub async fn try_new(
         client: Arc<UnityCatalog>,
         schema: &UCSchema,
-        table_creator: Arc<dyn Read>,
-        table_reference_creator: fn(&UCTable) -> Option<TableReference>,
+        table_creator: Arc<dyn UCTableProviderFactory>,
         include: Option<Arc<GlobSet>>,
     ) -> Result<Self> {
         let tables = client
@@ -169,7 +220,7 @@ impl UnityCatalogSchemaProvider {
                 continue;
             }
 
-            let Some(table_reference) = table_reference_creator(&table) else {
+            let Some(table_reference) = table_creator.table_reference(&table) else {
                 continue;
             };
 
@@ -238,7 +289,10 @@ impl UnityCatalogSchemaProvider {
         // Third pass: create table providers for permitted tables.
         let mut tables_map = HashMap::new();
         for (table, table_reference) in permission_results.into_iter().flatten() {
-            let table_provider = match table_creator.table_provider(table_reference.clone()).await {
+            let table_provider = match table_creator
+                .table_provider(&table, table_reference.clone())
+                .await
+            {
                 Ok(provider) => provider,
                 Err(source) => {
                     tracing::warn!("Couldn't get table provider for {table_reference}: {source}");
@@ -252,7 +306,6 @@ impl UnityCatalogSchemaProvider {
             tables: RwLock::new(tables_map),
             client,
             schema: schema.clone(),
-            table_reference_creator,
             include,
             table_creator,
         })
@@ -290,7 +343,6 @@ impl UnityCatalogSchemaProvider {
                 &self.schema,
                 &table,
                 Arc::clone(&self.table_creator),
-                self.table_reference_creator,
                 self.include.clone(),
                 Arc::clone(&self.client),
             )
@@ -343,8 +395,7 @@ impl UnityCatalogSchemaProvider {
     async fn provider_for_uc_table(
         schema: &UCSchema,
         table: &UCTable,
-        table_creator: Arc<dyn Read>,
-        table_reference_creator: fn(&UCTable) -> Option<TableReference>,
+        table_creator: Arc<dyn UCTableProviderFactory>,
         include: Option<Arc<GlobSet>>,
         client: Arc<UnityCatalog>,
     ) -> Option<Arc<dyn TableProvider>> {
@@ -358,7 +409,7 @@ impl UnityCatalogSchemaProvider {
         }
 
         let table_name = table.name.clone();
-        let table_reference = table_reference_creator(table)?;
+        let table_reference = table_creator.table_reference(table)?;
 
         let schema_with_table = format!("{}.{}", schema.name, table_name);
         tracing::debug!("Checking if table {} should be included", schema_with_table);
@@ -403,7 +454,10 @@ impl UnityCatalogSchemaProvider {
             );
         }
 
-        let table_provider = match table_creator.table_provider(table_reference.clone()).await {
+        let table_provider = match table_creator
+            .table_provider(table, table_reference.clone())
+            .await
+        {
             Ok(provider) => provider,
             Err(source) => {
                 tracing::warn!("Couldn't get table provider for {table_reference}: {source}");

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -36,7 +36,10 @@ use data_components::unity_catalog::CatalogId;
 use data_components::unity_catalog::Endpoint;
 use data_components::unity_catalog::UCTable;
 use data_components::unity_catalog::UnityCatalog as UnityCatalogClient;
-use data_components::unity_catalog::provider::UnityCatalogProvider;
+use data_components::unity_catalog::credential_vending::VendedDeltaTableFactory;
+use data_components::unity_catalog::provider::{
+    ReadTableProviderFactory, UCTableProviderFactory, UnityCatalogProvider,
+};
 use datafusion::sql::TableReference;
 use runtime_rate_control::RateController;
 use runtime_secrets::get_params_with_secrets;
@@ -77,6 +80,9 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("token")
         .secret()
         .description("The personal access token used to authenticate against the DataBricks API."),
+    ParameterSpec::component("credential_vending").description(
+        "When set to 'enabled' (requires 'mode' to be 'delta_lake'), short-lived storage credentials for each table are fetched from the Unity Catalog credential vending API instead of using static storage credentials. Defaults to 'disabled'.",
+    ),
     ParameterSpec::runtime("mode")
         .description("The execution mode for querying against Databricks.")
         .default("spark_connect"),
@@ -322,14 +328,44 @@ impl CatalogConnector for Databricks {
         let client = Arc::new(unity_catalog);
 
         let mode = self.params.get("mode").expose().ok();
-        let (table_creator, table_reference_creator) = if mode == Some("delta_lake") {
-            (
-                Arc::new(DeltaTableFactory::new(
+        let credential_vending = match params.get("credential_vending").expose().ok() {
+            Some("enabled") => true,
+            None | Some("disabled") => false,
+            Some(other) => {
+                return Err(super::Error::InvalidConfigurationNoSource {
+                    connector: "databricks".into(),
+                    message: format!(
+                        "Invalid value '{other}' for 'databricks_credential_vending'. Valid values: 'enabled', 'disabled'."
+                    ),
+                    connector_component: ConnectorComponent::from(catalog),
+                });
+            }
+        };
+        if credential_vending && mode != Some("delta_lake") {
+            return Err(super::Error::InvalidConfigurationNoSource {
+                connector: "databricks".into(),
+                message:
+                    "'databricks_credential_vending' is only supported when 'mode' is 'delta_lake'."
+                        .into(),
+                connector_component: ConnectorComponent::from(catalog),
+            });
+        }
+        let table_creator: Arc<dyn UCTableProviderFactory> = if mode == Some("delta_lake") {
+            if credential_vending {
+                Arc::new(VendedDeltaTableFactory::new(
+                    Arc::clone(&client),
                     params.to_secret_map(),
                     runtime.tokio_io_runtime(),
-                )) as Arc<dyn Read>,
-                table_reference_creator_delta_lake as fn(&UCTable) -> Option<TableReference>,
-            )
+                ))
+            } else {
+                Arc::new(ReadTableProviderFactory::new(
+                    Arc::new(DeltaTableFactory::new(
+                        params.to_secret_map(),
+                        runtime.tokio_io_runtime(),
+                    )) as Arc<dyn Read>,
+                    table_reference_creator_delta_lake,
+                ))
+            }
         } else if mode == Some("sql_warehouse") {
             let sql_warehouse_id = params.get("sql_warehouse_id").expose().ok_or_else(|p| {
                 super::Error::InvalidConfigurationNoSource {
@@ -375,10 +411,10 @@ impl CatalogConnector for Databricks {
                     connector_component: ConnectorComponent::from(catalog),
                 })?;
 
-            (
+            Arc::new(ReadTableProviderFactory::new(
                 Arc::new(read_provider) as Arc<dyn Read>,
-                table_reference_creator_spark as fn(&UCTable) -> Option<TableReference>,
-            )
+                table_reference_creator_spark,
+            ))
         } else {
             // Default to spark_connect
             let cluster_id = params.get("cluster_id").ok_or_else(|p| {
@@ -413,17 +449,16 @@ impl CatalogConnector for Databricks {
                 connector_component: ConnectorComponent::from(catalog),
             })?;
 
-            (
+            Arc::new(ReadTableProviderFactory::new(
                 Arc::new(read_provider) as Arc<dyn Read>,
-                table_reference_creator_spark as fn(&UCTable) -> Option<TableReference>,
-            )
+                table_reference_creator_spark,
+            ))
         };
 
         let catalog_provider = match UnityCatalogProvider::try_new(
             client,
             CatalogId(catalog_id),
             table_creator,
-            table_reference_creator,
             catalog.include.clone(),
         )
         .await
@@ -604,6 +639,7 @@ mod tests {
             data_source_format: "DELTA".to_string(),
             columns: vec![],
             storage_location: storage_location.map(ToString::to_string),
+            table_id: None,
         }
     }
 
@@ -728,6 +764,7 @@ mod tests {
             data_source_format: "PARQUET".to_string(),
             columns: vec![],
             storage_location: Some("s3://bucket/orders".to_string()),
+            table_id: None,
         };
         let reference =
             table_reference_creator_spark(&table).expect("spark creator should always return Some");

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -27,7 +27,10 @@ use data_components::RefreshableCatalogProvider;
 use data_components::delta_lake::DeltaTableFactory;
 use data_components::unity_catalog::UCTable;
 use data_components::unity_catalog::UnityCatalog as UnityCatalogClient;
-use data_components::unity_catalog::provider::UnityCatalogProvider;
+use data_components::unity_catalog::credential_vending::VendedDeltaTableFactory;
+use data_components::unity_catalog::provider::{
+    ReadTableProviderFactory, UCTableProviderFactory, UnityCatalogProvider,
+};
 use datafusion::sql::TableReference;
 use runtime_secrets::get_params_with_secrets;
 use secrecy::SecretString;
@@ -54,6 +57,9 @@ impl UnityCatalog {
 pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("token").secret().description(
         "The personal access token used to authenticate against the Unity Catalog API.",
+    ),
+    ParameterSpec::component("credential_vending").description(
+        "When set to 'enabled', short-lived storage credentials for each table are fetched from the Unity Catalog credential vending API instead of using static storage credentials. Defaults to 'disabled'.",
     ),
     // S3 storage options
     ParameterSpec::component("aws_region")
@@ -166,16 +172,40 @@ impl CatalogConnector for UnityCatalog {
             connector_component: ConnectorComponent::from(catalog),
         })?;
 
-        let delta_table_creator = Arc::new(DeltaTableFactory::new(
-            params.to_secret_map(),
-            runtime.tokio_io_runtime(),
-        )) as Arc<dyn Read>;
+        let credential_vending = match params.get("credential_vending").expose().ok() {
+            Some("enabled") => true,
+            None | Some("disabled") => false,
+            Some(other) => {
+                return Err(super::Error::InvalidConfigurationNoSource {
+                    connector: "unity_catalog".into(),
+                    message: format!(
+                        "Invalid value '{other}' for 'unity_catalog_credential_vending'. Valid values: 'enabled', 'disabled'."
+                    ),
+                    connector_component: ConnectorComponent::from(catalog),
+                });
+            }
+        };
+
+        let table_creator: Arc<dyn UCTableProviderFactory> = if credential_vending {
+            Arc::new(VendedDeltaTableFactory::new(
+                Arc::clone(&client),
+                params.to_secret_map(),
+                runtime.tokio_io_runtime(),
+            ))
+        } else {
+            Arc::new(ReadTableProviderFactory::new(
+                Arc::new(DeltaTableFactory::new(
+                    params.to_secret_map(),
+                    runtime.tokio_io_runtime(),
+                )) as Arc<dyn Read>,
+                table_reference_creator,
+            ))
+        };
 
         let catalog_provider = match UnityCatalogProvider::try_new(
             client,
             catalog_id,
-            delta_table_creator,
-            table_reference_creator,
+            table_creator,
             catalog.include.clone(),
         )
         .await
@@ -217,6 +247,7 @@ mod tests {
             data_source_format: "DELTA".to_string(),
             columns: vec![],
             storage_location: storage_location.map(ToString::to_string),
+            table_id: None,
         }
     }
 


### PR DESCRIPTION
## 📝 Summary

Adds support for **Unity Catalog credential vending**: the `unity_catalog` and `databricks` (delta mode) connectors can fetch short-lived, downscoped, per-table storage credentials from the Unity Catalog [`temporary-table-credentials`](https://docs.databricks.com/api/workspace/temporarytablecredentials) API instead of requiring static S3/Azure/GCS credentials in the spicepod. Works with both Databricks Unity Catalog and OSS Unity Catalog.

```yaml
catalogs:
  - from: unity_catalog:https://<host>/api/2.1/unity-catalog/catalogs/my_catalog
    name: uc
    params:
      unity_catalog_token: ${secrets:UC_TOKEN}
      unity_catalog_credential_vending: enabled   # no aws_* / azure_* / google_* needed

  - from: databricks:my_catalog
    name: dbx
    params:
      mode: delta_lake
      databricks_endpoint: ${secrets:DATABRICKS_ENDPOINT}
      databricks_token: ${secrets:DATABRICKS_TOKEN}
      databricks_credential_vending: enabled
```

Also supported for single `databricks` datasets in `delta_lake` mode.

### How it works

- New `UnityCatalog::temporary_table_credentials(table_id, READ)` client call (rate-controlled, retried), with actionable errors for denial (external data access / `EXTERNAL USE SCHEMA` / table eligibility).
- `VendedTableCredentials` caches one table's vended credentials and re-vends **5 minutes before expiry** with single-flight refresh. Per-cloud `object_store::CredentialProvider` implementations (AWS, Azure SAS, GCS OAuth) wrap the cache — `object_store` consults the provider on every request, so refreshed credentials apply transparently mid-query and for the entire table-provider lifetime. The scan path reuses the engine's object store, so both Delta log replay and parquet reads use vended credentials.
- The vending response carries no AWS region; it is resolved from the `aws_region` param → `AWS_REGION`/`AWS_DEFAULT_REGION` env → unauthenticated `HeadBucket` lookup.
- Vend failures (missing table ID, unsupported scheme, catalog denial) log a warning and **fall back to the configured static storage credentials**, so mixed catalogs keep working.
- Plumbing: `UnityCatalogProvider` now takes a `UCTableProviderFactory` trait object (receives the full `UCTable`, including the `table_id` needed for vending) instead of the previous `(Arc<dyn Read>, table_reference_creator fn)` pair; existing spark / SQL-warehouse paths are adapted mechanically via `ReadTableProviderFactory`.

### Limitations

- Cloudflare R2 vending responses are not yet supported (S3/Azure/GCS only).
- **Distributed (cluster) execution**: executors build object stores from static storage params encoded at registration; vended credentials live only in the head node's table provider. Enabling vending in a cluster deployment logs a warning and executors use static credentials. Executor-side vending is a follow-up.
- Enabling `databricks_credential_vending` with a mode other than `delta_lake` is rejected with a configuration error.

## 🚨 Breaking Changes

None. `UnityCatalogProvider::try_new`'s signature changed (crate-internal API).

## 📚 Docs

Needs a docs update for the new `unity_catalog_credential_vending` / `databricks_credential_vending` params and the Databricks-side prerequisites (metastore external data access, `EXTERNAL USE SCHEMA`). Will follow up in spiceai/docs.

## 👀 Notes for Reviewers

- The refresh margin guard: credentials vended with a TTL already inside the 5-minute margin are used until true expiry instead of re-vending per request (see `CachedCredentials::should_refresh` tests).
- Vending is exercised in unit tests with wiremock (single-flight vend, expiry re-vend, 403 remediation message).
- **Validated end-to-end against a live Databricks workspace** (`databricks` catalog, `mode: delta_lake`, `databricks_credential_vending: enabled`, no static storage credentials, S3-backed managed tables):
  - exactly one vend per table at registration; queries (counts + joins) return correct results; repeated queries reuse cached credentials (no per-query vend)
  - S3 region resolved via the `HeadBucket` fallback (no `aws_region`/`AWS_REGION` provided)
  - negative path: with `EXTERNAL USE SCHEMA` revoked, each table logs the remediation warning (metastore external data access / `EXTERNAL USE SCHEMA`) including the catalog's `PERMISSION_DENIED` detail, then falls back to static credentials
- `TemporaryTableCredentials` has a manual `Debug` impl so credential material can never reach logs.
