### PR TITLE
perf(cayenne): size-aware parallel encode for protected-snapshot subset compaction

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2343,34 +2343,6 @@ fn protected_snapshot_size_tier(bytes: u64, base_bytes: u64, growth: u64) -> u32
 /// bounds write amplification to O(log N) per byte (a run is rewritten only
 /// when it levels up), while the `min_runs` threshold bounds read amplification
 /// by keeping at most `min_runs - 1` un-merged runs per tier. The large
-/// Write shape — encoder fan-out cap and size estimate — for the
-/// subset-merge output (see `compact_protected_snapshots_subset`).
-///
-/// Pure so the position-vs-key parallel decision is unit-testable: when
-/// `keeps_positions_serial` (the table carries position-scoped deletes —
-/// either a PK table whose resolved `deletion_mode` is `position`, or a
-/// PK-less table on the legacy `PositionBased` strategy), the merge keeps the
-/// serial single-writer shape `(1, None)`; otherwise it passes the session's
-/// `target_partitions` and the selected tier's total bytes so
-/// `snapshot_shard_count` sizes a parallel encoder fan-out
-/// (`floor(bytes / target_file_size)`, min 1, capped by write concurrency
-/// and the global encode budget).
-///
-/// Note: output FILE COUNT is not a proxy for this decision — a single
-/// serial writer still rolls multiple files when the merged output exceeds
-/// the target file size. This function is the authoritative, testable gate.
-const fn subset_merge_write_shape(
-    keeps_positions_serial: bool,
-    session_target_partitions: usize,
-    total_input_bytes: u64,
-) -> (usize, Option<u64>) {
-    if keeps_positions_serial {
-        (1, None)
-    } else {
-        (session_target_partitions, Some(total_input_bytes))
-    }
-}
-
 /// carried-forward run sits alone in a high tier and is rewritten rarely
 /// instead of on every pass.
 ///
@@ -2413,6 +2385,34 @@ fn select_protected_snapshot_merge_tier(
     }
 
     Vec::new()
+}
+
+/// Write shape — encoder fan-out cap and size estimate — for the
+/// subset-merge output (see `compact_protected_snapshots_subset`).
+///
+/// Pure so the position-vs-key parallel decision is unit-testable: when
+/// `keeps_positions_serial` (the table carries position-scoped deletes —
+/// either a PK table whose resolved `deletion_mode` is `position`, or a
+/// PK-less table on the legacy `PositionBased` strategy), the merge keeps the
+/// serial single-writer shape `(1, None)`; otherwise it passes the session's
+/// `target_partitions` and the selected tier's total bytes so
+/// `snapshot_shard_count` sizes a parallel encoder fan-out
+/// (`floor(bytes / target_file_size)`, min 1, capped by write concurrency
+/// and the global encode budget).
+///
+/// Note: output FILE COUNT is not a proxy for this decision — a single
+/// serial writer still rolls multiple files when the merged output exceeds
+/// the target file size. This function is the authoritative, testable gate.
+const fn subset_merge_write_shape(
+    keeps_positions_serial: bool,
+    session_target_partitions: usize,
+    total_input_bytes: u64,
+) -> (usize, Option<u64>) {
+    if keeps_positions_serial {
+        (1, None)
+    } else {
+        (session_target_partitions, Some(total_input_bytes))
+    }
 }
 
 #[derive(Default)]
