### PR TITLE
feat(testoperator): add xlarge runner support; use it for chbench SF10+

### DIFF
--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -46,15 +46,16 @@ on:
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true
-        default: '60'
+        default: '300'
         type: string
       runner_type:
         description: 'Runner type'
         required: true
-        default: 'spiceai-dev-large-runners'
+        default: 'spiceai-dev-xlarge-runners'
         type: choice
         options:
           - 'spiceai-dev-large-runners'
+          - 'spiceai-dev-xlarge-runners'
 jobs:
   run-htap:
     name: Run CH-BenCHmark

--- a/test/spicepods/chbench/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-arrow.yaml
@@ -10,6 +10,13 @@ postgres_connection_params: &postgres_params
   pg_pass: bench
   pg_sslmode: disable
 
+runtime:
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-keymode.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-keymode.yaml
@@ -14,6 +14,11 @@ runtime:
   query:
     memory_limit: 40GiB
     target_partitions: 32
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
 
 postgres_connection_params: &postgres_params
   pg_host: 127.0.0.1

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
@@ -2,30 +2,31 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned
 
+# Target: xlarger-runner — 64 vCPU / 256 GiB RAM, SSD storage.
+#
+# Key tuning:
+#   - cdc_max_coalesced_envelopes 4096 (runtime max): larger CDC batches cut metastore round-trips.
+#   - target_partitions 64: read-path parallelism matched to vCPU count.
+#   - per-table cayenne_write_concurrency / segment_cache_mb / compaction_* for the high-volume
+#     upsert tables; reference tables use lighter settings.
 runtime:
   params:
     cdc_prefetch_buffer: '1024'
-    # 4096 = the runtime max (changes.rs:CDC_MAX_COALESCED_ENVELOPES_MAX). 8192
-    # was silently rejected and fell back to the default 256 — ~16x smaller CDC
-    # batches, multiplying the per-batch apply_on_conflict_deletions O(N)
-    # deletion-index clone and starving WAL drain under bursty OLTP.
     cdc_max_coalesced_envelopes: '4096'
     cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '4000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
-    cayenne_footer_cache_mb: '256'
+    cayenne_footer_cache_mb: '1024'
+    cayenne_metastore_cache_mb: '1024'
+    cayenne_metastore_mmap_mb: '4096'
   query:
-    # No memory_limit set on purpose — spiced auto-detects the budget from the
-    # cgroup/host memory cap and sizes the DataFusion pool to a safe fraction of
-    # it. Auto-detection is the right default here: it tracks the deployment's
-    # actual memory and inherently leaves headroom for the off-pool Vortex encode
-    # buffers + segment/footer caches that a fixed `memory_limit` would not count.
-    #
-    # Read-path scan/join parallelism = 2x the 16 logical cores. Does NOT raise the
-    # write/compaction shard count (parallel encode is CPU-bound and ceilings at
-    # the core count); per-table write fan-out is set via `cayenne_write_concurrency`.
-    target_partitions: 32
+    target_partitions: 64
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
 
 postgres_connection_params: &postgres_params
   pg_host: 127.0.0.1
@@ -58,14 +59,11 @@ datasets:
       params: &accel_high_volume
         cayenne_metastore: sqlite
         cayenne_file_path: .spice/cayenne/district
-        # 8-way parallel encode = half the 16 cores: leaves ~half for OLAP during
-        # an ingest burst (16-way encode would pin every core and cause the 80-90s
-        # single-query latency outliers). Compaction no longer competes here — it
-        # is now pinned to a single output shard. Raise toward the core count on
-        # larger hosts.
-        cayenne_write_concurrency: '8'
+        cayenne_write_concurrency: '4'
         cayenne_segment_cache_mb: '1024'
         cayenne_compaction_trigger_protected_snapshots: '3'
+        # Pinned to 4 GiB: on a 256 GiB host the memory-aware auto-default reaches the 8 GiB ceiling, which over-sizes the exact keyset for high-update tables.
+        cayenne_pk_keyset_cache_mb: '4096'
         cayenne_compaction_trigger_snapshot_age_ms: '15000'
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
@@ -146,10 +144,7 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        # 8 to match the HTAP budget (was 32, which a 16-core host clamped to 16
-        # anyway). order_line is the heaviest compactor, so capping its fan-out
-        # matters most for query latency. See the accel_high_volume note.
-        cayenne_write_concurrency: '8'
+        cayenne_write_concurrency: '4'
         cayenne_target_file_size_mb: '256'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned.yaml
@@ -2,7 +2,7 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned
 
-# Target: xlarger-runner — 64 vCPU / 256 GiB RAM, SSD storage.
+# Target: xlarge-runner — 64 vCPU / 256 GiB RAM, SSD storage.
 #
 # Key tuning:
 #   - cdc_max_coalesced_envelopes 4096 (runtime max): larger CDC batches cut metastore round-trips.

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
@@ -10,6 +10,13 @@ postgres_connection_params: &postgres_params
   pg_pass: bench
   pg_sslmode: disable
 
