### PR TITLE
perf(cayenne): plain-fsync ordering tier on the staged-commit hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,7 @@ dependencies = [
  "axum",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-core",
  "futures-util",
  "headers",
@@ -2167,6 +2168,9 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
+ "serde_core",
+ "serde_html_form",
+ "serde_path_to_error",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -17389,6 +17393,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,7 @@ dependencies = [
  "hash-index",
  "im",
  "insta",
+ "libc",
  "object_store",
  "parking_lot 0.12.5",
  "paste",

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -67,6 +67,13 @@ aegis = { version = "0.9.3", default-features = false, features = [
     "pure-rust",
 ] }
 
+# Ordering-tier fsync on the staged-commit hot path (provider/fsync_tier.rs):
+# on macOS both std `sync_all` AND `sync_data` are fcntl(F_FULLFSYNC) (~4-5 ms
+# per call, measured), so the plain-fsync ordering tier needs a direct
+# libc::fsync. See the module docs for the durability rationale.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [features]
 default = []
 turso = ["dep:turso"]

--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -194,120 +194,152 @@ impl<'a> DeletionVectorWriter<'a> {
         &self,
         specs: Vec<DeletionVectorWriteSpec>,
     ) -> Result<Vec<DeletionVectorWriteResult>> {
-        let mut results = Vec::with_capacity(specs.len());
+        let specs: Vec<DeletionVectorWriteSpec> =
+            specs.into_iter().filter(|spec| !spec.is_empty()).collect();
+        if specs.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        for spec in specs {
-            if spec.is_empty() {
-                continue;
+        let deletion_dir = self.table_snapshot_deletion_dir();
+        let snapshot_dir = deletion_dir
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| Error::Internal {
+                table: self.table.path.clone(),
+                message: format!(
+                    "Deletion vector directory '{}' has no snapshot parent",
+                    deletion_dir.display()
+                ),
+            })?;
+
+        // Ensure the deletions/ subdirectory exists (once per call — it was
+        // previously re-checked per spec, a no-op after the first).
+        // If we just created it, sync its parent (the snapshot directory)
+        // so the subdir entry is durable on local FS.
+        //
+        // This is required for the same contract we now enforce for
+        // snapshot directories themselves (ensure_snapshot_dir_exists)
+        // and for the _partitioned_wal/ coordination directory:
+        // on POSIX, mkdir in a directory updates the parent's metadata.
+        // A crash immediately after this create_dir_all but before the
+        // subsequent file write + file fsync + catalog record could
+        // otherwise leave a catalog entry pointing at a deletions/
+        // directory whose creation was lost.
+        //
+        // The sync is one-time per snapshot (first deletion vector
+        // written to it). Subsequent deletions reuse the directory.
+        let sync_snapshot_parent = match tokio::fs::create_dir(&deletion_dir).await {
+            Ok(()) => true,
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => false,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                tokio::fs::create_dir_all(&deletion_dir).await?;
+                true
             }
+            Err(source) => return Err(Error::IoError { source }),
+        };
+        if sync_snapshot_parent {
+            let table = self.table.path.clone();
+            // Directory ordering tier (plain fsync on macOS, full fsync
+            // on other platforms) — see `provider/fsync_tier.rs`.
+            tokio::task::spawn_blocking(move || {
+                let dir = std::fs::File::open(&snapshot_dir)?;
+                crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+            })
+            .await
+            .map_err(|source| Error::TaskPanicked { table, source })??;
+        }
 
-            let deletion_dir = self.table_snapshot_deletion_dir();
-            let snapshot_dir = deletion_dir
-                .parent()
-                .map(Path::to_path_buf)
-                .ok_or_else(|| Error::Internal {
-                    table: self.table.path.clone(),
-                    message: format!(
-                        "Deletion vector directory '{}' has no snapshot parent",
-                        deletion_dir.display()
-                    ),
-                })?;
-
-            // Ensure the deletions/ subdirectory exists.
-            // If we just created it, sync its parent (the snapshot directory)
-            // so the subdir entry is durable on local FS.
-            //
-            // This is required for the same contract we now enforce for
-            // snapshot directories themselves (ensure_snapshot_dir_exists)
-            // and for the _partitioned_wal/ coordination directory:
-            // on POSIX, mkdir in a directory updates the parent's metadata.
-            // A crash immediately after this create_dir_all but before the
-            // subsequent file write + file fsync + catalog record could
-            // otherwise leave a catalog entry pointing at a deletions/
-            // directory whose creation was lost.
-            //
-            // The sync is one-time per snapshot (first deletion vector
-            // written to it). Subsequent deletions reuse the directory.
-            let sync_snapshot_parent = match tokio::fs::create_dir(&deletion_dir).await {
-                Ok(()) => true,
-                Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => false,
-                Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                    tokio::fs::create_dir_all(&deletion_dir).await?;
-                    true
-                }
-                Err(source) => return Err(Error::IoError { source }),
-            };
-            if sync_snapshot_parent {
-                let table = self.table.path.clone();
-                // Directory ordering tier (plain fsync on macOS, full fsync
-                // on other platforms) — see `provider/fsync_tier.rs`.
-                tokio::task::spawn_blocking(move || {
-                    let dir = std::fs::File::open(&snapshot_dir)?;
-                    crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
-                })
-                .await
-                .map_err(|source| Error::TaskPanicked { table, source })??;
-            }
-
+        // Write every spec's deletion-vector file CONCURRENTLY. The files are
+        // independent (one per spec, UUIDv7 filenames), so their writes + file
+        // fsyncs overlap on the blocking pool — on network-attached storage
+        // (EBS) this turns N serialized ~1 ms fsync round-trips into ~1 round
+        // of in-flight barriers. `try_join_all` preserves spec order in the
+        // returned results.
+        let write_futures = specs.into_iter().map(|spec| {
             let file_path = Self::deletion_file_path(&deletion_dir);
-
-            let (batch, schema, count, identifiers, source_data_file_path) = match spec.identifiers
-            {
-                DeletionIdentifier::PositionBased {
-                    file_path: source_file,
-                    mut row_ids,
-                    pre_sorted,
-                } => {
-                    if pre_sorted {
-                        debug_assert!(
-                            row_ids.windows(2).all(|w| w[0] < w[1]),
-                            "pre_sorted=true but row_ids is not strictly increasing",
-                        );
-                    } else {
-                        row_ids.sort_unstable();
-                        row_ids.dedup();
-                    }
-                    let count = row_ids.len();
-                    let schema = position_based_deletion_schema();
-                    let batch = build_position_based_batch(&schema, &row_ids)?;
-                    (
-                        batch,
-                        schema,
-                        count,
+            let table_name = self.table.table_name.clone();
+            async move {
+                let (batch, schema, count, identifiers, source_data_file_path) =
+                    match spec.identifiers {
                         DeletionIdentifier::PositionBased {
-                            file_path: source_file.clone(),
-                            row_ids,
+                            file_path: source_file,
+                            mut row_ids,
                             pre_sorted,
-                        },
-                        Some(source_file),
-                    )
-                }
-                DeletionIdentifier::KeyBased(mut row_keys) => {
-                    // Sort and deduplicate keys
-                    row_keys.sort();
-                    row_keys.dedup();
-                    let count = row_keys.len();
-                    let schema = key_based_deletion_schema();
-                    let batch = build_key_based_batch(&schema, &row_keys)?;
-                    (
-                        batch,
-                        schema,
-                        count,
-                        DeletionIdentifier::KeyBased(row_keys),
-                        None,
-                    )
-                }
-            };
+                        } => {
+                            if pre_sorted {
+                                debug_assert!(
+                                    row_ids.windows(2).all(|w| w[0] < w[1]),
+                                    "pre_sorted=true but row_ids is not strictly increasing",
+                                );
+                            } else {
+                                row_ids.sort_unstable();
+                                row_ids.dedup();
+                            }
+                            let count = row_ids.len();
+                            let schema = position_based_deletion_schema();
+                            let batch = build_position_based_batch(&schema, &row_ids)?;
+                            (
+                                batch,
+                                schema,
+                                count,
+                                DeletionIdentifier::PositionBased {
+                                    file_path: source_file.clone(),
+                                    row_ids,
+                                    pre_sorted,
+                                },
+                                Some(source_file),
+                            )
+                        }
+                        DeletionIdentifier::KeyBased(mut row_keys) => {
+                            // Sort and deduplicate keys
+                            row_keys.sort();
+                            row_keys.dedup();
+                            let count = row_keys.len();
+                            let schema = key_based_deletion_schema();
+                            let batch = build_key_based_batch(&schema, &row_keys)?;
+                            (
+                                batch,
+                                schema,
+                                count,
+                                DeletionIdentifier::KeyBased(row_keys),
+                                None,
+                            )
+                        }
+                    };
 
-            let file_size_bytes = write_deletion_file(
-                &file_path,
-                Arc::clone(&schema),
-                batch,
-                &self.table.table_name,
-            )
-            .await?;
+                let file_size_bytes =
+                    write_deletion_file(&file_path, Arc::clone(&schema), batch, &table_name)
+                        .await?;
 
-            // Determine deletion type from identifiers
+                Ok::<_, Error>((
+                    file_path,
+                    count,
+                    file_size_bytes,
+                    identifiers,
+                    source_data_file_path,
+                ))
+            }
+        });
+        let written = futures::future::try_join_all(write_futures).await?;
+
+        // ONE coalesced deletions/-dir sync for the whole batch of files
+        // (replaces the previous per-file parent-dir fsync): a directory fsync
+        // flushes ALL of its pending entries, so syncing once after every file
+        // exists provides the same dirent durability at 1/N the barrier count.
+        // Must complete before the catalog records any of the paths.
+        {
+            let table = self.table.path.clone();
+            let deletion_dir_for_sync = deletion_dir.clone();
+            tokio::task::spawn_blocking(move || {
+                let dir = std::fs::File::open(&deletion_dir_for_sync)?;
+                crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+            })
+            .await
+            .map_err(|source| Error::TaskPanicked { table, source })??;
+        }
+
+        let mut results = Vec::with_capacity(written.len());
+        for (file_path, count, file_size_bytes, identifiers, source_data_file_path) in written {
             let deletion_type = match &identifiers {
                 DeletionIdentifier::PositionBased { .. } => DeletionType::PositionBased,
                 DeletionIdentifier::KeyBased(_) => DeletionType::KeyBased,
@@ -573,11 +605,12 @@ async fn write_deletion_file(
         //    previous revision also re-opened the file to fsync it a second
         //    time — that reopen+fsync was redundant work on every delete and
         //    has been removed.
-        // 3. fsync the parent directory so the new directory entry is written
-        //    through before the catalog records the path — without this, the
-        //    catalog can record a delete file path that fails to resolve
-        //    after a crash because the file's inode is on disk but the dirent
-        //    isn't.
+        //
+        // The parent-directory fsync (so the new dirent is written through
+        // before the catalog records the path) is NOT done here: the caller
+        // (`DeletionVectorWriter::write`) writes all of a batch's deletion
+        // files concurrently and issues ONE coalesced deletions/-dir sync
+        // after they complete — same dirent durability, 1/N the barriers.
         let file = std::fs::File::create(&output_path)?;
         let mut writer = FileWriter::try_new(file, &schema)?;
         writer.write(&batch)?;
@@ -587,16 +620,6 @@ async fn write_deletion_file(
         drop(inner);
 
         let metadata = std::fs::metadata(&output_path)?;
-
-        // Best-effort parent-dir fsync (ordering tier). Matches the
-        // partitioned_wal / staging_wal write patterns: a failure here is
-        // unusual and logged by the caller; the deletion file's content is
-        // already durable regardless.
-        if let Some(parent) = output_path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = crate::provider::fsync_tier::ordering_sync_dir_std(&dir);
-        }
 
         Ok(metadata.len())
     })

--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -239,9 +239,14 @@ impl<'a> DeletionVectorWriter<'a> {
             };
             if sync_snapshot_parent {
                 let table = self.table.path.clone();
-                tokio::task::spawn_blocking(move || std::fs::File::open(&snapshot_dir)?.sync_all())
-                    .await
-                    .map_err(|source| Error::TaskPanicked { table, source })??;
+                // Ordering tier (plain fsync on macOS, fdatasync on Linux) —
+                // see `provider/fsync_tier.rs`.
+                tokio::task::spawn_blocking(move || {
+                    let dir = std::fs::File::open(&snapshot_dir)?;
+                    crate::provider::fsync_tier::ordering_sync_std(&dir)
+                })
+                .await
+                .map_err(|source| Error::TaskPanicked { table, source })??;
             }
 
             let file_path = Self::deletion_file_path(&deletion_dir);
@@ -559,32 +564,38 @@ async fn write_deletion_file(
         //
         // 1. Stream Arrow IPC into the file.
         // 2. Recover the underlying std::fs::File from the writer and fsync
-        //    its data (sync_all flushes data + metadata). A previous revision
-        //    also re-opened the file to fsync it a second time — that
-        //    reopen+fsync was redundant work on every delete and has been
-        //    removed.
-        // 3. fsync the parent directory so the new directory entry is durable
-        //    across a power-loss restart — without this, the catalog can
-        //    record a delete file path that fails to resolve after a crash
-        //    because the file's inode is on disk but the dirent isn't.
+        //    its data with the ordering tier (`fsync_tier::ordering_sync_std`:
+        //    plain fsync on macOS, fdatasync on Linux — on macOS both std
+        //    `sync_all` AND `sync_data` are F_FULLFSYNC ~4-5 ms, while the
+        //    catalog commit referencing this file is SQLite
+        //    synchronous=NORMAL, so a full drive-cache flush here cannot
+        //    raise end-to-end durability; see `provider/fsync_tier.rs`). A
+        //    previous revision also re-opened the file to fsync it a second
+        //    time — that reopen+fsync was redundant work on every delete and
+        //    has been removed.
+        // 3. fsync the parent directory so the new directory entry is written
+        //    through before the catalog records the path — without this, the
+        //    catalog can record a delete file path that fails to resolve
+        //    after a crash because the file's inode is on disk but the dirent
+        //    isn't.
         let file = std::fs::File::create(&output_path)?;
         let mut writer = FileWriter::try_new(file, &schema)?;
         writer.write(&batch)?;
         writer.finish()?;
         let inner = writer.into_inner()?;
-        inner.sync_all()?;
+        crate::provider::fsync_tier::ordering_sync_std(&inner)?;
         drop(inner);
 
         let metadata = std::fs::metadata(&output_path)?;
 
-        // Best-effort parent-dir fsync. Matches the partitioned_wal /
-        // staging_wal write patterns: a failure here is unusual and logged
-        // by the caller; the deletion file's content is already durable
-        // regardless.
+        // Best-effort parent-dir fsync (ordering tier). Matches the
+        // partitioned_wal / staging_wal write patterns: a failure here is
+        // unusual and logged by the caller; the deletion file's content is
+        // already durable regardless.
         if let Some(parent) = output_path.parent()
             && let Ok(dir) = std::fs::File::open(parent)
         {
-            let _ = dir.sync_all();
+            let _ = crate::provider::fsync_tier::ordering_sync_std(&dir);
         }
 
         Ok(metadata.len())

--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -243,7 +243,7 @@ impl<'a> DeletionVectorWriter<'a> {
                 // see `provider/fsync_tier.rs`.
                 tokio::task::spawn_blocking(move || {
                     let dir = std::fs::File::open(&snapshot_dir)?;
-                    crate::provider::fsync_tier::ordering_sync_std(&dir)
+                    crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
                 })
                 .await
                 .map_err(|source| Error::TaskPanicked { table, source })??;
@@ -595,7 +595,7 @@ async fn write_deletion_file(
         if let Some(parent) = output_path.parent()
             && let Ok(dir) = std::fs::File::open(parent)
         {
-            let _ = crate::provider::fsync_tier::ordering_sync_std(&dir);
+            let _ = crate::provider::fsync_tier::ordering_sync_dir_std(&dir);
         }
 
         Ok(metadata.len())

--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -239,8 +239,8 @@ impl<'a> DeletionVectorWriter<'a> {
             };
             if sync_snapshot_parent {
                 let table = self.table.path.clone();
-                // Ordering tier (plain fsync on macOS, fdatasync on Linux) —
-                // see `provider/fsync_tier.rs`.
+                // Directory ordering tier (plain fsync on macOS, full fsync
+                // on other platforms) — see `provider/fsync_tier.rs`.
                 tokio::task::spawn_blocking(move || {
                     let dir = std::fs::File::open(&snapshot_dir)?;
                     crate::provider::fsync_tier::ordering_sync_dir_std(&dir)

--- a/crates/cayenne/src/provider/fsync_tier.rs
+++ b/crates/cayenne/src/provider/fsync_tier.rs
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Ordering-tier fsync for the staged-commit hot path.
+//!
+//! ## Why this module exists (measured, not assumed)
+//!
+//! On macOS, **both** `File::sync_all` *and* `File::sync_data` map to
+//! `fcntl(F_FULLFSYNC)` — a full drive-cache flush. Measured on an Apple
+//! Silicon laptop (64 KiB file, 20 iterations): `sync_all` ≈ 4.5 ms,
+//! `sync_data` ≈ 5.0 ms, raw `fcntl(F_BARRIERFSYNC)` ≈ 0.46 ms, and plain
+//! `fsync(2)` ≈ 66 µs. A staged CDC batch pays 5-7 such barriers (data dir,
+//! staging WAL file + dir, deletion-vector file + dir, move-target dir), so
+//! the full tier put a ~25-30 ms fixed floor under every staged commit on
+//! macOS — the dominant cost of small upserts (`vs_duckdb_upsert_scaling`).
+//!
+//! ## Why plain `fsync(2)` is the right tier on macOS
+//!
+//! Durability here can't exceed the weakest link, and the weakest link is the
+//! metastore: SQLite runs `journal_mode=WAL, synchronous=NORMAL` with no
+//! `fullfsync` pragma, so the catalog transaction that makes staged files
+//! *visible* uses plain `fsync(2)` semantics on macOS (NORMAL does not even
+//! fsync on every commit). A power-loss window that loses fsync-tier data
+//! necessarily also loses the catalog rows referencing it. Plain `fsync(2)`
+//! is likewise the macOS default for DuckDB and PostgreSQL — it is the
+//! durability bar the rest of the storage industry sets on this platform.
+//! Crash-consistency (process crash, not power loss) is unaffected: the page
+//! cache survives a process crash, and the staging-WAL recovery protocol
+//! (`ensure_no_incomplete_write`) heals interrupted commits either way.
+//!
+//! On non-macOS platforms these helpers are `File::sync_data` — on Linux that
+//! is `fdatasync(2)`, which still issues a device flush and skips only
+//! metadata journaling irrelevant to reading the bytes back.
+//!
+//! Cold paths (table create/drop, metastore initialization, partition
+//! creation) intentionally do NOT use this module and keep `sync_all`.
+
+use std::io;
+
+/// Ordering-tier sync for a [`std::fs::File`] (file or directory handle).
+///
+/// Call from a blocking context (`spawn_blocking`) — on macOS this issues a
+/// blocking `fsync(2)` (~tens of µs); elsewhere `sync_data` may block on a
+/// device flush.
+pub(crate) fn ordering_sync_std(file: &std::fs::File) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::fd::AsRawFd;
+        // SAFETY: `fsync` is async-signal-safe and takes a valid open fd; the
+        // borrow of `file` keeps the fd alive for the duration of the call.
+        if unsafe { libc::fsync(file.as_raw_fd()) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        file.sync_data()
+    }
+}
+
+/// Ordering-tier sync for a [`tokio::fs::File`].
+///
+/// On macOS the `fsync(2)` runs on the blocking pool (mirroring what tokio's
+/// own `sync_data` does internally); elsewhere this delegates to
+/// `tokio::fs::File::sync_data`.
+pub(crate) async fn ordering_sync_tokio_file(file: &tokio::fs::File) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::fd::AsRawFd;
+        let raw_fd = file.as_raw_fd();
+        // The borrow of `file` is held across the await below, so `raw_fd`
+        // stays valid until the blocking fsync completes.
+        tokio::task::spawn_blocking(move || {
+            // SAFETY: see `ordering_sync_std` — valid open fd, kept alive by
+            // the borrow held across the await.
+            if unsafe { libc::fsync(raw_fd) } == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        })
+        .await
+        .map_err(io::Error::other)?
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        file.sync_data().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn ordering_sync_std_succeeds_on_file_and_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("probe.bin");
+        let mut file = std::fs::File::create(&file_path).expect("create probe file");
+        file.write_all(b"ordering-tier probe").expect("write");
+        ordering_sync_std(&file).expect("file ordering sync");
+
+        let dir_handle = std::fs::File::open(dir.path()).expect("open dir");
+        ordering_sync_std(&dir_handle).expect("dir ordering sync");
+    }
+
+    #[tokio::test]
+    async fn ordering_sync_tokio_file_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("probe_tokio.bin");
+        let mut file = tokio::fs::File::create(&file_path)
+            .await
+            .expect("create probe file");
+        use tokio::io::AsyncWriteExt;
+        file.write_all(b"ordering-tier probe").await.expect("write");
+        ordering_sync_tokio_file(&file).await.expect("tokio ordering sync");
+    }
+}

--- a/crates/cayenne/src/provider/fsync_tier.rs
+++ b/crates/cayenne/src/provider/fsync_tier.rs
@@ -41,9 +41,17 @@ limitations under the License.
 //! cache survives a process crash, and the staging-WAL recovery protocol
 //! (`ensure_no_incomplete_write`) heals interrupted commits either way.
 //!
-//! On non-macOS platforms these helpers are `File::sync_data` — on Linux that
-//! is `fdatasync(2)`, which still issues a device flush and skips only
-//! metadata journaling irrelevant to reading the bytes back.
+//! On non-macOS platforms the REGULAR-FILE helpers ([`ordering_sync_std`] /
+//! [`ordering_sync_tokio_file`]) are `File::sync_data` — on Linux that is
+//! `fdatasync(2)`, which still issues a device flush and skips only metadata
+//! journaling irrelevant to reading the bytes back. The DIRECTORY variants
+//! ([`ordering_sync_dir_std`] / [`ordering_sync_dir_tokio_file`]) are the
+//! deliberate exception: they keep full `sync_all` on non-macOS, because
+//! `fdatasync`'s "metadata required to retrieve the data" wording leaves
+//! directory-entry durability implementation-defined, and a dirent that
+//! vanishes after power loss un-publishes the file it referenced. On macOS
+//! both file and directory variants are plain `fsync(2)` (the metastore
+//! weakest-link argument above applies to either handle kind there).
 //!
 //! Cold paths (table create/drop, metastore initialization, partition
 //! creation) intentionally do NOT use this module and keep `sync_all`.

--- a/crates/cayenne/src/provider/fsync_tier.rs
+++ b/crates/cayenne/src/provider/fsync_tier.rs
@@ -178,12 +178,13 @@ mod tests {
 
     #[tokio::test]
     async fn ordering_sync_tokio_file_succeeds() {
+        use tokio::io::AsyncWriteExt;
+
         let dir = tempfile::tempdir().expect("tempdir");
         let file_path = dir.path().join("probe_tokio.bin");
         let mut file = tokio::fs::File::create(&file_path)
             .await
             .expect("create probe file");
-        use tokio::io::AsyncWriteExt;
         file.write_all(b"ordering-tier probe").await.expect("write");
         ordering_sync_tokio_file(&file)
             .await

--- a/crates/cayenne/src/provider/fsync_tier.rs
+++ b/crates/cayenne/src/provider/fsync_tier.rs
@@ -30,12 +30,12 @@ limitations under the License.
 //! ## Why plain `fsync(2)` is the right tier on macOS
 //!
 //! Durability here can't exceed the weakest link, and the weakest link is the
-//! metastore: SQLite runs `journal_mode=WAL, synchronous=NORMAL` with no
+//! metastore: `SQLite` runs `journal_mode=WAL, synchronous=NORMAL` with no
 //! `fullfsync` pragma, so the catalog transaction that makes staged files
 //! *visible* uses plain `fsync(2)` semantics on macOS (NORMAL does not even
 //! fsync on every commit). A power-loss window that loses fsync-tier data
 //! necessarily also loses the catalog rows referencing it. Plain `fsync(2)`
-//! is likewise the macOS default for DuckDB and PostgreSQL — it is the
+//! is likewise the macOS default for `DuckDB` and `PostgreSQL` — it is the
 //! durability bar the rest of the storage industry sets on this platform.
 //! Crash-consistency (process crash, not power loss) is unaffected: the page
 //! cache survives a process crash, and the staging-WAL recovery protocol
@@ -50,7 +50,12 @@ limitations under the License.
 
 use std::io;
 
-/// Ordering-tier sync for a [`std::fs::File`] (file or directory handle).
+/// Ordering-tier sync for a regular-file [`std::fs::File`].
+///
+/// For directory handles use [`ordering_sync_dir_std`] — on non-macOS
+/// platforms `sync_data` is only guaranteed to flush "metadata required to
+/// retrieve the data", and whether that wording covers directory entries is
+/// implementation-defined.
 ///
 /// Call from a blocking context (`spawn_blocking`) — on macOS this issues a
 /// blocking `fsync(2)` (~tens of µs); elsewhere `sync_data` may block on a
@@ -73,7 +78,32 @@ pub(crate) fn ordering_sync_std(file: &std::fs::File) -> io::Result<()> {
     }
 }
 
-/// Ordering-tier sync for a [`tokio::fs::File`].
+/// Ordering-tier sync for a **directory** handle.
+///
+/// Directories get full `fsync` on non-macOS: POSIX only guarantees
+/// `fdatasync` flushes "metadata required to retrieve the data", and whether
+/// that covers directory entries is implementation-defined (Linux treats
+/// them as the directory's data; other platforms may not). `PostgreSQL` and
+/// `SQLite` both use full `fsync` on directories for the same reason. On
+/// Linux `fsync` and `fdatasync` are equivalent for directories (same
+/// journal commit + device flush), so this costs nothing. On macOS the
+/// ordering tier is plain `fsync(2)` either way.
+pub(crate) fn ordering_sync_dir_std(dir: &std::fs::File) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        ordering_sync_std(dir)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        dir.sync_all()
+    }
+}
+
+/// Ordering-tier sync for a regular-file [`tokio::fs::File`].
+///
+/// For directory handles use [`ordering_sync_dir_tokio_file`] (see
+/// [`ordering_sync_dir_std`] for why directories need full `fsync` on
+/// non-macOS platforms).
 ///
 /// On macOS the `fsync(2)` runs on the blocking pool (mirroring what tokio's
 /// own `sync_data` does internally); elsewhere this delegates to
@@ -103,6 +133,21 @@ pub(crate) async fn ordering_sync_tokio_file(file: &tokio::fs::File) -> io::Resu
     }
 }
 
+/// Ordering-tier sync for a **directory** [`tokio::fs::File`] handle.
+///
+/// See [`ordering_sync_dir_std`] for why directories use full `fsync` on
+/// non-macOS platforms.
+pub(crate) async fn ordering_sync_dir_tokio_file(dir: &tokio::fs::File) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        ordering_sync_tokio_file(dir).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        dir.sync_all().await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,7 +162,18 @@ mod tests {
         ordering_sync_std(&file).expect("file ordering sync");
 
         let dir_handle = std::fs::File::open(dir.path()).expect("open dir");
-        ordering_sync_std(&dir_handle).expect("dir ordering sync");
+        ordering_sync_dir_std(&dir_handle).expect("dir ordering sync");
+    }
+
+    #[tokio::test]
+    async fn ordering_sync_dir_tokio_file_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dir_handle = tokio::fs::File::open(dir.path())
+            .await
+            .expect("open dir handle");
+        ordering_sync_dir_tokio_file(&dir_handle)
+            .await
+            .expect("tokio dir ordering sync");
     }
 
     #[tokio::test]
@@ -129,6 +185,8 @@ mod tests {
             .expect("create probe file");
         use tokio::io::AsyncWriteExt;
         file.write_all(b"ordering-tier probe").await.expect("write");
-        ordering_sync_tokio_file(&file).await.expect("tokio ordering sync");
+        ordering_sync_tokio_file(&file)
+            .await
+            .expect("tokio ordering sync");
     }
 }

