### PR TITLE
Improve Cayenne adaptive tuning and schema safety

### DIFF
--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -128,15 +128,12 @@ impl CayenneContext {
             write_concurrency: wc_init,
         }));
         // Bounds keep the controller within sane, memory-/cpu-safe ranges. The
-        // memtable may grow up to 4× the static value (ingest-lag relief) but
-        // never past 256 MiB (the largest static memory ceiling); concurrency is
-        // capped at the core count (the global encode budget caps the aggregate).
-        let min_flush_bytes: i64 = 2 * 1024 * 1024;
-        let max_flush_bytes = config
-            .inline_flush_max_bytes
-            .max(min_flush_bytes)
-            .saturating_mul(4)
-            .clamp(min_flush_bytes, 256 * 1024 * 1024);
+        // memtable ceiling is derived from the runtime-installed memory budget so
+        // adaptive can use more RAM on large hosts while still shrinking first
+        // under observed memory pressure; concurrency is capped at the core count
+        // (the global encode budget caps the aggregate).
+        let inline_flush_bounds =
+            tuning::adaptive_inline_flush_bounds(config.inline_flush_max_bytes);
         // A pinned (operator-set) knob's bounds collapse to a single point so the
         // controller can never move it — that is how an explicit per-value
         // override is respected even in `adaptive` mode (`decide()` finds no room
