### PR TITLE
chore(chbench): add cayenne[file] adaptive + in-memory-CDC variants and schedule them

### DIFF
--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
@@ -8,13 +8,17 @@ name: postgres-cayenne[file]-adaptive
 # host + inferred schema, then runs the closed-feedback loop that adapts those knobs over time
 # within the environment-derived [floor, ceiling] as the workload shifts.
 #
-# Two requirements the adaptive loop gates on (both satisfied here):
-#   - `schema_inference: extended` per dataset — the data-aware warm-start needs the inferred
-#     row_count/table_bytes (PostgreSQL emits them); without it adaptive silently falls back to auto.
-#   - background compaction enabled — the controller rides the per-table compaction tick. Left at
-#     the auto-derived (non-zero) default here; NOT pinned, so the loop is free to move it.
-# No per-knob value is set anywhere: an explicit knob would *pin* it under adaptive (collapsing its
-# tuning bounds to a point), so basing this off the un-pinned baseline gives the loop full freedom.
+# `schema_inference: extended` (per dataset) does double duty here, so nothing else is hand-set:
+#   - It auto-detects the primary key, secondary indexes, and (non-CDC) sort columns from the
+#     PostgreSQL source and seeds an `upsert` on_conflict on the inferred PK — exactly what
+#     `refresh_mode: changes` needs to apply UPDATE/DELETE events. So PK / on_conflict / indexes
+#     are intentionally NOT declared below; inference fills them (it is gap-filling only and never
+#     overrides a user-set value, so declaring them would just suppress the very thing we test).
+#   - It supplies the inferred row_count/table_bytes the adaptive loop's data-aware warm-start
+#     gates on; without extended inference adaptive silently falls back to `auto` (static).
+# Background compaction stays at the auto-derived (non-zero) default — the controller rides its
+# tick. No per-knob value is set anywhere: an explicit knob would *pin* it under adaptive
+# (collapsing its tuning bounds to a point), so the un-pinned baseline gives the loop full freedom.
 #
 # sql_results / task_history stay off to match the baseline and the -cdc-tuned configs, so a
 # comparison isolates the effect of adaptive tuning, not caching/history overhead.
@@ -36,6 +40,8 @@ runtime:
 
 datasets:
   # ---- TPC-C core tables (mutated by OLTP workload) ----
+  # No primary_key / on_conflict / indexes: `schema_inference: extended` detects them from the
+  # PostgreSQL source and seeds the upsert on_conflict the CDC (changes) path requires.
 
   - from: postgres:warehouse
     name: warehouse
@@ -49,9 +55,6 @@ datasets:
       engine: cayenne
       mode: file
       refresh_mode: changes
-      primary_key: w_id
-      on_conflict:
-        w_id: upsert
       params: &cayenne_params
         cayenne_tuning: adaptive
 
@@ -62,11 +65,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_district
       pg_replication_initial_snapshot: 'true'
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (d_w_id, d_id)
-      on_conflict:
-        (d_w_id, d_id): upsert
+    acceleration: *cayenne_accel
 
   - from: postgres:customer
     name: customer
@@ -75,11 +74,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_customer
       pg_replication_initial_snapshot: 'true'
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (c_w_id, c_d_id, c_id)
-      on_conflict:
-        (c_w_id, c_d_id, c_id): upsert
+    acceleration: *cayenne_accel
 
   - from: postgres:new_order
     name: new_order
@@ -88,11 +83,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_new_order
       pg_replication_initial_snapshot: 'true'
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (no_w_id, no_d_id, no_o_id)
-      on_conflict:
-        (no_w_id, no_d_id, no_o_id): upsert
+    acceleration: *cayenne_accel
 
   - from: postgres:oorder
     name: oorder
@@ -101,11 +92,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_oorder
       pg_replication_initial_snapshot: 'true'
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (o_w_id, o_d_id, o_id)
-      on_conflict:
-        (o_w_id, o_d_id, o_id): upsert
+    acceleration: *cayenne_accel
 
   - from: postgres:order_line
     name: order_line
