### PR TITLE
fix(embeddings): non-nullable inner field for embedding FixedSizeList (fixes #6911)

### DIFF
--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -348,6 +348,23 @@ pub(crate) async fn compute_additional_embedding_columns(
     Ok(embed_arrays)
 }
 
+/// Append a null entry to a `FixedSizeList<Float32>` builder.
+///
+/// The inner Float32 field is non-nullable (an embedding vector never holds
+/// null components), so the fixed-stride placeholder slots are filled with
+/// zeros and only the outer list slot is marked null. The placeholder values
+/// are masked by the parent null and never read at query time.
+#[expect(clippy::cast_sign_loss)]
+fn append_null_vector(
+    builder: &mut FixedSizeListBuilder<PrimitiveBuilder<Float32Type>>,
+    vector_length: i32,
+) {
+    for _ in 0..vector_length as usize {
+        builder.values().append_value(0.0);
+    }
+    builder.append(false);
+}
+
 /// Embed a [`StringArray`] using the provided [`Embed`] model. The output is a [`FixedSizeListArray`],
 /// where each [`String`] gets embedded into a single [`f32`] vector.
 ///
@@ -411,7 +428,7 @@ pub(super) async fn get_vectors(
         vector_length,
         embedded_data.len() + nulls.len(),
     )
-    .with_field(Arc::new(Field::new("item", DataType::Float32, true)));
+    .with_field(Arc::new(Field::new("item", DataType::Float32, false)));
 
     // Current index into offset of the outputted [`FixedSizeList`].
     let mut output_ptr: usize = 0;
@@ -421,12 +438,13 @@ pub(super) async fn get_vectors(
 
     // Reconstruct correct output order by adding back nulls based on original indexes of nulls.
     for vector in embedded_data {
-        // Keep inserting nulls until we reach the next non-null value.
+        // Keep inserting nulls until we reach the next non-null value. The
+        // inner Float32 field is non-nullable, so a null row appends
+        // placeholder zeros and marks only the outer FixedSizeList slot null.
         while nulls.get(null_ptr).is_some_and(|&idx| idx == output_ptr) {
-            builder.values().append_nulls(vector_length as usize);
+            append_null_vector(&mut builder, vector_length);
             null_ptr += 1;
             output_ptr += 1;
-            builder.append(false);
         }
 
         builder.values().append_slice(&vector);
@@ -436,10 +454,9 @@ pub(super) async fn get_vectors(
 
     // Handle any trailing nulls/empty strings.
     while nulls.get(null_ptr).is_some_and(|&idx| idx == output_ptr) {
-        builder.values().append_nulls(vector_length as usize);
+        append_null_vector(&mut builder, vector_length);
         null_ptr += 1;
         output_ptr += 1;
-        builder.append(false);
     }
 
     Ok(builder.finish())
@@ -460,7 +477,7 @@ pub(super) fn get_vectors_in_process(
         vector_length,
         arr.len(),
     )
-    .with_field(Arc::new(Field::new("item", DataType::Float32, true)));
+    .with_field(Arc::new(Field::new("item", DataType::Float32, false)));
 
     let pool = build_embedding_pool(model.parallelism())?;
 
@@ -482,8 +499,9 @@ pub(super) fn get_vectors_in_process(
                 builder.values().append_slice(&embedding[0]);
                 builder.append(true);
             } else {
-                builder.values().append_nulls(vector_length as usize);
-                builder.append(false);
+                // Inner Float32 field is non-nullable: append placeholder
+                // zeros and mark only the outer FixedSizeList slot null.
+                append_null_vector(&mut builder, vector_length);
             }
         }
     } else {
@@ -1056,6 +1074,52 @@ mod tests {
         assert_eq!(values.value(3), 0.4);
         assert_eq!(values.value(6), 0.1);
         assert_eq!(values.value(7), 0.2);
+
+        Ok(())
+    }
+
+    /// Regression for #6911: the inner Float32 field of the embedding
+    /// `FixedSizeList` must be non-nullable, and null/empty source rows must
+    /// be encoded only on the outer list slot (with placeholder-zero inner
+    /// values), never as null inner components. A nullable inner field caused
+    /// a `FixedSizeList(... nullable: true)` vs `nullable: false` schema
+    /// mismatch against the accelerator write path.
+    #[tokio::test]
+    async fn test_get_vectors_inner_field_non_nullable()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use arrow::datatypes::DataType;
+
+        let result = get_vectors(
+            vec![None, Some("hello"), Some("")].into_iter(),
+            &MockEmbedder::default().with_pair("hello", vec![0.1, 0.2]),
+            2,
+        )
+        .await?;
+
+        // Inner item field must be declared non-nullable.
+        let DataType::FixedSizeList(inner, size) = result.data_type() else {
+            panic!("expected FixedSizeList, got {:?}", result.data_type());
+        };
+        assert_eq!(*size, 2);
+        assert!(
+            !inner.is_nullable(),
+            "embedding vector inner field must be non-nullable"
+        );
+
+        // Outer slots encode nullness; the inner values buffer holds no nulls.
+        assert_eq!(result.len(), 3);
+        assert!(result.is_null(0));
+        assert!(!result.is_null(1));
+        assert!(result.is_null(2));
+        let values = result.values().as_primitive::<Float32Type>();
+        assert_eq!(values.null_count(), 0, "inner values must contain no nulls");
+        // Null rows are placeholder zeros; the embedded row keeps its values.
+        assert_eq!(values.value(0), 0.0);
+        assert_eq!(values.value(1), 0.0);
+        assert_eq!(values.value(2), 0.1);
+        assert_eq!(values.value(3), 0.2);
+        assert_eq!(values.value(4), 0.0);
+        assert_eq!(values.value(5), 0.0);
 
         Ok(())
     }

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -770,9 +770,19 @@ impl EmbeddingTable {
                 )),
             ],
             // Scalar + unchunked: one vector per row.
