### PR TITLE
feat(cayenne): delta-write encoding levels (cayenne_delta_encoding, default auto) + make compression_strategy=zstd real

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -55,7 +55,11 @@ url = { workspace = true }
 util = { path = "../util", features = ["datafusion"] }
 uuid = { workspace = true, features = ["v7"] }
 flatbuffers = { workspace = true }
-vortex = { workspace = true }
+# `files` exposes `vortex::file::WriteStrategyBuilder` for the delta-encoding
+# write-strategy overrides (provider/delta_encoding.rs). The feature is already
+# enabled transitively by vortex-datafusion; naming it here keeps cayenne
+# building if that ever changes.
+vortex = { workspace = true, features = ["files"] }
 vortex-datafusion = { workspace = true }
 vortex-scan = { workspace = true }
 vortex-session = { workspace = true }

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -296,3 +296,7 @@ name = "get_max_delete_sequence_walk"
 [[bench]]
 harness = false
 name = "apply_on_conflict_keys_double_clone"
+
+[[bench]]
+harness = false
+name = "delta_encoding_sweep"

--- a/crates/cayenne/benches/delta_encoding_sweep.rs
+++ b/crates/cayenne/benches/delta_encoding_sweep.rs
@@ -1,0 +1,286 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Matrix sweep over `cayenne_delta_encoding` levels × `compression_strategy`
+//! families: write latency (criterion) and on-disk bytes (printed table) for
+//! one staged delta write per configuration.
+//!
+//! Lanes: {btrblocks, zstd} × {auto, 1..=9} on a 5,000-row staged write
+//! (above the inline admission cap, so the encoding level applies). The
+//! pre-pass prints a `(family, level) -> bytes` table — the engagement /
+//! compression-ratio half of the matrix that wall-clock alone can't show.
+//!
+//! Bench discipline (Tiger Style): setup outside the timed closure; every
+//! loop bounded; every `expect` carries a message; the timed write's row
+//! count is asserted; data generation is deterministic (no RNG).
+
+#![allow(clippy::expect_used)]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use cayenne::metadata::{CompressionStrategy, CreateTableOptions, DeltaEncoding, VortexConfig};
+use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use datafusion::prelude::SessionContext;
+use std::hint::black_box;
+
+/// Above the inline admission cap (default 1024) so the write takes the
+/// staged file path the encoding level applies to.
+const ROW_COUNT: usize = 5_000;
+
+/// Mixed-compressibility strings: a repetitive prefix (dict/FSST-friendly)
+/// plus a long deterministic pseudo-entropy tail (where zstd can win).
+const DISTINCT_PREFIXES: usize = 32;
+
+const FAMILIES: &[(&str, CompressionStrategy)] = &[
+    ("btrblocks", CompressionStrategy::Btrblocks),
+    ("zstd", CompressionStrategy::Zstd),
+];
+
+fn encodings() -> Vec<(String, DeltaEncoding)> {
+    let mut lanes = vec![("auto".to_string(), DeltaEncoding::Auto)];
+    for level in 1..=9_u8 {
+        lanes.push((format!("level{level}"), DeltaEncoding::Level(level)));
+    }
+    lanes
+}
+
+fn test_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]))
+}
+
+/// Deterministic pseudo-entropy suffix (xorshift on the row index) so string
+/// columns carry both repetitive and high-entropy content.
+fn entropy_suffix(row: usize) -> String {
+    let mut state = (row as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut out = String::with_capacity(48);
+    for _ in 0..6 {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.push_str(&format!("{state:016x}"));
+    }
+    out
+}
+
+fn workload_batch(rows: usize) -> RecordBatch {
+    let ids: Vec<i64> = (0..rows as i64).collect();
+    let names: Vec<String> = (0..rows)
+        .map(|i| {
+            format!(
+                "delta_sweep_prefix_{:02}_{}",
+                i % DISTINCT_PREFIXES,
+                entropy_suffix(i)
+            )
+        })
+        .collect();
+    RecordBatch::try_new(
+        test_schema(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(StringArray::from(names)),
+        ],
+    )
+    .expect("build workload batch")
+}
+
+struct SweepFixture {
+    _temp_dir: tempfile::TempDir,
+    table: Arc<CayenneTableProvider>,
+    data_path: std::path::PathBuf,
+    table_id: String,
+}
+
+async fn setup_lane(
+    lane_name: &str,
+    family: CompressionStrategy,
+    encoding: DeltaEncoding,
+) -> SweepFixture {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).expect("create data dir");
+    let db_path = temp_dir.path().join("catalog.db");
+    let catalog = Arc::new(
+        CayenneCatalog::new(format!("sqlite://{}", db_path.to_string_lossy())).expect("catalog"),
+    );
+    catalog.init().await.expect("catalog init");
+
+    let vortex_config = VortexConfig {
+        compression_strategy: family,
+        delta_encoding: encoding,
+        ..VortexConfig::default()
+    };
+    let ctx = SessionContext::new();
+    let table = Arc::new(
+        CayenneTableProvider::create_table(
+            Arc::clone(&catalog) as Arc<dyn MetadataCatalog>,
+            CreateTableOptions {
+                table_name: lane_name.to_string(),
+                schema: test_schema(),
+                primary_key: vec![],
+                on_conflict: None,
+                base_path: data_path.to_string_lossy().to_string(),
+                partition_column: None,
+                vortex_config,
+            },
+            ctx.runtime_env(),
+        )
+        .await
+        .expect("create table"),
+    );
+    let table_id = catalog
+        .get_table(lane_name)
+        .await
+        .expect("get table")
+        .table_id;
+    SweepFixture {
+        _temp_dir: temp_dir,
+        table,
+        data_path,
+        table_id,
+    }
+}
+
+/// Write one delta via the real `insert_into` path — the inline gate buffers
+/// the (over-cap) batch, computes an exact size estimate, and falls back to
+/// the staged file write, so `auto` resolves against the true delta size
+/// exactly as production inserts do.
+async fn staged_write(fixture: &SweepFixture, batch: RecordBatch) -> u64 {
+    use datafusion::datasource::TableProvider;
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::logical_expr::dml::InsertOp;
+    use datafusion::physical_plan::collect;
+
+    let ctx = SessionContext::new();
+    let schema = batch.schema();
+    let input_exec =
+        MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).expect("memory source");
+    let insert_plan = fixture
+        .table
+        .insert_into(&ctx.state(), input_exec, InsertOp::Append)
+        .await
+        .expect("insert plan");
+    let results = collect(insert_plan, ctx.task_ctx()).await.expect("insert");
+    results
+        .first()
+        .and_then(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+                .map(|counts| counts.value(0))
+        })
+        .unwrap_or(0)
+}
+
+fn vortex_bytes_under(dir: &Path) -> u64 {
+    let mut total = 0;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return 0,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            total += vortex_bytes_under(&path);
+        } else if path.extension().is_some_and(|ext| ext == "vortex") {
+            total += entry.metadata().map(|m| m.len()).unwrap_or(0);
+        }
+    }
+    total
+}
+
+fn bench_delta_encoding_sweep(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let batch = workload_batch(ROW_COUNT);
+
+    // --- Pre-pass: one write per lane, report on-disk bytes (engagement +
+    // ratio table; wall-clock alone can't show this half of the matrix). ---
+    eprintln!("\n=== delta_encoding_sweep on-disk bytes ({ROW_COUNT} rows) ===");
+    eprintln!("{:<12} {:<8} {:>12}", "family", "level", "vortex_bytes");
+    for (family_name, family) in FAMILIES {
+        for (encoding_name, encoding) in encodings() {
+            let lane = format!("sweep_{family_name}_{encoding_name}");
+            let bytes = runtime.block_on(async {
+                let fixture = setup_lane(&lane, family.clone(), encoding).await;
+                let rows = staged_write(&fixture, batch.clone()).await;
+                assert_eq!(rows as usize, ROW_COUNT, "staged write row count");
+                vortex_bytes_under(&fixture.data_path.join(&fixture.table_id))
+            });
+            assert!(bytes > 0, "lane {lane} produced no vortex bytes");
+            eprintln!("{family_name:<12} {encoding_name:<8} {bytes:>12}");
+        }
+    }
+    eprintln!();
+
+    // --- Timed matrix: staged write latency per (family, encoding). ---
+    let mut group = c.benchmark_group("delta_encoding_sweep");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(ROW_COUNT as u64));
+    for (family_name, family) in FAMILIES {
+        for (encoding_name, encoding) in encodings() {
+            let lane = format!("{family_name}/{encoding_name}");
+            let batch_for_lane = batch.clone();
+            group.bench_with_input(
+                BenchmarkId::new(*family_name, encoding_name.clone()),
+                &encoding,
+                |bencher, &encoding| {
+                    // Sync bencher with `runtime.block_on` in BOTH closures
+                    // (the `vs_duckdb_upsert_scaling` pattern): criterion's
+                    // async executor would otherwise drive the setup closure
+                    // from inside the runtime, and the nested `block_on`
+                    // panics ("Cannot start a runtime from within a runtime").
+                    bencher.iter_batched(
+                        || {
+                            let lane_table = format!(
+                                "bench_{}_{}",
+                                family_name,
+                                encoding_name.replace('/', "_")
+                            );
+                            runtime.block_on(setup_lane(&lane_table, family.clone(), encoding))
+                        },
+                        |fixture| {
+                            let batch = batch_for_lane.clone();
+                            runtime.block_on(async {
+                                let rows = staged_write(&fixture, batch).await;
+                                assert_eq!(
+                                    rows as usize, ROW_COUNT,
+                                    "timed staged write row count"
+                                );
+                                black_box(rows);
+                            });
+                        },
+                        criterion::BatchSize::PerIteration,
+                    );
+                },
+            );
+            let _ = lane;
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_delta_encoding_sweep);
+criterion_main!(benches);

--- a/crates/cayenne/benches/delta_encoding_sweep.rs
+++ b/crates/cayenne/benches/delta_encoding_sweep.rs
@@ -117,7 +117,9 @@ async fn setup_lane(
 ) -> SweepFixture {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let data_path = temp_dir.path().join("data");
-    std::fs::create_dir_all(&data_path).expect("create data dir");
+    tokio::fs::create_dir_all(&data_path)
+        .await
+        .expect("create data dir");
     let db_path = temp_dir.path().join("catalog.db");
     let catalog = Arc::new(
         CayenneCatalog::new(format!("sqlite://{}", db_path.to_string_lossy())).expect("catalog"),

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -3233,6 +3233,17 @@ fn log_configuration_differences(
         ));
     }
 
+    // Note: `delta_encoding` is deliberately NOT part of the data-compatibility
+    // gate (`is_data_compatible`): every level emits standard Vortex encodings
+    // readable by the same scan, so a level change applies to future writes
+    // only and must not force a table re-create. Surface it in the change log.
+    if stored.vortex_config.delta_encoding != options.vortex_config.delta_encoding {
+        differences.push(format!(
+            "delta_encoding: {} -> {} (write-time only; existing data unaffected)",
+            stored.vortex_config.delta_encoding, options.vortex_config.delta_encoding
+        ));
+    }
+
     if stored.path != options.base_path {
         differences.push(format!(
             "base_path: {:?} -> {:?}",

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -253,16 +253,16 @@ pub enum CompressionStrategy {
 ///
 /// zstd-style level scale (`cayenne_delta_encoding` param):
 ///
-/// - `auto` (default) — size-gated: a write smaller than a quarter of the
+/// - `7` (default) — the full default `BtrBlocks` cascade: byte-for-byte
+///   today's write behavior. Levels `8`–`10` are reserved for future
+///   heavier-effort search.
+/// - `auto` (opt-in) — size-gated: a write smaller than a quarter of the
 ///   target file size encodes at a light level (the file is transient by
 ///   definition — compaction exists to fold it); larger writes use the full
 ///   default encoding.
 /// - `0` — no compression (canonical arrays; cheapest encode).
 /// - `1`–`6` — progressively richer scheme sets. The cheap levels skip the
-///   per-file encoder-strategy search and FSST symbol-table training that
-///   dominate small-write encode cost.
-/// - `7`–`10` — the full default `BtrBlocks` cascade (today's behavior; the
-///   upper levels are reserved for future heavier-effort search).
+///   per-file encoder-strategy search and FSST symbol-table training.
 ///
 /// Maintenance writes (compaction outputs, sorted rewrites, overwrites) are
 /// NOT affected by this setting — they always use the full default encoding,
@@ -271,18 +271,32 @@ pub enum CompressionStrategy {
 ///
 /// The exact level → scheme-set mapping lives in
 /// `provider::delta_encoding::strategy_builder_for_level`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum DeltaEncoding {
     /// Size-gated: light for small deltas, full for large writes.
-    #[default]
     Auto,
     /// Fixed encoding level `0..=10` applied to every delta write.
     Level(u8),
 }
 
+impl Default for DeltaEncoding {
+    /// `Level(7)` — the full default cascade, i.e. unchanged write behavior.
+    /// This is also what pre-feature stored table configs deserialize to via
+    /// `#[serde(default)]`, so enabling the feature in a new build cannot
+    /// silently change how existing tables encode their deltas.
+    fn default() -> Self {
+        Self::Level(DELTA_ENCODING_FULL_LEVEL)
+    }
+}
+
 /// Maximum supported [`DeltaEncoding`] level.
 pub const DELTA_ENCODING_MAX_LEVEL: u8 = 10;
+
+/// First level that maps to the full default `BtrBlocks` cascade (levels
+/// `7..=10` are all "full" today). Shared with
+/// `provider::delta_encoding::FULL_LEVEL` so the two can't drift.
+pub const DELTA_ENCODING_FULL_LEVEL: u8 = 7;
 
 impl std::fmt::Display for DeltaEncoding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -473,7 +487,8 @@ pub struct VortexConfig {
     /// Defaults to Btrblocks
     pub compression_strategy: CompressionStrategy,
     /// Encoding effort for delta writes (fresh CDC/append snapshot files).
-    /// `auto` (default) size-gates: small deltas encode light and are folded
+    /// `7` (default) is the full default cascade — unchanged write behavior.
+    /// `auto` (opt-in) size-gates: small deltas encode light and are folded
     /// into properly-encoded files by compaction; explicit `0..=10` pins the
     /// level. Maintenance writes (compaction, rewrites) always use the full
     /// default encoding. See [`DeltaEncoding`].
@@ -726,6 +741,12 @@ impl Default for VortexConfig {
             // No sort columns by default
             sort_columns: Vec::new(),
             compression_strategy: CompressionStrategy::default(),
+            // Level(7) = full default cascade, i.e. unchanged write behavior.
+            // `auto` is deliberately opt-in until validated at CDC scale:
+            // local micro A/B (2026-06-06) was neutral on upsert/bulk lanes
+            // and showed light deltas making in-window compaction passes work
+            // harder (incremental_append +10%); the `auto` thesis (CPU per
+            // delta on the pipelined CDC route) needs a production-scale run.
             delta_encoding: DeltaEncoding::default(),
             upload_concurrency: default_upload_concurrency(),
             write_concurrency: None,

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -248,6 +248,87 @@ pub enum CompressionStrategy {
     Zstd,
 }
 
+/// Encoding effort for *delta* writes — fresh CDC/append snapshot files that
+/// the tiered compactor later folds into properly-encoded files.
+///
+/// zstd-style level scale (`cayenne_delta_encoding` param):
+///
+/// - `auto` (default) — size-gated: a write smaller than a quarter of the
+///   target file size encodes at a light level (the file is transient by
+///   definition — compaction exists to fold it); larger writes use the full
+///   default encoding.
+/// - `0` — no compression (canonical arrays; cheapest encode).
+/// - `1`–`6` — progressively richer scheme sets. The cheap levels skip the
+///   per-file encoder-strategy search and FSST symbol-table training that
+///   dominate small-write encode cost.
+/// - `7`–`10` — the full default `BtrBlocks` cascade (today's behavior; the
+///   upper levels are reserved for future heavier-effort search).
+///
+/// Maintenance writes (compaction outputs, sorted rewrites, overwrites) are
+/// NOT affected by this setting — they always use the full default encoding,
+/// because their output is the long-lived artifact whose encoding quality
+/// pays for scan throughput and storage footprint.
+///
+/// The exact level → scheme-set mapping lives in
+/// `provider::delta_encoding::strategy_builder_for_level`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub enum DeltaEncoding {
+    /// Size-gated: light for small deltas, full for large writes.
+    #[default]
+    Auto,
+    /// Fixed encoding level `0..=10` applied to every delta write.
+    Level(u8),
+}
+
+/// Maximum supported [`DeltaEncoding`] level.
+pub const DELTA_ENCODING_MAX_LEVEL: u8 = 10;
+
+impl std::fmt::Display for DeltaEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto"),
+            Self::Level(level) => write!(f, "{level}"),
+        }
+    }
+}
+
+impl std::str::FromStr for DeltaEncoding {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        let trimmed = value.trim();
+        if trimmed.eq_ignore_ascii_case("auto") {
+            return Ok(Self::Auto);
+        }
+        let level: u8 = trimmed.parse().map_err(|_| {
+            format!(
+                "invalid delta encoding '{value}': expected 'auto' or a level 0..={DELTA_ENCODING_MAX_LEVEL}"
+            )
+        })?;
+        if level > DELTA_ENCODING_MAX_LEVEL {
+            return Err(format!(
+                "invalid delta encoding level {level}: maximum is {DELTA_ENCODING_MAX_LEVEL}"
+            ));
+        }
+        Ok(Self::Level(level))
+    }
+}
+
+impl TryFrom<String> for DeltaEncoding {
+    type Error = String;
+
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<DeltaEncoding> for String {
+    fn from(value: DeltaEncoding) -> Self {
+        value.to_string()
+    }
+}
+
 /// Primary-key conflict detection behavior for Cayenne inserts.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -391,6 +472,13 @@ pub struct VortexConfig {
     /// Compression strategy to use for Vortex files
     /// Defaults to Btrblocks
     pub compression_strategy: CompressionStrategy,
+    /// Encoding effort for delta writes (fresh CDC/append snapshot files).
+    /// `auto` (default) size-gates: small deltas encode light and are folded
+    /// into properly-encoded files by compaction; explicit `0..=10` pins the
+    /// level. Maintenance writes (compaction, rewrites) always use the full
+    /// default encoding. See [`DeltaEncoding`].
+    #[serde(default)]
+    pub delta_encoding: DeltaEncoding,
     /// Maximum number of concurrent file uploads when writing multiple Vortex files.
     /// Each file uses multipart uploads internally via `object_store`.
     /// Defaults to the available CPU parallelism.
@@ -638,6 +726,7 @@ impl Default for VortexConfig {
             // No sort columns by default
             sort_columns: Vec::new(),
             compression_strategy: CompressionStrategy::default(),
+            delta_encoding: DeltaEncoding::default(),
             upload_concurrency: default_upload_concurrency(),
             write_concurrency: None,
             compaction_trigger_files: default_compaction_trigger_files(),

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -238,13 +238,22 @@ impl PartitionMetadata {
     }
 }
 
-/// Which compression strategy to use for the Vortex layout.
+/// Which compression strategy the table's FULL encoding tier uses — i.e.
+/// maintenance writes (compaction outputs, rewrites, overwrites) and delta
+/// writes that resolve to a full level (`7..=10`, or `auto` on large /
+/// unknown-size writes). Light delta levels (`0..=6`) are a fixed
+/// `BtrBlocks`-subset effort ladder and are not affected by this choice.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CompressionStrategy {
-    /// Uses the default Vortex Btrblocks compression.
+    /// The default Vortex `BtrBlocks` cascading scheme search.
     #[default]
     Btrblocks,
-    /// Uses the Vortex `CompactCompressor` with Zstd compression.
+    /// The default cascade PLUS the Zstd string schemes
+    /// (`StringCode::Zstd` / `ZstdBuffers`) in the search — the encoder picks
+    /// them when they beat FSST/dict on a column. Integer/float columns are
+    /// unchanged (Vortex has no zstd schemes for them at this revision).
+    /// Trades encode CPU and string-decode speed for better ratios on
+    /// long/high-entropy strings.
     Zstd,
 }
 
@@ -253,16 +262,16 @@ pub enum CompressionStrategy {
 ///
 /// zstd-style level scale (`cayenne_delta_encoding` param):
 ///
-/// - `7` (default) — the full default `BtrBlocks` cascade: byte-for-byte
-///   today's write behavior. Levels `8`–`10` are reserved for future
-///   heavier-effort search.
-/// - `auto` (opt-in) — size-gated: a write smaller than a quarter of the
+/// - `auto` (default) — size-gated: a write smaller than a quarter of the
 ///   target file size encodes at a light level (the file is transient by
-///   definition — compaction exists to fold it); larger writes use the full
-///   default encoding.
+///   definition — compaction exists to fold it); larger or unknown-size
+///   writes use the full default encoding.
 /// - `0` — no compression (canonical arrays; cheapest encode).
 /// - `1`–`6` — progressively richer scheme sets. The cheap levels skip the
 ///   per-file encoder-strategy search and FSST symbol-table training.
+/// - `7`–`10` — the full default `BtrBlocks` cascade: byte-for-byte the
+///   pre-feature write behavior (`7` is the explicit opt-out of `auto`;
+///   `8`–`10` are reserved for future heavier-effort search).
 ///
 /// Maintenance writes (compaction outputs, sorted rewrites, overwrites) are
 /// NOT affected by this setting — they always use the full default encoding,
@@ -281,12 +290,15 @@ pub enum DeltaEncoding {
 }
 
 impl Default for DeltaEncoding {
-    /// `Level(7)` — the full default cascade, i.e. unchanged write behavior.
-    /// This is also what pre-feature stored table configs deserialize to via
-    /// `#[serde(default)]`, so enabling the feature in a new build cannot
-    /// silently change how existing tables encode their deltas.
+    /// `Auto` — size-gated light encoding for small deltas. This is also what
+    /// pre-feature stored table configs deserialize to via
+    /// `#[serde(default)]`, so existing tables pick up the policy on upgrade
+    /// (write-time only; existing data files are unaffected and a level
+    /// change never forces a table re-create). Set the
+    /// `cayenne_delta_encoding` param to `7` to opt out (the full default
+    /// cascade, byte-for-byte the pre-feature behavior).
     fn default() -> Self {
-        Self::Level(DELTA_ENCODING_FULL_LEVEL)
+        Self::Auto
     }
 }
 
@@ -487,11 +499,11 @@ pub struct VortexConfig {
     /// Defaults to Btrblocks
     pub compression_strategy: CompressionStrategy,
     /// Encoding effort for delta writes (fresh CDC/append snapshot files).
-    /// `7` (default) is the full default cascade — unchanged write behavior.
-    /// `auto` (opt-in) size-gates: small deltas encode light and are folded
+    /// `auto` (default) size-gates: small deltas encode light and are folded
     /// into properly-encoded files by compaction; explicit `0..=10` pins the
-    /// level. Maintenance writes (compaction, rewrites) always use the full
-    /// default encoding. See [`DeltaEncoding`].
+    /// level (`7` = the full default cascade, the pre-feature behavior).
+    /// Maintenance writes (compaction, rewrites) always use the full default
+    /// encoding. See [`DeltaEncoding`].
     #[serde(default)]
     pub delta_encoding: DeltaEncoding,
     /// Maximum number of concurrent file uploads when writing multiple Vortex files.
@@ -741,12 +753,11 @@ impl Default for VortexConfig {
             // No sort columns by default
             sort_columns: Vec::new(),
             compression_strategy: CompressionStrategy::default(),
-            // Level(7) = full default cascade, i.e. unchanged write behavior.
-            // `auto` is deliberately opt-in until validated at CDC scale:
-            // local micro A/B (2026-06-06) was neutral on upsert/bulk lanes
-            // and showed light deltas making in-window compaction passes work
-            // harder (incremental_append +10%); the `auto` thesis (CPU per
-            // delta on the pipelined CDC route) needs a production-scale run.
+            // `auto`: size-gated light encoding for small deltas (re-encoded
+            // by compaction). Local micro A/B (2026-06-06) was neutral on the
+            // upsert/bulk lanes; the aggregate CPU-per-delta benefit targets
+            // production-scale CDC and is to be validated there. Set the
+            // param to `7` to opt out (pre-feature behavior).
             delta_encoding: DeltaEncoding::default(),
             upload_concurrency: default_upload_concurrency(),
             write_concurrency: None,

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -307,11 +307,20 @@ impl CayenneContext {
     /// The format carries Vortex scan/write options, including the shared
     /// segment-cache capacity for scans created from this context.
     fn create_vortex_format(config: &VortexConfig, dataset: &str) -> Arc<VortexFormat> {
-        // Create a Vortex session with default encodings. The session's
-        // default write strategy is the full BtrBlocks cascade; light
+        // Create a Vortex session with default encodings. The session's write
+        // strategy is the table's FULL encoding tier: the BtrBlocks cascade by
+        // default, optionally extended with the Zstd string scheme when
+        // `cayenne_compression_strategy=zstd` (this wiring is what makes that
+        // param real — see `delta_encoding::full_strategy_builder_for`).
+        // Maintenance writes and full-level delta writes inherit it; light
         // delta-encoding levels override it per write via
         // `write_format_with_strategy` (see `provider::delta_encoding`).
-        let vortex_session = VortexSession::default();
+        let mut vortex_session = VortexSession::default();
+        if let Some(full_strategy) =
+            super::delta_encoding::full_strategy_builder_for(&config.compression_strategy)
+        {
+            vortex_session = vortex_session.set(full_strategy);
+        }
 
         Arc::new(
             VortexFormat::new_with_options(vortex_session, Self::vortex_table_options(config))

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -21,10 +21,11 @@ use std::sync::Arc;
 use datafusion_execution::{config::SessionConfig, runtime_env::RuntimeEnv};
 use tokio::sync::Semaphore;
 use vortex::VortexSessionDefault;
-use vortex_datafusion::{ProjectionPushdown, VortexFormat, VortexTableOptions};
+use vortex::file::WriteStrategyBuilder;
+use vortex_datafusion::{ProjectionPushdown, VortexFormat, VortexTableOptions, WriteShardConfig};
 use vortex_session::VortexSession;
 
-use crate::metadata::{DeletionMode, PkConflictDetection, VortexConfig};
+use crate::metadata::{DeletionMode, DeltaEncoding, PkConflictDetection, VortexConfig};
 
 /// Shared context for Cayenne table operations.
 ///
@@ -43,6 +44,10 @@ pub struct CayenneContext {
     vortex_format: Arc<VortexFormat>,
     /// Configuration for encoding, compression, and file sizing.
     config: VortexConfig,
+    /// Dataset label the formats are tagged with (metrics attribution).
+    /// Retained so per-write format variants (e.g. delta-encoding strategy
+    /// overrides) carry the same label as the shared base format.
+    dataset: String,
     /// Session configuration for `DataFusion` listing options.
     session_config: SessionConfig,
     /// Shared semaphore for limiting concurrent file writes / uploads across all partitions.
@@ -79,10 +84,43 @@ impl CayenneContext {
         Arc::new(Self {
             vortex_format,
             config: config.clone(),
+            dataset: dataset.to_string(),
             session_config: SessionConfig::default(),
             upload_semaphore: Arc::new(Semaphore::new(config.upload_concurrency.max(1))),
             runtime_env,
         })
+    }
+
+    /// Encoding effort configured for delta writes (`cayenne_delta_encoding`).
+    #[must_use]
+    pub fn delta_encoding(&self) -> DeltaEncoding {
+        self.config.delta_encoding
+    }
+
+    /// Build a write-only `VortexFormat` whose session carries a
+    /// [`WriteStrategyBuilder`] override — used by light delta-encoding levels
+    /// (see `provider::delta_encoding`). The format mirrors the shared base
+    /// format's table options and dataset label; `shard` optionally enables
+    /// intra-write sharding exactly like
+    /// `CayenneTableProvider::write_shard_format` does on the default path.
+    ///
+    /// Scans never observe these formats: the scan path keeps using
+    /// [`Self::file_format`], so the strategy override affects only the files
+    /// this write produces.
+    #[must_use]
+    pub(crate) fn write_format_with_strategy(
+        &self,
+        strategy: WriteStrategyBuilder,
+        shard: Option<WriteShardConfig>,
+    ) -> Arc<VortexFormat> {
+        let session = VortexSession::default().set(strategy);
+        let format = VortexFormat::new_with_options(session, Self::vortex_table_options(&self.config))
+            .with_dataset_label(self.dataset.as_str());
+        let format = match shard {
+            Some(config) => format.with_write_shard(config),
+            None => format,
+        };
+        Arc::new(format)
     }
 
     /// Get the Vortex file format for creating listing tables.
@@ -268,12 +306,22 @@ impl CayenneContext {
     /// The format carries Vortex scan/write options, including the shared
     /// segment-cache capacity for scans created from this context.
     fn create_vortex_format(config: &VortexConfig, dataset: &str) -> Arc<VortexFormat> {
-        // Create a Vortex session with default encodings
-        // Note: Write strategy configuration (e.g., compression) is applied at write time via
-        // `session.write_options().with_strategy(...)`, not at the VortexFormat level
+        // Create a Vortex session with default encodings. The session's
+        // default write strategy is the full BtrBlocks cascade; light
+        // delta-encoding levels override it per write via
+        // `write_format_with_strategy` (see `provider::delta_encoding`).
         let vortex_session = VortexSession::default();
 
-        // Configure VortexFormat.
+        Arc::new(
+            VortexFormat::new_with_options(vortex_session, Self::vortex_table_options(config))
+                .with_dataset_label(dataset),
+        )
+    }
+
+    /// Table options shared by the base format and any per-write format
+    /// variants (delta-encoding strategy overrides) so write-only formats
+    /// behave identically apart from the encoding strategy.
+    fn vortex_table_options(config: &VortexConfig) -> VortexTableOptions {
         let segment_cache_size_bytes =
             config
                 .segment_cache_mb
@@ -286,16 +334,12 @@ impl CayenneContext {
                     None
                 });
 
-        let vortex_opts = VortexTableOptions {
+        VortexTableOptions {
             target_file_size_mb: config.target_vortex_file_size_mb,
             projection_pushdown: ProjectionPushdown::On,
             segment_cache_size_bytes,
             ..VortexTableOptions::default()
-        };
-
-        Arc::new(
-            VortexFormat::new_with_options(vortex_session, vortex_opts).with_dataset_label(dataset),
-        )
+        }
     }
 }
 

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -114,8 +114,9 @@ impl CayenneContext {
         shard: Option<WriteShardConfig>,
     ) -> Arc<VortexFormat> {
         let session = VortexSession::default().set(strategy);
-        let format = VortexFormat::new_with_options(session, Self::vortex_table_options(&self.config))
-            .with_dataset_label(self.dataset.as_str());
+        let format =
+            VortexFormat::new_with_options(session, Self::vortex_table_options(&self.config))
+                .with_dataset_label(self.dataset.as_str());
         let format = match shard {
             Some(config) => format.with_write_shard(config),
             None => format,

--- a/crates/cayenne/src/provider/delta_encoding.rs
+++ b/crates/cayenne/src/provider/delta_encoding.rs
@@ -244,9 +244,13 @@ mod tests {
         assert_eq!("AUTO".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Auto));
         assert_eq!("0".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Level(0)));
         assert_eq!("10".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Level(10)));
-        assert!("11".parse::<DeltaEncoding>().is_err());
-        assert!("fast".parse::<DeltaEncoding>().is_err());
-        assert!("-1".parse::<DeltaEncoding>().is_err());
+        "11".parse::<DeltaEncoding>()
+            .expect_err("level 11 must be rejected (max is 10)");
+        "fast"
+            .parse::<DeltaEncoding>()
+            .expect_err("non-numeric, non-auto values must be rejected");
+        "-1".parse::<DeltaEncoding>()
+            .expect_err("negative levels must be rejected");
     }
 
     #[test]

--- a/crates/cayenne/src/provider/delta_encoding.rs
+++ b/crates/cayenne/src/provider/delta_encoding.rs
@@ -25,14 +25,16 @@ limitations under the License.
 //! almost nothing. A compaction output is the long-lived artifact whose
 //! encoding pays for scan throughput, storage footprint, and (on S3) egress.
 //!
-//! Profiling a 2,000-row staged upsert showed the dominant fixed cost was the
-//! Vortex `BtrBlocks` per-file encoder-strategy search plus FSST symbol-table
-//! training (~10-12 ms per file regardless of row count) — big-file
-//! compression machinery paid on every small delta and then discarded at the
-//! next compaction pass. This is the storage-engine-universal per-level
-//! pattern: `RocksDB` flushes L0 with no/light compression and re-compresses
-//! at deeper levels, `ClickHouse` re-compresses on merge, and lakehouse
-//! `OPTIMIZE`/compaction rewrites small commits with proper encoding.
+//! Every delta write pays the Vortex `BtrBlocks` per-file encoder-strategy
+//! search (per column, with FSST symbol-table training for strings) for an
+//! encoding that is discarded at the next compaction pass. Local micro-benches
+//! showed this cost to be small per 2k-row delta on a laptop; the per-level
+//! design exists for the aggregate CPU spent across millions of CDC deltas at
+//! production scale, and as an explicit A/B knob for measuring exactly that.
+//! This is the storage-engine-universal per-level pattern: `RocksDB` flushes
+//! L0 with no/light compression and re-compresses at deeper levels,
+//! `ClickHouse` re-compresses on merge, and lakehouse `OPTIMIZE`/compaction
+//! rewrites small commits with proper encoding.
 //!
 //! ## The level scale
 //!
@@ -47,15 +49,16 @@ limitations under the License.
 //! | 4–6 | full default **minus FSST** (skips symbol-table training, keeps the rest) |
 //! | 7–10 | full default `BtrBlocks` cascade (today's behavior; upper levels reserved) |
 //!
-//! `auto` (the default) size-gates: a delta smaller than a quarter of the
-//! target file size encodes at [`AUTO_LIGHT_LEVEL`]; larger or unknown-size
-//! writes use the full default. Maintenance writes ([`WriteClass::Maintenance`])
-//! always use the full default regardless of the configured level.
+//! `auto` (opt-in; the config default is level `7` = unchanged behavior)
+//! size-gates: a delta smaller than a quarter of the target file size encodes
+//! at [`AUTO_LIGHT_LEVEL`]; larger or unknown-size writes use the full
+//! default. Maintenance writes ([`WriteClass::Maintenance`]) always use the
+//! full default regardless of the configured level.
 
 use vortex::compressor::{BtrBlocksCompressorBuilder, FloatCode, IntCode, StringCode};
 use vortex::file::WriteStrategyBuilder;
 
-use crate::metadata::{DELTA_ENCODING_MAX_LEVEL, DeltaEncoding};
+use crate::metadata::{DELTA_ENCODING_FULL_LEVEL, DELTA_ENCODING_MAX_LEVEL, DeltaEncoding};
 
 /// Classifies a snapshot write for encoding-policy purposes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,7 +74,9 @@ pub(crate) enum WriteClass {
 
 /// Level used for every [`WriteClass::Maintenance`] write and for large /
 /// unknown-size deltas under `auto`: the full default `BtrBlocks` cascade.
-pub(crate) const FULL_LEVEL: u8 = 7;
+/// Aliases the metadata constant so the config default and the mapping
+/// boundary can't drift apart.
+pub(crate) const FULL_LEVEL: u8 = DELTA_ENCODING_FULL_LEVEL;
 
 /// Level chosen by `auto` for small deltas. `Constant + Sparse + Dict` keeps
 /// the big repetitive-CDC wins (often 3-5×) while skipping the per-file
@@ -215,6 +220,26 @@ mod tests {
         assert!("11".parse::<DeltaEncoding>().is_err());
         assert!("fast".parse::<DeltaEncoding>().is_err());
         assert!("-1".parse::<DeltaEncoding>().is_err());
+    }
+
+    #[test]
+    fn default_is_full_level_unchanged_behavior() {
+        // The config default must be the full cascade (unchanged write
+        // behavior) — `auto` is opt-in until validated at CDC scale. This is
+        // also the `#[serde(default)]` value pre-feature stored table configs
+        // deserialize to, so a new build cannot silently change how existing
+        // tables encode their deltas.
+        assert_eq!(DeltaEncoding::default(), DeltaEncoding::Level(FULL_LEVEL));
+        assert!(
+            strategy_builder_for_level(effective_level(
+                DeltaEncoding::default(),
+                WriteClass::Delta,
+                Some(1),
+                TARGET
+            ))
+            .is_none(),
+            "the default encoding must resolve to the session-default (full) strategy"
+        );
     }
 
     #[test]

--- a/crates/cayenne/src/provider/delta_encoding.rs
+++ b/crates/cayenne/src/provider/delta_encoding.rs
@@ -49,16 +49,43 @@ limitations under the License.
 //! | 4–6 | full default **minus FSST** (skips symbol-table training, keeps the rest) |
 //! | 7–10 | full default `BtrBlocks` cascade (today's behavior; upper levels reserved) |
 //!
-//! `auto` (opt-in; the config default is level `7` = unchanged behavior)
-//! size-gates: a delta smaller than a quarter of the target file size encodes
-//! at [`AUTO_LIGHT_LEVEL`]; larger or unknown-size writes use the full
-//! default. Maintenance writes ([`WriteClass::Maintenance`]) always use the
-//! full default regardless of the configured level.
+//! `auto` (the default) size-gates: a delta smaller than a quarter of the
+//! target file size encodes at [`AUTO_LIGHT_LEVEL`]; larger or unknown-size
+//! writes use the full default. Level `7` is the explicit opt-out
+//! (byte-for-byte the pre-feature behavior). Maintenance writes
+//! ([`WriteClass::Maintenance`]) always use the full default regardless of
+//! the configured level.
 
 use vortex::compressor::{BtrBlocksCompressorBuilder, FloatCode, IntCode, StringCode};
 use vortex::file::WriteStrategyBuilder;
 
-use crate::metadata::{DELTA_ENCODING_FULL_LEVEL, DELTA_ENCODING_MAX_LEVEL, DeltaEncoding};
+use crate::metadata::{
+    CompressionStrategy, DELTA_ENCODING_FULL_LEVEL, DELTA_ENCODING_MAX_LEVEL, DeltaEncoding,
+};
+
+/// Map the table's [`CompressionStrategy`] to the FULL-tier write strategy —
+/// the session-level strategy the base `VortexFormat` carries, used by
+/// maintenance writes and by delta writes that resolve to a full level.
+///
+/// `Btrblocks` returns `None`: the Vortex session default IS the `BtrBlocks`
+/// cascade, so no override is registered (byte-for-byte the pre-feature
+/// behavior). `Zstd` extends the default search with the Zstd string schemes
+/// (which the default deliberately excludes); the cascade then picks them per
+/// column when they win. This is what makes the previously-dormant
+/// `cayenne_compression_strategy=zstd` param real.
+pub(crate) fn full_strategy_builder_for(
+    strategy: &CompressionStrategy,
+) -> Option<WriteStrategyBuilder> {
+    match strategy {
+        CompressionStrategy::Btrblocks => None,
+        CompressionStrategy::Zstd => {
+            let compressor = BtrBlocksCompressorBuilder::default()
+                .include_string([StringCode::Zstd, StringCode::ZstdBuffers])
+                .build();
+            Some(WriteStrategyBuilder::default().with_compressor(compressor))
+        }
+    }
+}
 
 /// Classifies a snapshot write for encoding-policy purposes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -223,13 +250,11 @@ mod tests {
     }
 
     #[test]
-    fn default_is_full_level_unchanged_behavior() {
-        // The config default must be the full cascade (unchanged write
-        // behavior) — `auto` is opt-in until validated at CDC scale. This is
-        // also the `#[serde(default)]` value pre-feature stored table configs
-        // deserialize to, so a new build cannot silently change how existing
-        // tables encode their deltas.
-        assert_eq!(DeltaEncoding::default(), DeltaEncoding::Level(FULL_LEVEL));
+    fn default_is_auto_with_light_small_deltas_and_full_opt_out() {
+        // Product decision: `auto` ships as the default — small known-size
+        // deltas encode light; large/unknown writes and maintenance stay on
+        // the full cascade. Level 7 is the explicit opt-out.
+        assert_eq!(DeltaEncoding::default(), DeltaEncoding::Auto);
         assert!(
             strategy_builder_for_level(effective_level(
                 DeltaEncoding::default(),
@@ -237,8 +262,28 @@ mod tests {
                 Some(1),
                 TARGET
             ))
+            .is_some(),
+            "default auto must light-encode a small known-size delta"
+        );
+        assert!(
+            strategy_builder_for_level(effective_level(
+                DeltaEncoding::default(),
+                WriteClass::Delta,
+                None,
+                TARGET
+            ))
             .is_none(),
-            "the default encoding must resolve to the session-default (full) strategy"
+            "default auto must keep unknown-size writes on the full strategy"
+        );
+        assert!(
+            strategy_builder_for_level(effective_level(
+                DeltaEncoding::Level(FULL_LEVEL),
+                WriteClass::Delta,
+                Some(1),
+                TARGET
+            ))
+            .is_none(),
+            "level 7 must be the explicit opt-out (full strategy) even for tiny deltas"
         );
     }
 
@@ -298,6 +343,50 @@ mod tests {
         assert_eq!(
             effective_level(DeltaEncoding::Level(9), WriteClass::Delta, None, TARGET),
             9
+        );
+    }
+
+    #[test]
+    fn zstd_full_strategy_includes_zstd_string_schemes() {
+        // Engagement at the mapping level: `zstd` must actually add the Zstd
+        // string schemes to the search (the default set excludes them), and
+        // `btrblocks` must register no override (session default = the
+        // pre-feature cascade). Build the compressors directly to verify.
+        assert!(
+            full_strategy_builder_for(&CompressionStrategy::Btrblocks).is_none(),
+            "btrblocks must use the session-default strategy (no override)"
+        );
+        assert!(
+            full_strategy_builder_for(&CompressionStrategy::Zstd).is_some(),
+            "zstd must register a full-tier strategy override"
+        );
+        let zstd_compressor = BtrBlocksCompressorBuilder::default()
+            .include_string([StringCode::Zstd, StringCode::ZstdBuffers])
+            .build();
+        let codes: Vec<StringCode> = zstd_compressor
+            .string_schemes
+            .iter()
+            .map(|scheme| scheme.code())
+            .collect();
+        // Note: only `Zstd` is registrable at the pinned Vortex revision —
+        // `ZstdBuffers` has a code but its scheme object is not in
+        // `ALL_STRING_SCHEMES`, so `include_string` is a forward-compat no-op
+        // for it until the fork advances.
+        assert!(
+            codes.contains(&StringCode::Zstd),
+            "the zstd full-tier compressor must include the Zstd string \
+             scheme in the search; got {codes:?}"
+        );
+        let default_compressor = BtrBlocksCompressorBuilder::default().build();
+        let default_codes: Vec<StringCode> = default_compressor
+            .string_schemes
+            .iter()
+            .map(|scheme| scheme.code())
+            .collect();
+        assert!(
+            !default_codes.contains(&StringCode::Zstd),
+            "the default cascade must NOT include Zstd (it is the zstd \
+             param's distinguishing addition); got {default_codes:?}"
         );
     }
 

--- a/crates/cayenne/src/provider/delta_encoding.rs
+++ b/crates/cayenne/src/provider/delta_encoding.rs
@@ -1,0 +1,298 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Delta-write encoding levels (`cayenne_delta_encoding`).
+//!
+//! ## Why delta writes get their own encoding policy
+//!
+//! Fresh CDC/append snapshot files and compaction outputs are different
+//! workloads wearing the same encoder. A staged CDC delta is small, written
+//! on the ingestion hot path, read a handful of times, and then folded into a
+//! properly-encoded file by the tiered compactor — its encoding quality buys
+//! almost nothing. A compaction output is the long-lived artifact whose
+//! encoding pays for scan throughput, storage footprint, and (on S3) egress.
+//!
+//! Profiling a 2,000-row staged upsert showed the dominant fixed cost was the
+//! Vortex `BtrBlocks` per-file encoder-strategy search plus FSST symbol-table
+//! training (~10-12 ms per file regardless of row count) — big-file
+//! compression machinery paid on every small delta and then discarded at the
+//! next compaction pass. This is the storage-engine-universal per-level
+//! pattern: `RocksDB` flushes L0 with no/light compression and re-compresses
+//! at deeper levels, `ClickHouse` re-compresses on merge, and lakehouse
+//! `OPTIMIZE`/compaction rewrites small commits with proper encoding.
+//!
+//! ## The level scale
+//!
+//! zstd-style: higher level = more encode effort = better ratio.
+//!
+//! | level | scheme set |
+//! |---|---|
+//! | 0 | `Uncompressed` only (canonical arrays; zero search, zero transform) |
+//! | 1 | + `Constant` / `Sparse` (near-free detection; common CDC shapes) |
+//! | 2 | + `Dict` (cheap, high-value on repetitive CDC data) |
+//! | 3 | + cheap numeric schemes (`For`, `BitPacking`, `ZigZag`, `RunEnd`, `Sequence`) |
+//! | 4–6 | full default **minus FSST** (skips symbol-table training, keeps the rest) |
+//! | 7–10 | full default `BtrBlocks` cascade (today's behavior; upper levels reserved) |
+//!
+//! `auto` (the default) size-gates: a delta smaller than a quarter of the
+//! target file size encodes at [`AUTO_LIGHT_LEVEL`]; larger or unknown-size
+//! writes use the full default. Maintenance writes ([`WriteClass::Maintenance`])
+//! always use the full default regardless of the configured level.
+
+use vortex::compressor::{BtrBlocksCompressorBuilder, FloatCode, IntCode, StringCode};
+use vortex::file::WriteStrategyBuilder;
+
+use crate::metadata::{DELTA_ENCODING_MAX_LEVEL, DeltaEncoding};
+
+/// Classifies a snapshot write for encoding-policy purposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WriteClass {
+    /// A fresh delta: staged/inline CDC appends, on-conflict snapshot inserts,
+    /// inline-memtable flushes. Subject to `cayenne_delta_encoding`.
+    Delta,
+    /// A maintenance rewrite: compaction outputs, sorted rewrites, overwrites.
+    /// Always encoded with the full default strategy — the output is the
+    /// long-lived artifact whose encoding quality pays for scan throughput.
+    Maintenance,
+}
+
+/// Level used for every [`WriteClass::Maintenance`] write and for large /
+/// unknown-size deltas under `auto`: the full default `BtrBlocks` cascade.
+pub(crate) const FULL_LEVEL: u8 = 7;
+
+/// Level chosen by `auto` for small deltas. `Constant + Sparse + Dict` keeps
+/// the big repetitive-CDC wins (often 3-5×) while skipping the per-file
+/// strategy search and FSST training that dominate small-write encode cost.
+pub(crate) const AUTO_LIGHT_LEVEL: u8 = 2;
+
+/// Under `auto`, a delta is "small" when its estimated bytes are below
+/// `target_file_size / AUTO_LIGHT_DENOMINATOR` — the same quarter-of-a-target
+/// classification the compaction picker uses for "small" files, on the
+/// rationale that a write smaller than a target file is transient by
+/// definition (compaction exists to fold it).
+pub(crate) const AUTO_LIGHT_DENOMINATOR: u64 = 4;
+
+/// Resolve the effective encoding level for one snapshot write.
+///
+/// `estimated_bytes` is the caller's pre-encode size estimate (`None` when
+/// the stream size is unknown, e.g. opaque staged streams). Unknown sizes
+/// resolve to [`FULL_LEVEL`] under `auto` — conservatively assuming large.
+pub(crate) fn effective_level(
+    encoding: DeltaEncoding,
+    write_class: WriteClass,
+    estimated_bytes: Option<u64>,
+    target_size_bytes: usize,
+) -> u8 {
+    if write_class == WriteClass::Maintenance {
+        return FULL_LEVEL;
+    }
+    match encoding {
+        DeltaEncoding::Level(level) => level.min(DELTA_ENCODING_MAX_LEVEL),
+        DeltaEncoding::Auto => {
+            let threshold =
+                u64::try_from(target_size_bytes).unwrap_or(u64::MAX) / AUTO_LIGHT_DENOMINATOR;
+            match estimated_bytes {
+                Some(bytes) if bytes < threshold.max(1) => AUTO_LIGHT_LEVEL,
+                _ => FULL_LEVEL,
+            }
+        }
+    }
+}
+
+/// Map an encoding level to a Vortex write strategy override.
+///
+/// Returns `None` for levels at or above [`FULL_LEVEL`] — the caller uses the
+/// session's default strategy (the full `BtrBlocks` cascade), which is
+/// byte-for-byte today's behavior. Lower levels return a
+/// [`WriteStrategyBuilder`] whose compressor is restricted to the level's
+/// scheme set (see the module table).
+pub(crate) fn strategy_builder_for_level(level: u8) -> Option<WriteStrategyBuilder> {
+    if level >= FULL_LEVEL {
+        return None;
+    }
+
+    let compressor = match level {
+        0 => BtrBlocksCompressorBuilder::empty()
+            .include_int([IntCode::Uncompressed])
+            .include_float([FloatCode::Uncompressed])
+            .include_string([StringCode::Uncompressed])
+            .build(),
+        1 => BtrBlocksCompressorBuilder::empty()
+            .include_int([IntCode::Uncompressed, IntCode::Constant, IntCode::Sparse])
+            .include_float([
+                FloatCode::Uncompressed,
+                FloatCode::Constant,
+                FloatCode::Sparse,
+            ])
+            .include_string([
+                StringCode::Uncompressed,
+                StringCode::Constant,
+                StringCode::Sparse,
+            ])
+            .build(),
+        2 => BtrBlocksCompressorBuilder::empty()
+            .include_int([
+                IntCode::Uncompressed,
+                IntCode::Constant,
+                IntCode::Sparse,
+                IntCode::Dict,
+            ])
+            .include_float([
+                FloatCode::Uncompressed,
+                FloatCode::Constant,
+                FloatCode::Sparse,
+                FloatCode::Dict,
+            ])
+            .include_string([
+                StringCode::Uncompressed,
+                StringCode::Constant,
+                StringCode::Sparse,
+                StringCode::Dict,
+            ])
+            .build(),
+        3 => BtrBlocksCompressorBuilder::empty()
+            .include_int([
+                IntCode::Uncompressed,
+                IntCode::Constant,
+                IntCode::Sparse,
+                IntCode::Dict,
+                IntCode::For,
+                IntCode::BitPacking,
+                IntCode::ZigZag,
+                IntCode::RunEnd,
+                IntCode::Sequence,
+            ])
+            .include_float([
+                FloatCode::Uncompressed,
+                FloatCode::Constant,
+                FloatCode::Sparse,
+                FloatCode::Dict,
+                FloatCode::RunEnd,
+            ])
+            .include_string([
+                StringCode::Uncompressed,
+                StringCode::Constant,
+                StringCode::Sparse,
+                StringCode::Dict,
+            ])
+            .build(),
+        // 4-6: everything in the default set except FSST — the symbol-table
+        // training is the profiled dominant fixed cost on small string-bearing
+        // deltas; numeric schemes keep their full default sets.
+        _ => BtrBlocksCompressorBuilder::default()
+            .exclude_string([StringCode::Fsst])
+            .build(),
+    };
+
+    Some(WriteStrategyBuilder::default().with_compressor(compressor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TARGET: usize = 256 * 1024 * 1024; // 256 MiB target file size
+
+    #[test]
+    fn parse_accepts_auto_and_levels() {
+        assert_eq!("auto".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Auto));
+        assert_eq!("AUTO".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Auto));
+        assert_eq!("0".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Level(0)));
+        assert_eq!("10".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Level(10)));
+        assert!("11".parse::<DeltaEncoding>().is_err());
+        assert!("fast".parse::<DeltaEncoding>().is_err());
+        assert!("-1".parse::<DeltaEncoding>().is_err());
+    }
+
+    #[test]
+    fn auto_gates_by_estimated_size() {
+        // Small delta (1 MiB << 64 MiB threshold) -> light level.
+        assert_eq!(
+            effective_level(
+                DeltaEncoding::Auto,
+                WriteClass::Delta,
+                Some(1024 * 1024),
+                TARGET
+            ),
+            AUTO_LIGHT_LEVEL
+        );
+        // Large write (at the threshold) -> full.
+        assert_eq!(
+            effective_level(
+                DeltaEncoding::Auto,
+                WriteClass::Delta,
+                Some(64 * 1024 * 1024),
+                TARGET
+            ),
+            FULL_LEVEL
+        );
+        // Unknown size -> conservatively full.
+        assert_eq!(
+            effective_level(DeltaEncoding::Auto, WriteClass::Delta, None, TARGET),
+            FULL_LEVEL
+        );
+    }
+
+    #[test]
+    fn maintenance_always_full_even_with_explicit_level() {
+        assert_eq!(
+            effective_level(
+                DeltaEncoding::Level(0),
+                WriteClass::Maintenance,
+                Some(1),
+                TARGET
+            ),
+            FULL_LEVEL
+        );
+    }
+
+    #[test]
+    fn explicit_level_applies_to_any_delta_size() {
+        assert_eq!(
+            effective_level(
+                DeltaEncoding::Level(3),
+                WriteClass::Delta,
+                Some(u64::MAX),
+                TARGET
+            ),
+            3
+        );
+        assert_eq!(
+            effective_level(DeltaEncoding::Level(9), WriteClass::Delta, None, TARGET),
+            9
+        );
+    }
+
+    #[test]
+    fn full_levels_use_default_strategy() {
+        for level in FULL_LEVEL..=DELTA_ENCODING_MAX_LEVEL {
+            assert!(
+                strategy_builder_for_level(level).is_none(),
+                "level {level} must use the session-default (full) strategy"
+            );
+        }
+    }
+
+    #[test]
+    fn light_levels_produce_strategy_overrides() {
+        for level in 0..FULL_LEVEL {
+            assert!(
+                strategy_builder_for_level(level).is_some(),
+                "level {level} must produce a restricted-scheme strategy override"
+            );
+        }
+    }
+}

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -75,6 +75,7 @@ pub(crate) mod context;
 pub(crate) mod delete;
 pub mod deletion_index;
 pub(crate) mod deletion_strategy;
+pub(crate) mod delta_encoding;
 pub(crate) mod memory_account;
 pub(crate) mod mutation_writer;
 pub(crate) mod overwrite;

--- a/crates/cayenne/src/provider/mutation_writer.rs
+++ b/crates/cayenne/src/provider/mutation_writer.rs
@@ -671,6 +671,7 @@ impl<'a> AppendMutationWriter<'a> {
                 // prior full-fan-out behavior. (Reached only when a write carries
                 // pending PK deletes or on-conflict upserts.)
                 None,
+                crate::provider::delta_encoding::WriteClass::Delta,
             )
             .await?;
         record_cayenne_write_phase(self.table.table_name(), "vortex_write", write_start);
@@ -848,6 +849,7 @@ impl<'a> AppendMutationWriter<'a> {
                 &staging_snapshot_id,
                 self.task_context.session_config().target_partitions(),
                 estimated_bytes,
+                crate::provider::delta_encoding::WriteClass::Delta,
             )
             .await
         {
@@ -906,6 +908,7 @@ impl<'a> AppendMutationWriter<'a> {
                 &target.staging_snapshot_id,
                 self.task_context.session_config().target_partitions(),
                 target.estimated_bytes,
+                crate::provider::delta_encoding::WriteClass::Delta,
             )
             .await
         {

--- a/crates/cayenne/src/provider/mutation_writer.rs
+++ b/crates/cayenne/src/provider/mutation_writer.rs
@@ -579,7 +579,11 @@ impl<'a> AppendMutationWriter<'a> {
         let (total_rows, write_stats_acc, validated_keys, superseded) = if needs_new_snapshot {
             let new_snapshot_start = Instant::now();
             let (rows, stats_acc, validated_keys, superseded) = self
-                .write_new_snapshot_after_validation(prepared_stream, &post_validation)
+                .write_new_snapshot_after_validation(
+                    prepared_stream,
+                    &post_validation,
+                    estimated_bytes,
+                )
                 .await?;
             tracing::debug!(
                 table = self.table.table_name(),
@@ -650,6 +654,7 @@ impl<'a> AppendMutationWriter<'a> {
         &self,
         prepared_stream: SendableRecordBatchStream,
         post_validation: &Arc<ParkingMutex<Option<PostValidationState>>>,
+        estimated_bytes: Option<u64>,
     ) -> Result<(
         u64,
         Arc<ColumnStatsAccumulator>,
@@ -666,11 +671,13 @@ impl<'a> AppendMutationWriter<'a> {
                 target_size_bytes,
                 &new_snapshot_id,
                 self.task_context.session_config().target_partitions(),
-                // This pending-deletions / on-conflict new-snapshot path does not
-                // pre-buffer the delta, so its size is unknown here; keep the
-                // prior full-fan-out behavior. (Reached only when a write carries
-                // pending PK deletes or on-conflict upserts.)
-                None,
+                // Lower-bound size estimate populated from the inline-gate
+                // buffer when the write attempted to inline first (the common
+                // on-conflict upsert shape: small deltas fully buffered by the
+                // gate, so the bound is exact). `None` when inlining was
+                // skipped (partition/retention tables) — those keep the prior
+                // full-fan-out behavior and the full default delta encoding.
+                estimated_bytes,
                 crate::provider::delta_encoding::WriteClass::Delta,
             )
             .await?;

--- a/crates/cayenne/src/provider/overwrite.rs
+++ b/crates/cayenne/src/provider/overwrite.rs
@@ -299,6 +299,7 @@ impl CayenneTableProvider {
                 &new_snapshot_id,
                 target_partitions,
                 None,
+                crate::provider::delta_encoding::WriteClass::Maintenance,
             )
             .await?;
 

--- a/crates/cayenne/src/provider/staging_wal.rs
+++ b/crates/cayenne/src/provider/staging_wal.rs
@@ -683,6 +683,7 @@ impl CayenneTableProvider {
                 // The prepared insert is a lazily-consumed stream of unknown
                 // size; shard across the full write concurrency (prior behavior).
                 None,
+                super::delta_encoding::WriteClass::Delta,
             )
             .await
         {

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4478,8 +4478,8 @@ impl CayenneTableProvider {
     /// The intra-write shard configuration this write earns, or `None` for a
     /// single serial writer. Shared by [`Self::write_shard_format`] (default
     /// encoding) and the delta-encoding strategy-override path
-    /// (`CayenneContext::write_format_with_strategy`) so both shard
-    /// identically.
+    /// (`CayenneContext::write_format_with_strategy`) so the two write paths
+    /// produce identically-sharded output formats.
     fn write_shard_config(
         &self,
         session_target_partitions: usize,

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4238,16 +4238,13 @@ impl CayenneTableProvider {
             estimated_bytes,
             target_size_bytes,
         );
-        let write_format =
-            match super::delta_encoding::strategy_builder_for_level(encoding_level) {
-                Some(strategy) => self.context.write_format_with_strategy(
-                    strategy,
-                    self.write_shard_config(target_partitions, target_size_bytes, estimated_bytes),
-                ),
-                None => {
-                    self.write_shard_format(target_partitions, target_size_bytes, estimated_bytes)
-                }
-            };
+        let write_format = match super::delta_encoding::strategy_builder_for_level(encoding_level) {
+            Some(strategy) => self.context.write_format_with_strategy(
+                strategy,
+                self.write_shard_config(target_partitions, target_size_bytes, estimated_bytes),
+            ),
+            None => self.write_shard_format(target_partitions, target_size_bytes, estimated_bytes),
+        };
 
         // Create a new ListingTable pointing to the snapshot directory
         let snapshot_listing_table = Self::create_listing_table(
@@ -4468,8 +4465,11 @@ impl CayenneTableProvider {
         estimated_bytes: Option<u64>,
     ) -> Arc<VortexFormat> {
         let base = self.context.file_format();
-        match self.write_shard_config(session_target_partitions, target_size_bytes, estimated_bytes)
-        {
+        match self.write_shard_config(
+            session_target_partitions,
+            target_size_bytes,
+            estimated_bytes,
+        ) {
             Some(config) => Arc::new(base.with_write_shard(config)),
             None => Arc::clone(base),
         }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4068,6 +4068,7 @@ impl CayenneTableProvider {
                 &new_snapshot_id,
                 target_partitions,
                 estimated_bytes,
+                super::delta_encoding::WriteClass::Delta,
             )
             .await?;
 
@@ -4184,6 +4185,7 @@ impl CayenneTableProvider {
         snapshot_id: &str,
         target_partitions: usize,
         estimated_bytes: Option<u64>,
+        write_class: super::delta_encoding::WriteClass,
     ) -> Result<(u64, usize, Arc<ColumnStatsAccumulator>)> {
         use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
         use std::time::Instant;
@@ -4223,8 +4225,29 @@ impl CayenneTableProvider {
         // config (only `create_writer_physical_plan` does). The shard count is
         // size-aware: a write smaller than one target file stays a single shard
         // regardless of `target_partitions` (see `snapshot_shard_count`).
+        //
+        // Delta writes additionally resolve a `cayenne_delta_encoding` level:
+        // small fresh deltas encode with a light scheme set (skipping the
+        // per-file BtrBlocks strategy search + FSST training that dominate
+        // small-write encode cost) and are re-encoded properly when compaction
+        // folds them. Maintenance writes (compaction, rewrites, overwrites)
+        // always use the full default strategy. See `provider::delta_encoding`.
+        let encoding_level = super::delta_encoding::effective_level(
+            self.context.delta_encoding(),
+            write_class,
+            estimated_bytes,
+            target_size_bytes,
+        );
         let write_format =
-            self.write_shard_format(target_partitions, target_size_bytes, estimated_bytes);
+            match super::delta_encoding::strategy_builder_for_level(encoding_level) {
+                Some(strategy) => self.context.write_format_with_strategy(
+                    strategy,
+                    self.write_shard_config(target_partitions, target_size_bytes, estimated_bytes),
+                ),
+                None => {
+                    self.write_shard_format(target_partitions, target_size_bytes, estimated_bytes)
+                }
+            };
 
         // Create a new ListingTable pointing to the snapshot directory
         let snapshot_listing_table = Self::create_listing_table(
@@ -4445,13 +4468,31 @@ impl CayenneTableProvider {
         estimated_bytes: Option<u64>,
     ) -> Arc<VortexFormat> {
         let base = self.context.file_format();
+        match self.write_shard_config(session_target_partitions, target_size_bytes, estimated_bytes)
+        {
+            Some(config) => Arc::new(base.with_write_shard(config)),
+            None => Arc::clone(base),
+        }
+    }
+
+    /// The intra-write shard configuration this write earns, or `None` for a
+    /// single serial writer. Shared by [`Self::write_shard_format`] (default
+    /// encoding) and the delta-encoding strategy-override path
+    /// (`CayenneContext::write_format_with_strategy`) so both shard
+    /// identically.
+    fn write_shard_config(
+        &self,
+        session_target_partitions: usize,
+        target_size_bytes: usize,
+        estimated_bytes: Option<u64>,
+    ) -> Option<WriteShardConfig> {
         let shard_count = self.snapshot_shard_count(
             session_target_partitions,
             target_size_bytes,
             estimated_bytes,
         );
         if shard_count <= 1 {
-            return Arc::clone(base);
+            return None;
         }
         let shard_key_columns = self
             .pk_column_indices
@@ -4464,10 +4505,10 @@ impl CayenneTableProvider {
                     .map(|f| f.name().clone())
             })
             .collect::<Vec<_>>();
-        Arc::new(base.with_write_shard(WriteShardConfig {
+        Some(WriteShardConfig {
             write_concurrency: shard_count,
             shard_key_columns,
-        }))
+        })
     }
 
     /// Requested number of intra-write shards (parallel encoders) for a snapshot
@@ -7577,7 +7618,14 @@ impl CayenneTableProvider {
         let (total_rows, chunk_count, _stats_acc) = self
             // Sorted rewrite: `has_sort_columns()` already forces a single shard
             // (and `target_partitions = 1`), so no size estimate is needed.
-            .write_to_snapshot(sorted_stream, target_size_bytes, &new_snapshot_id, 1, None)
+            .write_to_snapshot(
+                sorted_stream,
+                target_size_bytes,
+                &new_snapshot_id,
+                1,
+                None,
+                super::delta_encoding::WriteClass::Maintenance,
+            )
             .await?;
 
         if total_rows == 0 {
@@ -8327,6 +8375,7 @@ impl CayenneTableProvider {
                 // file is the whole point), so the shard count is forced to 1
                 // regardless; no size estimate needed.
                 None,
+                super::delta_encoding::WriteClass::Maintenance,
             )
             .await;
 
@@ -8708,6 +8757,7 @@ impl CayenneTableProvider {
                 // collapse read fan-out, so the shard count is forced to 1; no
                 // size estimate needed.
                 None,
+                super::delta_encoding::WriteClass::Maintenance,
             )
             .await;
 
@@ -10102,6 +10152,7 @@ impl CayenneTableProvider {
                         &self.get_current_snapshot_id(),
                         ctx.state().config().target_partitions(),
                         estimated_bytes,
+                        super::delta_encoding::WriteClass::Delta,
                     )
                     .await?;
                 stats

--- a/crates/cayenne/tests/delta_encoding_test.rs
+++ b/crates/cayenne/tests/delta_encoding_test.rs
@@ -91,7 +91,8 @@ async fn create_table_with_encoding(
         partition_column: None,
         vortex_config,
     };
-    let catalog: Arc<dyn MetadataCatalog> = Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
     let ctx = SessionContext::new();
     Arc::new(
         CayenneTableProvider::create_table(catalog, options, ctx.runtime_env())
@@ -153,13 +154,20 @@ async fn delta_encoding_levels_are_correct_and_actually_engage() {
     let written_full = insert_batch(&full_table, batch)
         .await
         .expect("insert level 9");
-    assert_eq!(written_level0 as usize, ROW_COUNT, "level-0 insert row count");
+    assert_eq!(
+        written_level0 as usize, ROW_COUNT,
+        "level-0 insert row count"
+    );
     assert_eq!(written_full as usize, ROW_COUNT, "level-9 insert row count");
 
     // Correctness: both tables return exactly the inserted rows.
     let level0_rows = scan_all_rows(&uncompressed_table, "delta_enc_level0").await;
     let full_rows = scan_all_rows(&full_table, "delta_enc_level9").await;
-    assert_eq!(total_rows(&level0_rows), ROW_COUNT, "level-0 scan row count");
+    assert_eq!(
+        total_rows(&level0_rows),
+        ROW_COUNT,
+        "level-0 scan row count"
+    );
     assert_eq!(total_rows(&full_rows), ROW_COUNT, "level-9 scan row count");
     let level0_pretty =
         arrow::util::pretty::pretty_format_batches(&level0_rows).expect("format level-0");

--- a/crates/cayenne/tests/delta_encoding_test.rs
+++ b/crates/cayenne/tests/delta_encoding_test.rs
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Integration tests for `cayenne_delta_encoding` (delta-write encoding levels).
+//!
+//! Two things must hold, and the second is the validity gate for the first:
+//!
+//! 1. **Correctness** — a table written at any encoding level returns exactly
+//!    the same rows as one written at the full default level. Every level
+//!    emits standard Vortex encodings; the scan path is encoding-agnostic.
+//! 2. **Engagement** — the level actually reaches the Vortex writer. A
+//!    level-0 (uncompressed) table's data files must be measurably LARGER on
+//!    compressible data than a full-level table's. Without this assertion the
+//!    correctness test could pass with the strategy override silently
+//!    ignored (both tables writing identical default-encoded files).
+
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use cayenne::metadata::{CreateTableOptions, DeltaEncoding, VortexConfig};
+use cayenne::{CayenneTableProvider, MetadataCatalog};
+use common::{BackendType, TestFixture, insert_batch};
+use datafusion::datasource::TableProvider;
+use datafusion::physical_plan::collect;
+use datafusion::prelude::SessionContext;
+
+/// Enough rows to exceed the inline-memtable admission cap (default 1024),
+/// forcing the staged file-write path the encoding level applies to.
+const ROW_COUNT: usize = 5_000;
+
+/// Distinct repeated string values — highly compressible (dictionary / FSST),
+/// so the level-0 vs full-level on-disk size gap is large and robust.
+const DISTINCT_NAMES: usize = 32;
+
+fn test_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]))
+}
+
+fn compressible_batch(rows: usize) -> RecordBatch {
+    let ids: Vec<i64> = (0..rows as i64).collect();
+    let names: Vec<String> = (0..rows)
+        .map(|i| format!("repeated_delta_encoding_value_{:02}", i % DISTINCT_NAMES))
+        .collect();
+    RecordBatch::try_new(
+        test_schema(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(StringArray::from(names)),
+        ],
+    )
+    .expect("build compressible batch")
+}
+
+async fn create_table_with_encoding(
+    fixture: &TestFixture,
+    table_name: &str,
+    delta_encoding: DeltaEncoding,
+) -> Arc<CayenneTableProvider> {
+    let vortex_config = VortexConfig {
+        delta_encoding,
+        ..VortexConfig::default()
+    };
+    let options = CreateTableOptions {
+        table_name: table_name.to_string(),
+        schema: test_schema(),
+        primary_key: vec![],
+        on_conflict: None,
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config,
+    };
+    let catalog: Arc<dyn MetadataCatalog> = Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let ctx = SessionContext::new();
+    Arc::new(
+        CayenneTableProvider::create_table(catalog, options, ctx.runtime_env())
+            .await
+            .expect("create table"),
+    )
+}
+
+/// Sum the sizes of all `.vortex` data files under a table's data directory.
+fn vortex_bytes_under(dir: &Path) -> u64 {
+    let mut total = 0;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return 0,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            total += vortex_bytes_under(&path);
+        } else if path.extension().is_some_and(|ext| ext == "vortex") {
+            total += entry.metadata().map(|m| m.len()).unwrap_or(0);
+        }
+    }
+    total
+}
+
+async fn scan_all_rows(table: &Arc<CayenneTableProvider>, name: &str) -> Vec<RecordBatch> {
+    let ctx = SessionContext::new();
+    ctx.register_table(name, Arc::clone(table) as Arc<dyn TableProvider>)
+        .expect("register table");
+    let df = ctx
+        .sql(&format!("SELECT id, name FROM {name} ORDER BY id"))
+        .await
+        .expect("plan scan");
+    let plan = df.create_physical_plan().await.expect("physical plan");
+    collect(plan, ctx.task_ctx()).await.expect("collect rows")
+}
+
+fn total_rows(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(RecordBatch::num_rows).sum()
+}
+
+#[tokio::test]
+async fn delta_encoding_levels_are_correct_and_actually_engage() {
+    let fixture = TestFixture::new(BackendType::Sqlite)
+        .await
+        .expect("fixture");
+
+    // Two identical tables, differing only in the pinned delta-encoding level.
+    let uncompressed_table =
+        create_table_with_encoding(&fixture, "delta_enc_level0", DeltaEncoding::Level(0)).await;
+    let full_table =
+        create_table_with_encoding(&fixture, "delta_enc_level9", DeltaEncoding::Level(9)).await;
+
+    let batch = compressible_batch(ROW_COUNT);
+    let written_level0 = insert_batch(&uncompressed_table, batch.clone())
+        .await
+        .expect("insert level 0");
+    let written_full = insert_batch(&full_table, batch)
+        .await
+        .expect("insert level 9");
+    assert_eq!(written_level0 as usize, ROW_COUNT, "level-0 insert row count");
+    assert_eq!(written_full as usize, ROW_COUNT, "level-9 insert row count");
+
+    // Correctness: both tables return exactly the inserted rows.
+    let level0_rows = scan_all_rows(&uncompressed_table, "delta_enc_level0").await;
+    let full_rows = scan_all_rows(&full_table, "delta_enc_level9").await;
+    assert_eq!(total_rows(&level0_rows), ROW_COUNT, "level-0 scan row count");
+    assert_eq!(total_rows(&full_rows), ROW_COUNT, "level-9 scan row count");
+    let level0_pretty =
+        arrow::util::pretty::pretty_format_batches(&level0_rows).expect("format level-0");
+    let full_pretty =
+        arrow::util::pretty::pretty_format_batches(&full_rows).expect("format level-9");
+    assert_eq!(
+        level0_pretty.to_string(),
+        full_pretty.to_string(),
+        "level-0 and full-level tables must return identical rows"
+    );
+
+    // Engagement (validity gate): the level must actually reach the Vortex
+    // writer. On this highly-repetitive data the uncompressed (level-0) files
+    // must be substantially larger than the full-level (BtrBlocks) files. If
+    // the strategy override were silently ignored, both totals would be equal
+    // and this assertion fails loudly.
+    let level0_table_id = fixture
+        .catalog
+        .get_table("delta_enc_level0")
+        .await
+        .expect("get level-0 table")
+        .table_id;
+    let full_table_id = fixture
+        .catalog
+        .get_table("delta_enc_level9")
+        .await
+        .expect("get level-9 table")
+        .table_id;
+    let level0_bytes = vortex_bytes_under(&fixture.data_path.join(&level0_table_id));
+    let full_bytes = vortex_bytes_under(&fixture.data_path.join(&full_table_id));
+    assert!(
+        level0_bytes > 0 && full_bytes > 0,
+        "both tables must have produced vortex data files \
+         (level0={level0_bytes} B, full={full_bytes} B)"
+    );
+    assert!(
+        level0_bytes as f64 > full_bytes as f64 * 1.3,
+        "level-0 (uncompressed) files must be substantially larger than \
+         full-level files on compressible data — got level0={level0_bytes} B \
+         vs full={full_bytes} B. If these are equal, the delta-encoding \
+         strategy override never reached the Vortex writer."
+    );
+}

--- a/crates/cayenne/tests/delta_encoding_test.rs
+++ b/crates/cayenne/tests/delta_encoding_test.rs
@@ -59,7 +59,8 @@ fn test_schema() -> SchemaRef {
 }
 
 fn compressible_batch(rows: usize) -> RecordBatch {
-    let ids: Vec<i64> = (0..rows as i64).collect();
+    let row_count = i64::try_from(rows).expect("row count fits i64");
+    let ids: Vec<i64> = (0..row_count).collect();
     let names: Vec<String> = (0..rows)
         .map(|i| format!("repeated_delta_encoding_value_{:02}", i % DISTINCT_NAMES))
         .collect();
@@ -104,9 +105,8 @@ async fn create_table_with_encoding(
 /// Sum the sizes of all `.vortex` data files under a table's data directory.
 fn vortex_bytes_under(dir: &Path) -> u64 {
     let mut total = 0;
-    let entries = match std::fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(_) => return 0,
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
     };
     for entry in entries.flatten() {
         let path = entry.path();
@@ -154,11 +154,9 @@ async fn delta_encoding_levels_are_correct_and_actually_engage() {
     let written_full = insert_batch(&full_table, batch)
         .await
         .expect("insert level 9");
-    assert_eq!(
-        written_level0 as usize, ROW_COUNT,
-        "level-0 insert row count"
-    );
-    assert_eq!(written_full as usize, ROW_COUNT, "level-9 insert row count");
+    let expected_rows = u64::try_from(ROW_COUNT).expect("row count fits u64");
+    assert_eq!(written_level0, expected_rows, "level-0 insert row count");
+    assert_eq!(written_full, expected_rows, "level-9 insert row count");
 
     // Correctness: both tables return exactly the inserted rows.
     let level0_rows = scan_all_rows(&uncompressed_table, "delta_enc_level0").await;
@@ -196,15 +194,26 @@ async fn delta_encoding_levels_are_correct_and_actually_engage() {
         .await
         .expect("get level-9 table")
         .table_id;
-    let level0_bytes = vortex_bytes_under(&fixture.data_path.join(&level0_table_id));
-    let full_bytes = vortex_bytes_under(&fixture.data_path.join(&full_table_id));
+    // Blocking std::fs walk — run on the blocking pool so it can't stall a
+    // tokio worker under contention.
+    let level0_dir = fixture.data_path.join(&level0_table_id);
+    let full_dir = fixture.data_path.join(&full_table_id);
+    let (level0_bytes, full_bytes) = tokio::task::spawn_blocking(move || {
+        (
+            vortex_bytes_under(&level0_dir),
+            vortex_bytes_under(&full_dir),
+        )
+    })
+    .await
+    .expect("size walk task");
     assert!(
         level0_bytes > 0 && full_bytes > 0,
         "both tables must have produced vortex data files \
          (level0={level0_bytes} B, full={full_bytes} B)"
     );
+    // Integer form of `level0 > full * 1.3` (avoids u64→f64 precision lints).
     assert!(
-        level0_bytes as f64 > full_bytes as f64 * 1.3,
+        level0_bytes.saturating_mul(10) > full_bytes.saturating_mul(13),
         "level-0 (uncompressed) files must be substantially larger than \
          full-level files on compressible data — got level0={level0_bytes} B \
          vs full={full_bytes} B. If these are equal, the delta-encoding \

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -1272,8 +1272,8 @@ const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
             .one_of(&["btrblocks", "zstd"])
             .default("btrblocks"),
         ParameterSpec::component("delta_encoding")
-            .description("Encoding effort for fresh delta writes (CDC/append snapshot files), zstd-style. '7' (default) is the full default BtrBlocks cascade — unchanged write behavior. 'auto' size-gates: deltas smaller than a quarter of the target file size encode with a light scheme set (skipping the per-file encoder-strategy search and FSST training) and are re-encoded by compaction; larger writes use the full default. Explicit levels 0..=10 pin the effort (0 = uncompressed canonical, 7..=10 = full default cascade). Compaction and rewrite outputs always use the full default encoding regardless of this setting.")
-            .default("7"),
+            .description("Encoding effort for fresh delta writes (CDC/append snapshot files), zstd-style. 'auto' (default) size-gates: deltas smaller than a quarter of the target file size encode with a light scheme set (skipping the per-file encoder-strategy search and FSST training) and are re-encoded by compaction; larger or unknown-size writes use the full default. Explicit levels 0..=10 pin the effort (0 = uncompressed canonical, 7 = the full default cascade i.e. the explicit opt-out, 8..=10 reserved). Compaction and rewrite outputs always use the full default encoding regardless of this setting.")
+            .default("auto"),
         ParameterSpec::component("pk_conflict_detection")
             .description("Whether Cayenne scans existing primary keys on insert. 'auto' (default) detects conflicts and applies on_conflict behavior. 'none' skips conflict detection and is only safe when the source enforces primary-key uniqueness and the ingestion path cannot replay existing rows, such as steady-state append-only CDC after bootstrap.")
             .one_of(&["auto", "none"])

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -1239,8 +1239,8 @@ fn wrap_with_native_vector_indexes(
 const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
     ParameterSpec,
     S3_PARAMS_LEN,
-    26,
-    { S3_PARAMS_LEN + 26 },
+    27,
+    { S3_PARAMS_LEN + 27 },
 >(
     S3_PARAMETERS,
     [

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -1272,8 +1272,8 @@ const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
             .one_of(&["btrblocks", "zstd"])
             .default("btrblocks"),
         ParameterSpec::component("delta_encoding")
-            .description("Encoding effort for fresh delta writes (CDC/append snapshot files), zstd-style. 'auto' (default) size-gates: deltas smaller than a quarter of the target file size encode with a light scheme set (skipping the per-file encoder-strategy search and FSST training that dominate small-write encode cost) and are re-encoded by compaction; larger writes use the full default. Explicit levels 0..=10 pin the effort (0 = uncompressed canonical, 7..=10 = full default BtrBlocks cascade). Compaction and rewrite outputs always use the full default encoding regardless of this setting.")
-            .default("auto"),
+            .description("Encoding effort for fresh delta writes (CDC/append snapshot files), zstd-style. '7' (default) is the full default BtrBlocks cascade — unchanged write behavior. 'auto' size-gates: deltas smaller than a quarter of the target file size encode with a light scheme set (skipping the per-file encoder-strategy search and FSST training) and are re-encoded by compaction; larger writes use the full default. Explicit levels 0..=10 pin the effort (0 = uncompressed canonical, 7..=10 = full default cascade). Compaction and rewrite outputs always use the full default encoding regardless of this setting.")
+            .default("7"),
         ParameterSpec::component("pk_conflict_detection")
             .description("Whether Cayenne scans existing primary keys on insert. 'auto' (default) detects conflicts and applies on_conflict behavior. 'none' skips conflict detection and is only safe when the source enforces primary-key uniqueness and the ingestion path cannot replay existing rows, such as steady-state append-only CDC after bootstrap.")
             .one_of(&["auto", "none"])

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -738,6 +738,22 @@ impl CayenneAccelerator {
                 }
             }
 
+            // Parse delta-write encoding level ('auto' or 0..=10, zstd-style).
+            // Applies only to fresh delta writes; compaction outputs always use
+            // the full default encoding. See `cayenne::metadata::DeltaEncoding`.
+            if let Some(encoding_str) = acceleration.params.get("cayenne_delta_encoding") {
+                match encoding_str.parse::<cayenne::metadata::DeltaEncoding>() {
+                    Ok(encoding) => {
+                        config.delta_encoding = encoding;
+                    }
+                    Err(reason) => {
+                        tracing::warn!(
+                            "Dataset '{table_name}' contains an invalid `cayenne_delta_encoding` - {reason}. Defaulting to 'auto'.",
+                        );
+                    }
+                }
+            }
+
             if let Some((key, value)) = ["cayenne_pk_conflict_detection", "pk_conflict_detection"]
                 .iter()
                 .find_map(|key| acceleration.params.get(*key).map(|value| (*key, value)))
@@ -907,13 +923,14 @@ impl CayenneAccelerator {
 
             tracing::debug!(
                 runtime_footer_cache_mb = ?config.footer_cache_mb,
-                "Cayenne Vortex config: segment_cache={}MB, target_file_size={}MB, upload_concurrency={}, write_concurrency_override={:?}, sort_columns={:?}, compression_strategy={:?}, pk_conflict_detection={}, compaction_trigger_files={}, compaction_trigger_protected_snapshots={}, compaction_trigger_snapshot_age_ms={}, compaction_max_levels={}, compaction_max_files_per_pick={}, compaction_background_interval_ms={}, inline_max_rows={}, inline_max_bytes={}, inline_max_buffer_bytes={}, inline_flush_max_rows={}, inline_flush_max_segments={}, inline_flush_max_bytes={}",
+                "Cayenne Vortex config: segment_cache={}MB, target_file_size={}MB, upload_concurrency={}, write_concurrency_override={:?}, sort_columns={:?}, compression_strategy={:?}, delta_encoding={}, pk_conflict_detection={}, compaction_trigger_files={}, compaction_trigger_protected_snapshots={}, compaction_trigger_snapshot_age_ms={}, compaction_max_levels={}, compaction_max_files_per_pick={}, compaction_background_interval_ms={}, inline_max_rows={}, inline_max_bytes={}, inline_max_buffer_bytes={}, inline_flush_max_rows={}, inline_flush_max_segments={}, inline_flush_max_bytes={}",
                 config.segment_cache_mb,
                 config.target_vortex_file_size_mb,
                 config.upload_concurrency,
                 config.write_concurrency,
                 config.sort_columns,
                 config.compression_strategy,
+                config.delta_encoding,
                 config.pk_conflict_detection.as_str(),
                 config.compaction_trigger_files,
                 config.compaction_trigger_protected_snapshots,
@@ -1254,6 +1271,9 @@ const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
             .description("Compression strategy to use for Vortex files. Options: 'btrblocks' (default), 'zstd'")
             .one_of(&["btrblocks", "zstd"])
             .default("btrblocks"),
+        ParameterSpec::component("delta_encoding")
+            .description("Encoding effort for fresh delta writes (CDC/append snapshot files), zstd-style. 'auto' (default) size-gates: deltas smaller than a quarter of the target file size encode with a light scheme set (skipping the per-file encoder-strategy search and FSST training that dominate small-write encode cost) and are re-encoded by compaction; larger writes use the full default. Explicit levels 0..=10 pin the effort (0 = uncompressed canonical, 7..=10 = full default BtrBlocks cascade). Compaction and rewrite outputs always use the full default encoding regardless of this setting.")
+            .default("auto"),
         ParameterSpec::component("pk_conflict_detection")
             .description("Whether Cayenne scans existing primary keys on insert. 'auto' (default) detects conflicts and applies on_conflict behavior. 'none' skips conflict detection and is only safe when the source enforces primary-key uniqueness and the ingestion path cannot replay existing rows, such as steady-state append-only CDC after bootstrap.")
             .one_of(&["auto", "none"])


### PR DESCRIPTION
## What

1. **`cayenne_delta_encoding` param** — zstd-style encoding-effort levels for **delta writes** (fresh CDC/append snapshot files):

| value | behavior |
|---|---|
| `auto` (**default**) | size-gated: deltas < `target_file_size/4` encode light (Constant+Sparse+Dict — no per-file strategy search, no FSST training) and are re-encoded when compaction folds them; larger/unknown-size writes use the full default |
| `0`–`6` | pinned effort ladder (0 = uncompressed canonical → 1–3 cheap schemes → 4–6 full-minus-FSST) |
| `7` | the full default cascade — **byte-for-byte pre-feature behavior; the explicit opt-out** (8–10 reserved) |

**Maintenance writes (compaction outputs, sorted rewrites, overwrites) always use the full default encoding** — enforced by an explicit `WriteClass` on `write_to_snapshot` (10 call sites). A level change never trips the table re-create gate (write-time only; surfaced in the config change log).

2. **`cayenne_compression_strategy=zstd` is now real.** It was parsed, stored, and drift-checked but consumed nowhere (the documented "Vortex CompactCompressor" doesn't exist at the pinned rev — `zstd` was a silent no-op). It now registers a full-tier write strategy on the base format session: the default cascade **plus the Zstd string scheme in the search** (picked per column when it beats FSST/dict; ints/floats unchanged — no vortex zstd schemes for them at this rev).

3. **`benches/delta_encoding_sweep.rs`** — {btrblocks, zstd} × {auto, 1..=9} matrix on a 5,000-row mixed-compressibility delta via the **real `insert_into` path** (the inline gate computes the exact size, so `auto` resolves exactly as production inserts do). On-disk bytes pre-pass + criterion-timed write per lane.

## Measured matrix (16-core macOS, means of 10 samples; noise band ~±2 ms)

**Write latency (= per-write CDC ingest rate, the primary criterion):**

| family | auto | L1–L5 | L6 | **L7–L9 (full)** |
|---|---|---|---|---|
| btrblocks | **26.05 ms** | 25.7–26.9 | 29.7 | **30.1–31.2 ms** |
| zstd | **25.84 ms** | 26.2–31.0 | 30.6 | **31.2–37.4 ms** |

→ **light (`auto`) ≈ −15% write latency vs full ≈ +17% per-write ingest rate** on the append path — the gap is ~2× the noise band. zstd's full-tier encode cost ≈ btrblocks within noise: **zstd is a size/egress knob, not an ingest knob**.

**On-disk bytes (engagement proof per lane):**

| family | auto / L1 / L2 | L3–L6 | **L7–L9 (full)** |
|---|---|---|---|
| btrblocks | 714 K | 674 K | **296 K** |
| zstd | 714 K | 674 K | **274 K (−7.3%)** |

→ `auto` is byte-identical to level 2 (the size gate provably fires on the real path); the ladder is monotone; **zstd demonstrably changes the on-disk encoding at the full tier** (won the search on high-entropy strings). Light levels are family-independent by design.

## Honest caveats

- Light deltas are ~2.4× larger on disk until compaction folds them, and compaction then re-encodes more input bytes (`vs_duckdb_incremental_append` showed ~+10% when the trigger fires inside the measurement window). **Sustained-CDC *net* ingest rate is validated on the production-scale run**; `cayenne_delta_encoding: 7` is the one-param revert if it disappoints.
- An earlier per-file encode-cost magnitude claim was retracted: it came from a whole-process `sample` profile contaminated by the bench's untimed per-iteration preload. The numbers above are criterion timed-region measurements.
- The on-conflict upsert path A/B (separate bench) was neutral — encode is a smaller share of that path's cost; the +17% applies to the plain append shape.
- Levels 4–6 collapse to L3 byte-wise on this dataset (FSST was the only differentiator); their value is data-shape-dependent.

## Tests

8 unit (parse, auto gate, explicit pinning, maintenance-always-full, default-is-auto + level-7 opt-out, full-levels-use-session-default, light-levels-override, **zstd-includes-Zstd-scheme / default-excludes-it**) + integration (`tests/delta_encoding_test.rs`: identical rows at level 0 vs 9 **and** level-0 bytes ≫ level-9 — fails loudly if the override silently never reaches the writer). Suites green: `staged_append`, `on_conflict`, `small_files_compaction`, `acid_compliance`. CI-flag clippy clean.