### PR TITLE
bench(cayenne): paired memory-budget, scan-under-compaction, and fleet-CDC benches vs DuckDB

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -252,6 +252,21 @@ required-features = ["duckdb-bench"]
 
 [[bench]]
 harness = false
+name = "vs_duckdb_memory_budget"
+required-features = ["duckdb-bench"]
+
+[[bench]]
+harness = false
+name = "vs_duckdb_scan_under_compaction"
+required-features = ["duckdb-bench"]
+
+[[bench]]
+harness = false
+name = "vs_duckdb_cdc_multitable"
+required-features = ["duckdb-bench"]
+
+[[bench]]
+harness = false
 name = "compaction_picker"
 
 [[bench]]

--- a/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
+++ b/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
@@ -1,0 +1,265 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Fleet CDC: sustained CDC apply across N tables concurrently.
+//!
+//! `vs_duckdb_scaling_cdc` pumps ONE table with N writers; this bench pumps
+//! N TABLES with one CDC writer each — the real HTAP topology (CH-benCH is
+//! 14 CDC datasets, each its own accelerator with its own metastore). The
+//! distinction matters because per-table write concurrency is sized in
+//! isolation: with T tables the effective encoder demand is the SUM across
+//! tables, which oversubscribes the box in exactly the way a single-table
+//! bench structurally cannot see. This curve is the micro-proxy guarding
+//! the global write-budget work.
+//!
+//! - **Cayenne**: each table is a fully independent fixture (own metastore,
+//!   own data dir — the per-dataset topology spiced creates). One persistent
+//!   writer task per table pumps `write_cdc_append_stream + finish()` (the
+//!   production `refresh_mode: changes` path) with a long-lived per-writer
+//!   `SessionContext`, batches of `WRITE_BATCH_ROWS` appends per tick.
+//! - **DuckDB**: one file-backed database with N tables; one writer thread
+//!   per table, each with its own `Connection`. DuckDB serializes writers
+//!   internally — the single-global-writer architecture Cayenne's
+//!   per-table encoders are traded against.
+//!
+//! Criterion `Throughput::Elements(N × WRITE_BATCH_ROWS)` makes the report
+//! read as aggregate rows/sec; a flat (or falling) elements-per-second curve
+//! as N grows is the oversubscription signal.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::sync::Arc;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use duckdb::Connection;
+use tokio::runtime::Runtime;
+
+use common::{
+    CAYENNE_LANES, CayenneFixture, cayenne_cdc_write, duckdb_insert_rows, make_batch, schema,
+    setup_cayenne_for, setup_duckdb,
+};
+
+/// Table-count sweep. 14 ≈ CH-benCH's table fleet; 16 keeps the axis on a
+/// power-of-two grid while covering it.
+const TABLE_COUNTS: &[usize] = &[1, 2, 4, 8, 16];
+
+/// Rows per CDC batch per table per tick — matches
+/// `vs_duckdb_scaling`'s WRITE_BATCH_ROWS so the N=1 lane of this bench is
+/// directly comparable to that bench's concurrency=1 CDC lane.
+const WRITE_BATCH_ROWS: usize = 1_024;
+
+/// Per-completion wait bound: a stalled writer surfaces as a labeled panic
+/// instead of a hung bench (same rationale as `vs_duckdb_scaling`).
+const COMPLETION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Persistent CDC writer task bound to ONE Cayenne table. Receives a tick,
+/// writes one batch through the production CDC path, signals done.
+struct CayenneTableWriter {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl CayenneTableWriter {
+    fn spawn(
+        rt: &Runtime,
+        fixture: Arc<CayenneFixture>,
+        mut go_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+        done_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    ) -> Self {
+        let handle = rt.spawn(async move {
+            // One long-lived session per writer — the long-running refresh
+            // loop shape (see `cayenne_cdc_write` docs for why per-batch
+            // SessionContext construction would dominate).
+            let ctx = datafusion::prelude::SessionContext::new();
+            let task_ctx = ctx.task_ctx();
+            let mut cursor: i64 = 0;
+            while go_rx.recv().await.is_some() {
+                let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
+                cursor += WRITE_BATCH_ROWS as i64;
+                let rows = cayenne_cdc_write(&fixture.table, &task_ctx, batch).await;
+                assert!(rows > 0, "cdc write acknowledged zero rows");
+                let _ = done_tx.send(());
+            }
+        });
+        Self { handle }
+    }
+}
+
+/// Persistent CDC-analog writer thread bound to ONE DuckDB table in the
+/// shared database file. Own `Connection` (connections are not `Send`).
+struct DuckDbTableWriter {
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl DuckDbTableWriter {
+    fn spawn(
+        db_path: std::path::PathBuf,
+        table_name: String,
+        go_rx: mpsc::Receiver<()>,
+        done_tx: mpsc::Sender<()>,
+    ) -> Self {
+        let handle = std::thread::spawn(move || {
+            let conn = Connection::open(&db_path).expect("duckdb writer connection open");
+            let mut cursor: i64 = 0;
+            while go_rx.recv().is_ok() {
+                let batch = make_batch(schema(), cursor, WRITE_BATCH_ROWS);
+                cursor += WRITE_BATCH_ROWS as i64;
+                duckdb_insert_rows(&conn, &table_name, &batch);
+                let _ = done_tx.send(());
+            }
+        });
+        Self { handle }
+    }
+}
+
+fn bench_cdc_multitable(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_cdc_multitable");
+    group.sample_size(10);
+
+    for &lane in CAYENNE_LANES {
+        let lane_label = format!("{}_cdc", lane.lane());
+
+        for &tables in TABLE_COUNTS {
+            group.throughput(Throughput::Elements((tables * WRITE_BATCH_ROWS) as u64));
+
+            // N independent fixtures: own metastore + data dir each, the
+            // per-dataset topology spiced creates for a CDC fleet.
+            let fixtures: Vec<Arc<CayenneFixture>> = (0..tables)
+                .map(|i| {
+                    Arc::new(rt.block_on(setup_cayenne_for(
+                        &format!("cdc_multi_{i}"),
+                        lane,
+                    )))
+                })
+                .collect();
+
+            let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+            let mut go_txs: Vec<tokio::sync::mpsc::UnboundedSender<()>> =
+                Vec::with_capacity(tables);
+            let mut workers: Vec<CayenneTableWriter> = Vec::with_capacity(tables);
+            for fixture in &fixtures {
+                let (go_tx, go_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+                go_txs.push(go_tx);
+                workers.push(CayenneTableWriter::spawn(
+                    &rt,
+                    Arc::clone(fixture),
+                    go_rx,
+                    done_tx.clone(),
+                ));
+            }
+            drop(done_tx);
+
+            let bench_ctx = format!("vs_duckdb_cdc_multitable/{lane_label}");
+            group.bench_with_input(
+                BenchmarkId::new(&lane_label, tables),
+                &tables,
+                |b, &n| {
+                    b.iter(|| {
+                        rt.block_on(async {
+                            for tx in &go_txs {
+                                tx.send(()).expect("cayenne cdc go-tx (worker exited?)");
+                            }
+                            for i in 0..n {
+                                match tokio::time::timeout(COMPLETION_TIMEOUT, done_rx.recv())
+                                    .await
+                                {
+                                    Ok(Some(())) => {}
+                                    Ok(None) => panic!(
+                                        "{bench_ctx}: done channel closed at completion {}/{n} \
+                                         (worker exited?)",
+                                        i + 1
+                                    ),
+                                    Err(_) => panic!(
+                                        "{bench_ctx}: stalled waiting for writer completion \
+                                         {}/{n} after {COMPLETION_TIMEOUT:?}",
+                                        i + 1
+                                    ),
+                                }
+                            }
+                        });
+                    });
+                },
+            );
+
+            // Teardown: dropping the go senders ends each worker loop; join
+            // them before the fixtures are torn down.
+            drop(go_txs);
+            for worker in workers {
+                let _ = rt.block_on(worker.handle);
+            }
+            drop(fixtures);
+        }
+    }
+
+    // --- DuckDB: one database file, N tables, one writer thread per table.
+    for &tables in TABLE_COUNTS {
+        group.throughput(Throughput::Elements((tables * WRITE_BATCH_ROWS) as u64));
+
+        let fixture = setup_duckdb("cdc_multi_0");
+        for i in 1..tables {
+            fixture
+                .conn
+                .execute_batch(&format!(
+                    "CREATE TABLE cdc_multi_{i} (id BIGINT, name VARCHAR NOT NULL, \
+                     value BIGINT NOT NULL);"
+                ))
+                .expect("duckdb create table");
+        }
+
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+        let mut go_txs: Vec<mpsc::Sender<()>> = Vec::with_capacity(tables);
+        let mut workers: Vec<DuckDbTableWriter> = Vec::with_capacity(tables);
+        for i in 0..tables {
+            let (go_tx, go_rx) = mpsc::channel::<()>();
+            go_txs.push(go_tx);
+            workers.push(DuckDbTableWriter::spawn(
+                fixture.db_path(),
+                format!("cdc_multi_{i}"),
+                go_rx,
+                done_tx.clone(),
+            ));
+        }
+        drop(done_tx);
+
+        let bench_ctx = format!("vs_duckdb_cdc_multitable/duckdb tables={tables}");
+        group.bench_with_input(BenchmarkId::new("duckdb", tables), &tables, |b, &n| {
+            b.iter(|| {
+                for tx in &go_txs {
+                    tx.send(()).expect("duckdb go-tx (worker exited?)");
+                }
+                for i in 0..n {
+                    done_rx.recv_timeout(COMPLETION_TIMEOUT).unwrap_or_else(|err| {
+                        panic!(
+                            "{bench_ctx}: stalled waiting for writer completion {}/{n} \
+                             after {COMPLETION_TIMEOUT:?} ({err})",
+                            i + 1
+                        )
+                    });
+                }
+            });
+        });
+
+        drop(go_txs);
+        for worker in workers {
+            let _ = worker.handle.join();
+        }
+        drop(fixture);
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cdc_multitable);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
+++ b/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 use std::sync::mpsc;
 use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, SamplingMode, Throughput, criterion_group, criterion_main};
 use duckdb::Connection;
 use tokio::runtime::Runtime;
 
@@ -59,6 +59,18 @@ const TABLE_COUNTS: &[usize] = &[1, 2, 4, 8, 16];
 /// `vs_duckdb_scaling`'s WRITE_BATCH_ROWS so the N=1 lane of this bench is
 /// directly comparable to that bench's concurrency=1 CDC lane.
 const WRITE_BATCH_ROWS: usize = 1_024;
+
+/// Batches pre-written into every table (both engines) before its lane is
+/// timed. A fresh table's per-batch cost is not stationary — snapshots and
+/// metadata accumulate as batches land, so lanes with cheaper iterations
+/// would silently run MORE iterations and age their tables further than
+/// expensive lanes, corrupting the cross-N comparison (a first cut of this
+/// bench produced a non-monotonic garbage curve exactly this way). The
+/// preload parks every table well past the steep start of that cost curve
+/// so marginal aging during the (bounded, flat-sampled) measurement is
+/// small and comparable across lanes. Preload ids are negative so timed
+/// writes (cursor 0..) never overlap them.
+const PRELOAD_BATCHES: usize = 64;
 
 /// Per-completion wait bound: a stalled writer surfaces as a labeled panic
 /// instead of a hung bench (same rationale as `vs_duckdb_scaling`).
@@ -126,7 +138,13 @@ impl DuckDbTableWriter {
 fn bench_cdc_multitable(c: &mut Criterion) {
     let rt = Runtime::new().expect("runtime");
     let mut group = c.benchmark_group("vs_duckdb_cdc_multitable");
+    // Flat sampling + bounded measurement: every sample runs the same
+    // iteration count and the lane stops aging its tables after a few
+    // hundred batches — see PRELOAD_BATCHES for why this matters.
+    group.sampling_mode(SamplingMode::Flat);
     group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(4));
 
     for &lane in CAYENNE_LANES {
         let lane_label = format!("{}_cdc", lane.lane());
@@ -144,6 +162,23 @@ fn bench_cdc_multitable(c: &mut Criterion) {
                     )))
                 })
                 .collect();
+
+            // Preload: park every table past the steep start of the
+            // per-batch cost curve (negative id range; timed writes use
+            // cursor 0.. and never overlap).
+            rt.block_on(async {
+                let preload_ctx = datafusion::prelude::SessionContext::new();
+                let task_ctx = preload_ctx.task_ctx();
+                let preload_start = -((PRELOAD_BATCHES * WRITE_BATCH_ROWS) as i64);
+                for fixture in &fixtures {
+                    for batch_idx in 0..PRELOAD_BATCHES {
+                        let start = preload_start + (batch_idx * WRITE_BATCH_ROWS) as i64;
+                        let batch = make_batch(schema(), start, WRITE_BATCH_ROWS);
+                        let rows = cayenne_cdc_write(&fixture.table, &task_ctx, batch).await;
+                        assert!(rows > 0, "preload cdc write acknowledged zero rows");
+                    }
+                }
+            });
 
             let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
             let mut go_txs: Vec<tokio::sync::mpsc::UnboundedSender<()>> =
@@ -216,6 +251,19 @@ fn bench_cdc_multitable(c: &mut Criterion) {
                      value BIGINT NOT NULL);"
                 ))
                 .expect("duckdb create table");