@@ -12955,11 +12955,21 @@ mod tests {
         use arrow::datatypes::{DataType, Field, Schema};
 
         const TRIGGER: usize = 4;
-        /// Rows per snapshot × ~2 KiB payload ≈ 400 KiB per snapshot; six
-        /// snapshots ≈ 2.4 MiB total — more than two 1 MiB target files, so
-        /// the merge earns >1 encoder shard.
+        /// Rows per snapshot × ~4 KiB payload ≈ 800 KiB raw per snapshot; six
+        /// snapshots ≈ 4.8 MiB raw. The shard gate sizes the fan-out from
+        /// ON-DISK bytes (`list_snapshot_files_with_sizes`), so the payload is
+        /// pseudo-random (near-incompressible — see [`entropy_payload`]) to
+        /// keep on-disk ≈ raw, and the test still does not *assume* a
+        /// compression ratio: it measures the merged inputs' on-disk total
+        /// and asserts it clears two 1 MiB target files before relying on the
+        /// widened path. (A repetitive payload compresses ~6:1 here, leaving
+        /// the gate at one shard — the multi-file output would then come from
+        /// serial file rolling and the test would pass without exercising the
+        /// parallel path at all.)
         const ROWS_PER_SNAPSHOT: i64 = 200;
-        const PAYLOAD_BYTES: usize = 2048;
+        const PAYLOAD_BYTES: usize = 4096;
+        // Mirrors `target_vortex_file_size_mb: 1` in the fixture config.
+        const TARGET_FILE_SIZE_BYTES: u64 = 1024 * 1024;
 
         let ctx = SessionContext::new();
         let temp_dir = tempfile::tempdir().expect("temp dir");
@@ -13018,7 +13028,7 @@ mod tests {
             let ids: Vec<i64> = (start..start + ROWS_PER_SNAPSHOT).collect();
             let payloads: Vec<String> = ids
                 .iter()
-                .map(|id| format!("{id:08}_{}", "p".repeat(PAYLOAD_BYTES)))
+                .map(|id| format!("{id:08}_{}", entropy_payload(*id, PAYLOAD_BYTES)))
                 .collect();
             let batch = RecordBatch::try_new(
                 Arc::clone(&schema),
@@ -13042,6 +13052,18 @@ mod tests {
             before.len() >= TRIGGER,
             "expected >= {TRIGGER} protected snapshots before compaction"
         );
+        // Record each input snapshot's ON-DISK size before compaction (the
+        // inputs may be cleaned up after the merge). The shard gate sizes the
+        // fan-out from these on-disk bytes, so the engagement precondition
+        // below must be pinned against them — not the raw payload bytes.
+        let mut on_disk_bytes: std::collections::HashMap<String, u64> =
+            std::collections::HashMap::with_capacity(before.len());
+        for id in &before {
+            let dir = std::path::Path::new(&data_dir)
+                .join(&provider.table_metadata.table_id)
+                .join(id);
+            on_disk_bytes.insert(id.clone(), sum_vortex_file_bytes(&dir).await);
+        }
         drop(compaction_setup_guard);
 
         let merged = provider
@@ -13057,6 +13079,26 @@ mod tests {
             .find(|id| !before.contains(*id))
             .expect("the merge must publish a new protected snapshot")
             .clone();
+
+        // Engagement precondition: the snapshots this merge consumed must
+        // exceed two target files ON DISK, or `snapshot_shard_count`
+        // (`floor(bytes / target_file_size)`, min 1) never earns a second
+        // shard and the `shard_files > 1` assertion below tests nothing. If
+        // a future encoding change compresses this fixture below the bar,
+        // fail HERE with the cause instead of as a mysterious single-file
+        // merge.
+        let merged_input_bytes: u64 = before
+            .iter()
+            .filter(|id| !after.contains_key(id.as_str()))
+            .map(|id| on_disk_bytes[id])
+            .sum();
+        assert!(
+            merged_input_bytes > 2 * TARGET_FILE_SIZE_BYTES,
+            "fixture precondition: merged inputs must exceed two 1 MiB target \
+             files on disk to earn >1 encoder shard (got {merged_input_bytes} \
+             bytes) — grow ROWS_PER_SNAPSHOT/PAYLOAD_BYTES or make the \
+             payload less compressible"
+        );
         let snapshot_dir = std::path::Path::new(&data_dir)
             .join(&provider.table_metadata.table_id)
             .join(&new_snapshot);
@@ -13071,10 +13113,18 @@ mod tests {
             "a merge spanning multiple target files must produce multiple \
              output files (got {shard_files})"
         );
+        // Upper bound: at most DEFAULT_WRITE_CONCURRENCY shard writers, each
+        // of which may additionally roll its stream at the target file size —
+        // so the ceiling is shards + (input bytes ÷ target size) roll-overs.
+        // Generous on purpose: it catches pathological per-batch/per-row file
+        // explosion without re-deriving the writer's exact roll math.
+        let max_expected_files = DEFAULT_WRITE_CONCURRENCY
+            + usize::try_from(merged_input_bytes / TARGET_FILE_SIZE_BYTES)
+                .expect("file-count bound fits usize");
         assert!(
-            shard_files <= DEFAULT_WRITE_CONCURRENCY,
-            "output file count must stay bounded by the write concurrency \
-             (got {shard_files} > {DEFAULT_WRITE_CONCURRENCY})"
+            shard_files <= max_expected_files,
+            "output file count must stay bounded by write concurrency plus \
+             target-size roll-overs (got {shard_files} > {max_expected_files})"
         );
 
         // Every row survives the parallel merge — content, not just count:
@@ -13119,6 +13169,50 @@ mod tests {
             }
         }
         shard_files
+    }
+
+    /// Deterministic pseudo-random payload (xorshift64 over a 64-symbol
+    /// alphabet), near-incompressible so on-disk size tracks raw size — the
+    /// subset-merge shard gate reads ON-DISK bytes, and a repetitive payload
+    /// compresses far below the target-file threshold the tests must cross.
+    /// Seeded per row id so payloads are unique and reproducible.
+    fn entropy_payload(seed: i64, len: usize) -> String {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        // Bit-preserving i64 -> u64; the splitmix-style multiply spreads
+        // small sequential ids across the state space, `| 1` avoids the
+        // xorshift zero fixed point.
+        let mut state =
+            u64::from_le_bytes(seed.to_le_bytes()).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+        let mut out = String::with_capacity(len);
+        while out.len() < len {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            for byte in state.to_le_bytes() {
+                if out.len() >= len {
+                    break;
+                }
+                out.push(char::from(ALPHABET[usize::from(byte & 63)]));
+            }
+        }
+        out
+    }
+
+    /// Sum the on-disk bytes of `.vortex` files in a snapshot directory —
+    /// the same quantity `list_snapshot_files_with_sizes` feeds the shard
+    /// gate as `total_input_bytes`.
+    async fn sum_vortex_file_bytes(snapshot_dir: &std::path::Path) -> u64 {
+        let mut total = 0_u64;
+        let mut entries = tokio::fs::read_dir(snapshot_dir)
+            .await
+            .expect("read snapshot dir");
+        while let Some(entry) = entries.next_entry().await.expect("dir entry") {
+            if entry.path().extension().is_some_and(|ext| ext == "vortex") {
+                total += entry.metadata().await.expect("file metadata").len();
+            }
+        }
+        total
     }
 
     /// Sibling of the parallel-merge engagement test: a PK table left on the

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2343,6 +2343,34 @@ fn protected_snapshot_size_tier(bytes: u64, base_bytes: u64, growth: u64) -> u32
 /// bounds write amplification to O(log N) per byte (a run is rewritten only
 /// when it levels up), while the `min_runs` threshold bounds read amplification
 /// by keeping at most `min_runs - 1` un-merged runs per tier. The large
+/// Write shape — encoder fan-out cap and size estimate — for the
+/// subset-merge output (see `compact_protected_snapshots_subset`).
+///
+/// Pure so the position-vs-key parallel decision is unit-testable: when
+/// `keeps_positions_serial` (the table carries position-scoped deletes —
+/// either a PK table whose resolved `deletion_mode` is `position`, or a
+/// PK-less table on the legacy `PositionBased` strategy), the merge keeps the
+/// serial single-writer shape `(1, None)`; otherwise it passes the session's
+/// `target_partitions` and the selected tier's total bytes so
+/// `snapshot_shard_count` sizes a parallel encoder fan-out
+/// (floor(bytes / target_file_size), min 1, capped by write concurrency and
+/// the global encode budget).
+///
+/// Note: output FILE COUNT is not a proxy for this decision — a single
+/// serial writer still rolls multiple files when the merged output exceeds
+/// the target file size. This function is the authoritative, testable gate.
+const fn subset_merge_write_shape(
+    keeps_positions_serial: bool,
+    session_target_partitions: usize,
+    total_input_bytes: u64,
+) -> (usize, Option<u64>) {
+    if keeps_positions_serial {
+        (1, None)
+    } else {
+        (session_target_partitions, Some(total_input_bytes))
+    }
+}
+
 /// carried-forward run sits alone in a high tier and is rewritten rarely
 /// instead of on every pass.
 ///
@@ -8696,12 +8724,13 @@ impl CayenneTableProvider {
         let target_size_bytes = self.context.target_file_size_bytes();
         // Size-aware parallel merge encode (EFF-1 / Pattern 12). Passing the
         // selected inputs' total bytes lets `snapshot_shard_count` size the
-        // encoder fan-out as ceil(bytes / target_file_size), capped at the
+        // encoder fan-out as floor(bytes / target_file_size), min 1 — a
+        // second shard is earned at >= 2x the target size — capped at the
         // write concurrency and the process-global encode budget:
         //
-        // - a merge whose output fits one target file still floors to ONE
-        //   shard — exactly one output file, so the read fan-out this
-        //   compaction exists to collapse is unchanged for small merges;
+        // - a merge whose output fits one target file stays exactly ONE
+        //   shard / one output file, so the read fan-out this compaction
+        //   exists to collapse is unchanged for small merges;
         // - a merge spanning multiple target files was always going to emit
         //   multiple files; it now encodes them in parallel (PK-hash
         //   clustered, like the append path) instead of streaming the whole
@@ -8711,15 +8740,20 @@ impl CayenneTableProvider {
         // - sorted tables: `snapshot_shard_count` returns 1 when
         //   `has_sort_columns()` — sharding a globally sorted stream would
         //   scatter its order across files;
-        // - position-delete tables: their tombstones are file-path scoped and
-        //   the rewrite's position bake-in assumes a single output sequence,
-        //   so they keep the serial single-file shape explicitly.
-        let (target_partitions, estimated_bytes) = if self.pk_deletion_strategy.is_position_based()
-        {
-            (1, None)
-        } else {
-            (state.config().target_partitions(), Some(total_input_bytes))
-        };
+        // - position-delete tables — BOTH families: PK tables whose resolved
+        //   `deletion_mode` is `position` (`serialize_position_deletes`, the
+        //   same predicate this function's writer/visibility guards use
+        //   above) and PK-less tables on the legacy `PositionBased` strategy.
+        //   Their tombstones are file-path scoped and the rewrite's position
+        //   bake-in assumes a single output sequence, so they keep the serial
+        //   single-file shape explicitly.
+        let keeps_positions_serial =
+            serialize_position_deletes || self.pk_deletion_strategy.is_position_based();
+        let (target_partitions, estimated_bytes) = subset_merge_write_shape(
+            keeps_positions_serial,
+            state.config().target_partitions(),
+            total_input_bytes,
+        );
         let write_start = std::time::Instant::now();
         let write_result = self
             .write_to_snapshot(
@@ -12571,6 +12605,30 @@ mod tests {
     }
 
     #[test]
+    fn subset_merge_write_shape_serializes_position_tables_only() {
+        // The gate the parallel-compaction change rides on (review-caught:
+        // an earlier revision keyed on `is_position_based()` alone, which
+        // covers only PK-less tables and would have widened PK tables whose
+        // resolved deletion_mode is `position`).
+        const CORES: usize = 16;
+        const BYTES: u64 = 64 * 1024 * 1024;
+
+        // Position-scoped deletes (either family) => serial single writer.
+        assert_eq!(
+            subset_merge_write_shape(true, CORES, BYTES),
+            (1, None),
+            "position tables must keep the serial (1, None) merge shape"
+        );
+        // Key/no-delete tables => widened, size-estimated parallel shape.
+        assert_eq!(
+            subset_merge_write_shape(false, CORES, BYTES),
+            (CORES, Some(BYTES)),
+            "non-position tables must widen to the session partitions with \
+             the tier's byte estimate"
+        );
+    }
+
+    #[test]
     fn protected_snapshot_size_tier_classifies_by_geometric_ceilings() {
         let base = 8 * 1024 * 1024; // 8 MiB
         let growth = 8;
@@ -12907,7 +12965,9 @@ mod tests {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let metadata_dir = format!("{}/metadata", temp_dir.path().to_str().expect("str path"));
         let data_dir = format!("{}/data", temp_dir.path().to_str().expect("str path"));
-        std::fs::create_dir_all(&metadata_dir).expect("metadata dir created");
+        tokio::fs::create_dir_all(&metadata_dir)
+            .await
+            .expect("metadata dir created");
         let connection_string = format!("sqlite://{metadata_dir}/cayenne.db");
         let catalog = Arc::new(CayenneCatalog::new(connection_string).expect("catalog created"))
             as Arc<dyn MetadataCatalog>;
@@ -12934,6 +12994,13 @@ mod tests {
                 target_vortex_file_size_mb: 1,
                 compaction_trigger_protected_snapshots: TRIGGER,
                 compaction_background_interval_ms: 3_600_000,
+                // The parallel-merge path requires a NON-position deletion
+                // mode: the default (`auto`) resolves to `position` for PK
+                // tables, which the gate deliberately keeps single-writer
+                // (file-path-scoped tombstones). Pin `key` so this test
+                // exercises the widened path; the sibling test below pins
+                // that position-mode tables stay serial.
+                deletion_mode: crate::metadata::DeletionMode::Key,
                 ..VortexConfig::default()
             },
         };
@@ -12993,27 +13060,185 @@ mod tests {
         let snapshot_dir = std::path::Path::new(&data_dir)
             .join(&provider.table_metadata.table_id)
             .join(&new_snapshot);
+        // NOTE: >1 files alone does not prove PARALLEL encode (a serial
+        // writer also rolls files past the target size) — the widened-shape
+        // decision is pinned by the pure `subset_merge_write_shape` unit
+        // test. This bounds the fan-out and smoke-tests the multi-file merge
+        // output end-to-end.
+        let shard_files = count_vortex_files(&snapshot_dir).await;
+        assert!(
+            shard_files > 1,
+            "a merge spanning multiple target files must produce multiple \
+             output files (got {shard_files})"
+        );
+        assert!(
+            shard_files <= DEFAULT_WRITE_CONCURRENCY,
+            "output file count must stay bounded by the write concurrency \
+             (got {shard_files} > {DEFAULT_WRITE_CONCURRENCY})"
+        );
+
+        // Every row survives the parallel merge — content, not just count:
+        // collect the id column, sort, and compare against the exact expected
+        // id set (a pathological regression could drop some ids and duplicate
+        // others while keeping the total stable).
+        let scan_ctx = SessionContext::new();
+        let plan = provider
+            .scan(&scan_ctx.state(), Some(&vec![0]), &[], None)
+            .await
+            .expect("scan plan");
+        let batches = datafusion::physical_plan::collect(plan, scan_ctx.task_ctx())
+            .await
+            .expect("collect rows");
+        let mut scanned_ids: Vec<i64> = Vec::with_capacity(expected_rows);
+        for batch in &batches {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id column");
+            scanned_ids.extend(ids.values().iter().copied());
+        }
+        scanned_ids.sort_unstable();
+        let expected_ids: Vec<i64> = (0..snapshots * ROWS_PER_SNAPSHOT).collect();
+        assert_eq!(
+            scanned_ids, expected_ids,
+            "parallel merge must preserve exactly the inserted id set"
+        );
+    }
+
+    /// Count `.vortex` files in a snapshot directory (async fs — keeps the
+    /// tokio worker unblocked in async tests).
+    async fn count_vortex_files(snapshot_dir: &std::path::Path) -> usize {
         let mut shard_files = 0_usize;
-        for entry in std::fs::read_dir(&snapshot_dir).expect("read merged snapshot dir") {
-            let entry = entry.expect("dir entry");
+        let mut entries = tokio::fs::read_dir(snapshot_dir)
+            .await
+            .expect("read merged snapshot dir");
+        while let Some(entry) = entries.next_entry().await.expect("dir entry") {
             if entry.path().extension().is_some_and(|ext| ext == "vortex") {
                 shard_files += 1;
             }
         }
+        shard_files
+    }
+
+    /// Sibling of the parallel-merge engagement test: a PK table left on the
+    /// DEFAULT deletion mode (`auto` resolves to `position`) must keep the
+    /// serial single-file merge shape even when the tier spans multiple
+    /// target files — position tombstones are file-path scoped and the
+    /// rewrite's bake-in assumes one output sequence. Pins the
+    /// `serialize_position_deletes || is_position_based()` gate.
+    #[tokio::test]
+    async fn protected_snapshot_subset_compaction_keeps_position_mode_serial() {
+        use arrow::array::StringArray;
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        const TRIGGER: usize = 4;
+        const ROWS_PER_SNAPSHOT: i64 = 200;
+        const PAYLOAD_BYTES: usize = 2048;
+
+        let ctx = SessionContext::new();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let metadata_dir = format!("{}/metadata", temp_dir.path().to_str().expect("str path"));
+        let data_dir = format!("{}/data", temp_dir.path().to_str().expect("str path"));
+        tokio::fs::create_dir_all(&metadata_dir)
+            .await
+            .expect("metadata dir created");
+        let connection_string = format!("sqlite://{metadata_dir}/cayenne.db");
+        let catalog = Arc::new(CayenneCatalog::new(connection_string).expect("catalog created"))
+            as Arc<dyn MetadataCatalog>;
+        catalog.init().await.expect("catalog initialized");
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::Utf8, false),
+        ]));
+        let options = CreateTableOptions {
+            table_name: "compact_subset_position_serial".to_string(),
+            schema: Arc::clone(&schema),
+            primary_key: vec!["id".to_string()],
+            on_conflict: Some(OnConflict::Upsert(
+                datafusion_table_providers::util::column_reference::ColumnReference::new(vec![
+                    "id".to_string(),
+                ]),
+            )),
+            base_path: data_dir.clone(),
+            partition_column: None,
+            vortex_config: VortexConfig {
+                inline_max_rows: 0,
+                target_vortex_file_size_mb: 1,
+                compaction_trigger_protected_snapshots: TRIGGER,
+                compaction_background_interval_ms: 3_600_000,
+                // Deliberately NOT overridden: default `auto` resolves to
+                // `position` for this PK table — the case that must stay
+                // serial.
+                ..VortexConfig::default()
+            },
+        };
+        let provider = CayenneTableProviderBuilder::new(Arc::clone(&catalog), ctx.runtime_env())
+            .create(options)
+            .await
+            .expect("table created");
         assert!(
-            shard_files > 1,
-            "a merge spanning multiple target files must encode in parallel \
-             shards (got {shard_files} file; the size estimate or the \
-             target_partitions widening never reached write_to_snapshot)"
-        );
-        assert!(
-            shard_files <= DEFAULT_WRITE_CONCURRENCY,
-            "shard fan-out must stay bounded by the write concurrency \
-             (got {shard_files} > {DEFAULT_WRITE_CONCURRENCY})"
+            provider.should_capture_positions(),
+            "fixture must resolve to position mode or this test pins nothing"
         );
 
-        // Every row survives the parallel merge: scan through the provider
-        // directly (projection = id only) and sum the row counts.
+        let compaction_setup_guard = provider.compaction_lock.lock().await;
+        let snapshots = i64::try_from(TRIGGER).expect("TRIGGER fits in i64") + 2;
+        let mut expected_rows: usize = 0;
+        for snapshot in 0..snapshots {
+            let start = snapshot * ROWS_PER_SNAPSHOT;
+            let ids: Vec<i64> = (start..start + ROWS_PER_SNAPSHOT).collect();
+            let payloads: Vec<String> = ids
+                .iter()
+                .map(|id| format!("{id:08}_{}", "p".repeat(PAYLOAD_BYTES)))
+                .collect();
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from(ids)),
+                    Arc::new(StringArray::from(payloads)),
+                ],
+            )
+            .expect("payload batch");
+            expected_rows += batch.num_rows();
+            insert_batch(&provider, batch).await;
+        }
+        let before: std::collections::HashSet<String> = provider
+            .protected_snapshots
+            .load_full()
+            .keys()
+            .cloned()
+            .collect();
+        drop(compaction_setup_guard);
+
+        let merged = provider
+            .compact_protected_snapshots_subset(usize::MAX)
+            .await
+            .expect("compaction should not error");
+        assert!(merged, "a tier with >= {TRIGGER} runs should have merged");
+
+        let after = provider.protected_snapshots.load_full();
+        let new_snapshot = after
+            .keys()
+            .find(|id| !before.contains(*id))
+            .expect("the merge must publish a new protected snapshot")
+            .clone();
+        let snapshot_dir = std::path::Path::new(&data_dir)
+            .join(&provider.table_metadata.table_id)
+            .join(&new_snapshot);
+        // File count is NOT asserted == 1: even the serial writer rolls
+        // multiple files when the merged output exceeds the target file size
+        // (this payload does). The serial-shape decision itself is pinned by
+        // the pure `subset_merge_write_shape` unit test; this test pins the
+        // end-to-end correctness of a position-mode merge under the corrected
+        // gate, with the count only bounded.
+        let shard_files = count_vortex_files(&snapshot_dir).await;
+        assert!(
+            shard_files >= 1 && shard_files <= DEFAULT_WRITE_CONCURRENCY,
+            "position-mode merge output file count out of bounds: {shard_files}"
+        );
+
         let scan_ctx = SessionContext::new();
         let plan = provider
             .scan(&scan_ctx.state(), Some(&vec![0]), &[], None)
@@ -13025,7 +13250,7 @@ mod tests {
         let scanned_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(
             scanned_rows, expected_rows,
-            "parallel merge must preserve every visible row"
+            "position-mode merge must preserve every visible row"
         );
     }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2411,7 +2411,16 @@ const fn subset_merge_write_shape(
     if keeps_positions_serial {
         (1, None)
     } else {
-        (session_target_partitions, Some(total_input_bytes))
+        // Clamp to >= 1, matching the defensive treatment of
+        // `target_partitions` elsewhere (e.g. vortex `format.rs` and the
+        // runtime builder treat 0 as invalid): a zeroed session config must
+        // not propagate a 0 cap into the write path.
+        let cap = if session_target_partitions == 0 {
+            1
+        } else {
+            session_target_partitions
+        };
+        (cap, Some(total_input_bytes))
     }
 }
 
@@ -8795,7 +8804,9 @@ impl CayenneTableProvider {
         //   above) and PK-less tables on the legacy `PositionBased` strategy.
         //   Their tombstones are file-path scoped and the rewrite's position
         //   bake-in assumes a single output sequence, so they keep the serial
-        //   single-file shape explicitly.
+        //   single-WRITER shape explicitly (even a serial writer still rolls
+        //   multiple files past the target size — see the
+        //   `subset_merge_write_shape` docs).
         let keeps_positions_serial =
             serialize_position_deletes || self.pk_deletion_strategy.is_position_based();
         let (target_partitions, estimated_bytes) = subset_merge_write_shape(
@@ -12678,6 +12689,13 @@ mod tests {
             (CORES, Some(BYTES)),
             "non-position tables must widen to the session partitions with \
              the tier's byte estimate"
+        );
+        // A zeroed session config must not propagate a 0 cap (defensive
+        // parity with `target_partitions().max(1)` call sites elsewhere).
+        assert_eq!(
+            subset_merge_write_shape(false, 0, BYTES),
+            (1, Some(BYTES)),
+            "target_partitions == 0 must clamp to a single writer, not zero"
         );
     }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -8694,9 +8694,32 @@ impl CayenneTableProvider {
         }
 
         let target_size_bytes = self.context.target_file_size_bytes();
-        // Protected-snapshot compaction exists to collapse read fan-out, so do
-        // not use the append-time write shard fan-out for the merged output.
-        let target_partitions = 1;
+        // Size-aware parallel merge encode (EFF-1 / Pattern 12). Passing the
+        // selected inputs' total bytes lets `snapshot_shard_count` size the
+        // encoder fan-out as ceil(bytes / target_file_size), capped at the
+        // write concurrency and the process-global encode budget:
+        //
+        // - a merge whose output fits one target file still floors to ONE
+        //   shard — exactly one output file, so the read fan-out this
+        //   compaction exists to collapse is unchanged for small merges;
+        // - a merge spanning multiple target files was always going to emit
+        //   multiple files; it now encodes them in parallel (PK-hash
+        //   clustered, like the append path) instead of streaming the whole
+        //   tier through one core.
+        //
+        // Two single-writer safety cases are preserved:
+        // - sorted tables: `snapshot_shard_count` returns 1 when
+        //   `has_sort_columns()` — sharding a globally sorted stream would
+        //   scatter its order across files;
+        // - position-delete tables: their tombstones are file-path scoped and
+        //   the rewrite's position bake-in assumes a single output sequence,
+        //   so they keep the serial single-file shape explicitly.
+        let (target_partitions, estimated_bytes) = if self.pk_deletion_strategy.is_position_based()
+        {
+            (1, None)
+        } else {
+            (state.config().target_partitions(), Some(total_input_bytes))
+        };
         let write_start = std::time::Instant::now();
         let write_result = self
             .write_to_snapshot(
@@ -8704,10 +8727,10 @@ impl CayenneTableProvider {
                 target_size_bytes,
                 &new_snapshot_id,
                 target_partitions,
-                // Protected-snapshot compaction pins `target_partitions = 1` to
-                // collapse read fan-out, so the shard count is forced to 1; no
-                // size estimate needed.
-                None,
+                // Total bytes of the selected tier inputs — the size estimate
+                // that drives the shard-count floor above. `None` (single
+                // serial writer) for position-delete tables.
+                estimated_bytes,
             )
             .await;
 
@@ -12860,6 +12883,150 @@ mod tests {
                 persisted.get(id),
             );
         }
+    }
+
+    /// Engagement test for the size-aware PARALLEL merge encode: a subset
+    /// merge whose selected inputs exceed one target file must shard its
+    /// output across multiple concurrently-encoded files (bounded by the
+    /// write concurrency), while preserving every visible row. The sibling
+    /// test above covers the floor: a merge smaller than one target file
+    /// stays a single output file (read fan-out unchanged).
+    #[tokio::test]
+    async fn protected_snapshot_subset_compaction_parallelizes_large_merges() {
+        use arrow::array::{Int64Array, StringArray};
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        const TRIGGER: usize = 4;
+        /// Rows per snapshot × ~2 KiB payload ≈ 400 KiB per snapshot; six
+        /// snapshots ≈ 2.4 MiB total — more than two 1 MiB target files, so
+        /// the merge earns >1 encoder shard.
+        const ROWS_PER_SNAPSHOT: i64 = 200;
+        const PAYLOAD_BYTES: usize = 2048;
+
+        let ctx = SessionContext::new();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let metadata_dir = format!("{}/metadata", temp_dir.path().to_str().expect("str path"));
+        let data_dir = format!("{}/data", temp_dir.path().to_str().expect("str path"));
+        std::fs::create_dir_all(&metadata_dir).expect("metadata dir created");
+        let connection_string = format!("sqlite://{metadata_dir}/cayenne.db");
+        let catalog = Arc::new(CayenneCatalog::new(connection_string).expect("catalog created"))
+            as Arc<dyn MetadataCatalog>;
+        catalog.init().await.expect("catalog initialized");
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::Utf8, false),
+        ]));
+        let options = CreateTableOptions {
+            table_name: "compact_subset_parallel".to_string(),
+            schema: Arc::clone(&schema),
+            primary_key: vec!["id".to_string()],
+            on_conflict: Some(OnConflict::Upsert(
+                datafusion_table_providers::util::column_reference::ColumnReference::new(vec![
+                    "id".to_string(),
+                ]),
+            )),
+            base_path: data_dir.clone(),
+            partition_column: None,
+            vortex_config: VortexConfig {
+                inline_max_rows: 0,
+                // 1 MiB target files so the merged tier spans several of them.
+                target_vortex_file_size_mb: 1,
+                compaction_trigger_protected_snapshots: TRIGGER,
+                compaction_background_interval_ms: 3_600_000,
+                ..VortexConfig::default()
+            },
+        };
+        let provider = CayenneTableProviderBuilder::new(Arc::clone(&catalog), ctx.runtime_env())
+            .create(options)
+            .await
+            .expect("table created");
+
+        let compaction_setup_guard = provider.compaction_lock.lock().await;
+
+        let snapshots = i64::try_from(TRIGGER).expect("TRIGGER fits in i64") + 2;
+        let mut expected_rows: usize = 0;
+        for snapshot in 0..snapshots {
+            let start = snapshot * ROWS_PER_SNAPSHOT;
+            let ids: Vec<i64> = (start..start + ROWS_PER_SNAPSHOT).collect();
+            let payloads: Vec<String> = ids
+                .iter()
+                .map(|id| format!("{id:08}_{}", "p".repeat(PAYLOAD_BYTES)))
+                .collect();
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from(ids)),
+                    Arc::new(StringArray::from(payloads)),
+                ],
+            )
+            .expect("payload batch");
+            expected_rows += batch.num_rows();
+            insert_batch(&provider, batch).await;
+        }
+
+        let before: std::collections::HashSet<String> = provider
+            .protected_snapshots
+            .load_full()
+            .keys()
+            .cloned()
+            .collect();
+        assert!(
+            before.len() >= TRIGGER,
+            "expected >= {TRIGGER} protected snapshots before compaction"
+        );
+        drop(compaction_setup_guard);
+
+        let merged = provider
+            .compact_protected_snapshots_subset(usize::MAX)
+            .await
+            .expect("compaction should not error");
+        assert!(merged, "a tier with >= {TRIGGER} runs should have merged");
+
+        // Find the NEW merged snapshot and count its vortex shard files.
+        let after = provider.protected_snapshots.load_full();
+        let new_snapshot = after
+            .keys()
+            .find(|id| !before.contains(*id))
+            .expect("the merge must publish a new protected snapshot")
+            .clone();
+        let snapshot_dir = std::path::Path::new(&data_dir)
+            .join(&provider.table_metadata.table_id)
+            .join(&new_snapshot);
+        let mut shard_files = 0_usize;
+        for entry in std::fs::read_dir(&snapshot_dir).expect("read merged snapshot dir") {
+            let entry = entry.expect("dir entry");
+            if entry.path().extension().is_some_and(|ext| ext == "vortex") {
+                shard_files += 1;
+            }
+        }
+        assert!(
+            shard_files > 1,
+            "a merge spanning multiple target files must encode in parallel \
+             shards (got {shard_files} file; the size estimate or the \
+             target_partitions widening never reached write_to_snapshot)"
+        );
+        assert!(
+            shard_files <= DEFAULT_WRITE_CONCURRENCY,
+            "shard fan-out must stay bounded by the write concurrency \
+             (got {shard_files} > {DEFAULT_WRITE_CONCURRENCY})"
+        );
+
+        // Every row survives the parallel merge: scan through the provider
+        // directly (projection = id only) and sum the row counts.
+        let scan_ctx = SessionContext::new();
+        let plan = provider
+            .scan(&scan_ctx.state(), Some(&vec![0]), &[], None)
+            .await
+            .expect("scan plan");
+        let batches = datafusion::physical_plan::collect(plan, scan_ctx.task_ctx())
+            .await
+            .expect("collect rows");
+        let scanned_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(
+            scanned_rows, expected_rows,
+            "parallel merge must preserve every visible row"
+        );
     }
 
     #[test]

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2353,8 +2353,8 @@ fn protected_snapshot_size_tier(bytes: u64, base_bytes: u64, growth: u64) -> u32
 /// serial single-writer shape `(1, None)`; otherwise it passes the session's
 /// `target_partitions` and the selected tier's total bytes so
 /// `snapshot_shard_count` sizes a parallel encoder fan-out
