### PR TITLE
perf(cayenne): parallelize deletion-vector writes + coalesce dir barriers per batch

### DIFF
--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -194,120 +194,152 @@ impl<'a> DeletionVectorWriter<'a> {
         &self,
         specs: Vec<DeletionVectorWriteSpec>,
     ) -> Result<Vec<DeletionVectorWriteResult>> {
-        let mut results = Vec::with_capacity(specs.len());
+        let specs: Vec<DeletionVectorWriteSpec> =
+            specs.into_iter().filter(|spec| !spec.is_empty()).collect();
+        if specs.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        for spec in specs {
-            if spec.is_empty() {
-                continue;
+        let deletion_dir = self.table_snapshot_deletion_dir();
+        let snapshot_dir = deletion_dir
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| Error::Internal {
+                table: self.table.path.clone(),
+                message: format!(
+                    "Deletion vector directory '{}' has no snapshot parent",
+                    deletion_dir.display()
+                ),
+            })?;
+
+        // Ensure the deletions/ subdirectory exists (once per call — it was
+        // previously re-checked per spec, a no-op after the first).
+        // If we just created it, sync its parent (the snapshot directory)
+        // so the subdir entry is durable on local FS.
+        //
+        // This is required for the same contract we now enforce for
+        // snapshot directories themselves (ensure_snapshot_dir_exists)
+        // and for the _partitioned_wal/ coordination directory:
+        // on POSIX, mkdir in a directory updates the parent's metadata.
+        // A crash immediately after this create_dir_all but before the
+        // subsequent file write + file fsync + catalog record could
+        // otherwise leave a catalog entry pointing at a deletions/
+        // directory whose creation was lost.
+        //
+        // The sync is one-time per snapshot (first deletion vector
+        // written to it). Subsequent deletions reuse the directory.
+        let sync_snapshot_parent = match tokio::fs::create_dir(&deletion_dir).await {
+            Ok(()) => true,
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => false,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                tokio::fs::create_dir_all(&deletion_dir).await?;
+                true
             }
+            Err(source) => return Err(Error::IoError { source }),
+        };
+        if sync_snapshot_parent {
+            let table = self.table.path.clone();
+            // Directory ordering tier (plain fsync on macOS, full fsync
+            // on other platforms) — see `provider/fsync_tier.rs`.
+            tokio::task::spawn_blocking(move || {
+                let dir = std::fs::File::open(&snapshot_dir)?;
+                crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+            })
+            .await
+            .map_err(|source| Error::TaskPanicked { table, source })??;
+        }
 
-            let deletion_dir = self.table_snapshot_deletion_dir();
-            let snapshot_dir = deletion_dir
-                .parent()
-                .map(Path::to_path_buf)
-                .ok_or_else(|| Error::Internal {
-                    table: self.table.path.clone(),
-                    message: format!(
-                        "Deletion vector directory '{}' has no snapshot parent",
-                        deletion_dir.display()
-                    ),
-                })?;
-
-            // Ensure the deletions/ subdirectory exists.
-            // If we just created it, sync its parent (the snapshot directory)
-            // so the subdir entry is durable on local FS.
-            //
-            // This is required for the same contract we now enforce for
-            // snapshot directories themselves (ensure_snapshot_dir_exists)
-            // and for the _partitioned_wal/ coordination directory:
-            // on POSIX, mkdir in a directory updates the parent's metadata.
-            // A crash immediately after this create_dir_all but before the
-            // subsequent file write + file fsync + catalog record could
-            // otherwise leave a catalog entry pointing at a deletions/
-            // directory whose creation was lost.
-            //
-            // The sync is one-time per snapshot (first deletion vector
-            // written to it). Subsequent deletions reuse the directory.
-            let sync_snapshot_parent = match tokio::fs::create_dir(&deletion_dir).await {
-                Ok(()) => true,
-                Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => false,
-                Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                    tokio::fs::create_dir_all(&deletion_dir).await?;
-                    true
-                }
-                Err(source) => return Err(Error::IoError { source }),
-            };
-            if sync_snapshot_parent {
-                let table = self.table.path.clone();
-                // Directory ordering tier (plain fsync on macOS, full fsync
-                // on other platforms) — see `provider/fsync_tier.rs`.
-                tokio::task::spawn_blocking(move || {
-                    let dir = std::fs::File::open(&snapshot_dir)?;
-                    crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
-                })
-                .await
-                .map_err(|source| Error::TaskPanicked { table, source })??;
-            }
-
+        // Write every spec's deletion-vector file CONCURRENTLY. The files are
+        // independent (one per spec, UUIDv7 filenames), so their writes + file
+        // fsyncs overlap on the blocking pool — on network-attached storage
+        // (EBS) this turns N serialized ~1 ms fsync round-trips into ~1 round
+        // of in-flight barriers. `try_join_all` preserves spec order in the
+        // returned results.
+        let write_futures = specs.into_iter().map(|spec| {
             let file_path = Self::deletion_file_path(&deletion_dir);
-
-            let (batch, schema, count, identifiers, source_data_file_path) = match spec.identifiers
-            {
-                DeletionIdentifier::PositionBased {
-                    file_path: source_file,
-                    mut row_ids,
-                    pre_sorted,
-                } => {
-                    if pre_sorted {
-                        debug_assert!(
-                            row_ids.windows(2).all(|w| w[0] < w[1]),
-                            "pre_sorted=true but row_ids is not strictly increasing",
-                        );
-                    } else {
-                        row_ids.sort_unstable();
-                        row_ids.dedup();
-                    }
-                    let count = row_ids.len();
-                    let schema = position_based_deletion_schema();
-                    let batch = build_position_based_batch(&schema, &row_ids)?;
-                    (
-                        batch,
-                        schema,
-                        count,
+            let table_name = self.table.table_name.clone();
+            async move {
+                let (batch, schema, count, identifiers, source_data_file_path) =
+                    match spec.identifiers {
                         DeletionIdentifier::PositionBased {
-                            file_path: source_file.clone(),
-                            row_ids,
+                            file_path: source_file,
+                            mut row_ids,
                             pre_sorted,
-                        },
-                        Some(source_file),
-                    )
-                }
-                DeletionIdentifier::KeyBased(mut row_keys) => {
-                    // Sort and deduplicate keys
-                    row_keys.sort();
-                    row_keys.dedup();
-                    let count = row_keys.len();
-                    let schema = key_based_deletion_schema();
-                    let batch = build_key_based_batch(&schema, &row_keys)?;
-                    (
-                        batch,
-                        schema,
-                        count,
-                        DeletionIdentifier::KeyBased(row_keys),
-                        None,
-                    )
-                }
-            };
+                        } => {
+                            if pre_sorted {
+                                debug_assert!(
+                                    row_ids.windows(2).all(|w| w[0] < w[1]),
+                                    "pre_sorted=true but row_ids is not strictly increasing",
+                                );
+                            } else {
+                                row_ids.sort_unstable();
+                                row_ids.dedup();
+                            }
+                            let count = row_ids.len();
+                            let schema = position_based_deletion_schema();
+                            let batch = build_position_based_batch(&schema, &row_ids)?;
+                            (
+                                batch,
+                                schema,
+                                count,
+                                DeletionIdentifier::PositionBased {
+                                    file_path: source_file.clone(),
+                                    row_ids,
+                                    pre_sorted,
+                                },
+                                Some(source_file),
+                            )
+                        }
+                        DeletionIdentifier::KeyBased(mut row_keys) => {
+                            // Sort and deduplicate keys
+                            row_keys.sort();
+                            row_keys.dedup();
+                            let count = row_keys.len();
+                            let schema = key_based_deletion_schema();
+                            let batch = build_key_based_batch(&schema, &row_keys)?;
+                            (
+                                batch,
+                                schema,
+                                count,
+                                DeletionIdentifier::KeyBased(row_keys),
+                                None,
+                            )
+                        }
+                    };
 
-            let file_size_bytes = write_deletion_file(
-                &file_path,
-                Arc::clone(&schema),
-                batch,
-                &self.table.table_name,
-            )
-            .await?;
+                let file_size_bytes =
+                    write_deletion_file(&file_path, Arc::clone(&schema), batch, &table_name)
+                        .await?;
 
-            // Determine deletion type from identifiers
+                Ok::<_, Error>((
+                    file_path,
+                    count,
+                    file_size_bytes,
+                    identifiers,
+                    source_data_file_path,
+                ))
+            }
+        });
+        let written = futures::future::try_join_all(write_futures).await?;
+
+        // ONE coalesced deletions/-dir sync for the whole batch of files
+        // (replaces the previous per-file parent-dir fsync): a directory fsync
+        // flushes ALL of its pending entries, so syncing once after every file
+        // exists provides the same dirent durability at 1/N the barrier count.
+        // Must complete before the catalog records any of the paths.
+        {
+            let table = self.table.path.clone();
+            let deletion_dir_for_sync = deletion_dir.clone();
+            tokio::task::spawn_blocking(move || {
+                let dir = std::fs::File::open(&deletion_dir_for_sync)?;
+                crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+            })
+            .await
+            .map_err(|source| Error::TaskPanicked { table, source })??;
+        }
+
+        let mut results = Vec::with_capacity(written.len());
+        for (file_path, count, file_size_bytes, identifiers, source_data_file_path) in written {
             let deletion_type = match &identifiers {
                 DeletionIdentifier::PositionBased { .. } => DeletionType::PositionBased,
                 DeletionIdentifier::KeyBased(_) => DeletionType::KeyBased,
@@ -573,11 +605,12 @@ async fn write_deletion_file(
         //    previous revision also re-opened the file to fsync it a second
         //    time — that reopen+fsync was redundant work on every delete and
         //    has been removed.
-        // 3. fsync the parent directory so the new directory entry is written
-        //    through before the catalog records the path — without this, the
-        //    catalog can record a delete file path that fails to resolve
-        //    after a crash because the file's inode is on disk but the dirent
-        //    isn't.
+        //
+        // The parent-directory fsync (so the new dirent is written through
+        // before the catalog records the path) is NOT done here: the caller
+        // (`DeletionVectorWriter::write`) writes all of a batch's deletion
+        // files concurrently and issues ONE coalesced deletions/-dir sync
+        // after they complete — same dirent durability, 1/N the barriers.
         let file = std::fs::File::create(&output_path)?;
         let mut writer = FileWriter::try_new(file, &schema)?;
         writer.write(&batch)?;
@@ -587,16 +620,6 @@ async fn write_deletion_file(
         drop(inner);
 
         let metadata = std::fs::metadata(&output_path)?;
-
-        // Best-effort parent-dir fsync (ordering tier). Matches the
-        // partitioned_wal / staging_wal write patterns: a failure here is
-        // unusual and logged by the caller; the deletion file's content is
-        // already durable regardless.
-        if let Some(parent) = output_path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = crate::provider::fsync_tier::ordering_sync_dir_std(&dir);
-        }
 
         Ok(metadata.len())
     })

--- a/crates/cayenne/tests/ingest_fsync_regression_test.rs
+++ b/crates/cayenne/tests/ingest_fsync_regression_test.rs
@@ -210,21 +210,43 @@ fn write_deletion_file_fsyncs_inner_fd_not_a_reopened_fd() {
 }
 
 #[test]
-fn write_deletion_file_still_fsyncs_parent_dir() {
+fn deletion_vector_write_parallelizes_files_and_coalesces_dir_sync() {
     // The companion fsync — the parent directory — must still happen, so the
-    // dirent for the new deletion-vector file is durable before the catalog
-    // is updated. This is the load-bearing half of the ACID-Durability fix
-    // that the removed reopen was *replicating*; we want to keep this one.
-    let body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write_deletion_file")
-        .expect("write_deletion_file function not found in delete/vector_io.rs");
-
+    // dirents for new deletion-vector files are durable before the catalog
+    // is updated. It now lives in `DeletionVectorWriter::write`, ONCE per
+    // batch: the per-spec files are written CONCURRENTLY (`try_join_all`,
+    // overlapping their file fsyncs — on EBS this collapses N serialized
+    // ~1 ms barrier round-trips into ~1), and a single deletions/-dir sync
+    // after they all complete flushes every pending dirent at once. Same
+    // durability contract, 1/N the directory barriers.
+    let write_body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write")
+        .expect("DeletionVectorWriter::write not found in delete/vector_io.rs");
     assert!(
-        body.contains("ordering_sync_dir_std(&dir)"),
-        "write_deletion_file must still fsync (ordering tier, \
-         `ordering_sync_dir_std(&dir)`) the parent directory of the deletion \
-         vector file. Without this, a crash after the catalog records the \
-         path can leave the directory entry unwritten — the catalog now \
-         references a file that does not exist on restart."
+        write_body.contains("try_join_all"),
+        "DeletionVectorWriter::write must write the batch's deletion-vector \
+         files concurrently (try_join_all) — serializing them re-introduces \
+         N fsync round-trips per batch on network-attached storage."
+    );
+    // Exactly two dir syncs in `write`: the one-time snapshot-parent sync
+    // (first deletion vector for the snapshot) and the per-batch coalesced
+    // deletions/-dir sync. A third occurrence means a per-file dir sync
+    // crept back in.
+    let dir_sync_count = write_body.matches("ordering_sync_dir_std(&dir)").count();
+    assert_eq!(
+        dir_sync_count, 2,
+        "DeletionVectorWriter::write must contain exactly two directory \
+         syncs (one-time snapshot-parent + per-batch coalesced deletions/ \
+         dir). Found {dir_sync_count}."
+    );
+
+    // And write_deletion_file itself must NOT dir-sync — that would undo the
+    // coalescing by re-adding a barrier per file.
+    let file_body = extract_fn_body(DELETE_VECTOR_IO_SRC, "write_deletion_file")
+        .expect("write_deletion_file function not found in delete/vector_io.rs");
+    assert!(
+        !file_body.contains("ordering_sync_dir_std"),
+        "write_deletion_file must not fsync the parent directory per file — \
+         the caller issues one coalesced deletions/-dir sync per batch."
     );
 }
 


### PR DESCRIPTION
**Stacked on #11198** (retarget to `trunk` when it merges).

## What

The EBS translation of the fsync-tier work: on network-attached storage the per-batch barrier cost is the **count of serialized fsync round-trips** (~1 ms each on gp3), not the per-call tier (#11198's lever, which is macOS-specific). `DeletionVectorWriter::write` now:

1. **Writes every spec's deletion-vector file concurrently** (`try_join_all`) — the per-file fsyncs overlap on the blocking pool, so N serialized round-trips become ~1 round of in-flight barriers. Position-mode upsert batches emit one spec per touched data file, so N > 1 is the steady-state CDC shape.
2. **Hoists** the deletions/-dir existence check + one-time snapshot-parent sync out of the per-spec loop (no-op re-check after the first spec).
3. **Coalesces the per-file parent-dir fsync into ONE deletions/-dir sync** after all files complete — a directory fsync flushes all pending dirents, so once-per-batch gives identical dirent-before-catalog durability at 1/N the barriers.

## Ordering contract (unchanged)

Every file's content is fsynced before the dir sync; the dir sync completes before the catalog records any path. Result order = spec order (`try_join_all`).

## Barrier math (EBS gp3, ~1 ms/RTT)

A position-mode upsert touching F data files previously paid `2F (+1 first-time)` serialized dir+file barriers in this stage; now `~1` overlapped file-barrier round `+ 1` dir barrier. Combined with the WAL (file→rename→dir, inherently ordered) and move-target stages, the staged path drops from ~5-7 serialized rounds toward ~3.

## Tests

Structural test re-pinned to the new contract: `try_join_all` present, **exactly two** dir syncs in `write()` (one-time parent + coalesced batch), **zero** in `write_deletion_file`. Suites green: `ingest_fsync_regression` (18), `position_based_deletion` (7), `keybased_deletion` (23), `int64_pk_deletion` (13), `deletion_vector_integration` (15), `acid_compliance` (13). CI-flag clippy (both passes) clean.