### PR TITLE
fix(cluster): distribute accelerated tables wrapped by metadata/index providers

### DIFF
--- a/crates/runtime/src/cluster/accelerated_partition_provider.rs
+++ b/crates/runtime/src/cluster/accelerated_partition_provider.rs
@@ -24,11 +24,11 @@ use std::sync::Arc;
 use arrow::datatypes::SchemaRef;
 use datafusion::{catalog::TableProvider, datasource::DefaultTableSource, sql::TableReference};
 use datafusion_expr::TableScan;
-use datafusion_federation::FederatedTableProviderAdaptor;
 use runtime_cluster::{ExecutorRegistry, PartitionValue};
 use runtime_datafusion::analyzer_rule::TablePartitionProvider;
 
 use crate::accelerated_table::AcceleratedTable;
+use crate::search::util::find_concrete_table_provider;
 
 /// Wraps an [`ExecutorRegistry`] with the `AcceleratedTable`-specific
 /// `should_partition` logic so it can be installed as a `TablePartitionProvider`.
@@ -42,27 +42,18 @@ impl AcceleratedPartitionProvider {
     }
 }
 
+/// Whether `table_provider` is (or wraps) an [`AcceleratedTable`].
+///
+/// The registered provider for an accelerated dataset is decorated depending on its
+/// configuration: a `FederatedTableProviderAdaptor` (`PolyTableProvider` engines),
+/// a `MetadataEnrichedTableProvider` (datasets with column/table metadata such as
+/// descriptions), an `IndexedTableProvider` / `EmbeddingTable` (embedding or
+/// full-text-search columns), or any nesting of these. We must see through all of
+/// them — otherwise the coordinator skips partition distribution and silently
+/// federates the read to the source. [`find_concrete_table_provider`] already knows
+/// how to unwrap every such decorator.
 fn is_accelerated_table_provider(table_provider: &Arc<dyn TableProvider>) -> bool {
-    if table_provider
-        .as_any()
-        .downcast_ref::<AcceleratedTable>()
-        .is_some()
-    {
-        return true;
-    }
-
-    if let Some(adaptor) = table_provider
-        .as_any()
-        .downcast_ref::<FederatedTableProviderAdaptor>()
-        && let Some(inner_provider) = adaptor.table_provider.as_ref()
-    {
-        return inner_provider
-            .as_any()
-            .downcast_ref::<AcceleratedTable>()
-            .is_some();
-    }
-
-    false
+    find_concrete_table_provider::<AcceleratedTable>(table_provider).is_some()
 }
 
 impl TablePartitionProvider for AcceleratedPartitionProvider {

--- a/crates/runtime/tests/cluster/distributed_acceleration.rs
+++ b/crates/runtime/tests/cluster/distributed_acceleration.rs
@@ -184,6 +184,204 @@ async fn test_distributed_acceleration_with_bucket_partitioning() -> Result<(), 
         .await
 }
 
