### PR TITLE
ci(docker): fix make_latest gate so 'Set as latest release' triggers spiced_docker

### DIFF
--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -68,7 +68,7 @@ jobs:
           github.event.action == 'edited'
           && !github.event.release.draft
           && github.event.changes.make_latest
-          && github.event.changes.make_latest.to == 'true'
+          && github.event.changes.make_latest.to == true
         )
       }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Marking a release as **latest** is supposed to trigger `spiced_docker` (per the endgame checklist), but the `release.edited` gate compared the **boolean** webhook field `github.event.changes.make_latest.to` against the **string** `'true'`. In Actions expressions, boolean-vs-string comparison coerces both operands to numbers (`true`→1, `'true'`→NaN), so the condition was always false — the branch was dead code.

Observed on v2.0.0: flipping the release to latest produced a skipped run ([27023783393](https://github.com/spiceai/spiceai/actions/runs/27023783393)); images had to be published via `workflow_dispatch` instead ([27024245715](https://github.com/spiceai/spiceai/actions/runs/27024245715)).

**Fix:** compare against the boolean literal: `== true`.

One-line change; no behavior change for the `published` (rc-tag) branch or `workflow_dispatch` path.