### PR TITLE
ci(chbench): run scheduled CH-benCHmark every 4 hours (6x/day)

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -4,14 +4,14 @@ on:
   schedule:
     # daily-main, 0900 UTC / 0200 PDT  — full bench suite + HTAP CH-benCHmark SF1
     - cron: '0 9 * * *'
-    # htap-sf1, 0100/1700 UTC — extra HTAP CH-benCHmark SF1 runs so SF1 fires
-    # every 8 hours (0100, 0900 via daily-main, 1700) without re-running the
-    # full daily-main suite three times a day.
-    - cron: '0 1,17 * * *'
-    # htap-sf10, every 8h anchored on the original 1200 UTC — HTAP CH-benCHmark SF10
-    - cron: '0 4,12,20 * * *'
-    # htap-sf100, every 8h anchored on the original 1600 UTC — HTAP CH-benCHmark SF100
-    - cron: '0 0,8,16 * * *'
+    # htap-sf1, every 4h — extra HTAP CH-benCHmark SF1 runs so SF1 fires every 4
+    # hours (0100, 0500, 0900 via daily-main, 1300, 1700, 2100) without
+    # re-running the full daily-main suite six times a day.
+    - cron: '0 1,5,13,17,21 * * *'
+    # htap-sf10, every 4h (0000, 0400, 0800, 1200, 1600, 2000) — HTAP CH-benCHmark SF10
+    - cron: '0 0,4,8,12,16,20 * * *'
+    # htap-sf100, every 4h (0200, 0600, 1000, 1400, 1800, 2200) — HTAP CH-benCHmark SF100
+    - cron: '0 2,6,10,14,18,22 * * *'
 
   workflow_dispatch:
     inputs:
@@ -106,11 +106,11 @@ jobs:
         id: sched
         run: |
           case "${{ github.event.schedule }}" in
-            '0 9 * * *')        NAME=daily-main ;;
-            '0 1,17 * * *')     NAME=htap-sf1   ;;
-            '0 4,12,20 * * *')  NAME=htap-sf10  ;;
-            '0 0,8,16 * * *')   NAME=htap-sf100 ;;
-            *)                  NAME=           ;;   # manual / unrecognized cron — match nothing
+            '0 9 * * *')               NAME=daily-main ;;
+            '0 1,5,13,17,21 * * *')    NAME=htap-sf1   ;;
+            '0 0,4,8,12,16,20 * * *')  NAME=htap-sf10  ;;
+            '0 2,6,10,14,18,22 * * *') NAME=htap-sf100 ;;
+            *)                         NAME=           ;;   # manual / unrecognized cron — match nothing
           esac
           echo "Resolved schedule name: $NAME"
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
@@ -240,9 +240,9 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
-      # HTAP CH-benCHmark — every SF runs 3x/day (every 8 hours). SF1 rides
-      # with daily-main at 0900 plus the htap-sf1 extras at 0100/1700;
-      # SF10 / SF100 each fire on their own every-8h cron.
+      # HTAP CH-benCHmark — every SF runs 6x/day (every 4 hours). SF1 rides
+      # with daily-main at 0900 plus the htap-sf1 extras at 0100/0500/1300/1700/2100;
+      # SF10 / SF100 each fire on their own every-4h cron.
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF1
         if: ${{ steps.sched.outputs.name == 'daily-main' || steps.sched.outputs.name == 'htap-sf1' }}
         run: |


### PR DESCRIPTION
## What

Doubles the cadence of the scheduled HTAP **CH-BenCHmark** runs in `testoperator_dispatch.yml` from **every 8 hours (3×/day)** to **every 4 hours (6×/day)** for all scale factors.

| Scale factor | Before (8h) | After (4h) |
|---|---|---|
| SF1 | 01, 09, 17 | **01, 05, 09, 13, 17, 21** |
| SF10 | 04, 12, 20 | **00, 04, 08, 12, 16, 20** |
| SF100 | 00, 08, 16 | **02, 06, 10, 14, 18, 22** |

(times UTC)

## How

Three in-sync spots were updated: the `on.schedule` crons (+ comments), and the `case` in the **Resolve schedule name** step that maps each exact cron string → scale factor.

SF1 continues to ride on the `daily-main` cron (`0 9`, which also runs the full bench suite) plus its own `htap-sf1` extras — only the extras changed, so the **daily suite still runs exactly once a day**.

Because the workflow distinguishes scale factors by *exact cron string*, the every-4h sets must not collide. SF100 is offset to the `+2h` slots (`02,06,10,…`) rather than reusing SF10's `00,04,08,…`, keeping every cron string unique so the `case` resolves correctly.

## Cost note

This roughly **2×'s the HTAP benchmark compute/runner load**, including SF100 (the largest). Intentional per request — flagging for awareness.

## Verification

- YAML parses cleanly.
- Every `on.schedule` cron has an exactly-matching `case` arm — no missing, extra, or duplicate (colliding) cron strings.
- Each scale factor lands on a clean 4-hour interval (6 firings/day):
  - SF1: 01,05,09,13,17,21 · SF10: 00,04,08,12,16,20 · SF100: 02,06,10,14,18,22

> Note: GitHub `schedule` events only fire from the default branch, so this takes effect once merged to `trunk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)