@@ -114,11 +101,7 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_order_line
       pg_replication_initial_snapshot: 'true'
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
-      on_conflict:
-        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+    acceleration: *cayenne_accel
 
   - from: postgres:stock
     name: stock
@@ -127,74 +110,40 @@ datasets:
       <<: *postgres_params
       pg_replication_slot: spice_stock
       pg_replication_initial_snapshot: 'true'
-    acceleration:
-      <<: *cayenne_accel
-      primary_key: (s_w_id, s_i_id)
-      on_conflict:
-        (s_w_id, s_i_id): upsert
+    acceleration: *cayenne_accel
 
   # ---- Static reference tables (no OLTP mutations, full refresh) ----
+  # Same: PK / on_conflict / indexes come from extended inference.
 
   - from: postgres:item
     name: item
     schema_inference: extended
     params:
       <<: *postgres_params
-    acceleration:
+    acceleration: &cayenne_accel_full
       enabled: true
       engine: cayenne
       mode: file
       refresh_mode: full
-      primary_key: i_id
-      on_conflict:
-        i_id: upsert
-      params:
-        <<: *cayenne_params
+      params: *cayenne_params
 
   - from: postgres:region
     name: region
     schema_inference: extended
     params:
       <<: *postgres_params
-    acceleration:
-      enabled: true
-      engine: cayenne
-      mode: file
-      refresh_mode: full
-      primary_key: r_regionkey
-      on_conflict:
-        r_regionkey: upsert
-      params:
-        <<: *cayenne_params
+    acceleration: *cayenne_accel_full
 
   - from: postgres:nation
     name: nation
     schema_inference: extended
     params:
       <<: *postgres_params
-    acceleration:
-      enabled: true
-      engine: cayenne
-      mode: file
-      refresh_mode: full
-      primary_key: n_nationkey
-      on_conflict:
-        n_nationkey: upsert
-      params:
-        <<: *cayenne_params
+    acceleration: *cayenne_accel_full
 
   - from: postgres:supplier
     name: supplier
     schema_inference: extended
     params:
       <<: *postgres_params