@@ -146,7 +143,7 @@ impl CayenneContext {
             inline_flush_max_bytes: if pins.inline_flush {
                 (config.inline_flush_max_bytes, config.inline_flush_max_bytes)
             } else {
-                (min_flush_bytes, max_flush_bytes)
+                inline_flush_bounds
             },
             compaction_background_interval_ms: if pins.compaction_interval {
                 (

--- a/crates/cayenne/src/provider/tuning.rs
+++ b/crates/cayenne/src/provider/tuning.rs
@@ -47,10 +47,9 @@ limitations under the License.
 //! [`LiveKnobs`] at the use sites, running [`decide`] on the per-table
 //! background task) lives in the provider.
 
-use std::sync::{
-    OnceLock,
-    atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering},
-};
+#[cfg(target_os = "linux")]
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use parking_lot::Mutex;

--- a/crates/cayenne/src/provider/tuning.rs
+++ b/crates/cayenne/src/provider/tuning.rs
@@ -90,6 +90,21 @@ const MEM_PRESSURE_HIGH: f64 = 0.85;
 /// [`MEM_PRESSURE_HIGH`] avoids grow/shrink flapping near the limit.
 const MEM_PRESSURE_OK: f64 = 0.75;
 
+const MIB: i64 = 1024 * 1024;
+
+/// Minimum live inline-memtable budget the adaptive loop may target.
+const INLINE_FLUSH_MIN_BYTES: i64 = 2 * MIB;
+
+/// Historical fallback ceiling when the runtime has not installed a memory budget.
+const INLINE_FLUSH_FALLBACK_MAX_BYTES: i64 = 256 * MIB;
+
+/// Absolute per-table ceiling when memory is known. This keeps adaptive from
+/// turning a memory-rich host into one giant inlined snapshot, while still giving
+/// it more room than the static warm start on SF-scale ingest.
+const INLINE_FLUSH_ADAPTIVE_MAX_BYTES: i64 = 1024 * MIB;
+
+const INLINE_FLUSH_BUDGET_FRACTION: u64 = 32;
+
 // ---------------------------------------------------------------------------
 // Environment detection: process memory budget + cgroup-aware usage
 // ---------------------------------------------------------------------------
@@ -114,23 +129,181 @@ fn global_memory_budget() -> Option<u64> {
     }
 }
 
+/// Compute the dynamic inline-memtable movement bounds for the table's static
+/// warm-start value. The adaptive ceiling is intentionally memory-budgeted rather
+/// than fixed: on memory-rich hosts the controller can grow far enough to reduce
+/// small-file churn; under pressure, the memory rule still shrinks first.
+#[must_use]
+pub(crate) fn adaptive_inline_flush_bounds(initial_bytes: i64) -> (i64, i64) {
+    adaptive_inline_flush_bounds_for_budget(initial_bytes, global_memory_budget())
+}
+
+fn adaptive_inline_flush_bounds_for_budget(
+    initial_bytes: i64,
+    memory_budget: Option<u64>,
+) -> (i64, i64) {
+    let initial = initial_bytes.max(INLINE_FLUSH_MIN_BYTES);
+    let fallback_ceiling = initial
+        .saturating_mul(4)
+        .clamp(INLINE_FLUSH_MIN_BYTES, INLINE_FLUSH_FALLBACK_MAX_BYTES);
+
+    let ceiling = memory_budget.map_or(fallback_ceiling, |budget| {
+        let budget_ceiling = budget
+            .checked_div(INLINE_FLUSH_BUDGET_FRACTION)
+            .and_then(|bytes| i64::try_from(bytes).ok())
+            .unwrap_or(i64::MAX)
+            .clamp(INLINE_FLUSH_MIN_BYTES, INLINE_FLUSH_ADAPTIVE_MAX_BYTES);
+        initial
+            .saturating_mul(8)
+            .min(budget_ceiling)
+            .max(fallback_ceiling.min(budget_ceiling))
+    });
+
+    // Keep the upper bound at least at the warm start. If the process is already
+    // over budget, the memory-pressure branch will make an explicit shrink move;
+    // a behind/read-amp growth rule must never accidentally shrink because the
+    // ceiling was below the current value.
+    (INLINE_FLUSH_MIN_BYTES, ceiling.max(initial))
+}
+
 /// Current process/cgroup memory usage in bytes — cgroup v2 (`memory.current`)
 /// then v1 (`memory.usage_in_bytes`); `None` when unavailable. This is the
 /// "detect the environment and adjust" read that closes the loop on memory.
 #[cfg(target_os = "linux")]
 fn current_memory_bytes() -> Option<u64> {
-    use std::fs;
-    for path in [
-        "/sys/fs/cgroup/memory.current",
-        "/sys/fs/cgroup/memory/memory.usage_in_bytes",
-    ] {
-        if let Ok(s) = fs::read_to_string(path)
-            && let Ok(v) = s.trim().parse::<u64>()
-        {
-            return Some(v);
-        }
+    cgroup_v2_memory_current()
+        .or_else(cgroup_v1_memory_current)
+        .or_else(proc_self_rss_bytes)
+}
+
+#[cfg(target_os = "linux")]
+fn cgroup_v2_memory_current() -> Option<u64> {
+    let cgroup_path = process_cgroup_v2_path()?;
+    let mountpoint = cgroup2_mountpoint().unwrap_or_else(|| "/sys/fs/cgroup".to_string());
+    read_u64_file(&cgroup_file_path(
+        &mountpoint,
+        &cgroup_path,
+        "memory.current",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn cgroup_v1_memory_current() -> Option<u64> {
+    let cgroup_path = process_cgroup_v1_path("memory")?;
+    let mountpoint =
+        cgroup_v1_mountpoint("memory").unwrap_or_else(|| "/sys/fs/cgroup/memory".to_string());
+    read_u64_file(&cgroup_file_path(
+        &mountpoint,
+        &cgroup_path,
+        "memory.usage_in_bytes",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn read_u64_file(path: &str) -> Option<u64> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+#[cfg(target_os = "linux")]
+fn cgroup_file_path(mountpoint: &str, cgroup_path: &str, filename: &str) -> String {
+    if cgroup_path == "/" || cgroup_path.is_empty() {
+        format!("{mountpoint}/{filename}")
+    } else {
+        format!("{mountpoint}{cgroup_path}/{filename}")
     }
-    None
+}
+
+#[cfg(target_os = "linux")]
+fn process_cgroup_v2_path() -> Option<String> {
+    parse_proc_cgroup_v2_path(&std::fs::read_to_string("/proc/self/cgroup").ok()?)
+}
+
+#[cfg(target_os = "linux")]
+fn process_cgroup_v1_path(controller: &str) -> Option<String> {
+    parse_proc_cgroup_v1_path(
+        &std::fs::read_to_string("/proc/self/cgroup").ok()?,
+        controller,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_cgroup_v2_path(contents: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        line.strip_prefix("0::").map(|path| {
+            let trimmed = path.trim();
+            if trimmed.is_empty() {
+                "/".to_string()
+            } else {
+                trimmed.to_string()
+            }
+        })
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_cgroup_v1_path(contents: &str, controller: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let mut parts = line.splitn(3, ':');
+        let _hierarchy = parts.next()?;
+        let controllers = parts.next()?;
+        let path = parts.next()?.trim();
+        controllers.split(',').any(|c| c == controller).then(|| {
+            if path.is_empty() {
+                "/".to_string()
+            } else {
+                path.to_string()
+            }
+        })
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn cgroup2_mountpoint() -> Option<String> {
+    parse_mountinfo_cgroup2(&std::fs::read_to_string("/proc/self/mountinfo").ok()?)
+}
+
+#[cfg(target_os = "linux")]
+fn cgroup_v1_mountpoint(controller: &str) -> Option<String> {
+    parse_mountinfo_cgroup_v1(
+        &std::fs::read_to_string("/proc/self/mountinfo").ok()?,
+        controller,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn parse_mountinfo_cgroup2(contents: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let (mount, fs) = line.split_once(" - ")?;
+        (fs.split_whitespace().next()? == "cgroup2")
+            .then(|| mount.split_whitespace().nth(4).map(ToString::to_string))?
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_mountinfo_cgroup_v1(contents: &str, controller: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let (mount, fs) = line.split_once(" - ")?;
+        let mut fs_parts = fs.split_whitespace();
+        if fs_parts.next()? != "cgroup" {
+            return None;
+        }
+        let _source = fs_parts.next()?;
+        let super_options = fs_parts.next()?;
+        super_options
+            .split(',')
+            .any(|opt| opt == controller)
+            .then(|| mount.split_whitespace().nth(4).map(ToString::to_string))?
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn proc_self_rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    status.lines().find_map(|line| {
+        let rest = line.strip_prefix("VmRSS:")?.trim();
+        let kb = rest.split_whitespace().next()?.parse::<u64>().ok()?;
+        kb.checked_mul(1024)
+    })
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -1142,5 +1315,52 @@ mod tests {
         // Rows track the inferred 256 B/row ratio (65536), NOT the 1 KiB fallback.
         assert_eq!(v.inline_flush_max_rows, 16 * 1024 * 1024 / 256);
         assert_ne!(v.inline_flush_max_rows, 16 * 1024 * 1024 / 1024);
+    }
+
+    #[test]
+    fn adaptive_inline_flush_ceiling_uses_memory_budget() {
+        let gib = 1024_u64 * 1024 * 1024;
+        let initial = 128 * MIB;
+
+        assert_eq!(
+            adaptive_inline_flush_bounds_for_budget(initial, None),
+            (INLINE_FLUSH_MIN_BYTES, INLINE_FLUSH_FALLBACK_MAX_BYTES)
+        );
+        assert_eq!(
+            adaptive_inline_flush_bounds_for_budget(initial, Some(64 * gib)),
+            (INLINE_FLUSH_MIN_BYTES, INLINE_FLUSH_ADAPTIVE_MAX_BYTES)
+        );
+        assert_eq!(
+            adaptive_inline_flush_bounds_for_budget(8 * MIB, Some(64 * gib)),
+            (INLINE_FLUSH_MIN_BYTES, 64 * MIB)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_cgroup_paths_and_mounts() {
+        assert_eq!(
+            parse_proc_cgroup_v2_path("0::/kubepods.slice/pod123\n"),
+            Some("/kubepods.slice/pod123".to_string())
+        );
+        assert_eq!(
+            parse_proc_cgroup_v1_path("7:cpu,cpuacct:/x\n8:memory:/mem\n", "memory"),
+            Some("/mem".to_string())
+        );
+        assert_eq!(
+            parse_mountinfo_cgroup2("29 28 0:25 / /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"),
+            Some("/sys/fs/cgroup".to_string())
+        );
+        assert_eq!(
+            parse_mountinfo_cgroup_v1(
+                "32 29 0:28 / /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n",
+                "memory"
+            ),
+            Some("/sys/fs/cgroup/memory".to_string())
+        );
+        assert_eq!(
+            cgroup_file_path("/sys/fs/cgroup", "/", "memory.current"),
+            "/sys/fs/cgroup/memory.current"
+        );
     }
 }

--- a/crates/cayenne/src/provider/tuning.rs
+++ b/crates/cayenne/src/provider/tuning.rs
@@ -47,7 +47,10 @@ limitations under the License.
 //! [`LiveKnobs`] at the use sites, running [`decide`] on the per-table
 //! background task) lives in the provider.
 
-use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering},
+};
 use std::time::Duration;
 
 use parking_lot::Mutex;
@@ -115,6 +118,12 @@ const INLINE_FLUSH_BUDGET_FRACTION: u64 = 32;
 /// without the memory rule. Process-wide because RAM is shared across tables.
 static GLOBAL_MEMORY_BUDGET: AtomicU64 = AtomicU64::new(0);
 
+#[cfg(target_os = "linux")]
+static CGROUP_V2_MEMORY_CURRENT_PATH: OnceLock<Option<String>> = OnceLock::new();
+
+#[cfg(target_os = "linux")]
+static CGROUP_V1_MEMORY_USAGE_PATH: OnceLock<Option<String>> = OnceLock::new();
+
 /// Install the process memory budget (cgroup-aware total) the dynamic tuner uses
 /// to compute memory pressure. Called once at startup by the runtime, mirroring
 /// the encode-concurrency budget.
@@ -178,9 +187,27 @@ fn current_memory_bytes() -> Option<u64> {
 
 #[cfg(target_os = "linux")]
 fn cgroup_v2_memory_current() -> Option<u64> {
+    read_u64_file(
+        CGROUP_V2_MEMORY_CURRENT_PATH
+            .get_or_init(resolve_cgroup_v2_memory_current_path)
+            .as_deref()?,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn cgroup_v1_memory_current() -> Option<u64> {
+    read_u64_file(
+        CGROUP_V1_MEMORY_USAGE_PATH
+            .get_or_init(resolve_cgroup_v1_memory_usage_path)
+            .as_deref()?,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_cgroup_v2_memory_current_path() -> Option<String> {
     let cgroup_path = process_cgroup_v2_path()?;
     let mountpoint = cgroup2_mountpoint().unwrap_or_else(|| "/sys/fs/cgroup".to_string());
-    read_u64_file(&cgroup_file_path(
+    Some(cgroup_file_path(
         &mountpoint,
         &cgroup_path,
         "memory.current",
@@ -188,11 +215,11 @@ fn cgroup_v2_memory_current() -> Option<u64> {
 }
 
 #[cfg(target_os = "linux")]
-fn cgroup_v1_memory_current() -> Option<u64> {
+fn resolve_cgroup_v1_memory_usage_path() -> Option<String> {
     let cgroup_path = process_cgroup_v1_path("memory")?;
     let mountpoint =
         cgroup_v1_mountpoint("memory").unwrap_or_else(|| "/sys/fs/cgroup/memory".to_string());
-    read_u64_file(&cgroup_file_path(
+    Some(cgroup_file_path(
         &mountpoint,
         &cgroup_path,
         "memory.usage_in_bytes",

--- a/crates/cayenne/src/schema.rs
+++ b/crates/cayenne/src/schema.rs
@@ -203,10 +203,6 @@ fn handle_unsupported_type(
             );
             Some(DataType::Utf8)
         }
-        (true, UnsupportedTypeAction::Error) => {
-            unsupported_fields.push(unsupported_field_detail(path, data_type));
-            Some(data_type.clone())
-        }
         (true, UnsupportedTypeAction::Ignore) => {
             tracing::warn!(
                 "Ignoring unsupported type {:?} for field '{}'",
@@ -223,7 +219,7 @@ fn handle_unsupported_type(
             );
             Some(data_type.clone())
         }
-        (false, _) => {
+        (true, UnsupportedTypeAction::Error) | (false, _) => {
             unsupported_fields.push(unsupported_field_detail(path, data_type));
             Some(data_type.clone())
         }

--- a/crates/cayenne/src/schema.rs
+++ b/crates/cayenne/src/schema.rs
@@ -127,7 +127,12 @@ fn transform_data_type_for_vortex(
             unsupported_fields,
         ))),
         DataType::Map(field, sorted) => Some(DataType::Map(
-            transform_nested_field(field, path, unsupported_type_action, unsupported_fields),
+            transform_nested_field(
+                field,
+                &format!("{path}.{}", field.name()),
+                unsupported_type_action,
+                unsupported_fields,
+            ),
             *sorted,
         )),
         DataType::Struct(fields) => {
@@ -165,7 +170,12 @@ fn transform_data_type_for_vortex(
         )),
         DataType::RunEndEncoded(run_ends, values) => Some(DataType::RunEndEncoded(
             Arc::clone(run_ends),
-            transform_nested_field(values, path, unsupported_type_action, unsupported_fields),
+            transform_nested_field(
+                values,
+                &format!("{path}.{}", values.name()),
+                unsupported_type_action,
+                unsupported_fields,
+            ),
         )),
         _ => Some(data_type.clone()),
     }
@@ -460,5 +470,67 @@ mod tests {
         let out = transform_schema_for_vortex(&schema, UnsupportedTypeAction::Error)
             .expect("map with supported children should be preserved");
         assert_eq!(out, schema);
+    }
+
+    #[test]
+    fn map_nested_unsupported_type_errors_with_entries_path() {
+        let schema = Schema::new(vec![Field::new(
+            "headers",
+            DataType::Map(
+                Arc::new(Field::new_struct(
+                    "entries",
+                    vec![
+                        Arc::new(Field::new("keys", DataType::Utf8, false)),
+                        Arc::new(Field::new(
+                            "values",
+                            DataType::Duration(TimeUnit::Second),
+                            true,
+                        )),
+                    ],
+                    false,
+                )),
+                false,
+            ),
+            true,
+        )]);
+
+        let err = transform_schema_for_vortex(&schema, UnsupportedTypeAction::Error)
+            .expect_err("nested map values duration should be unsupported");
+        let message = err.to_string();
+        assert!(
+            message.contains("headers.entries.values"),
+            "error should include map entries field path, got: {message}"
+        );
+    }
+
+    #[test]
+    fn run_end_encoded_nested_unsupported_type_errors_with_values_path() {
+        let schema = Schema::new(vec![Field::new(
+            "encoded",
+            DataType::RunEndEncoded(
+                Arc::new(Field::new("run_ends", DataType::Int32, false)),
+                Arc::new(Field::new(
+                    "values",
+                    DataType::Struct(
+                        vec![Field::new(
+                            "duration",
+                            DataType::Duration(TimeUnit::Second),
+                            true,
+                        )]
+                        .into(),
+                    ),
+                    true,
+                )),
+            ),
+            true,
+        )]);
+
+        let err = transform_schema_for_vortex(&schema, UnsupportedTypeAction::Error)
+            .expect_err("nested run-end encoded values duration should be unsupported");
+        let message = err.to_string();
+        assert!(
+            message.contains("encoded.values.duration"),
+            "error should include run-end encoded values field path, got: {message}"
+        );
     }
 }

--- a/crates/cayenne/src/schema.rs
+++ b/crates/cayenne/src/schema.rs
@@ -16,7 +16,9 @@ limitations under the License.
 
 //! Arrow schema transformations for Vortex compatibility.
 
-use arrow::datatypes::{DataType, Schema, TimeUnit};
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion_table_providers::UnsupportedTypeAction;
 
@@ -27,6 +29,207 @@ fn is_vortex_supported_type(data_type: &DataType) -> bool {
     )
 }
 
+fn unsupported_field_detail(path: &str, data_type: &DataType) -> String {
+    format!("'{path}' (type: {data_type:?})")
+}
+
+fn transform_field_for_vortex(
+    field: &Field,
+    path: &str,
+    unsupported_type_action: UnsupportedTypeAction,
+    top_level: bool,
+    unsupported_fields: &mut Vec<String>,
+) -> Option<Arc<Field>> {
+    let data_type = transform_data_type_for_vortex(
+        field.data_type(),
+        path,
+        unsupported_type_action,
+        top_level,
+        unsupported_fields,
+    )?;
+    Some(Arc::new(field.clone().with_data_type(data_type)))
+}
+
+fn transform_data_type_for_vortex(
+    data_type: &DataType,
+    path: &str,
+    unsupported_type_action: UnsupportedTypeAction,
+    top_level: bool,
+    unsupported_fields: &mut Vec<String>,
+) -> Option<DataType> {
+    if matches!(data_type, DataType::Float16) {
+        tracing::debug!("Converting Float16 field '{path}' to Float32 for Vortex compatibility");
+        return Some(DataType::Float32);
+    }
+
+    if let DataType::Timestamp(unit, tz) = data_type
+        && !matches!(unit, TimeUnit::Microsecond)
+    {
+        tracing::debug!(
+            "Converting timestamp field '{path}' from {:?} to Microsecond for Vortex compatibility",
+            unit
+        );
+        return Some(DataType::Timestamp(TimeUnit::Microsecond, tz.clone()));
+    }
+
+    if !is_vortex_supported_type(data_type) {
+        return handle_unsupported_type(
+            data_type,
+            path,
+            unsupported_type_action,
+            top_level,
+            unsupported_fields,
+        );
+    }
+
+    match data_type {
+        DataType::Dictionary(key_type, value_type) => {
+            let value_type = transform_data_type_for_vortex(
+                value_type,
+                path,
+                unsupported_type_action,
+                false,
+                unsupported_fields,
+            )?;
+            Some(DataType::Dictionary(key_type.clone(), Box::new(value_type)))
+        }
+        DataType::List(field) => Some(DataType::List(transform_nested_field(
+            field,
+            &format!("{path}[]"),
+            unsupported_type_action,
+            unsupported_fields,
+        ))),
+        DataType::LargeList(field) => Some(DataType::LargeList(transform_nested_field(
+            field,
+            &format!("{path}[]"),
+            unsupported_type_action,
+            unsupported_fields,
+        ))),
+        DataType::FixedSizeList(field, size) => Some(DataType::FixedSizeList(
+            transform_nested_field(
+                field,
+                &format!("{path}[]"),
+                unsupported_type_action,
+                unsupported_fields,
+            ),
+            *size,
+        )),
+        DataType::ListView(field) => Some(DataType::ListView(transform_nested_field(
+            field,
+            &format!("{path}[]"),
+            unsupported_type_action,
+            unsupported_fields,
+        ))),
+        DataType::LargeListView(field) => Some(DataType::LargeListView(transform_nested_field(
+            field,
+            &format!("{path}[]"),
+            unsupported_type_action,
+            unsupported_fields,
+        ))),
+        DataType::Map(field, sorted) => Some(DataType::Map(
+            transform_nested_field(field, path, unsupported_type_action, unsupported_fields),
+            *sorted,
+        )),
+        DataType::Struct(fields) => {
+            let fields: Vec<Field> = fields
+                .iter()
+                .map(|field| {
+                    transform_nested_field(
+                        field,
+                        &format!("{path}.{}", field.name()),
+                        unsupported_type_action,
+                        unsupported_fields,
+                    )
+                    .as_ref()
+                    .clone()
+                })
+                .collect();
+            Some(DataType::Struct(fields.into()))
+        }
+        DataType::Union(fields, mode) => Some(DataType::Union(
+            fields
+                .iter()
+                .map(|(type_id, field)| {
+                    (
+                        type_id,
+                        transform_nested_field(
+                            field,
+                            &format!("{path}.{}", field.name()),
+                            unsupported_type_action,
+                            unsupported_fields,
+                        ),
+                    )
+                })
+                .collect(),
+            *mode,
+        )),
+        DataType::RunEndEncoded(run_ends, values) => Some(DataType::RunEndEncoded(
+            Arc::clone(run_ends),
+            transform_nested_field(values, path, unsupported_type_action, unsupported_fields),
+        )),
+        _ => Some(data_type.clone()),
+    }
+}
+
+fn transform_nested_field(
+    field: &Arc<Field>,
+    path: &str,
+    unsupported_type_action: UnsupportedTypeAction,
+    unsupported_fields: &mut Vec<String>,
+) -> Arc<Field> {
+    transform_field_for_vortex(
+        field,
+        path,
+        unsupported_type_action,
+        false,
+        unsupported_fields,
+    )
+    .unwrap_or_else(|| Arc::clone(field))
+}
+
+fn handle_unsupported_type(
+    data_type: &DataType,
+    path: &str,
+    unsupported_type_action: UnsupportedTypeAction,
+    top_level: bool,
+    unsupported_fields: &mut Vec<String>,
+) -> Option<DataType> {
+    match (top_level, unsupported_type_action) {
+        (true, UnsupportedTypeAction::String) => {
+            tracing::warn!(
+                "Converting unsupported type {:?} for field '{}' to Utf8.",
+                data_type,
+                path
+            );
+            Some(DataType::Utf8)
+        }
+        (true, UnsupportedTypeAction::Error) => {
+            unsupported_fields.push(unsupported_field_detail(path, data_type));
+            Some(data_type.clone())
+        }
+        (true, UnsupportedTypeAction::Ignore) => {
+            tracing::warn!(
+                "Ignoring unsupported type {:?} for field '{}'",
+                data_type,
+                path
+            );
+            None
+        }
+        (_, UnsupportedTypeAction::Warn) => {
+            tracing::warn!(
+                "Including unsupported type {:?} for field '{}' - insertion may fail",
+                data_type,
+                path
+            );
+            Some(data_type.clone())
+        }
+        (false, _) => {
+            unsupported_fields.push(unsupported_field_detail(path, data_type));
+            Some(data_type.clone())
+        }
+    }
+}
+
 /// Transform an Arrow schema for Vortex compatibility.
 ///
 /// Always applies:
@@ -34,7 +237,9 @@ fn is_vortex_supported_type(data_type: &DataType) -> bool {
 /// - Non-microsecond `Timestamp` → `Timestamp(Microsecond, tz)`
 ///
 /// Truly unsupported types (`Interval`, `Duration`, `FixedSizeBinary`) are
-/// handled according to `unsupported_type_action`.
+/// handled according to `unsupported_type_action` at the top level. Nested
+/// unsupported types error unless the action is `warn`, because schema-only
+/// string conversion or field removal would not preserve nested data correctly.
 ///
 /// # Errors
 ///
@@ -48,77 +253,22 @@ pub fn transform_schema_for_vortex(
     let mut transformed_fields = Vec::new();
 
     for field in schema.fields() {
-        let data_type = field.data_type();
-
-        if matches!(data_type, DataType::Float16) {
-            tracing::debug!(
-                "Converting Float16 field '{}' to Float32 for Vortex compatibility",
-                field.name()
-            );
-            transformed_fields.push(std::sync::Arc::new(
-                field.as_ref().clone().with_data_type(DataType::Float32),
-            ));
-            continue;
-        }
-
-        if let DataType::Timestamp(unit, tz) = data_type
-            && !matches!(unit, TimeUnit::Microsecond)
-        {
-            tracing::debug!(
-                "Converting timestamp field '{}' from {:?} to Microsecond for Vortex compatibility",
-                field.name(),
-                unit
-            );
-            transformed_fields.push(std::sync::Arc::new(
-                field
-                    .as_ref()
-                    .clone()
-                    .with_data_type(DataType::Timestamp(TimeUnit::Microsecond, tz.clone())),
-            ));
-            continue;
-        }
-
-        if is_vortex_supported_type(data_type) {
-            transformed_fields.push(std::sync::Arc::clone(field));
-        } else {
-            match unsupported_type_action {
-                UnsupportedTypeAction::String => {
-                    tracing::warn!(
-                        "Converting unsupported type {:?} for field '{}' to Utf8.",
-                        data_type,
-                        field.name()
-                    );
-                    transformed_fields.push(std::sync::Arc::new(
-                        field.as_ref().clone().with_data_type(DataType::Utf8),
-                    ));
-                }
-                UnsupportedTypeAction::Error => {
-                    unsupported_fields.push(format!("'{}' (type: {:?})", field.name(), data_type));
-                }
-                UnsupportedTypeAction::Ignore => {
-                    tracing::warn!(
-                        "Ignoring unsupported type {:?} for field '{}'",
-                        data_type,
-                        field.name()
-                    );
-                }
-                UnsupportedTypeAction::Warn => {
-                    tracing::warn!(
-                        "Including unsupported type {:?} for field '{}' — insertion may fail",
-                        data_type,
-                        field.name()
-                    );
-                    transformed_fields.push(std::sync::Arc::clone(field));
-                }
-            }
+        if let Some(field) = transform_field_for_vortex(
+            field,
+            field.name(),
+            unsupported_type_action,
+            true,
+            &mut unsupported_fields,
+        ) {
+            transformed_fields.push(field);
         }
     }
 
     if !unsupported_fields.is_empty() {
         return Err(DataFusionError::Execution(format!(
             "Unsupported data type(s) in schema: {}. By default, unsupported types cause an \
-             error. To convert unsupported types to strings, set 'unsupported_type_action: string'; \
-             otherwise, remove the unsupported columns.",
+             error. To convert top-level unsupported columns to strings, set 'unsupported_type_action: string'; \
+             nested unsupported types must be removed or rewritten to preserve data correctness.",
             unsupported_fields.join(", ")
         )));
     }
@@ -132,6 +282,7 @@ pub fn transform_schema_for_vortex(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use datafusion_table_providers::UnsupportedTypeAction;
@@ -222,5 +373,96 @@ mod tests {
 
         assert_eq!(out.field(0).data_type(), &DataType::Utf8);
         assert_eq!(out.field(0).metadata(), &field_metadata);
+    }
+
+    #[test]
+    fn nested_safe_types_are_transformed_recursively() {
+        let mut nested_metadata = HashMap::new();
+        nested_metadata.insert("logicalType".to_string(), "TIMESTAMP_NTZ".to_string());
+
+        let schema = Schema::new(vec![Field::new(
+            "payload",
+            DataType::Struct(
+                vec![
+                    Field::new("score", DataType::Float16, true),
+                    Field::new(
+                        "events",
+                        DataType::List(Arc::new(
+                            Field::new(
+                                "item",
+                                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                                true,
+                            )
+                            .with_metadata(nested_metadata.clone()),
+                        )),
+                        true,
+                    ),
+                ]
+                .into(),
+            ),
+            true,
+        )]);
+
+        let out = transform_schema_for_vortex(&schema, UnsupportedTypeAction::Error)
+            .expect("nested supported conversions should succeed");
+        let DataType::Struct(fields) = out.field(0).data_type() else {
+            panic!("expected struct output");
+        };
+        assert_eq!(fields[0].data_type(), &DataType::Float32);
+        let DataType::List(item) = fields[1].data_type() else {
+            panic!("expected list output");
+        };
+        assert_eq!(
+            item.data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        assert_eq!(item.metadata(), &nested_metadata);
+    }
+
+    #[test]
+    fn nested_unsupported_type_errors_with_path() {
+        let schema = Schema::new(vec![Field::new(
+            "payload",
+            DataType::Struct(
+                vec![Field::new(
+                    "duration",
+                    DataType::Duration(TimeUnit::Second),
+                    true,
+                )]
+                .into(),
+            ),
+            true,
+        )]);
+
+        let err = transform_schema_for_vortex(&schema, UnsupportedTypeAction::String)
+            .expect_err("nested schema-only string conversion would be unsafe");
+        let message = err.to_string();
+        assert!(
+            message.contains("payload.duration"),
+            "error should include nested field path, got: {message}"
+        );
+    }
+
+    #[test]
+    fn map_with_supported_children_is_preserved() {
+        let schema = Schema::new(vec![Field::new(
+            "headers",
+            DataType::Map(
+                Arc::new(Field::new_struct(
+                    "entries",
+                    vec![
+                        Arc::new(Field::new("keys", DataType::Utf8, false)),
+                        Arc::new(Field::new("values", DataType::Utf8, true)),
+                    ],
+                    false,
+                )),
+                false,
+            ),
+            true,
+        )]);
+
+        let out = transform_schema_for_vortex(&schema, UnsupportedTypeAction::Error)
+            .expect("map with supported children should be preserved");
+        assert_eq!(out, schema);
     }
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/autotune.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/autotune.rs
@@ -279,6 +279,10 @@ pub(crate) struct WorkloadProfile {
     pub row_count: Option<u64>,
     /// Estimated source table byte size, if inferred.
     pub table_bytes: Option<u64>,
+    /// Whether the connector emitted any extended schema metadata. Primary key,
+    /// index, and sort metadata are useful adaptive warm-start signals even when
+    /// rough sizing is unavailable.
+    pub has_inferred_metadata: bool,
 }
 
 impl WorkloadProfile {
@@ -311,6 +315,7 @@ impl WorkloadProfile {
             pk_arity: primary_key.len(),
             row_count: inferred.row_count,
             table_bytes: inferred.table_bytes,
+            has_inferred_metadata: !inferred.is_empty(),
         }
     }
 
@@ -571,6 +576,7 @@ mod tests {
             pk_arity,
             row_count: Some(rows),
             table_bytes: None,
+            has_inferred_metadata: true,
         };
 
         // A small upsert table sizes the keyset DOWN to what it needs (saving
@@ -793,6 +799,7 @@ mod tests {
                 pk_arity: 3,
                 row_count: Some(5_000_000_000),
                 table_bytes: Some(2_000_000_000_000),
+                has_inferred_metadata: true,
             },
         ];
 

--- a/crates/runtime/src/dataaccelerator/cayenne/autotune.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/autotune.rs
@@ -282,7 +282,30 @@ pub(crate) struct WorkloadProfile {
     /// Whether the connector emitted any extended schema metadata. Primary key,
     /// index, and sort metadata are useful adaptive warm-start signals even when
     /// rough sizing is unavailable.
-    pub has_inferred_metadata: bool,
+    pub inferred_metadata: InferredMetadata,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum InferredMetadata {
+    #[default]
+    Absent,
+    Present,
+}
+
+impl InferredMetadata {
+    #[must_use]
+    pub(crate) fn from_schema(inferred: &InferredSchema) -> Self {
+        if inferred.is_empty() {
+            Self::Absent
+        } else {
+            Self::Present
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn is_present(self) -> bool {
+        matches!(self, Self::Present)
+    }
 }
 
 impl WorkloadProfile {
@@ -315,7 +338,7 @@ impl WorkloadProfile {
             pk_arity: primary_key.len(),
             row_count: inferred.row_count,
             table_bytes: inferred.table_bytes,
-            has_inferred_metadata: !inferred.is_empty(),
+            inferred_metadata: InferredMetadata::from_schema(inferred),
         }
     }
 
@@ -576,7 +599,7 @@ mod tests {
             pk_arity,
             row_count: Some(rows),
             table_bytes: None,
-            has_inferred_metadata: true,
+            inferred_metadata: InferredMetadata::Present,
         };
 
         // A small upsert table sizes the keyset DOWN to what it needs (saving
@@ -799,7 +822,7 @@ mod tests {
                 pk_arity: 3,
                 row_count: Some(5_000_000_000),
                 table_bytes: Some(2_000_000_000_000),
-                has_inferred_metadata: true,
+                inferred_metadata: InferredMetadata::Present,
             },
         ];
 

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -875,20 +875,15 @@ impl CayenneAccelerator {
                 );
             }
             config.dynamic_tuning = tuning_mode.as_deref() == Some("adaptive");
-            // `adaptive` depends on extended schema inference: the closed loop's
-            // data-aware warm-start (keyset sized to cardinality, memtable rows to
-            // real row width) needs the inferred `row_count`/`table_bytes`, which
-            // are present only when `schema_inference: extended` ran. Without them
-            // the loop would start blind, so fall back to `auto` (static) and tell
-            // the operator how to enable it. (`row_count`/`table_bytes` come ONLY
-            // from extended inference — unlike PK, which can also come from
-            // constraints — so they are the right signal to gate on.)
-            if config.dynamic_tuning
-                && workload.row_count.is_none()
-                && workload.table_bytes.is_none()
-            {
+            // `adaptive` depends on extended schema inference. Any emitted
+            // metadata counts: row_count/table_bytes refine memory sizing, while
+            // inferred primary key/index/sort metadata is applied upstream and
+            // feeds the same warm-start / query-health surface. Without any
+            // inferred metadata the loop starts blind, so fall back to `auto` and
+            // tell the operator how to enable it.
+            if config.dynamic_tuning && !workload.has_inferred_metadata {
                 tracing::warn!(
-                    "Dataset '{table_name}': `cayenne_tuning: adaptive` requires `schema_inference: extended` (the closed-loop tuner needs inferred cardinality/size for its warm-start), but no inferred schema was found; falling back to 'auto' (static). Set `schema_inference: extended` to enable adaptive tuning."
+                    "Dataset '{table_name}': `cayenne_tuning: adaptive` requires `schema_inference: extended` (the closed-loop tuner needs inferred source metadata for its warm-start), but no inferred schema metadata was found; falling back to 'auto' (static). Set `schema_inference: extended` on a connector that emits inferred metadata to enable adaptive tuning."
                 );
                 config.dynamic_tuning = false;
             }
@@ -900,6 +895,13 @@ impl CayenneAccelerator {
                     "Dataset '{table_name}': `cayenne_tuning: adaptive` needs background compaction enabled (the controller runs on its tick), but cayenne_compaction_background_interval_ms is 0; falling back to 'auto'. Set a non-zero interval to enable adaptive tuning."
                 );
                 config.dynamic_tuning = false;
+            }
+            if config.dynamic_tuning {
+                tracing::warn!(
+                    target: "spiced::acceleration::cayenne",
+                    table = %table_name,
+                    "`cayenne_tuning: adaptive` is in preview; verify query correctness and performance before using it for production workloads"
+                );
             }
             config.pinned_tuning_knobs = cayenne::metadata::PinnedTuningKnobs {
                 inline_flush: autotune::is_pinned(
@@ -961,6 +963,7 @@ impl CayenneAccelerator {
                 // (if requested) was gated off — makes that immediately visible.
                 inferred_row_count = ?workload.row_count,
                 inferred_table_bytes = ?workload.table_bytes,
+                inferred_extended_schema = workload.has_inferred_metadata,
                 has_primary_key = workload.has_primary_key,
                 is_upsert = workload.is_upsert,
                 "Cayenne auto-tuned config: segment_cache={}MB, pk_keyset_cache={:?}MB, target_file_size={}MB, upload_concurrency={}, write_concurrency_override={:?}, sort_columns={:?}, compression_strategy={:?}, delta_encoding={}, pk_conflict_detection={}, deletion_mode={:?}, compaction_trigger_files={}, compaction_trigger_protected_snapshots={}, compaction_trigger_snapshot_age_ms={}, compaction_max_levels={}, compaction_max_files_per_pick={}, compaction_background_interval_ms={}, inline_max_rows={}, inline_max_bytes={}, inline_max_buffer_bytes={}, inline_flush_max_rows={}, inline_flush_max_segments={}, inline_flush_max_bytes={}",

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -881,7 +881,7 @@ impl CayenneAccelerator {
             // feeds the same warm-start / query-health surface. Without any
             // inferred metadata the loop starts blind, so fall back to `auto` and
             // tell the operator how to enable it.
-            if config.dynamic_tuning && !workload.has_inferred_metadata {
+            if config.dynamic_tuning && !workload.inferred_metadata.is_present() {
                 tracing::warn!(
                     "Dataset '{table_name}': `cayenne_tuning: adaptive` requires `schema_inference: extended` (the closed-loop tuner needs inferred source metadata for its warm-start), but no inferred schema metadata was found; falling back to 'auto' (static). Set `schema_inference: extended` on a connector that emits inferred metadata to enable adaptive tuning."
                 );
@@ -963,7 +963,7 @@ impl CayenneAccelerator {
                 // (if requested) was gated off — makes that immediately visible.
                 inferred_row_count = ?workload.row_count,
                 inferred_table_bytes = ?workload.table_bytes,
-                inferred_extended_schema = workload.has_inferred_metadata,
+                inferred_extended_schema = workload.inferred_metadata.is_present(),
                 has_primary_key = workload.has_primary_key,
                 is_upsert = workload.is_upsert,
                 "Cayenne auto-tuned config: segment_cache={}MB, pk_keyset_cache={:?}MB, target_file_size={}MB, upload_concurrency={}, write_concurrency_override={:?}, sort_columns={:?}, compression_strategy={:?}, delta_encoding={}, pk_conflict_detection={}, deletion_mode={:?}, compaction_trigger_files={}, compaction_trigger_protected_snapshots={}, compaction_trigger_snapshot_age_ms={}, compaction_max_levels={}, compaction_max_files_per_pick={}, compaction_background_interval_ms={}, inline_max_rows={}, inline_max_bytes={}, inline_max_buffer_bytes={}, inline_flush_max_rows={}, inline_flush_max_segments={}, inline_flush_max_bytes={}",


### PR DESCRIPTION
## Summary
- make Cayenne adaptive inline flush bounds memory-budget aware, including better cgroup memory detection and RSS fallback
- plumb inferred extended schema metadata into adaptive gating and startup logging
- add a startup WARN that `cayenne_tuning: adaptive` is in preview
- harden Vortex schema transformation recursively so safe nested types are transformed and unsupported nested types fail safely with path context

## Validation
- `cargo fmt -p cayenne -p runtime`
- `cargo test -p cayenne schema::tests --lib`
- `cargo test -p cayenne provider::tuning::tests --lib`
- `cargo test -p runtime dataaccelerator::cayenne::autotune::tests --lib`
- `cargo test -p runtime test_transform_schema_for_vortex --lib`
- `git diff --check`