+/// Regression: same as `test_distributed_acceleration_with_bucket_partitioning`, but the
+/// source is a FEDERATED connector (`DuckDB`, a `PolyTableProvider`) instead of a local CSV
+/// file — the cloud shape (federated source + cayenne partitioned acceleration). The
+/// federation wrapper must not hide the inner `AcceleratedTable` from `should_partition`;
+/// the query must still distribute (`FlightSqlExec`).
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
+async fn cluster_distributes_accelerated_table_with_federated_source() -> Result<(), anyhow::Error>
+{
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::new("runtime=info,warn"))
+        .with_ansi(true)
+        .try_init();
+
+    // Build a local DuckDB database file to act as the federated source.
+    let duck_tempdir = tempfile::tempdir().expect("duckdb tempdir");
+    let db_path = duck_tempdir.path().join("source.duckdb");
+    {
+        let conn = duckdb::Connection::open(&db_path).expect("open duckdb");
+        conn.execute_batch(
+            "CREATE TABLE test_data (id BIGINT, name VARCHAR, age BIGINT, city VARCHAR, score BIGINT);
+             INSERT INTO test_data VALUES
+             (1,'John Doe',28,'New York',85),(2,'Jane Smith',34,'Los Angeles',92),
+             (3,'Mike Johnson',45,'Chicago',78),(4,'Emily Brown',31,'Houston',89),
+             (5,'David Lee',39,'Phoenix',76),(6,'Sarah Wilson',26,'Philadelphia',94),
+             (7,'Tom Anderson',52,'San Antonio',81),(8,'Lisa Taylor',29,'San Diego',88),
+             (9,'Chris Martin',37,'Dallas',79),(10,'Anna Garcia',41,'San Jose',90);",
+        )
+        .expect("populate duckdb");
+    }
+
+    let cayenne_tempdir = tempfile::tempdir().expect("cayenne tempdir");
+    let state_tempdir = tempfile::tempdir().expect("state tempdir");
+
+    test_request_context()
+        .scope(async {
+            configure_test_datafusion();
+            crate::utils::register_test_connectors().await;
+
+            // Cayenne file-mode acceleration with bucket(3, id), but federated DuckDB source.
+            let mut dataset = make_accelerated_dataset(
+                "duckdb:test_data",
+                "test_data",
+                3,
+                "id",
+                cayenne_tempdir.path(),
+            );
+            dataset.params = Some(spicepod::param::Params::from_string_map(
+                std::collections::HashMap::from([(
+                    "duckdb_open".to_string(),
+                    db_path.display().to_string(),
+                )]),
+            ));
+
+            // Local-filesystem cluster state (avoids the S3 partition store the other
+            // cluster tests use, so this runs hermetically without AWS creds).
+            let scheduler_cfg = SchedulerConfig {
+                state_location: format!("file://{}", state_tempdir.path().display()),
+                params: None,
+                partition_assignment_interval: "1s".to_string(),
+                max_partition_assignments_per_interval:
+                    spicepod::component::runtime::default_max_partition_assignments_per_interval(),
+                max_partitions_per_executor: 10,
+                partition_discovery_timeout:
+                    spicepod::component::runtime::default_partition_discovery_timeout(),
+            };
+
+            let app = AppBuilder::new("repro_federated_source")
+                .with_dataset(dataset)
+                .with_runtime(SpicepodRuntime {
+                    scheduler: Some(scheduler_cfg),
+                    ..SpicepodRuntime::default()
+                })
+                .build();
+
+            let harness = ClusterHarness::builder()
+                .scheduler(app)
+                .executors(1)
+                .start()
+                .await?;
+
+            sleep(Duration::from_secs(2)).await;
+            harness.wait_for_executors(Duration::from_secs(15)).await?;
+            wait_for_row_count(&harness, "test_data", 10, Duration::from_secs(60)).await?;
+            // Give the executor time to finish loading + acking its assigned partitions.
+            sleep(Duration::from_secs(8)).await;
+
+            let select_all_sql = "SELECT id, name, age, city, score FROM test_data ORDER BY id";
+            let plan = harness.explain(select_all_sql).await?;
+            let plan_fmt = arrow::util::pretty::pretty_format_batches(&plan)
+                .expect("format explain")
+                .to_string();
+
+            let distributes = plan_fmt.contains("FlightSqlExec");
+            harness.shutdown().await;
+
+            assert!(
+                distributes,
+                "federated-source accelerated table must distribute to executors \
+                 (expected FlightSqlExec), but the coordinator federated to the source:\n{plan_fmt}"
+            );
+            Ok(())
+        })
+        .await
+}
+
+/// Regression: a clustered cayenne-accelerated dataset that carries column metadata
+/// (descriptions) — like the cloud `amazon_reviews_accelerated` — must still distribute to
+/// executors. Column/table metadata makes `register_table` wrap the `AcceleratedTable` in a
+/// `MetadataEnrichedTableProvider`; the coordinator's `should_partition` must see through that
+/// wrapper (via `find_concrete_table_provider`), otherwise it silently federates the read to
+/// the source instead of distributing. This is identical to `bucket_partitioning_plan` EXCEPT
+/// the dataset has a column description.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
+async fn cluster_distributes_accelerated_table_with_column_metadata() -> Result<(), anyhow::Error> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::new("runtime=info,warn"))
+        .with_ansi(true)
+        .try_init();
+
+    let csv_tempdir = tempfile::tempdir().expect("csv tempdir");
+    let csv_path = csv_tempdir.path().join("test_data.csv");
+    tokio::fs::write(&csv_path, TEST_DATA_CSV)
+        .await
+        .expect("write test data");
+    let cayenne_tempdir = tempfile::tempdir().expect("cayenne tempdir");
+    let state_tempdir = tempfile::tempdir().expect("state tempdir");
+
+    test_request_context()
+        .scope(async {
+            configure_test_datafusion();
+            crate::utils::register_test_connectors().await;
+
+            let mut dataset = make_accelerated_dataset(
+                format!("file://{}", csv_path.display()),
+                "test_data",
+                3,
+                "id",
+                cayenne_tempdir.path(),
+            );
+            // THE ONLY DIFFERENCE vs the passing bucket_partitioning test: column descriptions.
+            let mut id_col = spicepod::semantic::Column::new("id");
+            id_col.description = Some("the row identifier".to_string());
+            dataset.columns = vec![id_col];
+
+            let scheduler_cfg = SchedulerConfig {
+                state_location: format!("file://{}", state_tempdir.path().display()),
+                params: None,
+                partition_assignment_interval: "1s".to_string(),
+                max_partition_assignments_per_interval:
+                    spicepod::component::runtime::default_max_partition_assignments_per_interval(),
+                max_partitions_per_executor: 10,
+                partition_discovery_timeout:
+                    spicepod::component::runtime::default_partition_discovery_timeout(),
+            };
+
+            let app = AppBuilder::new("repro_column_metadata")
+                .with_dataset(dataset)
+                .with_runtime(SpicepodRuntime {
+                    scheduler: Some(scheduler_cfg),
+                    ..SpicepodRuntime::default()
+                })
+                .build();
+
+            let harness = ClusterHarness::builder()
+                .scheduler(app)
+                .executors(1)
+                .start()
+                .await?;
+
+            sleep(Duration::from_secs(2)).await;
+            harness.wait_for_executors(Duration::from_secs(15)).await?;
+            wait_for_row_count(&harness, "test_data", 10, Duration::from_secs(60)).await?;
+            sleep(Duration::from_secs(5)).await;
+
+            let select_all_sql = "SELECT id, name, age, city, score FROM test_data ORDER BY id";
+            let plan = harness.explain(select_all_sql).await?;
+            let plan_fmt = arrow::util::pretty::pretty_format_batches(&plan)
+                .expect("format explain")
+                .to_string();
+            let rows = harness.query(select_all_sql).await?;
+            let row_count: usize = rows.iter().map(arrow::array::RecordBatch::num_rows).sum();
+
+            let distributes = plan_fmt.contains("FlightSqlExec");
+            harness.shutdown().await;
+
+            assert_eq!(row_count, 10, "query should return all 10 rows");
+            assert!(
+                distributes,
+                "accelerated table with column metadata must distribute to executors \
+                 (expected FlightSqlExec), but the coordinator federated to the source:\n{plan_fmt}"
+            );
+            Ok(())
+        })
+        .await
+}
+
 /// Test that 2 executors with `bucket(4, id)` partitioning produce correct query results.
 ///
 /// Verifies:


