### PR TITLE
fix: apply retention_sql after Arrow refresh writes

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -147,6 +147,15 @@ pub enum Error {
     FailedToWriteData { source: DataFusionError },
 
     #[snafu(display(
+        "Failed to apply retention_sql to accelerated dataset {dataset_name} after refresh data was written: {}. The accelerated dataset may contain rows that should have been retained away.",
+        format_datafusion_error(source)
+    ))]
+    FailedToApplyRetentionSql {
+        dataset_name: String,
+        source: DataFusionError,
+    },
+
+    #[snafu(display(
         "The accelerated table does not support delete operations. Use a different acceleration engine which supports delete operations. For details, visit: https://spiceai.org/docs/components/data-accelerators"
     ))]
     AcceleratedTableDoesntSupportDelete {},

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -39,6 +39,7 @@ use data_components::cdc::ChangesStream;
 use datafusion::common::TableReference;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::sqlparser;
+use datafusion_expr::Expr;
 use futures::future::BoxFuture;
 use opentelemetry::KeyValue;
 use rand::RngExt;
@@ -208,6 +209,10 @@ pub struct Refresh {
     pub(crate) retry_max_attempts: Option<usize>,
     /// TTL for cache entries. Data older than this is considered stale.
     pub(crate) caching_ttl: Option<Duration>,
+    /// Retention SQL delete expression to apply after a successful accelerator write.
+    /// Currently populated only for Arrow and PartitionedArrow accelerators;
+    /// DuckDB and Cayenne apply retention in their own write paths.
+    pub(crate) write_retention_sql_delete_expr: Option<Expr>,
 }
 
 /// [`RefreshOverrides`] specifies the configurable options for a individual run of a refresh task.
