### PR TITLE
Merge develop to trunk — 2026-06-06

### DIFF
--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -220,3 +220,8 @@ name = "object_filter"
 harness = false
 name = "mongodb_change_stream"
 required-features = ["mongodb"]
+
+[[bench]]
+harness = false
+name = "kafka_decode"
+required-features = ["bench", "kafka"]

--- a/crates/data_components/benches/kafka_decode.rs
+++ b/crates/data_components/benches/kafka_decode.rs
@@ -1,0 +1,75 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Head-to-head decode microbench for the Kafka change-stream JSON path:
+//! `direct` (raw bytes -> Arrow) vs `roundtrip` (bytes -> serde_json::Value ->
+//! to_string() -> Arrow). Run with:
+//!   cargo bench -p data_components --features bench,kafka --bench kafka_decode
+
+#![allow(clippy::expect_used, clippy::redundant_closure_for_method_calls)]
+
+use arrow::datatypes::{DataType, Field, Schema};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use data_components::kafka::bench_wrappers::{decode_direct, decode_roundtrip};
+use std::hint::black_box;
+use std::sync::Arc;
+
+fn record_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Utf8, false),
+        Field::new("category", DataType::Utf8, false),
+        Field::new("amount", DataType::Decimal128(38, 18), false),
+        Field::new("ts", DataType::Utf8, false),
+    ]))
+}
+
+/// Mixed-type messages: a string key, a category, an 18-dp decimal amount, and a
+/// timestamp string. The 18-decimal field exercises the precision-sensitive path.
+fn make_payloads(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|i| {
+            let frac = 123_456_789_012_345_678u64 + (i as u64 % 1000);
+            format!(
+                "{{\"key\":\"item_{i:04}\",\"category\":\"cat_{}\",\"amount\":{}.{frac:018},\"ts\":\"2026-01-01T00:00:{:02}Z\"}}",
+                i % 8,
+                600 + (i % 50),
+                i % 60
+            )
+            .into_bytes()
+        })
+        .collect()
+}
+
+fn bench_decode(c: &mut Criterion) {
+    let schema = record_schema();
+    let mut group = c.benchmark_group("kafka_json_decode");
+    for &n in &[100usize, 1_000, 10_000] {
+        let owned = make_payloads(n);
+        let payloads: Vec<&[u8]> = owned.iter().map(|v| v.as_slice()).collect();
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(BenchmarkId::new("direct", n), &payloads, |b, p| {
+            b.iter(|| black_box(decode_direct(black_box(p), &schema).expect("direct")));
+        });
+        group.bench_with_input(BenchmarkId::new("roundtrip", n), &payloads, |b, p| {
+            b.iter(|| black_box(decode_roundtrip(black_box(p), &schema).expect("roundtrip")));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_decode);
+criterion_main!(benches);

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -1039,21 +1039,29 @@ fn payloads_to_change_batch<'a>(
     payloads: impl Iterator<Item = &'a [u8]>,
     schema: &Arc<Schema>,
 ) -> Result<ChangeBatch, cdc::StreamError> {
-    let values = payloads
-        .map(|payload| {
-            serde_json::from_slice::<Value>(payload).map_err(|e| {
-                cdc::StreamError::Kafka(Error::UnableToDeserializeJsonMessage { source: e })
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    // Fast path (no flatten): feed the raw JSON payload bytes straight to the
+    // Arrow NDJSON reader, skipping the serde_json::Value tree + the
+    // re-serialization round-trip that values_to_change_batch performs.
+    // arrow-json accepts both newline-delimited and whitespace-separated JSON
+    // values, so joining payloads with '\n' is safe even when a producer emits
+    // pretty-printed (multi-line) objects.
+    let mut joined: Vec<u8> = Vec::new();
+    let mut count: usize = 0;
+    for payload in payloads {
+        if !joined.is_empty() {
+            joined.push(b'\n');
+        }
+        joined.extend_from_slice(payload);
+        count += 1;
+    }
 
-    if values.is_empty() {
+    if count == 0 {
         return Err(cdc::StreamError::Arrow(
             "No Kafka message payload found in batch".to_string(),
         ));
     }
 
-    values_to_change_batch(values.iter(), None, schema)
+    json_bytes_to_change_batch(&joined, schema)
 }
 
 fn values_to_change_batch<'a>(
@@ -1099,6 +1107,39 @@ fn json_bytes_to_change_batch(
 
     cdc::wrap_data_as_change_batch(schema, &rb)
         .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))
+}
+
+// Public wrappers for benchmarking the two JSON decode paths head-to-head.
+#[cfg(feature = "bench")]
+pub mod bench_wrappers {
+    use super::{
+        Arc, ChangeBatch, Error, Schema, Value, cdc, payloads_to_change_batch,
+        values_to_change_batch,
+    };
+
+    /// Direct path (production): raw payload bytes -> Arrow NDJSON reader.
+    pub fn decode_direct(
+        payloads: &[&[u8]],
+        schema: &Arc<Schema>,
+    ) -> Result<ChangeBatch, cdc::StreamError> {
+        payloads_to_change_batch(payloads.iter().copied(), schema)
+    }
+
+    /// Legacy round-trip path: bytes -> serde_json::Value -> to_string() -> Arrow.
+    pub fn decode_roundtrip(
+        payloads: &[&[u8]],
+        schema: &Arc<Schema>,
+    ) -> Result<ChangeBatch, cdc::StreamError> {
+        let values = payloads
+            .iter()
+            .map(|p| {
+                serde_json::from_slice::<Value>(p).map_err(|e| {
+                    cdc::StreamError::Kafka(Error::UnableToDeserializeJsonMessage { source: e })
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        values_to_change_batch(values.iter(), None, schema)
+    }
 }
 
 #[async_trait]
@@ -1290,6 +1331,61 @@ mod tests {
             }
             _ => panic!("Expected Arrow error"),
         }
+    }
+
+    #[test]
+    fn decimal_precision_roundtrip_vs_direct() {
+        use arrow::array::Decimal128Array;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("amt", DataType::Decimal128(38, 18), false),
+        ]));
+        // 18 fractional digits → exact scaled i128 = 1234567890123456789
+        let exact: i128 = 1_234_567_890_123_456_789;
+        let raw_num = br#"{"id":1,"amt":1.234567890123456789}"#;
+        let raw_str = br#"{"id":1,"amt":"1.234567890123456789"}"#;
+
+        // ChangeBatch.record is [op, primary_keys, data:Struct{table fields}];
+        // amt is field 1 of the nested data struct (col 2).
+        let amt = |b: &ChangeBatch| -> i128 {
+            b.record
+                .column(2)
+                .as_any()
+                .downcast_ref::<arrow::array::StructArray>()
+                .expect("data struct")
+                .column(1)
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .expect("decimal col")
+                .value(0)
+        };
+
+        // direct (this PR's fast path), number form
+        let direct_num = payloads_to_change_batch([raw_num.as_slice()].into_iter(), &schema)
+            .expect("direct num");
+        // current round-trip path, number form
+        let v_num = serde_json::from_slice::<Value>(raw_num).expect("parse num");
+        let rt_num = values_to_change_batch([v_num].iter(), None, &schema).expect("roundtrip num");
+        // direct, string form (decimal-as-string control)
+        let direct_str = payloads_to_change_batch([raw_str.as_slice()].into_iter(), &schema)
+            .expect("direct str");
+
+        eprintln!("[decimal-precision] exact          = {exact}");
+        eprintln!("[decimal-precision] direct(num)     = {}", amt(&direct_num));
+        eprintln!("[decimal-precision] roundtrip(num)  = {}", amt(&rt_num));
+        eprintln!("[decimal-precision] direct(str)     = {}", amt(&direct_str));
+
+        // The direct byte path preserves full Decimal128 precision for both
+        // number- and string-form JSON.
+        assert_eq!(amt(&direct_num), exact, "direct number-form must be exact");
+        assert_eq!(amt(&direct_str), exact, "direct string-form must be exact");
+        // The old serde_json::Value -> to_string() round-trip widens the number
+        // to f64 first and is therefore lossy beyond ~16 significant digits.
+        assert_ne!(
+            amt(&rt_num),
+            exact,
+            "round-trip via serde_json::Value is lossy through f64"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Merge `develop` into `trunk`.

### Commits included

cdb1337294 Merge remote-tracking branch 'origin/trunk' into develop
33acd4c424 fix(kafka): decode JSON payloads to Arrow directly — fixes lossy Decimal128 + removes double-parse (#11192)

## Test plan

- `make lint` passes locally
- CI checks pass