+        }
+
+        // Preload to the same per-table batch count as the Cayenne lanes.
+        {
+            let preload_start = -((PRELOAD_BATCHES * WRITE_BATCH_ROWS) as i64);
+            for i in 0..tables {
+                let table_name = format!("cdc_multi_{i}");
+                for batch_idx in 0..PRELOAD_BATCHES {
+                    let start = preload_start + (batch_idx * WRITE_BATCH_ROWS) as i64;
+                    let batch = make_batch(schema(), start, WRITE_BATCH_ROWS);
+                    duckdb_insert_rows(&fixture.conn, &table_name, &batch);
+                }
+            }
         }
 
         let (done_tx, done_rx) = mpsc::channel::<()>();

--- a/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
+++ b/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
@@ -42,7 +42,9 @@ use std::sync::Arc;
 use std::sync::mpsc;
 use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, SamplingMode, Throughput, criterion_group, criterion_main};
+use criterion::{
+    BenchmarkId, Criterion, SamplingMode, Throughput, criterion_group, criterion_main,
+};
 use duckdb::Connection;
 use tokio::runtime::Runtime;
 
@@ -155,12 +157,7 @@ fn bench_cdc_multitable(c: &mut Criterion) {
             // N independent fixtures: own metastore + data dir each, the
             // per-dataset topology spiced creates for a CDC fleet.
             let fixtures: Vec<Arc<CayenneFixture>> = (0..tables)
-                .map(|i| {
-                    Arc::new(rt.block_on(setup_cayenne_for(
-                        &format!("cdc_multi_{i}"),
-                        lane,
-                    )))
-                })
+                .map(|i| Arc::new(rt.block_on(setup_cayenne_for(&format!("cdc_multi_{i}"), lane))))
                 .collect();
 
             // Preload: park every table past the steep start of the
@@ -197,36 +194,30 @@ fn bench_cdc_multitable(c: &mut Criterion) {
             drop(done_tx);
 
             let bench_ctx = format!("vs_duckdb_cdc_multitable/{lane_label}");
-            group.bench_with_input(
-                BenchmarkId::new(&lane_label, tables),
-                &tables,
-                |b, &n| {
-                    b.iter(|| {
-                        rt.block_on(async {
-                            for tx in &go_txs {
-                                tx.send(()).expect("cayenne cdc go-tx (worker exited?)");
-                            }
-                            for i in 0..n {
-                                match tokio::time::timeout(COMPLETION_TIMEOUT, done_rx.recv())
-                                    .await
-                                {
-                                    Ok(Some(())) => {}
-                                    Ok(None) => panic!(
-                                        "{bench_ctx}: done channel closed at completion {}/{n} \
+            group.bench_with_input(BenchmarkId::new(&lane_label, tables), &tables, |b, &n| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        for tx in &go_txs {
+                            tx.send(()).expect("cayenne cdc go-tx (worker exited?)");
+                        }
+                        for i in 0..n {
+                            match tokio::time::timeout(COMPLETION_TIMEOUT, done_rx.recv()).await {
+                                Ok(Some(())) => {}
+                                Ok(None) => panic!(
+                                    "{bench_ctx}: done channel closed at completion {}/{n} \
                                          (worker exited?)",
-                                        i + 1
-                                    ),
-                                    Err(_) => panic!(
-                                        "{bench_ctx}: stalled waiting for writer completion \
+                                    i + 1
+                                ),
+                                Err(_) => panic!(
+                                    "{bench_ctx}: stalled waiting for writer completion \
                                          {}/{n} after {COMPLETION_TIMEOUT:?}",
-                                        i + 1
-                                    ),
-                                }
+                                    i + 1
+                                ),
                             }
-                        });
+                        }
                     });
-                },
-            );
+                });
+            });
 
             // Teardown: dropping the go senders ends each worker loop; join
             // them before the fixtures are torn down.
@@ -288,13 +279,15 @@ fn bench_cdc_multitable(c: &mut Criterion) {
                     tx.send(()).expect("duckdb go-tx (worker exited?)");
                 }
                 for i in 0..n {
-                    done_rx.recv_timeout(COMPLETION_TIMEOUT).unwrap_or_else(|err| {
-                        panic!(
-                            "{bench_ctx}: stalled waiting for writer completion {}/{n} \
+                    done_rx
+                        .recv_timeout(COMPLETION_TIMEOUT)
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "{bench_ctx}: stalled waiting for writer completion {}/{n} \
                              after {COMPLETION_TIMEOUT:?} ({err})",
-                            i + 1
-                        )
-                    });
+                                i + 1
+                            )
+                        });
                 }
             });
         });

--- a/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
+++ b/crates/cayenne/benches/vs_duckdb_cdc_multitable.rs
@@ -220,10 +220,13 @@ fn bench_cdc_multitable(c: &mut Criterion) {
             });
 
             // Teardown: dropping the go senders ends each worker loop; join
-            // them before the fixtures are torn down.
+            // them before the fixtures are torn down. Propagate panics — a
+            // writer that died late would otherwise be swallowed and the
+            // lane would report numbers from a partially failed run.
             drop(go_txs);
             for worker in workers {
-                let _ = rt.block_on(worker.handle);
+                rt.block_on(worker.handle)
+                    .expect("cayenne cdc writer task panicked");
             }
             drop(fixtures);
         }
@@ -294,7 +297,11 @@ fn bench_cdc_multitable(c: &mut Criterion) {
 
         drop(go_txs);
         for worker in workers {
-            let _ = worker.handle.join();
+            // Propagate late panics — same rationale as the Cayenne teardown.
+            worker
+                .handle
+                .join()
+                .expect("duckdb cdc writer thread panicked");
         }
         drop(fixture);
     }