@@ -614,6 +619,7 @@ impl Default for Refresh {
             retry_enabled: false,
             retry_max_attempts: None,
             caching_ttl: None,
+            write_retention_sql_delete_expr: None,
         }
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1122,34 +1122,39 @@ impl Refresher {
                     Some(res) = on_refresh_complete.recv() => {
                         tracing::debug!("Received refresh task completion callback: {res:?}");
 
-                        if matches!(res, Ok(())) {
+                        let refresh_succeeded = matches!(&res, Ok(()));
+                        // A retention failure can happen after a successful write, so cached
+                        // query results must be invalidated even though the refresh reports an error.
+                        let refresh_changed_accelerator = refresh_result_changed_accelerator(&res);
+
+                        if refresh_succeeded {
                             if let Some(notifier) = &notifier {
                                 notify_refresh_done(&dataset_name, &refresh, Arc::clone(notifier)).await;
                             }
                             initial_load_completed.store(true, Ordering::Relaxed);
+                        }
 
-                            if let Some(cache_provider_ref) = caching.as_ref() {
-                                // No cache provider means runtime is shutting down and cache is already cleaned up
-                                if let Some(cache_provider) = cache_provider_ref.upgrade()
-                                    && let Err(e) = cache_provider.invalidate_for_table(dataset_name.clone()) {
-                                        tracing::warn!("Failed to invalidate cached results for dataset {dataset_name}: {e}");
-                                    }
-                            }
+                        if refresh_changed_accelerator && let Some(cache_provider_ref) = caching.as_ref() {
+                            // No cache provider means runtime is shutting down and cache is already cleaned up
+                            if let Some(cache_provider) = cache_provider_ref.upgrade()
+                                && let Err(e) = cache_provider.invalidate_for_table(dataset_name.clone()) {
+                                    tracing::warn!("Failed to invalidate cached results for dataset {dataset_name}: {e}");
+                                }
+                        }
 
-                            if checkpoint_counting_enabled.load(Ordering::Acquire) && create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
-                                let refresh_sql = refresh.read().await.sql.as_ref().map(RefreshSQL::to_sql);
-                                create_checkpoint_and_snapshot(
-                                    checkpointer,
-                                    snapshot_manager.as_ref(),
-                                    &federated_schema,
-                                    &snapshot_mutex,
-                                    &dataset_name,
-                                    &last_updated_at,
-                                    ForceCreate(false),
-                                    Some(&accelerator),
-                                    refresh_sql.as_deref(),
-                                ).await;
-                            }
+                        if refresh_succeeded && checkpoint_counting_enabled.load(Ordering::Acquire) && create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {
+                            let refresh_sql = refresh.read().await.sql.as_ref().map(RefreshSQL::to_sql);
+                            create_checkpoint_and_snapshot(
+                                checkpointer,
+                                snapshot_manager.as_ref(),
+                                &federated_schema,
+                                &snapshot_mutex,
+                                &dataset_name,
+                                &last_updated_at,
+                                ForceCreate(false),
+                                Some(&accelerator),
+                                refresh_sql.as_deref(),
+                            ).await;
                         }
 
                         // The initial load has completed, let's synchronize further refreshes with the existing table and shutdown this refresher
@@ -1266,6 +1271,13 @@ pub(crate) fn get_timestamp(time: SystemTime) -> u128 {
         .as_nanos()
 }
 
+fn refresh_result_changed_accelerator(result: &super::Result<()>) -> bool {
+    matches!(
+        result,
+        Ok(()) | Err(super::Error::FailedToApplyRetentionSql { .. })
+    )
+}
+
 async fn notify_refresh_done(
     dataset_name: &TableReference,
     refresh: &Arc<RwLock<Refresh>>,
@@ -1371,6 +1383,28 @@ mod tests {
         ) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
             Ok(self.stored_refresh_sql.clone())
         }
+    }
+
+    #[test]
+    fn test_refresh_result_changed_accelerator() {
+        assert!(refresh_result_changed_accelerator(&Ok(())));
+
+        assert!(refresh_result_changed_accelerator(&Err(
+            super::super::Error::FailedToApplyRetentionSql {
+                dataset_name: "retained_table".to_string(),
+                source: datafusion::error::DataFusionError::Execution(
+                    "retention failed after write".to_string(),
+                ),
+            }
+        )));
+
+        assert!(!refresh_result_changed_accelerator(&Err(
+            super::super::Error::FailedToRefreshDataset {
+                source: datafusion::error::DataFusionError::Execution(
+                    "source refresh failed before write".to_string(),
+                ),
+            }
+        )));
     }
 
     async fn setup_and_test(

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -20,6 +20,7 @@ use super::refresh::get_timestamp;
 use super::sink::AccelerationSink;
 use super::synchronized_table::SynchronizedTable;
 use crate::accelerated_table::caching::CacheRefreshHelper;
+use crate::accelerated_table::retention;
 use crate::accelerated_table::timestamp_metrics_utils::with_find_max_timestamp_in_stream;
 use crate::component::dataset::TimeFormat;
 use crate::datafusion::builder::{AnalyzerRulesBuilder, get_df_default_config};
@@ -733,6 +734,7 @@ impl RefreshTask {
                 Some(start_time),
                 streaming_data_update,
                 refresh.display_sql().as_deref(),
+                refresh.write_retention_sql_delete_expr.clone(),
             )
             .await
         {
@@ -847,6 +849,7 @@ impl RefreshTask {
         start_time: Option<SystemTime>,
         data_update: StreamingDataUpdate,
         sql: Option<&str>,
+        retention_sql_delete_expr: Option<Expr>,
     ) -> Result<(), RetryError<super::Error>> {
         let dataset_name = self.dataset_name.clone();
 
@@ -948,6 +951,16 @@ impl RefreshTask {
             )
             .await;
             return Err(e);
+        }
+
+        if let Some(retention_sql_delete_expr) = retention_sql_delete_expr {
+            let _ = retention::apply_retention_filters_once(
+                &self.dataset_name,
+                &self.accelerator,
+                retention_sql_delete_expr,
+                &self.io_runtime,
+            )
+            .await;
         }
 
         let refresh_stat = on_written_data_stat_available.try_recv().ok();

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -953,15 +953,18 @@ impl RefreshTask {
             return Err(e);
         }
 
-        if let Some(retention_sql_delete_expr) = retention_sql_delete_expr {
-            let _ = retention::apply_retention_filters_once(
+        let retention_error = if let Some(retention_sql_delete_expr) = retention_sql_delete_expr {
+            retention::apply_retention_filters_once(
                 &self.dataset_name,
                 &self.accelerator,
                 retention_sql_delete_expr,
                 &self.io_runtime,
             )
-            .await;
-        }
+            .await
+            .err()
+        } else {
+            None
+        };
 
         let refresh_stat = on_written_data_stat_available.try_recv().ok();
 
@@ -978,13 +981,34 @@ impl RefreshTask {
             }
         }
 
+        let num_rows = refresh_stat.as_ref().map_or(0, |s| s.num_rows);
+
+        if let Some(error) = retention_error {
+            self.maybe_update_last_updated_at(&data_update.update_type, num_rows);
+
+            let error_message = format!(
+                "Failed to apply retention_sql after writing data for dataset {}: {}",
+                self.dataset_name,
+                format_datafusion_error(&error)
+            );
+            self.set_refresh_status(
+                sql,
+                status::ComponentStatus::error_with_message(error_message),
+            )
+            .await;
+
+            return Err(RetryError::permanent(
+                super::Error::FailedToApplyRetentionSql {
+                    dataset_name: self.dataset_name.to_string(),
+                    source: error,
+                },
+            ));
+        }
+
         self.set_refresh_status(sql, status::ComponentStatus::Ready)
             .await;
 
-        self.maybe_update_last_updated_at(
-            &data_update.update_type,
-            refresh_stat.map_or(0, |s| s.num_rows),
-        );
+        self.maybe_update_last_updated_at(&data_update.update_type, num_rows);
 
         Ok(())
     }
@@ -2117,7 +2141,8 @@ impl RefreshTask {
             | super::Error::UnableToScanTableProvider { source }
             | super::Error::UnableToCreateMemTableFromUpdate { source }
             | super::Error::FailedToQueryLatestTimestamp { source }
-            | super::Error::FailedToWriteData { source } => {
+            | super::Error::FailedToWriteData { source }
+            | super::Error::FailedToApplyRetentionSql { source, .. } => {
                 // Match against an Internal error with the message "Non Panic Task error":
                 // <https://github.com/apache/datafusion/blob/f6c92fecb23c927bdc6a9feb058f03a2fb61d63f/datafusion/physical-plan/src/stream.rs#L132>
                 if let DataFusionError::Internal(msg) = &source
@@ -2645,6 +2670,78 @@ mod tests {
         };
 
         assert!(schema_evolution_mismatch_refresh_message("dataset", "nation", &error).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_retention_failure_after_insert_is_permanent_and_advances_watermark() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+        let accelerator = Arc::new(
+            MemTable::try_new(Arc::clone(&schema), vec![vec![]])
+                .expect("accelerator mem table should be created"),
+        ) as Arc<dyn TableProvider>;
+        let federated_table = Arc::new(
+            MemTable::try_new(Arc::clone(&schema), vec![vec![]])
+                .expect("federated mem table should be created"),
+        ) as Arc<dyn TableProvider>;
+        let federated = Arc::new(FederatedTable::new_unchecked(federated_table));
+
+        let task = RefreshTaskBuilder::new(
+            crate::status::RuntimeStatus::new(),
+            TableReference::bare("retention_failure_after_insert"),
+            federated,
+            None,
+            Arc::clone(&accelerator),
+            Handle::current(),
+            Arc::new(Mutex::new(())),
+        )
+        .build();
+
+        let update_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        )
+        .expect("update batch should be created");
+        let update_stream: SendableRecordBatchStream = Box::pin(
+            MemoryStream::try_new(vec![update_batch], Arc::clone(&schema), None)
+                .expect("update stream should be created"),
+        );
+        let update = StreamingDataUpdate::new(update_stream, UpdateType::Append);
+
+        let result = task
+            .write_streaming_data_update(
+                None,
+                update,
+                None,
+                Some(col("missing_retention_column").eq(datafusion::prelude::lit(1_i32))),
+            )
+            .await;
+
+        let Err(RetryError::Permanent(super::super::Error::FailedToApplyRetentionSql {
+            dataset_name,
+            ..
+        })) = result
+        else {
+            panic!("retention failure after insert should return a permanent retention error");
+        };
+        assert_eq!(dataset_name, "retention_failure_after_insert");
+        assert!(
+            task.last_updated_at
+                .load(std::sync::atomic::Ordering::Relaxed)
+                > 0,
+            "append watermark should advance after the insert commits"
+        );
+
+        let ctx = SessionContext::new();
+        let plan = accelerator
+            .scan(&ctx.state(), None, &[], None)
+            .await
+            .expect("accelerator scan should succeed");
+        let batches = collect(plan, ctx.task_ctx())
+            .await
+            .expect("accelerator rows should be collected");
+        let row_count = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        assert_eq!(row_count, 1, "insert should remain committed");
     }
 
     /// Tests that `max_timestamp_df` returns the maximum value for integer time columns

--- a/crates/runtime/src/accelerated_table/retention.rs
+++ b/crates/runtime/src/accelerated_table/retention.rs
@@ -38,6 +38,60 @@ use runtime_object_store::registry::default_runtime_env;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
+pub(crate) async fn apply_retention_filters_once(
+    dataset_name: &TableReference,
+    accelerator: &Arc<dyn TableProvider>,
+    expr: Expr,
+    io_runtime: &Handle,
+) -> datafusion::error::Result<u64> {
+    tracing::trace!("[retention] Expr before simplification: {expr:?}");
+
+    let original_expr = format!("{expr:?}");
+    let expr = match util::expr::simplify_expr(expr, &accelerator.schema()) {
+        Ok(expr) => expr,
+        Err(e) => {
+            tracing::error!(
+                "[retention] Upon checking retention policy for table '{dataset_name}', an error occurred when attempting to simplify the relevant retention expression '{original_expr}'. Error: {e}"
+            );
+            return Err(e);
+        }
+    };
+
+    tracing::debug!("[retention] Expr: {expr:?}");
+
+    let ctx = SessionContext::new_with_config_rt(
+        get_df_default_config(),
+        default_runtime_env(io_runtime.clone()),
+    );
+
+    let plan = match accelerator.delete_from(&ctx.state(), vec![expr]).await {
+        Ok(plan) => plan,
+        Err(e) => {
+            tracing::error!("[retention] Error running retention check: {e}");
+            return Err(e);
+        }
+    };
+
+    let deleted = match collect(plan, ctx.task_ctx()).await {
+        Ok(deleted) => deleted,
+        Err(e) => {
+            tracing::error!("[retention] Error running retention check: {e}");
+            return Err(e);
+        }
+    };
+
+    let num_records = deleted.first().map_or(0, |f| {
+        f.column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .map_or(0, |v| v.values().first().copied().unwrap_or(0))
+    });
+
+    log_retention_result(dataset_name, num_records);
+
+    Ok(num_records)
+}
+
 impl super::AcceleratedTable {
     #[expect(clippy::cast_possible_truncation)]
     pub(crate) async fn start_retention_check(
@@ -141,57 +195,21 @@ impl super::AcceleratedTable {
                 continue;
             };
 
-            tracing::trace!("[retention] Expr before simplification: {expr:?}");
-
-            let expr = match util::expr::simplify_expr(expr.clone(), &accelerator.schema()) {
-                Ok(simplified) => simplified,
-                Err(e) => {
-                    tracing::error!(
-                        "[retention] Upon checking retention policy for table '{dataset_name}', an error occurred when attempting to simplify the relevant retention expression '{expr:?}'. Error: {e}"
-                    );
-                    continue;
+            match apply_retention_filters_once(&dataset_name, &accelerator, expr, &io_runtime).await
+            {
+                Ok(num_records) => {
+                    if num_records > 0
+                        && let Some(cache_provider) = caching.as_ref()
+                        && let Err(e) = cache_provider.invalidate_for_table(dataset_name.clone())
+                    {
+                        tracing::error!(
+                            "Failed to invalidate cached results for dataset {}: {e}",
+                            &dataset_name
+                        );
+                    }
                 }
+                Err(_) => continue,
             };
-
-            tracing::debug!("[retention] Expr: {expr:?}");
-
-            let ctx = SessionContext::new_with_config_rt(
-                get_df_default_config(),
-                default_runtime_env(io_runtime.clone()),
-            );
-
-            let plan = accelerator.delete_from(&ctx.state(), vec![expr]).await;
-            match plan {
-                Ok(plan) => match collect(plan, ctx.task_ctx()).await {
-                    Err(e) => {
-                        tracing::error!("[retention] Error running retention check: {e}");
-                    }
-                    Ok(deleted) => {
-                        let num_records = deleted.first().map_or(0, |f| {
-                            f.column(0)
-                                .as_any()
-                                .downcast_ref::<UInt64Array>()
-                                .map_or(0, |v| v.values().first().map_or(0, |f| *f))
-                        });
-
-                        log_retention_result(&dataset_name, num_records);
-
-                        if num_records > 0
-                            && let Some(cache_provider) = caching.as_ref()
-                            && let Err(e) =
-                                cache_provider.invalidate_for_table(dataset_name.clone())
-                        {
-                            tracing::error!(
-                                "Failed to invalidate cached results for dataset {}: {e}",
-                                &dataset_name
-                            );
-                        }
-                    }
-                },
-                Err(e) => {
-                    tracing::error!("[retention] Error running retention check: {e}");
-                }
-            }
         }
     }
 }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2318,6 +2318,31 @@ impl DataFusion {
             }
         }
 
+        let retention_delete_expr = match dataset.retention_sql() {
+            Some(retention_sql) => {
+                let parsed = retention_sql::parse_retention_sql(
+                    &dataset.name,
+                    retention_sql.as_str(),
+                    source_table_provider.schema(),
+                )
+                .context(RetentionSqlSnafu)?;
+
+                Some(parsed.delete_expr)
+            }
+            None => None,
+        };
+
+        // Arrow accelerators do not have engine-level write completion retention hooks,
+        // so apply retention_sql from the refresh write path.
+        if let Some(retention_delete_expr) = retention_delete_expr.clone()
+            && matches!(
+                acceleration_settings.engine,
+                Engine::Arrow | Engine::PartitionedArrow
+            )
+        {
+            refresh.write_retention_sql_delete_expr = Some(retention_delete_expr);
+        }
+
         // Create the accelerator write mutex early so it can be shared between the DataConnector, Refresher and the AcceleratedTable.
         let accelerator_write_mutex: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
 
@@ -2338,20 +2363,6 @@ impl DataFusion {
             // see the same columns they would have seen pre-isolation.
             accelerated_table_builder.user_facing_schema(Arc::clone(&refresh_schema));
         }
-
-        let retention_delete_expr = match dataset.retention_sql() {
-            Some(retention_sql) => {
-                let parsed = retention_sql::parse_retention_sql(
-                    &dataset.name,
-                    retention_sql.as_str(),
-                    source_table_provider.schema(),
-                )
-                .context(RetentionSqlSnafu)?;
-
-                Some(parsed.delete_expr)
-            }
-            None => None,
-        };
 
         let retention = Retention::builder()
             .time_column(dataset.time_column.clone())

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -51,6 +51,7 @@ mod partition_by_cayenne;
 #[cfg(feature = "postgres-accel")]
 mod query_push_down;
 mod refresh;
+mod retention_arrow;
 #[cfg(feature = "duckdb")]
 mod single_instance_duckdb;
 #[cfg(feature = "snapshots")]

--- a/crates/runtime/tests/acceleration/retention_arrow.rs
+++ b/crates/runtime/tests/acceleration/retention_arrow.rs
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use app::AppBuilder;
+use arrow::array::RecordBatch;
+use datafusion::assert_batches_eq;
+use datafusion::common::TableReference;
+use futures::TryStreamExt;
+use runtime::Runtime;
+use spicepod::{
+    acceleration::{Acceleration, Mode, RefreshMode},
+    component::dataset::Dataset,
+    partitioning::PartitionedBy,
+};
+use std::sync::Arc;
+
+use crate::utils::{runtime_ready_check, test_request_context};
+
+async fn run_query(rt: &Arc<Runtime>, sql: &str) -> Result<Vec<RecordBatch>, anyhow::Error> {
+    rt.datafusion()
+        .query_builder(sql)
+        .build()
+        .run()
+        .await
+        .map_err(|e| anyhow::anyhow!("Query failed: {e}"))?
+        .data
+        .try_collect()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to collect results: {e}"))
+}
+
+async fn refresh_table(rt: &Arc<Runtime>, table_name: &str) -> Result<(), anyhow::Error> {
+    let notifier = rt
+        .datafusion()
+        .refresh_table(&TableReference::from(table_name), None)
+        .await?;
+    notifier
+        .ok_or_else(|| anyhow::anyhow!("Failed to refresh table"))?
+        .notified()
+        .await;
+    Ok(())
+}
+
+fn make_dataset(name: &str, partition_by: Vec<PartitionedBy>) -> Result<Dataset, anyhow::Error> {
+    let test_file = std::env::current_dir()
+        .map_err(|e| anyhow::anyhow!("Failed to get current directory: {e}"))?
+        .join("tests/acceleration/data/partition_test.csv");
+
+    let mut dataset = Dataset::new(format!("file://{}", test_file.display()), name);
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("arrow".to_string()),
+        mode: Mode::Memory,
+        refresh_mode: Some(RefreshMode::Full),
+        retention_sql: Some(format!("DELETE FROM {name} WHERE score < 90")),
+        retention_check_enabled: false,
+        retention_check_interval: None,
+        partition_by,
+        ..Acceleration::default()
+    });
+    Ok(dataset)
+}
+
+async fn assert_retention_sql_applies_on_refresh(
+    dataset_name: &str,
+    partition_by: Vec<PartitionedBy>,
+) -> Result<(), anyhow::Error> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            crate::configure_test_datafusion();
+
+            let app = AppBuilder::new(dataset_name)
+                .with_dataset(make_dataset(dataset_name, partition_by)?)
+                .build();
+
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timeout waiting for components to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+            refresh_table(&rt, dataset_name).await?;
+
+            let retained = run_query(
+                &rt,
+                &format!("SELECT id, score FROM {dataset_name} ORDER BY id"),
+            )
+            .await?;
+            let expected = [
+                "+----+-------+",
+                "| id | score |",
+                "+----+-------+",
+                "| 2  | 92    |",
+                "| 6  | 94    |",
+                "| 10 | 90    |",
+                "+----+-------+",
+            ];
+            assert_batches_eq!(&expected, &retained);
+
+            let violating = run_query(
+                &rt,
+                &format!("SELECT id FROM {dataset_name} WHERE score < 90"),
+            )
+            .await?;
+            let violating_count: usize = violating.iter().map(RecordBatch::num_rows).sum();
+            assert_eq!(
+                violating_count, 0,
+                "retention_sql should be applied during the Arrow refresh write path"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_arrow_retention_sql_applies_on_refresh_without_retention_interval()
+-> Result<(), anyhow::Error> {
+    assert_retention_sql_applies_on_refresh("arrow_retention_write_path_test", Vec::new()).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_partitioned_arrow_retention_sql_applies_on_refresh_without_retention_interval()
+-> Result<(), anyhow::Error> {
+    assert_retention_sql_applies_on_refresh(
+        "partitioned_arrow_retention_write_path_test",
+        vec![PartitionedBy {
+            name: "expr0".to_string(),
+            expression: "bucket(3, id)".to_string(),
+        }],
+    )
+    .await
+}


### PR DESCRIPTION
## 📝 Summary

Applies `retention_sql` immediately after successful Arrow and PartitionedArrow refresh writes.

Previously, Arrow accelerators could parse `retention_sql`, but rows matching the retention predicate were not removed from the local accelerated table until periodic retention ran. This updates the refresh write path to apply the same retention delete expression after `insert_into`, while keeping periodic retention behavior unchanged.

If the insert succeeds but retention fails, the refresh now returns a permanent error instead of retrying the whole write. That avoids duplicate append risk while surfacing that the accelerated table is not in the configured retained state.

## 🔗 Related

Closes #10983

## 🚨 Breaking Changes

None.

## 📚 Docs

None.

## 👀 Notes for Reviewers

The post-write retention path is currently enabled only for Arrow and PartitionedArrow. DuckDB and Cayenne keep their existing engine-specific retention behavior.

The retention failure path updates committed-write bookkeeping before returning a permanent refresh error, so a committed append is not retried and duplicated. Cached query results are also invalidated when the accelerator changed, including the case where retention fails after a successful write.
