### PR TITLE
chore(chbench): tune cayenne[file]-cdc-tuned-sf100 for 64c/256GB; document non-tuned baseline

### DIFF
--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
@@ -2,21 +2,40 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned-sf100
 
-# Target: xlarge-runner — 64 vCPU / 256 GiB RAM, SSD storage.
+# Target: 64 vCPU / 256 GiB RAM, EBS gp3 (m7a.16xlarge-class). Goal: every CDC table under
+# 5s replication lag at SF-100 @ 10K txn/s, with >=5K QPH on the OLAP queries.
 #
-# Key tuning:
-#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384 (runtime max after Lever D
-#     raised CDC_PREFETCH_BUFFER_MAX / CDC_MAX_COALESCED_ENVELOPES_MAX 4096->16384):
-#     larger CDC bursts cut metastore round-trips and keep WAL drain ahead of bursty OLTP.
-#   - target_partitions 64: read-path parallelism matched to vCPU count.
+# Tuning (values validated on the 16-core local SF-100 run — all 7 tables <5s, ~97% of 5K
+# QPH — then scaled to 64c/256GB; the write-path values are core/RAM-invariant because the
+# wall is the single-writer-per-table metastore txn, not CPU or batch size):
+#   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
+#     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
+#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
+#     WAL drain ahead of bursty OLTP without enlarging the per-apply batch.
+#   - target_partitions 64: read-path parallelism matched to vCPU count (drives the QPH goal).
+#   - cayenne_pk_keyset_cache_mb 256 pinned on ALL tables: defeats the backwards memory-aware
+#     auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) and keeps the heavy-update tables
+#     (stock, order_line) on the cheap bloom path (256 = SF-100 sweep optimum).
 #   - per-table cayenne_write_concurrency / segment_cache_mb / compaction_* for the high-volume
-#     upsert tables; reference tables use lighter settings.
+#     upsert tables; reference tables lighter. write_concurrency stays moderate (4/2): lower
+#     fan-out relieves CPU contention for OLAP (validated on the 128-core write-concurrency run).
+#   - metastore/footer caches (1024/1024 MiB, 4096 MiB mmap) are sized to the SF-100 working set,
+#     bounded by catalog/footer size — so 256 GiB adds headroom, not bigger caches.
+#
+# NOTE: validated on 16-core local + the 128-core write-concurrency study; the 64c/256GB
+# end-to-end run is the remaining validation (m7a.16xlarge + gp3).
 runtime:
   params:
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
-    cdc_max_coalesce_age_ms: '4000'
+    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    # 250ms, NOT 4000: this is a real apply-loop linger (trunk #11196). At 4000ms the caught-up
+    # tables over-coalesce past the 1024-row inline admission cap (customer flips 100%
+    # inline->staged and builds a ~16 GB backlog) while apply-bound tables gain nothing (the
+    # deadline anchors at apply-start). Measured fixed cost ~120-250ms/batch, so ~250ms amortizes
+    # it without overflowing the inline cap. The wall is the single-writer metastore txn (per-row
+    # insert_records WAL), not batch size — bigger bursts don't help; 512 MB/4000ms regressed.
+    cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
     cayenne_footer_cache_mb: '1024'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
@@ -2,6 +2,13 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]
 
+# Non-tuned baseline: NO Cayenne/CDC performance tuning — the runtime auto-derives every knob
+# (write concurrency, segment/footer/keyset/metastore caches, compaction triggers, CDC
+# coalescing, file path, metastore backend) from the host. This is the out-of-box reference for
+# the postgres-cayenne[file]-cdc-tuned-* configs. The only non-defaults are the sql_results /
+# task_history toggles below, kept off to match the tuned configs so the comparison isolates the
+# effect of tuning, not caching/history overhead.
+
 postgres_connection_params: &postgres_params
   pg_host: 127.0.0.1
   pg_port: 5432


### PR DESCRIPTION
## Summary

Tunes the SF-100 CH-benCH Cayenne[file] config for the 64 vCPU / 256 GiB / EBS gp3 (m7a.16xlarge-class) target, and documents the non-tuned baseline.

## `postgres-cayenne[file]-cdc-tuned-sf100.yaml`

Two corrected values — everything else was already correct for 64c/256GB (`target_partitions: 64`, keyset pinned at 256 MiB on all table classes to defeat the backwards `mem/32 → ~8 GiB` auto-default, caches sized to the SF-100 working set):

- `cdc_max_coalesce_age_ms`: **4000 → 250**. At 4000 ms the caught-up tables over-coalesce past the 1024-row inline admission cap, flip from inline to staged, and build a multi-GB WAL backlog, while apply-bound tables gain nothing (the linger deadline anchors at apply-start). 250 ms amortizes the ~120–250 ms/batch fixed cost without overflowing the inline cap. The durable-write wall is the single-writer-per-table metastore transaction (per-row insert-records WAL volume), not batch size — larger bursts don't help.
- `cdc_max_coalesced_bytes`: **512 MB → 128 MB** (the matching cap for the 250 ms linger).

These are the values validated on the 16-core local SF-100 run (all 7 CDC tables <5 s lag, ~97% of the 5K QPH goal). The header now documents the full validated rationale and flags the remaining work: the 64c/256GB end-to-end validation run.

## `postgres-cayenne[file].yaml`

Already free of Cayenne/CDC tuning (no per-table params, no `runtime.params`, no `target_partitions`). Added a header documenting that it is the intentional non-tuned baseline — the runtime auto-derives every knob — and why the `sql_results` / `task_history` toggles stay off (to match the tuned configs so a baseline-vs-tuned comparison isolates the effect of tuning, not caching/history overhead). Nothing to remove.

## Validation

Config-only change. The sf100 values are validated on the 16-core local SF-100 run plus the 128-core write-concurrency study; the 64c/256GB end-to-end run is the next step.
