### PR TITLE
Update all CH-benCHmark configs to target 10,000 OLTP txns/s

### DIFF
--- a/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
@@ -6,4 +6,4 @@ tests:
     duration: 600
     ready_wait: 60
     query_overrides: duckdb
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
@@ -5,4 +5,4 @@ tests:
     scale_factor: 10
     duration: 600
     ready_wait: 300
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
@@ -6,4 +6,4 @@ tests:
     duration: 600
     ready_wait: 300
     query_overrides: duckdb
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
@@ -6,4 +6,4 @@ tests:
     terminals: 100
     duration: 600
     ready_wait: 600
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
@@ -7,4 +7,4 @@ tests:
     duration: 600
     ready_wait: 600
     query_overrides: duckdb
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -6,5 +6,4 @@ tests:
     terminals: 100
     duration: 600
     ready_wait: 600
-    # Target 10,000 OLTP txns/s ~= 10,000 CDC changes/s for the m7a (64-core/256 GiB) SF-1000 venue.
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -7,4 +7,4 @@ tests:
     duration: 600
     ready_wait: 600
     query_overrides: duckdb
-    rate: 5000
+    rate: 10000


### PR DESCRIPTION
## 📝 Summary

Update all CH-benCHmark configs to target 10,000 OLTP txns/s (now consistent with cdc-tuned config)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
