### PR TITLE
fix(cayenne): use available metadata during active inline CDC (query + stats paths)

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -78,6 +78,7 @@ use datafusion_execution::cache::cache_manager::FileStatisticsCache;
 use datafusion_execution::cache::cache_unit::DefaultFileStatisticsCache;
 use datafusion_execution::config::SessionConfig;
 use datafusion_expr::dml::InsertOp;
+use datafusion_expr::utils::conjunction;
 use datafusion_expr::{Expr, LogicalPlan, Operator, TableProviderFilterPushDown, TableType};
 use datafusion_physical_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::expressions::Column;
@@ -5757,8 +5758,16 @@ impl CayenneTableProvider {
     }
 
     fn cached_table_statistics_for_optimizer(&self) -> Option<Statistics> {
-        let has_pending_visibility_changes =
-            self.has_pending_deletions() || self.inlined_row_count.load(Ordering::Relaxed) > 0;
+        // Live inline/RAM-tier rows live only in the metastore — they are NOT
+        // reflected in the persisted file statistics (`commit_inlined_data_mutation`
+        // updates `inlined_row_count` but does not re-persist the table-stats
+        // `num_rows`). Fold their net count back into `num_rows` so the join
+        // planner sizes cardinalities against the real live row count instead of
+        // an undercount, while keeping the result `Inexact` (the inline rows are
+        // not represented in the column min/max/NDV, so we never claim `Exact`).
+        let inlined_rows = self.inlined_row_count.load(Ordering::Relaxed).max(0);
+        let has_pending_visibility_changes = self.has_pending_deletions() || inlined_rows > 0;
+        let inlined_rows = usize::try_from(inlined_rows).unwrap_or(usize::MAX);
 
         let cache = self.table_statistics.read();
         let cached_ref: Option<&Statistics> = if has_pending_visibility_changes {
@@ -5778,24 +5787,64 @@ impl CayenneTableProvider {
                     full_column_sync_limit = TABLE_STATISTICS_FULL_COLUMN_SYNC_LIMIT,
                     "Returning top-level table statistics only for wide table"
                 );
-                return Some(Self::top_level_statistics_only(source, false));
+                return Some(Self::add_inlined_rows_to_statistics(
+                    Self::top_level_statistics_only(source, false),
+                    inlined_rows,
+                ));
             }
-            return Some(source.clone());
+            return Some(Self::add_inlined_rows_to_statistics(
+                source.clone(),
+                inlined_rows,
+            ));
         }
 
         // Cache-miss visibility-overlay path: cache.optimizer_inexact is None,
         // so transform optimizer on-the-fly. Rare — test seed only.
         if has_pending_visibility_changes {
-            let optimizer = cache.optimizer.clone()?;
+            let Some(optimizer) = cache.optimizer.clone() else {
+                drop(cache);
+                // No persisted stats at all, but we DO know the inline live-row
+                // count. Hand the planner that cardinality (Inexact, columns
+                // unknown) rather than `None`, so a join against an actively
+                // inlining CDC table is still sized instead of treated as
+                // statistics-less.
+                return (inlined_rows > 0).then(|| Statistics {
+                    num_rows: datafusion_common::stats::Precision::Inexact(inlined_rows),
+                    total_byte_size: datafusion_common::stats::Precision::Absent,
+                    column_statistics: Vec::new(),
+                });
+            };
             drop(cache);
             let inexact = Self::statistics_to_inexact(optimizer);
             if inexact.column_statistics.len() > TABLE_STATISTICS_FULL_COLUMN_SYNC_LIMIT {
-                return Some(Self::top_level_statistics_only(&inexact, false));
+                return Some(Self::add_inlined_rows_to_statistics(
+                    Self::top_level_statistics_only(&inexact, false),
+                    inlined_rows,
+                ));
             }
-            return Some(inexact);
+            return Some(Self::add_inlined_rows_to_statistics(inexact, inlined_rows));
         }
 
         None
