### PR TITLE
ci(testoperator-dispatch): per-(branch × cron) concurrency; htap on trunk only

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -58,7 +58,7 @@ jobs:
           - 'trunk'
           - 'release/2.0'
     concurrency:
-      group: testoperator-dispatch-scheduled
+      group: testoperator-dispatch-scheduled-${{ matrix.branch }}-${{ github.event.schedule || github.event.ref }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -244,7 +244,7 @@ jobs:
       # with daily-main at 0900 plus the htap-sf1 extras at 0100/0500/1300/1700/2100;
       # SF10 / SF100 each fire on their own every-4h cron.
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF1
-        if: ${{ steps.sched.outputs.name == 'daily-main' || steps.sched.outputs.name == 'htap-sf1' }}
+        if: ${{ matrix.branch == 'trunk' && (steps.sched.outputs.name == 'daily-main' || steps.sched.outputs.name == 'htap-sf1') }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/sf1 --workflow htap
         env:
@@ -253,7 +253,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF10
-        if: ${{ steps.sched.outputs.name == 'htap-sf10' }}
+        if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'htap-sf10' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/sf10 --workflow htap
         env:
@@ -262,7 +262,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF100
-        if: ${{ steps.sched.outputs.name == 'htap-sf100' }}
+        if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'htap-sf100' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/sf100 --workflow htap
         env:


### PR DESCRIPTION
## 📝 Summary

- Split the `testoperator-dispatch-scheduled` concurrency group by matrix branch and cron schedule, so each (branch × cron) gets its own queue. Previously all four crons × two matrix branches shared one group, and a later cron's queued run would evict the `daily-main` run with the GH-Actions "higher priority waiting request" cancel.
- Gate the CH-benCHmark HTAP dispatches (SF1/SF10/SF100) on `matrix.branch == 'trunk'`. HTAP runs only against trunk; `release/2.0` no longer dispatches HTAP work on the htap-sf* crons.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

I'm going to refactor HTAP schedule to move logic into `dispatch_htap` as separate change