-/// (floor(bytes / target_file_size), min 1, capped by write concurrency and
-/// the global encode budget).
+/// (`floor(bytes / target_file_size)`, min 1, capped by write concurrency
+/// and the global encode budget).
 ///
 /// Note: output FILE COUNT is not a proxy for this decision — a single
 /// serial writer still rolls multiple files when the merged output exceeds
@@ -13235,7 +13235,7 @@ mod tests {
         // gate, with the count only bounded.
         let shard_files = count_vortex_files(&snapshot_dir).await;
         assert!(
-            shard_files >= 1 && shard_files <= DEFAULT_WRITE_CONCURRENCY,
+            (1..=DEFAULT_WRITE_CONCURRENCY).contains(&shard_files),
             "position-mode merge output file count out of bounds: {shard_files}"
         );
 


### PR DESCRIPTION
## Problem (EFF-1 / Pattern 12 from the Jun-5 audit)

The live tiered compaction path (`compact_protected_snapshots_subset`) pinned `target_partitions = 1` and passed no size estimate to `write_to_snapshot` — so while the UnionExec **read** side of a tier merge parallelizes, the CPU-heavy Vortex **encode** streamed through one core regardless of merge size. Measured headroom (in-repo `compaction_sort_serialization`, 16-core): serial sort-then-write **23.0 ms** vs sort-preserving parallel merge **7.1 ms** at 1M rows (**3.2×**), growing with size. Compaction drain rate is a sustained-CDC net-ingest factor: it's what keeps the protected-snapshot tier from backing up under load (and what makes light delta encoding's trade net-positive).