+    }
+
+    /// Fold the live inline/RAM-tier row count into a statistics object's
+    /// `num_rows`, downgrading it to `Inexact` (the inline rows are not reflected
+    /// in the column-level statistics, so the result is an estimate/superset and
+    /// must never claim `Exact`). A zero `inlined_rows` is returned unchanged so
+    /// the no-inline path keeps whatever precision it already had.
+    fn add_inlined_rows_to_statistics(mut stats: Statistics, inlined_rows: usize) -> Statistics {
+        use datafusion_common::stats::Precision;
+        if inlined_rows == 0 {
+            return stats;
+        }
+        stats.num_rows = match stats.num_rows {
+            Precision::Exact(n) | Precision::Inexact(n) => {
+                Precision::Inexact(n.saturating_add(inlined_rows))
+            }
+            Precision::Absent => Precision::Inexact(inlined_rows),
+        };
+        stats
     }
 
     fn top_level_statistics_only(stats: &Statistics, inexact: bool) -> Statistics {
@@ -10486,6 +10535,76 @@ impl CayenneTableProvider {
         Ok(Arc::new(filter_exec))
     }
 
+    /// Wrap an in-memory scan branch (the durable inline corpus or the RAM CDC
+    /// tier) with a `FilterExec` applying the query's scan-level `filters`.
+    ///
+    /// # Why
+    ///
+    /// The file-backed branches of a Cayenne scan get their predicate at
+    /// execution time from `VortexSource::try_pushdown_filters` (`DataFusion`'s
+    /// physical optimizer pushes the post-scan `FilterExec` into the source).
+    /// The inline / RAM-tier branches are `MemorySourceConfig` execs, which do
+    /// NOT support filter pushdown — so without this wrapper the post-scan
+    /// `FilterExec` can never be removed (its `if_all` pushdown fails on the
+    /// un-filterable memory branch) and survives, re-filtering *every* row in
+    /// the union, including the already-pruned file output.
+    ///
+    /// Adding the predicate as a `FilterExec` directly above each memory branch
+    /// makes that branch report the parent filters as fully handled during
+    /// pushdown, so the redundant post-scan `FilterExec` is dropped while the
+    /// inline / RAM rows are still correctly filtered. The predicate is the
+    /// query's own filter, evaluated by a real `FilterExec`, so it applies to
+    /// every returned row exactly — preserving correctness under active inline
+    /// CDC.
+    ///
+    /// Best-effort: if the predicate cannot be built against this branch's
+    /// (projected) schema, the branch is returned unwrapped. Correctness still
+    /// holds because the post-scan `FilterExec` then survives and filters it;
+    /// only the redundant-filter optimization is skipped for that scan.
+    fn wrap_memory_branch_with_scan_filters(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        filters: &[Expr],
+    ) -> Arc<dyn ExecutionPlan> {
+        if filters.is_empty() {
+            return plan;
+        }
+
+        let arrow_schema = plan.schema();
+        let Ok(df_schema) = DFSchema::try_from(arrow_schema.as_ref().clone()) else {
+            return plan;
+        };
+        let execution_props = ExecutionProps::new();
+
+        let Some(predicate) = conjunction(filters.iter().cloned()) else {
+            return plan;
+        };
+
+        match datafusion_physical_expr::create_physical_expr(
+            &predicate,
+            &df_schema,
+            &execution_props,
+        )
+        .and_then(|physical_filter| FilterExec::try_new(physical_filter, Arc::clone(&plan)))
+        {
+            Ok(filter_exec) => {
+                tracing::trace!(
+                    table = %self.table_metadata.table_name,
+                    "Applied scan filters to in-memory CDC branch so the post-scan FilterExec can be dropped"
+                );
+                Arc::new(filter_exec)
+            }
+            Err(e) => {
+                tracing::trace!(
+                    table = %self.table_metadata.table_name,
+                    error = %e,
+                    "Could not pre-filter in-memory CDC branch; leaving post-scan FilterExec to filter it"
+                );
+                plan
+            }
+        }
+    }
+
     /// Apply retention filters by running the configured delete sink against
     /// the current table state.
     ///
@@ -14595,13 +14714,18 @@ impl TableProvider for CayenneTableProvider {
             if projected_batches.is_empty() {
                 None
             } else {
-                Some(
+                let inline_exec: Arc<dyn ExecutionPlan> =
                     datafusion::datasource::memory::MemorySourceConfig::try_new_exec(
                         &[projected_batches],
                         proj_schema,
                         None,
-                    )?,
-                )
+                    )?;
+                // Pre-filter the inline branch with the query's scan filters so
+                // the post-scan FilterExec can be pushed away (this MemoryExec
+                // does not support filter pushdown on its own). The user filters
+                // are evaluated by a real FilterExec, so every returned inline
+                // row matches the predicate — correct under active inline CDC.
+                Some(self.wrap_memory_branch_with_scan_filters(inline_exec, filters))
             }
         };
 
