### PR TITLE
feat(cayenne): listing-time pruning, per-file stats, and scan pushdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,6 +3514,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
+ "datafusion-pruning",
  "datafusion-table-providers",
  "duckdb",
  "flatbuffers",

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -32,6 +32,7 @@ datafusion-execution = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-physical-expr = { workspace = true }
 datafusion-physical-plan = { workspace = true }
+datafusion-pruning = { workspace = true }
 datafusion-table-providers = { workspace = true }
 futures = { workspace = true }
 hash-index = { path = "../hash-index" }

--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -22,7 +22,7 @@ limitations under the License.
 
 use super::metadata::{
     CreateTableOptions, DeleteFile, InlinedData, InlinedDataStats, InlinedDelete,
-    PartitionMetadata, TableMetadata, TableStatistics,
+    PartitionMetadata, SnapshotFileStatistics, TableMetadata, TableStatistics,
 };
 use async_trait::async_trait;
 use snafu::Snafu;
@@ -561,6 +561,30 @@ pub trait MetadataCatalog: Send + Sync {
 
     /// Clear table-level aggregate statistics for a table.
     async fn clear_table_statistics(&self, table_id: &str) -> CatalogResult<()>;
+
+    /// Upsert per-file footer statistics for listing-time pruning.
+    async fn upsert_snapshot_file_statistics(
+        &self,
+        stats: &SnapshotFileStatistics,
+    ) -> CatalogResult<()>;
+
+    /// Get persisted per-file statistics for one object in a snapshot.
+    async fn get_snapshot_file_statistics(
+        &self,
+        table_id: &str,
+        snapshot_id: &str,
+        file_path: &str,
+    ) -> CatalogResult<Option<SnapshotFileStatistics>>;
+
+    /// Drop per-file statistics rows for snapshots other than the current one.
+    async fn clear_snapshot_file_statistics_except(
+        &self,
+        table_id: &str,
+        snapshot_id: &str,
+    ) -> CatalogResult<()>;
+
+    /// Clear all per-file statistics rows for a table.
+    async fn clear_snapshot_file_statistics(&self, table_id: &str) -> CatalogResult<()>;
 
     /// Upsert the persisted primary-key existence index (a bloom checkpoint),
     /// tagged with the snapshot id it covers. Stored in the metastore so it is

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -19,7 +19,8 @@ limitations under the License.
 use super::catalog::{CatalogError, CatalogResult, MetadataCatalog, SnapshotSequenceCommit};
 use super::metadata::{
     CreateTableOptions, DeleteFile, InlinedData, InlinedDataStats, InlinedDelete,
-    PartitionMetadata, PkConflictDetection, TableMetadata, TableStatistics,
+    PartitionMetadata, PkConflictDetection, SnapshotFileStatistics, TableMetadata,
+    TableStatistics,
 };
 use super::metastore::sqlite::SqliteMetastore;
 #[cfg(feature = "turso")]
@@ -553,6 +554,7 @@ impl CayenneCatalog {
              DELETE FROM cayenne_inlined_data WHERE table_id = {table_id_literal}; \
              DELETE FROM cayenne_inlined_delete WHERE table_id = {table_id_literal}; \
              DELETE FROM cayenne_table_statistics WHERE table_id = {table_id_literal}; \
+             DELETE FROM cayenne_snapshot_file_statistics WHERE table_id = {table_id_literal}; \
              DELETE FROM cayenne_pk_index WHERE table_id = {table_id_literal}; \
              UPDATE cayenne_table SET current_snapshot_id = {new_snapshot_id_literal} WHERE table_id = {table_id_literal};"
         );
@@ -2024,6 +2026,89 @@ impl MetadataCatalog for CayenneCatalog {
             .await
     }
 
+    async fn upsert_snapshot_file_statistics(
+        &self,
+        stats: &SnapshotFileStatistics,
+    ) -> CatalogResult<()> {
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "INSERT OR REPLACE INTO cayenne_snapshot_file_statistics \
+                      (table_id, snapshot_id, file_path, file_size_bytes, num_rows, statistics_blob) \
+                      VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params: vec![
+                    MetastoreValue::Text(stats.table_id.clone()),
+                    MetastoreValue::Text(stats.snapshot_id.clone()),
+                    MetastoreValue::Text(stats.file_path.clone()),
+                    MetastoreValue::Integer(stats.file_size_bytes),
+                    MetastoreValue::Integer(stats.num_rows),
+                    MetastoreValue::Blob(stats.statistics_blob.clone()),
+                ],
+            })
+            .await
+    }
+
+    async fn get_snapshot_file_statistics(
+        &self,
+        table_id: &str,
+        snapshot_id: &str,
+        file_path: &str,
+    ) -> CatalogResult<Option<SnapshotFileStatistics>> {
+        let results = self
+            .metastore
+            .query_helper(
+                QueryParams {
+                    sql: r"
+                    SELECT table_id, snapshot_id, file_path, file_size_bytes, num_rows, statistics_blob
+                    FROM cayenne_snapshot_file_statistics
+                    WHERE table_id = ?1 AND snapshot_id = ?2 AND file_path = ?3
+                    ",
+                    params: vec![
+                        MetastoreValue::Text(table_id.to_string()),
+                        MetastoreValue::Text(snapshot_id.to_string()),
+                        MetastoreValue::Text(file_path.to_string()),
+                    ],
+                },
+                |row| {
+                    Ok(SnapshotFileStatistics {
+                        table_id: row.get_string(0)?,
+                        snapshot_id: row.get_string(1)?,
+                        file_path: row.get_string(2)?,
+                        file_size_bytes: row.get_i64(3)?,
+                        num_rows: row.get_i64(4)?,
+                        statistics_blob: row.get_blob(5)?,
+                    })
+                },
+            )
+            .await?;
+        Ok(results.into_iter().next())
+    }
+
+    async fn clear_snapshot_file_statistics_except(
+        &self,
+        table_id: &str,
+        snapshot_id: &str,
+    ) -> CatalogResult<()> {
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_snapshot_file_statistics \
+                      WHERE table_id = ?1 AND snapshot_id != ?2",
+                params: vec![
+                    MetastoreValue::Text(table_id.to_string()),
+                    MetastoreValue::Text(snapshot_id.to_string()),
+                ],
+            })
+            .await
+    }
+
+    async fn clear_snapshot_file_statistics(&self, table_id: &str) -> CatalogResult<()> {
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_snapshot_file_statistics WHERE table_id = ?1",
+                params: vec![MetastoreValue::Text(table_id.to_string())],
+            })
+            .await
+    }
+
     async fn upsert_pk_index(
         &self,
         table_id: &str,
@@ -3212,6 +3297,18 @@ impl MetadataCatalog for CayenneCatalog {
             .await
             .map_err(|e| CatalogError::InvalidOperation {
                 message: "Failed to delete table statistics.".to_string(),
+                source: Box::new(e),
+            })?;
+
+        // 5b. Delete per-file snapshot statistics
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_snapshot_file_statistics WHERE table_id = ?1",
+                params: vec![MetastoreValue::Text(table_id.clone())],
+            })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to delete snapshot file statistics.".to_string(),
                 source: Box::new(e),
             })?;
 

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -19,8 +19,7 @@ limitations under the License.
 use super::catalog::{CatalogError, CatalogResult, MetadataCatalog, SnapshotSequenceCommit};
 use super::metadata::{
     CreateTableOptions, DeleteFile, InlinedData, InlinedDataStats, InlinedDelete,
-    PartitionMetadata, PkConflictDetection, SnapshotFileStatistics, TableMetadata,
-    TableStatistics,
+    PartitionMetadata, PkConflictDetection, SnapshotFileStatistics, TableMetadata, TableStatistics,
 };
 use super::metastore::sqlite::SqliteMetastore;
 #[cfg(feature = "turso")]

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -1048,6 +1048,31 @@ pub struct CreateTableOptions {
     pub vortex_config: VortexConfig,
 }
 
+/// Per-file statistics for one Vortex object in a snapshot directory.
+///
+/// Persisted in `cayenne_snapshot_file_statistics` so listing-time pruning can
+/// reuse footer min/max without re-reading every object on each scan. Rows are
+/// keyed by `(table_id, snapshot_id, file_path)` and invalidated when
+/// `file_size_bytes` no longer matches the object store metadata.
+///
+/// Consumers must treat these values as optimization hints only.
+#[derive(Debug, Clone)]
+pub struct SnapshotFileStatistics {
+    /// Table this stats entry belongs to (`UUIDv7`)
+    pub table_id: String,
+    /// Snapshot directory the file was listed from (`UUIDv7`)
+    pub snapshot_id: String,
+    /// Object-store path of the `.vortex` file (as returned by listing)
+    pub file_path: String,
+    /// Cached `ObjectMeta::size` at the time stats were captured
+    pub file_size_bytes: i64,
+    /// Row count from the file footer when stats were captured
+    pub num_rows: i64,
+    /// Serialized Vortex `FileStatistics` flatbuffer bytes (per-column min, max,
+    /// and null count)
+    pub statistics_blob: Vec<u8>,
+}
+
 /// Table-level statistics stored as a serialized Vortex [`FileStatistics`] blob.
 ///
 /// Stores per-column statistics (min, max, null count) maintained incrementally

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -117,6 +117,17 @@ pub const EXPECTED_TABLES: &[ExpectedTable] = &[
         columns: &["table_id", "statistics_blob", "num_rows", "ndv_sketches"],
     },
     ExpectedTable {
+        name: "cayenne_snapshot_file_statistics",
+        columns: &[
+            "table_id",
+            "snapshot_id",
+            "file_path",
+            "file_size_bytes",
+            "num_rows",
+            "statistics_blob",
+        ],
+    },
+    ExpectedTable {
         name: "cayenne_pk_index",
         columns: &["table_id", "snapshot_id", "index_blob"],
     },

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -608,6 +608,21 @@ impl SqliteMetastore {
         )
     ";
 
+    /// Per-file footer statistics for listing-time pruning without re-reading
+    /// every object on each scan. One row per `(table_id, snapshot_id, file_path)`.
+    const SNAPSHOT_FILE_STATISTICS_TABLE_DDL: &'static str = r"
+        CREATE TABLE IF NOT EXISTS cayenne_snapshot_file_statistics (
+            table_id TEXT NOT NULL,
+            snapshot_id TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            file_size_bytes BIGINT NOT NULL,
+            num_rows BIGINT NOT NULL DEFAULT 0,
+            statistics_blob BLOB NOT NULL,
+            FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
+            PRIMARY KEY (table_id, snapshot_id, file_path)
+        )
+    ";
+
     /// Schema for the `cayenne_pk_index` table.
     ///
     /// One row per table holding the serialized primary-key existence bloom