--- a/crates/cayenne/benches/vs_duckdb_helpers/common.rs
+++ b/crates/cayenne/benches/vs_duckdb_helpers/common.rs
@@ -240,6 +240,37 @@ async fn setup_cayenne_with(
     on_conflict: Option<OnConflict>,
     table_schema: Arc<Schema>,
 ) -> CayenneFixture {
+    setup_cayenne_custom(
+        table_name,
+        metastore,
+        primary_key,
+        on_conflict,
+        table_schema,
+        cayenne::metadata::VortexConfig::default(),
+        Arc::new(RuntimeEnv::default()),
+    )
+    .await
+}
+
+/// Fully-parameterized Cayenne fixture: callers control the `VortexConfig`
+/// (e.g. compaction triggers, inline-memtable size) and the `RuntimeEnv`
+/// (e.g. a budgeted memory pool). The simpler `setup_cayenne*` wrappers all
+/// route through this with defaults.
+///
+/// Pass the SAME `RuntimeEnv` to [`warm_session_with_runtime`] when queries
+/// must run under the same memory budget as the table's write path — that
+/// mirrors spiced, which shares one `RuntimeEnv` across the accelerator and
+/// the query sessions.
+#[allow(clippy::too_many_arguments)]
+pub async fn setup_cayenne_custom(
+    table_name: &str,
+    metastore: Metastore,
+    primary_key: Vec<String>,
+    on_conflict: Option<OnConflict>,
+    table_schema: Arc<Schema>,
+    vortex_config: cayenne::metadata::VortexConfig,
+    runtime_env: Arc<RuntimeEnv>,
+) -> CayenneFixture {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let data_path = temp_dir.path().join("data");
     tokio::fs::create_dir_all(&data_path)
@@ -260,9 +291,9 @@ async fn setup_cayenne_with(
                 on_conflict,
                 base_path: data_path.to_string_lossy().to_string(),
                 partition_column: None,
-                vortex_config: cayenne::metadata::VortexConfig::default(),
+                vortex_config,
             },
-            Arc::new(RuntimeEnv::default()),
+            runtime_env,
         )
         .await
         .expect("cayenne create_table"),
@@ -273,6 +304,24 @@ async fn setup_cayenne_with(
         table,
         catalog: Arc::clone(&catalog) as Arc<dyn MetadataCatalog>,
     }
+}
+
+/// Like [`warm_session_for`] but builds the session on a caller-provided
+/// [`RuntimeEnv`] — required when the query must execute under a budgeted
+/// memory pool. A plain `SessionContext::new()` would silently run queries
+/// against an UNLIMITED default pool, making any memory-budget comparison
+/// measure nothing (the fixture's budget would gate only the write path).
+pub fn warm_session_with_runtime(
+    table: &Arc<CayenneTableProvider>,
+    runtime_env: Arc<RuntimeEnv>,
+) -> datafusion::prelude::SessionContext {
+    use datafusion::datasource::TableProvider;
+    use datafusion::prelude::{SessionConfig, SessionContext};
+
+    let ctx = SessionContext::new_with_config_rt(SessionConfig::new(), runtime_env);
+    ctx.register_table("t", Arc::clone(table) as Arc<dyn TableProvider>)
+        .expect("register table");
+    ctx
 }
 
 /// A clean DuckDB file-mode database with the same schema.