@@ -14610,8 +14734,9 @@ impl TableProvider for CayenneTableProvider {
         // `filter_inlined_batch_for_deletions` path the durable inline corpus
         // uses; only the tombstone SOURCE differs — the in-RAM map vs the
         // metastore). `None` (and skipped) in file mode, where the tier is empty.
-        let mem_plan: Option<Arc<dyn ExecutionPlan>> =
-            self.build_mem_tier_scan_plan(&mem_tier_snapshot, effective_projection.as_ref())?;
+        let mem_plan: Option<Arc<dyn ExecutionPlan>> = self
+            .build_mem_tier_scan_plan(&mem_tier_snapshot, effective_projection.as_ref())?
+            .map(|mem_exec| self.wrap_memory_branch_with_scan_filters(mem_exec, filters));
 
         // Build the final plan:
         // - If protected snapshots exist: deletion filter on main, UNION with snapshots
@@ -14684,6 +14809,33 @@ impl TableProvider for CayenneTableProvider {
         Ok(Arc::new(CayenneAccelerationExec::new(plan)))
     }
 
+    // Filter-pushdown exactness contract (read before changing the arms below):
+    //
+    // * Partition-column filters → `Exact`. Partition pruning eliminates whole
+    //   partition directories during file listing, so every row the scan can
+    //   return provably satisfies the predicate. There is no inline/RAM-tier
+    //   partitioning, but partition tables also never inline (the staged path is
+    //   forced for partitioned tables — see `write_cdc_pipelined`), so a
+    //   partition filter can never leak an unfiltered inline row.
+    //
+    // * All other (data-column) filters → `Inexact`, deliberately, NOT `Exact`.
+    //   The file-backed branch applies a data predicate ONLY when DataFusion's
+    //   post-scan `FilterExec` is pushed into `VortexSource::try_pushdown_filters`
+    //   by the physical optimizer; nothing in `scan()` itself can set the Vortex
+    //   predicate (its fields are crate-private to `vortex-datafusion`). Reporting
+    //   `Exact` would make DataFusion DROP that `FilterExec` at the logical level,
+    //   leaving the file branch unfiltered for any predicate Vortex cannot convert
+    //   (`can_be_pushed_down == false`) — a correctness bug. So we keep `Inexact`
+    //   ("uncertain ⇒ Inexact").
+    //
+    //   The post-scan `FilterExec` is still NOT a permanent tax under active
+    //   inline CDC: `scan()` now wraps each in-memory branch (inline corpus + RAM
+    //   tier) with its own `FilterExec` for the same predicate
+    //   (`wrap_memory_branch_with_scan_filters`). Once every union child applies
+    //   the predicate (Vortex via pushdown, memory branches via their own
+    //   `FilterExec`), the physical `FilterPushdown` rule's `if_all` succeeds and
+    //   removes the redundant post-scan `FilterExec` for every Vortex-convertible
+    //   predicate — achieving the drop without the `Exact` correctness hazard.
     fn supports_filters_pushdown(
         &self,
         filters: &[&Expr],
@@ -14721,13 +14873,20 @@ impl TableProvider for CayenneTableProvider {
         // Prefer the metastore-persisted table statistics (loaded from Vortex
         // file footers) when present — they cover columns the ListingTable
         // does not expose synchronously without rescanning footers.
+        //
+        // `cached_table_statistics_for_optimizer` folds the live inline/RAM-tier
+        // row count into `num_rows` (Inexact), and synthesizes a count-only
+        // estimate even on a full stats cache-miss when inline rows exist — so an
+        // actively-inlining CDC table reports a real cardinality to the join
+        // planner instead of falling through to `None`.
         if let Some(stats) = self.cached_table_statistics_for_optimizer() {
             return Some(stats);
         }
 
-        // Inlined rows live only in the metastore; the ListingTable would
-        // under-count, so return None and let DataFusion treat the table as
-        // statistics-less rather than misleading the optimizer.
+        // Defensive: if we somehow reach here with inline rows present (no
+        // persisted stats AND `cached_table_statistics_for_optimizer` returned
+        // None), the ListingTable alone would under-count the inline rows, so
+        // return None rather than mislead the optimizer with a file-only count.
         if self.inlined_row_count.load(Ordering::Relaxed) > 0 {
             return None;
         }
@@ -19597,6 +19756,148 @@ mod tests {
             1,
             "exactly one visible row for PK=1, got {pairs:?}"
         );
+    }
+
+    /// Flatten `(id, value)` pairs from result batches, sorted. Shared by the
+    /// predicate-filtered scan tests.
+    fn collect_id_value_pairs_from_batches(batches: &[RecordBatch]) -> Vec<(i64, i64)> {
+        use arrow::array::Int64Array;
+        let mut pairs = Vec::new();
+        for batch in batches {
+            let id_idx = batch.schema().index_of("id").expect("id column");
+            let value_idx = batch.schema().index_of("value").expect("value column");
+            let ids = batch
+                .column(id_idx)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id is Int64");
+            let values = batch
+                .column(value_idx)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("value is Int64");
+            for row in 0..batch.num_rows() {
+                pairs.push((ids.value(row), values.value(row)));
+            }
+        }
+        pairs.sort_unstable();
+        pairs
+    }
+
+    /// P1-1: a predicate-filtered scan over an actively-inlining CDC table must
+    /// return ONLY the rows matching the predicate. The inline branch is a
+    /// `MemoryExec` that does not support filter pushdown, so the scan now wraps
+    /// it with its own `FilterExec`; this drives the full `DataFusion` logical +
+    /// physical pipeline (where the post-scan `FilterExec` may be dropped) and
+    /// proves correctness is preserved while inline rows are live.
+    #[tokio::test]
+    async fn test_inline_cdc_filtered_scan_returns_only_matching_rows() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) =
+            create_inline_enabled_upsert_table("inline_filtered_scan", ctx.runtime_env()).await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        // Seed several rows into the inline memtable (each small batch inlines).
+        for (id, value) in [(1_i64, 10_i64), (2, 20), (3, 30), (4, 40), (5, 50)] {
+            insert_batch(
+                &provider,
+                id_value_batch(Arc::clone(&schema), &[id], &[value]),
+            )
+            .await;
+        }
+        assert!(
+            provider.cached_inlined_row_count() >= 5,
+            "precondition: all five rows must be live in the inline memtable, got {}",
+            provider.cached_inlined_row_count()
+        );
+
+        ctx.deregister_table("inline_filtered_scan").ok();
+        ctx.register_table("inline_filtered_scan", Arc::new(provider.clone_for_write()))
+            .expect("table registered");
+
+        // Equality predicate: exactly one inline row matches.
+        let eq_rows = ctx
+            .sql("SELECT id, value FROM inline_filtered_scan WHERE id = 3")
+            .await
+            .expect("eq query planned")
+            .collect()
+            .await
+            .expect("eq query executed");
+        let eq_pairs = collect_id_value_pairs_from_batches(&eq_rows);
+        assert_eq!(
+            eq_pairs,
+            vec![(3, 30)],
+            "WHERE id = 3 must return exactly the matching inline row, got {eq_pairs:?}"
+        );
+
+        // Range predicate: a strict subset of the inline rows match.
+        let range_rows = ctx
+            .sql("SELECT id, value FROM inline_filtered_scan WHERE id > 3")
+            .await
+            .expect("range query planned")
+            .collect()
+            .await
+            .expect("range query executed");
+        let range_pairs = collect_id_value_pairs_from_batches(&range_rows);
+        assert_eq!(
+            range_pairs,
+            vec![(4, 40), (5, 50)],
+            "WHERE id > 3 must return only the matching inline rows, got {range_pairs:?}"
+        );
+
+        // A predicate matching no row returns nothing (no inline row leaks).
+        let none_rows = ctx
+            .sql("SELECT id, value FROM inline_filtered_scan WHERE id = 999")
+            .await
+            .expect("empty query planned")
+            .collect()
+            .await
+            .expect("empty query executed");
+        assert!(
+            collect_id_value_pairs_from_batches(&none_rows).is_empty(),
+            "a non-matching predicate must return no inline rows"
+        );
+    }
+
+    /// P1-2: `statistics()` must fold the live inline row count into `num_rows`
+    /// (as `Inexact`) so the join planner gets a real cardinality, instead of
+    /// returning `None`/an undercount, while inline CDC rows are live.
+    #[tokio::test]
+    async fn test_statistics_includes_inline_rows() {
+        use datafusion_common::stats::Precision;
+
+        let (provider, _catalog, _tmp) = create_inline_enabled_upsert_table(
+            "inline_stats_rowcount",
+            SessionContext::new().runtime_env(),
+        )
+        .await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        let seeded = 4_i64;
+        for id in 1..=seeded {
+            insert_batch(
+                &provider,
+                id_value_batch(Arc::clone(&schema), &[id], &[id * 10]),
+            )
+            .await;
+        }
+        assert_eq!(
+            provider.cached_inlined_row_count(),
+            seeded,
+            "precondition: all seeded rows live inline"
+        );
+
+        let stats = provider
+            .statistics()
+            .expect("statistics must be present while inline rows are live (not None)");
+
+        match stats.num_rows {
+            Precision::Inexact(n) => assert!(
+                n >= usize::try_from(seeded).expect("fits"),
+                "num_rows must include the {seeded} inline rows, got {n}"
+            ),
+            other => panic!("inline-row count must be Inexact (estimate), got {other:?}"),
+        }
     }
 
     /// Sequential delete+reinsert of the SAME PK across multiple large upserts

