### PR TITLE
fix(ci): stop generate_json_schema Create PR step hanging on git credential prompt

### DIFF
--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -27,6 +27,10 @@ env:
 jobs:
   generate_schema:
     runs-on: self-hosted
+    # Bound the blast radius: without this, a hung step runs until GitHub's
+    # default 6h job timeout. The Create PR step previously hung for ~5.5h on an
+    # interactive git credential prompt before being auto-cancelled.
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -79,13 +83,21 @@ jobs:
           if [[ $(git diff --exit-code .schema/spicepod.schema.json) ]]; then
             git add .schema/spicepod.schema.json
             git commit -m "Update spicepod.schema.json"
-            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:schema/${GITHUB_RUN_ID}
+            # Disable any credential helper configured on the (self-hosted) runner
+            # so git authenticates with the URL-embedded token only. Otherwise a
+            # helper (osxkeychain / git-credential-manager) can intercept the push
+            # and block on an interactive credential prompt, hanging the job.
+            git -c credential.helper='' -c credential.interactive=false \
+              push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:schema/${GITHUB_RUN_ID}
             gh pr create --title "Update spicepod.schema.json" --body "Updated Spicepod Schema" --base trunk --head schema/${GITHUB_RUN_ID}
           else
             echo "No changes detected"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Never fall back to an interactive prompt; fail fast if auth is rejected.
+          GIT_TERMINAL_PROMPT: '0'
+          GCM_INTERACTIVE: 'never'
 
       - name: Validate schema against test files
         continue-on-error: true


### PR DESCRIPTION
## Problem

`generate_json_schema.yml` (workflow_dispatch with `create_pr=true`) repeatedly runs for ~6h and is auto-cancelled. The schema is generated fine; the **Create PR** step is the hang.

In [run 27049298638](https://github.com/spiceai/spiceai/actions/runs/27049298638) the commit succeeds at 02:24:39, then there is no output for **5h29m** until `The operation was canceled` at 07:54 (GitHub's default 6h job timeout). Cleanup reveals the cause:

```
Terminate orphan process: pid (5586) (git-credential-)
Terminate orphan process: pid (5584) (git-remote-http)
```

`git push` (`git-remote-http`) blocked waiting on a credential helper (`git-credential-…`) that went **interactive** on the self-hosted macOS runner and never received input. (`gh pr create` doesn't spawn `git-remote-http`, so the push is the culprit, not the PR step.)

It's intermittent because it's runner-specific: the last success ran on Mac mini `runner-04-01`; the hangs ran on `runner-02-03`. The default `GITHUB_TOKEN` already has `write` permission and the push URL embeds it — the issue is purely the runner's inherited credential helper (osxkeychain / git-credential-manager) shadowing the URL token and prompting.

## Fix

- Disable the inherited credential helper for the push so git uses only the URL-embedded token: `git -c credential.helper='' -c credential.interactive=false push …`.
- Belt-and-suspenders env so git never waits on a prompt and fails fast instead: `GIT_TERMINAL_PROMPT=0`, `GCM_INTERACTIVE=never`.
- Add `timeout-minutes: 60` to the job so any future hang fails in minutes, not 6 hours.

No change to schema generation behavior.

This is the v2.0.0 endgame's "Generate Spicepod JSON schema" step; once merged it should be cherry-picked onto `release/2.0`.