### PR TITLE
fix(ci): drop -models image tag in Helm release-install e2e

### DIFF
--- a/.github/workflows/e2e_test_release_install_helm.yml
+++ b/.github/workflows/e2e_test_release_install_helm.yml
@@ -129,14 +129,16 @@ jobs:
             # Get latest release tag from GitHub
             RELEASE_VERSION=$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" -H "Authorization: token $GITHUB_TOKEN" | jq -r '.tag_name')
             echo "Using latest release version: $RELEASE_VERSION"
-            # remove prefix 'v' from RELEASE_VERSION. (i.e. v1.10.1 -> 1.10.1). 
-            IMAGE_TAG="${RELEASE_VERSION#v}-models"
+            # remove prefix 'v' from RELEASE_VERSION. (i.e. v1.10.1 -> 1.10.1).
+            # Models are included in the default image as of v2.0.0; there is no
+            # longer a separate `-models` image tag.
+            IMAGE_TAG="${RELEASE_VERSION#v}"
             echo "version=${RELEASE_VERSION#v}" >> $GITHUB_OUTPUT
             echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
             echo "source=github-release" >> $GITHUB_OUTPUT
           else
             echo "Using specified version: $CHART_VERSION"
-            IMAGE_TAG="${CHART_VERSION}-models"
+            IMAGE_TAG="${CHART_VERSION}"
             echo "version=$CHART_VERSION" >> $GITHUB_OUTPUT
             echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
             echo "source=local" >> $GITHUB_OUTPUT
@@ -314,7 +316,7 @@ jobs:
           helm upgrade spice-test ./deploy/chart \
             --namespace spice-system \
             --set image.repository=ghcr.io/spiceai/spiceai \
-            --set image.tag=${{ steps.chart-version.outputs.version }}-models \
+            --set image.tag=${{ steps.chart-version.outputs.version }} \
             --set replicaCount=1 \
             --set service.type=ClusterIP \
             --wait \


### PR DESCRIPTION
## Problem

`E2E Test Release Installation (Helm)` fails against the v2.0.0 release: the pod can't pull its image and `helm install --wait` times out.

[Run 27024682330](https://github.com/spiceai/spiceai/actions/runs/27024682330) pod events:
```
Failed to pull image "ghcr.io/spiceai/spiceai:2.0.0-models": ... not found
  -> ErrImagePull -> ImagePullBackOff
Error: INSTALLATION FAILED: context deadline exceeded
```

The workflow derives the install image tag as `<version>-models`, but **v2.0.0 folded models into the default image and dropped the separate `-models` variant** (#11037 / the v2.0.0 Distribution Changes). The OSS release publishes `ghcr.io/spiceai/spiceai:2.0.0` (models included), `:2.0.0-cuda`, `:latest`, `:latest-cuda` - there is no `:2.0.0-models`, so the pull 404s.

This passed for every `rc` (which still shipped `-models`) and breaks on the first real v2.0.0 release.

## Fix

Drop the `-models` suffix from the release install/upgrade image tags in `e2e_test_release_install_helm.yml`:
- latest-release path: `IMAGE_TAG="${RELEASE_VERSION#v}-models"` -> `"${RELEASE_VERSION#v}"`
- explicit-version path: `IMAGE_TAG="${CHART_VERSION}-models"` -> `"${CHART_VERSION}"`
- Test Helm upgrade: `--set image.tag=...-models` -> `--set image.tag=...`

The chart's `values.yaml` default (`spiceai-nightly:latest-models`) is unchanged - nightly still ships a `-models` tag; only the release-install path must not append it.

This is a v2.0.0 endgame release-install validation step; should be cherry-picked onto `release/2.0` after merge.