+            //
+            // The inner Float32 field is non-nullable: an embedding vector
+            // never contains null components. A null/empty source string maps
+            // to a null vector via the outer FixedSizeList slot, so the outer
+            // field stays nullable while the inner items do not. This matches
+            // the chunked and multi-vector paths (and the accelerator/index
+            // schemas in `index/duckdb.rs` and `index/elasticsearch`), which
+            // already declare the inner item non-nullable; declaring it
+            // nullable here caused a `FixedSizeList(... nullable: true)` vs
+            // `nullable: false` schema mismatch on the write path (#6911).
             (EmbeddingInputMode::Scalar, false) => vec![Arc::new(Field::new_fixed_size_list(
                 embedding_col!(field.name()),
-                Field::new("item", DataType::Float32, true),
+                Field::new("item", DataType::Float32, false),
                 cfg.vector_size,
                 true,
             ))],
@@ -1558,6 +1568,62 @@ mod tests {
         };
         assert_eq!(*size, 4);
         assert_eq!(leaf.data_type(), &DataType::Float32);
+    }
+
+    /// Regression for #6911: a scalar (unchunked) embedding column produces
+    /// `FixedSizeList<Float32, D>` whose inner `item` field is non-nullable
+    /// (embedding vectors never hold null components). The outer field stays
+    /// nullable so a null source row maps to a null vector. A nullable inner
+    /// field here disagreed with the array the write path actually builds and
+    /// triggered a `nullable: true` vs `nullable: false` schema mismatch.
+    #[test]
+    fn test_embedding_fields_scalar_inner_item_non_nullable() {
+        let c_field = Arc::new(Field::new("c", DataType::Utf8, true));
+        let base_schema = Arc::new(Schema::new(vec![Arc::clone(&c_field)]));
+
+        let embedded_columns = HashMap::from([(
+            "c".to_string(),
+            EmbeddingColumnConfig {
+                model_name: "m".to_string(),
+                vector_size: 4,
+                in_base_table: false,
+                chunker: None,
+                input_mode: EmbeddingInputMode::Scalar,
+            },
+        )]);
+
+        let base_table: Arc<dyn TableProvider> = Arc::new(
+            datafusion::catalog::MemTable::try_new(base_schema, vec![vec![]])
+                .expect("valid schema"),
+        );
+
+        let table = EmbeddingTable {
+            base_table,
+            embedded_columns,
+            embedding_models: Arc::new(RwLock::new(HashMap::new())),
+        };
+
+        let fields = table.embedding_fields(&c_field);
+        assert_eq!(
+            fields.len(),
+            1,
+            "scalar unchunked produces no offset column"
+        );
+        let emb = &fields[0];
+        assert_eq!(emb.name(), "c_embedding");
+        assert!(
+            emb.is_nullable(),
+            "outer FixedSizeList field is nullable (null row -> null vector)"
+        );
+        let DataType::FixedSizeList(leaf, size) = emb.data_type() else {
+            panic!("expected FixedSizeList, got {:?}", emb.data_type());
+        };
+        assert_eq!(*size, 4);
+        assert_eq!(leaf.data_type(), &DataType::Float32);
+        assert!(
+            !leaf.is_nullable(),
+            "embedding vector inner item field must be non-nullable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Embedding vector columns never contain null components, but the scalar-unchunked embedding path declared the inner `Float32` `item` field of the `FixedSizeList<Float32, D>` embedding column as **nullable**, while every other path (chunked, multi-vector) and the accelerator/index schemas (`index/duckdb.rs`, `index/elasticsearch`) declare it **non-nullable**.

That asymmetry produced a schema mismatch on the accelerator write path:

```
column types must match schema types, expected
FixedSizeList(Field { name: "item", data_type: Float32, nullable: true, ... }, 256)
but found
FixedSizeList(Field { name: "item", data_type: Float32, nullable: false, ... }, 256)
```

Fixes #6911.

## Root cause

- `EmbeddingTable::embedding_fields` declared the scalar-unchunked embedding column's inner item as `Field::new("item", Float32, true)`.
- `get_vectors` and `get_vectors_in_process` built the `FixedSizeListArray` with a nullable inner field and called `append_nulls(vector_length)` for null/empty source rows — putting nulls *inside* the vector.

## Changes

- Inner `item` field is now non-nullable in the schema declaration and both builders, matching the chunked path, the multi-vector path, and the DuckDB/Elasticsearch index schemas.
- Null/empty source rows are encoded **only** on the outer `FixedSizeList` slot (null row → null vector). The fixed-stride inner values for a null row are placeholder zeros (masked by the outer null), exactly as `build_multi_vector_list_array` already does.
- Extracted a shared `append_null_vector` helper for the two scalar builders.
- The outer `FixedSizeList` field stays nullable, so a null source row still maps to a null vector — no row-level behavior change.

## Test plan
- [x] Added regression test `test_get_vectors_inner_field_non_nullable` (inner field non-nullable; null rows on outer slot only; inner values buffer has zero nulls)
- [x] Added regression test `test_embedding_fields_scalar_inner_item_non_nullable` (schema: nullable outer, non-nullable inner)
- [x] `make lint` passes (workspace-wide format + clippy gate, not a scoped per-crate invocation)
- [x] `make test` passes