### PR TITLE
fix(deps): update hickory-resolver to 0.26 (evicts hickory-proto 0.25.x)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=4af854228e9f503bbaf6858fb76a9f4fcdcf091c#4af854228e9f503bbaf6858fb76a9f4fcdcf091c"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=4547bee1b5ab39b4b825f0c44c6026533c1f08c5#4547bee1b5ab39b4b825f0c44c6026533c1f08c5"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -6291,7 +6291,7 @@ dependencies = [
  "fundu",
  "futures",
  "geo-types",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "itertools 0.14.0",
  "mongodb",
  "mysql_async",
@@ -9001,36 +9001,11 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "idna",
  "ipnet",
  "jni",
  "rand 0.10.1",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -9060,27 +9035,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot 0.12.5",
- "rand 0.9.4",
- "resolv-conf",
- "smallvec 1.15.1",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -9088,7 +9042,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni",
@@ -11875,8 +11829,8 @@ dependencies = [
  "futures-util",
  "hex",
  "hickory-net",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
+ "hickory-proto",
+ "hickory-resolver",
  "hmac 0.12.1",
  "macro_magic",
  "md-5 0.10.6",
@@ -12349,7 +12303,7 @@ dependencies = [
 name = "ns_lookup"
 version = "2.0.0-unstable"
 dependencies = [
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "snafu",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,7 +428,7 @@ datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.g
 datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                    # spiceai-52.5
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "06e4b624c6073c40c7b2127ce620e281ec1979ae" }                # spiceai-52.5
 
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4af854228e9f503bbaf6858fb76a9f4fcdcf091c" } # spiceai-52
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4547bee1b5ab39b4b825f0c44c6026533c1f08c5" } # spiceai-52
 
 ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" }      # spiceai-52.5
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "07be66a8efff7e20c2abadaaba6ef62b02fc1ffc" } # spiceai-52.5

--- a/crates/ns_lookup/Cargo.toml
+++ b/crates/ns_lookup/Cargo.toml
@@ -12,5 +12,5 @@ version.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-hickory-resolver = "0.25.2"
+hickory-resolver = "0.26"
 url.workspace = true

--- a/crates/ns_lookup/Cargo.toml
+++ b/crates/ns_lookup/Cargo.toml
@@ -12,5 +12,5 @@ version.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-hickory-resolver = "0.26"
+hickory-resolver = "0.26.1"
 url.workspace = true

--- a/crates/ns_lookup/src/lib.rs
+++ b/crates/ns_lookup/src/lib.rs
@@ -90,7 +90,11 @@ pub async fn verify_ns_lookup_and_tcp_connect(host: &str, port: u16) -> Result<(
             host: host.to_string(),
             port,
         })?
-        .build();
+        .build()
+        .map_err(|_| Error::UnableToConnect {
+            host: host.to_string(),
+            port,
+        })?;
     match resolver.lookup_ip(host).await {
         Ok(ips) => {
             for ip in ips.iter() {

--- a/crates/ns_lookup/src/lib.rs
+++ b/crates/ns_lookup/src/lib.rs
@@ -91,9 +91,12 @@ pub async fn verify_ns_lookup_and_tcp_connect(host: &str, port: u16) -> Result<(
             port,
         })?
         .build()
-        .map_err(|_| Error::UnableToConnect {
-            host: host.to_string(),
-            port,
+        .map_err(|err| {
+            tracing::debug!("Failed to build DNS resolver: {err}");
+            Error::UnableToConnect {
+                host: host.to_string(),
+                port,
+            }
         })?;
     match resolver.lookup_ip(host).await {
         Ok(ips) => {


### PR DESCRIPTION
Evicts every `hickory-proto`/`hickory-resolver` 0.25.x copy from `Cargo.lock`, resolving two security advisories:

- **GHSA-3v94-mw7p-v465** (HIGH) — NSEC3 closest-encloser proof validation infinite loop / memory exhaustion in `hickory-proto` 0.25.0-alpha.3–0.25.2. No patched 0.25.x exists: the affected code moved to `hickory-net`, fixed in 0.26.1, so the remediation is moving consumers to the 0.26 line.
- **GHSA-q2qq-hmj6-3wpp** (MEDIUM) — name-compression CPU amplification in `hickory-proto` ≤ 0.26.0, fixed in 0.26.1.

Both 0.25.2 parents are addressed:

1. `crates/ns_lookup`: `hickory-resolver` `0.25.2` → `0.26`. In 0.26, `ResolverBuilder::build()` returns `Result`; the error is mapped to the existing `UnableToConnect` path (same shape as the `builder_tokio()` error handling above it).
2. `datafusion-table-providers` (`spiceai-52` branch) rev pin: `4af8542` → `4547bee`, picking up datafusion-contrib/datafusion-table-providers#662 — the same `hickory-resolver` 0.26 bump ported to `spiceai-52` (one-commit delta, no other changes).

After this, `Cargo.lock` contains only `hickory-{proto,resolver,net} 0.26.1` (mongodb 3.7.0 was already on 0.26).

Validation: `cargo check -p ns_lookup` and `cargo clippy -p ns_lookup --all-features` pass; lock diff is scoped to the hickory family + the d-t-p rev.