### PR DESCRIPTION
## Problem

In cluster mode, a cayenne-accelerated, partitioned dataset stops distributing queries to executors and instead silently federates the read to the source when the dataset carries **column/table metadata** (e.g. column `description`s) or an **embedding / full-text-search index** column.

Queries still return correct data (from the federated source), but the executor-resident accelerated partitions are never scanned — so the cluster does no distributed work and reads the full source on the coordinator instead.

## Root cause

The coordinator's partition-distribution rewrite gates on `AcceleratedPartitionProvider::should_partition`, which only recognized a bare `AcceleratedTable` or `FederatedTableProviderAdaptor(AcceleratedTable)`.

`register_table` enriches the registered provider via `table_provider_with_spicepod_metadata`:
- column/table metadata → `MetadataEnrichedTableProvider`
- embedding / full-text-search columns → `IndexedTableProvider` / `EmbeddingTable`

`should_partition` did not see through those wrappers, so it returned `false`, `PartitionedTableScanRewrite` became a no-op, and the `AcceleratedTable` federated the read to the source rather than fanning out to the executors holding the accelerated partitions.

## Fix

Route recognition through `find_concrete_table_provider::<AcceleratedTable>`, which already unwraps `MetadataEnrichedTableProvider`, `IndexedTableProvider`, `EmbeddingTable`, and `FederatedTableProviderAdaptor` in any nesting. Any provider chain that contains an `AcceleratedTable` is now distributed correctly.

## Tests

Two hermetic cluster regression tests (local-filesystem cluster state — no AWS creds needed):
- `cluster_distributes_accelerated_table_with_column_metadata` — a dataset with a column description must still distribute (`FlightSqlExec`). Fails without the fix (federates to source).
- `cluster_distributes_accelerated_table_with_federated_source` — federated (DuckDB) source + cayenne partitioning distributes correctly.

## Notes

- Draft pending local `make lint-rust` (in progress).
- The pre-existing `distributed_acceleration` tests are gated on AWS S3 secrets and were not run locally; the new tests intentionally use local-filesystem cluster state so they run hermetically.