-    acceleration:
-      enabled: true
-      engine: cayenne
-      mode: file
-      refresh_mode: full
-      primary_key: su_suppkey
-      on_conflict:
-        su_suppkey: upsert
-      params:
-        <<: *cayenne_params
+    acceleration: *cayenne_accel_full

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
@@ -1,0 +1,200 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]-adaptive
+
+# Adaptive-tuning variant of the non-tuned postgres-cayenne[file] baseline. Instead of either
+# the static `auto` derivation (the baseline) or a hand-pinned -cdc-tuned-* config, every Cayenne
+# table runs `cayenne_tuning: adaptive`: the runtime still warm-starts each knob from the detected
+# host + inferred schema, then runs the closed-feedback loop that adapts those knobs over time
+# within the environment-derived [floor, ceiling] as the workload shifts.
+#
+# Two requirements the adaptive loop gates on (both satisfied here):
+#   - `schema_inference: extended` per dataset — the data-aware warm-start needs the inferred
+#     row_count/table_bytes (PostgreSQL emits them); without it adaptive silently falls back to auto.
+#   - background compaction enabled — the controller rides the per-table compaction tick. Left at
+#     the auto-derived (non-zero) default here; NOT pinned, so the loop is free to move it.
+# No per-knob value is set anywhere: an explicit knob would *pin* it under adaptive (collapsing its
+# tuning bounds to a point), so basing this off the un-pinned baseline gives the loop full freedom.
+#
+# sql_results / task_history stay off to match the baseline and the -cdc-tuned configs, so a
+# comparison isolates the effect of adaptive tuning, not caching/history overhead.
+
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: 5432
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
+runtime:
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
+datasets:
+  # ---- TPC-C core tables (mutated by OLTP workload) ----
+
+  - from: postgres:warehouse
+    name: warehouse
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+    acceleration: &cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: w_id
+      on_conflict:
+        w_id: upsert
+      params: &cayenne_params
+        cayenne_tuning: adaptive
+
+  - from: postgres:district
+    name: district
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+
+  - from: postgres:customer
+    name: customer
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+
+  - from: postgres:new_order
+    name: new_order
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+
+  - from: postgres:oorder
+    name: oorder
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+
+  - from: postgres:order_line
+    name: order_line
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+
+  - from: postgres:stock
+    name: stock
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+
+  # ---- Static reference tables (no OLTP mutations, full refresh) ----
+
+  - from: postgres:item
+    name: item
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+      params:
+        <<: *cayenne_params
+
+  - from: postgres:region
+    name: region
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      params:
+        <<: *cayenne_params
+
+  - from: postgres:nation
+    name: nation
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      params:
+        <<: *cayenne_params
+
+  - from: postgres:supplier
+    name: supplier
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: su_suppkey
+      on_conflict:
+        su_suppkey: upsert
+      params:
+        <<: *cayenne_params

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-memory.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-memory.yaml
@@ -1,0 +1,183 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]-cdc-memory
+
+# In-memory CDC durability variant of the non-tuned postgres-cayenne[file] baseline. The 7 mutated
+# TPC-C tables (refresh_mode: changes) run `cayenne_cdc_durability: memory`: each CDC batch is
+# appended to an in-RAM tier and the source replication-slot ack is deferred to a periodic /
+# cap-triggered checkpoint, collapsing the per-batch durability cost (the single-writer metastore
+# txn) that walls CDC throughput. On crash the un-checkpointed tail is replayed from the slot; the
+# apply is PK-idempotent, so the result is exactly-once. The RAM tier is bounded by a per-table
+# byte cap plus a process-global byte budget, so it spills (checkpoints) rather than OOMing.
+#
+# Everything else matches the baseline: storage stays `mode: file` (memory durability is the CDC
+# write-path tier, not in-memory acceleration), every other knob is auto-derived, and the per-table
+# cap / max-age are left at their auto defaults. The static reference tables use refresh_mode: full,
+# which is not the small-write/CDC profile, so `cayenne_cdc_durability` does not apply to them — it
+# is set only on the changes tables (the runtime would otherwise warn and fall back to file).
+#
+# sql_results / task_history stay off to match the baseline and the -cdc-tuned configs, so a
+# comparison isolates the effect of in-memory CDC durability, not caching/history overhead.
+
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: 5432
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
+runtime:
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
+datasets:
+  # ---- TPC-C core tables (mutated by OLTP workload) ----
+
+  - from: postgres:warehouse
+    name: warehouse
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+    acceleration: &cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: w_id
+      on_conflict:
+        w_id: upsert
+      params:
+        cayenne_cdc_durability: memory
+
+  - from: postgres:district
+    name: district
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+
+  - from: postgres:customer
+    name: customer
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+
+  - from: postgres:new_order
+    name: new_order
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+
+  - from: postgres:oorder
+    name: oorder
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+
+  - from: postgres:order_line
+    name: order_line
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+
+  - from: postgres:stock
+    name: stock
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+    acceleration:
+      <<: *cayenne_accel
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+
+  # ---- Static reference tables (no OLTP mutations, full refresh) ----
+  # refresh_mode: full is not the small-write/CDC profile, so cayenne_cdc_durability
+  # does not apply here — left at the default (file).
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+
+  - from: postgres:region
+    name: region
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+
+  - from: postgres:nation
+    name: nation
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+
+  - from: postgres:supplier
+    name: supplier
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: su_suppkey
+      on_conflict:
+        su_suppkey: upsert

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive.yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-adaptive.yaml
+    runner_type: spiceai-dev-large-runners
+    scale_factor: 1
+    duration: 600
+    ready_wait: 60
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive.yaml
@@ -5,4 +5,4 @@ tests:
     scale_factor: 1
     duration: 600
     ready_wait: 60
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-memory.yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-memory.yaml
+    runner_type: spiceai-dev-large-runners
+    scale_factor: 1
+    duration: 600
+    ready_wait: 60
+    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-memory.yaml
@@ -5,4 +5,4 @@ tests:
     scale_factor: 1
     duration: 600
     ready_wait: 60
