### PR TITLE
perf(cayenne): cayenne_insert_record table_id as 16-byte raw-UUID BLOB (cut CDC WAL volume ~34%)

### DIFF
--- a/crates/cayenne/benches/folded_txn_decomposition.rs
+++ b/crates/cayenne/benches/folded_txn_decomposition.rs
@@ -106,7 +106,10 @@ const MAX_INSERT_RECORD_ROWS_PER_CHUNK: usize = MAX_PARAMS / INSERT_RECORD_PARAM
 const DELETE_FILE_PARAMS_PER_ROW: usize = 9;
 const MAX_DELETE_FILE_ROWS_PER_CHUNK: usize = MAX_PARAMS / DELETE_FILE_PARAMS_PER_ROW;
 
-const TABLE_ID: &str = "bench-table-id";
+/// A realistic UUIDv7 `table_id` so the `cayenne_insert_record` BLOB
+/// `table_id` encoding stores the 16 raw bytes (matching production), not the
+/// non-UUID fallback.
+const TABLE_ID: &str = "0197e8a0-1234-7890-abcd-ef0123456789";
 
 /// Apply the SAME pragmas the bench pod / runtime uses
 /// (`cayenne_metastore_cache_mb = 1024`, `cayenne_metastore_mmap_mb = 4096`),
@@ -181,7 +184,11 @@ fn build_insert_records_chunk_sql(
             sql.push_str(", ");
         }
         let _ = write!(sql, "(?{}, ?{}, ?{})", base, base + 1, base + 2);
-        params.push(MetastoreValue::Text(TABLE_ID.to_string()));
+        // `cayenne_insert_record.table_id` is the raw-UUID-bytes BLOB in the
+        // production schema; mirror that encoding here.
+        params.push(MetastoreValue::Blob(
+            cayenne::metastore::table_id_to_key_bytes(TABLE_ID),
+        ));
         params.push(MetastoreValue::Blob(pk_bytes.clone()));
         params.push(MetastoreValue::Integer(sequence_number));
     }
@@ -323,7 +330,12 @@ async fn run_one_closure_batch(
     }
 
     // insert-record rows — ONE multi-VALUES statement (no chunking needed:
-    // literals carry no bind-param budget), matching the fix's intent.
+    // literals carry no bind-param budget), matching the fix's intent. The
+    // `table_id` is a raw-UUID-bytes BLOB literal (`x'..'`) in production.
+    let table_id_hex: String = cayenne::metastore::table_id_to_key_bytes(TABLE_ID)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
     sql.push_str(
         "INSERT OR REPLACE INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES ",
     );