## Change

Reuse the append path's size-aware sharding — pass the selected tier inputs' **total bytes** (already computed for diagnostics) as the size estimate and the session's `target_partitions` as the cap, so `snapshot_shard_count` sizes the encoder fan-out as `floor(input_bytes / target_file_size)` (min 1 — a merge earns its second shard only once it fully fills a target file), bounded by the write concurrency **and the process-global encode budget** (`write_budget`, so a fleet of compacting tables can't oversubscribe the box).

| merge size | before | after |
|---|---|---|
| < 1 target file (steady-state small tiers) | 1 file, 1 core | **unchanged** — floors to 1 shard, 1 file |
| > 1 target file | N files…encoded serially through 1 core | same N files, **encoded in parallel** (PK-hash clustered, like appends) |

## Single-writer safety preserved (the constraints that made naive widening wrong)

- **Sorted tables**: `snapshot_shard_count` returns 1 when `has_sort_columns()` — sharding a globally sorted stream would scatter its order across files (`table.rs` test `test_write_shard_format_sorted_single_writer` pins this).
- **Position-delete tables**: explicit `(1, None)` serial shape — their tombstones are file-path scoped and the rewrite's position bake-in assumes a single output sequence.

## Tests

New **engagement test** (`protected_snapshot_subset_compaction_parallelizes_large_merges`): a ~2.4 MiB tier merge against 1 MiB target files must produce **>1 and ≤ write-concurrency** shard files AND preserve every visible row — fails loudly if the estimate/widening never reaches `write_to_snapshot`. The existing subset test doubles as the **floor proof** (small tiers still produce a single file). Suites green: subset-compaction (2), `small_files_compaction` (18), `acid_compliance` (13), `position_based_deletion` (8), `sort_rewrite` (11). CI-flag clippy (both passes) clean.

## Follow-up (not here)

Phase 2 of the audit plan — key-RANGE sharded merges for **sorted** tables (order-preserving parallel encode, RocksDB-subcompaction shape) — needs the range-partitioned write mode and the scan-side ordering contract; tracked in the audit report.