--- a/crates/cayenne/src/provider/vortex_format.rs
+++ b/crates/cayenne/src/provider/vortex_format.rs
@@ -81,12 +81,45 @@ impl VortexAccessPlanProvider for PositionDeletionAccessPlanProvider {
 
         Statistics {
             num_rows: adjust_num_rows_for_deletions(statistics.num_rows, &deletion_vector),
-            total_byte_size: statistics.total_byte_size,
-            column_statistics: vec![
-                ColumnStatistics::new_unknown();
-                statistics.column_statistics.len()
-            ],
+            // Position deletes only ever remove rows, so the footer byte size is
+            // now an over-estimate. Keep it as an (inexact) upper bound instead of
+            // dropping it, so size-based heuristics still have a signal.
+            total_byte_size: statistics.total_byte_size.to_inexact(),
+            column_statistics: statistics
+                .column_statistics
+                .into_iter()
+                .map(adjust_column_stats_for_deletions)
+                .collect(),
         }
+    }
+}
+
+/// Soundly downgrade a column's footer statistics for a file with position
+/// deletes attached.
+///
+/// Position deletes only ever *remove* rows, so the surviving rows are a subset
+/// of the rows the footer described. That makes the footer min/max a valid
+/// *superset* bound of the survivors (the true min can only rise, the true max
+/// can only fall), which is exactly what min/max pruning needs — but the precise
+/// boundary value may belong to a deleted row, so the precision must drop from
+/// `Exact` to `Inexact`. Counts (`null_count`, `distinct_count`) can only shrink
+/// after deletes, so the footer value is an upper-bound estimate and is likewise
+/// kept as `Inexact`. The aggregate `sum_value` cannot be bounded after removing
+/// rows of unknown sign, so it is dropped to `Absent` rather than handing an
+/// aggregate a value that no longer matches the live data.
+fn adjust_column_stats_for_deletions(stats: ColumnStatistics) -> ColumnStatistics {
+    ColumnStatistics {
+        // Upper-bound estimate after deletes.
+        null_count: stats.null_count.to_inexact(),
+        // Still-valid superset bounds; precision drops because the boundary row
+        // may have been deleted.
+        max_value: stats.max_value.to_inexact(),
+        min_value: stats.min_value.to_inexact(),
+        // Unsound to keep after removing rows of unknown sign.
+        sum_value: Precision::Absent,
+        // Upper-bound estimate after deletes.
+        distinct_count: stats.distinct_count.to_inexact(),
+        byte_size: stats.byte_size.to_inexact(),
     }
 }
 