+runtime:
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
@@ -11,12 +11,6 @@ postgres_connection_params: &postgres_params
   pg_sslmode: disable
 
 runtime:
-  params:
-    cdc_prefetch_buffer: '1024'
-    cdc_max_coalesced_envelopes: '4096'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
-    cdc_max_coalesce_age_ms: '4000'
-    cdc_commit_timeout_ms: '60000'
   caching:
     sql_results:
       enabled: false

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
@@ -11,6 +11,12 @@ postgres_connection_params: &postgres_params
   pg_sslmode: disable
 
 runtime:
+  params:
+    cdc_prefetch_buffer: '1024'
+    cdc_max_coalesced_envelopes: '4096'
+    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesce_age_ms: '4000'
+    cdc_commit_timeout_ms: '60000'
   caching:
     sql_results:
       enabled: false

--- a/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
@@ -10,6 +10,13 @@ postgres_connection_params: &postgres_params
   pg_pass: bench
   pg_sslmode: disable
 
+runtime:
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
 

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-arrow.yaml
@@ -5,3 +5,4 @@ tests:
     scale_factor: 1
     duration: 600
     ready_wait: 60
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-tuned.yaml
@@ -5,3 +5,4 @@ tests:
     scale_factor: 1
     duration: 600
     ready_wait: 60
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
@@ -5,3 +5,4 @@ tests:
     scale_factor: 1
     duration: 600
     ready_wait: 60
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
@@ -6,3 +6,4 @@ tests:
     duration: 600
     ready_wait: 60
     query_overrides: duckdb
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
@@ -5,3 +5,4 @@ tests:
     scale_factor: 10
     duration: 600
     ready_wait: 300
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-arrow.yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
     duration: 600
     ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
@@ -5,3 +5,4 @@ tests:
     scale_factor: 10
     duration: 600
     ready_wait: 300
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
     duration: 600
     ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
     duration: 600
     ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
@@ -5,3 +5,4 @@ tests:
     scale_factor: 10
     duration: 600
     ready_wait: 300
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
@@ -6,3 +6,4 @@ tests:
     duration: 600
     ready_wait: 300
     query_overrides: duckdb
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
     duration: 600
     ready_wait: 300

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
@@ -6,3 +6,4 @@ tests:
     terminals: 100
     duration: 600
     ready_wait: 600
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
@@ -6,3 +6,4 @@ tests:
     terminals: 100
     duration: 600
     ready_wait: 600
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
@@ -7,3 +7,4 @@ tests:
     duration: 600
     ready_wait: 600
     query_overrides: duckdb
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned.yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -6,3 +6,4 @@ tests:
     terminals: 100
     duration: 600
     ready_wait: 600
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-large-runners
+    runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -7,3 +7,4 @@ tests:
     duration: 600
     ready_wait: 600
     query_overrides: duckdb
+    rate: 5000

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -304,6 +304,8 @@ pub enum RunnerType {
     Dev,
     #[serde(rename = "spiceai-dev-large-runners")]
     DevLarge,
+    #[serde(rename = "spiceai-dev-xlarge-runners")]
+    DevXLarge,
 }
 
 /// Payload sent to the GitHub Actions workflow request. Should match inputs in `.github/workflows/testoperator_run_texttosql.yml`.
@@ -692,5 +694,30 @@ tests:
             serialized.get("terminals").is_none(),
             "terminals should be omitted when None"
         );
+    }
+
+    #[test]
+    fn test_xlarge_runner_type_round_trip() {
+        let yaml = "
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file].yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 10
+    duration: 600
+    ready_wait: 300
+";
+
+        let test_file: DispatchTestFile = yaml::from_str(yaml).expect("Failed to deserialize");
+
+        assert!(matches!(
+            test_file.tests.htap[0].runner_type,
+            RunnerType::DevXLarge
+        ));
+
+        // Verify it serializes back to the expected workflow input value
+        let serialized =
+            serde_json::to_value(&test_file.tests.htap[0]).expect("Failed to serialize");
+        assert_eq!(serialized["runner_type"], "spiceai-dev-xlarge-runners");
     }
 }


### PR DESCRIPTION
## 📝 Summary

- Add `spiceai-dev-xlarge-runners` as a `RunnerType` variant in testoperator dispatch
- Switch CH-BenCHmark (HTAP) dispatch configs at SF10 and higher to the xlarge runner; SF1 stays on large
- Update configs to disable sql results cache and task history
- Update dispatch configs to limit OLTP transaction generation rate to `5000` `txn/s` (~135k tpmC )
- Update `postgres-cayenne[file]-cdc-tune` config to better match `xlarge-runners` hardware configuration

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