-    rate: 5000
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-adaptive.yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-adaptive.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 10
+    duration: 600
+    ready_wait: 300
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-memory.yaml
@@ -1,0 +1,8 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-memory.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 10
+    duration: 600
+    ready_wait: 300
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-adaptive.yaml
@@ -1,0 +1,9 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-adaptive.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 100
+    terminals: 100
+    duration: 600
+    ready_wait: 600
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-memory.yaml
@@ -1,0 +1,9 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-memory.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 100
+    terminals: 100
+    duration: 600
+    ready_wait: 600
+    rate: 10000


### PR DESCRIPTION
## What

Adds two new postgres→Cayenne CH-benCHmark spicepods, both derived from the non-tuned `accelerated/postgres-cayenne[file].yaml` baseline, and wires them into the scheduled `testoperator dispatch` HTAP runs.

### New spicepods (`test/spicepods/chbench/accelerated/`)

- **`postgres-cayenne[file]-adaptive.yaml`** — every Cayenne table runs `cayenne_tuning: adaptive`: the runtime warm-starts each knob from the detected host + inferred schema, then runs the closed-feedback loop that adapts them over time within the environment-derived `[floor, ceiling]`. `schema_inference: extended` does double duty: (1) it supplies the inferred `row_count`/`table_bytes` the adaptive loop's data-aware warm-start gates on (without it adaptive silently falls back to static `auto`), and (2) it auto-detects the **primary key, secondary indexes, and sort columns** from the PostgreSQL source and seeds the **upsert `on_conflict`** the CDC (`changes`) path requires. So PK / on_conflict / indexes are intentionally **not** declared — `apply_inferred_schema` fills them (gap-filling only, never overrides). No per-knob value is set: an explicit knob would *pin* it under adaptive (collapsing its tuning bounds to a point), so building off the un-pinned baseline gives the controller full freedom.
- **`postgres-cayenne[file]-cdc-memory.yaml`** — the 7 mutated TPC-C tables (`refresh_mode: changes`) run `cayenne_cdc_durability: memory`: each CDC batch is appended to an in-RAM tier and the replication-slot ack is deferred to a periodic / cap-triggered checkpoint, collapsing the per-batch durability cost. Bounded by a per-table byte cap + a process-global byte budget (spills rather than OOMing); crash-replay from the slot is exactly-once (PK-idempotent apply). The static full-refresh reference tables stay on `file` — the CDC profile does not apply to them, so the param is set only on the changes tables (explicit PKs kept, since this config does not enable extended inference).

Both keep `sql_results` / `task_history` off to match the baseline and the `-cdc-tuned-*` configs, so a comparison isolates the effect of the variant, not caching/history overhead.

### Scheduled dispatch (`tools/testoperator/dispatch/chbench/`)

Adds dispatch entries for both variants at **sf1 / sf10 / sf100**, all at **10K req/s** (matching the `-cdc-tuned` workload; the per-scale runner type / terminals / duration / ready_wait mirror the baseline). The chbench dispatch globs the directory, so the daily-main / 4-hourly CH-benCHmark crons in `testoperator_dispatch.yml` pick them up automatically.

## Validation

- `spicepod-validator` loads both new spicepods cleanly (exit 0), matching the baseline — including the adaptive config with PK/on_conflict omitted (PK is optional at load time; inference applies it at runtime init).
- YAML anchor/merge resolution verified: in `-adaptive` all 11 datasets carry `schema_inference: extended` + `cayenne_tuning: adaptive` and **no** PK/on_conflict/indexes; in `-cdc-memory` the 7 changes tables carry `cayenne_cdc_durability: memory` and the 4 full-refresh tables carry none.