### PR TITLE
ci(nightly): build spiceai-nightly with the spicebench feature

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Build spiced and spice CLI
         working-directory: bin/spiced
-        run: cargo build --profile ${{ env.RUST_PROFILE }} --features release,models -p spiced -p spice --target-dir ../../target
+        run: cargo build --profile ${{ env.RUST_PROFILE }} --features release,models,spicebench -p spiced -p spice --target-dir ../../target
 
       - name: tar spiced binary
         run: |
@@ -199,7 +199,7 @@ jobs:
 
       - name: Build spiced and spice CLI
         working-directory: bin/spiced
-        run: cargo build --profile ${{ env.RUST_PROFILE }} --features release,models -p spiced -p spice --target-dir ../../target
+        run: cargo build --profile ${{ env.RUST_PROFILE }} --features release,models,spicebench -p spiced -p spice --target-dir ../../target
 
       - name: tar spiced binary
         run: |
@@ -269,7 +269,7 @@ jobs:
 
       - name: Build spiced and spice CLI
         working-directory: bin/spiced
-        run: cargo build --profile ${{ env.RUST_PROFILE }} --features release,models -p spiced -p spice --target-dir ../../target
+        run: cargo build --profile ${{ env.RUST_PROFILE }} --features release,models,spicebench -p spiced -p spice --target-dir ../../target
 
       - name: tar spiced binary
         run: |


### PR DESCRIPTION
## What

Add the `spicebench` cargo feature to the nightly binary builds (Linux x64, Linux aarch64, macOS aarch64) in `build_nightly.yml`.