--- a/crates/cayenne/benches/vs_duckdb_memory_budget.rs
+++ b/crates/cayenne/benches/vs_duckdb_memory_budget.rs
@@ -189,6 +189,7 @@ struct BudgetedCayenne {
 
 async fn setup_budgeted_cayenne(
     table_name: &str,
+    metastore: Metastore,
     budget_bytes: usize,
     with_pk: bool,
 ) -> BudgetedCayenne {
@@ -211,7 +212,7 @@ async fn setup_budgeted_cayenne(
 
     let fixture = setup_cayenne_custom(
         table_name,
-        Metastore::Sqlite,
+        metastore,
         primary_key,
         on_conflict,
         schema(),
@@ -306,88 +307,111 @@ fn bench_memory_budget(c: &mut Criterion) {
     write_parquet(&make_batch(schema(), 0, UPSERT_ROWS), &upsert_parquet);
 
     for &(budget_label, budget_bytes) in MEMORY_BUDGETS {
-        // --- Cayenne read lanes (scan + groupby) on one budgeted fixture.
-        {
-            let lane = rt.block_on(setup_budgeted_cayenne("memory_budget", budget_bytes, false));
-            let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
-            assert!(preload > 0, "cayenne preload must insert rows");
-            lane.pool.reset_high_water();
+        // All Cayenne metastore lanes (Sqlite, plus Turso when compiled in) —
+        // consistent with every other vs_duckdb_* bench, so memory-budget
+        // numbers stay directly comparable across the paired suite.
+        for &cay_lane in common::CAYENNE_LANES {
+            let lane_prefix = cay_lane.lane();
 
-            for (workload, sql) in [("scan_filter_sum", SCAN_SQL), ("groupby_16k", GROUPBY_SQL)] {
-                // Pre-flight once: a budget the workload cannot fit is a
-                // finding to report, not a panic.
-                if let Err(e) = rt.block_on(try_query(&lane.warm_ctx, sql)) {
-                    eprintln!("memory_budget: cayenne/{workload}@{budget_label} SKIPPED — {e}");
-                    continue;
-                }
+            // --- Cayenne read lanes (scan + groupby) on one budgeted fixture.
+            {
+                let lane = rt.block_on(setup_budgeted_cayenne(
+                    "memory_budget",
+                    cay_lane,
+                    budget_bytes,
+                    false,
+                ));
+                let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
+                assert!(preload > 0, "cayenne preload must insert rows");
                 lane.pool.reset_high_water();
-                group.bench_function(
-                    BenchmarkId::new(format!("cayenne_{workload}"), budget_label),
-                    |b| {
-                        b.iter(|| {
-                            rt.block_on(async {
-                                let batches = try_query(&lane.warm_ctx, sql)
-                                    .await
-                                    .expect("pre-flighted query failed mid-bench");
-                                black_box(batches);
+
+                for (workload, sql) in [("scan_filter_sum", SCAN_SQL), ("groupby_16k", GROUPBY_SQL)]
+                {
+                    // Pre-flight once: a budget the workload cannot fit is a
+                    // finding to report, not a panic.
+                    if let Err(e) = rt.block_on(try_query(&lane.warm_ctx, sql)) {
+                        eprintln!(
+                            "memory_budget: {lane_prefix}/{workload}@{budget_label} SKIPPED — {e}"
+                        );
+                        continue;
+                    }
+                    lane.pool.reset_high_water();
+                    group.bench_function(
+                        BenchmarkId::new(format!("{lane_prefix}_{workload}"), budget_label),
+                        |b| {
+                            b.iter(|| {
+                                rt.block_on(async {
+                                    let batches = try_query(&lane.warm_ctx, sql)
+                                        .await
+                                        .expect("pre-flighted query failed mid-bench");
+                                    black_box(batches);
+                                });
                             });
-                        });
-                    },
-                );
-                let high_water = lane.pool.high_water_bytes() as u64;
-                eprintln_lane_memory("cayenne", workload, budget_label, high_water);
-                assert!(
-                    high_water <= budget_bytes as u64,
-                    "cayenne/{workload}@{budget_label}: pool high-water {high_water} bytes \
-                     exceeds the configured budget {budget_bytes} — operator contract violated"
-                );
+                        },
+                    );
+                    let high_water = lane.pool.high_water_bytes() as u64;
+                    eprintln_lane_memory(lane_prefix, workload, budget_label, high_water);
+                    assert!(
+                        high_water <= budget_bytes as u64,
+                        "{lane_prefix}/{workload}@{budget_label}: pool high-water {high_water} \
+                         bytes exceeds the configured budget {budget_bytes} — operator contract \
+                         violated"
+                    );
+                }
             }
-        }
 
-        // --- Cayenne upsert lane on a budgeted PK fixture. The upsert runs
-        //     through the lane's BUDGETED warm session (see
-        //     `try_upsert_from_parquet`) so both the query-side decode and
-        //     the table-side write reservations draw on the same budgeted
-        //     pool — the spiced topology.
-        {
-            let lane = rt.block_on(setup_budgeted_cayenne(
-                "memory_budget_upsert",
-                budget_bytes,
-                true,
-            ));
-            let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
-            assert!(preload > 0, "cayenne upsert preload must insert rows");
-            // Pre-flight once: a budget the upsert cannot fit is a finding
-            // to report, not a panic.
-            if let Err(e) = rt.block_on(try_upsert_from_parquet(
-                &lane.warm_ctx,
-                &lane.fixture.table,
-                &upsert_parquet,
-            )) {
-                eprintln!("memory_budget: cayenne/upsert_16k@{budget_label} SKIPPED — {e}");
-            } else {
-                lane.pool.reset_high_water();
-                group.bench_function(BenchmarkId::new("cayenne_upsert_16k", budget_label), |b| {
-                    b.iter(|| {
-                        rt.block_on(async {
-                            let rows = try_upsert_from_parquet(
-                                &lane.warm_ctx,
-                                &lane.fixture.table,
-                                &upsert_parquet,
-                            )
-                            .await
-                            .expect("pre-flighted upsert failed mid-bench");
-                            black_box(rows);
-                        });
-                    });
-                });
-                let high_water = lane.pool.high_water_bytes() as u64;
-                eprintln_lane_memory("cayenne", "upsert_16k", budget_label, high_water);
-                assert!(
-                    high_water <= budget_bytes as u64,
-                    "cayenne/upsert_16k@{budget_label}: pool high-water {high_water} bytes \
-                     exceeds the configured budget {budget_bytes} — operator contract violated"
-                );
+            // --- Cayenne upsert lane on a budgeted PK fixture. The upsert
+            //     runs through the lane's BUDGETED warm session (see
+            //     `try_upsert_from_parquet`) so both the query-side decode and
+            //     the table-side write reservations draw on the same budgeted
+            //     pool — the spiced topology.
+            {
+                let lane = rt.block_on(setup_budgeted_cayenne(
+                    "memory_budget_upsert",
+                    cay_lane,
+                    budget_bytes,
+                    true,
+                ));
+                let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
+                assert!(preload > 0, "cayenne upsert preload must insert rows");
+                // Pre-flight once: a budget the upsert cannot fit is a finding
+                // to report, not a panic.
+                if let Err(e) = rt.block_on(try_upsert_from_parquet(
+                    &lane.warm_ctx,
+                    &lane.fixture.table,
+                    &upsert_parquet,
+                )) {
+                    eprintln!(
+                        "memory_budget: {lane_prefix}/upsert_16k@{budget_label} SKIPPED — {e}"
+                    );
+                } else {
+                    lane.pool.reset_high_water();
+                    group.bench_function(
+                        BenchmarkId::new(format!("{lane_prefix}_upsert_16k"), budget_label),
+                        |b| {
+                            b.iter(|| {
+                                rt.block_on(async {
+                                    let rows = try_upsert_from_parquet(
+                                        &lane.warm_ctx,
+                                        &lane.fixture.table,
+                                        &upsert_parquet,
+                                    )
+                                    .await
+                                    .expect("pre-flighted upsert failed mid-bench");
+                                    black_box(rows);
+                                });
+                            });
+                        },
+                    );
+                    let high_water = lane.pool.high_water_bytes() as u64;
+                    eprintln_lane_memory(lane_prefix, "upsert_16k", budget_label, high_water);
+                    assert!(
+                        high_water <= budget_bytes as u64,
+                        "{lane_prefix}/upsert_16k@{budget_label}: pool high-water {high_water} \
+                         bytes exceeds the configured budget {budget_bytes} — operator contract \
+                         violated"
+                    );
+                }
             }
         }
 

--- a/crates/cayenne/benches/vs_duckdb_memory_budget.rs
+++ b/crates/cayenne/benches/vs_duckdb_memory_budget.rs
@@ -73,8 +73,8 @@ use duckdb::Connection;
 use tokio::runtime::Runtime;
 
 use common::{
-    CayenneFixture, Metastore, cayenne_insert, cayenne_insert_from_parquet, make_batch,
-    make_batch_grouped, schema, setup_cayenne_custom, warm_session_with_runtime, write_parquet,
+    CayenneFixture, Metastore, cayenne_insert, make_batch, make_batch_grouped, schema,
+    setup_cayenne_custom, warm_session_with_runtime, write_parquet,
 };
 use datafusion_table_providers::util::{
     column_reference::ColumnReference, on_conflict::OnConflict,
@@ -226,6 +226,43 @@ async fn try_query(ctx: &SessionContext, sql: &str) -> DataFusionResult<Vec<Reco
     ctx.sql(sql).await?.collect().await
 }
 
+/// Upsert from parquet through the BUDGETED session. The shared
+/// `cayenne_insert_from_parquet` helper builds its own
+/// `SessionContext::new()` — an unbudgeted pool — and
+/// `CayenneTableProvider::insert_into` draws execution memory from the
+/// SESSION's runtime env, so routing this lane through the helper would
+/// bypass the budget the bench exists to enforce (only the table-internal
+/// reservations would land on the budgeted pool). Errors are returned, not
+/// panicked, so a too-small budget can be reported as a skip.
+async fn try_upsert_from_parquet(
+    ctx: &SessionContext,
+    table: &Arc<cayenne::CayenneTableProvider>,
+    parquet_path: &std::path::Path,
+) -> DataFusionResult<u64> {
+    use datafusion::datasource::TableProvider;
+    use datafusion::prelude::ParquetReadOptions;
+    use datafusion_expr::dml::InsertOp;
+
+    let parquet_path = parquet_path.to_string_lossy().into_owned();
+    let df = ctx
+        .read_parquet::<&str>(parquet_path.as_str(), ParquetReadOptions::default())
+        .await?;
+    let input_exec = df.create_physical_plan().await?;
+    let insert_plan = table
+        .insert_into(&ctx.state(), input_exec, InsertOp::Append)
+        .await?;
+    let results = datafusion::physical_plan::collect(insert_plan, ctx.task_ctx()).await?;
+    Ok(results
+        .first()
+        .and_then(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .map_or(0, |rows| rows.value(0)))
+}
+
 fn eprintln_lane_memory(engine: &str, workload: &str, budget_label: &str, bytes: u64) {
     eprintln!(
         "memory_budget: {engine}/{workload}@{budget_label} pool high-water = {bytes} bytes \
@@ -300,7 +337,11 @@ fn bench_memory_budget(c: &mut Criterion) {
             }
         }
 
-        // --- Cayenne upsert lane on a budgeted PK fixture.
+        // --- Cayenne upsert lane on a budgeted PK fixture. The upsert runs
+        //     through the lane's BUDGETED warm session (see
+        //     `try_upsert_from_parquet`) so both the query-side decode and
+        //     the table-side write reservations draw on the same budgeted
+        //     pool — the spiced topology.
         {
             let lane = rt.block_on(setup_budgeted_cayenne(
                 "memory_budget_upsert",
@@ -309,23 +350,38 @@ fn bench_memory_budget(c: &mut Criterion) {
             ));
             let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
             assert!(preload > 0, "cayenne upsert preload must insert rows");
-            lane.pool.reset_high_water();
-            group.bench_function(BenchmarkId::new("cayenne_upsert_16k", budget_label), |b| {
-                b.iter(|| {
-                    rt.block_on(async {
-                        let rows =
-                            cayenne_insert_from_parquet(&lane.fixture.table, &upsert_parquet).await;
-                        black_box(rows);
+            // Pre-flight once: a budget the upsert cannot fit is a finding
+            // to report, not a panic.
+            if let Err(e) = rt.block_on(try_upsert_from_parquet(
+                &lane.warm_ctx,
+                &lane.fixture.table,
+                &upsert_parquet,
+            )) {
+                eprintln!("memory_budget: cayenne/upsert_16k@{budget_label} SKIPPED — {e}");
+            } else {
+                lane.pool.reset_high_water();
+                group.bench_function(BenchmarkId::new("cayenne_upsert_16k", budget_label), |b| {
+                    b.iter(|| {
+                        rt.block_on(async {
+                            let rows = try_upsert_from_parquet(
+                                &lane.warm_ctx,
+                                &lane.fixture.table,
+                                &upsert_parquet,
+                            )
+                            .await
+                            .expect("pre-flighted upsert failed mid-bench");
+                            black_box(rows);
+                        });
                     });
                 });
-            });
-            let high_water = lane.pool.high_water_bytes() as u64;
-            eprintln_lane_memory("cayenne", "upsert_16k", budget_label, high_water);
-            assert!(
-                high_water <= budget_bytes as u64,
-                "cayenne/upsert_16k@{budget_label}: pool high-water {high_water} bytes \
-                 exceeds the configured budget {budget_bytes} — operator contract violated"
-            );
+                let high_water = lane.pool.high_water_bytes() as u64;
+                eprintln_lane_memory("cayenne", "upsert_16k", budget_label, high_water);
+                assert!(
+                    high_water <= budget_bytes as u64,
+                    "cayenne/upsert_16k@{budget_label}: pool high-water {high_water} bytes \
+                     exceeds the configured budget {budget_bytes} — operator contract violated"
+                );
+            }
         }
 
         // --- DuckDB lanes at the same budget.

--- a/crates/cayenne/benches/vs_duckdb_memory_budget.rs
+++ b/crates/cayenne/benches/vs_duckdb_memory_budget.rs
@@ -135,7 +135,14 @@ impl HighWaterPool {
     }
 
     fn reset_high_water(&self) {
-        self.high_water.store(0, Ordering::Relaxed);
+        // Seed with the CURRENT reservation, not 0: the high-water only
+        // advances on grow/try_grow, so a pool holding steady-state
+        // reservations that don't grow further during the measured window
+        // would otherwise read 0 — hiding held memory (e.g. table-side
+        // caches sized during a pre-flight upsert and retained across the
+        // timed iterations).
+        self.high_water
+            .store(self.inner.reserved(), Ordering::Relaxed);
     }
 }
 

--- a/crates/cayenne/benches/vs_duckdb_memory_budget.rs
+++ b/crates/cayenne/benches/vs_duckdb_memory_budget.rs
@@ -264,11 +264,7 @@ fn bench_memory_budget(c: &mut Criterion) {
     for &(budget_label, budget_bytes) in MEMORY_BUDGETS {
         // --- Cayenne read lanes (scan + groupby) on one budgeted fixture.
         {
-            let lane = rt.block_on(setup_budgeted_cayenne(
-                "memory_budget",
-                budget_bytes,
-                false,
-            ));
+            let lane = rt.block_on(setup_budgeted_cayenne("memory_budget", budget_bytes, false));
             let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
             assert!(preload > 0, "cayenne preload must insert rows");
             lane.pool.reset_high_water();
@@ -277,9 +273,7 @@ fn bench_memory_budget(c: &mut Criterion) {
                 // Pre-flight once: a budget the workload cannot fit is a
                 // finding to report, not a panic.
                 if let Err(e) = rt.block_on(try_query(&lane.warm_ctx, sql)) {
-                    eprintln!(
-                        "memory_budget: cayenne/{workload}@{budget_label} SKIPPED — {e}"
-                    );
+                    eprintln!("memory_budget: cayenne/{workload}@{budget_label} SKIPPED — {e}");
                     continue;
                 }
                 lane.pool.reset_high_water();
@@ -320,8 +314,7 @@ fn bench_memory_budget(c: &mut Criterion) {
                 b.iter(|| {
                     rt.block_on(async {
                         let rows =
-                            cayenne_insert_from_parquet(&lane.fixture.table, &upsert_parquet)
-                                .await;
+                            cayenne_insert_from_parquet(&lane.fixture.table, &upsert_parquet).await;
                         black_box(rows);
                     });
                 });

--- a/crates/cayenne/benches/vs_duckdb_memory_budget.rs
+++ b/crates/cayenne/benches/vs_duckdb_memory_budget.rs
@@ -1,0 +1,399 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Peak memory under a fixed budget: Cayenne vs DuckDB.
+//!
+//! Every other `vs_duckdb_*` bench runs Cayenne on `RuntimeEnv::default()` —
+//! an UNLIMITED memory pool — so none of them can see whether Cayenne lives
+//! within the budget an operator configures via `runtime.query.memory_limit`.
+//! This bench closes that gap: each lane runs the same workload at the same
+//! configured budget on both engines —
+//!
+//! - **Cayenne**: a `TrackConsumersPool<GreedyMemoryPool>` sized to the
+//!   budget (exactly how spiced builds the production pool — see
+//!   `crates/runtime/src/datafusion/builder.rs`), wrapped in a high-water
+//!   tracker, wired into BOTH the table's `RuntimeEnv` (write path) and the
+//!   query `SessionContext` (scan path), mirroring spiced's single shared
+//!   `RuntimeEnv`.
+//! - **DuckDB**: `SET memory_limit='<budget>'` on the same file-backed DB.
+//!
+//! Three workloads per budget: a filtered scan-aggregate, a GROUP BY with
+//! 16Ki groups, and a PK upsert from parquet (the CDC replace shape).
+//!
+//! Reported signals, per (engine, workload, budget):
+//! - criterion wall-clock (latency at the budget);
+//! - `pool high-water` lines on stderr — the maximum bytes the DataFusion
+//!   pool had reserved at any point during the lane (Cayenne), best-effort
+//!   `duckdb_memory()` usage (DuckDB);
+//! - a hard assert that Cayenne's pool high-water never exceeds the budget
+//!   (the operator contract — exceeding it is a bug, not a slow lane);
+//! - a lane that cannot complete at a budget (ResourcesExhausted) is
+//!   SKIPPED with an explanatory stderr line rather than panicking — "needs
+//!   more than 256 MiB for this workload" is a finding, not a crash.
+//!
+//! Pool high-water ≈ 0 while the workload clearly allocates (e.g. the upsert
+//! lane) is itself a signal: that work is running OFF-pool, invisible to the
+//! operator's budget — the known "ingest caches sized off total RAM" class
+//! of findings. For process-level peak RSS, wrap the bench invocation in
+//! `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux).
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use arrow::array::RecordBatch;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion::common::Result as DataFusionResult;
+use datafusion::execution::memory_pool::{
+    GreedyMemoryPool, MemoryLimit, MemoryPool, MemoryReservation, TrackConsumersPool,
+};
+use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+use datafusion::prelude::SessionContext;
+use duckdb::Connection;
+use tokio::runtime::Runtime;
+
+use common::{
+    CayenneFixture, Metastore, cayenne_insert, cayenne_insert_from_parquet, make_batch,
+    make_batch_grouped, schema, setup_cayenne_custom, warm_session_with_runtime, write_parquet,
+};
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+
+/// Budgets from the audit skill's three reference points: embedded /
+/// dev-laptop / production-server.
+const MEMORY_BUDGETS: &[(&str, usize)] = &[
+    ("256MiB", 256 * 1024 * 1024),
+    ("2GiB", 2 * 1024 * 1024 * 1024),
+    ("16GiB", 16 * 1024 * 1024 * 1024),
+];
+
+/// Rows in the pre-loaded fixture. Matches `vs_duckdb_scaling`'s READ_ROWS
+/// so latency lanes are comparable across benches.
+const BASE_ROWS: usize = 1_048_576;
+
+/// Distinct GROUP BY keys — the existing `vs_duckdb_groupby` high-cardinality
+/// lane, here re-run under a budgeted pool.
+const GROUPS: usize = 16_384;
+
+/// Rows per upsert batch (CDC replace shape: same ids re-written).
+const UPSERT_ROWS: usize = 16_384;
+
+const SCAN_SQL: &str = "SELECT SUM(value) FROM t WHERE id BETWEEN 1000 AND 11000";
+const GROUPBY_SQL: &str = "SELECT name, SUM(value) FROM t GROUP BY name";
+
+// ---------------------------------------------------------------------------
+// High-water memory pool
+// ---------------------------------------------------------------------------
+
+/// Wraps the production pool shape (`TrackConsumersPool<GreedyMemoryPool>`)
+/// and records the maximum total reservation ever observed. DataFusion's
+/// `MemoryPool::reserved()` only reports the CURRENT reservation; the budget
+/// question is about the peak.
+#[derive(Debug)]
+struct HighWaterPool {
+    inner: TrackConsumersPool<GreedyMemoryPool>,
+    high_water: AtomicUsize,
+}
+
+impl HighWaterPool {
+    fn new(budget_bytes: usize) -> Self {
+        let topn = NonZeroUsize::new(5).expect("non-zero top-n");
+        Self {
+            inner: TrackConsumersPool::new(GreedyMemoryPool::new(budget_bytes), topn),
+            high_water: AtomicUsize::new(0),
+        }
+    }
+
+    fn record_high_water(&self) {
+        let reserved = self.inner.reserved();
+        self.high_water.fetch_max(reserved, Ordering::Relaxed);
+    }
+
+    fn high_water_bytes(&self) -> usize {
+        self.high_water.load(Ordering::Relaxed)
+    }
+
+    fn reset_high_water(&self) {
+        self.high_water.store(0, Ordering::Relaxed);
+    }
+}
+
+impl MemoryPool for HighWaterPool {
+    fn register(&self, consumer: &datafusion::execution::memory_pool::MemoryConsumer) {
+        self.inner.register(consumer);
+    }
+
+    fn unregister(&self, consumer: &datafusion::execution::memory_pool::MemoryConsumer) {
+        self.inner.unregister(consumer);
+    }
+
+    fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+        self.inner.grow(reservation, additional);
+        self.record_high_water();
+    }
+
+    fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+        self.inner.shrink(reservation, shrink);
+    }
+
+    fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> DataFusionResult<()> {
+        self.inner.try_grow(reservation, additional)?;
+        self.record_high_water();
+        Ok(())
+    }
+
+    fn reserved(&self) -> usize {
+        self.inner.reserved()
+    }
+
+    fn memory_limit(&self) -> MemoryLimit {
+        self.inner.memory_limit()
+    }
+}
+
+/// A budgeted Cayenne fixture: the table AND the warm query session share one
+/// `RuntimeEnv` built on a [`HighWaterPool`] — the spiced topology.
+struct BudgetedCayenne {
+    fixture: CayenneFixture,
+    warm_ctx: SessionContext,
+    pool: Arc<HighWaterPool>,
+}
+
+async fn setup_budgeted_cayenne(
+    table_name: &str,
+    budget_bytes: usize,
+    with_pk: bool,
+) -> BudgetedCayenne {
+    let pool = Arc::new(HighWaterPool::new(budget_bytes));
+    let runtime_env: Arc<RuntimeEnv> = RuntimeEnvBuilder::default()
+        .with_memory_pool(Arc::clone(&pool) as Arc<dyn MemoryPool>)
+        .build_arc()
+        .expect("budgeted runtime env");
+
+    let (primary_key, on_conflict) = if with_pk {
+        (
+            vec!["id".to_string()],
+            Some(OnConflict::Upsert(ColumnReference::new(vec![
+                "id".to_string(),
+            ]))),
+        )
+    } else {
+        (vec![], None)
+    };
+
+    let fixture = setup_cayenne_custom(
+        table_name,
+        Metastore::Sqlite,
+        primary_key,
+        on_conflict,
+        schema(),
+        cayenne::metadata::VortexConfig::default(),
+        Arc::clone(&runtime_env),
+    )
+    .await;
+    let warm_ctx = warm_session_with_runtime(&fixture.table, runtime_env);
+    BudgetedCayenne {
+        fixture,
+        warm_ctx,
+        pool,
+    }
+}
+
+/// Run a query, returning the engine error instead of panicking — a budget
+/// too small for the workload is a reportable outcome, not a bench crash.
+async fn try_query(ctx: &SessionContext, sql: &str) -> DataFusionResult<Vec<RecordBatch>> {
+    ctx.sql(sql).await?.collect().await
+}
+
+fn eprintln_lane_memory(engine: &str, workload: &str, budget_label: &str, bytes: u64) {
+    eprintln!(
+        "memory_budget: {engine}/{workload}@{budget_label} pool high-water = {bytes} bytes \
+         ({:.1} MiB)",
+        bytes as f64 / (1024.0 * 1024.0)
+    );
+}
+
+/// Best-effort DuckDB memory usage via `duckdb_memory()` (sum of
+/// `memory_usage_bytes` across its internal allocators).
+fn duckdb_memory_bytes(conn: &Connection) -> Option<i64> {
+    conn.prepare("SELECT COALESCE(SUM(memory_usage_bytes), 0) FROM duckdb_memory()")
+        .ok()?
+        .query_row([], |row| row.get::<_, i64>(0))
+        .ok()
+}
+
+// ---------------------------------------------------------------------------
+// Bench
+// ---------------------------------------------------------------------------
+
+fn bench_memory_budget(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_memory_budget");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    let base_batch = make_batch_grouped(schema(), 0, BASE_ROWS, GROUPS);
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+    let base_parquet = parquet_dir.path().join("base.parquet");
+    write_parquet(&base_batch, &base_parquet);
+    // Upsert source: re-writes ids 0..UPSERT_ROWS (CDC replace shape).
+    let upsert_parquet = parquet_dir.path().join("upsert.parquet");
+    write_parquet(&make_batch(schema(), 0, UPSERT_ROWS), &upsert_parquet);
+
+    for &(budget_label, budget_bytes) in MEMORY_BUDGETS {
+        // --- Cayenne read lanes (scan + groupby) on one budgeted fixture.
+        {
+            let lane = rt.block_on(setup_budgeted_cayenne(
+                "memory_budget",
+                budget_bytes,
+                false,
+            ));
+            let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
+            assert!(preload > 0, "cayenne preload must insert rows");
+            lane.pool.reset_high_water();
+
+            for (workload, sql) in [("scan_filter_sum", SCAN_SQL), ("groupby_16k", GROUPBY_SQL)] {
+                // Pre-flight once: a budget the workload cannot fit is a
+                // finding to report, not a panic.
+                if let Err(e) = rt.block_on(try_query(&lane.warm_ctx, sql)) {
+                    eprintln!(
+                        "memory_budget: cayenne/{workload}@{budget_label} SKIPPED — {e}"
+                    );
+                    continue;
+                }
+                lane.pool.reset_high_water();
+                group.bench_function(
+                    BenchmarkId::new(format!("cayenne_{workload}"), budget_label),
+                    |b| {
+                        b.iter(|| {
+                            rt.block_on(async {
+                                let batches = try_query(&lane.warm_ctx, sql)
+                                    .await
+                                    .expect("pre-flighted query failed mid-bench");
+                                black_box(batches);
+                            });
+                        });
+                    },
+                );
+                let high_water = lane.pool.high_water_bytes() as u64;
+                eprintln_lane_memory("cayenne", workload, budget_label, high_water);
+                assert!(
+                    high_water <= budget_bytes as u64,
+                    "cayenne/{workload}@{budget_label}: pool high-water {high_water} bytes \
+                     exceeds the configured budget {budget_bytes} — operator contract violated"
+                );
+            }
+        }
+
+        // --- Cayenne upsert lane on a budgeted PK fixture.
+        {
+            let lane = rt.block_on(setup_budgeted_cayenne(
+                "memory_budget_upsert",
+                budget_bytes,
+                true,
+            ));
+            let preload = rt.block_on(cayenne_insert(&lane.fixture.table, base_batch.clone()));
+            assert!(preload > 0, "cayenne upsert preload must insert rows");
+            lane.pool.reset_high_water();
+            group.bench_function(BenchmarkId::new("cayenne_upsert_16k", budget_label), |b| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let rows =
+                            cayenne_insert_from_parquet(&lane.fixture.table, &upsert_parquet)
+                                .await;
+                        black_box(rows);
+                    });
+                });
+            });
+            let high_water = lane.pool.high_water_bytes() as u64;
+            eprintln_lane_memory("cayenne", "upsert_16k", budget_label, high_water);
+            assert!(
+                high_water <= budget_bytes as u64,
+                "cayenne/upsert_16k@{budget_label}: pool high-water {high_water} bytes \
+                 exceeds the configured budget {budget_bytes} — operator contract violated"
+            );
+        }
+
+        // --- DuckDB lanes at the same budget.
+        {
+            let fixture = common::setup_duckdb("memory_budget");
+            fixture
+                .conn
+                .execute_batch(&format!("SET memory_limit='{budget_label}';"))
+                .expect("duckdb SET memory_limit");
+            common::duckdb_insert_parquet(&fixture.conn, "memory_budget", &base_parquet);
+
+            for (workload, sql) in [
+                (
+                    "scan_filter_sum",
+                    "SELECT SUM(value) FROM memory_budget WHERE id BETWEEN 1000 AND 11000",
+                ),
+                (
+                    "groupby_16k",
+                    "SELECT name, SUM(value) FROM memory_budget GROUP BY name",
+                ),
+            ] {
+                group.bench_function(
+                    BenchmarkId::new(format!("duckdb_{workload}"), budget_label),
+                    |b| {
+                        b.iter(|| {
+                            let mut stmt = fixture.conn.prepare(sql).expect("duckdb prepare");
+                            let mut rows = stmt.query([]).expect("duckdb query");
+                            let mut n: i64 = 0;
+                            while let Some(_row) = rows.next().expect("duckdb row") {
+                                n += 1;
+                            }
+                            black_box(n);
+                        });
+                    },
+                );
+                if let Some(bytes) = duckdb_memory_bytes(&fixture.conn) {
+                    eprintln_lane_memory("duckdb", workload, budget_label, bytes.max(0) as u64);
+                }
+            }
+        }
+
+        // --- DuckDB upsert lane at the same budget (PK table).
+        {
+            let fixture = common::setup_duckdb_pk("memory_budget_upsert");
+            fixture
+                .conn
+                .execute_batch(&format!("SET memory_limit='{budget_label}';"))
+                .expect("duckdb SET memory_limit");
+            common::duckdb_insert_parquet(&fixture.conn, "memory_budget_upsert", &base_parquet);
+
+            group.bench_function(BenchmarkId::new("duckdb_upsert_16k", budget_label), |b| {
+                b.iter(|| {
+                    common::duckdb_upsert_parquet(
+                        &fixture.conn,
+                        "memory_budget_upsert",
+                        &upsert_parquet,
+                    );
+                });
+            });
+            if let Some(bytes) = duckdb_memory_bytes(&fixture.conn) {
+                eprintln_lane_memory("duckdb", "upsert_16k", budget_label, bytes.max(0) as u64);
+            }
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_memory_budget);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_memory_budget.rs
+++ b/crates/cayenne/benches/vs_duckdb_memory_budget.rs
@@ -41,6 +41,12 @@
 //! operator's budget — the known "ingest caches sized off total RAM" class
 //! of findings. For process-level peak RSS, wrap the bench invocation in
 //! `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux).
+//!
+//! READING THE NUMBERS: budgets run sequentially (256MiB → 2GiB → 16GiB), so
+//! slow systemic drift (thermal, page cache) accumulates toward the later
+//! budgets — compare ENGINES WITHIN a budget, not one engine across budgets.
+//! The high-water lines are order-robust; the wall-clock lanes are the
+//! within-budget pairing.
 
 #![allow(clippy::expect_used)]
 #![allow(clippy::cast_possible_wrap)]

--- a/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
@@ -109,8 +109,11 @@ async fn load_cayenne(lane: Metastore) -> CayenneFixture {
     let rows_per_snapshot = BASE_ROWS / PRELOAD_SNAPSHOTS;
     for snapshot in 0..PRELOAD_SNAPSHOTS {
         let start = (snapshot * rows_per_snapshot) as i64;
-        let _ = cayenne_insert(&fixture.table, make_batch(schema(), start, rows_per_snapshot))
-            .await;
+        let _ = cayenne_insert(
+            &fixture.table,
+            make_batch(schema(), start, rows_per_snapshot),
+        )
+        .await;
     }
     fixture
 }
@@ -253,9 +256,7 @@ fn bench_scan_under_compaction(c: &mut Criterion) {
         let merges = bg.merge_count();
         drop(bg);
         drop(fixture);
-        eprintln!(
-            "scan_under_compaction: {lane_label} background subset merges = {merges}"
-        );
+        eprintln!("scan_under_compaction: {lane_label} background subset merges = {merges}");
         assert!(
             merges > 0,
             "{lane_label}: background compactor never merged — the bench did not \

--- a/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
@@ -170,7 +170,17 @@ impl Drop for CayenneBgCompactor {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
         if let Some(handle) = self.handle.take() {
-            let _ = self.rt_handle.block_on(handle);
+            if let Err(join_err) = self.rt_handle.block_on(handle) {
+                // Propagate a background-compactor panic at the source —
+                // swallowed, it would resurface later as a misleading
+                // `merges = 0` validity failure (or as silently invalid
+                // numbers). Skip while already unwinding: panicking inside
+                // a panic-triggered drop aborts the process and eats the
+                // original message.
+                if join_err.is_panic() && !std::thread::panicking() {
+                    std::panic::resume_unwind(join_err.into_panic());
+                }
+            }
         }
     }
 }
@@ -224,7 +234,14 @@ impl Drop for DuckDbBgCheckpointer {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
         if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+            if let Err(panic_payload) = handle.join() {
+                // Same rationale as CayenneBgCompactor::drop — surface the
+                // background panic at the source instead of as a misleading
+                // checkpoint-validity failure later.
+                if !std::thread::panicking() {
+                    std::panic::resume_unwind(panic_payload);
+                }
+            }
         }
     }
 }

--- a/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
@@ -1,0 +1,277 @@
+// Copyright 2026 The Spice.ai OSS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Scan latency under background COMPACTION: Cayenne vs DuckDB.
+//!
+//! Sibling of `vs_duckdb_concurrent` (scan-under-*write*). Compaction is the
+//! heavier background writer: it re-reads and re-encodes whole snapshot
+//! subsets and contends with readers on the listing-refresh / snapshot-publish
+//! fence — a different (and worse) interference profile than small appends.
+//! The CH-benCH system runs measured exactly this state for hours at a time;
+//! no paired micro-bench covered it.
+//!
+//! Lane shape (RAII background worker, foreground timed scans — the
+//! `vs_duckdb_concurrent` pattern):
+//!
+//! - **Cayenne**: the fixture pins `inline_max_rows: 0` and a small
+//!   compaction trigger so every insert lands as a protected snapshot. The
+//!   background task loops: append a burst (creates a fresh snapshot), then
+//!   drive `compact_protected_snapshots_subset(usize::MAX)` — the same
+//!   entry point the background maintenance loop calls — counting merges
+//!   that actually happened.
+//! - **DuckDB**: the background thread loops: insert a burst, then force a
+//!   `CHECKPOINT` — DuckDB's analogous reader-contending maintenance write.
+//!
+//! VALIDITY: after the timed region each lane asserts its background
+//! maintenance actually ran (merge count / checkpoint count > 0) — a bench
+//! whose compactor never fired would just re-measure scan-under-append.
+//! The counts are printed to stderr so a run can also be sanity-checked for
+//! *how much* compaction the scans overlapped.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion::execution::runtime_env::RuntimeEnv;
+use duckdb::Connection;
+use tokio::runtime::Runtime;
+
+use common::{
+    CAYENNE_LANES, CayenneFixture, DuckDbFixture, Metastore, cayenne_insert, cayenne_query,
+    duckdb_insert_parquet, duckdb_insert_rows, duckdb_query_scalar, make_batch, schema,
+    setup_cayenne_custom, setup_duckdb, write_parquet,
+};
+
+/// Total preloaded rows, written as PRELOAD_SNAPSHOTS separate inserts so the
+/// table starts with a populated protected-snapshot tier for the compactor.
+const BASE_ROWS: usize = 49_152;
+const PRELOAD_SNAPSHOTS: usize = 12;
+
+/// Rows appended per background cycle (each append = one new snapshot).
+const BG_BURST_ROWS: usize = 2_048;
+
+/// Merge as soon as a tier holds this many runs — keeps the compactor busy.
+const COMPACTION_TRIGGER: usize = 4;
+
+/// Same scan as `vs_duckdb_concurrent`, so "scan under compaction" reads
+/// directly against "scan under write" and idle-scan numbers.
+const CAYENNE_SCAN_SQL: &str = "SELECT SUM(value) FROM t WHERE id BETWEEN 1000 AND 11000";
+const DUCKDB_SCAN_SQL: &str =
+    "SELECT SUM(value) FROM compaction_bench WHERE id BETWEEN 1000 AND 11000";
+
+async fn load_cayenne(lane: Metastore) -> CayenneFixture {
+    let vortex_config = cayenne::metadata::VortexConfig {
+        // Everything lands in Vortex files immediately — protected snapshots
+        // are what the compactor consumes.
+        inline_max_rows: 0,
+        compaction_trigger_protected_snapshots: COMPACTION_TRIGGER,
+        // Effectively disable the interval loop: the background task below
+        // drives compaction deterministically instead.
+        compaction_background_interval_ms: 3_600_000,
+        ..cayenne::metadata::VortexConfig::default()
+    };
+    let fixture = setup_cayenne_custom(
+        "compaction_bench",
+        lane,
+        vec![],
+        None,
+        schema(),
+        vortex_config,
+        Arc::new(RuntimeEnv::default()),
+    )
+    .await;
+    let rows_per_snapshot = BASE_ROWS / PRELOAD_SNAPSHOTS;
+    for snapshot in 0..PRELOAD_SNAPSHOTS {
+        let start = (snapshot * rows_per_snapshot) as i64;
+        let _ = cayenne_insert(&fixture.table, make_batch(schema(), start, rows_per_snapshot))
+            .await;
+    }
+    fixture
+}
+
+/// Background compactor for the Cayenne lane: append a burst (new snapshot),
+/// then drive a subset-compaction pass. Drop to stop + join.
+struct CayenneBgCompactor {
+    stop: Arc<AtomicBool>,
+    merges: Arc<AtomicUsize>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+    rt_handle: tokio::runtime::Handle,
+}
+
+impl CayenneBgCompactor {
+    fn spawn(rt: &Runtime, fixture: &CayenneFixture) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let merges = Arc::new(AtomicUsize::new(0));
+        let stop_clone = Arc::clone(&stop);
+        let merges_clone = Arc::clone(&merges);
+        let table = Arc::clone(&fixture.table);
+        let handle = rt.spawn(async move {
+            let mut cursor = BASE_ROWS as i64;
+            while !stop_clone.load(Ordering::Relaxed) {
+                let batch = make_batch(schema(), cursor, BG_BURST_ROWS);
+                cursor += BG_BURST_ROWS as i64;
+                let _ = cayenne_insert(&table, batch).await;
+                match table.compact_protected_snapshots_subset(usize::MAX).await {
+                    Ok(true) => {
+                        merges_clone.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Ok(false) => {}
+                    Err(e) => panic!("background compaction failed: {e}"),
+                }
+            }
+        });
+        Self {
+            stop,
+            merges,
+            handle: Some(handle),
+            rt_handle: rt.handle().clone(),
+        }
+    }
+
+    fn merge_count(&self) -> usize {
+        self.merges.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for CayenneBgCompactor {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = self.rt_handle.block_on(handle);
+        }
+    }
+}
+
+/// Background checkpointer for the DuckDB lane: insert a burst, then force a
+/// `CHECKPOINT` — the closest DuckDB analog to a maintenance rewrite that
+/// contends with readers. Drop to stop + join.
+struct DuckDbBgCheckpointer {
+    stop: Arc<AtomicBool>,
+    checkpoints: Arc<AtomicUsize>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl DuckDbBgCheckpointer {
+    fn spawn(fixture: &DuckDbFixture) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let checkpoints = Arc::new(AtomicUsize::new(0));
+        let stop_clone = Arc::clone(&stop);
+        let checkpoints_clone = Arc::clone(&checkpoints);
+        let db_path = fixture.db_path();
+        let handle = std::thread::spawn(move || {
+            let conn = Connection::open(&db_path).expect("bg duckdb open");
+            let mut cursor = BASE_ROWS as i64;
+            while !stop_clone.load(Ordering::Relaxed) {
+                let batch = make_batch(schema(), cursor, BG_BURST_ROWS);
+                cursor += BG_BURST_ROWS as i64;
+                duckdb_insert_rows(&conn, "compaction_bench", &batch);
+                // FORCE CHECKPOINT would abort concurrent transactions;
+                // plain CHECKPOINT contends with (but doesn't kill) readers —
+                // the apples-to-apples maintenance pressure.
+                conn.execute_batch("CHECKPOINT;")
+                    .expect("duckdb checkpoint");
+                checkpoints_clone.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        Self {
+            stop,
+            checkpoints,
+            handle: Some(handle),
+        }
+    }
+
+    fn checkpoint_count(&self) -> usize {
+        self.checkpoints.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for DuckDbBgCheckpointer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn bench_scan_under_compaction(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("vs_duckdb_scan_under_compaction");
+    // Like vs_duckdb_concurrent: the table is moving (background writer +
+    // compactor), so the signal is the delta vs the idle-scan bench, not
+    // absolute precision.
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(15));
+
+    let parquet_dir = tempfile::tempdir().expect("parquet dir");
+    let parquet_path = parquet_dir.path().join("base.parquet");
+    write_parquet(&make_batch(schema(), 0, BASE_ROWS), &parquet_path);
+
+    for &lane in CAYENNE_LANES {
+        let lane_label = lane.lane();
+        let fixture = rt.block_on(load_cayenne(lane));
+        let bg = CayenneBgCompactor::spawn(&rt, &fixture);
+
+        let table = Arc::clone(&fixture.table);
+        group.bench_function(BenchmarkId::new(lane_label, "scan_under_compaction"), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let batches = cayenne_query(&table, CAYENNE_SCAN_SQL).await;
+                    black_box(batches);
+                });
+            });
+        });
+
+        // VALIDITY GATE: if no merge ever fired, the bench measured
+        // scan-under-append, not scan-under-compaction.
+        let merges = bg.merge_count();
+        drop(bg);
+        drop(fixture);
+        eprintln!(
+            "scan_under_compaction: {lane_label} background subset merges = {merges}"
+        );
+        assert!(
+            merges > 0,
+            "{lane_label}: background compactor never merged — the bench did not \
+             measure scan-under-compaction (check trigger/threshold config)"
+        );
+    }
+
+    let duckdb_fixture = setup_duckdb("compaction_bench");
+    duckdb_insert_parquet(&duckdb_fixture.conn, "compaction_bench", &parquet_path);
+    let bg = DuckDbBgCheckpointer::spawn(&duckdb_fixture);
+    group.bench_function(BenchmarkId::new("duckdb", "scan_under_compaction"), |b| {
+        b.iter(|| {
+            let v = duckdb_query_scalar(&duckdb_fixture.conn, DUCKDB_SCAN_SQL);
+            black_box(v);
+        });
+    });
+    let checkpoints = bg.checkpoint_count();
+    drop(bg);
+    drop(duckdb_fixture);
+    eprintln!("scan_under_compaction: duckdb background checkpoints = {checkpoints}");
+    assert!(
+        checkpoints > 0,
+        "duckdb: background checkpointer never ran — the bench did not measure \
+         scan-under-checkpoint"
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan_under_compaction);
+criterion_main!(benches);

--- a/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
@@ -157,8 +157,12 @@ impl CayenneBgCompactor {
         }
     }
 
-    fn merge_count(&self) -> usize {
-        self.merges.load(Ordering::Relaxed)
+    /// Clone of the merge counter. Read it AFTER dropping the compactor —
+    /// the background task can complete one more in-flight pass during the
+    /// stop+join, so a pre-drop read can under-report (or, read as 0, fail
+    /// the validity gate spuriously).
+    fn merges_counter(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.merges)
     }
 }
 
@@ -209,8 +213,10 @@ impl DuckDbBgCheckpointer {
         }
     }
 
-    fn checkpoint_count(&self) -> usize {
-        self.checkpoints.load(Ordering::Relaxed)
+    /// Clone of the checkpoint counter — read after drop+join, see
+    /// [`CayenneBgCompactor::merges_counter`].
+    fn checkpoints_counter(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.checkpoints)
     }
 }
 
@@ -252,10 +258,13 @@ fn bench_scan_under_compaction(c: &mut Criterion) {
         });
 
         // VALIDITY GATE: if no merge ever fired, the bench measured
-        // scan-under-append, not scan-under-compaction.
-        let merges = bg.merge_count();
+        // scan-under-append, not scan-under-compaction. Read the counter
+        // only after drop(bg) joins the task — an in-flight pass can still
+        // complete (and increment) during the stop+join.
+        let merges_counter = bg.merges_counter();
         drop(bg);
         drop(fixture);
+        let merges = merges_counter.load(Ordering::Relaxed);
         eprintln!("scan_under_compaction: {lane_label} background subset merges = {merges}");
         assert!(
             merges > 0,
@@ -274,9 +283,11 @@ fn bench_scan_under_compaction(c: &mut Criterion) {
             black_box(v);
         });
     });
-    let checkpoints = bg.checkpoint_count();
+    // Same post-join read discipline as the Cayenne lane above.
+    let checkpoints_counter = bg.checkpoints_counter();
     drop(bg);
     drop(duckdb_fixture);
+    let checkpoints = checkpoints_counter.load(Ordering::Relaxed);
     eprintln!("scan_under_compaction: duckdb background checkpoints = {checkpoints}");
     assert!(
         checkpoints > 0,

--- a/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
+++ b/crates/cayenne/benches/vs_duckdb_scan_under_compaction.rs
@@ -18,7 +18,9 @@
 //! Lane shape (RAII background worker, foreground timed scans — the
 //! `vs_duckdb_concurrent` pattern):
 //!
-//! - **Cayenne**: the fixture pins `inline_max_rows: 0` and a small
+//! - **Cayenne**: a PK upsert fixture (protected snapshots — the
+//!   compactor's input — are a conflict-resolution construct; an append-only
+//!   table never produces any) pinning `inline_max_rows: 0` and a small
 //!   compaction trigger so every insert lands as a protected snapshot. The
 //!   background task loops: append a burst (creates a fresh snapshot), then
 //!   drive `compact_protected_snapshots_subset(usize::MAX)` — the same
@@ -53,7 +55,10 @@ use tokio::runtime::Runtime;
 use common::{
     CAYENNE_LANES, CayenneFixture, DuckDbFixture, Metastore, cayenne_insert, cayenne_query,
     duckdb_insert_parquet, duckdb_insert_rows, duckdb_query_scalar, make_batch, schema,
-    setup_cayenne_custom, setup_duckdb, write_parquet,
+    setup_cayenne_custom, setup_duckdb_pk, write_parquet,
+};
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
 };
 
 /// Total preloaded rows, written as PRELOAD_SNAPSHOTS separate inserts so the
@@ -84,11 +89,18 @@ async fn load_cayenne(lane: Metastore) -> CayenneFixture {
         compaction_background_interval_ms: 3_600_000,
         ..cayenne::metadata::VortexConfig::default()
     };
+    // PK + upsert table: protected snapshots — the compactor's input — are
+    // a conflict-resolution construct, so a plain append-only table never
+    // produces any and `compact_protected_snapshots_subset` is a no-op
+    // (the validity gate below caught exactly that on a non-PK draft of
+    // this bench: merges = 0).
     let fixture = setup_cayenne_custom(
         "compaction_bench",
         lane,
-        vec![],
-        None,
+        vec!["id".to_string()],
+        Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "id".to_string(),
+        ]))),
         schema(),
         vortex_config,
         Arc::new(RuntimeEnv::default()),
@@ -251,7 +263,8 @@ fn bench_scan_under_compaction(c: &mut Criterion) {
         );
     }
 
-    let duckdb_fixture = setup_duckdb("compaction_bench");
+    // PK table for parity with the Cayenne upsert fixture.
+    let duckdb_fixture = setup_duckdb_pk("compaction_bench");
     duckdb_insert_parquet(&duckdb_fixture.conn, "compaction_bench", &parquet_path);
     let bg = DuckDbBgCheckpointer::spawn(&duckdb_fixture);
     group.bench_function(BenchmarkId::new("duckdb", "scan_under_compaction"), |b| {


### PR DESCRIPTION
## What

Closes the top-3 coverage gaps in the paired `vs_duckdb_*` bench suite. The existing 14 benches measure the **latency** half of the mission well, but were structurally blind on three dimensions the perf-audit process treats as co-equal: peak memory under an operator budget, scan latency under background **compaction** (vs only under appends), and **fleet** CDC (vs only single-table).

### 1. `vs_duckdb_memory_budget`

Every existing paired bench builds Cayenne on `RuntimeEnv::default()` — an **unlimited** memory pool — so none can see whether Cayenne honors `runtime.query.memory_limit`. This bench wires the production pool shape (`TrackConsumersPool<GreedyMemoryPool>`, exactly how spiced builds it) wrapped in a high-water tracker into **both** the table's `RuntimeEnv` and the query session (the spiced single-`RuntimeEnv` topology), and runs scan / 16k-group aggregation / PK upsert at **256 MiB / 2 GiB / 16 GiB** against DuckDB at the same `SET memory_limit`.

- Hard-asserts the operator contract: pool high-water ≤ budget.
- A budget too small to complete a workload is **reported and skipped**, not panicked — "needs more than 256 MiB" is a finding.
- Pool high-water ≈ 0 while a lane clearly allocates exposes **off-pool** allocations (the known "ingest sized off total RAM" class).

Baseline (M-series macOS, trunk):

| lane @256MiB | Cayenne | DuckDB |
|---|---|---|
| scan_filter_sum | 663 µs / **0.2 MiB** pool high-water | 282 µs / ~4.9 MiB (`duckdb_memory()`) |
| groupby_16k | 3.87 ms / **72.2 MiB** | 3.43 ms / ~4.9 MiB |
| upsert_16k | ~86–105 ms / **57.5 MiB held** | ~2.5–4.4 ms / ~5.4 MiB |

Two observations already worth follow-up: (a) the 16k-group aggregation reserves **~15× DuckDB's** reported memory for near-identical wall-clock; (b) the upsert lane **holds 57.5 MiB on-pool at every budget for a ~0.5 MiB batch** (~120× amplification; sized once at the first upsert and retained — surfaced by seeding the high-water tracker with the current reservation at reset, since held-but-not-growing memory is otherwise invisible to a grow-only tracker) — and the rest of the known write-path caches don't appear in the pool at all. Post-review, the upsert lane runs through the lane's budgeted session (the shared helper builds its own unbudgeted `SessionContext`), so query-side decode and table-side writes draw on one pool — the spiced topology. Note: compare engines *within* a budget; budgets run sequentially so slow systemic drift accumulates toward later budgets (doc-commented).

### 2. `vs_duckdb_scan_under_compaction`

Sibling of `vs_duckdb_concurrent` (scan-under-append). Compaction is the heavier background writer — it re-reads/re-encodes snapshot subsets and contends on the listing/publish fence. Background task appends a burst then drives `compact_protected_snapshots_subset` (the live maintenance entry point); DuckDB lane pairs against INSERT + `CHECKPOINT`.

**Validity gate**: asserts background merges/checkpoints actually happened, with counts printed — a draft of this bench produced `merges = 0` (protected snapshots are a conflict-resolution construct; an append-only table never creates any) and the gate caught it before it shipped a number that silently re-measured scan-under-append. Fixture is PK+upsert on both engines now.

Baseline (81 subset merges / 628 checkpoints during the timed regions):

| | Cayenne | DuckDB |
|---|---|---|
| scan under compaction (median) | **7.44 ms** [5.2–12.1] | **255 µs** [210–321] |

~**29× slower under compaction** vs DuckDB's scan-under-checkpoint, and ~10–50× this table's idle-scan latency — the paired regression guard for the compaction-fence work.

### 3. `vs_duckdb_cdc_multitable`

`vs_duckdb_scaling_cdc` pumps ONE table with N writers; the HTAP reality is a **fleet** of CDC tables (CH-benCH = 14) whose per-table write concurrency is sized in isolation and **sums** across tables. This bench pumps N tables (1→16, each its own metastore — the per-dataset topology) with one CDC writer each through `write_cdc_append_stream + finish()`, vs DuckDB writing N tables over N connections on one file DB. Tables are preloaded 64 batches so per-batch cost is stationary (a first cut without preload produced a non-monotonic curve — lanes with cheaper iterations aged their tables further; doc-commented).

Baseline, aggregate throughput (median):

| tables | Cayenne | DuckDB | Cayenne advantage |
|---|---|---|---|
| 1 | 313 Kelem/s | 134 Kelem/s | 2.3× |
| 2 | 460 K | 184 K | 2.5× |
| 4 | 1.09 M | 455 K | 2.4× |
| 8 | 1.35 M | 476 K | 2.8× |
| 16 | 1.87 M | 762 K | 2.4× |

**Cayenne wins fleet CDC at every fleet size (2.3–2.8×)** and scales 6.0× from 1→16 tables. The sub-linear tail (16× tables → 6× throughput) is the oversubscription signal this bench exists to track as the global write-budget work iterates.

## Helpers

`setup_cayenne_custom` (caller-controlled `VortexConfig` + `RuntimeEnv`; existing wrappers route through it unchanged) and `warm_session_with_runtime` — a budgeted query session; `SessionContext::new()` would silently run queries on an unlimited default pool, budget-gating only the write path.

## How tested

- `cargo bench -p cayenne --features duckdb-bench --bench vs_duckdb_memory_budget --bench vs_duckdb_scan_under_compaction --bench vs_duckdb_cdc_multitable` — all lanes complete; validity gates pass (merge/checkpoint counts > 0; budget contract asserts hold; no skipped budget lanes on this host).
- Benches only; no library code changes.