@@ -331,7 +343,7 @@ async fn run_one_closure_batch(
         if i > 0 {
             sql.push_str(", ");
         }
-        let _ = write!(sql, "('{TABLE_ID}', x'");
+        let _ = write!(sql, "(x'{table_id_hex}', x'");
         for b in key {
             let _ = write!(sql, "{b:02x}");
         }
@@ -369,7 +381,9 @@ async fn clear_table(metastore: &SqliteMetastore) {
     metastore
         .execute(ExecuteParams {
             sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?1",
-            params: vec![MetastoreValue::Text(TABLE_ID.to_string())],
+            params: vec![MetastoreValue::Blob(
+                cayenne::metastore::table_id_to_key_bytes(TABLE_ID),
+            )],
         })
         .await
         .expect("clear insert_record");
@@ -726,7 +740,9 @@ fn bench_index_growth(c: &mut Criterion) {
                     .execute(ExecuteParams {
                         sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?1 AND sequence_number = ?2",
                         params: vec![
-                            MetastoreValue::Text(TABLE_ID.to_string()),
+                            MetastoreValue::Blob(cayenne::metastore::table_id_to_key_bytes(
+                                TABLE_ID,
+                            )),
                             MetastoreValue::Integer(seq),
                         ],
                     })

--- a/crates/cayenne/benches/insert_record_schema_variants.rs
+++ b/crates/cayenne/benches/insert_record_schema_variants.rs
@@ -6,38 +6,47 @@
 //
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Cycle-11 follow-up: the folded Stage-A txn's cost is ~98% the
-//! `cayenne_insert_record` INSERT OR REPLACE work (see
-//! `folded_txn_decomposition`). This bench pinpoints WHICH part of the
-//! insert-record write is expensive by contrasting schema variants on the same
-//! 20K-row burst, run inside one `BEGIN…COMMIT` against a real `SqliteMetastore`
-//! with the runtime pragmas.
+//! Insert-record write-cost / WAL-volume bench. The folded Stage-A txn's cost
+//! is ~98% the `cayenne_insert_record` INSERT OR REPLACE work (see
+//! `folded_txn_decomposition`). This bench contrasts the historical and current
+//! `cayenne_insert_record` schema shapes on the same burst, run inside one
+//! `BEGIN…COMMIT` against a real `SqliteMetastore` with the runtime pragmas, and
+//! reports the WAL-frame reduction of the current shape.
 //!
-//! The production schema is:
+//! The current (cycle-12) production schema is:
 //! ```sql
 //! CREATE TABLE cayenne_insert_record (
-//!     insert_record_id TEXT PRIMARY KEY,   -- a random UUIDv7, NEVER queried
-//!     table_id TEXT NOT NULL,
+//!     table_id BLOB NOT NULL,              -- 16 raw UUID bytes (was 36-char text)
 //!     pk_bytes BLOB NOT NULL,
 //!     sequence_number BIGINT NOT NULL,
-//!     UNIQUE(table_id, pk_bytes)           -- the ONLY access path used
-//! );
+//!     PRIMARY KEY (table_id, pk_bytes)     -- the ONLY access path used
+//! ) WITHOUT ROWID;                         -- one B-tree, no UUID PK, no FK
 //! ```
 //! Reads are always `SELECT pk_bytes, sequence_number … WHERE table_id = ?`;
-//! deletes are by `table_id` (checkpoint) or `(table_id, pk_bytes)`. The UUID PK
-//! is dead weight: every row maintains BOTH a rowid→UUID PK btree AND the
-//! `(table_id, pk_bytes)` unique index, and mints a UUID + 36-byte text alloc.
+//! deletes are by `table_id` (checkpoint) or `(table_id, pk_bytes)`. cycle-11
+//! dropped the dead `insert_record_id` UUID PK + redundant unique index;
+//! cycle-12 re-encodes the leading `table_id` from 36-char text to the 16 raw
+//! UUID bytes, cutting the WAL frames a hot upsert burst writes by ~a third
+//! (the column is identical on every row of a burst and leads the clustered
+//! key, so the shrink both narrows each cell and packs more rows per leaf).
 //!
 //! Variants (each a fresh DB, 20K rows, one txn, repeated):
-//! - `prod_or_replace_uuid_pk` — production: UUID TEXT PK + UNIQUE(table_id,
-//!   pk_bytes), `INSERT OR REPLACE`. Baseline.
+//! - `prod_or_replace_uuid_pk` — pre-cycle-11: UUID TEXT PK + UNIQUE(table_id,
+//!   pk_bytes), `INSERT OR REPLACE`. Original baseline.
 //! - `plain_insert_uuid_pk` — same schema, plain `INSERT` (no OR REPLACE).
 //!   Isolates the OR-REPLACE conflict-probe cost.
-//! - `without_rowid_composite_pk` — `PRIMARY KEY (table_id, pk_bytes) WITHOUT
-//!   ROWID`, no UUID column, `INSERT OR REPLACE`. The proposed fix: one btree,
-//!   no UUID.
-//! - `without_rowid_plain_insert` — same WITHOUT ROWID schema, plain `INSERT`.
-//!   Floor for the fix.
+//! - `without_rowid_composite_pk` — cycle-11: `PRIMARY KEY (table_id, pk_bytes)
+//!   WITHOUT ROWID`, no UUID column, TEXT `table_id`, `INSERT OR REPLACE`.
+//! - `without_rowid_plain_insert` — same cycle-11 schema, plain `INSERT`.
+//! - `blob_table_id_composite_pk` — cycle-12: the cycle-11 WITHOUT ROWID shape
+//!   but `table_id` stored as the 16 raw UUID bytes (`BLOB`) instead of 36-char
+//!   text. The current production shape; the WAL-volume lever.
+//!
+//! In addition to the criterion wall-time variants, [`bench_variants`] prints a
+//! one-shot **WAL-frame-count** comparison (cycle-11 TEXT `table_id` vs
+//! cycle-12 BLOB `table_id`) for a fixed 55K-key burst — the actual WAL-volume
+//! metric the lever targets (frames = `(-wal size − 32) / 4120`) — and asserts
+//! the BLOB shape writes strictly fewer frames.
 //!
 //! `cargo bench --bench insert_record_schema_variants -p cayenne`.
 
@@ -56,9 +65,85 @@ use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
 const BURST: usize = 20_000;
+/// The hot-table per-burst key count the WAL-volume lever is anchored on (the
+/// cycle-11 `insert_records_only` = 55.7 ms / 55K-keys measurement point).
+const WAL_BURST: usize = 55_000;
 const PK_KEY_BYTES: usize = 16;
 const MAX_PARAMS: usize = 32_000;
-const TABLE_ID: &str = "bench-table-id";
+/// A realistic UUIDv7 `table_id` so the cycle-12 BLOB shape stores the 16 raw
+/// bytes (`uuid::parse_str` succeeds) rather than the non-UUID fallback.
+const TABLE_ID: &str = "0197e8a0-1234-7890-abcd-ef0123456789";
+
+/// `cayenne_insert_record` row layout under test.
+#[derive(Clone, Copy)]
+enum Shape {
+    /// Pre-cycle-11: random-UUID `insert_record_id` TEXT PK + `UNIQUE(table_id,
+    /// pk_bytes)`; `table_id` TEXT. 4 bound params/row.
+    UuidPkText,
+    /// cycle-11: `PRIMARY KEY (table_id, pk_bytes) WITHOUT ROWID`; `table_id`
+    /// TEXT. 3 bound params/row.
+    WithoutRowidText,
+    /// cycle-12: cycle-11 shape but `table_id` is the 16 raw UUID bytes (BLOB).
+    /// 3 bound params/row. The production shape and WAL-volume lever.
+    WithoutRowidBlob,
+}
+
+impl Shape {
+    fn table(self) -> &'static str {
+        match self {
+            Shape::UuidPkText => "ir_uuid",
+            Shape::WithoutRowidText => "ir_wr",
+            Shape::WithoutRowidBlob => "ir_blob",
+        }
+    }
+
+    fn params_per_row(self) -> usize {
+        match self {
+            Shape::UuidPkText => 4,
+            Shape::WithoutRowidText | Shape::WithoutRowidBlob => 3,
+        }
+    }
+
+    fn ddl(self) -> &'static str {
+        match self {
+            Shape::UuidPkText => {
+                "CREATE TABLE ir_uuid (\
+                    insert_record_id TEXT PRIMARY KEY, \
+                    table_id TEXT NOT NULL, \
+                    pk_bytes BLOB NOT NULL, \
+                    sequence_number BIGINT NOT NULL, \
+                    UNIQUE(table_id, pk_bytes))"
+            }
+            Shape::WithoutRowidText => {
+                "CREATE TABLE ir_wr (\
+                    table_id TEXT NOT NULL, \
+                    pk_bytes BLOB NOT NULL, \
+                    sequence_number BIGINT NOT NULL, \
+                    PRIMARY KEY (table_id, pk_bytes)) WITHOUT ROWID"
+            }
+            Shape::WithoutRowidBlob => {
+                "CREATE TABLE ir_blob (\
+                    table_id BLOB NOT NULL, \
+                    pk_bytes BLOB NOT NULL, \
+                    sequence_number BIGINT NOT NULL, \
+                    PRIMARY KEY (table_id, pk_bytes)) WITHOUT ROWID"
+            }
+        }
+    }
+
+    /// The bound `table_id` value: 16 raw UUID bytes for the BLOB shape, the
+    /// 36-char text otherwise.
+    fn table_id_value(self) -> MetastoreValue {
+        match self {
+            Shape::UuidPkText | Shape::WithoutRowidText => {
+                MetastoreValue::Text(TABLE_ID.to_string())
+            }
+            Shape::WithoutRowidBlob => {
+                MetastoreValue::Blob(cayenne::metastore::table_id_to_key_bytes(TABLE_ID))
+            }
+        }
+    }
+}
 
 fn apply_runtime_pragmas() {
     set_sqlite_metastore_config(SqliteMetastoreConfig {
@@ -81,13 +166,11 @@ fn make_keys(n: usize) -> Vec<Vec<u8>> {
         .collect()
 }
 
-/// `with_uuid`: schema has the UUID TEXT PK + 4 params/row; otherwise the
-/// WITHOUT ROWID composite-PK schema with 3 params/row.
-/// `or_replace`: emit `INSERT OR REPLACE` vs plain `INSERT`.
+/// Build one chunk's `INSERT [OR REPLACE]` for the given shape.
 fn build_chunk_sql(
     keys: &[Vec<u8>],
     seq: i64,
-    with_uuid: bool,
+    shape: Shape,
     or_replace: bool,
 ) -> (String, Vec<MetastoreValue>) {
     let verb = if or_replace {
@@ -95,18 +178,18 @@ fn build_chunk_sql(
     } else {
         "INSERT"
     };
-    let (prefix, params_per_row) = if with_uuid {
-        (
+    let params_per_row = shape.params_per_row();
+    let prefix = match shape {
+        Shape::UuidPkText => format!(
+            "{verb} INTO {} (insert_record_id, table_id, pk_bytes, sequence_number) VALUES ",
+            shape.table()
+        ),
+        Shape::WithoutRowidText | Shape::WithoutRowidBlob => {
             format!(
-                "{verb} INTO ir_uuid (insert_record_id, table_id, pk_bytes, sequence_number) VALUES "
-            ),
-            4usize,
-        )
-    } else {
-        (
-            format!("{verb} INTO ir_wr (table_id, pk_bytes, sequence_number) VALUES "),
-            3usize,
-        )
+                "{verb} INTO {} (table_id, pk_bytes, sequence_number) VALUES ",
+                shape.table()
+            )
+        }
     };
     let mut sql = String::with_capacity(prefix.len() + keys.len() * 32);
     sql.push_str(&prefix);
@@ -116,7 +199,7 @@ fn build_chunk_sql(
         if i > 0 {
             sql.push_str(", ");
         }
-        if with_uuid {
+        if matches!(shape, Shape::UuidPkText) {
             let _ = write!(
                 sql,
                 "(?{}, ?{}, ?{}, ?{})",
@@ -126,12 +209,12 @@ fn build_chunk_sql(
                 base + 3
             );
             params.push(MetastoreValue::Text(uuid::Uuid::now_v7().to_string()));
-            params.push(MetastoreValue::Text(TABLE_ID.to_string()));
+            params.push(shape.table_id_value());
             params.push(MetastoreValue::Blob(key.clone()));
             params.push(MetastoreValue::Integer(seq));
         } else {
             let _ = write!(sql, "(?{}, ?{}, ?{})", base, base + 1, base + 2);
-            params.push(MetastoreValue::Text(TABLE_ID.to_string()));
+            params.push(shape.table_id_value());
             params.push(MetastoreValue::Blob(key.clone()));
             params.push(MetastoreValue::Integer(seq));
         }
@@ -139,64 +222,114 @@ fn build_chunk_sql(
     (sql, params)
 }
 
-async fn fresh(with_uuid: bool) -> (SqliteMetastore, TempDir) {
+async fn fresh(shape: Shape) -> (SqliteMetastore, TempDir) {
+    let (m, _path, td) = fresh_with_path(shape).await;
+    (m, td)
+}
+
+/// Like [`fresh`] but also returns the on-disk DB path so a caller can stat the
+/// `-wal` sidecar directly (the backend's WAL-size accessor is private).
+async fn fresh_with_path(shape: Shape) -> (SqliteMetastore, std::path::PathBuf, TempDir) {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let db_path = temp_dir.path().join("catalog.db");
     let metastore = SqliteMetastore::new(format!("sqlite://{}", db_path.display()));
     // init_schema applies the runtime pragmas to the connection; then we add the
-    // two experimental tables.
+    // experimental table for this shape.
     metastore.init_schema().await.expect("init_schema");
-    let ddl = if with_uuid {
-        "CREATE TABLE ir_uuid (\
-            insert_record_id TEXT PRIMARY KEY, \
-            table_id TEXT NOT NULL, \
-            pk_bytes BLOB NOT NULL, \
-            sequence_number BIGINT NOT NULL, \
-            UNIQUE(table_id, pk_bytes))"
-    } else {
-        "CREATE TABLE ir_wr (\
-            table_id TEXT NOT NULL, \
-            pk_bytes BLOB NOT NULL, \
-            sequence_number BIGINT NOT NULL, \
-            PRIMARY KEY (table_id, pk_bytes)) WITHOUT ROWID"
-    };
     metastore
-        .execute_batch(ddl)
+        .execute_batch(shape.ddl())
         .await
         .expect("create variant table");
-    (metastore, temp_dir)
+    (metastore, db_path, temp_dir)
+}
+
+fn wal_bytes(db_path: &std::path::Path) -> u64 {
+    // The WAL sidecar is `<db_path>-wal` (see SqliteMetastore::read_wal_bytes).
+    let wal = format!("{}-wal", db_path.display());
+    std::fs::metadata(&wal).map_or(0, |m| m.len())
+}
+
+async fn insert_burst(
+    metastore: &SqliteMetastore,
+    keys: &[Vec<u8>],
+    seq: i64,
+    shape: Shape,
+    or_replace: bool,
+) {
+    let rows_per_chunk = MAX_PARAMS / shape.params_per_row();
+    let tx = metastore.begin_transaction().await.expect("begin");
+    for chunk in keys.chunks(rows_per_chunk) {
+        let (sql, params) = build_chunk_sql(chunk, seq, shape, or_replace);
+        tx.execute(ExecuteParams { sql: &sql, params })
+            .await
+            .expect("insert");
+    }
+    tx.commit().await.expect("commit");
 }
 
 async fn run_burst(
     metastore: &SqliteMetastore,
     keys: &[Vec<u8>],
     seq: i64,
-    with_uuid: bool,
+    shape: Shape,
     or_replace: bool,
 ) {
-    let params_per_row = if with_uuid { 4 } else { 3 };
-    let rows_per_chunk = MAX_PARAMS / params_per_row;
-    let tx = metastore.begin_transaction().await.expect("begin");
-    for chunk in keys.chunks(rows_per_chunk) {
-        let (sql, params) = build_chunk_sql(chunk, seq, with_uuid, or_replace);
-        tx.execute(ExecuteParams { sql: &sql, params })
-            .await
-            .expect("insert");
-    }
-    tx.commit().await.expect("commit");
-    let table = if with_uuid { "ir_uuid" } else { "ir_wr" };
+    insert_burst(metastore, keys, seq, shape, or_replace).await;
     metastore
         .execute(ExecuteParams {
-            sql: &format!("DELETE FROM {table}"),
+            sql: &format!("DELETE FROM {}", shape.table()),
             params: vec![],
         })
         .await
         .expect("clear");
 }
 
+/// Measure the WAL frames written by exactly one `WAL_BURST`-key `INSERT OR
+/// REPLACE` burst for a shape. The WAL is checkpoint-truncated to zero *before*
+/// the burst so the `-wal` size reflects only this COMMIT's dirty pages; with
+/// `synchronous=NORMAL` + `wal_autocheckpoint=0`, frames = `(size − 32) / 4120`.
+async fn wal_frames_for_burst(shape: Shape, keys: &[Vec<u8>]) -> u64 {
+    let (metastore, db_path, _td) = fresh_with_path(shape).await;
+    // Drain the DDL/init frames out of the WAL so we start from ~0.
+    metastore.checkpoint_wal().await.expect("pre-checkpoint");
+    let before = wal_bytes(&db_path);
+    insert_burst(&metastore, keys, 1_234_567, shape, true).await;
+    let after = wal_bytes(&db_path);
+    let delta = after.saturating_sub(before);
+    // Each frame is a 4096-byte page + 24-byte header.
+    delta / (4096 + 24)
+}
+
+/// Print (and assert) the WAL-frame reduction of the cycle-12 BLOB `table_id`
+/// vs the cycle-11 TEXT `table_id` for a fixed `WAL_BURST` burst. This is the
+/// WAL-volume metric the lever targets; it runs once at bench start.
+fn report_wal_frame_reduction(rt: &Runtime, keys: &[Vec<u8>]) {
+    let text_frames = rt.block_on(wal_frames_for_burst(Shape::WithoutRowidText, keys));
+    let blob_frames = rt.block_on(wal_frames_for_burst(Shape::WithoutRowidBlob, keys));
+    let pct = if text_frames > 0 {
+        100.0 * (text_frames as f64 - blob_frames as f64) / text_frames as f64
+    } else {
+        0.0
+    };
+    eprintln!(
+        "[wal-volume] {WAL_BURST}-key burst: TEXT table_id = {text_frames} frames, \
+         BLOB table_id = {blob_frames} frames, reduction = {pct:.1}%"
+    );
+    assert!(
+        blob_frames < text_frames,
+        "BLOB table_id must write strictly fewer WAL frames than TEXT \
+         (BLOB={blob_frames}, TEXT={text_frames})"
+    );
+}
+
 fn bench_variants(c: &mut Criterion) {
     apply_runtime_pragmas();
     let rt = Runtime::new().expect("runtime");
+
+    // One-shot WAL-volume report on the 55K-key anchor point.
+    let wal_keys = make_keys(WAL_BURST);
+    report_wal_frame_reduction(&rt, &wal_keys);
+
     let keys = make_keys(BURST);
 
     let mut group = c.benchmark_group("insert_record_schema");
@@ -204,23 +337,24 @@ fn bench_variants(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(12));
     group.throughput(Throughput::Elements(BURST as u64));
 
-    let cases: &[(&str, bool, bool)] = &[
-        ("prod_or_replace_uuid_pk", true, true),
-        ("plain_insert_uuid_pk", true, false),
-        ("without_rowid_composite_pk", false, true),
-        ("without_rowid_plain_insert", false, false),
+    let cases: &[(&str, Shape, bool)] = &[
+        ("prod_or_replace_uuid_pk", Shape::UuidPkText, true),
+        ("plain_insert_uuid_pk", Shape::UuidPkText, false),
+        ("without_rowid_composite_pk", Shape::WithoutRowidText, true),
+        ("without_rowid_plain_insert", Shape::WithoutRowidText, false),
+        ("blob_table_id_composite_pk", Shape::WithoutRowidBlob, true),
     ];
 
-    for &(name, with_uuid, or_replace) in cases {
+    for &(name, shape, or_replace) in cases {
         group.bench_function(name, |b| {
-            let (metastore, _td) = rt.block_on(fresh(with_uuid));
+            let (metastore, _td) = rt.block_on(fresh(shape));
             let mut seq = 100_i64;
             b.to_async(&rt).iter(|| {
                 seq += 10;
                 let keys = &keys;
                 let metastore = &metastore;
                 async move {
-                    run_burst(metastore, keys, seq, with_uuid, or_replace).await;
+                    run_burst(metastore, keys, seq, shape, or_replace).await;
                     black_box(());
                 }
             });

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -394,10 +394,14 @@ impl CayenneCatalog {
         }
 
         let table_id_literal = sql_text_literal(table_id);
+        // `cayenne_insert_record.table_id` is a raw-UUID-bytes BLOB, so it must
+        // be matched with a BLOB literal, not the TEXT literal the other tables
+        // use (a TEXT literal never equals a BLOB in SQLite).
+        let insert_record_table_id_literal = insert_record_table_id_blob_literal(table_id);
         let new_snapshot_id_literal = sql_text_literal(new_snapshot_id);
         let batch_sql = format!(
             "DELETE FROM cayenne_delete_file WHERE table_id = {table_id_literal}; \
-             DELETE FROM cayenne_insert_record WHERE table_id = {table_id_literal}; \
+             DELETE FROM cayenne_insert_record WHERE table_id = {insert_record_table_id_literal}; \
              DELETE FROM cayenne_snapshot_sequence WHERE table_id = {table_id_literal}; \
              UPDATE cayenne_table SET current_snapshot_id = {new_snapshot_id_literal} WHERE table_id = {table_id_literal};"
         );
@@ -537,10 +541,14 @@ impl CayenneCatalog {
         }
 
         let table_id_literal = sql_text_literal(table_id);
+        // `cayenne_insert_record.table_id` is a raw-UUID-bytes BLOB, so it must
+        // be matched with a BLOB literal, not the TEXT literal the other tables
+        // use (a TEXT literal never equals a BLOB in SQLite).
+        let insert_record_table_id_literal = insert_record_table_id_blob_literal(table_id);
         let new_snapshot_id_literal = sql_text_literal(new_snapshot_id);
         let batch_sql = format!(
             "DELETE FROM cayenne_delete_file WHERE table_id = {table_id_literal}; \
-             DELETE FROM cayenne_insert_record WHERE table_id = {table_id_literal}; \
+             DELETE FROM cayenne_insert_record WHERE table_id = {insert_record_table_id_literal}; \
              DELETE FROM cayenne_snapshot_sequence WHERE table_id = {table_id_literal}; \
              DELETE FROM cayenne_inlined_data WHERE table_id = {table_id_literal}; \
              DELETE FROM cayenne_inlined_delete WHERE table_id = {table_id_literal}; \
@@ -625,7 +633,7 @@ impl CayenneCatalog {
             }
             // `write!` into a `String` is infallible.
             let _ = write!(sql, "(?{}, ?{}, ?{})", base, base + 1, base + 2);
-            params.push(MetastoreValue::Text(table_id.to_string()));
+            params.push(insert_record_table_id_value(table_id));
             params.push(MetastoreValue::Blob(pk_bytes.clone()));
             params.push(MetastoreValue::Integer(sequence_number));
         }
@@ -1386,7 +1394,7 @@ impl MetadataCatalog for CayenneCatalog {
             .execute_helper(ExecuteParams {
                 sql: "INSERT OR REPLACE INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES (?1, ?2, ?3)",
                 params: vec![
-                    MetastoreValue::Text(table_id.to_string()),
+                    insert_record_table_id_value(table_id),
                     MetastoreValue::Blob(pk_bytes),
                     MetastoreValue::Integer(sequence_number),
                 ],
@@ -1469,7 +1477,7 @@ impl MetadataCatalog for CayenneCatalog {
             .query_helper(
                 QueryParams {
                     sql: "SELECT pk_bytes, sequence_number FROM cayenne_insert_record WHERE table_id = ?1",
-                    params: vec![MetastoreValue::Text(table_id.to_string())],
+                    params: vec![insert_record_table_id_value(table_id)],
                 },
                 |row| {
                     let pk_bytes = row.get_blob(0)?;
@@ -1497,7 +1505,7 @@ impl MetadataCatalog for CayenneCatalog {
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?1",
-                params: vec![MetastoreValue::Text(table_id.to_string())],
+                params: vec![insert_record_table_id_value(table_id)],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -3143,12 +3151,15 @@ impl MetadataCatalog for CayenneCatalog {
             return Ok(false); // Table doesn't exist
         };
 
-        // Delete all related metadata in order (respect foreign key constraints)
+        // Delete all related metadata in order. `cayenne_insert_record` no
+        // longer has a foreign key (its `table_id` is a raw-bytes BLOB; see
+        // `insert_record_table_id_value`), so it must be cleared explicitly
+        // here rather than via ON DELETE CASCADE.
         // 1. Delete insert records
         self.metastore
             .execute_helper(ExecuteParams {
                 sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?1",
-                params: vec![MetastoreValue::Text(table_id.clone())],
+                params: vec![insert_record_table_id_value(&table_id)],
             })
             .await
             .map_err(|e| CatalogError::InvalidOperation {
@@ -3424,6 +3435,32 @@ fn constraint_violation_message_contains_all(message: &str, required_parts: &[&s
 
 fn sql_text_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
+}
+
+/// Encode a `table_id` UUID string as the compact `BLOB` key value bound into
+/// `cayenne_insert_record` (the 16 raw UUID bytes, not the 36-char text). See
+/// [`crate::metastore::table_id_to_key_bytes`] for the encoding contract and
+/// why this cuts WAL volume on hot upsert bursts.
+fn insert_record_table_id_value(table_id: &str) -> MetastoreValue {
+    MetastoreValue::Blob(crate::metastore::table_id_to_key_bytes(table_id))
+}
+
+/// SQL `BLOB` literal (`x'<hex>'`) of the `cayenne_insert_record` `table_id`
+/// key for the batch paths that interpolate it (`commit_compaction_in_txn`,
+/// `commit_overwrite_in_txn`) rather than binding a parameter. The bytes are
+/// the same raw-UUID encoding as [`insert_record_table_id_value`]; the callers
+/// already validate `table_id` is a well-formed UUID before interpolating.
+fn insert_record_table_id_blob_literal(table_id: &str) -> String {
+    use std::fmt::Write as _;
+    let bytes = crate::metastore::table_id_to_key_bytes(table_id);
+    let mut hex = String::with_capacity(bytes.len() * 2 + 3);
+    hex.push_str("x'");
+    for b in bytes {
+        // Writing to a String is infallible.
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex.push('\'');
+    hex
 }
 
 async fn ensure_snapshot_directory_exists(table: &TableMetadata) -> CatalogResult<()> {
@@ -5215,6 +5252,124 @@ mod tests {
         }
 
         // Cleanup
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(format!("{db_path}-shm"));
+        let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    }
+
+    /// Delete-then-reinsert visibility round-trips through the raw-UUID-bytes
+    /// `table_id` BLOB encoding: an insert-record written for a re-inserted PK
+    /// is read back verbatim (`pk_bytes` + `sequence_number`), a checkpoint
+    /// clear (`clear_insert_records`) empties it, and a fresh re-insert lands
+    /// again. This exercises the full catalog write→BLOB→read→clear cycle the
+    /// deletion-visibility ordering depends on (insert_seq > delete_seq ⇒ the
+    /// PK is resurrected). Uses a real `now_v7()` `table_id` from `create_table`
+    /// so the 16-byte encoding path (not the non-UUID fallback) is taken.
+    #[tokio::test]
+    async fn test_insert_record_delete_reinsert_visibility_roundtrip_blob_key() {
+        let test_db = format!(
+            "sqlite://./.test_insert_record_vis_{}.db",
+            uuid::Uuid::now_v7()
+        );
+        let db_path = test_db.strip_prefix("sqlite://").expect("test db path");
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "id",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+
+        let catalog = CayenneCatalog::new(&test_db).expect("create catalog");
+        catalog.init().await.expect("init");
+
+        let table_id = catalog
+            .create_table(CreateTableOptions {
+                table_name: "vis_roundtrip".to_string(),
+                schema,
+                primary_key: vec!["id".to_string()],
+                on_conflict: None,
+                base_path: "/tmp/vis_roundtrip".to_string(),
+                partition_column: None,
+                vortex_config: crate::metadata::VortexConfig::default(),
+            })
+            .await
+            .expect("create table");
+
+        // The table_id minted by create_table is a well-formed UUID, so the
+        // compact 16-byte encoding (not the fallback) is what gets stored.
+        assert!(
+            uuid::Uuid::parse_str(&table_id).is_ok(),
+            "create_table must mint a UUID table_id"
+        );
+
+        // A PK that was deleted (at some delete_seq) is re-inserted at seq=5.
+        let pk: Vec<u8> = 7_i64.to_be_bytes().to_vec();
+        catalog
+            .add_insert_record(&table_id, pk.clone(), 5)
+            .await
+            .expect("add insert record");
+
+        // Read back: the reader returns pk_bytes + sequence_number, keyed by
+        // the BLOB table_id WHERE filter.
+        let records = catalog
+            .get_insert_records(&table_id)
+            .await
+            .expect("get insert records");
+        let key: Box<[u8]> = pk.clone().into_boxed_slice();
+        assert_eq!(
+            records.get(&key),
+            Some(&5_i64),
+            "the re-inserted PK's insert sequence (5) must round-trip through the BLOB key"
+        );
+
+        // Re-insert the SAME PK with a newer sequence → INSERT OR REPLACE
+        // collapses to one row with the latest seq (the conflict target is
+        // still (table_id, pk_bytes) with the BLOB table_id).
+        catalog
+            .add_insert_record(&table_id, pk.clone(), 9)
+            .await
+            .expect("re-add insert record");
+        let records = catalog
+            .get_insert_records(&table_id)
+            .await
+            .expect("get insert records 2");
+        assert_eq!(records.len(), 1, "same PK must not duplicate");
+        assert_eq!(
+            records.get(&key),
+            Some(&9_i64),
+            "the later insert sequence must win the upsert"
+        );
+
+        // Checkpoint clear empties the insert-records for this table_id.
+        catalog
+            .clear_insert_records(&table_id)
+            .await
+            .expect("clear insert records");
+        let records = catalog
+            .get_insert_records(&table_id)
+            .await
+            .expect("get insert records after clear");
+        assert!(
+            records.is_empty(),
+            "clear_insert_records must empty the BLOB-keyed rows"
+        );
+
+        // A fresh re-insert after the clear lands again (post-clear rebuild).
+        catalog
+            .add_insert_record(&table_id, pk.clone(), 12)
+            .await
+            .expect("add after clear");
+        let records = catalog
+            .get_insert_records(&table_id)
+            .await
+            .expect("get after re-add");
+        assert_eq!(
+            records.get(&key),
+            Some(&12_i64),
+            "re-insert after a checkpoint clear must be visible again"
+        );
+
+        catalog.shutdown().await.expect("shutdown");
         let _ = std::fs::remove_file(db_path);
         let _ = std::fs::remove_file(format!("{db_path}-shm"));
         let _ = std::fs::remove_file(format!("{db_path}-wal"));

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -100,6 +100,12 @@ pub const EXPECTED_TABLES: &[ExpectedTable] = &[
         // `insert_record_id` UUID column was never read and is dropped. SQLite
         // declares it `WITHOUT ROWID`; Turso uses a plain rowid table because it
         // does not support `WITHOUT ROWID` under its `mvcc` journal mode.
+        //
+        // `table_id` stores the 16 raw bytes of the UUID (`BLOB`) rather than
+        // the 36-char text — a pure re-encoding to cut WAL write volume on hot
+        // upsert bursts (see [`table_id_to_key_bytes`] and the DDL doc in
+        // `sqlite.rs`). Only column *names* are validated here, so the
+        // text→blob value change does not affect schema validation.
         columns: &["table_id", "pk_bytes", "sequence_number"],
     },
     ExpectedTable {
@@ -147,6 +153,43 @@ pub const EXPECTED_TABLES: &[ExpectedTable] = &[
         ],
     },
 ];
+
+/// Encode a `table_id` UUID string into the compact key bytes stored in the
+/// `cayenne_insert_record.table_id` column.
+///
+/// `cayenne_insert_record` is a hot, high-volume table: one row per
+/// deleted-then-reinserted PK of a CDC burst (20K–55K rows on hot upsert
+/// tables), and `table_id` is the leading field of its clustered
+/// `WITHOUT ROWID` primary key — physically rewritten on every row even though
+/// it is identical across the whole burst. Storing the 16 raw bytes of the
+/// UUID instead of its 36-char hyphenated text both narrows each B-tree cell
+/// and packs more rows per leaf page, cutting the WAL frames a burst writes by
+/// roughly a third.
+///
+/// This is a **pure re-encoding of an existing constant**: the same value is
+/// produced at every write, read, delete, and migration access path, so the
+/// `(table_id, pk_bytes)` upsert conflict target and the `WHERE table_id = ?`
+/// prefix scan are preserved exactly. The only consumer of the table
+/// (`get_insert_records`) reads back `pk_bytes` + `sequence_number` and never
+/// the encoded key beyond the `WHERE` filter, so the on-disk encoding is
+/// invisible to deletion-visibility ordering.
+///
+/// The function is **total**: a well-formed UUID (every production `table_id`
+/// is minted via `uuid::Uuid::now_v7().to_string()`) yields its 16 raw bytes;
+/// any other string falls back to its raw UTF-8 bytes. Because writer and
+/// reader call this same function, they always agree on the stored key
+/// regardless of which branch is taken — the fallback can never desync the
+/// upsert/lookup, it only forgoes the size win for a (non-production) non-UUID
+/// id. The hyphenated-text form is never written, so no other code path needs
+/// to recognise the legacy encoding except the one-shot `init_schema`
+/// migration, which converts existing TEXT rows via this same function.
+#[must_use]
+pub fn table_id_to_key_bytes(table_id: &str) -> Vec<u8> {
+    match uuid::Uuid::parse_str(table_id) {
+        Ok(uuid) => uuid.as_bytes().to_vec(),
+        Err(_) => table_id.as_bytes().to_vec(),
+    }
+}
 
 /// Validate the existing metadata table schemas against the expected definitions.
 ///
@@ -576,6 +619,53 @@ pub trait MetastoreBackend: Send + Sync {
 mod tests {
     use super::*;
     use crate::catalog::CatalogError;
+
+    /// A well-formed UUID `table_id` encodes to its 16 raw bytes (the compact
+    /// WAL-volume form), and those bytes equal `Uuid::as_bytes`.
+    #[test]
+    fn test_table_id_to_key_bytes_uuid_is_16_raw_bytes() {
+        let id = uuid::Uuid::now_v7();
+        let bytes = table_id_to_key_bytes(&id.to_string());
+        assert_eq!(bytes.len(), 16, "a UUID must encode to exactly 16 bytes");
+        assert_eq!(
+            bytes,
+            id.as_bytes().to_vec(),
+            "the encoded bytes must be the UUID's raw bytes"
+        );
+        // Strictly smaller than the 36-char hyphenated text (the whole point).
+        assert!(bytes.len() < id.to_string().len());
+    }
+
+    /// The encoder is total and deterministic: a non-UUID string falls back to
+    /// its raw UTF-8 bytes (never panics), and repeated calls agree — so the
+    /// writer and reader always produce the same key regardless of input.
+    #[test]
+    fn test_table_id_to_key_bytes_non_uuid_falls_back_to_utf8() {
+        for s in ["bench-table-id", "", "not-a-uuid", "1234"] {
+            let a = table_id_to_key_bytes(s);
+            let b = table_id_to_key_bytes(s);
+            assert_eq!(a, b, "encoding must be deterministic for {s:?}");
+            assert_eq!(
+                a,
+                s.as_bytes().to_vec(),
+                "a non-UUID id must fall back to its raw UTF-8 bytes"
+            );
+        }
+    }
+
+    /// UUIDs that differ only in case / hyphenation still encode to the same
+    /// 16 bytes (UUID parsing is canonicalizing), so the key is stable.
+    #[test]
+    fn test_table_id_to_key_bytes_uuid_canonicalizes() {
+        let id = uuid::Uuid::now_v7();
+        let lower = id.to_string();
+        let upper = lower.to_uppercase();
+        assert_eq!(
+            table_id_to_key_bytes(&lower),
+            table_id_to_key_bytes(&upper),
+            "case differences in a UUID must not change the encoded key"
+        );
+    }
 
     #[tokio::test]
     async fn test_validate_existing_schema_matching_columns() {

--- a/crates/cayenne/src/metastore/snapshot.rs
+++ b/crates/cayenne/src/metastore/snapshot.rs
@@ -48,7 +48,9 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::{Deserialize, Serialize};
 
-use super::{EXPECTED_TABLES, ExecuteParams, MetastoreBackend, MetastoreValue, QueryParams};
+use super::{
+    EXPECTED_TABLES, ExecuteParams, MetastoreBackend, MetastoreValue, QueryParams, QueryRowParams,
+};
 use crate::catalog::{CatalogError, CatalogResult};
 
 /// Current slice format version. Incremented on incompatible format changes.
@@ -289,13 +291,22 @@ pub async fn export_dataset(
                 vec![MetastoreValue::Text(dataset_name.to_string())],
             )
         } else {
+            // `cayenne_insert_record.table_id` is stored as the raw-UUID-bytes
+            // BLOB (see `metastore::table_id_to_key_bytes`), so its filter must
+            // bind a BLOB — a TEXT bind never matches a BLOB column in SQLite.
+            // Every other child table keeps `table_id` as TEXT.
+            let table_id_param = if expected.name == "cayenne_insert_record" {
+                MetastoreValue::Blob(super::table_id_to_key_bytes(&table_id))
+            } else {
+                MetastoreValue::Text(table_id.clone())
+            };
             (
                 format!(
                     "SELECT {} FROM {} WHERE table_id = ?",
                     expected.columns.join(", "),
                     expected.name
                 ),
-                vec![MetastoreValue::Text(table_id.clone())],
+                vec![table_id_param],
             )
         };
 
@@ -379,7 +390,30 @@ pub async fn import_dataset(
 
     let txn = metastore.begin_transaction().await?;
 
-    // Wholesale-replace any existing rows for this dataset.
+    // Wholesale-replace any existing rows for this dataset. `cayenne_table`'s
+    // `ON DELETE CASCADE` clears the dependent rows of every child table whose
+    // foreign key still references it — but `cayenne_insert_record` no longer
+    // has that foreign key (its `table_id` is a raw-bytes BLOB; see
+    // `metastore::table_id_to_key_bytes`), so resolve the existing `table_id`
+    // and clear its insert-records explicitly first, inside the same
+    // transaction, before the parent row is removed.
+    if let Ok(values) = txn
+        .query_row_values(QueryRowParams {
+            sql: "SELECT table_id FROM cayenne_table WHERE table_name = ?",
+            params: vec![MetastoreValue::Text(slice.dataset_name.clone())],
+        })
+        .await
+        && let Some(MetastoreValue::Text(existing_table_id)) = values.into_iter().next()
+    {
+        txn.execute(ExecuteParams {
+            sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?",
+            params: vec![MetastoreValue::Blob(super::table_id_to_key_bytes(
+                &existing_table_id,
+            ))],
+        })
+        .await?;
+    }
+
     txn.execute(ExecuteParams {
         sql: "DELETE FROM cayenne_table WHERE table_name = ?",
         params: vec![MetastoreValue::Text(slice.dataset_name.clone())],
@@ -668,6 +702,110 @@ mod tests {
             .await
             .expect("q riders");
         assert_eq!(riders, vec!["r1".to_string()]);
+    }
+
+    /// A `cayenne_insert_record` row (BLOB `table_id`) survives an
+    /// export→import round-trip into a fresh metastore — the export filter and
+    /// the verbatim re-insert both handle the BLOB key — and a subsequent
+    /// wholesale-replace import (whose slice carries no insert-records) clears
+    /// the prior insert-record via the explicit delete that replaced the
+    /// dropped `ON DELETE CASCADE`.
+    #[tokio::test]
+    async fn insert_record_blob_round_trips_and_wholesale_replace_clears_it() {
+        let (ms_a, tmp_a) = fresh_metastore().await;
+        let anchor_a = tmp_a.path();
+
+        // Realistic UUID table_id so the 16-byte BLOB encoding path is taken.
+        let table_id = uuid::Uuid::now_v7().to_string();
+        let table_path = anchor_a.join("ds.dir").to_string_lossy().into_owned();
+        ms_a.execute(ExecuteParams {
+            sql: "INSERT INTO cayenne_table (table_id, table_name, path, path_is_relative, schema_json, primary_key_json, on_conflict_json, current_snapshot_id, partition_column, vortex_config_json, current_sequence_number) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params: sample_table_row(&table_id, "ds", &table_path),
+        })
+        .await
+        .expect("insert table");
+        // Plant an insert-record with the BLOB-encoded table_id (the write path).
+        ms_a.execute(ExecuteParams {
+            sql: "INSERT INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES (?, ?, ?)",
+            params: vec![
+                MetastoreValue::Blob(crate::metastore::table_id_to_key_bytes(&table_id)),
+                MetastoreValue::Blob(7_i64.to_be_bytes().to_vec()),
+                MetastoreValue::Integer(13),
+            ],
+        })
+        .await
+        .expect("insert insert_record");
+
+        let slice = export_dataset(ms_a.as_ref(), "ds", anchor_a)
+            .await
+            .expect("export");
+        assert_eq!(
+            slice.tables["cayenne_insert_record"].len(),
+            1,
+            "the BLOB-keyed insert-record must be captured by the export filter"
+        );
+
+        // Import into a fresh metastore; the BLOB table_id round-trips.
+        let (ms_b, tmp_b) = fresh_metastore().await;
+        import_dataset(ms_b.as_ref(), &slice, tmp_b.path())
+            .await
+            .expect("import");
+        let seq: i64 = ms_b
+            .query_row(
+                QueryRowParams {
+                    sql: "SELECT sequence_number FROM cayenne_insert_record WHERE table_id = ?",
+                    params: vec![MetastoreValue::Blob(
+                        crate::metastore::table_id_to_key_bytes(&table_id),
+                    )],
+                },
+                |row| row.get_i64(0),
+            )
+            .await
+            .expect("read imported insert_record");
+        assert_eq!(
+            seq, 13,
+            "the insert-record sequence must survive the round-trip"
+        );
+
+        // Re-import a slice for the SAME dataset that carries NO insert-records:
+        // the wholesale-replace must clear the prior insert-record explicitly
+        // (the FK + cascade is gone).
+        let mut tables: BTreeMap<String, Vec<SliceRow>> = BTreeMap::new();
+        tables.insert(
+            "cayenne_table".to_string(),
+            vec![
+                sample_table_row(&table_id, "ds", "ds.dir")
+                    .iter()
+                    .map(SliceValue::from)
+                    .collect(),
+            ],
+        );
+        let replace_slice = DatasetMetastoreSlice {
+            format_version: SLICE_FORMAT_VERSION,
+            engine: SLICE_ENGINE.to_string(),
+            dataset_name: "ds".to_string(),
+            exported_at_ms: 0,
+            tables,
+        };
+        import_dataset(ms_b.as_ref(), &replace_slice, tmp_b.path())
+            .await
+            .expect("wholesale-replace import");
+        let remaining: i64 = ms_b
+            .query_row(
+                QueryRowParams {
+                    sql: "SELECT COUNT(*) FROM cayenne_insert_record WHERE table_id = ?",
+                    params: vec![MetastoreValue::Blob(
+                        crate::metastore::table_id_to_key_bytes(&table_id),
+                    )],
+                },
+                |row| row.get_i64(0),
+            )
+            .await
+            .expect("count after replace");
+        assert_eq!(
+            remaining, 0,
+            "wholesale-replace import must clear prior insert-records (no cascade)"
+        );
     }
 
     #[tokio::test]

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -546,12 +546,32 @@ impl SqliteMetastore {
     /// `TEXT PRIMARY KEY` was never read, filtered, or joined — it added a
     /// second B-tree and a 36-byte text alloc per row for no benefit, so it
     /// is dropped (see `init_schema` for the legacy-schema migration).
+    ///
+    /// `table_id` is stored as the **16 raw bytes of the table's UUID**
+    /// (`BLOB`), not the 36-char hyphenated text. It is the leading field of
+    /// the clustered `WITHOUT ROWID` key and is identical for every row of a
+    /// burst, so the 20-byte/row text→raw-bytes shrink removes ~37% of the WAL
+    /// frames a hot upsert burst writes (it both narrows each cell and packs
+    /// more rows per B-tree leaf). The value is a pure re-encoding of the same
+    /// constant — `cayenne_catalog::table_id_blob` translates the `table_id`
+    /// `&str` once per call at every access path, so the `WHERE table_id = ?`
+    /// prefix scan and the `(table_id, pk_bytes)` upsert conflict target are
+    /// preserved 1:1; the reader (`get_insert_records`) only ever returns
+    /// `pk_bytes` + `sequence_number` and never the key beyond the filter.
+    ///
+    /// The `FOREIGN KEY (table_id) → cayenne_table(table_id)` is intentionally
+    /// **dropped**: under `PRAGMA foreign_keys = ON`, `SQLite` never equates a
+    /// `BLOB` child value to the `TEXT`-affinity parent key, so the FK could
+    /// not be satisfied by the raw-bytes encoding. The cascade it provided was
+    /// belt-and-suspenders — `drop_table` already deletes the insert-records
+    /// explicitly before the parent row, and `metastore::snapshot::import_dataset`
+    /// now clears them explicitly too (it previously leaned on the cascade).
+    /// The table is also fully cleared at every checkpoint/overwrite.
     const INSERT_RECORD_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_insert_record (
-            table_id TEXT NOT NULL,
+            table_id BLOB NOT NULL,
             pk_bytes BLOB NOT NULL,
             sequence_number BIGINT NOT NULL,
-            FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
             PRIMARY KEY (table_id, pk_bytes)
         ) WITHOUT ROWID
     ";
@@ -822,39 +842,75 @@ impl MetastoreBackend for SqliteMetastore {
                     conn.execute("UPDATE cayenne_inlined_delete SET published = 1", [])?;
                 }
 
-                // Migrate a legacy `cayenne_insert_record` (UUID `insert_record_id`
-                // TEXT PRIMARY KEY + redundant `UNIQUE(table_id, pk_bytes)`) to the
-                // `WITHOUT ROWID` composite-PK schema. The `CREATE TABLE IF NOT
-                // EXISTS` above leaves a pre-existing table untouched, so detect the
-                // old layout here and copy its rows forward into the new shape.
+                // Migrate a legacy `cayenne_insert_record` to the current shape:
+                // a `WITHOUT ROWID` composite PK `(table_id, pk_bytes)` whose
+                // `table_id` is the 16 raw UUID bytes (`BLOB`) and which carries
+                // no foreign key (see `INSERT_RECORD_TABLE_DDL`). Two legacy
+                // layouts predate this and both store `table_id` as `TEXT`:
+                //   (a) the pre-WITHOUT-ROWID UUID `insert_record_id` TEXT PK +
+                //       redundant `UNIQUE(table_id, pk_bytes)`; and
+                //   (b) the WITHOUT-ROWID composite PK with a TEXT `table_id`
+                //       and a `cayenne_table(table_id)` FOREIGN KEY.
+                // Both are detected by a single check — the declared type of the
+                // `table_id` column is not `BLOB` — and migrated identically.
                 //
-                // The table is ephemeral (fully cleared at every checkpoint via
-                // commit_compaction / commit_overwrite, and recoverable from the
-                // snapshot), so dropping it would be safe — but we copy the
-                // (table_id, pk_bytes, sequence_number) rows forward anyway to
-                // preserve any in-flight pre-checkpoint re-insert sequences across
-                // the upgrade at trivial cost. Runs inside the schema-init
-                // transaction so the swap is atomic.
-                let has_legacy_uuid_column = conn
+                // The `CREATE TABLE IF NOT EXISTS` above leaves a pre-existing
+                // table untouched, so we recreate it here in the new shape and
+                // copy its rows forward, re-encoding each TEXT `table_id` to the
+                // raw-bytes key via `table_id_to_key_bytes` (the same function the
+                // write path uses, guaranteeing the migrated key matches what the
+                // reader/upsert produce). The table is ephemeral (cleared at every
+                // checkpoint via commit_compaction / commit_overwrite and
+                // recoverable from the snapshot), so the copy-forward only
+                // preserves in-flight pre-checkpoint re-insert sequences across
+                // the upgrade — but it does so at trivial cost and keeps the
+                // upgrade lossless. Runs inside the schema-init transaction so the
+                // swap is atomic.
+                let table_id_is_blob = conn
                     .prepare("PRAGMA table_info('cayenne_insert_record')")?
-                    .query_map([], |row| row.get::<_, String>(1))?
-                    .collect::<Result<Vec<String>, _>>()?
+                    .query_map([], |row| {
+                        Ok((row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+                    })?
+                    .collect::<Result<Vec<(String, String)>, _>>()?
                     .iter()
-                    .any(|name| name == "insert_record_id");
-                if has_legacy_uuid_column {
+                    .any(|(name, col_type)| {
+                        name == "table_id" && col_type.eq_ignore_ascii_case("BLOB")
+                    });
+                if !table_id_is_blob {
+                    // Read the legacy rows out (TEXT `table_id`), re-encode the
+                    // `table_id` in Rust, then re-insert into the new BLOB table.
+                    let legacy_rows: Vec<(String, Vec<u8>, i64)> = conn
+                        .prepare(
+                            "SELECT table_id, pk_bytes, sequence_number FROM cayenne_insert_record",
+                        )?
+                        .query_map([], |row| {
+                            Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, i64>(2)?))
+                        })?
+                        .collect::<Result<Vec<_>, _>>()?;
+
                     conn.execute_batch(
-                        "CREATE TABLE cayenne_insert_record_new (
-                            table_id TEXT NOT NULL,
+                        "DROP TABLE cayenne_insert_record;
+                        CREATE TABLE cayenne_insert_record (
+                            table_id BLOB NOT NULL,
                             pk_bytes BLOB NOT NULL,
                             sequence_number BIGINT NOT NULL,
-                            FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
                             PRIMARY KEY (table_id, pk_bytes)
-                        ) WITHOUT ROWID;
-                        INSERT OR REPLACE INTO cayenne_insert_record_new (table_id, pk_bytes, sequence_number)
-                            SELECT table_id, pk_bytes, sequence_number FROM cayenne_insert_record;
-                        DROP TABLE cayenne_insert_record;
-                        ALTER TABLE cayenne_insert_record_new RENAME TO cayenne_insert_record;",
+                        ) WITHOUT ROWID;",
                     )?;
+
+                    if !legacy_rows.is_empty() {
+                        let mut stmt = conn.prepare(
+                            "INSERT OR REPLACE INTO cayenne_insert_record \
+                             (table_id, pk_bytes, sequence_number) VALUES (?1, ?2, ?3)",
+                        )?;
+                        for (table_id_text, pk_bytes, sequence_number) in legacy_rows {
+                            stmt.execute(rusqlite::params![
+                                crate::metastore::table_id_to_key_bytes(&table_id_text),
+                                pk_bytes,
+                                sequence_number,
+                            ])?;
+                        }
+                    }
                 }
 
                 Ok::<_, rusqlite::Error>(())
@@ -1685,6 +1741,7 @@ mod tests {
 
     // ------------------------------------------------------------------
     // cycle-11: `cayenne_insert_record` WITHOUT ROWID composite-PK schema.
+    // cycle-12: `table_id` stored as the raw-UUID-bytes BLOB (no FK).
     // ------------------------------------------------------------------
 
     /// Read the ordered column names of a table off a live pooled connection.
@@ -1704,8 +1761,27 @@ mod tests {
             .expect("table_info")
     }
 
+    /// Read the declared type of one column off a live pooled connection.
+    async fn column_type(metastore: &SqliteMetastore, table: &str, column: &str) -> String {
+        let table = table.to_string();
+        let column = column.to_string();
+        let pool = metastore.pool().await.expect("pool");
+        let guard = pool.conns[0].lock().await;
+        guard
+            .call(move |conn| {
+                conn.query_row(
+                    &format!("SELECT type FROM pragma_table_info('{table}') WHERE name = ?1"),
+                    [&column],
+                    |row| row.get::<_, String>(0),
+                )
+            })
+            .await
+            .expect("column type")
+    }
+
     /// A fresh `cayenne_insert_record` has exactly the 3 composite-PK columns
-    /// (no `insert_record_id`) and is a `WITHOUT ROWID` table.
+    /// (no `insert_record_id`), is a `WITHOUT ROWID` table, stores `table_id`
+    /// as a `BLOB`, and carries no foreign key.
     #[tokio::test]
     async fn test_insert_record_schema_is_without_rowid_composite_pk() {
         let _guard = CONFIG_LOCK.lock().await;
@@ -1718,6 +1794,33 @@ mod tests {
             cols,
             vec!["table_id", "pk_bytes", "sequence_number"],
             "the never-read insert_record_id UUID column must be gone"
+        );
+
+        // `table_id` is the raw-UUID-bytes BLOB (cycle-12 WAL-volume lever).
+        assert_eq!(
+            column_type(&metastore, "cayenne_insert_record", "table_id").await,
+            "BLOB",
+            "table_id must be declared BLOB (16 raw UUID bytes, not 36-char text)"
+        );
+
+        // The foreign key was dropped (a BLOB child cannot satisfy the TEXT
+        // parent key under foreign_keys=ON); foreign_key_list must be empty.
+        let fk_count: i64 = {
+            let pool = metastore.pool().await.expect("pool");
+            let g = pool.conns[0].lock().await;
+            g.call(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM pragma_foreign_key_list('cayenne_insert_record')",
+                    [],
+                    |row| row.get(0),
+                )
+            })
+            .await
+            .expect("fk list")
+        };
+        assert_eq!(
+            fk_count, 0,
+            "cayenne_insert_record must carry no foreign key (BLOB table_id)"
         );
 
         // WITHOUT ROWID tables have no implicit `rowid`; selecting it errors.
@@ -1744,7 +1847,8 @@ mod tests {
 
     /// INSERT OR REPLACE on a duplicate `(table_id, pk_bytes)` updates the
     /// sequence in place and keeps exactly one row (the composite PK is the
-    /// conflict target the catalog relies on).
+    /// conflict target the catalog relies on). The `table_id` is bound as the
+    /// raw-UUID-bytes BLOB, matching the production write path.
     #[tokio::test]
     async fn test_insert_record_duplicate_pk_upserts_sequence() {
         let _guard = CONFIG_LOCK.lock().await;
@@ -1752,15 +1856,10 @@ mod tests {
         let (_dir, metastore) = temp_metastore();
         metastore.init_schema().await.expect("init schema");
 
-        // Parent row so the FK is satisfied.
+        // No FK to satisfy any more, but a realistic UUID table_id is used so
+        // the raw-bytes encoding is exercised.
         let table_id = uuid::Uuid::now_v7().to_string();
-        metastore
-            .execute_batch(&format!(
-                "INSERT INTO cayenne_table (table_id, table_name, path, path_is_relative, schema_json, primary_key_json, current_snapshot_id) \
-                 VALUES ('{table_id}', 'dup_pk_t', '/tmp', 1, '{{}}', '[]', '{table_id}')"
-            ))
-            .await
-            .expect("seed parent");
+        let table_id_blob = crate::metastore::table_id_to_key_bytes(&table_id);
 
         for seq in [11_i64, 42] {
             // Second iteration upserts the SAME (table_id, pk_bytes) → REPLACE.
@@ -1768,7 +1867,7 @@ mod tests {
                 .execute(ExecuteParams {
                     sql: "INSERT OR REPLACE INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES (?1, ?2, ?3)",
                     params: vec![
-                        MetastoreValue::Text(table_id.clone()),
+                        MetastoreValue::Blob(table_id_blob.clone()),
                         MetastoreValue::Blob(b"pk-dup".to_vec()),
                         MetastoreValue::Integer(seq),
                     ],
@@ -1778,13 +1877,13 @@ mod tests {
         }
 
         let (count, seq): (i64, i64) = {
-            let table_id = table_id.clone();
+            let table_id_blob = table_id_blob.clone();
             let pool = metastore.pool().await.expect("pool");
             let g = pool.conns[0].lock().await;
             g.call(move |conn| {
                 conn.query_row(
                     "SELECT COUNT(*), MAX(sequence_number) FROM cayenne_insert_record WHERE table_id = ?1",
-                    [&table_id],
+                    [&table_id_blob],
                     |row| Ok((row.get(0)?, row.get(1)?)),
                 )
             })
@@ -1800,7 +1899,9 @@ mod tests {
 
     /// `DELETE FROM cayenne_insert_record WHERE table_id = ?` (the checkpoint
     /// clear) empties only the target table's rows — still served by the
-    /// leading-prefix of the composite PK.
+    /// leading-prefix of the composite PK with the BLOB `table_id`. Rows seeded
+    /// via a BLOB hex literal (mirroring the `commit_*_in_txn` batch path) and
+    /// a second table's row stays untouched.
     #[tokio::test]
     async fn test_insert_record_checkpoint_clear_by_table_id() {
         let _guard = CONFIG_LOCK.lock().await;
@@ -1809,12 +1910,21 @@ mod tests {
         metastore.init_schema().await.expect("init schema");
 
         let table_id = uuid::Uuid::now_v7().to_string();
+        let other_table_id = uuid::Uuid::now_v7().to_string();
+        let table_id_blob = crate::metastore::table_id_to_key_bytes(&table_id);
+        // Build the `x'..'` BLOB literal of the raw UUID bytes.
+        let blob_lit = |id: &str| {
+            let bytes = crate::metastore::table_id_to_key_bytes(id);
+            let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+            format!("x'{hex}'")
+        };
+        let tid_lit = blob_lit(&table_id);
+        let other_lit = blob_lit(&other_table_id);
         metastore
             .execute_batch(&format!(
-                "INSERT INTO cayenne_table (table_id, table_name, path, path_is_relative, schema_json, primary_key_json, current_snapshot_id) \
-                 VALUES ('{table_id}', 'clear_t', '/tmp', 1, '{{}}', '[]', '{table_id}'); \
-                 INSERT INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES ('{table_id}', x'01', 1); \
-                 INSERT INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES ('{table_id}', x'02', 2);"
+                "INSERT INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES ({tid_lit}, x'01', 1); \
+                 INSERT INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES ({tid_lit}, x'02', 2); \
+                 INSERT INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) VALUES ({other_lit}, x'01', 9);"
             ))
             .await
             .expect("seed rows");
@@ -1822,7 +1932,7 @@ mod tests {
         metastore
             .execute(ExecuteParams {
                 sql: "DELETE FROM cayenne_insert_record WHERE table_id = ?1",
-                params: vec![MetastoreValue::Text(table_id.clone())],
+                params: vec![MetastoreValue::Blob(table_id_blob.clone())],
             })
             .await
             .expect("checkpoint clear");
@@ -1831,7 +1941,7 @@ mod tests {
             .query_row(
                 QueryRowParams {
                     sql: "SELECT COUNT(*) FROM cayenne_insert_record WHERE table_id = ?1",
-                    params: vec![MetastoreValue::Text(table_id)],
+                    params: vec![MetastoreValue::Blob(table_id_blob)],
                 },
                 |row| row.get_i64(0),
             )
@@ -1841,68 +1951,101 @@ mod tests {
             remaining, 0,
             "checkpoint clear must empty the table's insert records"
         );
+
+        let other_remaining: i64 = metastore
+            .query_row(
+                QueryRowParams {
+                    sql: "SELECT COUNT(*) FROM cayenne_insert_record WHERE table_id = ?1",
+                    params: vec![MetastoreValue::Blob(
+                        crate::metastore::table_id_to_key_bytes(&other_table_id),
+                    )],
+                },
+                |row| row.get_i64(0),
+            )
+            .await
+            .expect("count other after clear");
+        assert_eq!(
+            other_remaining, 1,
+            "clearing one table_id must not touch another table's insert records"
+        );
     }
 
-    /// A DB created with the legacy schema (UUID `insert_record_id` TEXT PRIMARY
-    /// KEY + redundant `UNIQUE(table_id, pk_bytes)`) and carrying rows is
-    /// migrated by `init_schema` to the `WITHOUT ROWID` composite-PK layout,
-    /// copying the `(table_id, pk_bytes, sequence_number)` rows forward.
-    #[tokio::test]
-    async fn test_insert_record_legacy_schema_migrates_with_rows_present() {
+    /// Drive the legacy→current `cayenne_insert_record` migration for a given
+    /// legacy DDL (which stores `table_id` as TEXT). Asserts the migrated table
+    /// is the BLOB-`table_id` WITHOUT-ROWID composite-PK shape with no FK, and
+    /// that the two seeded rows survive with their `table_id` re-encoded to the
+    /// raw UUID bytes (so the BLOB-keyed reader/clear find them).
+    async fn assert_legacy_insert_record_migrates(legacy_create_sql: &str, with_uuid_pk: bool) {
         let _guard = CONFIG_LOCK.lock().await;
         set_sqlite_metastore_config(SqliteMetastoreConfig::default());
         let (_dir, metastore) = temp_metastore();
 
         // Build a realistic "old deployment": init the current full schema for
         // every OTHER table, then DOWNGRADE only cayenne_insert_record back to
-        // the legacy UUID-PK shape and seed a parent row + two insert records.
-        // Re-running init_schema must then detect & migrate just this table
-        // (and leave every other table matching EXPECTED_TABLES).
+        // a legacy TEXT-`table_id` shape and seed a parent row + two insert
+        // records. Re-running init_schema must then detect & migrate just this
+        // table (leaving every other table matching EXPECTED_TABLES).
         metastore.init_schema().await.expect("baseline init schema");
         let table_id = uuid::Uuid::now_v7().to_string();
-        metastore
-            .execute_batch(&format!(
-                "DROP TABLE cayenne_insert_record; \
-                 CREATE TABLE cayenne_insert_record (\
-                    insert_record_id TEXT PRIMARY KEY, table_id TEXT NOT NULL, \
-                    pk_bytes BLOB NOT NULL, sequence_number BIGINT NOT NULL, \
-                    FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE, \
-                    UNIQUE(table_id, pk_bytes)); \
-                 INSERT INTO cayenne_table (table_id, table_name, path, path_is_relative, schema_json, primary_key_json, current_snapshot_id) \
-                    VALUES ('{table_id}', 'legacy_t', '/tmp', 1, '{{}}', '[]', '{table_id}'); \
-                 INSERT INTO cayenne_insert_record (insert_record_id, table_id, pk_bytes, sequence_number) \
+
+        let insert_rows = if with_uuid_pk {
+            format!(
+                "INSERT INTO cayenne_insert_record (insert_record_id, table_id, pk_bytes, sequence_number) \
                     VALUES ('{u1}', '{table_id}', x'0a', 7); \
                  INSERT INTO cayenne_insert_record (insert_record_id, table_id, pk_bytes, sequence_number) \
                     VALUES ('{u2}', '{table_id}', x'0b', 9);",
                 u1 = uuid::Uuid::now_v7(),
                 u2 = uuid::Uuid::now_v7(),
+            )
+        } else {
+            format!(
+                "INSERT INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) \
+                    VALUES ('{table_id}', x'0a', 7); \
+                 INSERT INTO cayenne_insert_record (table_id, pk_bytes, sequence_number) \
+                    VALUES ('{table_id}', x'0b', 9);"
+            )
+        };
+
+        metastore
+            .execute_batch(&format!(
+                "DROP TABLE cayenne_insert_record; \
+                 {legacy_create_sql} \
+                 INSERT INTO cayenne_table (table_id, table_name, path, path_is_relative, schema_json, primary_key_json, current_snapshot_id) \
+                    VALUES ('{table_id}', 'legacy_t', '/tmp', 1, '{{}}', '[]', '{table_id}'); \
+                 {insert_rows}"
             ))
             .await
             .expect("downgrade cayenne_insert_record to legacy schema + seed rows");
 
-        // Sanity: the legacy column is present pre-migration.
-        let before = table_columns(&metastore, "cayenne_insert_record").await;
-        assert!(
-            before.contains(&"insert_record_id".to_string()),
-            "precondition: legacy UUID column present, got {before:?}"
+        // Sanity: the legacy `table_id` column is TEXT pre-migration.
+        assert_eq!(
+            column_type(&metastore, "cayenne_insert_record", "table_id").await,
+            "TEXT",
+            "precondition: legacy table_id is TEXT"
         );
 
         metastore.init_schema().await.expect("init schema migrates");
 
-        // Post-migration: the new 3-column WITHOUT ROWID schema and both rows
-        // (with their original sequences) survived the copy-forward.
+        // Post-migration: the new 3-column schema with a BLOB table_id.
         let after = table_columns(&metastore, "cayenne_insert_record").await;
         assert_eq!(
             after,
             vec!["table_id", "pk_bytes", "sequence_number"],
             "legacy table must be migrated to the composite-PK schema"
         );
+        assert_eq!(
+            column_type(&metastore, "cayenne_insert_record", "table_id").await,
+            "BLOB",
+            "migrated table_id must be BLOB"
+        );
 
+        // The rows survived AND are now keyed by the raw-UUID-bytes BLOB — i.e.
+        // a BLOB-encoded lookup (what the production reader does) finds them.
         let rows: Vec<(Vec<u8>, i64)> = metastore
             .query(
                 QueryParams {
                     sql: "SELECT pk_bytes, sequence_number FROM cayenne_insert_record WHERE table_id = ?1 ORDER BY pk_bytes",
-                    params: vec![MetastoreValue::Text(table_id)],
+                    params: vec![MetastoreValue::Blob(crate::metastore::table_id_to_key_bytes(&table_id))],
                 },
                 |row| Ok((row.get_blob(0)?, row.get_i64(1)?)),
             )
@@ -1911,15 +2054,48 @@ mod tests {
         assert_eq!(
             rows,
             vec![(vec![0x0a_u8], 7_i64), (vec![0x0b_u8], 9_i64)],
-            "the (table_id, pk_bytes, sequence_number) rows must be copied forward"
+            "the (table_id, pk_bytes, sequence_number) rows must be copied forward and re-encoded"
         );
 
-        // The migrated DB also passes the EXPECTED_TABLES validation that
-        // init_schema runs at the end (no SchemaMismatch was returned above),
-        // and re-running init_schema is idempotent (the column is now gone).
+        // Re-running init_schema is idempotent (table_id is already BLOB).
         metastore
             .init_schema()
             .await
             .expect("second init_schema is a no-op");
+        assert_eq!(
+            column_type(&metastore, "cayenne_insert_record", "table_id").await,
+            "BLOB",
+            "re-running init_schema must not re-migrate (already BLOB)"
+        );
+    }
+
+    /// Pre-cycle-11 legacy shape: UUID `insert_record_id` TEXT PRIMARY KEY +
+    /// redundant `UNIQUE(table_id, pk_bytes)` + TEXT `table_id` + FK.
+    #[tokio::test]
+    async fn test_insert_record_legacy_uuid_pk_schema_migrates_with_rows_present() {
+        assert_legacy_insert_record_migrates(
+            "CREATE TABLE cayenne_insert_record (\
+                insert_record_id TEXT PRIMARY KEY, table_id TEXT NOT NULL, \
+                pk_bytes BLOB NOT NULL, sequence_number BIGINT NOT NULL, \
+                FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE, \
+                UNIQUE(table_id, pk_bytes));",
+            true,
+        )
+        .await;
+    }
+
+    /// cycle-11 legacy shape: WITHOUT ROWID composite PK with a TEXT `table_id`
+    /// and a `cayenne_table(table_id)` foreign key (the shape this lever
+    /// replaces). The TEXT→BLOB re-encode must still fire.
+    #[tokio::test]
+    async fn test_insert_record_cycle11_text_schema_migrates_with_rows_present() {
+        assert_legacy_insert_record_migrates(
+            "CREATE TABLE cayenne_insert_record (\
+                table_id TEXT NOT NULL, pk_bytes BLOB NOT NULL, sequence_number BIGINT NOT NULL, \
+                FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE, \
+                PRIMARY KEY (table_id, pk_bytes)) WITHOUT ROWID;",
+            false,
+        )
+        .await;
     }
 }

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -267,6 +267,20 @@ impl TursoMetastore {
     /// `TEXT PRIMARY KEY` (plus a redundant `UNIQUE(table_id, pk_bytes)`) is
     /// dropped (see `init_schema` for the legacy-schema migration).
     ///
+    /// `table_id` stores the 16 raw bytes of the UUID (`BLOB`), not the 36-char
+    /// text — a pure re-encoding (via `cayenne_catalog::insert_record_table_id_value`
+    /// / `metastore::table_id_to_key_bytes`) that cuts the WAL/journal volume of
+    /// hot upsert bursts; see the `SQLite` `INSERT_RECORD_TABLE_DDL` doc for the
+    /// full rationale and correctness contract. The catalog builders bind the
+    /// same `MetastoreValue::Blob` regardless of backend, so this column shape
+    /// must match `SQLite`.
+    ///
+    /// The `cayenne_table(table_id)` foreign key is dropped: under
+    /// `PRAGMA foreign_keys = ON` a `BLOB` child value can never satisfy the
+    /// `TEXT` parent key. The cascade was belt-and-suspenders (the table is
+    /// cleared at every checkpoint/overwrite, `drop_table` deletes it
+    /// explicitly, and `snapshot::import_dataset` now does too).
+    ///
     /// Unlike the `SQLite` backend, this table is NOT declared `WITHOUT ROWID`.
     /// `WITHOUT ROWID` is not currently supported by Turso under the `mvcc`
     /// journal mode that the metastore relies on for `BEGIN CONCURRENT`
@@ -274,10 +288,9 @@ impl TursoMetastore {
     /// supported in MVCC mode").
     const INSERT_RECORD_TABLE_DDL: &'static str = r"
         CREATE TABLE IF NOT EXISTS cayenne_insert_record (
-            table_id TEXT NOT NULL,
+            table_id BLOB NOT NULL,
             pk_bytes BLOB NOT NULL,
             sequence_number BIGINT NOT NULL,
-            FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
             PRIMARY KEY (table_id, pk_bytes)
         )
     ";
@@ -577,29 +590,39 @@ impl MetastoreBackend for TursoMetastore {
                 })?;
         }
 
-        // Migrate a legacy `cayenne_insert_record` (UUID `insert_record_id` TEXT
-        // PRIMARY KEY + redundant `UNIQUE(table_id, pk_bytes)`) to the composite-PK
-        // schema. The `CREATE TABLE IF NOT EXISTS` above leaves a pre-existing
-        // table untouched, so detect the old layout here and copy its rows
-        // forward. The table is ephemeral (cleared at every checkpoint and
-        // recoverable from the snapshot), but we copy the
-        // (table_id, pk_bytes, sequence_number) rows forward to preserve any
-        // in-flight pre-checkpoint re-insert sequences across the upgrade.
+        // Migrate a legacy `cayenne_insert_record` to the current shape: a
+        // composite PK `(table_id, pk_bytes)` whose `table_id` is the 16 raw
+        // UUID bytes (`BLOB`) and which carries no foreign key (see
+        // `INSERT_RECORD_TABLE_DDL`). Two legacy layouts predate this and both
+        // store `table_id` as `TEXT`: the pre-composite UUID `insert_record_id`
+        // TEXT PK + redundant `UNIQUE(table_id, pk_bytes)`, and the composite-PK
+        // TEXT-`table_id` shape with a `cayenne_table(table_id)` foreign key.
+        // Both are detected by a single check — the declared type of the
+        // `table_id` column is not `BLOB` — and migrated identically: read the
+        // legacy rows out, re-encode each TEXT `table_id` to the raw-bytes key
+        // via `table_id_to_key_bytes` (the same function the write path uses),
+        // recreate the table in the new shape, and re-insert.
+        //
+        // The table is ephemeral (cleared at every checkpoint and recoverable
+        // from the snapshot), but the copy-forward preserves in-flight
+        // pre-checkpoint re-insert sequences across the upgrade at trivial cost.
         let mut ir_cols = conn
             .query("PRAGMA table_info('cayenne_insert_record')", ())
             .await
             .map_err(|e| CatalogError::Database {
                 message: format!("Failed to read cayenne_insert_record schema for migration: {e}"),
             })?;
-        let mut has_legacy_uuid_column = false;
+        let mut table_id_is_blob = false;
         loop {
             match ir_cols.next().await {
-                // Column name is at index 1 of PRAGMA table_info.
+                // PRAGMA table_info: name at index 1, declared type at index 2.
                 Ok(Some(row)) => {
-                    if let Ok(turso::Value::Text(name)) = row.get_value(1)
-                        && name == "insert_record_id"
+                    if let (Ok(turso::Value::Text(name)), Ok(turso::Value::Text(col_type))) =
+                        (row.get_value(1), row.get_value(2))
+                        && name == "table_id"
+                        && col_type.eq_ignore_ascii_case("BLOB")
                     {
-                        has_legacy_uuid_column = true;
+                        table_id_is_blob = true;
                     }
                 }
                 Ok(None) => break,
@@ -613,28 +636,97 @@ impl MetastoreBackend for TursoMetastore {
             }
         }
         drop(ir_cols);
-        if has_legacy_uuid_column {
+        if !table_id_is_blob {
+            // Read the legacy rows out (TEXT `table_id`) before recreating.
+            let mut legacy_rows: Vec<(String, Vec<u8>, i64)> = Vec::new();
+            let mut rows = conn
+                .query(
+                    "SELECT table_id, pk_bytes, sequence_number FROM cayenne_insert_record",
+                    (),
+                )
+                .await
+                .map_err(|e| CatalogError::Database {
+                    message: format!("Failed to read legacy cayenne_insert_record rows: {e}"),
+                })?;
+            loop {
+                match rows.next().await {
+                    Ok(Some(row)) => {
+                        let table_id = match row.get_value(0) {
+                            Ok(turso::Value::Text(t)) => t,
+                            _ => {
+                                return Err(CatalogError::Database {
+                                    message: "legacy cayenne_insert_record.table_id is not TEXT"
+                                        .to_string(),
+                                });
+                            }
+                        };
+                        let pk_bytes = match row.get_value(1) {
+                            Ok(turso::Value::Blob(b)) => b,
+                            _ => {
+                                return Err(CatalogError::Database {
+                                    message: "legacy cayenne_insert_record.pk_bytes is not BLOB"
+                                        .to_string(),
+                                });
+                            }
+                        };
+                        let sequence_number = match row.get_value(2) {
+                            Ok(turso::Value::Integer(i)) => i,
+                            _ => {
+                                return Err(CatalogError::Database {
+                                    message:
+                                        "legacy cayenne_insert_record.sequence_number is not INTEGER"
+                                            .to_string(),
+                                });
+                            }
+                        };
+                        legacy_rows.push((table_id, pk_bytes, sequence_number));
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        return Err(CatalogError::Database {
+                            message: format!(
+                                "Failed to read legacy cayenne_insert_record rows: {e}"
+                            ),
+                        });
+                    }
+                }
+            }
+            drop(rows);
+
             // NOTE: not `WITHOUT ROWID` here, intentionally. Turso does not
             // currently support `WITHOUT ROWID` tables under the `mvcc` journal
             // mode this metastore uses for `BEGIN CONCURRENT` (see
             // `INSERT_RECORD_TABLE_DDL`).
             conn.execute_batch(
-                "CREATE TABLE cayenne_insert_record_new (
-                    table_id TEXT NOT NULL,
+                "DROP TABLE cayenne_insert_record;
+                CREATE TABLE cayenne_insert_record (
+                    table_id BLOB NOT NULL,
                     pk_bytes BLOB NOT NULL,
                     sequence_number BIGINT NOT NULL,
-                    FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
                     PRIMARY KEY (table_id, pk_bytes)
-                );
-                INSERT OR REPLACE INTO cayenne_insert_record_new (table_id, pk_bytes, sequence_number)
-                    SELECT table_id, pk_bytes, sequence_number FROM cayenne_insert_record;
-                DROP TABLE cayenne_insert_record;
-                ALTER TABLE cayenne_insert_record_new RENAME TO cayenne_insert_record;",
+                );",
             )
             .await
             .map_err(|e| CatalogError::Database {
                 message: format!("Failed to migrate cayenne_insert_record to composite PK: {e}"),
             })?;
+
+            for (table_id, pk_bytes, sequence_number) in legacy_rows {
+                let params: Vec<turso::Value> = vec![
+                    turso::Value::Blob(crate::metastore::table_id_to_key_bytes(&table_id)),
+                    turso::Value::Blob(pk_bytes),
+                    turso::Value::Integer(sequence_number),
+                ];
+                conn.execute(
+                    "INSERT OR REPLACE INTO cayenne_insert_record \
+                     (table_id, pk_bytes, sequence_number) VALUES (?1, ?2, ?3)",
+                    params,
+                )
+                .await
+                .map_err(|e| CatalogError::Database {
+                    message: format!("Failed to re-insert migrated cayenne_insert_record row: {e}"),
+                })?;
+            }
         }
 
         // Must run AFTER the `published` column migration above: the partial index


### PR DESCRIPTION
## Summary

Re-encodes the per-row `table_id` in `cayenne_insert_record` from a 36-char hyphenated-UUID **TEXT** value to the **16 raw bytes** of the UUID (**BLOB**). This is the durable-write-throughput lever for the CDC insert-records path — the measured ~98% segment of the folded Stage-A metastore txn.

`cayenne_insert_record` is a `WITHOUT ROWID` composite-PK table (`(table_id, pk_bytes)`). `table_id` is the **leading** field of the clustered key and is **identical for every row of a burst** (20K–55K rows on hot upsert tables), yet physically rewritten on each row. Because it leads the key, the 36→16-byte shrink both narrows every B-tree cell **and** packs more rows per leaf, so it cuts the WAL frames each burst's COMMIT appends.

This stacks cleanly on the cycle-11 `WITHOUT ROWID` win (which dropped the dead `insert_record_id` UUID PK + redundant unique index); cycle-11 left this *second* per-row UUID behind, now as the leading key column.

## Modeled / measured WAL-volume reduction

Anchored on the cycle-11 post-fix point (`insert_records_only` = **55.7 ms / 55K keys**). Measured on the production schema with the runtime pragmas (`synchronous=NORMAL`, `wal_autocheckpoint=0`, 4096-byte pages), counting actual WAL frames written by one 55K-key burst's COMMIT:

| `table_id` encoding | WAL frames (55K-key burst) |
|---|---|
| TEXT (36 char) | **920** |
| BLOB (16 raw bytes) | **603** |
| **reduction** | **−34.5%** |

Cross-checked with a standalone SQLite harness: **−37%** for a sequential Int64 PK burst, **−33%** for a scattered 16-byte composite-PK (stock-style) burst. The win beats the naive byte-ratio (20/36 ≈ −56% of the *table_id bytes*, ≈ −21% of the row) because narrowing the leading key column also improves leaf packing — fewer leaves ⇒ fewer 4 KB frames. This multiplies with the orthogonal WAL *mechanism* tuning on the base branch (autocheckpoint off, passive background drain): fewer frames ⇒ the 160 MiB TRUNCATE fires less often and the per-burst writer-held window shrinks again.

## Correctness argument

The value re-encoded is a stable per-table constant. A single `metastore::table_id_to_key_bytes(&str) -> Vec<u8>` is used at **every** access path, so the encoding is invisible to semantics:

- **Upsert conflict target** `(table_id, pk_bytes)` and **prefix scan** `WHERE table_id = ?` are preserved 1:1 (`build_insert_records_chunk_sql`, `add_insert_record`, `get_insert_records`, `clear_insert_records`, `drop_table`, and the two literal-interpolating batch deletes in `commit_compaction_in_txn` / `commit_overwrite_in_txn`).
- The **only reader**, `get_insert_records`, returns just `pk_bytes` + `sequence_number` and never the key beyond the `WHERE` filter — so deletion-visibility ordering (`insert_seq > delete_seq` ⇒ PK resurrected) is untouched. `pk_bytes` stays byte-identical (it is *not* a lever); only the constant leading prefix shrinks.
- **Sequence monotonicity** and **`pk_bytes` uniqueness/ordering** are unchanged.
- **Stage-A crash-safety / exactly-once**: same `BEGIN IMMEDIATE`..`COMMIT`, same statement set/order, same busy-retry control flow — only one bound value per row changes type.
- `table_id_to_key_bytes` is **total**: a well-formed UUID (every production `table_id`) yields its 16 raw bytes; any other string falls back to its UTF-8 bytes. Writer and reader call the same function, so they always agree on the stored key regardless of input — the fallback can never desync the upsert/lookup.

### Foreign key

The `FOREIGN KEY (table_id) → cayenne_table(table_id)` is **dropped**. Verified empirically (sqlite 3.51): under `PRAGMA foreign_keys = ON`, SQLite never equates a `BLOB` child value to the `TEXT`-affinity parent key, so the FK could not be satisfied by the raw-bytes encoding (it raised `FOREIGN KEY constraint failed`). The `ON DELETE CASCADE` it provided was belt-and-suspenders:
- `drop_table` already deletes insert-records explicitly before the parent row.
- The table is fully cleared at every checkpoint/overwrite.
- `metastore::snapshot::import_dataset` previously leaned on the cascade for its wholesale-replace; it now resolves the existing `table_id` and clears the insert-records explicitly first (covered by a new test).

## Encoding choice — BLOB, not integer surrogate

The scope offered a 16-byte BLOB (~−21% modeled, lowest surface) or an integer surrogate (~−36% modeled, but needs a new `table_id → seq` resolver, a new column/table on `cayenne_table`, a cache, FK retargeting, and a surrogate-assigning migration for every existing table). I chose the **BLOB**: it is a pure re-encoding with no new tables/columns/resolvers, the lowest correctness surface, and it **measured −34.5%** in practice (the leaf-packing compounding the scope attributed to the surrogate also materializes for the BLOB) — capturing most of the surrogate's ceiling at a fraction of the risk.

## Migration

`init_schema` migrates **both** legacy shapes — the pre-`WITHOUT ROWID` UUID-PK shape *and* the cycle-11 `WITHOUT ROWID` TEXT-`table_id` shape — detected by a single check: the declared type of the `table_id` column is not `BLOB`. It reads the legacy rows, re-encodes each TEXT `table_id` via the same `table_id_to_key_bytes`, recreates the table in the new BLOB/no-FK shape, and re-inserts. Runs inside the schema-init transaction (atomic). The table is ephemeral (checkpoint-rebuildable), but the copy-forward preserves in-flight pre-checkpoint sequences losslessly. Mirrored on sqlite + turso. `EXPECTED_TABLES` validates column *names* only, so the text→blob value change needs no validation change.

## Tests

- **Encoder unit tests** — 16-byte UUID encoding, non-UUID UTF-8 fallback (total/deterministic), case/hyphenation canonicalization.
- **Schema** — asserts `table_id` is `BLOB` and the FK is gone; still `WITHOUT ROWID`.
- **Upsert** — duplicate `(table_id, pk_bytes)` collapses to one row, latest seq wins (BLOB-bound).
- **Checkpoint clear** — `DELETE WHERE table_id = <blob>` empties the target table; a second table's rows stay untouched.
- **Migration** — both legacy shapes migrate with rows present, re-encode TEXT→BLOB, and re-running `init_schema` is idempotent.
- **Visibility round-trip** — full catalog `create_table` (real UUID) → `add_insert_record` → `get_insert_records` → re-insert (upsert) → `clear_insert_records` → re-insert, all through the BLOB key.
- **Snapshot** — a BLOB-keyed insert-record survives export→import into a fresh metastore, and a wholesale-replace import clears the prior one (validating the dropped-cascade replacement).
- **Bench** — new WAL-frame-count report in `insert_record_schema_variants` asserts the BLOB shape writes strictly fewer frames than TEXT for the 55K-key burst; both benches updated to the production BLOB encoding (and a UUID `TABLE_ID` so the 16-byte path is exercised).

`cargo test -p cayenne --lib` → 473 passed. `cargo clippy -p cayenne --no-deps --lib` (full CI pedantic flags) → clean. `cargo check -p cayenne --features turso` → green. `cargo fmt` clean.

## Stacking

Stacked on `lukim/cayenne-cdc-throughput` (#11206), where cycle-11 lives — this lever is the natural next increment on the same `cayenne_insert_record` seam and is orthogonal to the WAL *mechanism* tuning there (it reduces the *volume* those mechanisms move).