@@ -122,5 +155,49 @@ mod tests {
             adjust_num_rows_for_deletions(Precision::Inexact(10), &deletion_vector),
             Precision::Inexact(7)
         );
+    }
+
+    #[test]
+    fn column_stats_are_downgraded_soundly_for_deletions() {
+        use datafusion_common::ScalarValue;
+
+        let exact = ColumnStatistics {
+            null_count: Precision::Exact(2),
+            max_value: Precision::Exact(ScalarValue::Int64(Some(100))),
+            min_value: Precision::Exact(ScalarValue::Int64(Some(1))),
+            sum_value: Precision::Exact(ScalarValue::Int64(Some(5050))),
+            distinct_count: Precision::Exact(100),
+            byte_size: Precision::Exact(800),
+        };
+
+        let adjusted = adjust_column_stats_for_deletions(exact);
+
+        // min/max stay valid superset bounds but are no longer exact (the row
+        // holding the boundary value may have been deleted).
+        assert_eq!(
+            adjusted.min_value,
+            Precision::Inexact(ScalarValue::Int64(Some(1)))
+        );
+        assert_eq!(
+            adjusted.max_value,
+            Precision::Inexact(ScalarValue::Int64(Some(100)))
+        );
+        // Counts can only shrink after deletes — keep as inexact upper bounds.
+        assert_eq!(adjusted.null_count, Precision::Inexact(2));
+        assert_eq!(adjusted.distinct_count, Precision::Inexact(100));
+        assert_eq!(adjusted.byte_size, Precision::Inexact(800));
+        // Sum cannot be bounded after removing rows of unknown sign.
+        assert_eq!(adjusted.sum_value, Precision::Absent);
+    }
+
+    #[test]
+    fn absent_column_stats_stay_absent_after_adjustment() {
+        let adjusted = adjust_column_stats_for_deletions(ColumnStatistics::new_unknown());
+
+        assert_eq!(adjusted.min_value, Precision::Absent);
+        assert_eq!(adjusted.max_value, Precision::Absent);
+        assert_eq!(adjusted.null_count, Precision::Absent);
+        assert_eq!(adjusted.distinct_count, Precision::Absent);
+        assert_eq!(adjusted.sum_value, Precision::Absent);
     }
 }