@@ -797,7 +812,7 @@ impl MetastoreBackend for SqliteMetastore {
             .call(|conn| {
                 // Create tables in a transaction
                 conn.execute_batch(&format!(
-                    "{}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
+                    "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
                     Self::TABLE_TABLE_DDL,
                     Self::TABLE_NAME_UNIQUE_INDEX_DDL,
                     Self::DELETE_FILE_TABLE_DDL,
@@ -805,6 +820,7 @@ impl MetastoreBackend for SqliteMetastore {
                     Self::INSERT_RECORD_TABLE_DDL,
                     Self::SNAPSHOT_SEQUENCE_TABLE_DDL,
                     Self::TABLE_STATISTICS_DDL,
+                    Self::SNAPSHOT_FILE_STATISTICS_TABLE_DDL,
                     Self::INLINED_DATA_TABLE_DDL,
                     Self::INLINED_DELETE_TABLE_DDL,
                     Self::PK_INDEX_TABLE_DDL

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -321,6 +321,19 @@ impl TursoMetastore {
         )
     ";
 
+    const SNAPSHOT_FILE_STATISTICS_TABLE_DDL: &'static str = r"
+        CREATE TABLE IF NOT EXISTS cayenne_snapshot_file_statistics (
+            table_id TEXT NOT NULL,
+            snapshot_id TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            file_size_bytes BIGINT NOT NULL,
+            num_rows BIGINT NOT NULL DEFAULT 0,
+            statistics_blob BLOB NOT NULL,
+            FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
+            PRIMARY KEY (table_id, snapshot_id, file_path)
+        )
+    ";
+
     /// Schema for the `cayenne_pk_index` table. Mirrors the `SQLite` definition;
     /// captured in metastore snapshots via `EXPECTED_TABLES`.
     const PK_INDEX_TABLE_DDL: &'static str = r"
@@ -518,7 +531,7 @@ impl MetastoreBackend for TursoMetastore {
 
         // Create tables
         let schema_sql = format!(
-            "{}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
+            "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
             Self::TABLE_TABLE_DDL,
             Self::TABLE_NAME_UNIQUE_INDEX_DDL,
             Self::DELETE_FILE_TABLE_DDL,
@@ -526,6 +539,7 @@ impl MetastoreBackend for TursoMetastore {
             Self::INSERT_RECORD_TABLE_DDL,
             Self::SNAPSHOT_SEQUENCE_TABLE_DDL,
             Self::TABLE_STATISTICS_DDL,
+            Self::SNAPSHOT_FILE_STATISTICS_TABLE_DDL,
             Self::INLINED_DATA_TABLE_DDL,
             Self::INLINED_DELETE_TABLE_DDL,
             Self::PK_INDEX_TABLE_DDL

--- a/crates/cayenne/src/provider/delete.rs
+++ b/crates/cayenne/src/provider/delete.rs
@@ -49,8 +49,7 @@ pub(crate) use sink::file_based::FileBasedDeletionSink;
 
 // Crate-internal types used by table.rs
 pub(crate) use filter_exec::{
-    InsertRecordHandling, Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
-    is_pk_visible_i64,
+    InsertRecordHandling, Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec, is_pk_visible_i64,
 };
 pub(crate) use vector_io::{
     DeletionIdentifier, DeletionVectorWriteResult, DeletionVectorWriteSpec, DeletionVectorWriter,

--- a/crates/cayenne/src/provider/delete.rs
+++ b/crates/cayenne/src/provider/delete.rs
@@ -50,6 +50,7 @@ pub(crate) use sink::file_based::FileBasedDeletionSink;
 // Crate-internal types used by table.rs
 pub(crate) use filter_exec::{
     InsertRecordHandling, Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec,
+    is_pk_visible_i64,
 };
 pub(crate) use vector_io::{
     DeletionIdentifier, DeletionVectorWriteResult, DeletionVectorWriteSpec, DeletionVectorWriter,

--- a/crates/cayenne/src/provider/file_pruning.rs
+++ b/crates/cayenne/src/provider/file_pruning.rs
@@ -26,20 +26,20 @@ use std::sync::Arc;
 use arrow::record_batch::RecordBatch;
 use arrow_schema::SchemaRef;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter;
+use datafusion_common::ScalarValue;
 use datafusion_common::pruning::PrunableStatistics;
 use datafusion_common::tree_node::TreeNode;
 use datafusion_common::{DFSchema, Result, Statistics};
 use datafusion_datasource::PartitionedFile;
 use datafusion_expr::utils::conjunction;
-use datafusion_expr::{col, lit, Expr};
-use datafusion_common::ScalarValue;
+use datafusion_expr::{Expr, col, lit};
 
-use super::delete::{is_pk_visible_i64, InsertRecordHandling};
+use super::delete::{InsertRecordHandling, is_pk_visible_i64};
 use super::deletion_index::DeletionIndex;
 use datafusion_physical_expr::execution_props::ExecutionProps;
-use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
+use datafusion_physical_expr::{PhysicalExpr, create_physical_expr};
 use datafusion_physical_plan::metrics::Count;
-use datafusion_pruning::{build_pruning_predicate, FilePruner};
+use datafusion_pruning::{FilePruner, build_pruning_predicate};
 
 use super::table::ColumnStatsAccumulator;
 
@@ -144,8 +144,7 @@ pub(crate) fn should_prune_statistics(
         return Ok(false);
     }
 
-    let prunable =
-        PrunableStatistics::new(vec![Arc::new(stats.clone())], Arc::clone(schema));
+    let prunable = PrunableStatistics::new(vec![Arc::new(stats.clone())], Arc::clone(schema));
     let Some(pruning_predicate) =
         build_pruning_predicate(Arc::clone(predicate), schema, &Count::default())
     else {
@@ -279,7 +278,10 @@ mod tests {
             ],
         );
 
-        assert_eq!(stats.num_rows, datafusion_common::stats::Precision::Exact(3));
+        assert_eq!(
+            stats.num_rows,
+            datafusion_common::stats::Precision::Exact(3)
+        );
         assert_eq!(
             stats.column_statistics[0].min_value,
             datafusion_common::stats::Precision::Exact(ScalarValue::Int64(Some(1)))
@@ -293,7 +295,8 @@ mod tests {
     #[test]
     fn prunes_segment_disjoint_from_predicate() {
         let schema = test_schema();
-        let stats = statistics_from_record_batches(&schema, &[batch(&[1, 2, 3], &[None, None, None])]);
+        let stats =
+            statistics_from_record_batches(&schema, &[batch(&[1, 2, 3], &[None, None, None])]);
         let predicate = build_listing_pruning_predicate(&schema, &[col("id").eq(lit(99))])
             .expect("predicate")
             .expect("some");
@@ -307,14 +310,9 @@ mod tests {
     #[test]
     fn tombstone_exclusion_builds_negated_in_list() {
         let index = DeletionIndex::from_map(HashMap::from([(10, 1), (20, 2)]));
-        let filter = tombstone_exclusion_filter(
-            "id",
-            &index,
-            InsertRecordHandling::Ignore,
-            None,
-            256,
-        )
-        .expect("filter");
+        let filter =
+            tombstone_exclusion_filter("id", &index, InsertRecordHandling::Ignore, None, 256)
+                .expect("filter");
         let Expr::InList(in_list) = filter else {
             panic!("expected negated IN list");
         };
@@ -324,10 +322,7 @@ mod tests {
 
     #[test]
     fn tombstone_exclusion_skips_reinserted_upsert_keys() {
-        let index = DeletionIndex::from_maps(
-            HashMap::from([(10, 5)]),
-            HashMap::from([(10, 6)]),
-        );
+        let index = DeletionIndex::from_maps(HashMap::from([(10, 5)]), HashMap::from([(10, 6)]));
         assert!(
             tombstone_exclusion_filter("id", &index, InsertRecordHandling::Apply, None, 256)
                 .is_none(),
@@ -338,7 +333,8 @@ mod tests {
     #[test]
     fn keeps_segment_overlapping_predicate() {
         let schema = test_schema();
-        let stats = statistics_from_record_batches(&schema, &[batch(&[1, 2, 3], &[None, None, None])]);
+        let stats =
+            statistics_from_record_batches(&schema, &[batch(&[1, 2, 3], &[None, None, None])]);
         let predicate = build_listing_pruning_predicate(&schema, &[col("id").eq(lit(2))])
             .expect("predicate")
             .expect("some");

--- a/crates/cayenne/src/provider/file_pruning.rs
+++ b/crates/cayenne/src/provider/file_pruning.rs
@@ -1,0 +1,351 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Listing-time and in-memory segment pruning via `DataFusion`'s `FilePruner`.
+//!
+//! Uses footer- or batch-derived min/max statistics to drop whole Vortex files
+//! (before `DataSourceExec` planning) and whole inline / RAM-tier segments
+//! (before Arrow decode into the scan union) when a predicate is provably
+//! unsatisfiable. Conservative: any uncertainty keeps the container.
+
+use std::sync::Arc;
+
+use arrow::record_batch::RecordBatch;
+use arrow_schema::SchemaRef;
+use datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter;
+use datafusion_common::pruning::PrunableStatistics;
+use datafusion_common::tree_node::TreeNode;
+use datafusion_common::{DFSchema, Result, Statistics};
+use datafusion_datasource::PartitionedFile;
+use datafusion_expr::utils::conjunction;
+use datafusion_expr::{col, lit, Expr};
+use datafusion_common::ScalarValue;
+
+use super::delete::{is_pk_visible_i64, InsertRecordHandling};
+use super::deletion_index::DeletionIndex;
+use datafusion_physical_expr::execution_props::ExecutionProps;
+use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
+use datafusion_physical_plan::metrics::Count;
+use datafusion_pruning::{build_pruning_predicate, FilePruner};
+
+use super::table::ColumnStatsAccumulator;
+
+/// Build a physical conjunction from data-column scan filters for file/segment pruning.
+pub(crate) fn build_listing_pruning_predicate(
+    schema: &SchemaRef,
+    filters: &[Expr],
+) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+    if filters.is_empty() {
+        return Ok(None);
+    }
+
+    let df_schema = DFSchema::try_from(schema.as_ref().clone())?;
+    let mut coerced_filters = Vec::with_capacity(filters.len());
+    for filter in filters {
+        let mut rewriter = TypeCoercionRewriter::new(&df_schema);
+        coerced_filters.push(filter.clone().rewrite(&mut rewriter)?.data);
+    }
+
+    let Some(predicate) = conjunction(coerced_filters) else {
+        return Ok(None);
+    };
+
+    let execution_props = ExecutionProps::new();
+    Ok(Some(create_physical_expr(
+        &predicate,
+        &df_schema,
+        &execution_props,
+    )?))
+}
+
+/// Returns `true` when the file's statistics prove the predicate cannot match any row.
+pub(crate) fn should_prune_partitioned_file(
+    file: &PartitionedFile,
+    schema: &SchemaRef,
+    predicate: &Arc<dyn PhysicalExpr>,
+) -> Result<bool> {
+    if !file.has_statistics() {
+        return Ok(false);
+    }
+
+    let Some(mut pruner) =
+        FilePruner::try_new(Arc::clone(predicate), schema, file, Count::default())
+    else {
+        return Ok(false);
+    };
+
+    pruner.should_prune()
+}
+
+/// Build `pk NOT IN (hidden keys)` for sparse Int64 tombstone sets so Vortex and
+/// listing-time pruning can skip rows/files before the deletion filter exec runs.
+/// Returns `None` when the set is empty, too large, or not single-column Int64.
+pub(crate) fn tombstone_exclusion_filter(
+    pk_column_name: &str,
+    tombstones: &DeletionIndex,
+    insert_record_handling: InsertRecordHandling,
+    min_delete_seq_to_apply: Option<i64>,
+    max_keys: usize,
+) -> Option<Expr> {
+    if !tombstones.has_deletions() {
+        return None;
+    }
+
+    let mut hidden_keys = Vec::new();
+    for (pk, _) in tombstones.iter_entries() {
+        if !is_pk_visible_i64(
+            pk,
+            tombstones,
+            insert_record_handling,
+            min_delete_seq_to_apply,
+        ) {
+            hidden_keys.push(pk);
+            if hidden_keys.len() > max_keys {
+                return None;
+            }
+        }
+    }
+
+    if hidden_keys.is_empty() {
+        return None;
+    }
+
+    let literals: Vec<Expr> = hidden_keys
+        .into_iter()
+        .map(|pk| lit(ScalarValue::Int64(Some(pk))))
+        .collect();
+    Some(Expr::InList(datafusion_expr::expr::InList::new(
+        Box::new(col(pk_column_name)),
+        literals,
+        true,
+    )))
+}
+
+/// Returns `true` when container statistics prove the predicate cannot match any row.
+pub(crate) fn should_prune_statistics(
+    stats: &Statistics,
+    schema: &SchemaRef,
+    predicate: &Arc<dyn PhysicalExpr>,
+) -> Result<bool> {
+    if stats.column_statistics.is_empty() {
+        return Ok(false);
+    }
+
+    let prunable =
+        PrunableStatistics::new(vec![Arc::new(stats.clone())], Arc::clone(schema));
+    let Some(pruning_predicate) =
+        build_pruning_predicate(Arc::clone(predicate), schema, &Count::default())
+    else {
+        return Ok(false);
+    };
+
+    match pruning_predicate.prune(&prunable) {
+        Ok(values) => Ok(values.into_iter().all(|matched| !matched)),
+        Err(error) => {
+            tracing::debug!(
+                error = %error,
+                "Ignoring error building pruning predicate for in-memory segment"
+            );
+            Ok(false)
+        }
+    }
+}
+
+/// Compute exact min/max/null_count statistics for one or more in-memory batches.
+#[must_use]
+pub(crate) fn statistics_from_record_batches(
+    schema: &SchemaRef,
+    batches: &[RecordBatch],
+) -> Statistics {
+    let num_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    let column_statistics = (0..schema.fields().len())
+        .map(|col_idx| {
+            let mut min_value = datafusion_common::stats::Precision::Absent;
+            let mut max_value = datafusion_common::stats::Precision::Absent;
+            let mut null_count = 0usize;
+
+            for batch in batches {
+                if col_idx >= batch.num_columns() || batch.num_rows() == 0 {
+                    continue;
+                }
+                let col = batch.column(col_idx);
+                null_count += col.null_count();
+                let col_stats = ColumnStatsAccumulator::compute_column_stats(col.as_ref());
+                min_value = merge_min(min_value, col_stats.min_value);
+                max_value = merge_max(max_value, col_stats.max_value);
+            }
+
+            datafusion_common::ColumnStatistics {
+                null_count: datafusion_common::stats::Precision::Exact(null_count),
+                min_value,
+                max_value,
+                sum_value: datafusion_common::stats::Precision::Absent,
+                distinct_count: datafusion_common::stats::Precision::Absent,
+                byte_size: datafusion_common::stats::Precision::Absent,
+            }
+        })
+        .collect();
+
+    Statistics {
+        num_rows: datafusion_common::stats::Precision::Exact(num_rows),
+        total_byte_size: datafusion_common::stats::Precision::Absent,
+        column_statistics,
+    }
+}
+
+fn merge_min(
+    current: datafusion_common::stats::Precision<datafusion_common::ScalarValue>,
+    next: datafusion_common::stats::Precision<datafusion_common::ScalarValue>,
+) -> datafusion_common::stats::Precision<datafusion_common::ScalarValue> {
+    match (current.get_value(), next.get_value()) {
+        (None, None) => datafusion_common::stats::Precision::Absent,
+        (None, Some(v)) => datafusion_common::stats::Precision::Exact(v.clone()),
+        (Some(v), None) => datafusion_common::stats::Precision::Exact(v.clone()),
+        (Some(left), Some(right)) => {
+            if left.partial_cmp(right) == Some(std::cmp::Ordering::Greater) {
+                datafusion_common::stats::Precision::Exact(right.clone())
+            } else {
+                datafusion_common::stats::Precision::Exact(left.clone())
+            }
+        }
+    }
+}
+
+fn merge_max(
+    current: datafusion_common::stats::Precision<datafusion_common::ScalarValue>,
+    next: datafusion_common::stats::Precision<datafusion_common::ScalarValue>,
+) -> datafusion_common::stats::Precision<datafusion_common::ScalarValue> {
+    match (current.get_value(), next.get_value()) {
+        (None, None) => datafusion_common::stats::Precision::Absent,
+        (None, Some(v)) => datafusion_common::stats::Precision::Exact(v.clone()),
+        (Some(v), None) => datafusion_common::stats::Precision::Exact(v.clone()),
+        (Some(left), Some(right)) => {
+            if left.partial_cmp(right) == Some(std::cmp::Ordering::Less) {
+                datafusion_common::stats::Precision::Exact(right.clone())
+            } else {
+                datafusion_common::stats::Precision::Exact(left.clone())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int64Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::{col, lit};
+    use std::collections::HashMap;
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Int64, true),
+        ]))
+    }
+
+    fn batch(ids: &[i64], values: &[Option<i64>]) -> RecordBatch {
+        RecordBatch::try_new(
+            test_schema(),
+            vec![
+                Arc::new(Int64Array::from(ids.to_vec())),
+                Arc::new(Int64Array::from(values.to_vec())),
+            ],
+        )
+        .expect("batch")
+    }
+
+    #[test]
+    fn statistics_from_batches_tracks_min_max() {
+        let stats = statistics_from_record_batches(
+            &test_schema(),
+            &[
+                batch(&[1, 2], &[Some(10), Some(20)]),
+                batch(&[5], &[Some(5)]),
+            ],
+        );
+
+        assert_eq!(stats.num_rows, datafusion_common::stats::Precision::Exact(3));
+        assert_eq!(
+            stats.column_statistics[0].min_value,
+            datafusion_common::stats::Precision::Exact(ScalarValue::Int64(Some(1)))
+        );
+        assert_eq!(
+            stats.column_statistics[0].max_value,
+            datafusion_common::stats::Precision::Exact(ScalarValue::Int64(Some(5)))
+        );
+    }
+
+    #[test]
+    fn prunes_segment_disjoint_from_predicate() {
+        let schema = test_schema();
+        let stats = statistics_from_record_batches(&schema, &[batch(&[1, 2, 3], &[None, None, None])]);
+        let predicate = build_listing_pruning_predicate(&schema, &[col("id").eq(lit(99))])
+            .expect("predicate")
+            .expect("some");
+
+        assert!(
+            should_prune_statistics(&stats, &schema, &predicate).expect("prune check"),
+            "segment [1,3] must be pruned for id = 99"
+        );
+    }
+
+    #[test]
+    fn tombstone_exclusion_builds_negated_in_list() {
+        let index = DeletionIndex::from_map(HashMap::from([(10, 1), (20, 2)]));
+        let filter = tombstone_exclusion_filter(
+            "id",
+            &index,
+            InsertRecordHandling::Ignore,
+            None,
+            256,
+        )
+        .expect("filter");
+        let Expr::InList(in_list) = filter else {
+            panic!("expected negated IN list");
+        };
+        assert!(in_list.negated);
+        assert_eq!(in_list.list.len(), 2);
+    }
+
+    #[test]
+    fn tombstone_exclusion_skips_reinserted_upsert_keys() {
+        let index = DeletionIndex::from_maps(
+            HashMap::from([(10, 5)]),
+            HashMap::from([(10, 6)]),
+        );
+        assert!(
+            tombstone_exclusion_filter("id", &index, InsertRecordHandling::Apply, None, 256)
+                .is_none(),
+            "re-inserted keys must not be pushed into NOT IN"
+        );
+    }
+
+    #[test]
+    fn keeps_segment_overlapping_predicate() {
+        let schema = test_schema();
+        let stats = statistics_from_record_batches(&schema, &[batch(&[1, 2, 3], &[None, None, None])]);
+        let predicate = build_listing_pruning_predicate(&schema, &[col("id").eq(lit(2))])
+            .expect("predicate")
+            .expect("some");
+
+        assert!(
+            !should_prune_statistics(&stats, &schema, &predicate).expect("prune check"),
+            "segment containing id=2 must be kept"
+        );
+    }
+}

--- a/crates/cayenne/src/provider/mem_tier.rs
+++ b/crates/cayenne/src/provider/mem_tier.rs
@@ -38,8 +38,8 @@ use std::time::Instant;
 
 use arrow::record_batch::RecordBatch;
 use arrow_schema::Schema;
-use datafusion_common::Statistics;
 use async_trait::async_trait;
+use datafusion_common::Statistics;
 
 /// In-RAM tombstones for one mem tier, mirroring the strategy split that
 /// `load_inlined_deletion_maps` produces for the durable inline path. Each map
@@ -184,10 +184,12 @@ impl MemTier {
         let statistics = batches.first().map_or_else(
             || Arc::new(Statistics::new_unknown(&Schema::empty())),
             |first| {
-                Arc::new(crate::provider::file_pruning::statistics_from_record_batches(
-                    first.schema_ref(),
-                    batches.as_ref(),
-                ))
+                Arc::new(
+                    crate::provider::file_pruning::statistics_from_record_batches(
+                        first.schema_ref(),
+                        batches.as_ref(),
+                    ),
+                )
             },
         );
         let mut segments = Vec::with_capacity(self.segments.len() + 1);

--- a/crates/cayenne/src/provider/mem_tier.rs
+++ b/crates/cayenne/src/provider/mem_tier.rs
@@ -37,6 +37,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use arrow::record_batch::RecordBatch;
+use arrow_schema::Schema;
+use datafusion_common::Statistics;
 use async_trait::async_trait;
 
 /// In-RAM tombstones for one mem tier, mirroring the strategy split that
@@ -110,6 +112,8 @@ pub(crate) struct MemSegment {
     /// The inline data sequence assigned to this segment's rows (the visibility
     /// watermark used by the merge-on-read deletion filter).
     pub(crate) data_sequence: i64,
+    /// Exact min/max over this segment's batches for predicate-based pruning.
+    pub(crate) statistics: Arc<Statistics>,
 }
 
 /// The in-memory CDC tier for one table. Immutable once constructed: every
@@ -177,11 +181,21 @@ impl MemTier {
         incoming_rows: u64,
         superseded: u64,
     ) -> Self {
+        let statistics = batches.first().map_or_else(
+            || Arc::new(Statistics::new_unknown(&Schema::empty())),
+            |first| {
+                Arc::new(crate::provider::file_pruning::statistics_from_record_batches(
+                    first.schema_ref(),
+                    batches.as_ref(),
+                ))
+            },
+        );
         let mut segments = Vec::with_capacity(self.segments.len() + 1);
         segments.extend(self.segments.iter().cloned());
         segments.push(MemSegment {
             batches,
             data_sequence,
+            statistics,
         });
 
         let mut merged_tombstones = self.tombstones.clone();

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -76,6 +76,7 @@ pub(crate) mod delete;
 pub mod deletion_index;
 pub(crate) mod deletion_strategy;
 pub(crate) mod delta_encoding;
+pub(crate) mod file_pruning;
 pub(crate) mod fsync_tier;
 pub(crate) mod mem_tier;
 pub(crate) mod mem_tier_budget;

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -11086,10 +11086,7 @@ impl CayenneTableProvider {
 
         if let Err(error) = self
             .catalog
-            .clear_snapshot_file_statistics_except(
-                &self.table_metadata.table_id,
-                &current_snapshot,
-            )
+            .clear_snapshot_file_statistics_except(&self.table_metadata.table_id, &current_snapshot)
             .await
         {
             tracing::debug!(
@@ -12787,11 +12784,11 @@ impl CayenneTableProvider {
         let visible_batches = self
             .visible_mem_tier_batches(snapshot, pruning_predicate)
             .map_err(|e| {
-            datafusion_common::DataFusionError::Execution(format!(
-                "Failed to apply in-memory CDC tier deletion visibility for table {}: {e}",
-                self.table_metadata.table_name
-            ))
-        })?;
+                datafusion_common::DataFusionError::Execution(format!(
+                    "Failed to apply in-memory CDC tier deletion visibility for table {}: {e}",
+                    self.table_metadata.table_name
+                ))
+            })?;
 
         if visible_batches.is_empty() {
             return Ok(None);
@@ -13940,7 +13937,10 @@ impl CayenneTableProvider {
     ) -> datafusion_common::Result<SnapshotFilesForScan> {
         let collect_stats = request.options.collect_stat
             && !(self.pk_deletion_strategy.is_position_based() && self.has_pending_deletions());
-        let store = request.state.runtime_env().object_store(request.table_url)?;
+        let store = request
+            .state
+            .runtime_env()
+            .object_store(request.table_url)?;
         let meta_fetch_concurrency = request
             .state
             .config_options()
@@ -14007,41 +14007,36 @@ impl CayenneTableProvider {
                 }
             });
 
-        let (file_group, inexact_stats) = Self::collect_scan_files_with_limit(
-            files,
-            request.limit,
-            collect_stats,
-        )
-        .await?;
+        let (file_group, inexact_stats) =
+            Self::collect_scan_files_with_limit(files, request.limit, collect_stats).await?;
 
         let threshold = request
             .state
             .config_options()
             .optimizer
             .preserve_file_partitions;
-        let (file_groups, grouped_by_partition) =
-            if threshold > 0 && !request.options.table_partition_cols.is_empty() {
-                let grouped = file_group
-                    .group_by_partition_values(request.options.target_partitions);
-                if grouped.len() >= threshold {
-                    (grouped, true)
-                } else {
-                    let all_files = grouped
-                        .into_iter()
-                        .flat_map(FileGroup::into_inner)
-                        .collect::<Vec<_>>();
-                    (
-                        FileGroup::new(all_files)
-                            .split_files(request.options.target_partitions),
-                        false,
-                    )
-                }
+        let (file_groups, grouped_by_partition) = if threshold > 0
+            && !request.options.table_partition_cols.is_empty()
+        {
+            let grouped = file_group.group_by_partition_values(request.options.target_partitions);
+            if grouped.len() >= threshold {
+                (grouped, true)
             } else {
+                let all_files = grouped
+                    .into_iter()
+                    .flat_map(FileGroup::into_inner)
+                    .collect::<Vec<_>>();
                 (
-                    file_group.split_files(request.options.target_partitions),
+                    FileGroup::new(all_files).split_files(request.options.target_partitions),
                     false,
                 )
-            };
+            }
+        } else {
+            (
+                file_group.split_files(request.options.target_partitions),
+                false,
+            )
+        };
 
         let (file_groups, statistics) = compute_all_files_statistics(
             file_groups,
@@ -14074,16 +14069,11 @@ impl CayenneTableProvider {
         }
 
         let file_path = part_file.object_meta.location.to_string();
-        let file_size_bytes =
-            i64::try_from(part_file.object_meta.size).unwrap_or(i64::MAX);
+        let file_size_bytes = i64::try_from(part_file.object_meta.size).unwrap_or(i64::MAX);
 
         if let Ok(Some(persisted)) = self
             .catalog
-            .get_snapshot_file_statistics(
-                &self.table_metadata.table_id,
-                snapshot_id,
-                &file_path,
-            )
+            .get_snapshot_file_statistics(&self.table_metadata.table_id, snapshot_id, &file_path)
             .await
             && persisted.file_size_bytes == file_size_bytes
             && let Some(statistics) = crate::stats::statistics_from_persisted_blob(
@@ -14536,7 +14526,11 @@ impl CayenneTableProvider {
         if self.pk_column_indices.len() != 1 {
             return false;
         }
-        let pk_name = self.table_metadata.schema.field(self.pk_column_indices[0]).name();
+        let pk_name = self
+            .table_metadata
+            .schema
+            .field(self.pk_column_indices[0])
+            .name();
         filters
             .iter()
             .any(|expr| pk_selective_in_or_range(expr, pk_name))
@@ -14556,7 +14550,11 @@ impl CayenneTableProvider {
         if self.pk_column_indices.len() != 1 {
             return None;
         }
-        let pk_name = self.table_metadata.schema.field(self.pk_column_indices[0]).name();
+        let pk_name = self
+            .table_metadata
+            .schema
+            .field(self.pk_column_indices[0])
+            .name();
         super::file_pruning::tombstone_exclusion_filter(
             pk_name,
             tombstones,
@@ -14616,7 +14614,10 @@ fn pk_selective_in_or_range(expr: &Expr, pk_name: &str) -> bool {
             if len == 0 || len > MAX_PK_SELECTIVE_INLIST_VALUES {
                 return false;
             }
-            in_list.list.iter().all(|item| extract_integer_literal(item).is_some())
+            in_list
+                .list
+                .iter()
+                .all(|item| extract_integer_literal(item).is_some())
         }
         Expr::Between(between) => {
             if between.negated || !matches_column(&between.expr, pk_name) {
@@ -14920,9 +14921,8 @@ impl TableProvider for CayenneTableProvider {
         // `pk_in_list_vs_range_rewrite` bench.
         let effective_filters = rewritten_scan_filters(filters, retention_keep_filter.as_ref());
         let mut scan_filters_owned = effective_filters.unwrap_or_else(|| filters.to_vec());
-        if let Some(tombstone_filter) =
-            self.vortex_key_delete_pushdown_filter(&deletion_snapshot)
-        {
+        let mem_tier_pruning_filters = scan_filters_owned.clone();
+        if let Some(tombstone_filter) = self.vortex_key_delete_pushdown_filter(&deletion_snapshot) {
             tracing::trace!(
                 table = %self.table_metadata.table_name,
                 "Injected sparse key-delete tombstone exclusion into Vortex scan filters"
@@ -14941,6 +14941,10 @@ impl TableProvider for CayenneTableProvider {
         let segment_pruning_predicate = super::file_pruning::build_listing_pruning_predicate(
             &self.table_metadata.schema,
             scan_filters,
+        )?;
+        let mem_tier_pruning_predicate = super::file_pruning::build_listing_pruning_predicate(
+            &self.table_metadata.schema,
+            &mem_tier_pruning_filters,
         )?;
         let inlined_batches = self
             .pruned_inlined_batches(
@@ -15069,7 +15073,7 @@ impl TableProvider for CayenneTableProvider {
             .build_mem_tier_scan_plan(
                 &mem_tier_snapshot,
                 effective_projection.as_ref(),
-                segment_pruning_predicate.as_ref(),
+                mem_tier_pruning_predicate.as_ref(),
             )?
             .map(|mem_exec| self.wrap_memory_branch_with_scan_filters(mem_exec, filters));
 
@@ -15217,6 +15221,13 @@ impl TableProvider for CayenneTableProvider {
         // None), the ListingTable alone would under-count the inline rows, so
         // return None rather than mislead the optimizer with a file-only count.
         if self.inlined_row_count.load(Ordering::Relaxed) > 0 {
+            return None;
+        }
+
+        // Position deletes are applied inside the Vortex access plan. If no
+        // cached table stats are available, the synchronous ListingTable stats
+        // are raw file-footer stats and do not account for the pending bitmap.
+        if self.pk_deletion_strategy.is_position_based() && self.has_pending_deletions() {
             return None;
         }
 
@@ -19942,7 +19953,10 @@ mod tests {
 
     #[test]
     fn pk_selective_wide_between_rejected() {
-        assert!(!pk_selective_in_or_range(&between_int("id", 1, 10_000), "id"));
+        assert!(!pk_selective_in_or_range(
+            &between_int("id", 1, 10_000),
+            "id"
+        ));
     }
 
     #[test]
@@ -21417,6 +21431,54 @@ mod tests {
                 .expect("read inline tombstones")
                 .is_empty(),
             "a position-based table must persist no inline tombstone"
+        );
+    }
+
+    /// When position deletes are pending and the cached aggregate stats are not
+    /// available, `statistics()` must not fall back to raw ListingTable footer
+    /// stats. Those stats do not account for the Vortex access-plan deletion
+    /// bitmap and can overstate cardinality until maintenance repopulates the
+    /// cache.
+    #[tokio::test]
+    async fn test_statistics_cache_miss_with_position_deletes_returns_none() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) =
+            create_position_based_table("position_stats_cache_miss", ctx.runtime_env()).await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        insert_batch(
+            &provider,
+            id_value_batch(Arc::clone(&schema), &[1, 2, 3], &[10, 20, 30]),
+        )
+        .await;
+        provider
+            .flush_pending_maintenance()
+            .await
+            .expect("flush stats");
+        assert!(
+            provider.statistics().is_some(),
+            "precondition: position table should expose stats before deletes"
+        );
+
+        let delete_plan = provider
+            .delete_from(
+                &ctx.state(),
+                vec![col("id").eq(datafusion_expr::lit(2_i64))],
+            )
+            .await
+            .expect("delete plan");
+        collect(delete_plan, ctx.task_ctx())
+            .await
+            .expect("delete executed");
+        assert!(
+            provider.has_pending_deletions(),
+            "precondition: delete should leave a pending position bitmap"
+        );
+
+        provider.clear_cached_table_statistics_unlocked();
+        assert!(
+            provider.statistics().is_none(),
+            "with pending position deletes and no cached aggregate, raw ListingTable stats must be suppressed"
         );
     }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -28,7 +28,7 @@ use super::streaming::StreamingExec;
 use crate::catalog::{CatalogError, CatalogResult, MetadataCatalog, SnapshotSequenceCommit};
 use crate::metadata::{
     CreateTableOptions, InlinedData, InlinedDataStats, InlinedDelete, PkConflictDetection,
-    TableMetadata, TableStatistics,
+    SnapshotFileStatistics, TableMetadata, TableStatistics,
 };
 use crate::provider::scan::{CayenneAccelerationExec, round_robin_repartition_if_needed};
 use crate::provider::sink::CayenneDataSink;
@@ -139,6 +139,12 @@ const PK_KEYSET_CACHE_HASHMAP_ENTRY_OVERHEAD_BYTES: usize = 16;
 const TABLE_STATISTICS_FULL_COLUMN_SYNC_LIMIT: usize = 256;
 const PROTECTED_SNAPSHOT_AGE_WARNING_KEY_LIMIT: usize = 1024;
 const MIN_CONSECUTIVE_INLIST_REWRITE_VALUES: usize = 4;
+/// Upper bound on PK `IN` list cardinality that qualifies for `target_partitions = 1`.
+const MAX_PK_SELECTIVE_INLIST_VALUES: usize = 32;
+/// Upper bound on PK `BETWEEN` span (inclusive) for selective scan fan-out control.
+const MAX_PK_SELECTIVE_RANGE_SPAN: i64 = 32;
+/// Maximum tombstone keys pushed into the Vortex scan predicate as `NOT IN`.
+const MAX_VORTEX_KEY_DELETE_PUSHDOWN: usize = 256;
 
 #[derive(Debug, Default)]
 struct BoundedWarningKeys {
@@ -349,6 +355,8 @@ struct InlinedViewEntry {
     /// Batches already decoded from IPC and filtered through the deletion map.
     /// Empty when all rows in this entry were removed by the deletion filter.
     batches: Vec<RecordBatch>,
+    /// Conservative min/max over the decoded IPC batches (pre-tombstone filter).
+    statistics: Arc<Statistics>,
 }
 
 /// Cached result of [`CayenneTableProvider::read_inlined_batches`] and
@@ -908,7 +916,9 @@ impl ColumnStatsAccumulator {
     }
 
     /// Compute `DataFusion` `ColumnStatistics` from a single Arrow column.
-    fn compute_column_stats(col: &dyn arrow::array::Array) -> datafusion_common::ColumnStatistics {
+    pub(crate) fn compute_column_stats(
+        col: &dyn arrow::array::Array,
+    ) -> datafusion_common::ColumnStatistics {
         use datafusion_common::stats::Precision;
 
         let null_count = Precision::Exact(col.null_count());
@@ -1387,6 +1397,17 @@ fn inline_memtable_pressure_with_thresholds(
         return Some(InlineMemtablePressure::IpcBytes);
     }
     None
+}
+
+struct SnapshotScanListingRequest<'a> {
+    state: &'a dyn Session,
+    table_url: &'a ListingTableUrl,
+    options: &'a ListingOptions,
+    partition_filters: &'a [Expr],
+    data_filters: &'a [Expr],
+    snapshot_id: &'a str,
+    limit: Option<usize>,
+    scan_schema: SchemaRef,
 }
 
 struct SnapshotFilesForScan {
@@ -6158,7 +6179,16 @@ impl CayenneTableProvider {
         );
         let scan_schema = Self::snapshot_scan_schema(&self.table_metadata.schema, &options);
         let listed = self
-            .list_files_for_snapshot_scan(&state, &table_url, &options, &[], None, scan_schema)
+            .list_files_for_snapshot_scan(&SnapshotScanListingRequest {
+                state: &state,
+                table_url: &table_url,
+                options: &options,
+                partition_filters: &[],
+                data_filters: &[],
+                snapshot_id: &snapshot_id,
+                limit: None,
+                scan_schema,
+            })
             .await
             .map_err(|err| CatalogError::InvalidOperationNoSource {
                 message: format!("Position capture: failed to list snapshot files: {err}"),
@@ -11007,7 +11037,7 @@ impl CayenneTableProvider {
         // uses `refresh_listing_table_under_held_fence` instead so it can hold
         // every participating partition's fence across one barrier window.
         let _fence = self.listing_fence.write().await;
-        self.refresh_listing_table_under_held_fence()
+        self.refresh_listing_table_under_held_fence().await
     }
 
     /// Drop every entry in [`Self::scan_file_statistics`].
@@ -11031,7 +11061,7 @@ impl CayenneTableProvider {
     /// # Errors
     ///
     /// Returns an error if the listing table cannot be reconstructed.
-    pub(crate) fn refresh_listing_table_under_held_fence(&self) -> Result<()> {
+    pub(crate) async fn refresh_listing_table_under_held_fence(&self) -> Result<()> {
         // Construct URL to current snapshot using the live snapshot ID
         // (which may differ from table_metadata after compaction)
         let current_snapshot = self.get_current_snapshot_id();
@@ -11053,6 +11083,21 @@ impl CayenneTableProvider {
         )?;
 
         self.listing_table.store(new_listing_table);
+
+        if let Err(error) = self
+            .catalog
+            .clear_snapshot_file_statistics_except(
+                &self.table_metadata.table_id,
+                &current_snapshot,
+            )
+            .await
+        {
+            tracing::debug!(
+                table = %self.table_metadata.table_name,
+                error = %error,
+                "Failed to clear stale per-file snapshot statistics after listing refresh"
+            );
+        }
 
         tracing::debug!(
             "Refreshed listing table for {} (under held fence) to pick up new files",
@@ -11995,6 +12040,7 @@ impl CayenneTableProvider {
         Ok(InlinedViewEntry {
             batches: filtered_batches,
             envelope: entry.envelope.clone(),
+            statistics: Arc::clone(&entry.statistics),
         })
     }
 
@@ -12008,6 +12054,12 @@ impl CayenneTableProvider {
     ) -> Result<InlinedViewEntry> {
         let entry_batches = deserialize_ipc_to_batch(&entry.data_ipc)
             .map_err(|e| super::Error::Arrow { source: e })?;
+        // Pre-filter stats are a conservative superset: tombstone removal can only
+        // shrink row ranges, never widen min/max.
+        let statistics = Arc::new(super::file_pruning::statistics_from_record_batches(
+            &self.table_metadata.schema,
+            &entry_batches,
+        ));
         let mut filtered_batches = Vec::with_capacity(entry_batches.len());
         for batch in entry_batches {
             if let Some(filtered) = self.filter_inlined_batch_for_deletions(
@@ -12021,6 +12073,7 @@ impl CayenneTableProvider {
         Ok(InlinedViewEntry {
             batches: filtered_batches,
             envelope: entry,
+            statistics,
         })
     }
 
@@ -12310,26 +12363,47 @@ impl CayenneTableProvider {
         !snapshot.tombstones.int64_pk.is_empty() || !snapshot.tombstones.row_keys.is_empty()
     }
 
-    fn inlined_batches_with_mem_tier_visibility(
+    fn pruned_inlined_batches(
         &self,
         view: &[InlinedViewEntry],
         mem_tier: &crate::provider::mem_tier::MemTier,
+        pruning_predicate: Option<&Arc<dyn PhysicalExpr>>,
     ) -> Result<Vec<RecordBatch>> {
         if view.is_empty() {
             return Ok(Vec::new());
         }
 
-        if !Self::mem_tier_has_tombstones(mem_tier) {
-            return Ok(view
-                .iter()
-                .flat_map(|entry| entry.batches.iter().cloned())
-                .collect());
-        }
+        let schema = Arc::clone(&self.table_metadata.schema);
+        let removal = if Self::mem_tier_has_tombstones(mem_tier) {
+            Some(Self::mem_tier_deletion_maps(mem_tier))
+        } else {
+            None
+        };
 
-        let removal = Self::mem_tier_deletion_maps(mem_tier);
         let mut batches = Vec::new();
         for entry in view {
-            let visible = self.apply_tombstone_removal_to_entry(entry, &removal)?;
+            let visible = if let Some(ref removal) = removal {
+                self.apply_tombstone_removal_to_entry(entry, removal)?
+            } else if entry.batches.is_empty() {
+                continue;
+            } else {
+                entry.clone()
+            };
+
+            if visible.batches.is_empty() {
+                continue;
+            }
+
+            if let Some(predicate) = pruning_predicate
+                && super::file_pruning::should_prune_statistics(
+                    visible.statistics.as_ref(),
+                    &schema,
+                    predicate,
+                )?
+            {
+                continue;
+            }
+
             batches.extend(visible.batches);
         }
         Ok(batches)
@@ -12338,14 +12412,26 @@ impl CayenneTableProvider {
     fn visible_mem_tier_batches(
         &self,
         snapshot: &crate::provider::mem_tier::MemTier,
+        pruning_predicate: Option<&Arc<dyn PhysicalExpr>>,
     ) -> Result<Vec<RecordBatch>> {
         if snapshot.segments.is_empty() {
             return Ok(Vec::new());
         }
 
+        let schema = Arc::clone(&self.table_metadata.schema);
         let inlined_deletions = Self::mem_tier_deletion_maps(snapshot);
         let mut visible_batches: Vec<RecordBatch> = Vec::new();
         for segment in snapshot.segments.iter() {
+            if let Some(predicate) = pruning_predicate
+                && super::file_pruning::should_prune_statistics(
+                    segment.statistics.as_ref(),
+                    &schema,
+                    predicate,
+                )?
+            {
+                continue;
+            }
+
             for batch in segment.batches.iter() {
                 let Some(visible) = self.filter_inlined_batch_for_deletions(
                     batch.clone(),
@@ -12509,9 +12595,8 @@ impl CayenneTableProvider {
         }
         let flushed_epoch = snapshot.epoch;
         let inlined_view = self.cached_inlined_view().await?;
-        let mut batches =
-            self.inlined_batches_with_mem_tier_visibility(&inlined_view, &snapshot)?;
-        let mem_batches = self.visible_mem_tier_batches(&snapshot)?;
+        let mut batches = self.pruned_inlined_batches(&inlined_view, &snapshot, None)?;
+        let mem_batches = self.visible_mem_tier_batches(&snapshot, None)?;
         let flushed_mem_rows: usize = mem_batches.iter().map(RecordBatch::num_rows).sum();
         batches.extend(mem_batches);
 
@@ -12619,7 +12704,7 @@ impl CayenneTableProvider {
                 i64::try_from(remaining_mem_rows).unwrap_or(i64::MAX),
                 Ordering::Relaxed,
             );
-            self.refresh_listing_table_under_held_fence()?;
+            self.refresh_listing_table_under_held_fence().await?;
             stats
         };
 
@@ -12693,12 +12778,15 @@ impl CayenneTableProvider {
         &self,
         snapshot: &crate::provider::mem_tier::MemTier,
         effective_projection: Option<&Vec<usize>>,
+        pruning_predicate: Option<&Arc<dyn PhysicalExpr>>,
     ) -> datafusion_common::Result<Option<Arc<dyn ExecutionPlan>>> {
         if snapshot.is_empty() || snapshot.segments.is_empty() {
             return Ok(None);
         }
 
-        let visible_batches = self.visible_mem_tier_batches(snapshot).map_err(|e| {
+        let visible_batches = self
+            .visible_mem_tier_batches(snapshot, pruning_predicate)
+            .map_err(|e| {
             datafusion_common::DataFusionError::Execution(format!(
                 "Failed to apply in-memory CDC tier deletion visibility for table {}: {e}",
                 self.table_metadata.table_name
@@ -12850,7 +12938,7 @@ impl CayenneTableProvider {
             };
 
             self.clear_inlined_metadata_after_checkpoint().await?;
-            self.refresh_listing_table_under_held_fence()?;
+            self.refresh_listing_table_under_held_fence().await?;
             // The flush moved every inline row to a file, but the keyset still tags
             // those rows `Inlined`. Without this flip a later upsert will lead to duplicate record.
             self.flip_inlined_keyset_entries_to_file_unlocated();
@@ -13772,14 +13860,16 @@ impl CayenneTableProvider {
             statistics,
             grouped_by_partition,
         } = self
-            .list_files_for_snapshot_scan(
+            .list_files_for_snapshot_scan(&SnapshotScanListingRequest {
                 state,
-                &table_url,
-                &options,
-                &partition_filters,
-                statistic_file_limit,
-                Arc::clone(&scan_schema),
-            )
+                table_url: &table_url,
+                options: &options,
+                partition_filters: &partition_filters,
+                data_filters: &data_filters,
+                snapshot_id,
+                limit: statistic_file_limit,
+                scan_schema: Arc::clone(&scan_schema),
+            })
             .await?;
 
         if partitioned_file_lists.is_empty() {
@@ -13846,52 +13936,93 @@ impl CayenneTableProvider {
 
     async fn list_files_for_snapshot_scan(
         &self,
-        state: &dyn Session,
-        table_url: &ListingTableUrl,
-        options: &ListingOptions,
-        partition_filters: &[Expr],
-        limit: Option<usize>,
-        scan_schema: SchemaRef,
+        request: &SnapshotScanListingRequest<'_>,
     ) -> datafusion_common::Result<SnapshotFilesForScan> {
-        let collect_stats = options.collect_stat
+        let collect_stats = request.options.collect_stat
             && !(self.pk_deletion_strategy.is_position_based() && self.has_pending_deletions());
-        let store = state.runtime_env().object_store(table_url)?;
-        let meta_fetch_concurrency = state.config_options().execution.meta_fetch_concurrency;
+        let store = request.state.runtime_env().object_store(request.table_url)?;
+        let meta_fetch_concurrency = request
+            .state
+            .config_options()
+            .execution
+            .meta_fetch_concurrency;
         let file_list = pruned_partition_list(
-            state,
+            request.state,
             store.as_ref(),
-            table_url,
-            partition_filters,
-            &options.file_extension,
-            &options.table_partition_cols,
+            request.table_url,
+            request.partition_filters,
+            &request.options.file_extension,
+            &request.options.table_partition_cols,
         )
         .await?;
 
+        let listing_pruning_predicate = if collect_stats && !request.data_filters.is_empty() {
+            super::file_pruning::build_listing_pruning_predicate(
+                &request.scan_schema,
+                request.data_filters,
+            )?
+        } else {
+            None
+        };
+
+        let table_name = self.table_metadata.table_name.clone();
         let files = file_list
             .map(|part_file| async {
                 let part_file = part_file?;
                 let statistics = if collect_stats {
                     self.collect_scan_file_statistics(
-                        state,
+                        request.state,
+                        request.snapshot_id,
                         &store,
-                        options.format.as_ref(),
+                        request.options.format.as_ref(),
                         &part_file,
                     )
                     .await?
                 } else {
                     Arc::new(Statistics::new_unknown(&self.table_metadata.schema))
                 };
-                DataFusionResult::Ok(part_file.with_statistics(statistics))
+                let part_file = part_file.with_statistics(statistics);
+                if let Some(ref predicate) = listing_pruning_predicate
+                    && super::file_pruning::should_prune_partitioned_file(
+                        &part_file,
+                        &request.scan_schema,
+                        predicate,
+                    )?
+                {
+                    tracing::debug!(
+                        table = %table_name,
+                        file = %part_file.object_meta.location,
+                        "Pruned Vortex file at listing time via footer statistics"
+                    );
+                    return Ok(None);
+                }
+                Ok(Some(part_file))
             })
-            .buffer_unordered(meta_fetch_concurrency);
+            .buffer_unordered(meta_fetch_concurrency)
+            .filter_map(|result| async move {
+                match result {
+                    Ok(Some(file)) => Some(Ok(file)),
+                    Ok(None) => None,
+                    Err(err) => Some(Err(err)),
+                }
+            });
 
-        let (file_group, inexact_stats) =
-            Self::collect_scan_files_with_limit(files, limit, collect_stats).await?;
+        let (file_group, inexact_stats) = Self::collect_scan_files_with_limit(
+            files,
+            request.limit,
+            collect_stats,
+        )
+        .await?;
 
-        let threshold = state.config_options().optimizer.preserve_file_partitions;
+        let threshold = request
+            .state
+            .config_options()
+            .optimizer
+            .preserve_file_partitions;
         let (file_groups, grouped_by_partition) =
-            if threshold > 0 && !options.table_partition_cols.is_empty() {
-                let grouped = file_group.group_by_partition_values(options.target_partitions);
+            if threshold > 0 && !request.options.table_partition_cols.is_empty() {
+                let grouped = file_group
+                    .group_by_partition_values(request.options.target_partitions);
                 if grouped.len() >= threshold {
                     (grouped, true)
                 } else {
@@ -13900,16 +14031,24 @@ impl CayenneTableProvider {
                         .flat_map(FileGroup::into_inner)
                         .collect::<Vec<_>>();
                     (
-                        FileGroup::new(all_files).split_files(options.target_partitions),
+                        FileGroup::new(all_files)
+                            .split_files(request.options.target_partitions),
                         false,
                     )
                 }
             } else {
-                (file_group.split_files(options.target_partitions), false)
+                (
+                    file_group.split_files(request.options.target_partitions),
+                    false,
+                )
             };
 
-        let (file_groups, statistics) =
-            compute_all_files_statistics(file_groups, scan_schema, collect_stats, inexact_stats)?;
+        let (file_groups, statistics) = compute_all_files_statistics(
+            file_groups,
+            Arc::clone(&request.scan_schema),
+            collect_stats,
+            inexact_stats,
+        )?;
 
         Ok(SnapshotFilesForScan {
             file_groups,
@@ -13921,6 +14060,7 @@ impl CayenneTableProvider {
     async fn collect_scan_file_statistics(
         &self,
         state: &dyn Session,
+        snapshot_id: &str,
         store: &Arc<dyn ObjectStore>,
         format: &dyn FileFormat,
         part_file: &PartitionedFile,
@@ -13933,6 +14073,36 @@ impl CayenneTableProvider {
             return Ok(cached.statistics);
         }
 
+        let file_path = part_file.object_meta.location.to_string();
+        let file_size_bytes =
+            i64::try_from(part_file.object_meta.size).unwrap_or(i64::MAX);
+
+        if let Ok(Some(persisted)) = self
+            .catalog
+            .get_snapshot_file_statistics(
+                &self.table_metadata.table_id,
+                snapshot_id,
+                &file_path,
+            )
+            .await
+            && persisted.file_size_bytes == file_size_bytes
+            && let Some(statistics) = crate::stats::statistics_from_persisted_blob(
+                &persisted.statistics_blob,
+                &self.table_metadata.schema,
+                persisted.num_rows,
+            )
+        {
+            self.scan_file_statistics.put(
+                &part_file.object_meta.location,
+                CachedFileMetadata::new(
+                    part_file.object_meta.clone(),
+                    Arc::clone(&statistics),
+                    None,
+                ),
+            );
+            return Ok(statistics);
+        }
+
         let statistics = Arc::new(
             format
                 .infer_stats(
@@ -13943,6 +14113,36 @@ impl CayenneTableProvider {
                 )
                 .await?,
         );
+
+        if let Some(blob) = crate::stats::statistics_to_persisted_blob(
+            statistics.as_ref(),
+            &self.table_metadata.schema,
+        ) {
+            let num_rows = match statistics.num_rows {
+                DFPrecision::Exact(rows) => i64::try_from(rows).unwrap_or(0),
+                DFPrecision::Inexact(rows) => i64::try_from(rows).unwrap_or(0),
+                DFPrecision::Absent => 0,
+            };
+            if let Err(error) = self
+                .catalog
+                .upsert_snapshot_file_statistics(&SnapshotFileStatistics {
+                    table_id: self.table_metadata.table_id.clone(),
+                    snapshot_id: snapshot_id.to_string(),
+                    file_path,
+                    file_size_bytes,
+                    num_rows,
+                    statistics_blob: blob,
+                })
+                .await
+            {
+                tracing::debug!(
+                    table = %self.table_metadata.table_name,
+                    error = %error,
+                    "Failed to persist per-file snapshot statistics; continuing with footer stats"
+                );
+            }
+        }
+
         self.scan_file_statistics.put(
             &part_file.object_meta.location,
             CachedFileMetadata::new(part_file.object_meta.clone(), Arc::clone(&statistics), None),
@@ -14325,6 +14525,46 @@ impl CayenneTableProvider {
                 .any(|expr| pk_column_equals_literal(expr, pk_name))
         })
     }
+
+    /// Returns `true` when scan filters are selective enough that byte-range
+    /// file-group fan-out is wasted work: point equality on every PK column,
+    /// or (single-column Int64 PK only) a small `IN` list or tight `BETWEEN`.
+    fn is_pk_selective_scan(&self, filters: &[Expr]) -> bool {
+        if self.is_pk_point_lookup(filters) {
+            return true;
+        }
+        if self.pk_column_indices.len() != 1 {
+            return false;
+        }
+        let pk_name = self.table_metadata.schema.field(self.pk_column_indices[0]).name();
+        filters
+            .iter()
+            .any(|expr| pk_selective_in_or_range(expr, pk_name))
+    }
+
+    /// Build a Vortex-pushdown tombstone exclusion filter for sparse Int64 PK
+    /// deletes on the main scan path. Rows guaranteed hidden by the deletion
+    /// index are expressed as `pk NOT IN (...)` so Vortex can prune chunks and
+    /// listing can drop non-overlapping files before decode.
+    fn vortex_key_delete_pushdown_filter(
+        &self,
+        deletion_snapshot: &PkDeletionSnapshot,
+    ) -> Option<Expr> {
+        let PkDeletionSnapshot::Int64Pk { tombstones } = deletion_snapshot else {
+            return None;
+        };
+        if self.pk_column_indices.len() != 1 {
+            return None;
+        }
+        let pk_name = self.table_metadata.schema.field(self.pk_column_indices[0]).name();
+        super::file_pruning::tombstone_exclusion_filter(
+            pk_name,
+            tombstones,
+            InsertRecordHandling::Apply,
+            None,
+            MAX_VORTEX_KEY_DELETE_PUSHDOWN,
+        )
+    }
 }
 
 /// Walks `expr` looking for `Column(name) = Literal` (or the flipped form).
@@ -14361,6 +14601,42 @@ fn is_literal_like(expr: &Expr) -> bool {
         Expr::Literal(_, _) => true,
         Expr::Cast(c) => is_literal_like(&c.expr),
         Expr::TryCast(c) => is_literal_like(&c.expr),
+        _ => false,
+    }
+}
+
+/// `true` when `expr` is a selective single-column Int64 PK `IN` or `BETWEEN`.
+fn pk_selective_in_or_range(expr: &Expr, pk_name: &str) -> bool {
+    match expr {
+        Expr::InList(in_list) => {
+            if in_list.negated || !matches_column(&in_list.expr, pk_name) {
+                return false;
+            }
+            let len = in_list.list.len();
+            if len == 0 || len > MAX_PK_SELECTIVE_INLIST_VALUES {
+                return false;
+            }
+            in_list.list.iter().all(|item| extract_integer_literal(item).is_some())
+        }
+        Expr::Between(between) => {
+            if between.negated || !matches_column(&between.expr, pk_name) {
+                return false;
+            }
+            match (
+                extract_integer_literal(&between.low),
+                extract_integer_literal(&between.high),
+            ) {
+                (Some(lo), Some(hi)) => {
+                    let span = hi.checked_sub(lo).and_then(|d| d.checked_add(1));
+                    span.is_some_and(|span| span <= MAX_PK_SELECTIVE_RANGE_SPAN)
+                }
+                _ => false,
+            }
+        }
+        Expr::BinaryExpr(bin) if bin.op == Operator::And => {
+            pk_selective_in_or_range(&bin.left, pk_name)
+                || pk_selective_in_or_range(&bin.right, pk_name)
+        }
         _ => false,
     }
 }
@@ -14563,14 +14839,6 @@ impl TableProvider for CayenneTableProvider {
             })?;
         };
         let deletion_snapshot = deletion_snapshot.with_mem_tier_tombstones(&mem_tier_snapshot);
-        let inlined_batches = self
-            .inlined_batches_with_mem_tier_visibility(&inlined_view, &mem_tier_snapshot)
-            .map_err(|e| {
-                datafusion_common::DataFusionError::Execution(format!(
-                    "Failed to apply in-memory CDC tier tombstone visibility to inlined data for table {}: {e}",
-                    self.table_metadata.table_name
-                ))
-            })?;
         let need_pk_deletion = deletion_snapshot.has_deletions();
 
         // For PK-based deletion, we need to ensure PK columns are included in the projection
@@ -14651,7 +14919,17 @@ impl TableProvider for CayenneTableProvider {
         // row (two `i64` comparisons vs an N-element set probe). See
         // `pk_in_list_vs_range_rewrite` bench.
         let effective_filters = rewritten_scan_filters(filters, retention_keep_filter.as_ref());
-        let scan_filters: &[Expr] = effective_filters.as_ref().map_or(filters, Vec::as_slice);
+        let mut scan_filters_owned = effective_filters.unwrap_or_else(|| filters.to_vec());
+        if let Some(tombstone_filter) =
+            self.vortex_key_delete_pushdown_filter(&deletion_snapshot)
+        {
+            tracing::trace!(
+                table = %self.table_metadata.table_name,
+                "Injected sparse key-delete tombstone exclusion into Vortex scan filters"
+            );
+            scan_filters_owned.push(tombstone_filter);
+        }
+        let scan_filters: &[Expr] = &scan_filters_owned;
         if retention_keep_filter.is_some() {
             tracing::trace!(
                 table = %self.table_metadata.table_name,
@@ -14660,6 +14938,23 @@ impl TableProvider for CayenneTableProvider {
             );
         }
 
+        let segment_pruning_predicate = super::file_pruning::build_listing_pruning_predicate(
+            &self.table_metadata.schema,
+            scan_filters,
+        )?;
+        let inlined_batches = self
+            .pruned_inlined_batches(
+                &inlined_view,
+                &mem_tier_snapshot,
+                segment_pruning_predicate.as_ref(),
+            )
+            .map_err(|e| {
+                datafusion_common::DataFusionError::Execution(format!(
+                    "Failed to apply in-memory CDC tier tombstone visibility to inlined data for table {}: {e}",
+                    self.table_metadata.table_name
+                ))
+            })?;
+
         // For PK point lookups (e.g. `WHERE pk_col = K`), force the inner
         // `ListingTable` to use `target_partitions = 1` so DataFusion does NOT
         // byte-range-split the matching file across N file_groups. The fan-out
@@ -14667,7 +14962,7 @@ impl TableProvider for CayenneTableProvider {
         // up the lookup because only one chunk in one file_group actually
         // contains K. See `pk_lookup_file_group_fanout` bench.
         let scan_listing_config_override;
-        let scan_listing_config = if self.is_pk_point_lookup(scan_filters) {
+        let scan_listing_config = if self.is_pk_selective_scan(scan_filters) {
             scan_listing_config_override = state.config().clone().with_target_partitions(1);
             &scan_listing_config_override
         } else {
@@ -14771,7 +15066,11 @@ impl TableProvider for CayenneTableProvider {
         // uses; only the tombstone SOURCE differs — the in-RAM map vs the
         // metastore). `None` (and skipped) in file mode, where the tier is empty.
         let mem_plan: Option<Arc<dyn ExecutionPlan>> = self
-            .build_mem_tier_scan_plan(&mem_tier_snapshot, effective_projection.as_ref())?
+            .build_mem_tier_scan_plan(
+                &mem_tier_snapshot,
+                effective_projection.as_ref(),
+                segment_pruning_predicate.as_ref(),
+            )?
             .map(|mem_exec| self.wrap_memory_branch_with_scan_filters(mem_exec, filters));
 
         // Build the final plan:
@@ -14902,10 +15201,6 @@ impl TableProvider for CayenneTableProvider {
     }
 
     fn statistics(&self) -> Option<datafusion_common::Statistics> {
-        if self.pk_deletion_strategy.is_position_based() && self.has_pending_deletions() {
-            return None;
-        }
-
         // Prefer the metastore-persisted table statistics (loaded from Vortex
         // file footers) when present — they cover columns the ListingTable
         // does not expose synchronously without rescanning footers.
@@ -17816,14 +18111,16 @@ mod tests {
         let file_limit = Some(rows_per_file + 1);
 
         let direct_files = provider
-            .list_files_for_snapshot_scan(
-                &ctx.state(),
-                &table_url,
-                &options,
-                &[],
-                file_limit,
-                Arc::clone(&scan_schema),
-            )
+            .list_files_for_snapshot_scan(&SnapshotScanListingRequest {
+                state: &ctx.state(),
+                table_url: &table_url,
+                options: &options,
+                partition_filters: &[],
+                data_filters: &[],
+                snapshot_id: &snapshot_id,
+                limit: file_limit,
+                scan_schema: Arc::clone(&scan_schema),
+            })
             .await
             .expect("direct scan file listing should succeed");
         let listing_files = listing_table
@@ -19615,6 +19912,37 @@ mod tests {
     fn pk_range_rejected() {
         let expr = col("id").gt(lit_i64(42));
         assert!(!pk_column_equals_literal(&expr, "id"));
+    }
+
+    #[test]
+    fn pk_selective_small_inlist() {
+        let in_list = Expr::InList(datafusion_expr::expr::InList::new(
+            Box::new(col("id")),
+            vec![lit_i64(1), lit_i64(2), lit_i64(3)],
+            false,
+        ));
+        assert!(pk_selective_in_or_range(&in_list, "id"));
+    }
+
+    #[test]
+    fn pk_selective_large_inlist_rejected() {
+        let values: Vec<Expr> = (0..64).map(lit_i64).collect();
+        let in_list = Expr::InList(datafusion_expr::expr::InList::new(
+            Box::new(col("id")),
+            values,
+            false,
+        ));
+        assert!(!pk_selective_in_or_range(&in_list, "id"));
+    }
+
+    #[test]
+    fn pk_selective_tight_between() {
+        assert!(pk_selective_in_or_range(&between_int("id", 10, 20), "id"));
+    }
+
+    #[test]
+    fn pk_selective_wide_between_rejected() {
+        assert!(!pk_selective_in_or_range(&between_int("id", 1, 10_000), "id"));
     }
 
     #[test]

--- a/crates/cayenne/src/stats.rs
+++ b/crates/cayenne/src/stats.rs
@@ -242,6 +242,32 @@ pub fn file_statistics_to_df(file_stats: &FileStatistics, num_rows: i64) -> Stat
     }
 }
 
+/// Serialize `DataFusion` scan statistics to a persisted Vortex blob.
+///
+/// Returns `None` when any column cannot be converted or serialization fails.
+pub(crate) fn statistics_to_persisted_blob(stats: &Statistics, schema: &Schema) -> Option<Vec<u8>> {
+    if stats.column_statistics.len() != schema.fields().len() {
+        return None;
+    }
+    let column_stats: Vec<StatsSet> = stats
+        .column_statistics
+        .iter()
+        .map(column_stats_to_stats_set)
+        .collect();
+    let file_stats = build_file_statistics(column_stats, schema);
+    serialize_file_statistics(&file_stats).ok()
+}
+
+/// Restore `DataFusion` scan statistics from a persisted Vortex blob.
+pub(crate) fn statistics_from_persisted_blob(
+    blob: &[u8],
+    schema: &Schema,
+    num_rows: i64,
+) -> Option<Arc<Statistics>> {
+    let file_stats = deserialize_file_statistics(blob, schema).ok()?;
+    Some(Arc::new(file_statistics_to_df(&file_stats, num_rows)))
+}
+
 /// Serialize a Vortex [`FileStatistics`] to bytes.
 pub(crate) fn serialize_file_statistics(stats: &FileStatistics) -> VortexResult<Vec<u8>> {
     let fb = stats.write_flatbuffer_bytes()?;

--- a/crates/cayenne/tests/file_pruning_test.rs
+++ b/crates/cayenne/tests/file_pruning_test.rs
@@ -25,12 +25,18 @@ use std::sync::Arc;
 use arrow::array::Int64Array;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use cayenne::metadata::{CreateTableOptions, VortexConfig};
-use cayenne::CayenneTableProvider;
+use cayenne::metadata::{CdcDurability, CreateTableOptions, DeletionMode, VortexConfig};
+use cayenne::{CayenneTableProvider, MetadataCatalog, SlotAdvancer};
 use datafusion::datasource::TableProvider;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::prelude::*;
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
 
 test_with_backends!(test_listing_file_pruning_disjoint_id_ranges_impl);
+test_with_backends!(test_mem_tier_upsert_point_lookup_not_pruned_by_own_tombstone_impl);
 
 fn files_scanned_from_plan(plan: &str) -> Option<usize> {
     plan.lines().find_map(|line| {
@@ -39,6 +45,39 @@ fn files_scanned_from_plan(plan: &str) -> Option<usize> {
             .and_then(|part| part.split('=').nth(1))
             .and_then(|n| n.trim().parse().ok())
     })
+}
+
+fn batch_to_stream(batch: RecordBatch) -> SendableRecordBatchStream {
+    let schema = batch.schema();
+    Box::pin(RecordBatchStreamAdapter::new(
+        schema,
+        futures::stream::iter([Ok(batch)]),
+    ))
+}
+
+async fn collect_pairs(
+    ctx: &SessionContext,
+    sql: &str,
+) -> Result<Vec<(i64, i64)>, Box<dyn std::error::Error>> {
+    let batches = ctx.sql(sql).await?.collect().await?;
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("id column should be Int64");
+        let values = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("value column should be Int64");
+        for row in 0..batch.num_rows() {
+            rows.push((ids.value(row), values.value(row)));
+        }
+    }
+    rows.sort_unstable();
+    Ok(rows)
 }
 
 /// Writes two disjoint id ranges into separate Vortex files, then verifies that
@@ -136,7 +175,100 @@ async fn test_listing_file_pruning_disjoint_id_ranges_impl(
         .collect()
         .await?;
     let count: usize = rows.iter().map(RecordBatch::num_rows).sum();
-    assert_eq!(count, 1, "high-range point lookup must return exactly one row");
+    assert_eq!(
+        count, 1,
+        "high-range point lookup must return exactly one row"
+    );
+
+    Ok(())
+}
+
+/// Memory-mode upserts append replacement rows to the RAM tier and keep their
+/// tombstones in the same snapshot. The tombstone-derived scan filter can prune
+/// disk/inline data, but it must not be used to prune the RAM segment that holds
+/// the replacement row itself.
+async fn test_mem_tier_upsert_point_lookup_not_pruned_by_own_tombstone_impl(
+    fixture: common::TestFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+
+    let table_options = CreateTableOptions {
+        table_name: "mem_tier_pruning".to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec!["id".to_string()],
+        on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+            "id".to_string(),
+        ]))),
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: VortexConfig {
+            cdc_durability: CdcDurability::Memory,
+            deletion_mode: DeletionMode::Key,
+            ..VortexConfig::default()
+        },
+    };
+
+    let ctx = SessionContext::new();
+    let catalog: Arc<dyn MetadataCatalog> = fixture.catalog.clone();
+    let provider = Arc::new(
+        CayenneTableProvider::create_table(catalog, table_options, ctx.runtime_env()).await?,
+    );
+    ctx.register_table(
+        "mem_tier_pruning",
+        Arc::clone(&provider) as Arc<dyn TableProvider>,
+    )?;
+
+    common::insert_batch(
+        provider.as_ref(),
+        RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![42])),
+                Arc::new(Int64Array::from(vec![1])),
+            ],
+        )?,
+    )
+    .await?;
+
+    struct TestAdvancer;
+    #[async_trait::async_trait]
+    impl SlotAdvancer for TestAdvancer {
+        async fn on_checkpoint_durable(&self, _durable_epoch: u64) {}
+    }
+    provider.install_slot_advancer(Arc::new(TestAdvancer));
+
+    let replacement = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![42])),
+            Arc::new(Int64Array::from(vec![2])),
+        ],
+    )?;
+    let write = provider
+        .write_cdc_append_stream(batch_to_stream(replacement), &ctx.task_ctx())
+        .await?;
+    assert_eq!(
+        write.in_memory_epoch(),
+        Some(1),
+        "precondition: replacement row must be published through the RAM tier"
+    );
+
+    let rows = collect_pairs(&ctx, "SELECT id, value FROM mem_tier_pruning WHERE id = 42").await?;
+    assert_eq!(
+        rows,
+        vec![(42, 2)],
+        "point lookup must keep the RAM-tier replacement row above its own tombstone"
+    );
+
+    let rows = collect_pairs(&ctx, "SELECT id, value FROM mem_tier_pruning").await?;
+    assert_eq!(
+        rows,
+        vec![(42, 2)],
+        "full scan must hide the old row and keep the RAM-tier replacement"
+    );
 
     Ok(())
 }

--- a/crates/cayenne/tests/file_pruning_test.rs
+++ b/crates/cayenne/tests/file_pruning_test.rs
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::expect_used)]
+
+//! Integration tests for listing-time Vortex file pruning and correctness.
+
+mod common;
+
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use cayenne::metadata::{CreateTableOptions, VortexConfig};
+use cayenne::CayenneTableProvider;
+use datafusion::datasource::TableProvider;
+use datafusion::prelude::*;
+
+test_with_backends!(test_listing_file_pruning_disjoint_id_ranges_impl);
+
+fn files_scanned_from_plan(plan: &str) -> Option<usize> {
+    plan.lines().find_map(|line| {
+        line.split(',')
+            .find(|part| part.trim().starts_with("files_scanned="))
+            .and_then(|part| part.split('=').nth(1))
+            .and_then(|n| n.trim().parse().ok())
+    })
+}
+
+/// Writes two disjoint id ranges into separate Vortex files, then verifies that
+/// a point lookup on one range prunes files from the other range at listing time.
+async fn test_listing_file_pruning_disjoint_id_ranges_impl(
+    fixture: common::TestFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+
+    let table_options = CreateTableOptions {
+        table_name: "file_pruning_table".to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec![],
+        on_conflict: None,
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: VortexConfig {
+            sort_columns: vec!["id".to_string()],
+            target_vortex_file_size_mb: 1,
+            ..VortexConfig::default()
+        },
+    };
+
+    let ctx = SessionContext::new();
+    let provider = Arc::new(
+        CayenneTableProvider::create_table(
+            fixture.catalog.clone(),
+            table_options,
+            ctx.runtime_env(),
+        )
+        .await?,
+    );
+    ctx.register_table(
+        "file_pruning_table",
+        Arc::clone(&provider) as Arc<dyn TableProvider>,
+    )?;
+
+    // Two large appends (> INLINE_MAX_ROWS) with disjoint id ranges so each
+    // lands in its own Vortex file(s) with non-overlapping min/max on `id`.
+    let low_ids: Vec<i64> = (0..2_000).collect();
+    let high_ids: Vec<i64> = (10_000..12_000).collect();
+    for ids in [low_ids, high_ids] {
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(ids.clone())),
+                Arc::new(Int64Array::from(ids)),
+            ],
+        )?;
+        common::insert_batch(provider.as_ref(), batch).await?;
+    }
+
+    let unfiltered = ctx
+        .sql("SELECT id FROM file_pruning_table")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let unfiltered_plan = datafusion::physical_plan::displayable(unfiltered.as_ref())
+        .indent(true)
+        .to_string();
+    let unfiltered_files = files_scanned_from_plan(&unfiltered_plan).unwrap_or(0);
+    assert!(
+        unfiltered_files >= 2,
+        "expected at least two Vortex files, got {unfiltered_files} in plan:\n{unfiltered_plan}"
+    );
+
+    let filtered = ctx
+        .sql("SELECT id FROM file_pruning_table WHERE id = 42")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let filtered_plan = datafusion::physical_plan::displayable(filtered.as_ref())
+        .indent(true)
+        .to_string();
+    let filtered_files = files_scanned_from_plan(&filtered_plan).unwrap_or(0);
+    assert!(
+        filtered_files < unfiltered_files,
+        "listing-time pruning should drop disjoint files: unfiltered={unfiltered_files} filtered={filtered_files}\n{filtered_plan}"
+    );
+
+    let rows = ctx
+        .sql("SELECT id FROM file_pruning_table WHERE id = 42")
+        .await?
+        .collect()
+        .await?;
+    let count: usize = rows.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(count, 1, "point lookup must return exactly one row");
+
+    let rows = ctx
+        .sql("SELECT id FROM file_pruning_table WHERE id = 11000")
+        .await?
+        .collect()
+        .await?;
+    let count: usize = rows.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(count, 1, "high-range point lookup must return exactly one row");
+
+    Ok(())
+}

--- a/crates/cayenne/tests/position_mode_upsert_test.rs
+++ b/crates/cayenne/tests/position_mode_upsert_test.rs
@@ -105,6 +105,24 @@ async fn test_position_mode_composite_pk_upsert_impl(
         .collect()
         .await?;
 
+    let plan = ctx
+        .sql("SELECT w_id, o_id, amount FROM pos_upsert WHERE w_id = 1")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let plan = datafusion::physical_plan::displayable(plan.as_ref())
+        .indent(true)
+        .to_string();
+    let has_direct_current_snapshot_scan =
+        plan.lines().collect::<Vec<_>>().windows(2).any(|lines| {
+            lines[0].contains("CayenneAccelerationExec: snapshots_scanned=1")
+                && lines[1].contains("DataSourceExec")
+        });
+    assert!(
+        has_direct_current_snapshot_scan,
+        "position-mode upsert must keep the current-snapshot Vortex scan on the direct position-delete path:\n{plan}"
+    );
+
     let batches = ctx
         .sql("SELECT w_id, o_id, amount FROM pos_upsert ORDER BY w_id, o_id")
         .await?


### PR DESCRIPTION
Stacked on #11118 (`lukim/vortex`).

Implements the Cayenne Vortex audit priorities 1–6 for multi-file CDC workloads: prune earlier, persist stronger bounds, and push sparse tombstones into the scan layer.

## Changes

### 1. Listing-time file pruning
Drop non-overlapping `.vortex` files during `list_files_for_snapshot_scan` using footer/batch min/max + data-column filters, before `DataSourceExec` is built.

### 2. Metastore per-file statistics
New `cayenne_snapshot_file_statistics` table and catalog APIs. Listing reuses persisted per-file stats (matched by `file_size_bytes`) instead of re-reading footers on every scan.

### 3. Inline / RAM tier segment pruning
Per-segment min/max statistics on inline memtable entries and `MemTier` segments; skip whole segments when predicates are provably disjoint (conservative pre-tombstone bounds).

### 4. Broader PK selective-scan heuristics
Extend `target_partitions = 1` beyond point equality to single-column Int64 PK `IN` lists (≤32) and tight `BETWEEN` spans (≤32).

### 5. Stats freshness during CDC deletes
`TableProvider::statistics()` no longer returns `None` for position-based tables with pending deletions; serves cached `optimizer_inexact` stats so join reordering stays usable.

### 6. Key-delete Vortex pushdown
For sparse Int64 tombstone sets (≤256 keys), inject `pk NOT IN (...)` into Vortex scan filters so chunk pruning and listing-time file prune apply before the deletion filter exec (upsert re-inserts excluded).

## Files

- `crates/cayenne/src/provider/file_pruning.rs` (new)
- `crates/cayenne/tests/file_pruning_test.rs` (new)
- `table.rs`, `stats.rs`, `mem_tier.rs`, metastore/catalog/metadata wiring

## Validation

```bash
cargo check -p cayenne
cargo test -p cayenne --lib file_pruning pk_selective tombstone_exclusion
cargo test -p cayenne --test file_pruning_test
```

## Correctness

Pruning only drops files/segments when statistics prove the predicate cannot match. Uncertainty keeps the container. Tombstone `NOT IN` pushdown only includes keys guaranteed hidden under upsert semantics.