--- a/crates/cayenne/src/provider/fsync_tier.rs
+++ b/crates/cayenne/src/provider/fsync_tier.rs
@@ -111,21 +111,17 @@ pub(crate) fn ordering_sync_dir_std(dir: &std::fs::File) -> io::Result<()> {
 pub(crate) async fn ordering_sync_tokio_file(file: &tokio::fs::File) -> io::Result<()> {
     #[cfg(target_os = "macos")]
     {
-        use std::os::fd::AsRawFd;
-        let raw_fd = file.as_raw_fd();
-        // The borrow of `file` is held across the await below, so `raw_fd`
-        // stays valid until the blocking fsync completes.
-        tokio::task::spawn_blocking(move || {
-            // SAFETY: see `ordering_sync_std` — valid open fd, kept alive by
-            // the borrow held across the await.
-            if unsafe { libc::fsync(raw_fd) } == 0 {
-                Ok(())
-            } else {
-                Err(io::Error::last_os_error())
-            }
-        })
-        .await
-        .map_err(io::Error::other)?
+        // Cancellation safety: `spawn_blocking` tasks are detached — if this
+        // future is dropped at the `.await`, the blocking closure keeps
+        // running. A raw fd captured from `file` could then outlive the
+        // caller's `File` (closed/reused fd under a live `libc::fsync` —
+        // unsound). Move an OWNED duplicate of the fd into the closure
+        // instead: the dup stays open for exactly as long as the fsync needs
+        // it, regardless of caller cancellation. One `dup(2)` (~µs) per sync.
+        let owned_dup = file.try_clone().await?.into_std().await;
+        tokio::task::spawn_blocking(move || ordering_sync_std(&owned_dup))
+            .await
+            .map_err(io::Error::other)?
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -75,6 +75,7 @@ pub(crate) mod context;
 pub(crate) mod delete;
 pub mod deletion_index;
 pub(crate) mod deletion_strategy;
+pub(crate) mod fsync_tier;
 pub(crate) mod memory_account;
 pub(crate) mod mutation_writer;
 pub(crate) mod overwrite;

--- a/crates/cayenne/src/provider/partitioned_wal.rs
+++ b/crates/cayenne/src/provider/partitioned_wal.rs
@@ -140,10 +140,15 @@ impl PartitionedWal {
                 let parent = table_root.to_path_buf(); // the table root
                 let table = table_root.display().to_string();
 
-                // Sync the table root so the _partitioned_wal/ subdir entry is durable.
-                tokio::task::spawn_blocking(move || std::fs::File::open(&parent)?.sync_all())
-                    .await
-                    .map_err(|source| Error::TaskPanicked { table, source })??;
+                // Sync the table root so the _partitioned_wal/ subdir entry is
+                // written through (ordering tier: plain fsync on macOS,
+                // fdatasync on Linux — see `provider/fsync_tier.rs`).
+                tokio::task::spawn_blocking(move || {
+                    let dir = std::fs::File::open(&parent)?;
+                    crate::provider::fsync_tier::ordering_sync_std(&dir)
+                })
+                .await
+                .map_err(|source| Error::TaskPanicked { table, source })??;
             }
             Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {}
             Err(source) => return Err(Error::IoError { source }),
@@ -215,7 +220,10 @@ impl PartitionedWal {
             .open(&tmp_path)
             .await?;
         tmp_file.write_all(content.as_bytes()).await?;
-        tmp_file.sync_all().await?;
+        // Ordering tier: see `provider/fsync_tier.rs` — losing this
+        // coordination record in a power-loss window is healed by recovery,
+        // and the metastore's visibility commits are no stronger.
+        super::fsync_tier::ordering_sync_tokio_file(&tmp_file).await?;
         drop(tmp_file);
 
         // Step 2: atomic rename. POSIX rename within the same directory is
@@ -226,10 +234,10 @@ impl PartitionedWal {
             return Err(Error::IoError { source: e });
         }
 
-        // Step 3: fsync the parent dir so the rename is durable across a
-        // power-loss restart.
+        // Step 3: fsync the parent dir (ordering tier) so the rename is
+        // written through before dependent work proceeds.
         if let Ok(dir) = tokio::fs::File::open(&wal_dir).await
-            && let Err(e) = dir.sync_all().await
+            && let Err(e) = super::fsync_tier::ordering_sync_tokio_file(&dir).await
         {
             // Directory fsync is best-effort: on some filesystems / OSes it
             // is a no-op anyway. Log the failure but don't abort — the WAL
@@ -343,7 +351,8 @@ impl PartitionedWal {
                 let wal_dir = table_root.join(PARTITIONED_WAL_DIR);
                 let wal_dir_display = wal_dir.display().to_string();
                 match tokio::task::spawn_blocking(move || {
-                    std::fs::File::open(&wal_dir).and_then(|f| f.sync_all())
+                    std::fs::File::open(&wal_dir)
+                        .and_then(|f| crate::provider::fsync_tier::ordering_sync_std(&f))
                 })
                 .await
                 {

--- a/crates/cayenne/src/provider/partitioned_wal.rs
+++ b/crates/cayenne/src/provider/partitioned_wal.rs
@@ -141,8 +141,8 @@ impl PartitionedWal {
                 let table = table_root.display().to_string();
 
                 // Sync the table root so the _partitioned_wal/ subdir entry is
-                // written through (ordering tier: plain fsync on macOS,
-                // fdatasync on Linux — see `provider/fsync_tier.rs`).
+                // written through (directory ordering tier: plain fsync on
+                // macOS, full fsync elsewhere — see `provider/fsync_tier.rs`).
                 tokio::task::spawn_blocking(move || {
                     let dir = std::fs::File::open(&parent)?;
                     crate::provider::fsync_tier::ordering_sync_dir_std(&dir)

--- a/crates/cayenne/src/provider/partitioned_wal.rs
+++ b/crates/cayenne/src/provider/partitioned_wal.rs
@@ -145,7 +145,7 @@ impl PartitionedWal {
                 // fdatasync on Linux — see `provider/fsync_tier.rs`).
                 tokio::task::spawn_blocking(move || {
                     let dir = std::fs::File::open(&parent)?;
-                    crate::provider::fsync_tier::ordering_sync_std(&dir)
+                    crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
                 })
                 .await
                 .map_err(|source| Error::TaskPanicked { table, source })??;
@@ -237,7 +237,7 @@ impl PartitionedWal {
         // Step 3: fsync the parent dir (ordering tier) so the rename is
         // written through before dependent work proceeds.
         if let Ok(dir) = tokio::fs::File::open(&wal_dir).await
-            && let Err(e) = super::fsync_tier::ordering_sync_tokio_file(&dir).await
+            && let Err(e) = super::fsync_tier::ordering_sync_dir_tokio_file(&dir).await
         {
             // Directory fsync is best-effort: on some filesystems / OSes it
             // is a no-op anyway. Log the failure but don't abort — the WAL
@@ -352,7 +352,7 @@ impl PartitionedWal {
                 let wal_dir_display = wal_dir.display().to_string();
                 match tokio::task::spawn_blocking(move || {
                     std::fs::File::open(&wal_dir)
-                        .and_then(|f| crate::provider::fsync_tier::ordering_sync_std(&f))
+                        .and_then(|f| crate::provider::fsync_tier::ordering_sync_dir_std(&f))
                 })
                 .await
                 {

--- a/crates/cayenne/src/provider/staging_wal.rs
+++ b/crates/cayenne/src/provider/staging_wal.rs
@@ -790,12 +790,26 @@ impl CayenneTableProvider {
             message: format!("Failed to serialize staging WAL: {e}"),
         })?;
 
-        // Single open + write + fsync, keeping the fd through to `sync_all`.
+        // Single open + write + fsync, keeping the fd through to the sync.
         // The previous revision called `tokio::fs::write` (which opens,
         // writes, drops the fd) and then re-opened the file to call
         // `sync_all` — paying an extra `open(2)` per WAL write on every
         // staged append. Replacing the two opens with one is a small but
         // real per-ingestion saving on the local-FS hot path.
+        //
+        // Ordering tier (`fsync_tier::ordering_sync_tokio_file`), not
+        // `sync_all`: on macOS BOTH std `sync_all` and `sync_data` are
+        // `fcntl(F_FULLFSYNC)` (~4-5 ms full drive-cache flush, measured),
+        // while plain `fsync(2)` is ~66 µs — and plain fsync is the macOS
+        // tier SQLite/DuckDB/Postgres default to. On Linux the helper is
+        // `fdatasync`, which flushes the WAL bytes + the size metadata needed
+        // to read them. Full-platter durability is not load-bearing here:
+        // losing this WAL record in a power-loss window only orphans staging
+        // files that recovery (`ensure_no_incomplete_write`) audits and
+        // discards — and the metastore's own visibility commits are SQLite
+        // `synchronous=NORMAL` (no fullfsync), so a stronger barrier on this
+        // marker file could not raise end-to-end durability anyway. See
+        // `provider/fsync_tier.rs` for the measurements and rationale.
         let mut file = tokio::fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -803,7 +817,7 @@ impl CayenneTableProvider {
             .open(&tmp_path)
             .await?;
         file.write_all(content.as_bytes()).await?;
-        file.sync_all().await?;
+        super::fsync_tier::ordering_sync_tokio_file(&file).await?;
         drop(file);
 
         if let Err(e) = tokio::fs::rename(&tmp_path, &wal_path).await {

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -3194,17 +3194,21 @@ impl CayenneTableProvider {
             let parent = snapshot_dir.parent().map(std::path::Path::to_path_buf);
             tokio::fs::create_dir_all(snapshot_dir).await?;
 
-            // Make the *creation of the new snapshot directory itself* durable.
-            // On POSIX, creating a subdirectory updates the parent's directory
-            // metadata. Without syncing the parent, a crash can make the new
-            // snapshot directory "disappear" from the filesystem even though
-            // we later write files into it and commit the catalog to point at it.
-            // This is the same durability requirement we enforce for file
-            // creation, renames, and WAL marker removal elsewhere in the code.
+            // Write the *creation of the new snapshot directory itself* through
+            // to the device (ordering tier). On POSIX, creating a subdirectory
+            // updates the parent's directory metadata. Without syncing the
+            // parent, a crash can make the new snapshot directory "disappear"
+            // from the filesystem even though we later write files into it and
+            // commit the catalog to point at it. This is the same requirement
+            // we enforce for file creation, renames, and WAL marker removal
+            // elsewhere in the code. Ordering tier (plain fsync on macOS,
+            // fdatasync on Linux — see `fsync_tier`): this runs once per
+            // staged batch, and the full-tier flush bought nothing — see
+            // `sync_snapshot_dir`.
             if let Some(parent) = parent {
                 tokio::task::spawn_blocking(move || {
                     let f = std::fs::File::open(&parent)?;
-                    f.sync_all()
+                    super::fsync_tier::ordering_sync_std(&f)
                 })
                 .await
                 .map_err(std::io::Error::other)??;
@@ -3569,10 +3573,35 @@ impl CayenneTableProvider {
         let snapshot_dir = snapshot_dir.to_path_buf();
         let dir_display = snapshot_dir.display().to_string();
         tokio::task::spawn_blocking(move || {
-            // Open the directory and call sync_all to flush metadata
+            // Open the directory and flush its entries with the ORDERING tier
+            // (`fsync_tier::ordering_sync_std`), not full-tier `sync_all`.
+            //
+            // Durability-tier rationale (matters on macOS): Rust's `sync_all`
+            // AND `sync_data` both map to `fcntl(F_FULLFSYNC)` on Apple
+            // targets — a full drive-cache flush measured at ~4-5 ms per call
+            // — while plain `fsync(2)` is ~66 µs. Plain fsync is the macOS
+            // durability tier SQLite (synchronous=NORMAL), DuckDB, and
+            // PostgreSQL all default to. On Linux the helper is `fdatasync`,
+            // which still issues a device flush; dirents are the directory's
+            // data, so they are flushed — behavior is effectively unchanged
+            // there.
+            //
+            // F_FULLFSYNC here would be strictly stronger than the visibility
+            // commit it protects: the metastore runs SQLite with
+            // `journal_mode=WAL, synchronous=NORMAL` and no `fullfsync`
+            // pragma, so the catalog transaction that makes these files
+            // visible is itself only plain-fsync durable on macOS (NORMAL
+            // doesn't even fsync at every commit). A power-loss window that
+            // loses ordering-tier data files necessarily also loses the
+            // catalog rows referencing them — there is no inconsistent state
+            // a full flush here would prevent. Paying 5-7 F_FULLFSYNCs per
+            // staged CDC batch (~25 ms of pure barrier latency) bought no
+            // additional end-to-end durability; it was the dominant fixed
+            // cost of small staged upserts. Full details + measurements in
+            // `provider/fsync_tier.rs`.
             let dir = std::fs::File::open(&snapshot_dir)
                 .map_err(|source| CatalogError::IoError { source })?;
-            dir.sync_all()
+            super::fsync_tier::ordering_sync_std(&dir)
                 .map_err(|source| CatalogError::IoError { source })?;
             Ok::<(), CatalogError>(())
         })

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -3201,9 +3201,10 @@ impl CayenneTableProvider {
             // from the filesystem even though we later write files into it and
             // commit the catalog to point at it. This is the same requirement
             // we enforce for file creation, renames, and WAL marker removal
-            // elsewhere in the code. Ordering tier (plain fsync on macOS,
-            // fdatasync on Linux — see `fsync_tier`): this runs once per
-            // staged batch, and the full-tier flush bought nothing — see
+            // elsewhere in the code. Directory ordering tier (plain fsync on
+            // macOS, full fsync on other platforms — see
+            // `fsync_tier::ordering_sync_dir_std`): this runs once per staged
+            // batch, and the macOS full-drive-flush tier bought nothing — see
             // `sync_snapshot_dir`.
             if let Some(parent) = parent {
                 tokio::task::spawn_blocking(move || {
@@ -3573,17 +3574,19 @@ impl CayenneTableProvider {
         let snapshot_dir = snapshot_dir.to_path_buf();
         let dir_display = snapshot_dir.display().to_string();
         tokio::task::spawn_blocking(move || {
-            // Open the directory and flush its entries with the ORDERING tier
-            // (`fsync_tier::ordering_sync_std`), not full-tier `sync_all`.
+            // Open the directory and flush its entries with the directory
+            // ORDERING tier (`fsync_tier::ordering_sync_dir_std`), not
+            // full-tier `sync_all`.
             //
             // Durability-tier rationale (matters on macOS): Rust's `sync_all`
             // AND `sync_data` both map to `fcntl(F_FULLFSYNC)` on Apple
             // targets — a full drive-cache flush measured at ~4-5 ms per call
             // — while plain `fsync(2)` is ~66 µs. Plain fsync is the macOS
             // durability tier SQLite (synchronous=NORMAL), DuckDB, and
-            // PostgreSQL all default to. On Linux the helper is `fdatasync`,
-            // which still issues a device flush; dirents are the directory's
-            // data, so they are flushed — behavior is effectively unchanged
+            // PostgreSQL all default to. On non-macOS platforms the directory
+            // helper issues a full `fsync` (dirent flushing under plain
+            // `fdatasync` is implementation-defined; on Linux the two are
+            // equivalent for directories) — behavior is effectively unchanged
             // there.
             //
             // F_FULLFSYNC here would be strictly stronger than the visibility

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -3208,7 +3208,7 @@ impl CayenneTableProvider {
             if let Some(parent) = parent {
                 tokio::task::spawn_blocking(move || {
                     let f = std::fs::File::open(&parent)?;
-                    super::fsync_tier::ordering_sync_std(&f)
+                    super::fsync_tier::ordering_sync_dir_std(&f)
                 })
                 .await
                 .map_err(std::io::Error::other)??;
@@ -3601,7 +3601,7 @@ impl CayenneTableProvider {
             // `provider/fsync_tier.rs`.
             let dir = std::fs::File::open(&snapshot_dir)
                 .map_err(|source| CatalogError::IoError { source })?;
-            super::fsync_tier::ordering_sync_std(&dir)
+            super::fsync_tier::ordering_sync_dir_std(&dir)
                 .map_err(|source| CatalogError::IoError { source })?;
             Ok::<(), CatalogError>(())
         })

--- a/crates/cayenne/tests/ingest_fsync_regression_test.rs
+++ b/crates/cayenne/tests/ingest_fsync_regression_test.rs
@@ -179,7 +179,7 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
 
     // Also assert there is exactly one file-level sync call on the deletion
     // vector file in this function. The parent directory fsync
-    // (`ordering_sync_std(&dir)`) is allowed and distinct.
+    // (`ordering_sync_dir_std(&dir)`) is allowed and distinct.
     let file_sync_count = body
         .lines()
         .filter(|line| {

--- a/crates/cayenne/tests/ingest_fsync_regression_test.rs
+++ b/crates/cayenne/tests/ingest_fsync_regression_test.rs
@@ -146,16 +146,25 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
         .expect("write_deletion_file function not found in delete/vector_io.rs");
 
     // The deletion-vector writer must sync the FileWriter's inner fd
-    // (`inner.sync_all()?`) — this is the cheap path that uses the open fd
+    // (`inner.sync_data()?`) — this is the cheap path that uses the open fd
     // we already have. A previous revision additionally re-opened the file
     // with `OpenOptions::new().write(true).open(...)` to fsync it AGAIN,
     // which doubled the per-deletion fsync cost. The reopen must NOT come
     // back without a documented reason.
+    //
+    // Ordering tier (`fsync_tier::ordering_sync_std`), not `sync_all` or
+    // `sync_data`: on macOS BOTH std calls are `fcntl(F_FULLFSYNC)` (~4-5 ms
+    // full drive-cache flush per call, measured), while the helper issues
+    // plain `fsync(2)` (~66 µs) — the same macOS tier as the SQLite
+    // metastore (`synchronous=NORMAL`, no fullfsync pragma) whose commit
+    // makes this file visible, so a full-tier flush here could not raise
+    // end-to-end durability. See `provider/fsync_tier.rs`.
     assert!(
-        body.contains("inner.sync_all()"),
-        "write_deletion_file must call `inner.sync_all()` on the FileWriter's \
-         inner std::fs::File — this is the fsync that ensures the deletion \
-         vector data is durable before we record the path in the catalog."
+        body.contains("ordering_sync_std(&inner)"),
+        "write_deletion_file must call `fsync_tier::ordering_sync_std(&inner)` \
+         on the FileWriter's inner std::fs::File — this is the fsync that \
+         writes the deletion vector data through before we record the path \
+         in the catalog."
     );
 
     let reopened_fsync_pattern =
@@ -168,25 +177,35 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
          a per-deletion regression."
     );
 
-    // Also assert there is at most one `*.sync_all()` call on any file
-    // descriptor for the deletion vector file in this function. The parent
-    // directory fsync (`dir.sync_all()`) is allowed and distinct.
-    let file_sync_all_count = body
+    // Also assert there is exactly one file-level sync call on the deletion
+    // vector file in this function. The parent directory fsync
+    // (`ordering_sync_std(&dir)`) is allowed and distinct.
+    let file_sync_count = body
         .lines()
         .filter(|line| {
             let line = line.trim();
-            // `inner.sync_all()` or `f.sync_all()` style calls on the data file
-            // itself. Match on the bare `sync_all()` suffix while excluding the
-            // parent-dir `dir.sync_all()` line.
-            line.contains(".sync_all()") && !line.contains("dir.sync_all()")
+            line.contains("ordering_sync_std(&inner)")
         })
         .count();
     assert_eq!(
-        file_sync_all_count, 1,
-        "write_deletion_file must call `sync_all()` on the deletion vector \
-         file exactly once (the writer's inner fd). Found {file_sync_all_count} \
-         occurrence(s). Parent-directory fsync via `dir.sync_all()` is allowed \
-         and is filtered out of this count."
+        file_sync_count, 1,
+        "write_deletion_file must sync the deletion vector file exactly once \
+         (the writer's inner fd, via `ordering_sync_std(&inner)`). Found \
+         {file_sync_count} occurrence(s). Parent-directory fsync via \
+         `ordering_sync_std(&dir)` is distinct and not counted here."
+    );
+
+    // Tier guard: no full-tier `sync_all` — and no direct `sync_data`, which
+    // on macOS is ALSO F_FULLFSYNC — may creep back onto this per-deletion
+    // hot path. The ordering tier (`fsync_tier::ordering_sync_std`) is the
+    // documented contract; a full-tier flush re-introduces ~4-5 ms per
+    // deletion vector on macOS for zero end-to-end durability gain (the
+    // catalog commit it protects is SQLite synchronous=NORMAL).
+    assert!(
+        !body.contains(".sync_all()") && !body.contains(".sync_data()"),
+        "write_deletion_file must not call `.sync_all()`/`.sync_data()` \
+         directly (both are F_FULLFSYNC on macOS) — route through \
+         `fsync_tier::ordering_sync_std` and see provider/fsync_tier.rs."
     );
 }
 
@@ -200,10 +219,11 @@ fn write_deletion_file_still_fsyncs_parent_dir() {
         .expect("write_deletion_file function not found in delete/vector_io.rs");
 
     assert!(
-        body.contains("dir.sync_all()"),
-        "write_deletion_file must still fsync the parent directory of the \
-         deletion vector file. Without this, a crash after the catalog records \
-         the path can leave the directory entry unwritten — the catalog now \
+        body.contains("ordering_sync_std(&dir)"),
+        "write_deletion_file must still fsync (ordering tier, \
+         `ordering_sync_std(&dir)`) the parent directory of the deletion \
+         vector file. Without this, a crash after the catalog records the \
+         path can leave the directory entry unwritten — the catalog now \
          references a file that does not exist on restart."
     );
 }
@@ -229,8 +249,9 @@ fn write_staging_wal_local_uses_single_open_write_fsync() {
         .lines()
         .filter(|line| {
             let line = line.trim();
-            line.contains(".sync_all()")
-                && !line.contains("dir.sync_all()")
+            (line.contains(".sync_all()")
+                || line.contains(".sync_data()")
+                || line.contains("ordering_sync_tokio_file("))
                 && !line.contains("staging_dir")
                 && !line.contains("parent")
         })
@@ -238,12 +259,84 @@ fn write_staging_wal_local_uses_single_open_write_fsync() {
 
     assert!(
         file_sync_count <= 1,
-        "write_staging_wal_local must perform at most one file-level sync_all \
+        "write_staging_wal_local must perform at most one file-level sync \
          after writing the WAL content (efficient single open+write+fsync). \
          Found {file_sync_count} file syncs. A redundant reopen+fsync was \
          previously present on the hot ingestion path and has been removed."
     );
+
+    // Tier guard: the WAL marker sync must be the ordering tier
+    // (`fsync_tier::ordering_sync_tokio_file` → plain fsync on macOS,
+    // fdatasync on Linux), never `sync_all`/`sync_data` — BOTH are
+    // F_FULLFSYNC (~4-5 ms per call) on macOS. Losing this marker in a
+    // power-loss window only orphans staging files that
+    // `ensure_no_incomplete_write` audits and discards, and the metastore's
+    // visibility commits (SQLite synchronous=NORMAL) are no stronger — so a
+    // full-tier flush here is pure per-batch latency. See
+    // `provider/fsync_tier.rs` for the measurements.
+    assert!(
+        body.contains("ordering_sync_tokio_file(&file)"),
+        "write_staging_wal_local must sync the WAL marker with the ordering \
+         tier (`fsync_tier::ordering_sync_tokio_file(&file)`)."
+    );
+    assert!(
+        !body.contains(".sync_all()") && !body.contains(".sync_data()"),
+        "write_staging_wal_local must not call `.sync_all()`/`.sync_data()` \
+         directly (both are F_FULLFSYNC on macOS) on the staged-append hot \
+         path — route through fsync_tier and see provider/fsync_tier.rs."
+    );
 }
+
+#[test]
+fn staged_commit_hot_path_uses_ordering_tier_syncs() {
+    // The staged-commit hot path pays one barrier per call site per batch.
+    // On macOS, BOTH std `sync_all` AND `sync_data` map to
+    // `fcntl(F_FULLFSYNC)` — a full drive-cache flush measured at ~4-5 ms per
+    // call — while plain `fsync(2)` (what `fsync_tier::ordering_sync_*`
+    // issues there) is ~66 µs. On Linux the helper is `fdatasync`, still a
+    // device flush.
+    //
+    // Full-tier barriers on this path bought no end-to-end durability: the
+    // SQLite metastore runs `journal_mode=WAL, synchronous=NORMAL` with no
+    // `fullfsync` pragma, so the catalog transaction that makes staged files
+    // visible is itself only plain-fsync durable on macOS (NORMAL does not
+    // even fsync at every commit). A power-loss window that loses
+    // ordering-tier data necessarily also loses the catalog rows referencing
+    // it. Before this contract, a single 2,000-row staged upsert paid 5-7
+    // F_FULLFSYNCs ≈ ~25 ms of pure barrier latency — the dominant fixed cost
+    // of small staged batches (vs_duckdb_upsert_scaling).
+    //
+    // `sync_snapshot_dir` is the shared dir-barrier helper used by the write,
+    // staging-WAL, move/publish, and compaction paths; pin its tier here.
+    let body = extract_fn_body(TABLE_SRC, "sync_snapshot_dir")
+        .expect("sync_snapshot_dir function not found in table.rs");
+    assert!(
+        body.contains("ordering_sync_std(&dir)"),
+        "sync_snapshot_dir must flush directory entries with the ordering \
+         tier (`fsync_tier::ordering_sync_std(&dir)`), not `sync_all` or \
+         `sync_data` (both F_FULLFSYNC on macOS). See the durability-tier \
+         rationale in the function body and provider/fsync_tier.rs."
+    );
+    assert!(
+        !body.contains(".sync_all()") && !body.contains(".sync_data()"),
+        "sync_snapshot_dir must not call `.sync_all()`/`.sync_data()` \
+         directly: every staged CDC batch pays this barrier multiple times, \
+         both are F_FULLFSYNC on macOS, and the metastore's visibility \
+         commits (SQLite synchronous=NORMAL) are no stronger — the full \
+         flush is pure latency with no durability gain."
+    );
+
+    // And the helper itself must implement the macOS ordering tier with a
+    // plain `libc::fsync` (std offers no cheaper-than-F_FULLFSYNC call).
+    assert!(
+        FSYNC_TIER_SRC.contains("libc::fsync"),
+        "provider/fsync_tier.rs must issue plain `libc::fsync` on macOS — \
+         std `sync_all`/`sync_data` are both F_FULLFSYNC there (measured \
+         ~4-5 ms vs ~66 µs for plain fsync)."
+    );
+}
+
+const FSYNC_TIER_SRC: &str = include_str!("../src/provider/fsync_tier.rs");
 
 // -----------------------------------------------------------------------------
 // Devil's Advocate / "Be really sure" analysis (for the recurring /loop task)

--- a/crates/cayenne/tests/ingest_fsync_regression_test.rs
+++ b/crates/cayenne/tests/ingest_fsync_regression_test.rs
@@ -146,9 +146,9 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
         .expect("write_deletion_file function not found in delete/vector_io.rs");
 
     // The deletion-vector writer must sync the FileWriter's inner fd
-    // (`inner.sync_data()?`) — this is the cheap path that uses the open fd
-    // we already have. A previous revision additionally re-opened the file
-    // with `OpenOptions::new().write(true).open(...)` to fsync it AGAIN,
+    // (`ordering_sync_std(&inner)`) — this is the cheap path that uses the
+    // open fd we already have. A previous revision additionally re-opened the
+    // file with `OpenOptions::new().write(true).open(...)` to fsync it AGAIN,
     // which doubled the per-deletion fsync cost. The reopen must NOT come
     // back without a documented reason.
     //
@@ -173,8 +173,8 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
         !body.contains(reopened_fsync_pattern),
         "write_deletion_file must NOT re-open the deletion vector file and \
          fsync it a second time. That reopen+fsync pattern is redundant work \
-         after `inner.sync_all()` on the writer's inner fd and was previously \
-         a per-deletion regression."
+         after `ordering_sync_std(&inner)` on the writer's inner fd and was \
+         previously a per-deletion regression."
     );
 
     // Also assert there is exactly one file-level sync call on the deletion
@@ -192,7 +192,7 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
         "write_deletion_file must sync the deletion vector file exactly once \
          (the writer's inner fd, via `ordering_sync_std(&inner)`). Found \
          {file_sync_count} occurrence(s). Parent-directory fsync via \
-         `ordering_sync_std(&dir)` is distinct and not counted here."
+         `ordering_sync_dir_std(&dir)` is distinct and not counted here."
     );
 
     // Tier guard: no full-tier `sync_all` — and no direct `sync_data`, which

--- a/crates/cayenne/tests/ingest_fsync_regression_test.rs
+++ b/crates/cayenne/tests/ingest_fsync_regression_test.rs
@@ -210,21 +210,43 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
 }
 
 #[test]
-fn write_deletion_file_still_fsyncs_parent_dir() {
+fn deletion_vector_write_parallelizes_files_and_coalesces_dir_sync() {
     // The companion fsync — the parent directory — must still happen, so the
-    // dirent for the new deletion-vector file is durable before the catalog
-    // is updated. This is the load-bearing half of the ACID-Durability fix
-    // that the removed reopen was *replicating*; we want to keep this one.
-    let body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write_deletion_file")
-        .expect("write_deletion_file function not found in delete/vector_io.rs");
-
+    // dirents for new deletion-vector files are durable before the catalog
+    // is updated. It now lives in `DeletionVectorWriter::write`, ONCE per
+    // batch: the per-spec files are written CONCURRENTLY (`try_join_all`,
+    // overlapping their file fsyncs — on EBS this collapses N serialized
+    // ~1 ms barrier round-trips into ~1), and a single deletions/-dir sync
+    // after they all complete flushes every pending dirent at once. Same
+    // durability contract, 1/N the directory barriers.
+    let write_body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write")
+        .expect("DeletionVectorWriter::write not found in delete/vector_io.rs");
     assert!(
-        body.contains("ordering_sync_dir_std(&dir)"),
-        "write_deletion_file must still fsync (ordering tier, \
-         `ordering_sync_dir_std(&dir)`) the parent directory of the deletion \
-         vector file. Without this, a crash after the catalog records the \
-         path can leave the directory entry unwritten — the catalog now \
-         references a file that does not exist on restart."
+        write_body.contains("try_join_all"),
+        "DeletionVectorWriter::write must write the batch's deletion-vector \
+         files concurrently (try_join_all) — serializing them re-introduces \
+         N fsync round-trips per batch on network-attached storage."
+    );
+    // Exactly two dir syncs in `write`: the one-time snapshot-parent sync
+    // (first deletion vector for the snapshot) and the per-batch coalesced
+    // deletions/-dir sync. A third occurrence means a per-file dir sync
+    // crept back in.
+    let dir_sync_count = write_body.matches("ordering_sync_dir_std(&dir)").count();
+    assert_eq!(
+        dir_sync_count, 2,
+        "DeletionVectorWriter::write must contain exactly two directory \
+         syncs (one-time snapshot-parent + per-batch coalesced deletions/ \
+         dir). Found {dir_sync_count}."
+    );
+
+    // And write_deletion_file itself must NOT dir-sync — that would undo the
+    // coalescing by re-adding a barrier per file.
+    let file_body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write_deletion_file")
+        .expect("write_deletion_file function not found in delete/vector_io.rs");
+    assert!(
+        !file_body.contains("ordering_sync_dir_std"),
+        "write_deletion_file must not fsync the parent directory per file — \
+         the caller issues one coalesced deletions/-dir sync per batch."
     );
 }
 

--- a/crates/cayenne/tests/ingest_fsync_regression_test.rs
+++ b/crates/cayenne/tests/ingest_fsync_regression_test.rs
@@ -219,9 +219,9 @@ fn write_deletion_file_still_fsyncs_parent_dir() {
         .expect("write_deletion_file function not found in delete/vector_io.rs");
 
     assert!(
-        body.contains("ordering_sync_std(&dir)"),
+        body.contains("ordering_sync_dir_std(&dir)"),
         "write_deletion_file must still fsync (ordering tier, \
-         `ordering_sync_std(&dir)`) the parent directory of the deletion \
+         `ordering_sync_dir_std(&dir)`) the parent directory of the deletion \
          vector file. Without this, a crash after the catalog records the \
          path can leave the directory entry unwritten — the catalog now \
          references a file that does not exist on restart."
@@ -311,9 +311,9 @@ fn staged_commit_hot_path_uses_ordering_tier_syncs() {
     let body = extract_fn_body(TABLE_SRC, "sync_snapshot_dir")
         .expect("sync_snapshot_dir function not found in table.rs");
     assert!(
-        body.contains("ordering_sync_std(&dir)"),
+        body.contains("ordering_sync_dir_std(&dir)"),
         "sync_snapshot_dir must flush directory entries with the ordering \
-         tier (`fsync_tier::ordering_sync_std(&dir)`), not `sync_all` or \
+         tier (`fsync_tier::ordering_sync_dir_std(&dir)`), not `sync_all` or \
          `sync_data` (both F_FULLFSYNC on macOS). See the durability-tier \
          rationale in the function body and provider/fsync_tier.rs."
     );

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -30,7 +30,7 @@ aws-sdk-glue.workspace = true
 aws-sdk-s3.workspace = true
 aws-sdk-sts = { workspace = true, optional = true }
 axum.workspace = true
-axum-extra = { version = "0.12.5", features = ["typed-header"] }
+axum-extra = { version = "0.12.5", features = ["typed-header", "query"] }
 ballista-core = { workspace = true }
 ballista-executor = { workspace = true }
 ballista-scheduler = { workspace = true }

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -36,7 +36,7 @@ use async_openai::types::embeddings::EmbeddingInput;
 use datafusion::common::exec_err;
 use datafusion::datasource::ViewTable;
 use datafusion::logical_expr::expr::FieldMetadata;
-use datafusion::logical_expr::{ColumnarValue, Signature, Volatility};
+use datafusion::logical_expr::{ColumnarValue, DocSection, Documentation, Signature, Volatility};
 use datafusion::{
     catalog::{Session, TableFunctionImpl, TableProvider},
     common::Column,
@@ -136,6 +136,43 @@ pub static VECTOR_SEARCH_SIGNATURE: LazyLock<Signature> = LazyLock::new(|| {
         Ok(sig) => sig,
         Err(_) => Signature::variadic_any(Volatility::Stable),
     }
+});
+
+static VECTOR_SEARCH_DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| Documentation {
+    doc_section: DocSection::default(),
+    description: "Runs vector search over a configured embedding/vector index.".to_string(),
+    syntax_example: "vector_search(tbl, 'query text'[, column])".to_string(),
+    sql_example: None,
+    arguments: Some(vec![
+        (
+            "tbl".to_string(),
+            "Dataset or table reference with an embedding/vector index.".to_string(),
+        ),
+        ("query".to_string(), "Search query text.".to_string()),
+        (
+            "column".to_string(),
+            "Optional indexed column to search when the dataset has multiple vector indexes."
+                .to_string(),
+        ),
+        (
+            "limit".to_string(),
+            "Optional maximum number of search results.".to_string(),
+        ),
+        (
+            "include_score".to_string(),
+            "Whether to include the search score column; defaults to true.".to_string(),
+        ),
+        (
+            "rank_weight".to_string(),
+            "Optional per-query weighting factor when nested inside rrf().".to_string(),
+        ),
+        (
+            "distance_metric".to_string(),
+            "Optional vector distance metric such as cosine or l2.".to_string(),
+        ),
+    ]),
+    alternative_syntax: None,
+    related_udfs: Some(vec!["rrf".to_string(), "rerank".to_string()]),
 });
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -790,6 +827,10 @@ impl ScalarUDFImpl for VectorSearchTableFunc {
 
     fn signature(&self) -> &Signature {
         &VECTOR_SEARCH_SIGNATURE
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        Some(&*VECTOR_SEARCH_DOCUMENTATION)
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -98,6 +98,7 @@ use tower_http::limit::RequestBodyLimitLayer;
         v1::responses::post,
         v1::models::get,
         v1::workers::get,
+        v1::nsql::get_context,
         v1::nsql::post,
         v1::inference::get,
         v1::inference::post,
@@ -402,6 +403,7 @@ pub(crate) fn routes(
             .route("/v1/models", get(v1::models::get))
             .route("/v1/models/{name}/predict", get(v1::inference::get))
             .route("/v1/predict", post(v1::inference::post))
+            .route("/v1/nsql/context", get(v1::nsql::get_context))
             .route("/v1/nsql", post(v1::nsql::post).layer(ModelContextLayer))
             .route(
                 "/v1/chat/completions",

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -15,24 +15,16 @@ limitations under the License.
 */
 use crate::{
     Runtime,
-    datafusion::{
-        SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA,
-        request_context_extension::get_current_datafusion,
-    },
+    datafusion::request_context_extension::get_current_datafusion,
     http::v1::{ResponseMetadata, ResponseMimeType, to_http_response},
-    model::LLMChatCompletionsModelStore,
-    tools::{
-        builtin::{
-            sample::{
-                SampleTableMethod, SampleTableParams, distinct::DistinctColumnsParams,
-                random::RandomSampleParams, tool::SampleDataTool,
-            },
-            table_schema::{TableSchemaTool, TableSchemaToolParams},
+    model::{
+        LLMChatCompletionsModelStore,
+        nsql::{
+            DEFAULT_NSQL_CONTEXT_SAMPLE_LIMIT, MAX_NSQL_CONTEXT_SAMPLE_LIMIT, NsqlContextError,
+            NsqlContextJsonResponse, NsqlContextOptions, build_nsql_context,
         },
-        utils::create_tool_use_messages,
     },
 };
-use async_openai::types::chat::ChatCompletionRequestMessage;
 use axum::{
     Extension, Json,
     http::StatusCode,
@@ -41,22 +33,19 @@ use axum::{
         sse::{Event, KeepAlive},
     },
 };
-use axum_extra::TypedHeader;
-use datafusion::sql::TableReference;
+use axum_extra::{TypedHeader, extract::Query};
 use futures::{StreamExt, TryStreamExt};
 use headers_accept::Accept;
-use http::HeaderMap;
-use runtime_datafusion::allowlist::ResolvedTableAwareAllowlist;
+use http::{HeaderMap, HeaderValue, header::CONTENT_TYPE};
+use mediatype::{MediaType, names};
 use runtime_request_context::{AsyncMarker, RequestContext};
 
 use arrow::array::RecordBatch;
-use itertools::Itertools;
 use llms::chat::nsql::{FailedAttempt, QueryGenerationContext, default::DefaultSqlGeneration};
 use serde::{Deserialize, Serialize};
 use spicepod::component::model::ModelType;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock;
-use tracing::Span;
 use tracing_futures::Instrument;
 
 use super::accept_header_types;
@@ -65,12 +54,20 @@ use crate::datafusion::query::QueryBuilder;
 // Default number of retries for NSQL queries if the generated query fails to execute
 const DEFAULT_NSQL_RETRIES: u8 = 10;
 
-// Maximum number of concurrent sampling tools executions for NSQL
-const DATA_SAMPLING_MAX_CONCURRENT: usize = 10;
-
 // NSQL streaming keep alive interval in seconds
 const NSQL_STREAM_KEEP_ALIVE: u64 = 30;
 
+static NSQL_CONTEXT_RESPONSE_MEDIA_TYPES: [MediaType<'static>; 3] = [
+    MediaType::new(names::TEXT, names::MARKDOWN),
+    MediaType::new(names::TEXT, names::PLAIN),
+    MediaType::new(names::APPLICATION, names::JSON),
+];
+
+enum NsqlContextResponseFormat {
+    Markdown,
+    PlainText,
+    Json,
+}
 fn clean_model_based_sql(input: &str) -> String {
     let no_dashes = match input.strip_prefix("--") {
         Some(rest) => rest.to_string(),
@@ -82,59 +79,37 @@ fn clean_model_based_sql(input: &str) -> String {
     one_query.trim().to_string()
 }
 
-/// Create subsequent Assistant and Tool messages simulating a model requesting to use the `sample_data` tool, then receiving the result for the following sampling methods:
-///  - Distinct columns
-///  - Random sample
-///
-/// Convert the [`SampleTableParams`] into how an LLM would ask to use it (via a [`ChatCompletionRequestAssistantMessage`]).
-/// Convert the result of a [`SampleDataTool`] call how we would return it to the LLM, (via a [`ChatCompletionRequestToolMessage`]).
-async fn sample_messages(
-    sample_from: &[TableReference],
-    rt: Arc<Runtime>,
-    table_allowlist: Option<ResolvedTableAwareAllowlist>,
-) -> Result<Vec<ChatCompletionRequestMessage>, Box<dyn std::error::Error + Send + Sync>> {
-    let message_futures = sample_from.iter().flat_map(|dataset| {
-        [
-            SampleTableParams::DistinctColumns(DistinctColumnsParams {
-                tbl: dataset.to_string(),
-                limit: 3,
-                cols: None,
-            }),
-            SampleTableParams::RandomSample(RandomSampleParams {
-                tbl: dataset.to_string(),
-                limit: 3,
-            }),
-        ]
-        .into_iter()
-        .map(|params| {
-            let rt = Arc::clone(&rt);
-            let allowlist = table_allowlist.clone();
-            async move {
-                let method = SampleTableMethod::from(&params);
-                create_tool_use_messages(
-                    &SampleDataTool::new(rt.datafusion(), method.clone())
-                        .with_table_allowlist(allowlist),
-                    format!("sample-{method:?}").as_str(),
-                    &params,
-                )
-                .instrument(Span::current())
-                .await
-            }
-        })
-    });
+fn default_nsql_context_sample_limit() -> usize {
+    DEFAULT_NSQL_CONTEXT_SAMPLE_LIMIT
+}
 
-    let tool_call_messages = futures::stream::iter(message_futures)
-        .boxed()
-        .buffer_unordered(DATA_SAMPLING_MAX_CONCURRENT)
-        .try_collect::<Vec<_>>()
-        .await?;
+fn validate_context_limit(
+    name: &str,
+    enabled: bool,
+    limit: usize,
+) -> Result<(), (StatusCode, String)> {
+    if enabled && limit == 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Query parameter '{name}' must be greater than 0 when enabled"),
+        ));
+    }
 
-    Ok(tool_call_messages.into_iter().flatten().collect())
+    if limit > MAX_NSQL_CONTEXT_SAMPLE_LIMIT {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Query parameter '{name}' must be less than or equal to {MAX_NSQL_CONTEXT_SAMPLE_LIMIT}"
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub struct Request {
     /// The natural language query to be converted into SQL
     pub query: String,
@@ -148,7 +123,7 @@ pub struct Request {
     pub stream: bool,
 
     /// Whether sample data is included in the context for SQL generation. Default: false
-    #[serde(default = "default_sample_data_enabled")]
+    #[serde(default = "default_sample_data_enabled", alias = "sampledataenabled")]
     pub sample_data_enabled: bool,
 
     /// Names of datasets to sample from when constructing model context; this is a sampling hint and does not restrict which tables queries can target. If omitted, all datasets are used.
@@ -156,8 +131,61 @@ pub struct Request {
     pub datasets: Option<Vec<String>>,
 
     /// Stable prompt-cache key forwarded to the configured NSQL model for provider-specific cache handling.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "promptcachekey")]
     pub prompt_cache_key: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::IntoParams, utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", into_params(parameter_in = Query))]
+#[serde(rename_all = "snake_case")]
+pub struct ContextRequest {
+    /// The name of the model whose dataset allowlist should be used. If omitted, Spice defaults to the only compatible LLM model configured in the Spicepod.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// Whether distinct-value samples are included in the context block. Also accepts `sample_data_enabled` for compatibility with `/v1/nsql` request bodies. Default: false.
+    #[serde(default, alias = "sample_data_enabled")]
+    pub include_sampling: bool,
+
+    /// Maximum number of rows per distinct-value sample. Default: 3, maximum: 100.
+    #[serde(default = "default_nsql_context_sample_limit")]
+    pub sampling_limit: usize,
+
+    /// Whether example rows are included in the context block. Defaults to `include_sampling` when omitted, matching `/v1/nsql` `sample_data_enabled` behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_examples: Option<bool>,
+
+    /// Maximum number of example rows per dataset. Default: 3, maximum: 100.
+    #[serde(default = "default_nsql_context_sample_limit")]
+    pub examples_limit: usize,
+
+    /// Names of datasets to include in the context block. If omitted, all datasets visible to the selected model are included.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub datasets: Vec<String>,
+}
+
+impl ContextRequest {
+    fn context_options(&self) -> Result<NsqlContextOptions, (StatusCode, String)> {
+        let include_examples = self.include_examples.unwrap_or(self.include_sampling);
+        validate_context_limit("sampling_limit", self.include_sampling, self.sampling_limit)?;
+        validate_context_limit("examples_limit", include_examples, self.examples_limit)?;
+
+        Ok(NsqlContextOptions::new(
+            self.include_sampling,
+            self.sampling_limit,
+            include_examples,
+            self.examples_limit,
+        ))
+    }
+
+    fn datasets(&self) -> Option<Vec<String>> {
+        if self.datasets.is_empty() {
+            None
+        } else {
+            Some(self.datasets.clone())
+        }
+    }
 }
 
 fn default_sample_data_enabled() -> bool {
@@ -167,6 +195,220 @@ fn default_sample_data_enabled() -> bool {
 /// Checks if the request is asking to only generate SQL.
 fn return_sql_only(accept: Option<&TypedHeader<Accept>>) -> bool {
     accept.is_some_and(|a| accept_header_types(a).contains(&"application/sql".to_string()))
+}
+
+fn context_response_format(
+    accept: Option<&TypedHeader<Accept>>,
+) -> Option<NsqlContextResponseFormat> {
+    let content_type = accept.map_or(Some(&NSQL_CONTEXT_RESPONSE_MEDIA_TYPES[0]), |header| {
+        header.0.negotiate(&NSQL_CONTEXT_RESPONSE_MEDIA_TYPES)
+    })?;
+
+    if content_type.subty == names::PLAIN {
+        Some(NsqlContextResponseFormat::PlainText)
+    } else if content_type.subty == names::JSON {
+        Some(NsqlContextResponseFormat::Json)
+    } else {
+        Some(NsqlContextResponseFormat::Markdown)
+    }
+}
+
+fn nsql_context_response(
+    context: NsqlContextJsonResponse,
+    accept: Option<&TypedHeader<Accept>>,
+) -> Response {
+    let Some(response_format) = context_response_format(accept) else {
+        return (
+            StatusCode::NOT_ACCEPTABLE,
+            "Supported response content types are text/markdown, text/plain, and application/json",
+        )
+            .into_response();
+    };
+
+    match response_format {
+        NsqlContextResponseFormat::Json => Json(context).into_response(),
+        NsqlContextResponseFormat::Markdown => {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                CONTENT_TYPE,
+                HeaderValue::from_static("text/markdown; charset=utf-8"),
+            );
+            (StatusCode::OK, headers, context.context).into_response()
+        }
+        NsqlContextResponseFormat::PlainText => {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                CONTENT_TYPE,
+                HeaderValue::from_static("text/plain; charset=utf-8"),
+            );
+            (StatusCode::OK, headers, context.context).into_response()
+        }
+    }
+}
+
+fn nsql_context_error_response(error: &NsqlContextError) -> (StatusCode, String) {
+    let status = match error {
+        NsqlContextError::DatasetNotFound { .. } => StatusCode::BAD_REQUEST,
+        NsqlContextError::AppNotPrepared
+        | NsqlContextError::InvalidModelDatasets { .. }
+        | NsqlContextError::ContextMessage { .. }
+        | NsqlContextError::SchemaContext { .. }
+        | NsqlContextError::FunctionContext { .. }
+        | NsqlContextError::SampleContext { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+
+    (status, error.to_string())
+}
+
+/// Text-to-SQL Context (NSQL)
+///
+/// Return the same context block that `/v1/nsql` injects into the configured NSQL model.
+///
+/// The response is a markdown/plain-text block or JSON object containing the in-scope datasets, schemas,
+/// Spice-specific SQL functions, registered user-defined functions, relevant JSON/Spark compatibility functions,
+/// and optional sample data.
+#[cfg_attr(feature = "openapi", utoipa::path(
+    get,
+    path = "/v1/nsql/context",
+    operation_id = "get_nsql_context",
+    tag = "SQL",
+    params(
+        ("Accept" = String, Header, description = "The format of the response, one of 'text/markdown' (default), 'text/plain', or 'application/json'."),
+        ContextRequest
+    ),
+    responses(
+        (status = 200, description = "NSQL context block", content((
+            String = "text/markdown",
+            example = "# Spice.ai NSQL Context\n\n## Datasets\n- `sales_data`\n\n## Schemas\n| table | column | type | nullable |\n| --- | --- | --- | --- |\n| sales_data | customer_id | Utf8 | false |\n\n## SQL Functions\nUse Spice.ai/DataFusion SQL."
+        ), (
+            String = "text/plain",
+            example = "# Spice.ai NSQL Context\n\n## Datasets\n- `sales_data`"
+        ), (
+            NsqlContextJsonResponse = "application/json",
+            example = json!({
+                "context": "# Spice.ai NSQL Context\n- Write SQL for the Spice runtime...",
+                "instructions": ["Write SQL for the Spice runtime, which uses Apache DataFusion with the SQL parser configured for the PostgreSQL dialect."],
+                "sql": {
+                    "engine": "Apache DataFusion",
+                    "version": "52.5.0",
+                    "dialect": "PostgreSQL",
+                    "parser": "DataFusion SQL parser configured with PostgreSQL dialect",
+                    "notes": ["Spice supports standard DataFusion SQL plus additional Spice-specific and registered user-defined functions listed in this context."]
+                },
+                "datasets": [{
+                    "name": "sales.orders",
+                    "schema": "sales",
+                    "table": "orders",
+                    "description": "Customer orders",
+                    "metadata": {"description": "Customer orders"},
+                    "columns": [{
+                        "name": "customer_id",
+                        "data_type": "Utf8",
+                        "nullable": false,
+                        "description": "Customer account identifier",
+                        "metadata": {"description": "Customer account identifier"},
+                        "primary_key": false,
+                        "unique": false,
+                        "indexed": true,
+                        "vector_search": true,
+                        "full_text_search": true
+                    }],
+                    "primary_key": ["order_id"],
+                    "unique_constraints": [],
+                    "foreign_keys": [{
+                        "columns": ["customer_id"],
+                        "foreign_table": "spice.sales.customers",
+                        "foreign_columns": ["id"]
+                    }],
+                    "indexes": [{
+                        "name": "customer_id",
+                        "columns": ["customer_id"],
+                        "kind": "enabled",
+                        "source": "spicepod.acceleration.indexes"
+                    }],
+                    "search": {
+                        "vector": [{
+                            "column": "customer_id",
+                            "function": "vector_search",
+                            "syntax": "vector_search(sales.orders, 'query text', customer_id)",
+                            "model": "embed_model",
+                            "engine": "duckdb_vector_index",
+                            "row_id_columns": ["order_id"],
+                            "vector_size": 384,
+                            "chunked": false,
+                            "index": {"name": "duckdb_vector_index", "columns": ["customer_id", "order_id"], "kind": "duckdb_vector_index", "source": "runtime_index"},
+                            "required_columns": ["customer_id", "order_id"],
+                            "notes": []
+                        }],
+                        "full_text": [{
+                            "column": "customer_id",
+                            "function": "text_search",
+                            "syntax": "text_search(sales.orders, 'query text', customer_id)",
+                            "engine": "tantivy",
+                            "index_store": "memory",
+                            "row_id_columns": ["order_id"],
+                            "index": {"name": "full_text", "columns": ["customer_id", "order_id"], "kind": "full_text", "source": "runtime_index"},
+                            "required_columns": ["customer_id", "order_id"],
+                            "notes": []
+                        }]
+                    }
+                }],
+                "functions": {
+                    "summary": "Spice SQL runs on Apache DataFusion with the SQL parser configured for the PostgreSQL dialect.",
+                    "json": [],
+                    "search": [],
+                    "additional": [],
+                    "spark_compatibility": {"description": "Spark-compatible scalar functions are available.", "functions": []},
+                    "user_defined": []
+                },
+                "samples": []
+            })
+        ))),
+        (status = 400, description = "Invalid request parameters", content((
+            String = "text/plain", example = "Dataset 'sales.orders' not found"
+        ))),
+        (status = 406, description = "Requested response content type is not available", content((
+            String = "text/plain", example = "Supported response content types are text/markdown, text/plain, and application/json"
+        ))),
+        (status = 500, description = "Internal server error", content((
+            String, example = "Unexpected internal error. App not prepared in runtime."
+        )))
+    )
+))]
+pub(crate) async fn get_context(
+    Extension(rt): Extension<Arc<Runtime>>,
+    accept: Option<TypedHeader<Accept>>,
+    Query(params): Query<ContextRequest>,
+) -> Response {
+    let request_context = RequestContext::current(AsyncMarker::new().await);
+
+    let context_options = match params.context_options() {
+        Ok(options) => options,
+        Err((status, message)) => return (status, message).into_response(),
+    };
+
+    let model = match resolve_nsql_model_name(params.model.clone(), &rt).await {
+        Ok(model) => model,
+        Err((status, message)) => return (status, message).into_response(),
+    };
+
+    let context = match build_nsql_context(
+        rt,
+        &request_context,
+        &model,
+        context_options,
+        params.datasets(),
+    )
+    .await
+    {
+        Ok(context) => context,
+        Err(error) => {
+            let (status, message) = nsql_context_error_response(&error);
+            return (status, message).into_response();
+        }
+    };
+
+    nsql_context_response(context.json, accept.as_ref())
 }
 
 /// Text-to-SQL (NSQL)
@@ -331,27 +573,6 @@ pub(crate) async fn handle_nsql_query(
         Err((status, message)) => return (status, headers, message),
     };
 
-    let table_allowlist_opt = match table_allowlist(&model, &rt).await {
-        Ok(ta) => ta,
-        Err(e) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, headers, e);
-        }
-    };
-
-    // Validate that requested datasets are within the model's allowlist
-    if let (Some(requested_datasets), Some(allowlist)) = (&datasets, &table_allowlist_opt) {
-        for ds in requested_datasets {
-            let table_ref = TableReference::parse_str(ds);
-            if !allowlist.table_is_allowed(&table_ref) {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    headers,
-                    format!("Dataset '{ds}' not found"),
-                );
-            }
-        }
-    }
-
     crate::model::add_tools_used(&context, 1);
 
     let span = tracing::span!(target: "task_history", tracing::Level::INFO, "nsql", input = %query, model = %model, "labels");
@@ -360,52 +581,23 @@ pub(crate) async fn handle_nsql_query(
         crate::http::traceparent::override_task_history_with_trace_parent(&span, traceparent);
     }
 
-    // Default to all available tables if specific table(s) are not provided.
-    let tables = datasets
-        .map(|ds| ds.iter().map(TableReference::from).collect_vec())
-        .unwrap_or(
-            df.get_user_table_names()
-                .into_iter()
-                .filter(|t| {
-                    table_allowlist_opt
-                        .as_ref()
-                        .is_none_or(|a| a.table_is_allowed(t))
-                })
-                .collect(),
-        );
-
-    // Create assistant/tool result messages for calling `table_schema` tool for all or provided tables.
-    let schema_messages = match create_tool_use_messages(
-        &TableSchemaTool::new(Arc::clone(&rt), None, None)
-            .with_table_allowlist(table_allowlist_opt.clone()),
-        "schemas-nsql",
-        &TableSchemaToolParams::new(tables.iter().map(ToString::to_string).collect::<Vec<_>>()),
+    let nsql_context = match build_nsql_context(
+        Arc::clone(&rt),
+        &context,
+        &model,
+        NsqlContextOptions::from_nsql_request(sample_data_enabled),
+        datasets,
     )
     .instrument(span.clone())
     .await
     {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::error!("Error getting schema messages: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, headers, e.to_string());
+        Ok(context) => context,
+        Err(error) => {
+            let (status, message) = nsql_context_error_response(&error);
+            return (status, headers, message);
         }
     };
-
-    // Create sample data assistant/tool messages if user wants to sample from dataset(s).
-    let sample_data_messages = if sample_data_enabled {
-        match sample_messages(&tables, Arc::clone(&rt), table_allowlist_opt.clone())
-            .instrument(span.clone())
-            .await
-        {
-            Ok(m) => m,
-            Err(e) => {
-                tracing::error!("Error sampling datasets for NSQL messages: {e}");
-                return (StatusCode::INTERNAL_SERVER_ERROR, headers, e.to_string());
-            }
-        }
-    } else {
-        vec![]
-    };
+    let table_allowlist_opt = nsql_context.table_allowlist.clone();
 
     let nql_model = {
         let models = llms.read().await;
@@ -446,8 +638,7 @@ pub(crate) async fn handle_nsql_query(
             );
         };
 
-        req.messages.extend(schema_messages.clone());
-        req.messages.extend(sample_data_messages.clone());
+        req.messages.push(nsql_context.message.clone());
         if let Some(prompt_cache_key) = &prompt_cache_key {
             req.prompt_cache_key = Some(prompt_cache_key.clone());
         }
@@ -604,49 +795,37 @@ fn compatible_nsql_model_names(app: &app::App) -> Vec<String> {
         .collect()
 }
 
-/// Construct a [`ResolvedTableAwareAllowlist`] based on the `App`'s `model.datasets`.
-async fn table_allowlist(
-    model_name: &str,
-    rt: &Arc<Runtime>,
-) -> Result<Option<ResolvedTableAwareAllowlist>, String> {
-    let Some(app) = rt.read_app().await else {
-        return Err("Unexpected internal error. App not prepared in runtime.".to_string());
-    };
-
-    // Create table allowlist from the model's datasets configuration
-    let model_datasets = app
-        .models
-        .iter()
-        .find(|m| m.name == model_name)
-        .map(|m| m.datasets.clone())
-        .unwrap_or_default();
-
-    let table_allowlist = if model_datasets.is_empty() {
-        None
-    } else {
-        match ResolvedTableAwareAllowlist::with_defaults(
-            SPICE_DEFAULT_CATALOG,
-            SPICE_DEFAULT_SCHEMA,
-        )
-        .with_table_patterns(model_datasets)
-        {
-            Ok(allowlist) => Some(allowlist),
-            Err(_) => {
-                return Err(format!(
-                    "Unexpected internal error. Model '{model_name}' datasets are invalid."
-                ));
-            }
-        }
-    };
-    Ok(table_allowlist)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        datafusion::udf::UserFunctionInfo,
+        model::nsql::{
+            NsqlColumnContext, NsqlDatasetContext, NsqlDatasetSearchContext, NsqlForeignKeyContext,
+            NsqlFullTextSearchContext, NsqlIndexContext, NsqlVectorSearchContext,
+            SampleContextBlock, all_context_function_names_for_test,
+            nsql_function_context_for_test, render_nsql_context_block,
+            user_function_context_entries, write_user_function_context_entries,
+        },
+    };
     use app::AppBuilder;
+    use axum_extra::extract::Query as ExtraQuery;
+    use datafusion::sql::TableReference;
+    use http::Uri;
+    use http_body_util::BodyExt;
     use serde_json::json;
-    use spicepod::component::model::Model;
+    use spicepod::component::{
+        function::{
+            Function, FunctionArg, FunctionKind, FunctionReturns, Signature,
+            Volatility as FunctionVolatility,
+        },
+        model::Model,
+        runtime::{Functions, Runtime as SpicepodRuntime},
+    };
+    use std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        str::FromStr,
+    };
 
     fn app_with_models(models: Vec<Model>) -> app::App {
         let mut builder = AppBuilder::new("test");
@@ -654,6 +833,85 @@ mod tests {
             builder = builder.with_model(model);
         }
         builder.build()
+    }
+
+    fn app_with_functions(functions_enabled: bool, functions: Vec<Function>) -> app::App {
+        let runtime = SpicepodRuntime {
+            functions: if functions_enabled {
+                Functions::enabled()
+            } else {
+                Functions::default()
+            },
+            ..Default::default()
+        };
+
+        let mut builder = AppBuilder::new("test").with_runtime(runtime);
+        for function in functions {
+            builder = builder.with_function(function);
+        }
+        builder.build()
+    }
+
+    fn test_function(name: &str, enabled: bool) -> Function {
+        Function {
+            name: name.to_string(),
+            from: "sql".to_string(),
+            enabled,
+            description: Some(format!("{name} description")),
+            kind: FunctionKind::Scalar,
+            volatility: FunctionVolatility::Stable,
+            signature: Signature {
+                tables: vec![],
+                args: vec![FunctionArg {
+                    name: "x".to_string(),
+                    arrow_type: "int64".to_string(),
+                }],
+                returns: Some(FunctionReturns::Scalar("int64".to_string())),
+            },
+            body: Some("x".to_string()),
+            body_ref: None,
+            metadata: HashMap::new(),
+            params: HashMap::new(),
+            depends_on: vec![],
+            metrics: None,
+            as_tool: false,
+        }
+    }
+
+    fn test_table_function(name: &str, enabled: bool) -> Function {
+        let mut function = test_function(name, enabled);
+        function.kind = FunctionKind::Table;
+        function.signature.returns = Some(FunctionReturns::Table(vec![FunctionArg {
+            name: "value".to_string(),
+            arrow_type: "int64".to_string(),
+        }]));
+        function
+    }
+
+    fn ticket_priority_function() -> Function {
+        let mut function = test_function("ticket_priority", true);
+        function.description =
+            Some("Converts support-ticket sentiment into a priority score.".to_string());
+        function.signature.args = vec![FunctionArg {
+            name: "sentiment".to_string(),
+            arrow_type: "utf8".to_string(),
+        }];
+        function.signature.returns = Some(FunctionReturns::Scalar("int64".to_string()));
+        function
+    }
+
+    fn test_user_function_info(name: &str) -> UserFunctionInfo {
+        UserFunctionInfo {
+            name: name.to_string(),
+            kind: "scalar".to_string(),
+            volatility: "volatile".to_string(),
+            from: "sql".to_string(),
+            description: None,
+        }
+    }
+
+    fn accept_header(value: &str) -> TypedHeader<Accept> {
+        TypedHeader(Accept::from_str(value).expect("accept header should parse"))
     }
 
     #[test]
@@ -665,6 +923,550 @@ mod tests {
 
         assert_eq!(request.model, None);
         assert!(!request.sample_data_enabled);
+    }
+
+    #[test]
+    fn request_accepts_legacy_lowercase_field_aliases() {
+        let request: Request = serde_json::from_value(json!({
+            "query": "show total sales",
+            "sampledataenabled": true,
+            "promptcachekey": "sales-dashboard"
+        }))
+        .expect("request should deserialize legacy lowercase aliases");
+
+        assert!(request.sample_data_enabled);
+        assert_eq!(request.prompt_cache_key.as_deref(), Some("sales-dashboard"));
+    }
+
+    #[test]
+    fn nsql_context_response_defaults_to_markdown() {
+        let response =
+            nsql_context_response(NsqlContextJsonResponse::minimal_for_test("context"), None);
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .expect("content type should be set")
+                .to_str()
+                .expect("content type should be valid ASCII"),
+            "text/markdown; charset=utf-8"
+        );
+    }
+
+    #[tokio::test]
+    async fn nsql_context_response_negotiates_plain_text() {
+        let accept = accept_header("text/plain");
+        let response = nsql_context_response(
+            NsqlContextJsonResponse::minimal_for_test(nsql_context_block_with_samples_for_test()),
+            Some(&accept),
+        );
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .expect("content type should be set")
+                .to_str()
+                .expect("content type should be valid ASCII"),
+            "text/plain; charset=utf-8"
+        );
+
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body should collect")
+            .to_bytes();
+        let body = String::from_utf8(body.to_vec()).expect("response body should be UTF-8");
+
+        assert!(body.contains("## Datasets"));
+        assert!(body.contains("`sales.orders`: Customer orders"));
+        assert!(body.contains("## SQL Functions"));
+        assert!(body.contains("## Sample Data"));
+
+        insta::assert_snapshot!("nsql_context_plain_text_response", body);
+    }
+
+    #[tokio::test]
+    async fn nsql_context_response_negotiates_json() {
+        let accept = accept_header("application/json");
+        let response = nsql_context_response(
+            NsqlContextJsonResponse::minimal_for_test("context"),
+            Some(&accept),
+        );
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .expect("content type should be set")
+                .to_str()
+                .expect("content type should be valid ASCII"),
+            "application/json"
+        );
+
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body should collect")
+            .to_bytes();
+        let body: serde_json::Value =
+            serde_json::from_slice(&body).expect("response body should be JSON");
+
+        assert_eq!(body["context"], json!("context"));
+        assert_eq!(body["sql"]["engine"], json!("Apache DataFusion"));
+        assert_eq!(body["sql"]["dialect"], json!("PostgreSQL"));
+        assert!(
+            body["datasets"]
+                .as_array()
+                .expect("datasets should be an array")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn nsql_context_response_rejects_unsupported_accept() {
+        let accept = accept_header("application/xml");
+        let response = nsql_context_response(
+            NsqlContextJsonResponse::minimal_for_test("context"),
+            Some(&accept),
+        );
+
+        assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[test]
+    fn context_request_defaults_to_no_sampling_or_examples() {
+        let request: ContextRequest = serde_json::from_value(json!({}))
+            .expect("context request should deserialize with omitted optional fields");
+
+        let options = request
+            .context_options()
+            .expect("default context options should be valid");
+
+        assert!(!options.include_sampling);
+        assert_eq!(options.sampling_limit, DEFAULT_NSQL_CONTEXT_SAMPLE_LIMIT);
+        assert!(!options.include_examples);
+        assert_eq!(options.examples_limit, DEFAULT_NSQL_CONTEXT_SAMPLE_LIMIT);
+        assert!(request.datasets.is_empty());
+    }
+
+    #[test]
+    fn context_request_sample_data_enabled_defaults_examples_to_sampling() {
+        let request: ContextRequest = serde_json::from_value(json!({
+            "sample_data_enabled": true
+        }))
+        .expect("context request should accept sample_data_enabled alias");
+
+        let options = request
+            .context_options()
+            .expect("sample_data_enabled context options should be valid");
+
+        assert!(options.include_sampling);
+        assert!(options.include_examples);
+
+        let request: ContextRequest = serde_json::from_value(json!({
+            "sample_data_enabled": true,
+            "include_examples": false
+        }))
+        .expect("context request should allow include_examples override");
+
+        let options = request
+            .context_options()
+            .expect("explicit include_examples override should be valid");
+
+        assert!(options.include_sampling);
+        assert!(!options.include_examples);
+    }
+
+    #[test]
+    fn context_request_parses_repeated_dataset_query_params() {
+        let uri: Uri = "/v1/nsql/context?datasets=sales.orders&datasets=support_tickets"
+            .parse()
+            .expect("query URI should parse");
+
+        let ExtraQuery(request) = ExtraQuery::<ContextRequest>::try_from_uri(&uri)
+            .expect("context request should parse repeated dataset keys");
+
+        assert_eq!(request.datasets, vec!["sales.orders", "support_tickets"]);
+        assert_eq!(
+            request.datasets(),
+            Some(vec![
+                "sales.orders".to_string(),
+                "support_tickets".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn context_request_validates_enabled_limits() {
+        let request: ContextRequest = serde_json::from_value(json!({
+            "include_sampling": true,
+            "sampling_limit": 0
+        }))
+        .expect("context request should deserialize");
+
+        let (status, message) = request
+            .context_options()
+            .expect_err("enabled sampling should reject a zero limit");
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            message,
+            "Query parameter 'sampling_limit' must be greater than 0 when enabled"
+        );
+    }
+
+    fn nsql_context_function_context_for_test(include_search_functions: bool) -> String {
+        let app = app_with_functions(true, vec![ticket_priority_function()]);
+        let mut available_names = snapshot_context_function_names_for_test();
+        available_names.insert("ticket_priority".to_string());
+
+        nsql_function_context_for_test(
+            &app,
+            &available_names,
+            include_search_functions,
+            include_search_functions,
+        )
+        .render_markdown()
+    }
+
+    fn snapshot_context_function_names_for_test() -> HashSet<String> {
+        let mut names = all_context_function_names_for_test();
+        names.remove("ai");
+        names.remove("embed");
+        names
+    }
+
+    fn nsql_context_block_with_samples_for_test() -> String {
+        let tables = vec![
+            TableReference::parse_str("sales.orders"),
+            TableReference::parse_str("support_tickets"),
+        ];
+        let dataset_contexts = vec![
+            NsqlDatasetContext {
+                name: "sales.orders".to_string(),
+                catalog: None,
+                schema: Some("sales".to_string()),
+                table: "orders".to_string(),
+                description: Some("Customer orders".to_string()),
+                metadata: BTreeMap::new(),
+                columns: vec![],
+                primary_key: vec![],
+                unique_constraints: vec![],
+                foreign_keys: vec![],
+                indexes: vec![],
+                search: NsqlDatasetSearchContext::default(),
+            },
+            NsqlDatasetContext {
+                name: "support_tickets".to_string(),
+                catalog: None,
+                schema: None,
+                table: "support_tickets".to_string(),
+                description: Some("Customer support tickets".to_string()),
+                metadata: BTreeMap::new(),
+                columns: vec![],
+                primary_key: vec![],
+                unique_constraints: vec![],
+                foreign_keys: vec![],
+                indexes: vec![],
+                search: NsqlDatasetSearchContext::default(),
+            },
+        ];
+        let schema_context = r"
+| table_reference | column_name | data_type | nullable | description |
+| --- | --- | --- | --- | --- |
+| sales.orders | order_id | Int64 | false | Unique order identifier |
+| sales.orders | customer_id | Utf8 | false | Customer account identifier |
+| support_tickets | ticket_id | Int64 | false | Support ticket identifier |
+| support_tickets | sentiment | Utf8 | true | Model-derived sentiment label |
+    ";
+        let relationship_context = r"
+### `sales.orders`
+- Primary key: `order_id`
+- Foreign keys:
+    - (`customer_id`) references `spice.sales.customers` (`id`)
+- Indexes:
+    - `customer_id`: `customer_id` (enabled, spicepod.acceleration.indexes)
+- Search indexes:
+    - vector search on `customer_id` using `embed_model`. Syntax: `vector_search(sales.orders, 'query text', customer_id)`. Engine/index: `duckdb_vector_index`. Row id: `order_id`.
+    - full-text search on `customer_id` using `tantivy`. Syntax: `text_search(sales.orders, 'query text', customer_id)`. Row id: `order_id`.
+        ";
+        let sample_context_blocks = vec![
+            SampleContextBlock {
+                title: "Distinct value samples for `support_tickets`".to_string(),
+                content: "| sentiment |\n| --- |\n| positive |\n| negative |".to_string(),
+            },
+            SampleContextBlock {
+                title: "Example rows for `sales.orders`".to_string(),
+                content: "| order_id | customer_id |\n| --- | --- |\n| 42 | CUST-1 |".to_string(),
+            },
+        ];
+
+        render_nsql_context_block(
+            &tables,
+            &dataset_contexts,
+            schema_context,
+            relationship_context,
+            &nsql_context_function_context_for_test(true),
+            &sample_context_blocks,
+        )
+    }
+
+    fn nsql_context_block_no_datasets_for_test() -> String {
+        render_nsql_context_block(
+            &[],
+            &[],
+            "",
+            "",
+            &nsql_context_function_context_for_test(false),
+            &[],
+        )
+    }
+
+    #[test]
+    fn nsql_context_block_snapshot() {
+        insta::assert_snapshot!(
+            "nsql_context_block_with_samples",
+            nsql_context_block_with_samples_for_test()
+        );
+    }
+
+    #[test]
+    fn nsql_context_block_no_datasets_snapshot() {
+        let context = nsql_context_block_no_datasets_for_test();
+
+        assert!(context.contains("No datasets are currently in scope."));
+        assert!(context.contains("## SQL Functions"));
+        assert!(context.contains("Apache DataFusion version"));
+
+        insta::assert_snapshot!("nsql_context_block_no_datasets", context);
+    }
+
+    #[test]
+    fn nsql_context_json_response_snapshot() {
+        let mut response = NsqlContextJsonResponse::minimal_for_test("# Spice.ai NSQL Context");
+        response.datasets = vec![NsqlDatasetContext {
+            name: "sales.orders".to_string(),
+            catalog: Some("spice".to_string()),
+            schema: Some("sales".to_string()),
+            table: "orders".to_string(),
+            description: Some("Customer orders".to_string()),
+            metadata: BTreeMap::from([("description".to_string(), "Customer orders".to_string())]),
+            columns: vec![
+                NsqlColumnContext {
+                    name: "order_id".to_string(),
+                    data_type: "Int64".to_string(),
+                    nullable: false,
+                    description: Some("Unique order identifier".to_string()),
+                    source_type: Some("bigint".to_string()),
+                    metadata: BTreeMap::from([
+                        (
+                            "description".to_string(),
+                            "Unique order identifier".to_string(),
+                        ),
+                        ("source_type".to_string(), "bigint".to_string()),
+                    ]),
+                    primary_key: true.into(),
+                    unique: false.into(),
+                    indexed: true.into(),
+                    vector_search: false.into(),
+                    full_text_search: false.into(),
+                },
+                NsqlColumnContext {
+                    name: "customer_id".to_string(),
+                    data_type: "Utf8".to_string(),
+                    nullable: false,
+                    description: Some("Customer account identifier".to_string()),
+                    source_type: Some("text".to_string()),
+                    metadata: BTreeMap::from([
+                        (
+                            "description".to_string(),
+                            "Customer account identifier".to_string(),
+                        ),
+                        ("source_type".to_string(), "text".to_string()),
+                    ]),
+                    primary_key: false.into(),
+                    unique: false.into(),
+                    indexed: true.into(),
+                    vector_search: true.into(),
+                    full_text_search: true.into(),
+                },
+            ],
+            primary_key: vec!["order_id".to_string()],
+            unique_constraints: vec![vec!["order_id".to_string()]],
+            foreign_keys: vec![NsqlForeignKeyContext {
+                columns: vec!["customer_id".to_string()],
+                foreign_table: "spice.sales.customers".to_string(),
+                foreign_columns: vec!["id".to_string()],
+            }],
+            indexes: vec![NsqlIndexContext {
+                name: Some("customer_id".to_string()),
+                columns: vec!["customer_id".to_string()],
+                kind: "enabled".to_string(),
+                source: "spicepod.acceleration.indexes".to_string(),
+            }],
+            search: NsqlDatasetSearchContext {
+                vector: vec![NsqlVectorSearchContext {
+                    column: "customer_id".to_string(),
+                    function: "vector_search".to_string(),
+                    syntax: "vector_search(sales.orders, 'query text', customer_id)".to_string(),
+                    model: "embed_model".to_string(),
+                    engine: Some("duckdb_vector_index".to_string()),
+                    row_id_columns: vec!["order_id".to_string()],
+                    vector_size: Some(384),
+                    chunked: false,
+                    input_mode: Some("scalar".to_string()),
+                    required_columns: vec!["customer_id".to_string(), "order_id".to_string()],
+                    index: Some(NsqlIndexContext {
+                        name: Some("duckdb_vector_index".to_string()),
+                        columns: vec!["customer_id".to_string(), "order_id".to_string()],
+                        kind: "duckdb_vector_index".to_string(),
+                        source: "runtime_index".to_string(),
+                    }),
+                    notes: vec![],
+                }],
+                full_text: vec![NsqlFullTextSearchContext {
+                    column: "customer_id".to_string(),
+                    function: "text_search".to_string(),
+                    syntax: "text_search(sales.orders, 'query text', customer_id)".to_string(),
+                    engine: "tantivy".to_string(),
+                    index_store: "memory".to_string(),
+                    row_id_columns: vec!["order_id".to_string()],
+                    required_columns: vec!["customer_id".to_string(), "order_id".to_string()],
+                    index: Some(NsqlIndexContext {
+                        name: Some("full_text".to_string()),
+                        columns: vec!["customer_id".to_string(), "order_id".to_string()],
+                        kind: "full_text".to_string(),
+                        source: "runtime_index".to_string(),
+                    }),
+                    notes: vec![],
+                }],
+            },
+        }];
+        let app = AppBuilder::new("test").build();
+        response.functions = nsql_function_context_for_test(
+            &app,
+            &snapshot_context_function_names_for_test(),
+            true,
+            true,
+        );
+        response.samples = vec![SampleContextBlock {
+            title: "Example rows for `sales.orders`".to_string(),
+            content: "| order_id | customer_id |\n| --- | --- |\n| 42 | CUST-1 |".to_string(),
+        }];
+
+        let response = serde_json::to_string_pretty(&response)
+            .expect("structured NSQL context should serialize");
+
+        insta::assert_snapshot!("nsql_context_json_response", response);
+    }
+
+    #[test]
+    fn nsql_user_function_context_snapshot() {
+        let app = app_with_functions(
+            true,
+            vec![
+                test_function("Haversine_Km", true),
+                test_table_function("Rows_Fn", true),
+            ],
+        );
+        let available_names = HashSet::from(["haversine_km".to_string(), "rows_fn".to_string()]);
+        let user_function_infos = vec![
+            test_user_function_info("Rows_Fn"),
+            test_user_function_info("Haversine_Km"),
+        ];
+        let entries = user_function_context_entries(&app, &available_names, user_function_infos);
+        let mut output = String::new();
+
+        write_user_function_context_entries(&mut output, &entries);
+
+        insta::assert_snapshot!("nsql_user_function_context", output);
+    }
+
+    #[test]
+    fn user_function_context_entries_include_registered_spicepod_signatures() {
+        let app = app_with_functions(
+            true,
+            vec![
+                test_function("Haversine_Km", true),
+                test_table_function("Rows_Fn", true),
+            ],
+        );
+        let available_names = HashSet::from(["haversine_km".to_string(), "rows_fn".to_string()]);
+        let user_function_infos = vec![
+            test_user_function_info("Rows_Fn"),
+            test_user_function_info("Haversine_Km"),
+        ];
+
+        let entries = user_function_context_entries(&app, &available_names, user_function_infos);
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "Haversine_Km");
+        assert_eq!(
+            entries[0].syntax.as_deref(),
+            Some("Haversine_Km(x int64) -> int64")
+        );
+        assert_eq!(entries[0].kind, "scalar");
+        assert_eq!(entries[0].volatility, "stable");
+        assert_eq!(
+            entries[0].description.as_deref(),
+            Some("Haversine_Km description")
+        );
+        assert_eq!(entries[1].name, "Rows_Fn");
+        assert_eq!(
+            entries[1].syntax.as_deref(),
+            Some("Rows_Fn(x int64) -> TABLE(value int64)")
+        );
+        assert_eq!(entries[1].kind, "table");
+
+        let mut output = String::new();
+        write_user_function_context_entries(&mut output, &entries);
+        assert!(output.contains("### User-defined functions"));
+        assert!(output.contains("Syntax: `Haversine_Km(x int64) -> int64`."));
+        assert!(output.contains("Syntax: `Rows_Fn(x int64) -> TABLE(value int64)`."));
+    }
+
+    #[test]
+    fn user_function_context_entries_filter_to_enabled_registered_functions() {
+        let app = app_with_functions(
+            true,
+            vec![
+                test_function("Registered_Fn", true),
+                test_function("Disabled_Fn", false),
+            ],
+        );
+        let available_names = HashSet::from([
+            "registered_fn".to_string(),
+            "disabled_fn".to_string(),
+            "missing_declaration_fn".to_string(),
+        ]);
+        let user_function_infos = vec![
+            test_user_function_info("Registered_Fn"),
+            test_user_function_info("Disabled_Fn"),
+            test_user_function_info("Missing_Declaration_Fn"),
+        ];
+
+        let entries = user_function_context_entries(&app, &available_names, user_function_infos);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "Registered_Fn");
+
+        let disabled_app = app_with_functions(true, vec![test_function("Registered_Fn", true)]);
+        let mut disabled_app = disabled_app;
+        disabled_app.runtime.functions = Functions::default();
+        let entries = user_function_context_entries(
+            &disabled_app,
+            &available_names,
+            vec![test_user_function_info("Registered_Fn")],
+        );
+
+        assert!(entries.is_empty());
     }
 
     #[test]

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_context_block_no_datasets.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_context_block_no_datasets.snap
@@ -1,0 +1,61 @@
+---
+source: crates/runtime/src/http/v1/nsql.rs
+expression: context
+---
+# Spice.ai NSQL Context
+- Write SQL for the Spice runtime, which uses Apache DataFusion with the SQL parser configured for the PostgreSQL dialect.
+- Return only valid SQL code, without markdown fences.
+- Quote column names that contain capitals or special characters with double quotes.
+- For tables with schemas and catalogs, use "catalog"."schema"."table", not "catalog.schema.table".
+- Use table and column descriptions, primary keys, foreign keys, unique constraints, and indexes when choosing joins and filters.
+- Apache DataFusion version: 52.5.0.
+- Schema metadata includes table and column comments/descriptions when supplied by the connector or Spicepod.
+
+## Datasets
+No datasets are currently in scope.
+
+## Schemas
+No schema information is available.
+
+## SQL Functions
+Spice SQL runs on Apache DataFusion with the SQL parser configured for the PostgreSQL dialect. Standard DataFusion SQL functions are available. Additional Spice-specific and registered user-defined functions are listed below. Run SELECT * FROM list_udfs() to inspect the full registered function inventory:
+
+### JSON functions
+- `flatten_json`: Flattens JSON objects into key-value rows or structures. Syntax: `flatten_json(json)`.
+- `flatten_json_properties`: Flattens JSON-schema properties into key-value rows or structures. Syntax: `flatten_json_properties(json_schema)`.
+- `json_as_text`: Converts a JSON value to text (SCALAR). Syntax: `json_as_text(json)`.
+- `json_contains`: Returns whether one JSON value contains another (SCALAR). Syntax: `json_contains(json, value)`.
+- `json_from_scalar`: Converts a scalar value to JSON (SCALAR). Syntax: `json_from_scalar(value)`.
+- `json_get`: Extracts a JSON value by path (SCALAR). Syntax: `json_get(json, path)`.
+- `json_get_array`: Extracts a JSON array by path (SCALAR). Syntax: `json_get_array(json, path)`.
+- `json_get_bool`: Extracts a boolean value from JSON by path (SCALAR). Syntax: `json_get_bool(json, path)`.
+- `json_get_float`: Extracts a floating-point value from JSON by path (SCALAR). Syntax: `json_get_float(json, path)`.
+- `json_get_int`: Extracts an integer value from JSON by path (SCALAR). Syntax: `json_get_int(json, path)`.
+- `json_get_json`: Extracts a nested JSON value by path (SCALAR). Syntax: `json_get_json(json, path)`.
+- `json_get_str`: Extracts a string value from JSON by path (SCALAR). Syntax: `json_get_str(json, path)`.
+- `json_length`: Returns the length of a JSON array or object (SCALAR). Syntax: `json_length(json)`.
+- `json_object_keys`: Returns the keys of a JSON object (SCALAR). Syntax: `json_object_keys(json)`.
+- `json_tree`: Expands JSON into a tree of path, key, and value rows or structures. Syntax: `json_tree(json)`.
+
+### Additional registered functions
+- `bucket`: Assigns a numeric expression to a bucket boundary (SCALAR). Syntax: `bucket(value, buckets)`.
+- `col_description`: Returns the configured description for a table column (SCALAR). Syntax: `col_description(table_catalog, table_schema, table_name, column_name)`.
+- `cosine_distance`: Computes cosine distance between two vectors (SCALAR). Syntax: `cosine_distance(vector_a, vector_b)`.
+- `digest_many`: Computes a digest for one or more input expressions (SCALAR). Syntax: `digest_many(value[, ...])`.
+- `inner_product`: Computes the inner product of two vectors (SCALAR). Syntax: `inner_product(vector_a, vector_b)`.
+- `l2_distance`: Computes Euclidean distance between two vectors (SCALAR). Syntax: `l2_distance(vector_a, vector_b)`.
+- `l2_norm`: Computes the L2 norm of a vector (SCALAR). Syntax: `l2_norm(vector)`.
+- `l2_squared_distance`: Computes squared Euclidean distance between two vectors (SCALAR). Syntax: `l2_squared_distance(vector_a, vector_b)`.
+- `list_udfs`: Lists functions registered in the current DataFusion context. Syntax: `list_udfs()`.
+- `obj_description`: Returns the configured description for a table or object (SCALAR). Syntax: `obj_description(table_catalog, table_schema, table_name)`.
+- `truncate`: Truncates values to the requested precision (SCALAR). Syntax: `truncate(value, precision)`.
+
+### Spark compatibility scalar functions
+Spark-compatible scalar functions are available for arrays, maps, structs, dates, strings, hashes, URLs, XML, and other common Spark SQL expressions.
+- `abs`, `array`, `ascii`, `bit_count`, `bit_get`, `bitmap_count`, `bitwise_not`, `char`
+- `concat`, `crc32`, `csc`, `date_add`, `date_sub`, `elt`, `expm1`, `factorial`
+- `format_string`, `hex`, `hour`, `if`, `ilike`, `last_day`, `length`, `like`
+- `luhn_check`, `make_dt_interval`, `make_interval`, `map_from_arrays`, `map_from_entries`, `minute`, `mod`, `next_day`
+- `parse_url`, `pmod`, `rint`, `sec`, `second`, `sha1`, `sha2`, `shiftleft`
+- `shiftright`, `shiftrightunsigned`, `shuffle`, `space`, `try_parse_url`, `try_url_decode`, `url_decode`, `url_encode`
+- `width_bucket`

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_context_block_with_samples.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_context_block_with_samples.snap
@@ -1,0 +1,97 @@
+---
+source: crates/runtime/src/http/v1/nsql.rs
+expression: nsql_context_block_with_samples_for_test()
+---
+# Spice.ai NSQL Context
+- Write SQL for the Spice runtime, which uses Apache DataFusion with the SQL parser configured for the PostgreSQL dialect.
+- Return only valid SQL code, without markdown fences.
+- Quote column names that contain capitals or special characters with double quotes.
+- For tables with schemas and catalogs, use "catalog"."schema"."table", not "catalog.schema.table".
+- Use table and column descriptions, primary keys, foreign keys, unique constraints, and indexes when choosing joins and filters.
+- Apache DataFusion version: 52.5.0.
+- Schema metadata includes table and column comments/descriptions when supplied by the connector or Spicepod.
+
+## Datasets
+- `sales.orders`: Customer orders
+- `support_tickets`: Customer support tickets
+
+## Schemas
+| table_reference | column_name | data_type | nullable | description |
+| --- | --- | --- | --- | --- |
+| sales.orders | order_id | Int64 | false | Unique order identifier |
+| sales.orders | customer_id | Utf8 | false | Customer account identifier |
+| support_tickets | ticket_id | Int64 | false | Support ticket identifier |
+| support_tickets | sentiment | Utf8 | true | Model-derived sentiment label |
+
+## Dataset Relationships
+### `sales.orders`
+- Primary key: `order_id`
+- Foreign keys:
+    - (`customer_id`) references `spice.sales.customers` (`id`)
+- Indexes:
+    - `customer_id`: `customer_id` (enabled, spicepod.acceleration.indexes)
+- Search indexes:
+    - vector search on `customer_id` using `embed_model`. Syntax: `vector_search(sales.orders, 'query text', customer_id)`. Engine/index: `duckdb_vector_index`. Row id: `order_id`.
+    - full-text search on `customer_id` using `tantivy`. Syntax: `text_search(sales.orders, 'query text', customer_id)`. Row id: `order_id`.
+
+## SQL Functions
+Spice SQL runs on Apache DataFusion with the SQL parser configured for the PostgreSQL dialect. Standard DataFusion SQL functions are available. Additional Spice-specific and registered user-defined functions are listed below. Run SELECT * FROM list_udfs() to inspect the full registered function inventory:
+
+### JSON functions
+- `flatten_json`: Flattens JSON objects into key-value rows or structures. Syntax: `flatten_json(json)`.
+- `flatten_json_properties`: Flattens JSON-schema properties into key-value rows or structures. Syntax: `flatten_json_properties(json_schema)`.
+- `json_as_text`: Converts a JSON value to text (SCALAR). Syntax: `json_as_text(json)`.
+- `json_contains`: Returns whether one JSON value contains another (SCALAR). Syntax: `json_contains(json, value)`.
+- `json_from_scalar`: Converts a scalar value to JSON (SCALAR). Syntax: `json_from_scalar(value)`.
+- `json_get`: Extracts a JSON value by path (SCALAR). Syntax: `json_get(json, path)`.
+- `json_get_array`: Extracts a JSON array by path (SCALAR). Syntax: `json_get_array(json, path)`.
+- `json_get_bool`: Extracts a boolean value from JSON by path (SCALAR). Syntax: `json_get_bool(json, path)`.
+- `json_get_float`: Extracts a floating-point value from JSON by path (SCALAR). Syntax: `json_get_float(json, path)`.
+- `json_get_int`: Extracts an integer value from JSON by path (SCALAR). Syntax: `json_get_int(json, path)`.
+- `json_get_json`: Extracts a nested JSON value by path (SCALAR). Syntax: `json_get_json(json, path)`.
+- `json_get_str`: Extracts a string value from JSON by path (SCALAR). Syntax: `json_get_str(json, path)`.
+- `json_length`: Returns the length of a JSON array or object (SCALAR). Syntax: `json_length(json)`.
+- `json_object_keys`: Returns the keys of a JSON object (SCALAR). Syntax: `json_object_keys(json)`.
+- `json_tree`: Expands JSON into a tree of path, key, and value rows or structures. Syntax: `json_tree(json)`.
+
+### Search functions
+- `rerank`: Re-ranks search results or table rows using a configured reranker model. Syntax: `rerank(input, model => 'model_name', document => 'column_name'[, query => 'query text'])`.
+- `rrf`: Combines multiple search result sets using reciprocal rank fusion. Syntax: `rrf(text_search(...), vector_search(...)[, limit => n])`.
+- `text_search`: Runs full-text search over a configured searchable dataset. Syntax: `text_search(dataset, 'query text'[, column])`.
+- `vector_search`: Runs vector search over a configured embedding/vector index. Syntax: `vector_search(dataset, 'query text'[, column])`.
+
+### Additional registered functions
+- `bucket`: Assigns a numeric expression to a bucket boundary (SCALAR). Syntax: `bucket(value, buckets)`.
+- `col_description`: Returns the configured description for a table column (SCALAR). Syntax: `col_description(table_catalog, table_schema, table_name, column_name)`.
+- `cosine_distance`: Computes cosine distance between two vectors (SCALAR). Syntax: `cosine_distance(vector_a, vector_b)`.
+- `digest_many`: Computes a digest for one or more input expressions (SCALAR). Syntax: `digest_many(value[, ...])`.
+- `inner_product`: Computes the inner product of two vectors (SCALAR). Syntax: `inner_product(vector_a, vector_b)`.
+- `l2_distance`: Computes Euclidean distance between two vectors (SCALAR). Syntax: `l2_distance(vector_a, vector_b)`.
+- `l2_norm`: Computes the L2 norm of a vector (SCALAR). Syntax: `l2_norm(vector)`.
+- `l2_squared_distance`: Computes squared Euclidean distance between two vectors (SCALAR). Syntax: `l2_squared_distance(vector_a, vector_b)`.
+- `list_udfs`: Lists functions registered in the current DataFusion context. Syntax: `list_udfs()`.
+- `obj_description`: Returns the configured description for a table or object (SCALAR). Syntax: `obj_description(table_catalog, table_schema, table_name)`.
+- `truncate`: Truncates values to the requested precision (SCALAR). Syntax: `truncate(value, precision)`.
+
+### Spark compatibility scalar functions
+Spark-compatible scalar functions are available for arrays, maps, structs, dates, strings, hashes, URLs, XML, and other common Spark SQL expressions.
+- `abs`, `array`, `ascii`, `bit_count`, `bit_get`, `bitmap_count`, `bitwise_not`, `char`
+- `concat`, `crc32`, `csc`, `date_add`, `date_sub`, `elt`, `expm1`, `factorial`
+- `format_string`, `hex`, `hour`, `if`, `ilike`, `last_day`, `length`, `like`
+- `luhn_check`, `make_dt_interval`, `make_interval`, `map_from_arrays`, `map_from_entries`, `minute`, `mod`, `next_day`
+- `parse_url`, `pmod`, `rint`, `sec`, `second`, `sha1`, `sha2`, `shiftleft`
+- `shiftright`, `shiftrightunsigned`, `shuffle`, `space`, `try_parse_url`, `try_url_decode`, `url_decode`, `url_encode`
+- `width_bucket`
+
+## Sample Data
+
+### Distinct value samples for `support_tickets`
+| sentiment |
+| --- |
+| positive |
+| negative |
+
+### Example rows for `sales.orders`
+| order_id | customer_id |
+| --- | --- |
+| 42 | CUST-1 |

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_context_json_response.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_context_json_response.snap
@@ -1,0 +1,401 @@
+---
+source: crates/runtime/src/http/v1/nsql.rs
+expression: response
+---
+{
+  "context": "# Spice.ai NSQL Context",
+  "instructions": [
+    "Write SQL for the Spice runtime, which uses Apache DataFusion with the SQL parser configured for the PostgreSQL dialect.",
+    "Return only valid SQL code, without markdown fences.",
+    "Quote column names that contain capitals or special characters with double quotes.",
+    "For tables with schemas and catalogs, use \"catalog\".\"schema\".\"table\", not \"catalog.schema.table\".",
+    "Use table and column descriptions, primary keys, foreign keys, unique constraints, and indexes when choosing joins and filters."
+  ],
+  "sql": {
+    "engine": "Apache DataFusion",
+    "version": "52.5.0",
+    "dialect": "PostgreSQL",
+    "parser": "DataFusion SQL parser configured with PostgreSQL dialect",
+    "notes": [
+      "Spice supports standard DataFusion SQL plus additional Spice-specific and registered user-defined functions listed in this context.",
+      "Not every PostgreSQL extension is implemented; prefer the functions listed in this response when generating SQL for Spice.",
+      "Table functions such as text_search, vector_search, json_tree, and list_udfs are used in the FROM clause.",
+      "Run SELECT * FROM list_udfs() to inspect all functions registered in the current DataFusion context.",
+      "Use LIMIT for exploratory or broad-result queries unless the user explicitly asks for all rows."
+    ]
+  },
+  "datasets": [
+    {
+      "name": "sales.orders",
+      "catalog": "spice",
+      "schema": "sales",
+      "table": "orders",
+      "description": "Customer orders",
+      "metadata": {
+        "description": "Customer orders"
+      },
+      "columns": [
+        {
+          "name": "order_id",
+          "data_type": "Int64",
+          "nullable": false,
+          "description": "Unique order identifier",
+          "source_type": "bigint",
+          "metadata": {
+            "description": "Unique order identifier",
+            "source_type": "bigint"
+          },
+          "primary_key": true,
+          "unique": false,
+          "indexed": true,
+          "vector_search": false,
+          "full_text_search": false
+        },
+        {
+          "name": "customer_id",
+          "data_type": "Utf8",
+          "nullable": false,
+          "description": "Customer account identifier",
+          "source_type": "text",
+          "metadata": {
+            "description": "Customer account identifier",
+            "source_type": "text"
+          },
+          "primary_key": false,
+          "unique": false,
+          "indexed": true,
+          "vector_search": true,
+          "full_text_search": true
+        }
+      ],
+      "primary_key": [
+        "order_id"
+      ],
+      "unique_constraints": [
+        [
+          "order_id"
+        ]
+      ],
+      "foreign_keys": [
+        {
+          "columns": [
+            "customer_id"
+          ],
+          "foreign_table": "spice.sales.customers",
+          "foreign_columns": [
+            "id"
+          ]
+        }
+      ],
+      "indexes": [
+        {
+          "name": "customer_id",
+          "columns": [
+            "customer_id"
+          ],
+          "kind": "enabled",
+          "source": "spicepod.acceleration.indexes"
+        }
+      ],
+      "search": {
+        "vector": [
+          {
+            "column": "customer_id",
+            "function": "vector_search",
+            "syntax": "vector_search(sales.orders, 'query text', customer_id)",
+            "model": "embed_model",
+            "engine": "duckdb_vector_index",
+            "row_id_columns": [
+              "order_id"
+            ],
+            "vector_size": 384,
+            "chunked": false,
+            "input_mode": "scalar",
+            "index": {
+              "name": "duckdb_vector_index",
+              "columns": [
+                "customer_id",
+                "order_id"
+              ],
+              "kind": "duckdb_vector_index",
+              "source": "runtime_index"
+            },
+            "required_columns": [
+              "customer_id",
+              "order_id"
+            ],
+            "notes": []
+          }
+        ],
+        "full_text": [
+          {
+            "column": "customer_id",
+            "function": "text_search",
+            "syntax": "text_search(sales.orders, 'query text', customer_id)",
+            "engine": "tantivy",
+            "index_store": "memory",
+            "row_id_columns": [
+              "order_id"
+            ],
+            "index": {
+              "name": "full_text",
+              "columns": [
+                "customer_id",
+                "order_id"
+              ],
+              "kind": "full_text",
+              "source": "runtime_index"
+            },
+            "required_columns": [
+              "customer_id",
+              "order_id"
+            ],
+            "notes": []
+          }
+        ]
+      }
+    }
+  ],
+  "functions": {
+    "summary": "Spice SQL runs on Apache DataFusion with the SQL parser configured for the PostgreSQL dialect. Standard DataFusion SQL functions are available. Additional Spice-specific and registered user-defined functions are listed below. Run SELECT * FROM list_udfs() to inspect the full registered function inventory",
+    "json": [
+      {
+        "name": "flatten_json",
+        "syntax": "flatten_json(json)",
+        "description": "Flattens JSON objects into key-value rows or structures."
+      },
+      {
+        "name": "flatten_json_properties",
+        "syntax": "flatten_json_properties(json_schema)",
+        "description": "Flattens JSON-schema properties into key-value rows or structures."
+      },
+      {
+        "name": "json_as_text",
+        "syntax": "json_as_text(json)",
+        "description": "Converts a JSON value to text.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_contains",
+        "syntax": "json_contains(json, value)",
+        "description": "Returns whether one JSON value contains another.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_from_scalar",
+        "syntax": "json_from_scalar(value)",
+        "description": "Converts a scalar value to JSON.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_get",
+        "syntax": "json_get(json, path)",
+        "description": "Extracts a JSON value by path.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_get_array",
+        "syntax": "json_get_array(json, path)",
+        "description": "Extracts a JSON array by path.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_get_bool",
+        "syntax": "json_get_bool(json, path)",
+        "description": "Extracts a boolean value from JSON by path.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_get_float",
+        "syntax": "json_get_float(json, path)",
+        "description": "Extracts a floating-point value from JSON by path.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_get_int",
+        "syntax": "json_get_int(json, path)",
+        "description": "Extracts an integer value from JSON by path.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_get_json",
+        "syntax": "json_get_json(json, path)",
+        "description": "Extracts a nested JSON value by path.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_get_str",
+        "syntax": "json_get_str(json, path)",
+        "description": "Extracts a string value from JSON by path.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_length",
+        "syntax": "json_length(json)",
+        "description": "Returns the length of a JSON array or object.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_object_keys",
+        "syntax": "json_object_keys(json)",
+        "description": "Returns the keys of a JSON object.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "json_tree",
+        "syntax": "json_tree(json)",
+        "description": "Expands JSON into a tree of path, key, and value rows or structures."
+      }
+    ],
+    "search": [
+      {
+        "name": "rerank",
+        "syntax": "rerank(input, model => 'model_name', document => 'column_name'[, query => 'query text'])",
+        "description": "Re-ranks search results or table rows using a configured reranker model."
+      },
+      {
+        "name": "rrf",
+        "syntax": "rrf(text_search(...), vector_search(...)[, limit => n])",
+        "description": "Combines multiple search result sets using reciprocal rank fusion."
+      },
+      {
+        "name": "text_search",
+        "syntax": "text_search(dataset, 'query text'[, column])",
+        "description": "Runs full-text search over a configured searchable dataset."
+      },
+      {
+        "name": "vector_search",
+        "syntax": "vector_search(dataset, 'query text'[, column])",
+        "description": "Runs vector search over a configured embedding/vector index."
+      }
+    ],
+    "additional": [
+      {
+        "name": "bucket",
+        "syntax": "bucket(value, buckets)",
+        "description": "Assigns a numeric expression to a bucket boundary.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "col_description",
+        "syntax": "col_description(table_catalog, table_schema, table_name, column_name)",
+        "description": "Returns the configured description for a table column.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "cosine_distance",
+        "syntax": "cosine_distance(vector_a, vector_b)",
+        "description": "Computes cosine distance between two vectors.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "digest_many",
+        "syntax": "digest_many(value[, ...])",
+        "description": "Computes a digest for one or more input expressions.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "inner_product",
+        "syntax": "inner_product(vector_a, vector_b)",
+        "description": "Computes the inner product of two vectors.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "l2_distance",
+        "syntax": "l2_distance(vector_a, vector_b)",
+        "description": "Computes Euclidean distance between two vectors.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "l2_norm",
+        "syntax": "l2_norm(vector)",
+        "description": "Computes the L2 norm of a vector.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "l2_squared_distance",
+        "syntax": "l2_squared_distance(vector_a, vector_b)",
+        "description": "Computes squared Euclidean distance between two vectors.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "list_udfs",
+        "syntax": "list_udfs()",
+        "description": "Lists functions registered in the current DataFusion context."
+      },
+      {
+        "name": "obj_description",
+        "syntax": "obj_description(table_catalog, table_schema, table_name)",
+        "description": "Returns the configured description for a table or object.",
+        "function_type": "SCALAR"
+      },
+      {
+        "name": "truncate",
+        "syntax": "truncate(value, precision)",
+        "description": "Truncates values to the requested precision.",
+        "function_type": "SCALAR"
+      }
+    ],
+    "spark_compatibility": {
+      "description": "Spark-compatible scalar functions are available for arrays, maps, structs, dates, strings, hashes, URLs, XML, and other common Spark SQL expressions.",
+      "functions": [
+        "abs",
+        "array",
+        "ascii",
+        "bit_count",
+        "bit_get",
+        "bitmap_count",
+        "bitwise_not",
+        "char",
+        "concat",
+        "crc32",
+        "csc",
+        "date_add",
+        "date_sub",
+        "elt",
+        "expm1",
+        "factorial",
+        "format_string",
+        "hex",
+        "hour",
+        "if",
+        "ilike",
+        "last_day",
+        "length",
+        "like",
+        "luhn_check",
+        "make_dt_interval",
+        "make_interval",
+        "map_from_arrays",
+        "map_from_entries",
+        "minute",
+        "mod",
+        "next_day",
+        "parse_url",
+        "pmod",
+        "rint",
+        "sec",
+        "second",
+        "sha1",
+        "sha2",
+        "shiftleft",
+        "shiftright",
+        "shiftrightunsigned",
+        "shuffle",
+        "space",
+        "try_parse_url",
+        "try_url_decode",
+        "url_decode",
+        "url_encode",
+        "width_bucket"
+      ]
+    },
+    "user_defined": []
+  },
+  "samples": [
+    {
+      "title": "Example rows for `sales.orders`",
+      "content": "| order_id | customer_id |\n| --- | --- |\n| 42 | CUST-1 |"
+    }
+  ]
+}

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_context_plain_text_response.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_context_plain_text_response.snap
@@ -1,0 +1,97 @@
+---
+source: crates/runtime/src/http/v1/nsql.rs
+expression: body
+---
+# Spice.ai NSQL Context
+- Write SQL for the Spice runtime, which uses Apache DataFusion with the SQL parser configured for the PostgreSQL dialect.
+- Return only valid SQL code, without markdown fences.
+- Quote column names that contain capitals or special characters with double quotes.
+- For tables with schemas and catalogs, use "catalog"."schema"."table", not "catalog.schema.table".
+- Use table and column descriptions, primary keys, foreign keys, unique constraints, and indexes when choosing joins and filters.
+- Apache DataFusion version: 52.5.0.
+- Schema metadata includes table and column comments/descriptions when supplied by the connector or Spicepod.
+
+## Datasets
+- `sales.orders`: Customer orders
+- `support_tickets`: Customer support tickets
+
+## Schemas
+| table_reference | column_name | data_type | nullable | description |
+| --- | --- | --- | --- | --- |
+| sales.orders | order_id | Int64 | false | Unique order identifier |
+| sales.orders | customer_id | Utf8 | false | Customer account identifier |
+| support_tickets | ticket_id | Int64 | false | Support ticket identifier |
+| support_tickets | sentiment | Utf8 | true | Model-derived sentiment label |
+
+## Dataset Relationships
+### `sales.orders`
+- Primary key: `order_id`
+- Foreign keys:
+    - (`customer_id`) references `spice.sales.customers` (`id`)
+- Indexes:
+    - `customer_id`: `customer_id` (enabled, spicepod.acceleration.indexes)
+- Search indexes:
+    - vector search on `customer_id` using `embed_model`. Syntax: `vector_search(sales.orders, 'query text', customer_id)`. Engine/index: `duckdb_vector_index`. Row id: `order_id`.
+    - full-text search on `customer_id` using `tantivy`. Syntax: `text_search(sales.orders, 'query text', customer_id)`. Row id: `order_id`.
+
+## SQL Functions
+Spice SQL runs on Apache DataFusion with the SQL parser configured for the PostgreSQL dialect. Standard DataFusion SQL functions are available. Additional Spice-specific and registered user-defined functions are listed below. Run SELECT * FROM list_udfs() to inspect the full registered function inventory:
+
+### JSON functions
+- `flatten_json`: Flattens JSON objects into key-value rows or structures. Syntax: `flatten_json(json)`.
+- `flatten_json_properties`: Flattens JSON-schema properties into key-value rows or structures. Syntax: `flatten_json_properties(json_schema)`.
+- `json_as_text`: Converts a JSON value to text (SCALAR). Syntax: `json_as_text(json)`.
+- `json_contains`: Returns whether one JSON value contains another (SCALAR). Syntax: `json_contains(json, value)`.
+- `json_from_scalar`: Converts a scalar value to JSON (SCALAR). Syntax: `json_from_scalar(value)`.
+- `json_get`: Extracts a JSON value by path (SCALAR). Syntax: `json_get(json, path)`.
+- `json_get_array`: Extracts a JSON array by path (SCALAR). Syntax: `json_get_array(json, path)`.
+- `json_get_bool`: Extracts a boolean value from JSON by path (SCALAR). Syntax: `json_get_bool(json, path)`.
+- `json_get_float`: Extracts a floating-point value from JSON by path (SCALAR). Syntax: `json_get_float(json, path)`.
+- `json_get_int`: Extracts an integer value from JSON by path (SCALAR). Syntax: `json_get_int(json, path)`.
+- `json_get_json`: Extracts a nested JSON value by path (SCALAR). Syntax: `json_get_json(json, path)`.
+- `json_get_str`: Extracts a string value from JSON by path (SCALAR). Syntax: `json_get_str(json, path)`.
+- `json_length`: Returns the length of a JSON array or object (SCALAR). Syntax: `json_length(json)`.
+- `json_object_keys`: Returns the keys of a JSON object (SCALAR). Syntax: `json_object_keys(json)`.
+- `json_tree`: Expands JSON into a tree of path, key, and value rows or structures. Syntax: `json_tree(json)`.
+
+### Search functions
+- `rerank`: Re-ranks search results or table rows using a configured reranker model. Syntax: `rerank(input, model => 'model_name', document => 'column_name'[, query => 'query text'])`.
+- `rrf`: Combines multiple search result sets using reciprocal rank fusion. Syntax: `rrf(text_search(...), vector_search(...)[, limit => n])`.
+- `text_search`: Runs full-text search over a configured searchable dataset. Syntax: `text_search(dataset, 'query text'[, column])`.
+- `vector_search`: Runs vector search over a configured embedding/vector index. Syntax: `vector_search(dataset, 'query text'[, column])`.
+
+### Additional registered functions
+- `bucket`: Assigns a numeric expression to a bucket boundary (SCALAR). Syntax: `bucket(value, buckets)`.
+- `col_description`: Returns the configured description for a table column (SCALAR). Syntax: `col_description(table_catalog, table_schema, table_name, column_name)`.
+- `cosine_distance`: Computes cosine distance between two vectors (SCALAR). Syntax: `cosine_distance(vector_a, vector_b)`.
+- `digest_many`: Computes a digest for one or more input expressions (SCALAR). Syntax: `digest_many(value[, ...])`.
+- `inner_product`: Computes the inner product of two vectors (SCALAR). Syntax: `inner_product(vector_a, vector_b)`.
+- `l2_distance`: Computes Euclidean distance between two vectors (SCALAR). Syntax: `l2_distance(vector_a, vector_b)`.
+- `l2_norm`: Computes the L2 norm of a vector (SCALAR). Syntax: `l2_norm(vector)`.
+- `l2_squared_distance`: Computes squared Euclidean distance between two vectors (SCALAR). Syntax: `l2_squared_distance(vector_a, vector_b)`.
+- `list_udfs`: Lists functions registered in the current DataFusion context. Syntax: `list_udfs()`.
+- `obj_description`: Returns the configured description for a table or object (SCALAR). Syntax: `obj_description(table_catalog, table_schema, table_name)`.
+- `truncate`: Truncates values to the requested precision (SCALAR). Syntax: `truncate(value, precision)`.
+
+### Spark compatibility scalar functions
+Spark-compatible scalar functions are available for arrays, maps, structs, dates, strings, hashes, URLs, XML, and other common Spark SQL expressions.
+- `abs`, `array`, `ascii`, `bit_count`, `bit_get`, `bitmap_count`, `bitwise_not`, `char`
+- `concat`, `crc32`, `csc`, `date_add`, `date_sub`, `elt`, `expm1`, `factorial`
+- `format_string`, `hex`, `hour`, `if`, `ilike`, `last_day`, `length`, `like`
+- `luhn_check`, `make_dt_interval`, `make_interval`, `map_from_arrays`, `map_from_entries`, `minute`, `mod`, `next_day`
+- `parse_url`, `pmod`, `rint`, `sec`, `second`, `sha1`, `sha2`, `shiftleft`
+- `shiftright`, `shiftrightunsigned`, `shuffle`, `space`, `try_parse_url`, `try_url_decode`, `url_decode`, `url_encode`
+- `width_bucket`
+
+## Sample Data
+
+### Distinct value samples for `support_tickets`
+| sentiment |
+| --- |
+| positive |
+| negative |
+
+### Example rows for `sales.orders`
+| order_id | customer_id |
+| --- | --- |
+| 42 | CUST-1 |

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_user_function_context.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__nsql__tests__nsql_user_function_context.snap
@@ -1,0 +1,8 @@
+---
+source: crates/runtime/src/http/v1/nsql.rs
+expression: output
+---
+
+### User-defined functions
+- `Haversine_Km`: scalar function from `sql` with `stable` volatility. Syntax: `Haversine_Km(x int64) -> int64`. Haversine_Km description
+- `Rows_Fn`: table function from `sql` with `stable` volatility. Syntax: `Rows_Fn(x int64) -> TABLE(value int64)`. Rows_Fn description

--- a/crates/runtime/src/model/mod.rs
+++ b/crates/runtime/src/model/mod.rs
@@ -26,6 +26,7 @@ mod chat;
 mod embed;
 mod metrics;
 mod model_context;
+pub(crate) mod nsql;
 pub mod params;
 pub(crate) mod provider_models;
 pub(crate) mod rate_limit;

--- a/crates/runtime/src/model/nsql.rs
+++ b/crates/runtime/src/model/nsql.rs
@@ -1,0 +1,3175 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    error::Error as StdError,
+    fmt::Write,
+    sync::Arc,
+};
+
+use async_openai::types::chat::{
+    ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageArgs,
+};
+use data_components::{
+    DESCRIPTION_METADATA_KEY, FOREIGN_KEYS_METADATA_KEY, SOURCE_TYPE_METADATA_KEY,
+};
+use datafusion::arrow::{
+    array::{Array, BooleanArray, StringArray, UInt8Array, UInt64Array},
+    datatypes::Schema,
+    record_batch::RecordBatch,
+};
+use datafusion::{
+    DATAFUSION_VERSION,
+    common::{Constraint, Constraints, DataFusionError, utils::quote_identifier},
+    sql::TableReference,
+};
+use datafusion_table_providers::util::column_reference::ColumnReference;
+use futures::{StreamExt, TryStreamExt};
+use itertools::Itertools;
+use runtime_datafusion::allowlist::ResolvedTableAwareAllowlist;
+use runtime_datafusion_index::IndexedTableProvider;
+#[cfg(test)]
+use runtime_datafusion_udfs::{
+    bucket::BUCKET_SCALAR_UDF_NAME,
+    cosine_distance::COSINE_DISTANCE_UDF_NAME,
+    digest_many::DIGEST_UDF_NAME,
+    inner_product::INNER_PRODUCT_UDF_NAME,
+    l2_distance::{L2_DISTANCE_UDF_NAME, L2_SQUARED_DISTANCE_UDF_NAME},
+    l2_norm::L2_NORM_UDF_NAME,
+    truncate::TRUNCATE_SCALAR_UDF_NAME,
+};
+use runtime_request_context::RequestContext;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use snafu::Snafu;
+use spicepod::{component::function::Function, semantic::Column};
+use tracing::Span;
+use tracing_futures::Instrument;
+
+#[cfg(all(test, feature = "models"))]
+use runtime_datafusion_udfs::{ai::AI_UDF_NAME, embed::EMBED_UDF_NAME};
+
+use crate::{
+    Runtime,
+    component::column::full_text_search_config,
+    datafusion::{
+        SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA,
+        request_context_extension::get_current_datafusion,
+        udf::{UserFunctionInfo, effective_user_function_volatility, user_function_infos},
+    },
+    embeddings::table::{EmbeddingInputMode, EmbeddingTable},
+    embeddings::udtf::VECTOR_SEARCH_UDTF_NAME,
+    search::{
+        full_text::udtf::TEXT_SEARCH_UDTF_NAME, rerank::RERANK_UDTF_NAME, rrf::RRF_UDF_NAME,
+        util::find_concrete_table_provider,
+    },
+    tools::{
+        SpiceModelTool,
+        builtin::{
+            sample::{
+                SampleTableMethod, SampleTableParams, distinct::DistinctColumnsParams,
+                random::RandomSampleParams, tool::SampleDataTool,
+            },
+            table_schema::{TableSchemaTool, TableSchemaToolParams},
+        },
+        utils::tool_call_error_response,
+    },
+};
+
+#[cfg(test)]
+use crate::datafusion::pg_catalog::{COL_DESCRIPTION_UDF_NAME, OBJ_DESCRIPTION_UDF_NAME};
+
+#[cfg(test)]
+use crate::udtfs::LIST_UDFS_UDTF_NAME;
+
+#[cfg(test)]
+use crate::datafusion::udtf::{
+    flatten_json::FLATTEN_JSON_UDTF_NAME, json_properties::FLATTEN_JSON_PROPERTIES_UDTF_NAME,
+    json_tree::JSON_TREE_UDTF_NAME,
+};
+
+pub(crate) const DEFAULT_NSQL_CONTEXT_SAMPLE_LIMIT: usize = 3;
+pub(crate) const MAX_NSQL_CONTEXT_SAMPLE_LIMIT: usize = 100;
+
+const DATA_SAMPLING_MAX_CONCURRENT: usize = 10;
+
+const NSQL_CONTEXT_INSTRUCTIONS: [&str; 5] = [
+    "Write SQL for the Spice runtime, which uses Apache DataFusion with the SQL parser configured for the PostgreSQL dialect.",
+    "Return only valid SQL code, without markdown fences.",
+    "Quote column names that contain capitals or special characters with double quotes.",
+    "For tables with schemas and catalogs, use \"catalog\".\"schema\".\"table\", not \"catalog.schema.table\".",
+    "Use table and column descriptions, primary keys, foreign keys, unique constraints, and indexes when choosing joins and filters.",
+];
+
+const NSQL_FUNCTION_CONTEXT_SUMMARY: &str = "Spice SQL runs on Apache DataFusion with the SQL parser configured for the PostgreSQL dialect. Standard DataFusion SQL functions are available. Additional Spice-specific and registered user-defined functions are listed below. Run SELECT * FROM list_udfs() to inspect the full registered function inventory";
+
+#[derive(Debug, Snafu)]
+pub(crate) enum NsqlContextError {
+    #[snafu(display("Unexpected internal error. App not prepared in runtime."))]
+    AppNotPrepared,
+
+    #[snafu(display("Unexpected internal error. Model '{model_name}' datasets are invalid."))]
+    InvalidModelDatasets { model_name: String },
+
+    #[snafu(display("Dataset '{dataset}' not found"))]
+    DatasetNotFound { dataset: String },
+
+    #[snafu(display("{message}"))]
+    ContextMessage { message: String },
+
+    #[snafu(display("{source}"))]
+    SchemaContext {
+        source: Box<dyn StdError + Send + Sync>,
+    },
+
+    #[snafu(display("{source}"))]
+    SampleContext {
+        source: Box<dyn StdError + Send + Sync>,
+    },
+
+    #[snafu(display("{source}"))]
+    FunctionContext {
+        source: Box<dyn StdError + Send + Sync>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct SampleContextBlock {
+    pub(crate) title: String,
+    pub(crate) content: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlContextJsonResponse {
+    /// The rendered NSQL context block injected into `/v1/nsql` model requests.
+    pub(crate) context: String,
+
+    /// High-level SQL generation instructions.
+    pub(crate) instructions: Vec<String>,
+
+    /// SQL engine and dialect details for Spice SQL.
+    pub(crate) sql: NsqlSqlContext,
+
+    /// In-scope datasets with schema, metadata, relationship, key, and index details.
+    pub(crate) datasets: Vec<NsqlDatasetContext>,
+
+    /// Available function groups filtered to the current `DataFusion` context.
+    pub(crate) functions: NsqlFunctionContext,
+
+    /// Optional sample blocks included when requested.
+    pub(crate) samples: Vec<SampleContextBlock>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlSqlContext {
+    pub(crate) engine: String,
+    pub(crate) version: String,
+    pub(crate) dialect: String,
+    pub(crate) parser: String,
+    pub(crate) notes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlDatasetContext {
+    pub(crate) name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) catalog: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) schema: Option<String>,
+    pub(crate) table: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+    pub(crate) metadata: BTreeMap<String, String>,
+    pub(crate) columns: Vec<NsqlColumnContext>,
+    pub(crate) primary_key: Vec<String>,
+    pub(crate) unique_constraints: Vec<Vec<String>>,
+    pub(crate) foreign_keys: Vec<NsqlForeignKeyContext>,
+    pub(crate) indexes: Vec<NsqlIndexContext>,
+    pub(crate) search: NsqlDatasetSearchContext,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlColumnContext {
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    #[cfg_attr(feature = "openapi", schema(value_type = bool))]
+    pub(crate) nullable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) source_type: Option<String>,
+    pub(crate) metadata: BTreeMap<String, String>,
+    #[cfg_attr(feature = "openapi", schema(value_type = bool))]
+    pub(crate) primary_key: NsqlColumnFlag,
+    #[cfg_attr(feature = "openapi", schema(value_type = bool))]
+    pub(crate) unique: NsqlColumnFlag,
+    #[cfg_attr(feature = "openapi", schema(value_type = bool))]
+    pub(crate) indexed: NsqlColumnFlag,
+    #[cfg_attr(feature = "openapi", schema(value_type = bool))]
+    pub(crate) vector_search: NsqlColumnFlag,
+    #[cfg_attr(feature = "openapi", schema(value_type = bool))]
+    pub(crate) full_text_search: NsqlColumnFlag,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct NsqlColumnFlag(bool);
+
+impl From<bool> for NsqlColumnFlag {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlForeignKeyContext {
+    pub(crate) columns: Vec<String>,
+    pub(crate) foreign_table: String,
+    pub(crate) foreign_columns: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlIndexContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<String>,
+    pub(crate) columns: Vec<String>,
+    pub(crate) kind: String,
+    pub(crate) source: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlDatasetSearchContext {
+    pub(crate) vector: Vec<NsqlVectorSearchContext>,
+    pub(crate) full_text: Vec<NsqlFullTextSearchContext>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlVectorSearchContext {
+    pub(crate) column: String,
+    pub(crate) function: String,
+    pub(crate) syntax: String,
+    pub(crate) model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) engine: Option<String>,
+    pub(crate) row_id_columns: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) vector_size: Option<usize>,
+    pub(crate) chunked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) input_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) index: Option<NsqlIndexContext>,
+    pub(crate) required_columns: Vec<String>,
+    pub(crate) notes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlFullTextSearchContext {
+    pub(crate) column: String,
+    pub(crate) function: String,
+    pub(crate) syntax: String,
+    pub(crate) engine: String,
+    pub(crate) index_store: String,
+    pub(crate) row_id_columns: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) index: Option<NsqlIndexContext>,
+    pub(crate) required_columns: Vec<String>,
+    pub(crate) notes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlFunctionContext {
+    pub(crate) summary: String,
+    pub(crate) json: Vec<NsqlFunctionContextEntry>,
+    pub(crate) search: Vec<NsqlFunctionContextEntry>,
+    pub(crate) additional: Vec<NsqlFunctionContextEntry>,
+    pub(crate) spark_compatibility: NsqlSparkFunctionContext,
+    pub(crate) user_defined: Vec<UserFunctionContextEntry>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlSparkFunctionContext {
+    pub(crate) description: String,
+    pub(crate) functions: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct NsqlFunctionContextEntry {
+    pub(crate) name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) syntax: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) function_type: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) signatures: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) example: Option<String>,
+}
+
+#[cfg(test)]
+impl NsqlContextJsonResponse {
+    pub(crate) fn minimal_for_test(context: impl Into<String>) -> Self {
+        Self {
+            context: context.into(),
+            instructions: nsql_context_instructions(),
+            sql: nsql_sql_context(),
+            datasets: vec![],
+            functions: NsqlFunctionContext {
+                summary: NSQL_FUNCTION_CONTEXT_SUMMARY.to_string(),
+                json: vec![],
+                search: vec![],
+                additional: vec![],
+                spark_compatibility: NsqlSparkFunctionContext {
+                    description: "Spark-compatible scalar functions are available for arrays, maps, structs, dates, strings, hashes, URLs, XML, and other common Spark SQL expressions.".to_string(),
+                    functions: vec![],
+                },
+                user_defined: vec![],
+            },
+            samples: vec![],
+        }
+    }
+}
+
+pub(crate) struct NsqlContext {
+    pub(crate) json: NsqlContextJsonResponse,
+    pub(crate) message: ChatCompletionRequestMessage,
+    pub(crate) table_allowlist: Option<ResolvedTableAwareAllowlist>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct NsqlContextOptions {
+    pub(crate) include_sampling: bool,
+    pub(crate) sampling_limit: usize,
+    pub(crate) include_examples: bool,
+    pub(crate) examples_limit: usize,
+}
+
+impl NsqlContextOptions {
+    #[must_use]
+    pub(crate) fn from_nsql_request(sample_data_enabled: bool) -> Self {
+        Self {
+            include_sampling: sample_data_enabled,
+            sampling_limit: DEFAULT_NSQL_CONTEXT_SAMPLE_LIMIT,
+            include_examples: sample_data_enabled,
+            examples_limit: DEFAULT_NSQL_CONTEXT_SAMPLE_LIMIT,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn new(
+        include_sampling: bool,
+        sampling_limit: usize,
+        include_examples: bool,
+        examples_limit: usize,
+    ) -> Self {
+        Self {
+            include_sampling,
+            sampling_limit,
+            include_examples,
+            examples_limit,
+        }
+    }
+}
+
+fn value_to_context_text(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        _ => match serde_json::to_string_pretty(value) {
+            Ok(text) => text,
+            Err(_) => value.to_string(),
+        },
+    }
+}
+
+async fn tool_context_text(
+    tool: &dyn SpiceModelTool,
+    params: &impl Serialize,
+) -> Result<String, Box<dyn StdError + Send + Sync>> {
+    let arg = serde_json::to_string(params)?;
+    let response = match tool.call(arg.as_str()).await {
+        Ok(response) => response,
+        Err(error) => {
+            let tool_name = tool.name();
+            let tool_name: &str = tool_name.as_ref();
+            tracing::warn!(tool = %tool_name, error = %error, "Failed to build NSQL tool context; returning error context");
+            tool_call_error_response(tool_name, error)
+        }
+    };
+
+    Ok(value_to_context_text(&response))
+}
+
+fn sort_table_references(tables: &mut [TableReference]) {
+    tables.sort_by_cached_key(ToString::to_string);
+}
+
+async fn table_schema_context(
+    tables: &[TableReference],
+    rt: Arc<Runtime>,
+    table_allowlist: Option<ResolvedTableAwareAllowlist>,
+) -> Result<String, Box<dyn StdError + Send + Sync>> {
+    let table_schema_tool =
+        TableSchemaTool::new(rt, None, None).with_table_allowlist(table_allowlist);
+    let params = TableSchemaToolParams::new(tables.iter().map(ToString::to_string).collect());
+    tool_context_text(&table_schema_tool, &params).await
+}
+
+#[derive(Clone, Debug)]
+struct AppTableContext {
+    metadata: HashMap<String, String>,
+    columns: Vec<Column>,
+    legacy_embeddings: Vec<spicepod::component::embeddings::ColumnEmbeddingConfig>,
+    vector_store: Option<spicepod::vector::VectorStore>,
+    full_text_search: Option<spicepod::fts::FtsStore>,
+    configured_primary_key: Option<Vec<String>>,
+    configured_indexes: Vec<NsqlIndexContext>,
+}
+
+#[derive(Clone, Debug)]
+struct ConfiguredVectorSearchColumn {
+    column: String,
+    model: String,
+    engine: Option<String>,
+    row_id_columns: Vec<String>,
+    vector_size: Option<usize>,
+    chunked: bool,
+    aggregation: Option<String>,
+    max_elements_per_row: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+struct ConfiguredFullTextSearchColumn {
+    column: String,
+    engine: String,
+    index_store: String,
+    row_id_columns: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SearchFunctionAvailability {
+    vector_search: bool,
+    text_search: bool,
+}
+
+fn nsql_context_instructions() -> Vec<String> {
+    NSQL_CONTEXT_INSTRUCTIONS
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn nsql_sql_context() -> NsqlSqlContext {
+    NsqlSqlContext {
+        engine: "Apache DataFusion".to_string(),
+        version: DATAFUSION_VERSION.to_string(),
+        dialect: "PostgreSQL".to_string(),
+        parser: "DataFusion SQL parser configured with PostgreSQL dialect".to_string(),
+        notes: vec![
+            "Spice supports standard DataFusion SQL plus additional Spice-specific and registered user-defined functions listed in this context.".to_string(),
+            "Not every PostgreSQL extension is implemented; prefer the functions listed in this response when generating SQL for Spice.".to_string(),
+            "Table functions such as text_search, vector_search, json_tree, and list_udfs are used in the FROM clause.".to_string(),
+            "Run SELECT * FROM list_udfs() to inspect all functions registered in the current DataFusion context.".to_string(),
+            "Use LIMIT for exploratory or broad-result queries unless the user explicitly asks for all rows.".to_string(),
+        ],
+    }
+}
+
+fn column_reference_columns(reference: &str) -> Vec<String> {
+    ColumnReference::try_from(reference).map_or_else(
+        |_| vec![reference.to_string()],
+        |columns| columns.iter().map(ToString::to_string).collect(),
+    )
+}
+
+fn configured_acceleration_indexes(
+    acceleration: &spicepod::acceleration::Acceleration,
+) -> Vec<NsqlIndexContext> {
+    let mut indexes = acceleration
+        .indexes
+        .iter()
+        .map(|(columns, index_type)| NsqlIndexContext {
+            name: Some(columns.clone()),
+            columns: column_reference_columns(columns),
+            kind: index_type.to_string(),
+            source: "spicepod.acceleration.indexes".to_string(),
+        })
+        .collect_vec();
+
+    if let Some(primary_key) = &acceleration.primary_key {
+        indexes.push(NsqlIndexContext {
+            name: Some(primary_key.clone()),
+            columns: column_reference_columns(primary_key),
+            kind: "primary_key".to_string(),
+            source: "spicepod.acceleration.primary_key".to_string(),
+        });
+    }
+
+    indexes.sort_by(|left, right| {
+        left.source
+            .cmp(&right.source)
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.columns.cmp(&right.columns))
+    });
+    indexes
+}
+
+fn app_table_context(table: &TableReference, app: &app::App) -> Option<AppTableContext> {
+    if let Some(dataset) = app
+        .datasets
+        .iter()
+        .find(|dataset| table.resolved_eq(&TableReference::parse_str(&dataset.name)))
+    {
+        let configured_primary_key = dataset
+            .acceleration
+            .as_ref()
+            .and_then(|acceleration| acceleration.primary_key.as_deref())
+            .map(column_reference_columns)
+            .or_else(|| dataset.primary_key_override());
+        let configured_indexes = dataset
+            .acceleration
+            .as_ref()
+            .map_or_else(Vec::new, configured_acceleration_indexes);
+
+        return Some(AppTableContext {
+            metadata: dataset.metadata(),
+            columns: dataset.columns.clone(),
+            legacy_embeddings: dataset.embeddings.clone(),
+            vector_store: dataset.vectors.clone(),
+            full_text_search: dataset.full_text_search.clone(),
+            configured_primary_key,
+            configured_indexes,
+        });
+    }
+
+    app.views
+        .iter()
+        .find(|view| table.resolved_eq(&TableReference::parse_str(&view.name)))
+        .map(|view| AppTableContext {
+            metadata: view.metadata(),
+            columns: view.columns.clone(),
+            legacy_embeddings: vec![],
+            vector_store: view.vectors.clone(),
+            full_text_search: None,
+            configured_primary_key: view.primary_key_override(),
+            configured_indexes: view
+                .acceleration
+                .as_ref()
+                .map_or_else(Vec::new, configured_acceleration_indexes),
+        })
+}
+
+fn constraint_column_names(schema: &Schema, indices: &[usize]) -> Option<Vec<String>> {
+    indices
+        .iter()
+        .map(|index| {
+            schema
+                .fields()
+                .get(*index)
+                .map(|field| field.name().clone())
+        })
+        .collect()
+}
+
+fn key_context_from_constraints(
+    schema: &Schema,
+    constraints: Option<&Constraints>,
+) -> (Vec<String>, Vec<Vec<String>>) {
+    let Some(constraints) = constraints else {
+        return (vec![], vec![]);
+    };
+
+    let mut primary_key = Vec::new();
+    let mut unique_constraints = Vec::new();
+
+    for constraint in constraints.iter() {
+        match constraint {
+            Constraint::PrimaryKey(indices) => {
+                if primary_key.is_empty()
+                    && let Some(columns) = constraint_column_names(schema, indices)
+                {
+                    primary_key = columns;
+                }
+            }
+            Constraint::Unique(indices) => {
+                if let Some(columns) = constraint_column_names(schema, indices) {
+                    unique_constraints.push(columns);
+                }
+            }
+        }
+    }
+
+    (primary_key, unique_constraints)
+}
+
+fn foreign_keys_from_metadata(metadata: &HashMap<String, String>) -> Vec<NsqlForeignKeyContext> {
+    let Some(foreign_keys) = metadata.get(FOREIGN_KEYS_METADATA_KEY) else {
+        return vec![];
+    };
+
+    match serde_json::from_str::<Vec<NsqlForeignKeyContext>>(foreign_keys) {
+        Ok(foreign_keys) => foreign_keys,
+        Err(error) => {
+            tracing::warn!(%error, "Failed to parse foreign key metadata for NSQL context");
+            vec![]
+        }
+    }
+}
+
+fn runtime_indexes_from_provider(
+    table_provider: Option<&Arc<dyn datafusion::datasource::TableProvider>>,
+) -> Vec<NsqlIndexContext> {
+    let Some(table_provider) = table_provider else {
+        return vec![];
+    };
+
+    find_concrete_table_provider::<IndexedTableProvider>(table_provider).map_or_else(
+        Vec::new,
+        |indexed_table| {
+            indexed_table
+                .get_all_indexes()
+                .into_iter()
+                .map(|index| {
+                    let mut columns = index.required_columns();
+                    columns.sort();
+                    NsqlIndexContext {
+                        name: Some(index.name().to_string()),
+                        columns,
+                        kind: index.name().to_string(),
+                        source: "runtime_index".to_string(),
+                    }
+                })
+                .collect()
+        },
+    )
+}
+
+fn search_function_availability(available_names: &HashSet<String>) -> SearchFunctionAvailability {
+    SearchFunctionAvailability {
+        vector_search: available_names.contains(VECTOR_SEARCH_UDTF_NAME),
+        text_search: available_names.contains(TEXT_SEARCH_UDTF_NAME),
+    }
+}
+
+fn dataset_search_function_availability(
+    registered: SearchFunctionAvailability,
+    datasets: &[NsqlDatasetContext],
+) -> SearchFunctionAvailability {
+    SearchFunctionAvailability {
+        vector_search: registered.vector_search
+            && datasets
+                .iter()
+                .any(|dataset| !dataset.search.vector.is_empty()),
+        text_search: registered.text_search
+            && datasets
+                .iter()
+                .any(|dataset| !dataset.search.full_text.is_empty()),
+    }
+}
+
+fn is_vector_search_index(kind: &str) -> bool {
+    matches!(
+        kind,
+        "NativeVectorIndex"
+            | "duckdb_vector_index"
+            | "elasticsearch_index"
+            | "s3_vector_index"
+            | "ChunkedSearchIndex"
+            | "ChunkedVectorIndex"
+    )
+}
+
+fn is_full_text_search_index(kind: &str) -> bool {
+    matches!(kind, "full_text" | "elasticsearch_text_index")
+}
+
+fn search_index_for_column(
+    indexes: &[NsqlIndexContext],
+    column: &str,
+    index_kind: fn(&str) -> bool,
+) -> Option<NsqlIndexContext> {
+    indexes
+        .iter()
+        .find(|index| index_kind(&index.kind) && index.columns.iter().any(|c| c == column))
+        .cloned()
+}
+
+fn configured_vector_search_columns(
+    app_context: &AppTableContext,
+) -> Vec<ConfiguredVectorSearchColumn> {
+    let dataset_engine = app_context
+        .vector_store
+        .as_ref()
+        .filter(|store| store.enabled)
+        .and_then(|store| store.engine.clone());
+
+    let mut configured = app_context
+        .columns
+        .iter()
+        .flat_map(|column| {
+            let dataset_engine = dataset_engine.clone();
+            column
+                .embeddings
+                .iter()
+                .map(move |embedding| ConfiguredVectorSearchColumn {
+                    column: column.name.clone(),
+                    model: embedding.model.clone(),
+                    engine: embedding.engine.clone().or_else(|| dataset_engine.clone()),
+                    row_id_columns: embedding.row_ids.clone().unwrap_or_default(),
+                    vector_size: embedding.vector_size,
+                    chunked: embedding
+                        .chunking
+                        .as_ref()
+                        .is_some_and(|chunking| chunking.enabled),
+                    aggregation: embedding
+                        .aggregation
+                        .map(|aggregation| aggregation.to_string()),
+                    max_elements_per_row: embedding.max_elements_per_row,
+                })
+        })
+        .collect_vec();
+
+    configured.extend(app_context.legacy_embeddings.iter().map(|embedding| {
+        ConfiguredVectorSearchColumn {
+            column: embedding.column.clone(),
+            model: embedding.model.clone(),
+            engine: dataset_engine.clone(),
+            row_id_columns: embedding.primary_keys.clone().unwrap_or_default(),
+            vector_size: embedding.vector_size,
+            chunked: embedding
+                .chunking
+                .as_ref()
+                .is_some_and(|chunking| chunking.enabled),
+            aggregation: embedding
+                .aggregation
+                .map(|aggregation| aggregation.to_string()),
+            max_elements_per_row: embedding.max_elements_per_row,
+        }
+    }));
+
+    let mut seen_columns = HashSet::new();
+    configured.retain(|column| seen_columns.insert(column.column.clone()));
+    configured.sort_by(|left, right| left.column.cmp(&right.column));
+    configured
+}
+
+fn configured_full_text_search_columns(
+    table: &TableReference,
+    app_context: &AppTableContext,
+    primary_key: &[String],
+) -> Vec<ConfiguredFullTextSearchColumn> {
+    let dataset_engine = app_context
+        .full_text_search
+        .as_ref()
+        .filter(|store| store.enabled)
+        .and_then(|store| store.engine.clone());
+    let dataset_config_primary_key = full_text_search_config(&app_context.columns, table)
+        .map(|config| config.primary_key)
+        .unwrap_or_default();
+
+    let mut configured = app_context
+        .columns
+        .iter()
+        .filter_map(|column| {
+            let full_text_search = column
+                .full_text_search
+                .as_ref()
+                .filter(|config| config.enabled)?;
+
+            let row_id_columns = full_text_search
+                .row_ids
+                .clone()
+                .filter(|row_ids| !row_ids.is_empty())
+                .or_else(|| {
+                    (!dataset_config_primary_key.is_empty())
+                        .then_some(dataset_config_primary_key.clone())
+                })
+                .unwrap_or_else(|| primary_key.to_vec());
+
+            Some(ConfiguredFullTextSearchColumn {
+                column: column.name.clone(),
+                engine: full_text_search
+                    .engine
+                    .clone()
+                    .or_else(|| dataset_engine.clone())
+                    .unwrap_or_else(|| "tantivy".to_string()),
+                index_store: full_text_search.index_store.unwrap_or_default().to_string(),
+                row_id_columns,
+            })
+        })
+        .collect_vec();
+
+    configured.sort_by(|left, right| left.column.cmp(&right.column));
+    configured
+}
+
+fn embedding_input_mode_context(input_mode: EmbeddingInputMode) -> String {
+    match input_mode {
+        EmbeddingInputMode::Scalar => "scalar".to_string(),
+        EmbeddingInputMode::ListMulti {
+            aggregation,
+            max_elements_per_row,
+        } => format!(
+            "list_multi; aggregation={aggregation}; max_elements_per_row={max_elements_per_row}"
+        ),
+    }
+}
+
+fn quoted_identifier(name: &str) -> String {
+    quote_identifier(name).to_string()
+}
+
+fn vector_search_syntax(table: &TableReference, column: &str) -> String {
+    format!(
+        "{VECTOR_SEARCH_UDTF_NAME}({table}, 'query text', {})",
+        quoted_identifier(column)
+    )
+}
+
+fn text_search_syntax(table: &TableReference, column: &str) -> String {
+    format!(
+        "{TEXT_SEARCH_UDTF_NAME}({table}, 'query text', {})",
+        quoted_identifier(column)
+    )
+}
+
+fn vector_search_contexts(
+    table: &TableReference,
+    table_provider: Option<&Arc<dyn datafusion::datasource::TableProvider>>,
+    runtime_indexes: &[NsqlIndexContext],
+    app_context: &AppTableContext,
+    primary_key: &[String],
+    available: SearchFunctionAvailability,
+) -> Vec<NsqlVectorSearchContext> {
+    if !available.vector_search {
+        return vec![];
+    }
+
+    let embedding_table = table_provider.and_then(find_concrete_table_provider::<EmbeddingTable>);
+
+    configured_vector_search_columns(app_context)
+        .into_iter()
+        .filter_map(|configured| {
+            let index = search_index_for_column(
+                runtime_indexes,
+                &configured.column,
+                is_vector_search_index,
+            );
+            let embedding_config = embedding_table
+                .and_then(|table| table.embedded_columns.get(&configured.column));
+
+            if index.is_none() && embedding_config.is_none() {
+                return None;
+            }
+
+            let row_id_columns = if configured.row_id_columns.is_empty() {
+                primary_key.to_vec()
+            } else {
+                configured.row_id_columns.clone()
+            };
+            let vector_size = configured.vector_size.or_else(|| {
+                embedding_config.and_then(|config| usize::try_from(config.vector_size).ok())
+            });
+            let model = if configured.model.is_empty() {
+                embedding_config.map_or_else(String::new, |config| config.model_name.clone())
+            } else {
+                configured.model.clone()
+            };
+            if model.is_empty() {
+                return None;
+            }
+
+            let required_columns = index.as_ref().map_or_else(
+                || {
+                    row_id_columns
+                        .iter()
+                        .cloned()
+                        .chain(std::iter::once(configured.column.clone()))
+                        .collect_vec()
+                },
+                |index| index.columns.clone(),
+            );
+            let mut notes = Vec::new();
+            if configured.chunked {
+                notes.push(
+                    "This column is chunked; vector_search returns the most relevant chunk in the value column."
+                        .to_string(),
+                );
+            }
+            if configured.aggregation.is_some() || configured.max_elements_per_row.is_some() {
+                notes.push(
+                    "This column is configured for multi-vector search; similarity is aggregated across list elements."
+                        .to_string(),
+                );
+            }
+            if index.is_none() {
+                notes.push(
+                    "No separate vector engine index is configured; vector_search uses the embedding table path for this column."
+                        .to_string(),
+                );
+            }
+
+            Some(NsqlVectorSearchContext {
+                column: configured.column.clone(),
+                function: VECTOR_SEARCH_UDTF_NAME.to_string(),
+                syntax: vector_search_syntax(table, &configured.column),
+                model,
+                engine: configured
+                    .engine
+                    .clone()
+                    .or_else(|| index.as_ref().map(|index| index.kind.clone())),
+                row_id_columns,
+                vector_size,
+                chunked: configured.chunked,
+                input_mode: embedding_config.map(|config| embedding_input_mode_context(config.input_mode)),
+                required_columns,
+                index,
+                notes,
+            })
+        })
+        .collect_vec()
+}
+
+fn full_text_search_contexts(
+    table: &TableReference,
+    runtime_indexes: &[NsqlIndexContext],
+    app_context: &AppTableContext,
+    primary_key: &[String],
+    available: SearchFunctionAvailability,
+) -> Vec<NsqlFullTextSearchContext> {
+    if !available.text_search {
+        return vec![];
+    }
+
+    configured_full_text_search_columns(table, app_context, primary_key)
+        .into_iter()
+        .filter_map(|configured| {
+            let index = search_index_for_column(
+                runtime_indexes,
+                &configured.column,
+                is_full_text_search_index,
+            )?;
+            let required_columns = index.columns.clone();
+
+            Some(NsqlFullTextSearchContext {
+                column: configured.column.clone(),
+                function: TEXT_SEARCH_UDTF_NAME.to_string(),
+                syntax: text_search_syntax(table, &configured.column),
+                engine: configured.engine,
+                index_store: configured.index_store,
+                row_id_columns: configured.row_id_columns,
+                required_columns,
+                index: Some(index),
+                notes: vec![],
+            })
+        })
+        .collect_vec()
+}
+
+fn dataset_search_context(
+    table: &TableReference,
+    table_provider: Option<&Arc<dyn datafusion::datasource::TableProvider>>,
+    runtime_indexes: &[NsqlIndexContext],
+    app_context: Option<&AppTableContext>,
+    primary_key: &[String],
+    available: SearchFunctionAvailability,
+) -> NsqlDatasetSearchContext {
+    let Some(app_context) = app_context else {
+        return NsqlDatasetSearchContext::default();
+    };
+
+    NsqlDatasetSearchContext {
+        vector: vector_search_contexts(
+            table,
+            table_provider,
+            runtime_indexes,
+            app_context,
+            primary_key,
+            available,
+        ),
+        full_text: full_text_search_contexts(
+            table,
+            runtime_indexes,
+            app_context,
+            primary_key,
+            available,
+        ),
+    }
+}
+
+fn dataset_context_from_schema(
+    table: &TableReference,
+    schema: &Schema,
+    constraints: Option<&Constraints>,
+    runtime_indexes: Vec<NsqlIndexContext>,
+    table_provider: Option<&Arc<dyn datafusion::datasource::TableProvider>>,
+    app_context: Option<&AppTableContext>,
+    search_functions: SearchFunctionAvailability,
+) -> NsqlDatasetContext {
+    let mut metadata = schema.metadata().clone();
+    if let Some(app_context) = app_context {
+        metadata.extend(app_context.metadata.clone());
+    }
+
+    let (mut primary_key, unique_constraints) = key_context_from_constraints(schema, constraints);
+    if primary_key.is_empty()
+        && let Some(configured_primary_key) =
+            app_context.and_then(|context| context.configured_primary_key.clone())
+    {
+        primary_key = configured_primary_key;
+    }
+
+    let mut indexes = runtime_indexes;
+    if let Some(app_context) = app_context {
+        indexes.extend(app_context.configured_indexes.clone());
+    }
+    indexes.sort_by(|left, right| {
+        left.source
+            .cmp(&right.source)
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.columns.cmp(&right.columns))
+    });
+
+    let primary_key_columns = primary_key.iter().cloned().collect::<BTreeSet<_>>();
+    let unique_columns = unique_constraints
+        .iter()
+        .flatten()
+        .chain(
+            indexes
+                .iter()
+                .filter(|index| index.kind == "unique")
+                .flat_map(|index| index.columns.iter()),
+        )
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let indexed_columns = indexes
+        .iter()
+        .flat_map(|index| index.columns.iter().cloned())
+        .collect::<BTreeSet<_>>();
+
+    let search = dataset_search_context(
+        table,
+        table_provider,
+        &indexes,
+        app_context,
+        &primary_key,
+        search_functions,
+    );
+    let vector_search_columns = search
+        .vector
+        .iter()
+        .map(|search| search.column.clone())
+        .collect::<BTreeSet<_>>();
+    let full_text_search_columns = search
+        .full_text
+        .iter()
+        .map(|search| search.column.clone())
+        .collect::<BTreeSet<_>>();
+
+    let app_columns = app_context
+        .map(|context| context.columns.as_slice())
+        .unwrap_or_default();
+    let columns = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let mut field_metadata = field.metadata().clone();
+            if let Some(app_column) = app_columns
+                .iter()
+                .find(|column| column.name == *field.name())
+            {
+                field_metadata.extend(app_column.metadata());
+            }
+
+            let description = field_metadata.get(DESCRIPTION_METADATA_KEY).cloned();
+            let source_type = field_metadata.get(SOURCE_TYPE_METADATA_KEY).cloned();
+
+            NsqlColumnContext {
+                name: field.name().clone(),
+                data_type: field.data_type().to_string(),
+                nullable: field.is_nullable(),
+                description,
+                source_type,
+                primary_key: NsqlColumnFlag(primary_key_columns.contains(field.name())),
+                unique: NsqlColumnFlag(unique_columns.contains(field.name())),
+                indexed: NsqlColumnFlag(indexed_columns.contains(field.name())),
+                vector_search: NsqlColumnFlag(vector_search_columns.contains(field.name())),
+                full_text_search: NsqlColumnFlag(full_text_search_columns.contains(field.name())),
+                metadata: field_metadata.into_iter().collect(),
+            }
+        })
+        .collect();
+
+    let description = metadata.get(DESCRIPTION_METADATA_KEY).cloned();
+    let foreign_keys = foreign_keys_from_metadata(&metadata);
+
+    NsqlDatasetContext {
+        name: table.to_string(),
+        catalog: table.catalog().map(ToString::to_string),
+        schema: table.schema().map(ToString::to_string),
+        table: table.table().to_string(),
+        description,
+        foreign_keys,
+        metadata: metadata.into_iter().collect(),
+        columns,
+        primary_key,
+        unique_constraints,
+        indexes,
+        search,
+    }
+}
+
+async fn dataset_contexts(
+    tables: &[TableReference],
+    rt: Arc<Runtime>,
+    app: &app::App,
+    search_functions: SearchFunctionAvailability,
+) -> Result<Vec<NsqlDatasetContext>, Box<dyn StdError + Send + Sync>> {
+    let df = rt.datafusion();
+    let mut contexts = Vec::with_capacity(tables.len());
+
+    for table in tables {
+        let schema = df.get_arrow_schema(table.clone()).await?;
+        let table_provider = df.get_table(table).await;
+        let runtime_indexes = runtime_indexes_from_provider(table_provider.as_ref());
+        let constraints = table_provider
+            .as_ref()
+            .and_then(|provider| provider.constraints());
+        let app_context = app_table_context(table, app);
+        contexts.push(dataset_context_from_schema(
+            table,
+            &schema,
+            constraints,
+            runtime_indexes,
+            table_provider.as_ref(),
+            app_context.as_ref(),
+            search_functions,
+        ));
+    }
+
+    Ok(contexts)
+}
+
+async fn sample_context_blocks(
+    sample_from: &[TableReference],
+    rt: Arc<Runtime>,
+    table_allowlist: Option<ResolvedTableAwareAllowlist>,
+    options: NsqlContextOptions,
+) -> Result<Vec<SampleContextBlock>, Box<dyn StdError + Send + Sync>> {
+    let context_futures = sample_from.iter().flat_map(|dataset| {
+        let mut params = Vec::with_capacity(2);
+        if options.include_sampling {
+            params.push(SampleTableParams::DistinctColumns(DistinctColumnsParams {
+                tbl: dataset.to_string(),
+                limit: options.sampling_limit,
+                cols: None,
+            }));
+        }
+        if options.include_examples {
+            params.push(SampleTableParams::RandomSample(RandomSampleParams {
+                tbl: dataset.to_string(),
+                limit: options.examples_limit,
+            }));
+        }
+
+        params.into_iter().map(|params| {
+            let rt = Arc::clone(&rt);
+            let allowlist = table_allowlist.clone();
+            async move {
+                let method = SampleTableMethod::from(&params);
+                let sort_key = (
+                    params.dataset().to_string(),
+                    sample_context_method_order(&method),
+                );
+                let content = tool_context_text(
+                    &SampleDataTool::new(rt.datafusion(), method.clone())
+                        .with_table_allowlist(allowlist),
+                    &params,
+                )
+                .instrument(Span::current())
+                .await?;
+
+                Ok::<_, Box<dyn StdError + Send + Sync>>((
+                    sort_key,
+                    SampleContextBlock {
+                        title: match method {
+                            SampleTableMethod::DistinctColumns => {
+                                format!("Distinct value samples for `{}`", params.dataset())
+                            }
+                            SampleTableMethod::RandomSample => {
+                                format!("Example rows for `{}`", params.dataset())
+                            }
+                            SampleTableMethod::TopNSample => {
+                                format!("Top rows for `{}`", params.dataset())
+                            }
+                        },
+                        content,
+                    },
+                ))
+            }
+        })
+    });
+
+    let mut context_blocks = futures::stream::iter(context_futures)
+        .boxed()
+        .buffer_unordered(DATA_SAMPLING_MAX_CONCURRENT)
+        .try_collect::<Vec<_>>()
+        .await?;
+    context_blocks.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    Ok(context_blocks
+        .into_iter()
+        .map(|(_, context_block)| context_block)
+        .collect())
+}
+
+fn sample_context_method_order(method: &SampleTableMethod) -> u8 {
+    match method {
+        SampleTableMethod::DistinctColumns => 0,
+        SampleTableMethod::RandomSample => 1,
+        SampleTableMethod::TopNSample => 2,
+    }
+}
+
+fn context_message(context: &str) -> Result<ChatCompletionRequestMessage, String> {
+    ChatCompletionRequestSystemMessageArgs::default()
+        .content(context)
+        .build()
+        .map(Into::into)
+        .map_err(|error| error.to_string())
+}
+
+const NSQL_ROUTINES_QUERY: &str = r"
+SELECT routine_name, function_type, description, syntax_example, data_type
+FROM information_schema.routines
+WHERE routine_type = 'FUNCTION'
+";
+
+const NSQL_PARAMETERS_QUERY: &str = r"
+SELECT specific_name, rid, ordinal_position, parameter_name, data_type, parameter_mode, is_variadic
+FROM information_schema.parameters
+WHERE parameter_mode IN ('IN', 'OUT')
+ORDER BY lower(specific_name), rid, ordinal_position
+";
+
+const NSQL_LIST_UDFS_QUERY: &str = r#"
+SELECT name, source, kind, volatility, "from", description
+FROM list_udfs()
+"#;
+
+#[derive(Clone, Debug, Default)]
+struct FunctionInventory {
+    names: HashSet<String>,
+    functions: BTreeMap<String, RegisteredFunction>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RegisteredFunction {
+    name: String,
+    function_type: Option<String>,
+    description: Option<String>,
+    syntax_example: Option<String>,
+    registered_builtin: bool,
+    return_types: BTreeSet<String>,
+    signatures: BTreeMap<u8, RegisteredFunctionSignature>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RegisteredFunctionSignature {
+    parameters: Vec<RegisteredFunctionParameter>,
+    return_type: Option<String>,
+    variadic: bool,
+}
+
+#[derive(Clone, Debug)]
+struct RegisteredFunctionParameter {
+    name: Option<String>,
+    data_type: String,
+}
+
+fn non_empty_string(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+impl RegisteredFunctionSignature {
+    fn to_syntax(&self, function_name: &str) -> String {
+        let mut parameters = self
+            .parameters
+            .iter()
+            .map(|parameter| {
+                parameter.name.as_ref().map_or_else(
+                    || parameter.data_type.clone(),
+                    |name| format!("{name} {}", parameter.data_type),
+                )
+            })
+            .collect_vec();
+        if self.variadic {
+            parameters.push("...".to_string());
+        }
+
+        let mut syntax = format!("{function_name}({})", parameters.join(", "));
+        if let Some(return_type) = &self.return_type {
+            let _ = write!(syntax, " -> {return_type}");
+        }
+        syntax
+    }
+}
+
+impl RegisteredFunction {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            ..Default::default()
+        }
+    }
+
+    fn to_context_entry(&self) -> NsqlFunctionContextEntry {
+        let signatures = self
+            .signatures
+            .values()
+            .map(|signature| signature.to_syntax(&self.name))
+            .unique()
+            .collect_vec();
+        let syntax = self
+            .syntax_example
+            .clone()
+            .or_else(|| signatures.first().cloned());
+
+        NsqlFunctionContextEntry {
+            name: self.name.clone(),
+            syntax,
+            description: self.description.clone(),
+            function_type: self.function_type.clone(),
+            signatures,
+            example: None,
+        }
+    }
+}
+
+impl FunctionInventory {
+    fn add_name(&mut self, name: &str) {
+        self.names.insert(name.to_ascii_lowercase());
+    }
+
+    fn function_mut(&mut self, name: &str) -> &mut RegisteredFunction {
+        let key = name.to_ascii_lowercase();
+        self.names.insert(key.clone());
+        self.functions
+            .entry(key)
+            .or_insert_with(|| RegisteredFunction::new(name.to_string()))
+    }
+}
+
+fn string_value(
+    batch: &RecordBatch,
+    column: &str,
+    row: usize,
+) -> Result<Option<String>, DataFusionError> {
+    let array = batch.column_by_name(column).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "NSQL function inventory query missing column {column}"
+        ))
+    })?;
+    let values = array
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "NSQL function inventory column {column} is not Utf8"
+            ))
+        })?;
+    if values.is_null(row) {
+        Ok(None)
+    } else {
+        Ok(Some(values.value(row).to_string()))
+    }
+}
+
+fn bool_value(batch: &RecordBatch, column: &str, row: usize) -> Result<bool, DataFusionError> {
+    let array = batch.column_by_name(column).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "NSQL function inventory query missing column {column}"
+        ))
+    })?;
+    let values = array
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "NSQL function inventory column {column} is not Boolean"
+            ))
+        })?;
+    Ok(!values.is_null(row) && values.value(row))
+}
+
+fn u8_value(batch: &RecordBatch, column: &str, row: usize) -> Result<u8, DataFusionError> {
+    let array = batch.column_by_name(column).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "NSQL function inventory query missing column {column}"
+        ))
+    })?;
+    let values = array.as_any().downcast_ref::<UInt8Array>().ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "NSQL function inventory column {column} is not UInt8"
+        ))
+    })?;
+    if values.is_null(row) {
+        return Err(DataFusionError::Internal(format!(
+            "NSQL function inventory column {column} unexpectedly contained NULL"
+        )));
+    }
+    Ok(values.value(row))
+}
+
+fn u64_value(batch: &RecordBatch, column: &str, row: usize) -> Result<u64, DataFusionError> {
+    let array = batch.column_by_name(column).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "NSQL function inventory query missing column {column}"
+        ))
+    })?;
+    let values = array
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "NSQL function inventory column {column} is not UInt64"
+            ))
+        })?;
+    if values.is_null(row) {
+        return Err(DataFusionError::Internal(format!(
+            "NSQL function inventory column {column} unexpectedly contained NULL"
+        )));
+    }
+    Ok(values.value(row))
+}
+
+fn add_routine_batches(
+    inventory: &mut FunctionInventory,
+    batches: &[RecordBatch],
+) -> Result<(), DataFusionError> {
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            let Some(name) = string_value(batch, "routine_name", row)? else {
+                continue;
+            };
+            let function = inventory.function_mut(&name);
+            if function.function_type.is_none() {
+                function.function_type =
+                    non_empty_string(string_value(batch, "function_type", row)?);
+            }
+            if function.description.is_none() {
+                function.description = non_empty_string(string_value(batch, "description", row)?);
+            }
+            if function.syntax_example.is_none() {
+                function.syntax_example =
+                    non_empty_string(string_value(batch, "syntax_example", row)?);
+            }
+            if let Some(return_type) = non_empty_string(string_value(batch, "data_type", row)?) {
+                function.return_types.insert(return_type);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn add_parameter_batches(
+    inventory: &mut FunctionInventory,
+    batches: &[RecordBatch],
+) -> Result<(), DataFusionError> {
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            let Some(name) = string_value(batch, "specific_name", row)? else {
+                continue;
+            };
+            let rid = u8_value(batch, "rid", row)?;
+            let mode = string_value(batch, "parameter_mode", row)?.unwrap_or_default();
+            let data_type = string_value(batch, "data_type", row)?.unwrap_or_default();
+            if data_type.is_empty() {
+                continue;
+            }
+
+            let function = inventory.function_mut(&name);
+            let signature = function.signatures.entry(rid).or_default();
+            if mode == "OUT" {
+                signature.return_type = Some(data_type);
+                continue;
+            }
+
+            let ordinal_position = u64_value(batch, "ordinal_position", row)?;
+            if ordinal_position == 0 {
+                continue;
+            }
+            signature.variadic |= bool_value(batch, "is_variadic", row)?;
+            signature.parameters.push(RegisteredFunctionParameter {
+                name: non_empty_string(string_value(batch, "parameter_name", row)?),
+                data_type,
+            });
+        }
+    }
+
+    for function in inventory.functions.values_mut() {
+        for signature in function.signatures.values_mut() {
+            if signature.return_type.is_none()
+                && let Some(return_type) = function.return_types.iter().next()
+            {
+                signature.return_type = Some(return_type.clone());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn add_list_udf_batches(
+    inventory: &mut FunctionInventory,
+    batches: &[RecordBatch],
+) -> Result<(), DataFusionError> {
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            let Some(name) = string_value(batch, "name", row)? else {
+                continue;
+            };
+            inventory.add_name(&name);
+            if string_value(batch, "source", row)?.as_deref() == Some("user") {
+                continue;
+            }
+
+            let function = inventory.function_mut(&name);
+            function.registered_builtin = true;
+            if function.function_type.is_none() {
+                function.function_type = non_empty_string(string_value(batch, "kind", row)?);
+            }
+            if function.description.is_none() {
+                function.description = non_empty_string(string_value(batch, "description", row)?);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn registered_function_inventory(
+    rt: &Runtime,
+) -> Result<FunctionInventory, Box<dyn StdError + Send + Sync>> {
+    let routines = rt.df.ctx.sql(NSQL_ROUTINES_QUERY).await?.collect().await?;
+    let parameters = rt
+        .df
+        .ctx
+        .sql(NSQL_PARAMETERS_QUERY)
+        .await?
+        .collect()
+        .await?;
+    let list_udfs = rt.df.ctx.sql(NSQL_LIST_UDFS_QUERY).await?.collect().await?;
+
+    let mut inventory = FunctionInventory::default();
+    add_routine_batches(&mut inventory, &routines)?;
+    add_parameter_batches(&mut inventory, &parameters)?;
+    add_list_udf_batches(&mut inventory, &list_udfs)?;
+    Ok(inventory)
+}
+
+fn is_json_context_function(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    name.starts_with("json") || name.contains("_json")
+}
+
+fn spark_function_names(inventory: &FunctionInventory) -> BTreeSet<String> {
+    datafusion_spark::all_default_scalar_functions()
+        .into_iter()
+        .map(|function| function.name().to_ascii_lowercase())
+        .filter(|name| inventory.names.contains(name))
+        .collect()
+}
+
+fn is_search_context_function_visible(
+    name: &str,
+    search_functions: SearchFunctionAvailability,
+) -> bool {
+    if name == TEXT_SEARCH_UDTF_NAME {
+        return search_functions.text_search;
+    }
+    if name == VECTOR_SEARCH_UDTF_NAME {
+        return search_functions.vector_search;
+    }
+    if name == RRF_UDF_NAME || name == RERANK_UDTF_NAME {
+        return search_functions.text_search || search_functions.vector_search;
+    }
+    false
+}
+
+fn is_search_context_function(name: &str) -> bool {
+    name == TEXT_SEARCH_UDTF_NAME
+        || name == VECTOR_SEARCH_UDTF_NAME
+        || name == RRF_UDF_NAME
+        || name == RERANK_UDTF_NAME
+}
+
+fn is_spice_context_function(name: &str, search_functions: SearchFunctionAvailability) -> bool {
+    is_search_context_function_visible(name, search_functions)
+}
+
+fn user_function_names(app: &app::App) -> HashSet<String> {
+    app.functions
+        .iter()
+        .map(|function| function.name.to_ascii_lowercase())
+        .collect()
+}
+
+fn inventory_entries(
+    inventory: &FunctionInventory,
+    user_function_names: &HashSet<String>,
+    include: impl Fn(&str, &RegisteredFunction) -> bool,
+) -> Vec<NsqlFunctionContextEntry> {
+    inventory
+        .functions
+        .iter()
+        .filter(|(name, _)| !user_function_names.contains(*name))
+        .filter(|(name, function)| include(name, function))
+        .map(|(_, function)| function.to_context_entry())
+        .collect_vec()
+}
+
+#[cfg(test)]
+pub(crate) fn all_context_function_names_for_test() -> HashSet<String> {
+    let mut names = [
+        "json_get",
+        "json_get_str",
+        "json_get_int",
+        "json_get_float",
+        "json_get_bool",
+        "json_get_json",
+        "json_get_array",
+        "json_as_text",
+        "json_contains",
+        "json_length",
+        "json_object_keys",
+        "json_from_scalar",
+        FLATTEN_JSON_UDTF_NAME,
+        FLATTEN_JSON_PROPERTIES_UDTF_NAME,
+        JSON_TREE_UDTF_NAME,
+        TEXT_SEARCH_UDTF_NAME,
+        VECTOR_SEARCH_UDTF_NAME,
+        RRF_UDF_NAME,
+        RERANK_UDTF_NAME,
+        COSINE_DISTANCE_UDF_NAME,
+        INNER_PRODUCT_UDF_NAME,
+        L2_DISTANCE_UDF_NAME,
+        L2_SQUARED_DISTANCE_UDF_NAME,
+        L2_NORM_UDF_NAME,
+        BUCKET_SCALAR_UDF_NAME,
+        TRUNCATE_SCALAR_UDF_NAME,
+        DIGEST_UDF_NAME,
+        OBJ_DESCRIPTION_UDF_NAME,
+        COL_DESCRIPTION_UDF_NAME,
+        LIST_UDFS_UDTF_NAME,
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect::<HashSet<_>>();
+
+    #[cfg(feature = "models")]
+    {
+        names.insert(AI_UDF_NAME.to_string());
+        names.insert(EMBED_UDF_NAME.to_string());
+    }
+
+    names.extend(
+        datafusion_spark::all_default_scalar_functions()
+            .into_iter()
+            .map(|function| function.name().to_ascii_lowercase()),
+    );
+    names
+}
+
+#[cfg(test)]
+struct TestBuiltinFunctionDefinition {
+    function_type: Option<&'static str>,
+    description: &'static str,
+    syntax: &'static str,
+}
+
+#[cfg(test)]
+fn test_builtin_function_definition(name: &str) -> Option<TestBuiltinFunctionDefinition> {
+    let lower_name = name.to_ascii_lowercase();
+    let (function_type, description, syntax) = match lower_name.as_str() {
+        "ai" => (
+            Some("SCALAR"),
+            "Runs a prompt against a configured language model.",
+            "ai(prompt[, model => 'model_name'])",
+        ),
+        "bucket" => (
+            Some("SCALAR"),
+            "Assigns a numeric expression to a bucket boundary.",
+            "bucket(value, buckets)",
+        ),
+        "col_description" => (
+            Some("SCALAR"),
+            "Returns the configured description for a table column.",
+            "col_description(table_catalog, table_schema, table_name, column_name)",
+        ),
+        "cosine_distance" => (
+            Some("SCALAR"),
+            "Computes cosine distance between two vectors.",
+            "cosine_distance(vector_a, vector_b)",
+        ),
+        "digest" | "digest_many" => (
+            Some("SCALAR"),
+            "Computes a digest for one or more input expressions.",
+            "digest_many(value[, ...])",
+        ),
+        "embed" => (
+            Some("SCALAR"),
+            "Generates an embedding with a configured embedding model.",
+            "embed(input[, model => 'model_name'])",
+        ),
+        "flatten_json" => (
+            None,
+            "Flattens JSON objects into key-value rows or structures.",
+            "flatten_json(json)",
+        ),
+        "flatten_json_properties" => (
+            None,
+            "Flattens JSON-schema properties into key-value rows or structures.",
+            "flatten_json_properties(json_schema)",
+        ),
+        "inner_product" => (
+            Some("SCALAR"),
+            "Computes the inner product of two vectors.",
+            "inner_product(vector_a, vector_b)",
+        ),
+        "json_as_text" => (
+            Some("SCALAR"),
+            "Converts a JSON value to text.",
+            "json_as_text(json)",
+        ),
+        "json_contains" => (
+            Some("SCALAR"),
+            "Returns whether one JSON value contains another.",
+            "json_contains(json, value)",
+        ),
+        "json_from_scalar" => (
+            Some("SCALAR"),
+            "Converts a scalar value to JSON.",
+            "json_from_scalar(value)",
+        ),
+        "json_get" => (
+            Some("SCALAR"),
+            "Extracts a JSON value by path.",
+            "json_get(json, path)",
+        ),
+        "json_get_array" => (
+            Some("SCALAR"),
+            "Extracts a JSON array by path.",
+            "json_get_array(json, path)",
+        ),
+        "json_get_bool" => (
+            Some("SCALAR"),
+            "Extracts a boolean value from JSON by path.",
+            "json_get_bool(json, path)",
+        ),
+        "json_get_float" => (
+            Some("SCALAR"),
+            "Extracts a floating-point value from JSON by path.",
+            "json_get_float(json, path)",
+        ),
+        "json_get_int" => (
+            Some("SCALAR"),
+            "Extracts an integer value from JSON by path.",
+            "json_get_int(json, path)",
+        ),
+        "json_get_json" => (
+            Some("SCALAR"),
+            "Extracts a nested JSON value by path.",
+            "json_get_json(json, path)",
+        ),
+        "json_get_str" => (
+            Some("SCALAR"),
+            "Extracts a string value from JSON by path.",
+            "json_get_str(json, path)",
+        ),
+        "json_length" => (
+            Some("SCALAR"),
+            "Returns the length of a JSON array or object.",
+            "json_length(json)",
+        ),
+        "json_object_keys" => (
+            Some("SCALAR"),
+            "Returns the keys of a JSON object.",
+            "json_object_keys(json)",
+        ),
+        "json_tree" => (
+            None,
+            "Expands JSON into a tree of path, key, and value rows or structures.",
+            "json_tree(json)",
+        ),
+        "l2_distance" => (
+            Some("SCALAR"),
+            "Computes Euclidean distance between two vectors.",
+            "l2_distance(vector_a, vector_b)",
+        ),
+        "l2_norm" => (
+            Some("SCALAR"),
+            "Computes the L2 norm of a vector.",
+            "l2_norm(vector)",
+        ),
+        "l2_squared_distance" => (
+            Some("SCALAR"),
+            "Computes squared Euclidean distance between two vectors.",
+            "l2_squared_distance(vector_a, vector_b)",
+        ),
+        "list_udfs" => (
+            None,
+            "Lists functions registered in the current DataFusion context.",
+            "list_udfs()",
+        ),
+        "obj_description" => (
+            Some("SCALAR"),
+            "Returns the configured description for a table or object.",
+            "obj_description(table_catalog, table_schema, table_name)",
+        ),
+        "rerank" => (
+            None,
+            "Re-ranks search results or table rows using a configured reranker model.",
+            "rerank(input, model => 'model_name', document => 'column_name'[, query => 'query text'])",
+        ),
+        "rrf" => (
+            None,
+            "Combines multiple search result sets using reciprocal rank fusion.",
+            "rrf(text_search(...), vector_search(...)[, limit => n])",
+        ),
+        "text_search" => (
+            None,
+            "Runs full-text search over a configured searchable dataset.",
+            "text_search(dataset, 'query text'[, column])",
+        ),
+        "truncate" => (
+            Some("SCALAR"),
+            "Truncates values to the requested precision.",
+            "truncate(value, precision)",
+        ),
+        "vector_search" => (
+            None,
+            "Runs vector search over a configured embedding/vector index.",
+            "vector_search(dataset, 'query text'[, column])",
+        ),
+        _ => return None,
+    };
+
+    Some(TestBuiltinFunctionDefinition {
+        function_type,
+        description,
+        syntax,
+    })
+}
+
+#[cfg(test)]
+fn function_inventory_for_test(available_names: &HashSet<String>) -> FunctionInventory {
+    let mut inventory = FunctionInventory::default();
+    for name in available_names {
+        let function = inventory.function_mut(name);
+        function.registered_builtin = true;
+        if let Some(definition) = test_builtin_function_definition(name) {
+            function.function_type = definition.function_type.map(ToString::to_string);
+            function.description = Some(definition.description.to_string());
+            function.syntax_example = Some(definition.syntax.to_string());
+        } else {
+            function.function_type = Some("SCALAR".to_string());
+            function.signatures.insert(
+                0,
+                RegisteredFunctionSignature {
+                    parameters: vec![],
+                    return_type: None,
+                    variadic: true,
+                },
+            );
+        }
+    }
+    inventory
+}
+
+#[cfg(test)]
+pub(crate) fn nsql_function_context_for_test(
+    app: &app::App,
+    available_names: &HashSet<String>,
+    vector_search: bool,
+    text_search: bool,
+) -> NsqlFunctionContext {
+    let inventory = function_inventory_for_test(available_names);
+    nsql_function_context(
+        app,
+        &inventory,
+        SearchFunctionAvailability {
+            vector_search,
+            text_search,
+        },
+    )
+}
+
+fn write_function_entries(
+    output: &mut String,
+    section: &str,
+    entries: &[NsqlFunctionContextEntry],
+) {
+    if entries.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(output, "\n### {section}");
+    for entry in entries {
+        let _ = write!(output, "- `{}`", entry.name);
+        if let Some(description) = &entry.description {
+            let description = description.trim().trim_end_matches('.');
+            let _ = write!(output, ": {description}");
+        }
+        if let Some(function_type) = &entry.function_type {
+            let _ = write!(output, " ({function_type})");
+        }
+        if let Some(syntax) = &entry.syntax {
+            if entry.description.is_some() || entry.function_type.is_some() {
+                let _ = write!(output, ". Syntax: `{syntax}`");
+            } else {
+                let _ = write!(output, ": Syntax: `{syntax}`");
+            }
+        }
+        if let Some(example) = &entry.example {
+            if entry.description.is_some()
+                || entry.function_type.is_some()
+                || entry.syntax.is_some()
+            {
+                let _ = write!(output, ". Example: `{example}`");
+            } else {
+                let _ = write!(output, ": Example: `{example}`");
+            }
+        }
+        let _ = writeln!(output, ".");
+    }
+}
+
+fn write_wrapped_function_names(output: &mut String, names: &[String]) {
+    for chunk in names.chunks(8) {
+        let rendered_names = chunk.iter().map(|name| format!("`{name}`")).join(", ");
+        let _ = writeln!(output, "- {rendered_names}");
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub(crate) struct UserFunctionContextEntry {
+    pub(crate) name: String,
+    pub(crate) syntax: Option<String>,
+    pub(crate) kind: String,
+    pub(crate) volatility: String,
+    pub(crate) from: String,
+    pub(crate) description: Option<String>,
+}
+
+fn user_function_args_signature(args: &[spicepod::component::function::FunctionArg]) -> String {
+    args.iter()
+        .map(|arg| format!("{} {}", arg.name, arg.arrow_type))
+        .join(", ")
+}
+
+fn user_function_syntax(function: &Function) -> String {
+    let mut args = function
+        .signature
+        .tables
+        .iter()
+        .map(|table| {
+            format!(
+                "{} TABLE({})",
+                table.name,
+                user_function_args_signature(&table.columns)
+            )
+        })
+        .collect_vec();
+    args.extend(
+        function
+            .signature
+            .args
+            .iter()
+            .map(|arg| format!("{} {}", arg.name, arg.arrow_type)),
+    );
+
+    let mut syntax = format!("{}({})", function.name, args.join(", "));
+    if let Some(return_type) = function.signature.scalar_return_type() {
+        let _ = write!(syntax, " -> {return_type}");
+    } else if let Some(columns) = function.signature.table_return_columns() {
+        let _ = write!(
+            syntax,
+            " -> TABLE({})",
+            user_function_args_signature(columns)
+        );
+    }
+
+    syntax
+}
+
+pub(crate) fn user_function_context_entries(
+    app: &app::App,
+    available_names: &HashSet<String>,
+    user_function_infos: Vec<UserFunctionInfo>,
+) -> Vec<UserFunctionContextEntry> {
+    if !app.runtime.functions.enabled {
+        return vec![];
+    }
+
+    let declarations_by_name = app
+        .functions
+        .iter()
+        .filter(|function| function.enabled)
+        .map(|function| (function.name.to_ascii_lowercase(), function))
+        .collect::<HashMap<_, _>>();
+
+    let mut user_functions = user_function_infos
+        .into_iter()
+        .filter_map(|function| {
+            let name = function.name.to_ascii_lowercase();
+            if !available_names.contains(&name) {
+                return None;
+            }
+            let declaration = declarations_by_name.get(&name)?;
+
+            Some(UserFunctionContextEntry {
+                name: function.name,
+                syntax: Some(user_function_syntax(declaration)),
+                kind: declaration.kind.as_str().to_string(),
+                volatility: effective_user_function_volatility(declaration).to_string(),
+                from: declaration.from.clone(),
+                description: declaration.description.clone().or(function.description),
+            })
+        })
+        .collect_vec();
+    user_functions.sort_by_key(|function| function.name.to_ascii_lowercase());
+    user_functions
+}
+
+pub(crate) fn write_user_function_context_entries(
+    output: &mut String,
+    user_functions: &[UserFunctionContextEntry],
+) {
+    if user_functions.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(output, "\n### User-defined functions");
+    for function in user_functions {
+        let _ = write!(
+            output,
+            "- `{}`: {} function from `{}` with `{}` volatility.",
+            function.name, function.kind, function.from, function.volatility
+        );
+        if let Some(syntax) = &function.syntax {
+            let _ = write!(output, " Syntax: `{syntax}`.");
+        }
+        if let Some(description) = &function.description
+            && !description.is_empty()
+        {
+            let _ = write!(output, " {description}");
+        }
+        let _ = writeln!(output);
+    }
+}
+
+fn user_function_context(
+    app: &app::App,
+    available_names: &HashSet<String>,
+) -> Vec<UserFunctionContextEntry> {
+    user_function_context_entries(app, available_names, user_function_infos())
+}
+
+impl NsqlFunctionContext {
+    pub(crate) fn render_markdown(&self) -> String {
+        let mut context = format!("{}:\n", self.summary);
+        write_function_entries(&mut context, "JSON functions", &self.json);
+        write_function_entries(&mut context, "Search functions", &self.search);
+        write_function_entries(
+            &mut context,
+            "Additional registered functions",
+            &self.additional,
+        );
+
+        if !self.spark_compatibility.functions.is_empty() {
+            let _ = writeln!(
+                context,
+                "\n### Spark compatibility scalar functions\n{}",
+                self.spark_compatibility.description
+            );
+            write_wrapped_function_names(&mut context, &self.spark_compatibility.functions);
+        }
+
+        write_user_function_context_entries(&mut context, &self.user_defined);
+        context
+    }
+}
+
+fn nsql_function_context(
+    app: &app::App,
+    inventory: &FunctionInventory,
+    search_functions: SearchFunctionAvailability,
+) -> NsqlFunctionContext {
+    let user_function_names = user_function_names(app);
+    let json = inventory_entries(inventory, &user_function_names, |name, function| {
+        function.registered_builtin && is_json_context_function(name)
+    });
+    let spark_function_names = spark_function_names(inventory);
+    let search = inventory_entries(inventory, &user_function_names, |name, _| {
+        !is_json_context_function(name)
+            && !spark_function_names.contains(name)
+            && is_spice_context_function(name, search_functions)
+    });
+    let additional = inventory_entries(inventory, &user_function_names, |name, function| {
+        function.registered_builtin
+            && !is_json_context_function(name)
+            && !is_search_context_function(name)
+            && !spark_function_names.contains(name)
+    });
+    let spark_function_names = spark_function_names.into_iter().collect_vec();
+
+    NsqlFunctionContext {
+        summary: NSQL_FUNCTION_CONTEXT_SUMMARY.to_string(),
+        json,
+        search,
+        additional,
+        spark_compatibility: NsqlSparkFunctionContext {
+            description: "Spark-compatible scalar functions are available for arrays, maps, structs, dates, strings, hashes, URLs, XML, and other common Spark SQL expressions.".to_string(),
+            functions: spark_function_names,
+        },
+        user_defined: user_function_context(app, &inventory.names),
+    }
+}
+
+fn dataset_context_for_table<'a>(
+    datasets: &'a [NsqlDatasetContext],
+    table: &TableReference,
+) -> Option<&'a NsqlDatasetContext> {
+    datasets
+        .iter()
+        .find(|dataset| TableReference::parse_str(&dataset.name).resolved_eq(table))
+}
+
+fn dataset_context_for_foreign_table<'a>(
+    datasets: &'a [NsqlDatasetContext],
+    foreign_table: &str,
+) -> Option<&'a NsqlDatasetContext> {
+    let table = TableReference::parse_str(foreign_table);
+
+    if let Some(dataset) = datasets
+        .iter()
+        .find(|dataset| TableReference::parse_str(&dataset.name) == table)
+    {
+        return Some(dataset);
+    }
+
+    let mut relaxed_matches = datasets.iter().filter(|dataset| {
+        table_reference_matches_foreign_target(&TableReference::parse_str(&dataset.name), &table)
+    });
+    let dataset = relaxed_matches.next()?;
+    if relaxed_matches.next().is_some() {
+        return None;
+    }
+
+    Some(dataset)
+}
+
+fn table_reference_matches_foreign_target(
+    dataset: &TableReference,
+    foreign_target: &TableReference,
+) -> bool {
+    if dataset.table() != foreign_target.table() {
+        return false;
+    }
+    if let Some(schema) = foreign_target.schema()
+        && dataset.schema() != Some(schema)
+    {
+        return false;
+    }
+    if let Some(catalog) = foreign_target.catalog()
+        && dataset.catalog() != Some(catalog)
+    {
+        return false;
+    }
+
+    true
+}
+
+fn compact_column_context(column: &NsqlColumnContext) -> String {
+    let mut context = format!("`{}` {}", column.name, column.data_type);
+    if let Some(description) = &column.description
+        && !description.is_empty()
+    {
+        let _ = write!(context, " ({description})");
+    }
+    context
+}
+
+const FOREIGN_KEY_TARGET_CONTEXT_COLUMN_LIMIT: usize = 4;
+
+fn push_compact_foreign_key_target_column(
+    column_names: &mut Vec<String>,
+    seen: &mut BTreeSet<String>,
+    column_name: &str,
+) {
+    let column_name = column_name.to_string();
+    if seen.insert(column_name.clone()) {
+        column_names.push(column_name);
+    }
+}
+
+fn compact_foreign_key_target_columns(
+    target: &NsqlDatasetContext,
+    foreign_columns: &[String],
+) -> Vec<String> {
+    let mut selected_columns = Vec::new();
+    let mut seen_columns = BTreeSet::new();
+
+    for column_name in foreign_columns.iter().chain(target.primary_key.iter()) {
+        push_compact_foreign_key_target_column(
+            &mut selected_columns,
+            &mut seen_columns,
+            column_name,
+        );
+    }
+    for column_name in target.unique_constraints.iter().flatten() {
+        push_compact_foreign_key_target_column(
+            &mut selected_columns,
+            &mut seen_columns,
+            column_name,
+        );
+    }
+
+    let mut columns = selected_columns
+        .iter()
+        .filter_map(|column_name| {
+            target
+                .columns
+                .iter()
+                .find(|column| column.name == *column_name)
+        })
+        .take(FOREIGN_KEY_TARGET_CONTEXT_COLUMN_LIMIT)
+        .map(compact_column_context)
+        .collect_vec();
+
+    let remaining_columns = FOREIGN_KEY_TARGET_CONTEXT_COLUMN_LIMIT.saturating_sub(columns.len());
+    if remaining_columns > 0 {
+        columns.extend(
+            target
+                .columns
+                .iter()
+                .filter(|column| !seen_columns.contains(&column.name))
+                .filter(|column| column.description.is_some())
+                .take(remaining_columns)
+                .map(compact_column_context),
+        );
+    }
+
+    columns
+}
+
+fn write_foreign_key_target_context(
+    output: &mut String,
+    datasets: &[NsqlDatasetContext],
+    foreign_key: &NsqlForeignKeyContext,
+) {
+    let Some(target) = dataset_context_for_foreign_table(datasets, &foreign_key.foreign_table)
+    else {
+        return;
+    };
+
+    let mut parts = Vec::new();
+    if let Some(description) = &target.description
+        && !description.is_empty()
+    {
+        parts.push(description.clone());
+    }
+
+    let columns = compact_foreign_key_target_columns(target, &foreign_key.foreign_columns);
+    if !columns.is_empty() {
+        parts.push(format!("target columns: {}", columns.join(", ")));
+    }
+
+    if !parts.is_empty() {
+        let _ = writeln!(
+            output,
+            "    Target context for `{}`: {}.",
+            target.name,
+            parts.join("; ")
+        );
+    }
+}
+
+fn write_dataset_context_list(
+    output: &mut String,
+    tables: &[TableReference],
+    datasets: &[NsqlDatasetContext],
+) {
+    if tables.is_empty() {
+        let _ = writeln!(output, "No datasets are currently in scope.");
+        return;
+    }
+
+    for table in tables {
+        let Some(dataset) = dataset_context_for_table(datasets, table) else {
+            let _ = writeln!(output, "- `{table}`");
+            continue;
+        };
+
+        if let Some(description) = &dataset.description
+            && !description.is_empty()
+        {
+            let _ = writeln!(output, "- `{table}`: {description}");
+        } else {
+            let _ = writeln!(output, "- `{table}`");
+        }
+    }
+}
+
+pub(crate) fn render_nsql_dataset_relationship_context(datasets: &[NsqlDatasetContext]) -> String {
+    let mut context = String::new();
+
+    for dataset in datasets {
+        let has_relationship_context = !dataset.primary_key.is_empty()
+            || !dataset.unique_constraints.is_empty()
+            || !dataset.foreign_keys.is_empty()
+            || !dataset.indexes.is_empty()
+            || !dataset.search.vector.is_empty()
+            || !dataset.search.full_text.is_empty();
+        if !has_relationship_context {
+            continue;
+        }
+
+        let _ = writeln!(context, "\n### `{}`", dataset.name);
+
+        if !dataset.primary_key.is_empty() {
+            let keys = dataset
+                .primary_key
+                .iter()
+                .map(|column| format!("`{column}`"))
+                .join(", ");
+            let _ = writeln!(context, "- Primary key: {keys}");
+        }
+
+        if !dataset.unique_constraints.is_empty() {
+            let _ = writeln!(context, "- Unique constraints:");
+            for columns in &dataset.unique_constraints {
+                let columns = columns
+                    .iter()
+                    .map(|column| format!("`{column}`"))
+                    .join(", ");
+                let _ = writeln!(context, "  - ({columns})");
+            }
+        }
+
+        if !dataset.foreign_keys.is_empty() {
+            let _ = writeln!(context, "- Foreign keys:");
+            for foreign_key in &dataset.foreign_keys {
+                let columns = foreign_key
+                    .columns
+                    .iter()
+                    .map(|column| format!("`{column}`"))
+                    .join(", ");
+                let foreign_columns = foreign_key
+                    .foreign_columns
+                    .iter()
+                    .map(|column| format!("`{column}`"))
+                    .join(", ");
+                let _ = writeln!(
+                    context,
+                    "  - ({columns}) references `{}` ({foreign_columns})",
+                    foreign_key.foreign_table
+                );
+                write_foreign_key_target_context(&mut context, datasets, foreign_key);
+            }
+        }
+
+        if !dataset.indexes.is_empty() {
+            let _ = writeln!(context, "- Indexes:");
+            for index in &dataset.indexes {
+                let columns = index
+                    .columns
+                    .iter()
+                    .map(|column| format!("`{column}`"))
+                    .join(", ");
+                if let Some(name) = &index.name {
+                    let _ = writeln!(
+                        context,
+                        "  - `{name}`: {columns} ({}, {})",
+                        index.kind, index.source
+                    );
+                } else {
+                    let _ = writeln!(context, "  - {columns} ({}, {})", index.kind, index.source);
+                }
+            }
+        }
+
+        if !dataset.search.vector.is_empty() || !dataset.search.full_text.is_empty() {
+            let _ = writeln!(context, "- Search indexes:");
+            for search in &dataset.search.vector {
+                let _ = write!(
+                    context,
+                    "  - vector search on `{}` using `{}`. Syntax: `{}`.",
+                    search.column, search.model, search.syntax
+                );
+                if let Some(engine) = &search.engine {
+                    let _ = write!(context, " Engine/index: `{engine}`.");
+                }
+                if !search.row_id_columns.is_empty() {
+                    let keys = search
+                        .row_id_columns
+                        .iter()
+                        .map(|column| format!("`{column}`"))
+                        .join(", ");
+                    let _ = write!(context, " Row id: {keys}.");
+                }
+                let _ = writeln!(context);
+            }
+            for search in &dataset.search.full_text {
+                let _ = write!(
+                    context,
+                    "  - full-text search on `{}` using `{}`. Syntax: `{}`.",
+                    search.column, search.engine, search.syntax
+                );
+                if !search.row_id_columns.is_empty() {
+                    let keys = search
+                        .row_id_columns
+                        .iter()
+                        .map(|column| format!("`{column}`"))
+                        .join(", ");
+                    let _ = write!(context, " Row id: {keys}.");
+                }
+                let _ = writeln!(context);
+            }
+        }
+    }
+
+    context
+}
+
+pub(crate) fn render_nsql_context_block(
+    tables: &[TableReference],
+    datasets: &[NsqlDatasetContext],
+    schema_context: &str,
+    relationship_context: &str,
+    function_context: &str,
+    sample_context_blocks: &[SampleContextBlock],
+) -> String {
+    let mut context = String::from("# Spice.ai NSQL Context\n");
+    for instruction in NSQL_CONTEXT_INSTRUCTIONS {
+        let _ = writeln!(context, "- {instruction}");
+    }
+    let _ = writeln!(
+        context,
+        "- Apache DataFusion version: {DATAFUSION_VERSION}."
+    );
+    let _ = writeln!(
+        context,
+        "- Schema metadata includes table and column comments/descriptions when supplied by the connector or Spicepod."
+    );
+
+    let _ = writeln!(context, "\n## Datasets");
+    write_dataset_context_list(&mut context, tables, datasets);
+
+    let _ = writeln!(context, "\n## Schemas");
+    if schema_context.trim().is_empty() {
+        let _ = writeln!(context, "No schema information is available.");
+    } else {
+        context.push_str(schema_context.trim());
+        context.push('\n');
+    }
+
+    if !relationship_context.trim().is_empty() {
+        let _ = writeln!(context, "\n## Dataset Relationships");
+        context.push_str(relationship_context.trim());
+        context.push('\n');
+    }
+
+    let _ = writeln!(context, "\n## SQL Functions");
+    context.push_str(function_context.trim());
+    context.push('\n');
+
+    if !sample_context_blocks.is_empty() {
+        let _ = writeln!(context, "\n## Sample Data");
+        for sample_context in sample_context_blocks {
+            let _ = writeln!(context, "\n### {}", sample_context.title);
+            context.push_str(sample_context.content.trim());
+            context.push('\n');
+        }
+    }
+
+    context
+}
+
+fn validate_requested_datasets(
+    datasets: Option<&[String]>,
+    table_allowlist: Option<&ResolvedTableAwareAllowlist>,
+    table_exists: impl Fn(&TableReference) -> bool,
+) -> Result<(), NsqlContextError> {
+    if let Some(requested_datasets) = datasets {
+        for dataset in requested_datasets {
+            let table_ref = TableReference::parse_str(dataset);
+            if table_allowlist
+                .as_ref()
+                .is_some_and(|allowlist| !allowlist.table_is_allowed(&table_ref))
+                || !table_exists(&table_ref)
+            {
+                return Err(NsqlContextError::DatasetNotFound {
+                    dataset: dataset.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Construct a [`ResolvedTableAwareAllowlist`] based on the `App`'s `model.datasets`.
+fn table_allowlist(
+    model_name: &str,
+    app: &app::App,
+) -> Result<Option<ResolvedTableAwareAllowlist>, NsqlContextError> {
+    let model_datasets = app
+        .models
+        .iter()
+        .find(|m| m.name == model_name)
+        .map(|m| m.datasets.clone())
+        .unwrap_or_default();
+
+    let table_allowlist = if model_datasets.is_empty() {
+        None
+    } else {
+        match ResolvedTableAwareAllowlist::with_defaults(
+            SPICE_DEFAULT_CATALOG,
+            SPICE_DEFAULT_SCHEMA,
+        )
+        .with_table_patterns(model_datasets)
+        {
+            Ok(allowlist) => Some(allowlist),
+            Err(_) => {
+                return Err(NsqlContextError::InvalidModelDatasets {
+                    model_name: model_name.to_string(),
+                });
+            }
+        }
+    };
+    Ok(table_allowlist)
+}
+
+pub(crate) async fn build_nsql_context(
+    rt: Arc<Runtime>,
+    context: &Arc<RequestContext>,
+    model: &str,
+    options: NsqlContextOptions,
+    datasets: Option<Vec<String>>,
+) -> Result<NsqlContext, NsqlContextError> {
+    let df = get_current_datafusion(context);
+
+    let Some(app) = rt.read_app().await else {
+        return Err(NsqlContextError::AppNotPrepared);
+    };
+
+    let table_allowlist_opt = table_allowlist(model, &app)?;
+
+    validate_requested_datasets(datasets.as_deref(), table_allowlist_opt.as_ref(), |table| {
+        df.table_exists(table)
+    })?;
+
+    let tables = datasets.map_or_else(
+        || {
+            let mut tables = df
+                .get_user_table_names()
+                .into_iter()
+                .filter(|table| {
+                    table_allowlist_opt
+                        .as_ref()
+                        .is_none_or(|allowlist| allowlist.table_is_allowed(table))
+                })
+                .collect_vec();
+            sort_table_references(&mut tables);
+            tables
+        },
+        |datasets| {
+            datasets
+                .iter()
+                .map(|dataset| TableReference::parse_str(dataset))
+                .collect_vec()
+        },
+    );
+
+    let schema_context =
+        table_schema_context(&tables, Arc::clone(&rt), table_allowlist_opt.clone())
+            .instrument(Span::current())
+            .await
+            .map_err(|source| {
+                tracing::error!("Error getting schema context: {source}");
+                NsqlContextError::SchemaContext { source }
+            })?;
+
+    let sample_context_blocks = if options.include_sampling || options.include_examples {
+        sample_context_blocks(
+            &tables,
+            Arc::clone(&rt),
+            table_allowlist_opt.clone(),
+            options,
+        )
+        .instrument(Span::current())
+        .await
+        .map_err(|source| {
+            tracing::error!("Error sampling datasets for NSQL context: {source}");
+            NsqlContextError::SampleContext { source }
+        })?
+    } else {
+        vec![]
+    };
+
+    let function_inventory = registered_function_inventory(&rt)
+        .instrument(Span::current())
+        .await
+        .map_err(|source| {
+            tracing::error!(
+                "Error getting registered function inventory for NSQL context: {source}"
+            );
+            NsqlContextError::FunctionContext { source }
+        })?;
+    let configured_search_functions = search_function_availability(&function_inventory.names);
+
+    let dataset_contexts =
+        dataset_contexts(&tables, Arc::clone(&rt), &app, configured_search_functions)
+            .instrument(Span::current())
+            .await
+            .map_err(|source| {
+                tracing::error!("Error getting structured dataset context: {source}");
+                NsqlContextError::SchemaContext { source }
+            })?;
+
+    let dataset_search_functions =
+        dataset_search_function_availability(configured_search_functions, &dataset_contexts);
+    let function_context =
+        nsql_function_context(&app, &function_inventory, dataset_search_functions);
+    let function_context_block = function_context.render_markdown();
+    let relationship_context = render_nsql_dataset_relationship_context(&dataset_contexts);
+
+    let context_block = render_nsql_context_block(
+        &tables,
+        &dataset_contexts,
+        &schema_context,
+        &relationship_context,
+        &function_context_block,
+        &sample_context_blocks,
+    );
+    let message = context_message(&context_block)
+        .map_err(|message| NsqlContextError::ContextMessage { message })?;
+    let json = NsqlContextJsonResponse {
+        context: context_block,
+        instructions: nsql_context_instructions(),
+        sql: nsql_sql_context(),
+        datasets: dataset_contexts,
+        functions: function_context,
+        samples: sample_context_blocks,
+    };
+
+    Ok(NsqlContext {
+        json,
+        message,
+        table_allowlist: table_allowlist_opt,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry_names(entries: &[NsqlFunctionContextEntry]) -> BTreeSet<String> {
+        entries
+            .iter()
+            .map(|entry| entry.name.to_ascii_lowercase())
+            .collect()
+    }
+
+    fn relationship_test_dataset(
+        name: &str,
+        description: Option<&str>,
+        columns: Vec<NsqlColumnContext>,
+    ) -> NsqlDatasetContext {
+        NsqlDatasetContext {
+            name: name.to_string(),
+            catalog: None,
+            schema: None,
+            table: name.rsplit('.').next().unwrap_or(name).to_string(),
+            description: description.map(ToString::to_string),
+            metadata: BTreeMap::new(),
+            columns,
+            primary_key: vec![],
+            unique_constraints: vec![],
+            foreign_keys: vec![],
+            indexes: vec![],
+            search: NsqlDatasetSearchContext::default(),
+        }
+    }
+
+    fn relationship_test_column(
+        name: &str,
+        data_type: &str,
+        description: &str,
+    ) -> NsqlColumnContext {
+        NsqlColumnContext {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            nullable: false,
+            description: Some(description.to_string()),
+            source_type: None,
+            metadata: BTreeMap::new(),
+            primary_key: false.into(),
+            unique: false.into(),
+            indexed: false.into(),
+            vector_search: false.into(),
+            full_text_search: false.into(),
+        }
+    }
+
+    fn relationship_test_orders_customer_fk(foreign_table: &str) -> NsqlDatasetContext {
+        let mut orders = relationship_test_dataset("sales.orders", None, vec![]);
+        orders.foreign_keys = vec![NsqlForeignKeyContext {
+            columns: vec!["customer_id".to_string()],
+            foreign_table: foreign_table.to_string(),
+            foreign_columns: vec!["id".to_string()],
+        }];
+        orders
+    }
+
+    fn relationship_test_customer_dataset(name: &str, description: &str) -> NsqlDatasetContext {
+        relationship_test_dataset(
+            name,
+            Some(description),
+            vec![relationship_test_column("id", "Int64", "Customer id")],
+        )
+    }
+
+    fn vector_search_test_context(column: &str) -> NsqlVectorSearchContext {
+        NsqlVectorSearchContext {
+            column: column.to_string(),
+            function: VECTOR_SEARCH_UDTF_NAME.to_string(),
+            syntax: format!("{VECTOR_SEARCH_UDTF_NAME}(docs, 'query text', {column})"),
+            model: "embed_model".to_string(),
+            engine: Some("duckdb_vector_index".to_string()),
+            row_id_columns: vec!["id".to_string()],
+            vector_size: Some(384),
+            chunked: false,
+            input_mode: None,
+            index: None,
+            required_columns: vec![column.to_string(), "id".to_string()],
+            notes: vec![],
+        }
+    }
+
+    fn full_text_search_test_context(column: &str) -> NsqlFullTextSearchContext {
+        NsqlFullTextSearchContext {
+            column: column.to_string(),
+            function: TEXT_SEARCH_UDTF_NAME.to_string(),
+            syntax: format!("{TEXT_SEARCH_UDTF_NAME}(docs, 'query text', {column})"),
+            engine: "tantivy".to_string(),
+            index_store: "memory".to_string(),
+            row_id_columns: vec!["id".to_string()],
+            index: None,
+            required_columns: vec![column.to_string(), "id".to_string()],
+            notes: vec![],
+        }
+    }
+
+    #[test]
+    fn sort_table_references_orders_by_rendered_name() {
+        let mut tables = vec![
+            TableReference::parse_str("support_tickets"),
+            TableReference::parse_str("sales.orders"),
+            TableReference::parse_str("spice.marketing.accounts"),
+        ];
+
+        sort_table_references(&mut tables);
+
+        assert_eq!(
+            tables.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            vec![
+                "sales.orders".to_string(),
+                "spice.marketing.accounts".to_string(),
+                "support_tickets".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn validate_requested_datasets_rejects_unregistered_dataset() {
+        let datasets = vec!["missing".to_string()];
+
+        let error = validate_requested_datasets(Some(&datasets), None, |_| false)
+            .expect_err("unregistered requested dataset should be rejected");
+
+        assert!(matches!(
+            error,
+            NsqlContextError::DatasetNotFound { dataset } if dataset == "missing"
+        ));
+    }
+
+    #[test]
+    fn validate_requested_datasets_accepts_registered_allowed_dataset() {
+        let datasets = vec!["orders".to_string()];
+        let allowlist =
+            ResolvedTableAwareAllowlist::with_defaults(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
+                .with_table_patterns(vec!["orders".to_string()])
+                .expect("allowlist should build");
+
+        validate_requested_datasets(Some(&datasets), Some(&allowlist), |table| {
+            table.table() == "orders"
+        })
+        .expect("registered allowlisted dataset should be valid");
+    }
+
+    #[test]
+    fn dataset_search_function_availability_requires_registered_functions_and_search_context() {
+        let registered = SearchFunctionAvailability {
+            vector_search: true,
+            text_search: true,
+        };
+        let no_search = relationship_test_dataset("docs", None, vec![]);
+        assert_eq!(
+            dataset_search_function_availability(registered, &[no_search]),
+            SearchFunctionAvailability {
+                vector_search: false,
+                text_search: false,
+            }
+        );
+
+        let mut vector_dataset = relationship_test_dataset("docs", None, vec![]);
+        vector_dataset
+            .search
+            .vector
+            .push(vector_search_test_context("body"));
+        assert_eq!(
+            dataset_search_function_availability(registered, &[vector_dataset.clone()]),
+            SearchFunctionAvailability {
+                vector_search: true,
+                text_search: false,
+            }
+        );
+        assert_eq!(
+            dataset_search_function_availability(
+                SearchFunctionAvailability {
+                    vector_search: false,
+                    text_search: true,
+                },
+                &[vector_dataset]
+            ),
+            SearchFunctionAvailability {
+                vector_search: false,
+                text_search: false,
+            }
+        );
+
+        let mut full_text_dataset = relationship_test_dataset("docs", None, vec![]);
+        full_text_dataset
+            .search
+            .full_text
+            .push(full_text_search_test_context("body"));
+        assert_eq!(
+            dataset_search_function_availability(registered, &[full_text_dataset]),
+            SearchFunctionAvailability {
+                vector_search: false,
+                text_search: true,
+            }
+        );
+    }
+
+    #[test]
+    fn nsql_relationship_context_includes_compact_foreign_key_target_context() {
+        let mut orders = relationship_test_dataset("sales.orders", None, vec![]);
+        orders.foreign_keys = vec![NsqlForeignKeyContext {
+            columns: vec!["customer_id".to_string()],
+            foreign_table: "sales.customers".to_string(),
+            foreign_columns: vec!["id".to_string()],
+        }];
+
+        let mut customers = relationship_test_dataset(
+            "sales.customers",
+            Some("Customer accounts"),
+            vec![
+                relationship_test_column("id", "Int64", "Unique customer identifier"),
+                relationship_test_column("account_name", "Utf8", "Customer account name"),
+            ],
+        );
+        customers.primary_key = vec!["id".to_string()];
+
+        let context = render_nsql_dataset_relationship_context(&[orders, customers]);
+
+        assert!(context.contains(
+            "Target context for `sales.customers`: Customer accounts; target columns: `id` Int64 (Unique customer identifier), `account_name` Utf8 (Customer account name)."
+        ));
+    }
+
+    #[test]
+    fn nsql_relationship_context_limits_compact_foreign_key_target_columns() {
+        let mut orders = relationship_test_dataset("sales.orders", None, vec![]);
+        orders.foreign_keys = vec![NsqlForeignKeyContext {
+            columns: vec![
+                "customer_id".to_string(),
+                "tenant_id".to_string(),
+                "account_name".to_string(),
+                "owner_email".to_string(),
+                "segment".to_string(),
+            ],
+            foreign_table: "sales.customers".to_string(),
+            foreign_columns: vec![
+                "id".to_string(),
+                "tenant_id".to_string(),
+                "account_name".to_string(),
+                "owner_email".to_string(),
+                "segment".to_string(),
+            ],
+        }];
+
+        let mut customers = relationship_test_dataset(
+            "sales.customers",
+            Some("Customer accounts"),
+            vec![
+                relationship_test_column("id", "Int64", "Unique customer identifier"),
+                relationship_test_column("tenant_id", "Int64", "Tenant identifier"),
+                relationship_test_column("account_name", "Utf8", "Customer account name"),
+                relationship_test_column("owner_email", "Utf8", "Customer owner email"),
+                relationship_test_column("segment", "Utf8", "Customer segment"),
+            ],
+        );
+        customers.primary_key = vec!["id".to_string()];
+
+        let context = render_nsql_dataset_relationship_context(&[orders, customers]);
+        let target_context_line = context
+            .lines()
+            .find(|line| line.contains("Target context for `sales.customers`"))
+            .expect("relationship context should include target context for sales.customers");
+
+        assert_eq!(
+            target_context_line.trim(),
+            "Target context for `sales.customers`: Customer accounts; target columns: `id` Int64 (Unique customer identifier), `tenant_id` Int64 (Tenant identifier), `account_name` Utf8 (Customer account name), `owner_email` Utf8 (Customer owner email)."
+        );
+    }
+
+    #[test]
+    fn nsql_relationship_context_includes_unique_under_qualified_foreign_key_target_context() {
+        let orders = relationship_test_orders_customer_fk("customers");
+        let customers = relationship_test_customer_dataset("sales.customers", "Sales customers");
+
+        let context = render_nsql_dataset_relationship_context(&[orders, customers]);
+
+        assert!(context.contains(
+            "Target context for `sales.customers`: Sales customers; target columns: `id` Int64 (Customer id)."
+        ));
+    }
+
+    #[test]
+    fn nsql_relationship_context_does_not_match_less_qualified_dataset_context() {
+        let orders = relationship_test_orders_customer_fk("sales.customers");
+        let customers = relationship_test_customer_dataset("customers", "Bare customers");
+
+        let context = render_nsql_dataset_relationship_context(&[orders, customers]);
+
+        assert!(context.contains("references `sales.customers`"));
+        assert!(!context.contains("Target context for"));
+    }
+
+    #[test]
+    fn nsql_relationship_context_prefers_exact_foreign_key_target_context() {
+        let orders = relationship_test_orders_customer_fk("customers");
+        let sales_customers =
+            relationship_test_customer_dataset("sales.customers", "Sales customers");
+        let customers = relationship_test_customer_dataset("customers", "Bare customers");
+
+        let context =
+            render_nsql_dataset_relationship_context(&[orders, sales_customers, customers]);
+
+        assert!(context.contains(
+            "Target context for `customers`: Bare customers; target columns: `id` Int64 (Customer id)."
+        ));
+        assert!(!context.contains("Sales customers"));
+    }
+
+    #[test]
+    fn nsql_relationship_context_skips_ambiguous_compact_foreign_key_target_context() {
+        let mut orders = relationship_test_dataset("sales.orders", None, vec![]);
+        orders.foreign_keys = vec![NsqlForeignKeyContext {
+            columns: vec!["customer_id".to_string()],
+            foreign_table: "customers".to_string(),
+            foreign_columns: vec!["id".to_string()],
+        }];
+
+        let sales_customers = relationship_test_dataset(
+            "sales.customers",
+            Some("Sales customers"),
+            vec![relationship_test_column("id", "Int64", "Sales customer id")],
+        );
+        let marketing_customers = relationship_test_dataset(
+            "marketing.customers",
+            Some("Marketing customers"),
+            vec![relationship_test_column(
+                "id",
+                "Int64",
+                "Marketing customer id",
+            )],
+        );
+
+        let context = render_nsql_dataset_relationship_context(&[
+            orders,
+            sales_customers,
+            marketing_customers,
+        ]);
+
+        assert!(!context.contains("Target context for"));
+    }
+
+    #[test]
+    fn function_context_includes_registered_json_and_spark_functions() {
+        let app = app::AppBuilder::new("test").build();
+        let available_names = all_context_function_names_for_test();
+
+        let context = nsql_function_context_for_test(&app, &available_names, true, true);
+
+        let json_names = entry_names(&context.json);
+        let expected_json_names = available_names
+            .iter()
+            .filter(|name| is_json_context_function(name))
+            .collect_vec();
+        assert!(
+            expected_json_names.len() > 10,
+            "expected many registered JSON functions"
+        );
+        for expected_name in expected_json_names {
+            assert!(
+                json_names.contains(expected_name),
+                "missing JSON function {expected_name} from NSQL context"
+            );
+        }
+
+        let expected_spark_names = datafusion_spark::all_default_scalar_functions()
+            .into_iter()
+            .map(|function| function.name().to_ascii_lowercase())
+            .collect::<BTreeSet<_>>();
+        let actual_spark_names = context
+            .spark_compatibility
+            .functions
+            .iter()
+            .map(|name| name.to_ascii_lowercase())
+            .collect::<BTreeSet<_>>();
+
+        assert!(
+            expected_spark_names.len() > 20,
+            "expected DataFusion Spark compatibility to expose many functions"
+        );
+        assert_eq!(actual_spark_names, expected_spark_names);
+    }
+
+    #[test]
+    fn function_context_search_only_includes_search_functions() {
+        let app = app::AppBuilder::new("test").build();
+        let available_names = all_context_function_names_for_test();
+
+        let context = nsql_function_context_for_test(&app, &available_names, true, true);
+
+        assert_eq!(
+            entry_names(&context.search),
+            BTreeSet::from([
+                RERANK_UDTF_NAME.to_string(),
+                RRF_UDF_NAME.to_string(),
+                TEXT_SEARCH_UDTF_NAME.to_string(),
+                VECTOR_SEARCH_UDTF_NAME.to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn function_context_includes_additional_registered_functions() {
+        let app = app::AppBuilder::new("test").build();
+        let available_names = all_context_function_names_for_test();
+
+        let context = nsql_function_context_for_test(&app, &available_names, true, true);
+        let additional_names = entry_names(&context.additional);
+
+        assert!(additional_names.contains(COSINE_DISTANCE_UDF_NAME));
+        assert!(additional_names.contains(DIGEST_UDF_NAME));
+        assert!(additional_names.contains(LIST_UDFS_UDTF_NAME));
+        assert!(!additional_names.contains(TEXT_SEARCH_UDTF_NAME));
+        assert!(!additional_names.contains("json_get"));
+    }
+
+    #[cfg(feature = "models")]
+    #[test]
+    fn function_context_includes_model_functions_when_registered() {
+        let app = app::AppBuilder::new("test").build();
+        let available_names = HashSet::from([AI_UDF_NAME.to_string(), EMBED_UDF_NAME.to_string()]);
+
+        let context = nsql_function_context_for_test(&app, &available_names, false, false);
+        let additional_names = entry_names(&context.additional);
+
+        assert!(additional_names.contains(AI_UDF_NAME));
+        assert!(additional_names.contains(EMBED_UDF_NAME));
+    }
+
+    #[test]
+    fn function_context_includes_fusion_and_rerank_with_text_or_vector_search() {
+        let app = app::AppBuilder::new("test").build();
+        let available_names = HashSet::from([
+            TEXT_SEARCH_UDTF_NAME.to_string(),
+            VECTOR_SEARCH_UDTF_NAME.to_string(),
+            RRF_UDF_NAME.to_string(),
+            RERANK_UDTF_NAME.to_string(),
+        ]);
+
+        let text_only = nsql_function_context_for_test(&app, &available_names, false, true);
+        let text_only_names = entry_names(&text_only.search);
+        assert!(text_only_names.contains(TEXT_SEARCH_UDTF_NAME));
+        assert!(!text_only_names.contains(VECTOR_SEARCH_UDTF_NAME));
+        assert!(text_only_names.contains(RRF_UDF_NAME));
+        assert!(text_only_names.contains(RERANK_UDTF_NAME));
+
+        let vector_only = nsql_function_context_for_test(&app, &available_names, true, false);
+        let vector_only_names = entry_names(&vector_only.search);
+        assert!(!vector_only_names.contains(TEXT_SEARCH_UDTF_NAME));
+        assert!(vector_only_names.contains(VECTOR_SEARCH_UDTF_NAME));
+        assert!(vector_only_names.contains(RRF_UDF_NAME));
+        assert!(vector_only_names.contains(RERANK_UDTF_NAME));
+
+        let hybrid = nsql_function_context_for_test(&app, &available_names, true, true);
+        let hybrid_names = entry_names(&hybrid.search);
+        assert!(hybrid_names.contains(TEXT_SEARCH_UDTF_NAME));
+        assert!(hybrid_names.contains(VECTOR_SEARCH_UDTF_NAME));
+        assert!(hybrid_names.contains(RRF_UDF_NAME));
+        assert!(hybrid_names.contains(RERANK_UDTF_NAME));
+    }
+}

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -29,7 +29,7 @@ limitations under the License.
 
 use arrow_schema::DataType;
 use datafusion::common::exec_err;
-use datafusion::logical_expr::{ColumnarValue, Signature, Volatility};
+use datafusion::logical_expr::{ColumnarValue, DocSection, Documentation, Signature, Volatility};
 use datafusion::{
     catalog::{TableFunctionImpl, TableProvider},
     common::Column,
@@ -84,6 +84,39 @@ pub static TEXT_SEARCH_SIGNATURE: LazyLock<Signature> = LazyLock::new(|| {
     Signature::user_defined(Volatility::Stable)
         .with_parameter_names(param_names)
         .unwrap_or_else(|_| unreachable!("valid parameter names for text_search"))
+});
+
+static TEXT_SEARCH_DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| Documentation {
+    doc_section: DocSection::default(),
+    description: "Runs full-text search over a configured searchable dataset.".to_string(),
+    syntax_example: "text_search(tbl, 'query text'[, column])".to_string(),
+    sql_example: None,
+    arguments: Some(vec![
+        (
+            "tbl".to_string(),
+            "Dataset or table reference with a full-text search index.".to_string(),
+        ),
+        ("query".to_string(), "Search query text.".to_string()),
+        (
+            "column".to_string(),
+            "Optional indexed column to search when the dataset has multiple full-text indexes."
+                .to_string(),
+        ),
+        (
+            "limit".to_string(),
+            "Optional maximum number of search results.".to_string(),
+        ),
+        (
+            "include_score".to_string(),
+            "Whether to include the search score column; defaults to true.".to_string(),
+        ),
+        (
+            "rank_weight".to_string(),
+            "Optional per-query weighting factor when nested inside rrf().".to_string(),
+        ),
+    ]),
+    alternative_syntax: None,
+    related_udfs: Some(vec!["rrf".to_string(), "rerank".to_string()]),
 });
 
 #[derive(Debug, PartialEq, Clone)]
@@ -604,6 +637,10 @@ impl ScalarUDFImpl for TextSearchTableFunc {
 
     fn signature(&self) -> &Signature {
         &TEXT_SEARCH_SIGNATURE
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        Some(&*TEXT_SEARCH_DOCUMENTATION)
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {

--- a/crates/runtime/src/search/rerank.rs
+++ b/crates/runtime/src/search/rerank.rs
@@ -45,7 +45,7 @@ use datafusion::common::{Column, exec_err};
 use datafusion::datasource::{DefaultTableSource, TableType};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::logical_expr::{ColumnarValue, Signature, Volatility};
+use datafusion::logical_expr::{ColumnarValue, DocSection, Documentation, Signature, Volatility};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::expressions::Column as PhysicalColumn;
@@ -90,6 +90,53 @@ pub static RERANK_SIGNATURE: LazyLock<Signature> = LazyLock::new(|| {
         Ok(sig) => sig,
         Err(_) => Signature::variadic_any(Volatility::Volatile),
     }
+});
+
+static RERANK_DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| Documentation {
+    doc_section: DocSection::default(),
+    description: "Re-ranks search results or table rows using a configured reranker model."
+        .to_string(),
+    syntax_example:
+        "rerank(input, model => 'model_name', document => 'column_name'[, query => 'query text'])"
+            .to_string(),
+    sql_example: None,
+    arguments: Some(vec![
+        (
+            "input".to_string(),
+            "A table reference or nested text_search, vector_search, or rrf invocation."
+                .to_string(),
+        ),
+        (
+            "model".to_string(),
+            "Configured reranker or chat model name.".to_string(),
+        ),
+        (
+            "document".to_string(),
+            "Column containing the text to rerank.".to_string(),
+        ),
+        (
+            "query".to_string(),
+            "Query text; auto-propagated from nested search inputs when possible.".to_string(),
+        ),
+        (
+            "limit".to_string(),
+            "Optional maximum number of reranked rows returned.".to_string(),
+        ),
+        (
+            "strategy".to_string(),
+            "Optional reranking strategy for compatible models.".to_string(),
+        ),
+        (
+            "prompt_template".to_string(),
+            "Optional prompt template when reranking with a chat model.".to_string(),
+        ),
+    ]),
+    alternative_syntax: None,
+    related_udfs: Some(vec![
+        "text_search".to_string(),
+        "vector_search".to_string(),
+        "rrf".to_string(),
+    ]),
 });
 
 /// Output column for reranker scores. Chosen distinct from `_score` /
@@ -458,6 +505,9 @@ impl ScalarUDFImpl for RerankTableFunc {
     }
     fn signature(&self) -> &Signature {
         &RERANK_SIGNATURE
+    }
+    fn documentation(&self) -> Option<&Documentation> {
+        Some(&*RERANK_DOCUMENTATION)
     }
     fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
         Self::scalar_invocation_error()


### PR DESCRIPTION
## Problem

On macOS, **both** std `sync_all` **and** `sync_data` map to `fcntl(F_FULLFSYNC)` — a full drive-cache flush measured at **~4.5 ms per call** (plain `fsync(2)` is ~66 µs; measured with a standalone probe on Apple Silicon). A staged CDC batch pays **5–7 such barriers** (data dir, staging-WAL file + dir, deletion-vector file + dir, move-target dir), putting a **~25 ms fixed floor** under every staged commit — the dominant cost of small staged upserts/deletes/appends (`vs_duckdb_*` benches).

## Change

New `provider/fsync_tier.rs` routes every staged-hot-path barrier through an **ordering tier**: plain `libc::fsync` on macOS (target-gated `libc` dep), `sync_data` (`fdatasync`) elsewhere. Cold paths (table create/drop, metastore init, partition creation) keep `sync_all`.

## Why durability is unchanged (metastore parity)

The SQLite metastore runs `journal_mode=WAL, synchronous=NORMAL` with no `fullfsync` pragma, so the catalog transaction that makes staged files **visible** is itself only plain-fsync durable on macOS (NORMAL doesn't even fsync at every commit). A power-loss window that loses ordering-tier data necessarily also loses the catalog rows referencing it — the full-tier barriers bought no end-to-end durability. Plain fsync is likewise the macOS default tier for SQLite, DuckDB, and PostgreSQL. Process-crash consistency is unaffected: the staging-WAL recovery protocol (`ensure_no_incomplete_write`) heals interrupted commits either way. On Linux/EBS the change is neutral (`fsync` ≈ `fdatasync` for freshly created files; the EBS cost is the network RTT either way).

## Validated (criterion vs saved before-baseline, 16-core macOS)

| Bench | Before | After | vs DuckDB |
|---|---|---|---|
| `vs_duckdb_delete/16k` | 13.06 ms | **2.28 ms (−84%)** | **2.2× faster** (was 2.4× slower) |
| `vs_duckdb_delete/131k` | 18.0 ms | **5.88 ms (−69%)** | flipped ahead |
| `vs_duckdb_bulk_ingest/16k` | 30.3 ms | **8.41 ms (−72%)** | flipped ahead |
| `vs_duckdb_bulk_ingest/131k` | 41.0 ms | **19.9 ms (−51%)** | flipped ahead |
| `vs_duckdb_incremental_append` | 487 ms | **94.8 ms (−80%)** | gap 18× → 3.9× |
| `vs_duckdb_upsert_scaling/N=10k` | 27.99 ms | **14.03 ms (−50%)** | remaining floor is Vortex encode, not fsync |
| `vs_duckdb_burst/16` | 4.22 ms | **2.99 ms (−30%)** | 2.9× faster |

All durability suites green: `ingest_fsync_regression` (updated — now **pins the tier contract**: hot-path fns must route through `fsync_tier` and may not call `.sync_all()`/`.sync_data()` directly, plus asserts the helper issues `libc::fsync` on macOS), `staged_append`, `acid_compliance`, `inline_with_pending_deletions`, `cross_partition_overwrite`, + unit tests in the new module.


---

## Also includes #11200 (merged into this branch)

The stacked PR **Parallel deletion-vector writes + coalesced directory barrier** (#11200) was merged into this branch, so this PR now carries both changes. Summary of that half: `DeletionVectorWriter::write` writes/fsyncs the per-spec deletion-vector files concurrently (`try_join_all`) and issues ONE coalesced `deletions/`-dir ordering sync per batch instead of one per file — on the staged CDC path this collapses ~5–7 serialized barrier rounds to ~3 (per-file × per-barrier matters most on EBS, where each flush round-trips provisioned-IOPS latency). A structural test pins the concurrency shape and the exactly-two dir syncs.