### PR DESCRIPTION
## Summary

During active inline CDC ingestion the query path was ignoring metadata it actually has, forcing avoidable work on every scan. This change makes three read-side paths use the available metadata so live inline rows no longer degrade scan / statistics / skip decisions. Stacked on #11206 (retargets to `trunk` on that merge).

## Changes

**P1-1 — exact-as-feasible filter pushdown across in-memory branches** (`provider/table.rs`)
The file branch receives the scan predicate via the physical `FilterPushdown` rule, but the in-memory union branches (inline corpus + RAM tier) are `MemorySourceConfig` execs that report `PushedDown::No`, so the post-scan `FilterExec` survived and re-filtered every union row. Each in-memory branch now wraps its own `FilterExec` for the scan filters, so once every union child applies the predicate the physical rule drops the redundant post-scan `FilterExec` for Vortex-convertible predicates — no double-filtering. Data-column filters stay `Inexact` in `supports_filters_pushdown` (partition filters stay `Exact`): returning `Exact` would let the optimizer drop the FilterExec at the logical level, leaving the file branch unfiltered for any predicate Vortex cannot convert — a correctness bug. Best-effort wrapping: a branch whose predicate can't be built against its projected schema is left to the surviving post-scan filter (correctness preserved, optimization skipped).

**P1-2 — statistics include live inline rows** (`provider/table.rs`)
Inline writes update `inlined_row_count` but never re-persist the optimizer-stats `num_rows`, so `statistics()` undercounted (or returned `None`) while inline rows were live → poor join plans. It now folds the net live inline count into `num_rows` as `Inexact` (never claims `Exact` precision the column stats can't back).

**P1-4 — sound column statistics under position deletes** (`provider/vortex_format.rs`)
Position-delete scans returned `ColumnStatistics::new_unknown()` (zeroed), defeating stats-based file/row-group skipping and forcing full decodes. Stats are now downgraded soundly instead: min/max kept as `Inexact` supersets (survivors are a subset of the footer range), null/distinct counts kept as `Inexact` upper bounds, `sum` set `Absent` (cannot be bounded after removing rows of unknown sign), `total_byte_size` `Inexact`.

**P1-3 — write-lock serialization: already resolved, no change**
The original concern (per-table `write_lock` held across the whole CDC append, serializing single-table ingest) is already addressed by the CDC-pipelining on the base branch: `write_lock` is released after Stage A (consumed by `prepare()`, or dropped once the staging WAL is durable), and Stage B publishes under `visibility_lock` / `listing_fence`, not `write_lock` — so the next append already overlaps the backgrounded publish.

## Testing
- `cargo test -p cayenne --lib`: **471 passed / 0 failed**, including 3 new tests covering filtered inline scans (no row leakage), inline-row statistics, and position-delete stat soundness.
- Integration tests pass: position-based deletion, inline-with-pending-deletions, stats edge cases, on-conflict.
- `cargo clippy` (CI pedantic gate) and `cargo fmt` clean; release build green.

## Validation
Correctness is covered by the unit + integration tests above. These are read-side (scan / statistics) changes; the end-to-end CH-benCH QPH measurement is pending and will follow separately.
