### PR TITLE
feat(cayenne): restore gated ExactLeftAccumulator join rewriter on DF53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5592,7 +5592,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5616,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5664,7 +5664,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "futures",
  "log",
@@ -5674,7 +5674,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5710,7 +5710,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5733,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5755,7 +5755,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5778,7 +5778,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5826,12 +5826,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5853,7 +5853,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5959,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5980,7 +5980,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -6004,7 +6004,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6028,7 +6028,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6043,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6060,7 +6060,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6069,7 +6069,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6079,7 +6079,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "chrono",
@@ -6129,7 +6129,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -6152,7 +6152,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6166,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -6182,7 +6182,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -6231,7 +6231,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "chrono",
@@ -6261,7 +6261,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6273,7 +6273,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6289,7 +6289,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6302,7 +6302,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6327,7 +6327,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6345,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0b0be50fd8c8929a2248a9ce5c75d878c1a68b55#0b0be50fd8c8929a2248a9ce5c75d878c1a68b55"
+source = "git+https://github.com/spiceai/datafusion.git?rev=506dabefda59c4812e867fb11ddd2ff92d365ae0#506dabefda59c4812e867fb11ddd2ff92d365ae0"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,41 +384,41 @@ lto = "off"
 
 [patch.crates-io]
 # DataFusion 53.1.0 fork: UDTF cache-correctness (#98), BigQuery FLOAT64 unparser, vortex-shuffle
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "0b0be50fd8c8929a2248a9ce5c75d878c1a68b55" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "506dabefda59c4812e867fb11ddd2ff92d365ae0" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -117,15 +117,42 @@ use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::joins::{HashJoinExec, SortMergeJoinExec};
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion_common::stats::Precision;
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr::expressions::Column;
+use datafusion_physical_plan::repartition::RepartitionExec;
+use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
+use runtime_datafusion::extension::bytes_processed::BytesProcessedExec;
+use runtime_datafusion::join_accumulator::{
+    DEFAULT_MAXIMUM_SHARED_INLIST_MEMORY_BYTES, ExactLeftAccumulator,
+};
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use crate::provider::CayenneAccelerationExec;
+use crate::provider::delete::{Int64PkDeletionFilterExec, KeyBasedDeletionFilterExec};
 use crate::provider::scan::{ScanDynamicFilter, ScanIdentity};
+
+/// Optimizer rule that rewrites `HashJoinExec` nodes to use `ExactLeftAccumulator`
+/// when the probe side is a `CayenneAccelerationExec`.
+///
+/// Opt-in: this rule is only registered when the runtime
+/// `cayenne_optimizer_rules.exact_join_filter` flag is enabled. By default the
+/// ordinary inner-join probe filter is handled by DataFusion 53's native
+/// hash-join dynamic-filter pushdown (whose `InList` budget is raised in the
+/// runtime session builder's `configure_hash_join_memory_limits`).
+#[derive(Default)]
+pub struct CayenneJoinRewriter;
+
+impl CayenneJoinRewriter {
+    /// Create a new `CayenneJoinRewriter` optimizer rule.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
 
 /// Shares already-pushed hash-join dynamic filters between same-source Cayenne
 /// scans when the current hash join proves the relevant columns are equi-joined.
@@ -163,6 +190,8 @@ pub struct CayenneAntiJoinSortMergeRewriter;
 /// in-memory hash table is usually faster than two explicit sort buffers.
 const ANTI_JOIN_SORT_MERGE_MIN_EXACT_ROWS: usize = 10_000_000;
 const ANTI_JOIN_SORT_MERGE_MEMORY_POOL_FRACTION: f64 = 0.125;
+const EXACT_JOIN_FILTER_MIN_PROBE_ROWS: usize = 100_000;
+const EXACT_JOIN_FILTER_MIN_PROBE_TO_BUILD_RATIO: usize = 10;
 
 extensions_options! {
     /// Cayenne optimizer configuration.
@@ -175,6 +204,15 @@ extensions_options! {
 
         /// Effective query memory pool size in bytes. Runtime wiring sets this from `runtime.query.memory_limit`; direct DataFusion users can leave it unset to use the row-count gate only.
         pub sort_merge_memory_pool_bytes: Option<usize>, default = None
+
+        /// Maximum estimated LEFT/build-side join-key bytes before preserving DataFusion's default hash-join accumulator instead of using Cayenne's exact in-list accumulator.
+        pub exact_join_filter_max_bytes: usize, default = DEFAULT_MAXIMUM_SHARED_INLIST_MEMORY_BYTES
+
+        /// Minimum known RIGHT/probe-side row count before using Cayenne's exact in-list accumulator.
+        pub exact_join_filter_min_probe_rows: usize, default = EXACT_JOIN_FILTER_MIN_PROBE_ROWS
+
+        /// Minimum known RIGHT/probe-side to LEFT/build-side row-count ratio before using Cayenne's exact in-list accumulator. Set to 0 to disable the ratio gate.
+        pub exact_join_filter_min_probe_to_build_ratio: usize, default = EXACT_JOIN_FILTER_MIN_PROBE_TO_BUILD_RATIO
     }
 }
 
@@ -592,6 +630,137 @@ fn spillable_rewrite_build_input_exact_rows(hash_join: &HashJoinExec) -> Option<
     }
 }
 
+fn exact_join_filter_build_key_bytes(
+    hash_join: &HashJoinExec,
+    build_row_count: usize,
+    max_build_bytes: usize,
+) -> Option<usize> {
+    let build_schema = hash_join.left().schema();
+    let mut estimated_build_bytes = 0_usize;
+
+    for (left_key, _) in hash_join.on() {
+        let data_type = left_key.data_type(build_schema.as_ref()).ok()?;
+        if !supports_exact_join_filter_fallback(&data_type) {
+            return None;
+        }
+
+        let key_width = estimated_arrow_width(&data_type)?;
+        estimated_build_bytes =
+            estimated_build_bytes.saturating_add(build_row_count.saturating_mul(key_width));
+        if estimated_build_bytes > max_build_bytes {
+            break;
+        }
+    }
+
+    Some(estimated_build_bytes)
+}
+
+fn exact_join_filter_probe_rows(hash_join: &HashJoinExec) -> Option<usize> {
+    match hash_join.right().partition_statistics(None).ok()?.num_rows {
+        Precision::Exact(row_count) | Precision::Inexact(row_count) => Some(row_count),
+        Precision::Absent => None,
+    }
+}
+
+fn supports_exact_join_filter_fallback(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Decimal32(_, _)
+            | DataType::Decimal64(_, _)
+            | DataType::Decimal128(_, _)
+            | DataType::Decimal256(_, _)
+            | DataType::Date32
+            | DataType::Date64
+            | DataType::Time32(_)
+            | DataType::Time64(_)
+            | DataType::Timestamp(_, _)
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Utf8View
+    )
+}
+
+fn should_rewrite_with_exact_accumulator(hash_join: &HashJoinExec, config: &ConfigOptions) -> bool {
+    if *hash_join.join_type() != JoinType::Inner {
+        tracing::debug!(
+            join_type = ?hash_join.join_type(),
+            "Keeping HashJoinExec default accumulator because DataFusion only pushes join dynamic filters through inner joins"
+        );
+        return false;
+    }
+
+    let optimizer_config = cayenne_optimizer_config(config);
+    let max_build_bytes = optimizer_config.exact_join_filter_max_bytes;
+    let Some(build_row_count) = spillable_rewrite_build_input_exact_rows(hash_join) else {
+        tracing::debug!(
+            "Keeping HashJoinExec default accumulator because exact build-side row statistics are unavailable"
+        );
+        return false;
+    };
+
+    let Some(probe_row_count) = exact_join_filter_probe_rows(hash_join) else {
+        tracing::debug!(
+            "Keeping HashJoinExec default accumulator because probe-side row statistics are unavailable"
+        );
+        return false;
+    };
+
+    if probe_row_count < optimizer_config.exact_join_filter_min_probe_rows {
+        tracing::debug!(
+            probe_row_count,
+            min_probe_rows = optimizer_config.exact_join_filter_min_probe_rows,
+            "Keeping HashJoinExec default accumulator because the Cayenne probe side is too small for exact join-filter collection to pay off"
+        );
+        return false;
+    }
+
+    let min_probe_to_build_ratio = optimizer_config.exact_join_filter_min_probe_to_build_ratio;
+    if build_row_count > 0
+        && min_probe_to_build_ratio > 0
+        && probe_row_count < build_row_count.saturating_mul(min_probe_to_build_ratio)
+    {
+        tracing::debug!(
+            build_row_count,
+            probe_row_count,
+            min_probe_to_build_ratio,
+            "Keeping HashJoinExec default accumulator because the Cayenne probe side is not much larger than the build-side key domain"
+        );
+        return false;
+    }
+
+    let Some(estimated_build_bytes) =
+        exact_join_filter_build_key_bytes(hash_join, build_row_count, max_build_bytes)
+    else {
+        tracing::debug!(
+            "Keeping HashJoinExec default accumulator because fallback-compatible build-side join-key types are unavailable"
+        );
+        return false;
+    };
+
+    if estimated_build_bytes > max_build_bytes {
+        tracing::debug!(
+            build_row_count,
+            estimated_build_bytes,
+            max_build_bytes,
+            "Keeping HashJoinExec default accumulator because estimated exact join-filter memory exceeds the configured budget"
+        );
+        return false;
+    }
+
+    true
+}
+
 fn join_key_ordering(
     keys: impl Iterator<Item = Arc<dyn PhysicalExpr>>,
     sort_options: &[SortOptions],
@@ -801,6 +970,195 @@ fn apply_filter_additions(
 
     plan.with_new_children(new_children)
         .map(|plan| (plan, true))
+}
+
+impl std::fmt::Debug for CayenneJoinRewriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CayenneJoinRewriter").finish()
+    }
+}
+
+/// Flatten transparent nodes (like `ProjectionExec` that just pass through columns)
+/// to find the underlying plan node.
+// `CoalesceBatchesExec` is deprecated in DF53 (superseded by arrow-rs
+// `BatchCoalescer`) but the physical planner still emits it, so we keep seeing
+// through it here — mirrors `provider::scan::is_identity_preserving_wrapper`.
+#[expect(deprecated)]
+fn flatten_transparent_nodes(plan: &Arc<dyn ExecutionPlan>) -> &Arc<dyn ExecutionPlan> {
+    // ProjectionExec is transparent if it just passes through columns
+    if let Some(projection) = plan.as_any().downcast_ref::<ProjectionExec>() {
+        return flatten_transparent_nodes(projection.input());
+    }
+
+    if let Some(bytes_processed_exec) = plan.as_any().downcast_ref::<BytesProcessedExec>() {
+        let children = bytes_processed_exec.children();
+        let Some(input) = children.first() else {
+            return plan;
+        };
+
+        return flatten_transparent_nodes(input);
+    }
+
+    if let Some(repartitioned) = plan.as_any().downcast_ref::<RepartitionExec>() {
+        return flatten_transparent_nodes(repartitioned.input());
+    }
+
+    if let Some(coalesce) = plan
+        .as_any()
+        .downcast_ref::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
+    {
+        return flatten_transparent_nodes(coalesce.input());
+    }
+
+    // Deletion-filter execs sit directly above the Cayenne scan whenever
+    // key-deletes are pending. They preserve the child's schema and
+    // partitioning (they only remove deleted rows), so for the purpose of
+    // identifying a Cayenne-backed scan on a join build/probe side they are
+    // transparent — see through them so the dynamic-filter join rewrite still
+    // fires on tables undergoing CDC deletes.
+    if let Some(int64_delete) = plan.as_any().downcast_ref::<Int64PkDeletionFilterExec>() {
+        let children = int64_delete.children();
+        let Some(input) = children.first() else {
+            return plan;
+        };
+
+        return flatten_transparent_nodes(input);
+    }
+
+    if let Some(key_delete) = plan.as_any().downcast_ref::<KeyBasedDeletionFilterExec>() {
+        let children = key_delete.children();
+        let Some(input) = children.first() else {
+            return plan;
+        };
+
+        return flatten_transparent_nodes(input);
+    }
+
+    if let Some(schema_cast_scan) = plan.as_any().downcast_ref::<SchemaCastScanExec>() {
+        let children = schema_cast_scan.children();
+        let Some(input) = children.first() else {
+            return plan;
+        };
+
+        return flatten_transparent_nodes(input);
+    }
+
+    plan
+}
+
+fn hash_join_build_side_is_cayenne(join: &HashJoinExec) -> bool {
+    let build_side = flatten_transparent_nodes(join.left());
+
+    if build_side
+        .as_any()
+        .downcast_ref::<CayenneAccelerationExec>()
+        .is_some()
+    {
+        true
+    } else if let Some(nested_join) = build_side.as_any().downcast_ref::<HashJoinExec>() {
+        // Recursively check the build side of the nested join
+        hash_join_build_side_is_cayenne(nested_join)
+    } else {
+        false
+    }
+}
+
+/// Check if the probe side of the first input `HashJoinExec` is either `CayenneAccelerationExec` or another `HashJoinExec`.
+///
+/// For nested hash joins, the build side of the join must also be a `CayenneAccelerationExec` as the dynamic filter from this `HashJoinExec` will push into the build side of the next join.
+///
+/// This handles nested join patterns like:
+/// ```text
+///      HashJoinExec (top)
+///         | - DataSourceExec (build)
+///         | - HashJoinExec (probe/nested)
+///               | - DataSourceExec (build of nested)
+///               | - DataSourceExec (probe of nested)
+/// ```
+fn is_cayenne_backed_join(hash_join: &HashJoinExec) -> bool {
+    // Check the probe side first (right child)
+    let probe_side = flatten_transparent_nodes(hash_join.right());
+
+    if probe_side
+        .as_any()
+        .downcast_ref::<CayenneAccelerationExec>()
+        .is_some()
+    {
+        return true;
+    }
+
+    // If probe side is another `HashJoinExec`, check the build side of the nested join is Cayenne
+    if let Some(nested_join) = probe_side.as_any().downcast_ref::<HashJoinExec>() {
+        // The nested join's build side must also be Cayenne
+        return hash_join_build_side_is_cayenne(nested_join);
+    }
+
+    // Unknown node type on probe side - not Cayenne-backed
+    false
+}
+
+impl PhysicalOptimizerRule for CayenneJoinRewriter {
+    fn name(&self) -> &'static str {
+        "CayenneJoinRewriter"
+    }
+
+    fn schema_check(&self) -> bool {
+        false
+    }
+
+    fn optimize(
+        &self,
+        plan: std::sync::Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        // For each `HashJoinExec`, determine if probe side is a `CayenneAccelerationExec` with a Cayenne accelerator
+        // If so, that `HashJoinExec` can be replaced with one which uses a `ExactLeftAccumulator` so we can push down exact dynamic filter bounds into Cayenne
+        // The build side is irrelevant for the collection, as we only push the filter down to the probe side
+        //
+        // This can become more complex for plans like:
+        //      `HashJoinExec`
+        //         | - `CayenneAccelerationExec`
+        //         | - `HashJoinExec`
+        //               | - `CayenneAccelerationExec`
+        //               | - `CayenneAccelerationExec`
+        //
+        // In this scenario, the "build side" is the very first `CayenneAccelerationExec` - the probe side becomes the remaining `HashJoinExec`, which includes the other 2 `CayenneAccelerationExec`s.
+        // The dynamic filter from the top `CayenneAccelerationExec` will push down into the build side of the second `HashJoinExec`.
+        // After that, the dynamic filter from the second `HashJoinExec` will push down into its probe side `CayenneAccelerationExec` - sourced from its own build-side dynamic filter.
+        //
+        // Therefore, after we encounter a `HashJoinExec` we need to continue traversing down the build side of any subsequent `HashJoinExec`s to ensure it is a `CayenneAccelerationExec`.
+
+        plan.transform_down(|node| {
+            let Some(hash_join) = node.as_any().downcast_ref::<HashJoinExec>() else {
+                return Ok(Transformed::no(node));
+            };
+
+            if *hash_join.join_type() != JoinType::Inner {
+                return Ok(Transformed::no(node));
+            }
+
+            if hash_join.null_equality() != NullEquality::NullEqualsNothing {
+                return Ok(Transformed::no(node));
+            }
+
+            if !is_cayenne_backed_join(hash_join) {
+                return Ok(Transformed::no(node));
+            }
+
+            if !should_rewrite_with_exact_accumulator(hash_join, config) {
+                return Ok(Transformed::no(node));
+            }
+
+            tracing::debug!(
+                "Replacing HashJoinExec with ExactLeftAccumulator for Cayenne acceleration"
+            );
+
+            let new_join = hash_join.recreate_with_accumulator::<ExactLeftAccumulator>();
+
+            Ok(Transformed::yes(Arc::new(new_join)))
+        })
+        .data()
+    }
 }
 
 #[cfg(test)]

--- a/crates/runtime-datafusion/src/join_accumulator/mod.rs
+++ b/crates/runtime-datafusion/src/join_accumulator/mod.rs
@@ -1,0 +1,1883 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    any::{Any, type_name},
+    cmp::Ordering,
+    collections::HashSet,
+    fmt::{Debug, Display},
+    hash::{Hash, Hasher},
+    mem::size_of,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering as AtomicOrdering},
+    },
+};
+
+use arrow::{
+    array::{
+        Array, ArrayRef, BooleanArray, BooleanBuilder, GenericStringArray, OffsetSizeTrait,
+        PrimitiveArray, RecordBatch, StringViewArray,
+    },
+    compute::{max, max_string, max_string_view, min, min_string, min_string_view},
+    datatypes::{
+        ArrowPrimitiveType, DataType, Date32Type, Date64Type, Decimal32Type, Decimal64Type,
+        Decimal128Type, Decimal256Type, Field, Float16Type, Float32Type, Float64Type, Int8Type,
+        Int16Type, Int32Type, Int64Type, Schema, SchemaRef, Time32MillisecondType,
+        Time32SecondType, Time64MicrosecondType, Time64NanosecondType, TimeUnit,
+        TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
+        TimestampSecondType, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+    },
+};
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::{
+    common::hash_utils::{combine_hashes, with_hashes},
+    logical_expr::Operator,
+    physical_plan::{
+        ColumnarValue, PhysicalExpr,
+        expressions::{BinaryExpr, InListExpr, Literal},
+        joins::{CollectLeftAccumulator, ColumnBounds, SeededRandomState},
+    },
+    scalar::ScalarValue,
+};
+
+pub const DEFAULT_MAXIMUM_SHARED_INLIST_MEMORY_BYTES: usize = 128 * 1024 * 1024; // 128Mb - can store approximately 32 million i32 keys.
+const DEFAULT_MAXIMUM_BLOOM_FILTER_MEMORY_BYTES: usize = 8 * 1024 * 1024;
+const MAXIMUM_RANGE_INTERVALS: usize = 64;
+const UNCONFIGURED_SHARED_INLIST_MEMORY_BYTES: usize = usize::MAX;
+
+static MAXIMUM_SHARED_INLIST_MEMORY_BYTES: AtomicUsize =
+    AtomicUsize::new(UNCONFIGURED_SHARED_INLIST_MEMORY_BYTES);
+static CURRENT_INLIST_MEMORY_BYTES: AtomicUsize = AtomicUsize::new(0);
+// The exact in-list path reserves against one process-wide budget shared across
+// all accumulator instances. This keeps dynamic join filters bounded under query
+// concurrency; individual accumulators still keep their own local cap.
+
+#[must_use]
+pub fn maximum_shared_inlist_memory_bytes() -> usize {
+    match MAXIMUM_SHARED_INLIST_MEMORY_BYTES.load(AtomicOrdering::Relaxed) {
+        UNCONFIGURED_SHARED_INLIST_MEMORY_BYTES => DEFAULT_MAXIMUM_SHARED_INLIST_MEMORY_BYTES,
+        limit => limit,
+    }
+}
+
+/// Conservatively clamps the process-wide exact in-list reservation budget.
+///
+/// `DataFusion` constructs `CollectLeftAccumulator` instances without session
+/// state, so the Cayenne join rewriter cannot attach a per-session limit at
+/// accumulator construction time. If multiple `DataFusion` instances are built
+/// in one process, use the strictest configured limit instead of letting the
+/// most recent builder raise the shared budget for existing instances.
+pub fn clamp_maximum_shared_inlist_memory_bytes(limit: usize) {
+    let configured_limit = limit.min(UNCONFIGURED_SHARED_INLIST_MEMORY_BYTES.saturating_sub(1));
+    let _ = MAXIMUM_SHARED_INLIST_MEMORY_BYTES.fetch_update(
+        AtomicOrdering::Relaxed,
+        AtomicOrdering::Relaxed,
+        |current| {
+            Some(if current == UNCONFIGURED_SHARED_INLIST_MEMORY_BYTES {
+                configured_limit
+            } else {
+                current.min(configured_limit)
+            })
+        },
+    );
+}
+
+#[derive(Debug)]
+struct InListMemoryReservation {
+    bytes: usize,
+}
+
+impl InListMemoryReservation {
+    fn try_new(bytes: usize) -> Option<Self> {
+        reserve_inlist_memory(bytes).then_some(Self { bytes })
+    }
+
+    fn try_grow(&mut self, bytes: usize) -> bool {
+        if !reserve_inlist_memory(bytes) {
+            return false;
+        }
+
+        self.bytes = self.bytes.saturating_add(bytes);
+        true
+    }
+}
+
+impl Drop for InListMemoryReservation {
+    fn drop(&mut self) {
+        CURRENT_INLIST_MEMORY_BYTES.fetch_sub(self.bytes, AtomicOrdering::Relaxed);
+    }
+}
+
+fn reserve_inlist_memory(bytes: usize) -> bool {
+    reserve_inlist_memory_with_limit(bytes, maximum_shared_inlist_memory_bytes())
+}
+
+fn reserve_inlist_memory_with_limit(bytes: usize, limit: usize) -> bool {
+    if bytes == 0 {
+        return true;
+    }
+
+    if limit == 0 || bytes > limit {
+        return false;
+    }
+
+    CURRENT_INLIST_MEMORY_BYTES
+        .fetch_update(
+            AtomicOrdering::Relaxed,
+            AtomicOrdering::Relaxed,
+            |current| current.checked_add(bytes).filter(|next| *next <= limit),
+        )
+        .is_ok()
+}
+
+fn bloom_memory_limit(max_inlist_memory_size: usize) -> usize {
+    if max_inlist_memory_size == 0 {
+        0
+    } else {
+        (max_inlist_memory_size / 16).min(DEFAULT_MAXIMUM_BLOOM_FILTER_MEMORY_BYTES)
+    }
+}
+
+/// A simple implementation of a `CollectLeftAccumulator` that collects exact values for dynamic filtering.
+/// Performs no approximation or range merging, simply storing all values seen.
+///
+/// Tradeoff: potentially higher memory usage on the build-side of the join, but more precise filtering on the probe-side.
+/// If `JoinSelection` has correctly re-ordered the plan so the larger scan is on the probe-side, this can be beneficial.
+pub struct ExactLeftAccumulator {
+    arrays: Vec<Arc<dyn Array>>,
+    expr: Arc<dyn PhysicalExpr>,
+    total_memory_size: usize,
+    max_inlist_memory_size: usize,
+    max_bloom_filter_memory_size: usize,
+    inlist_memory_reservation: Option<InListMemoryReservation>,
+    range_bounds: RangeBounds,
+    exact_values_exceeded_memory_limit: bool,
+}
+
+impl CollectLeftAccumulator for ExactLeftAccumulator {
+    fn name(&self) -> &'static str {
+        "ExactLeftAccumulator"
+    }
+
+    fn static_name() -> &'static str
+    where
+        Self: Sized,
+    {
+        "ExactLeftAccumulator"
+    }
+
+    fn try_new(expr: Arc<dyn PhysicalExpr>, _schema: &SchemaRef) -> DataFusionResult<Self> {
+        Ok(Self::new_with_memory_limit(
+            expr,
+            maximum_shared_inlist_memory_bytes(),
+        ))
+    }
+
+    fn update_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
+        if batch.num_rows() == 0 {
+            tracing::debug!("ExactLeftAccumulator received empty batch, skipping.");
+            return Ok(());
+        }
+
+        tracing::debug!(
+            "ExactLeftAccumulator updating batch with {} rows",
+            batch.num_rows()
+        );
+
+        if self.exact_values_exceeded_memory_limit {
+            let array = self.expr.evaluate(batch)?.into_array(batch.num_rows())?;
+            self.total_memory_size = self
+                .total_memory_size
+                .saturating_add(array.get_array_memory_size());
+            self.range_bounds.update(array.as_ref())?;
+            return Ok(());
+        }
+
+        // eagerly evaluate the expression and store the resulting array
+        // this avoids storing the entire record batch in memory, only storing the evaluated column
+        let array = self.expr.evaluate(batch)?.into_array(batch.num_rows())?;
+
+        let array_memory_size = array.get_array_memory_size();
+        let total_memory_size = self.total_memory_size.saturating_add(array_memory_size);
+
+        if total_memory_size > self.max_inlist_memory_size {
+            tracing::warn!(
+                total_memory_size,
+                max_inlist_memory_size = self.max_inlist_memory_size,
+                "ExactLeftAccumulator exceeded its local in-list memory limit and switched to range dynamic filtering for this join. Consider increasing memory limits or reducing cardinality of the build side."
+            );
+            self.inlist_memory_reservation = None;
+            self.range_bounds = self.range_bounds_from_collected_arrays(array.as_ref())?;
+            self.arrays.clear();
+            self.total_memory_size = total_memory_size;
+            self.exact_values_exceeded_memory_limit = true;
+            return Ok(());
+        }
+
+        if !self.try_reserve_inlist_memory(array_memory_size) {
+            tracing::warn!(
+                requested_bytes = array_memory_size,
+                current_shared_inlist_memory_bytes =
+                    CURRENT_INLIST_MEMORY_BYTES.load(AtomicOrdering::Relaxed),
+                maximum_shared_inlist_memory_bytes = maximum_shared_inlist_memory_bytes(),
+                "ExactLeftAccumulator shared in-list memory budget is exhausted and switched to range dynamic filtering for this join. Consider increasing memory limits or reducing cardinality of the build side."
+            );
+            self.inlist_memory_reservation = None;
+            self.range_bounds = self.range_bounds_from_collected_arrays(array.as_ref())?;
+            self.arrays.clear();
+            self.total_memory_size = total_memory_size;
+            self.exact_values_exceeded_memory_limit = true;
+            return Ok(());
+        }
+
+        self.total_memory_size = total_memory_size;
+        self.arrays.push(array);
+        Ok(())
+    }
+
+    fn evaluate(self) -> DataFusionResult<Arc<dyn ColumnBounds>> {
+        let Self {
+            arrays,
+            total_memory_size,
+            range_bounds,
+            exact_values_exceeded_memory_limit,
+            inlist_memory_reservation,
+            ..
+        } = self;
+
+        Ok(Arc::new(ExactColumnBounds {
+            arrays,
+            total_memory_size,
+            range_bounds,
+            exact_values_exceeded_memory_limit,
+            _inlist_memory_reservation: inlist_memory_reservation,
+        }))
+    }
+}
+
+impl ExactLeftAccumulator {
+    /// Creates an accumulator with a custom local in-list memory limit.
+    #[must_use]
+    pub fn new_with_memory_limit(
+        expr: Arc<dyn PhysicalExpr>,
+        max_inlist_memory_size: usize,
+    ) -> Self {
+        tracing::debug!("Trying to build ExactLeftAccumulator.");
+        Self {
+            arrays: Vec::new(),
+            expr,
+            total_memory_size: 0,
+            max_inlist_memory_size,
+            max_bloom_filter_memory_size: bloom_memory_limit(max_inlist_memory_size),
+            inlist_memory_reservation: None,
+            range_bounds: RangeBounds::new(bloom_memory_limit(max_inlist_memory_size)),
+            exact_values_exceeded_memory_limit: false,
+        }
+    }
+
+    fn try_reserve_inlist_memory(&mut self, bytes: usize) -> bool {
+        if let Some(reservation) = &mut self.inlist_memory_reservation {
+            reservation.try_grow(bytes)
+        } else {
+            let Some(reservation) = InListMemoryReservation::try_new(bytes) else {
+                return false;
+            };
+            self.inlist_memory_reservation = Some(reservation);
+            true
+        }
+    }
+
+    fn range_bounds_from_collected_arrays(
+        &self,
+        array: &dyn Array,
+    ) -> DataFusionResult<RangeBounds> {
+        let mut range_bounds = RangeBounds::new(self.max_bloom_filter_memory_size);
+        for collected_array in &self.arrays {
+            range_bounds.update(collected_array.as_ref())?;
+        }
+        range_bounds.update(array)?;
+        Ok(range_bounds)
+    }
+}
+
+#[derive(Debug)]
+pub struct ExactColumnBounds {
+    arrays: Vec<Arc<dyn Array>>,
+    total_memory_size: usize,
+    range_bounds: RangeBounds,
+    exact_values_exceeded_memory_limit: bool,
+    _inlist_memory_reservation: Option<InListMemoryReservation>,
+}
+
+impl ColumnBounds for ExactColumnBounds {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Converts the collected arrays into an `InListExpr` for use in dynamic filtering.
+    /// This builds an IN expression with all collected values.
+    ///
+    /// If the exact in-list exceeds its memory budget, return the accumulated
+    /// range/bloom fallback. The Cayenne optimizer only installs this exact
+    /// accumulator for inner joins with null-equals-nothing semantics, which
+    /// keeps the fallback in the same safety envelope as `DataFusion`'s native
+    /// min/max dynamic filter while bounding the exact in-list allocation.
+    ///
+    /// The `CoalescePartitionsExec` + iterative flatten wrapper detection added
+    /// in the optimizer ensures more plans (including those with partition
+    /// coalescing between join and Cayenne scan) now correctly route through
+    /// `ExactLeftAccumulator`, increasing the importance of these edge cases
+    /// being well understood and tested.
+    ///
+    /// NULL handling: In the exact path, NULLs from the build side are collected
+    /// as `ScalarValue::Null`. The generated expression is a non-negated `IN`
+    /// predicate, so probe rows only match concrete collected values. If either
+    /// side is NULL, SQL three-valued logic yields NULL rather than true, and the
+    /// dynamic filter does not keep that row on the basis of the NULL alone.
+    fn physical_expr(
+        &self,
+        left_expr: Arc<dyn PhysicalExpr>,
+    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        if self.exact_values_exceeded_memory_limit {
+            tracing::warn!(
+                range_interval_count = self.range_bounds.intervals.len(),
+                "ExactLeftAccumulator exact values exceeded memory limit; returning range dynamic filter."
+            );
+            return Ok(self.range_bounds.physical_expr(left_expr));
+        }
+
+        let unique_values = self
+            .arrays
+            .iter()
+            .flat_map(|array| {
+                (0..array.len()).map(move |i| ScalarValue::try_from_array(array.as_ref(), i))
+            })
+            .collect::<DataFusionResult<HashSet<ScalarValue>>>()?;
+
+        if unique_values.is_empty() {
+            tracing::debug!(
+                "ExactLeftAccumulator collected no build-side values, returning always-false filter."
+            );
+            return Ok(literal_false());
+        }
+
+        let expr_values = unique_values
+            .into_iter()
+            .map(|sv| Arc::new(Literal::new(sv)) as Arc<dyn PhysicalExpr>)
+            .collect::<Vec<_>>();
+
+        // Build a schema compatible with `left_expr` so InListExpr::try_new can validate data types.
+        // If `left_expr` is a Column referencing index N, we need at least N+1 fields.
+        // Literals carry their own type, so only the field at the column's index matters.
+        let data_type = expr_values
+            .first()
+            .and_then(|e| {
+                let s = Schema::new(vec![Field::new(
+                    "_",
+                    arrow::datatypes::DataType::Null,
+                    true,
+                )]);
+                e.data_type(&s).ok()
+            })
+            .unwrap_or(arrow::datatypes::DataType::Null);
+
+        let col_index = left_expr
+            .as_any()
+            .downcast_ref::<datafusion::physical_plan::expressions::Column>()
+            .map_or(0, datafusion::physical_expr::expressions::Column::index);
+
+        let mut fields: Vec<Field> = (0..col_index)
+            .map(|i| Field::new(format!("_pad{i}"), arrow::datatypes::DataType::Null, true))
+            .collect();
+        fields.push(Field::new("_col", data_type, true));
+        let dummy_schema = Schema::new(fields);
+
+        let in_expr = Arc::new(InListExpr::try_new(
+            left_expr,
+            expr_values,
+            false, // not negated (IN, not NOT IN)
+            &dummy_schema,
+        )?);
+
+        tracing::debug!(
+            "ExactLeftAccumulator created InListExpr with {} values ({} bytes).",
+            in_expr.list().len(),
+            self.total_memory_size,
+        );
+
+        Ok(in_expr)
+    }
+}
+
+#[derive(Debug)]
+struct RangeBounds {
+    intervals: Vec<RangeInterval>,
+    bloom_filter: Option<BloomFilter>,
+    supports_range_filter: bool,
+}
+
+impl RangeBounds {
+    fn new(max_bloom_filter_memory_size: usize) -> Self {
+        Self {
+            intervals: Vec::new(),
+            bloom_filter: BloomFilter::try_new(max_bloom_filter_memory_size),
+            supports_range_filter: true,
+        }
+    }
+
+    fn update(&mut self, array: &dyn Array) -> DataFusionResult<()> {
+        if !self.supports_range_filter {
+            return Ok(());
+        }
+
+        let batch_bounds = min_max_values(array)?;
+        let RangeBatchBounds::Values {
+            min_value,
+            max_value,
+        } = batch_bounds
+        else {
+            if matches!(batch_bounds, RangeBatchBounds::Unsupported) {
+                self.supports_range_filter = false;
+            }
+            return Ok(());
+        };
+
+        if !supports_range_comparison(&min_value) || !supports_range_comparison(&max_value) {
+            self.supports_range_filter = false;
+            return Ok(());
+        }
+
+        self.update_bloom_filter(array)?;
+        if !self.add_interval(RangeInterval::new(min_value, max_value)) {
+            self.supports_range_filter = false;
+        }
+
+        Ok(())
+    }
+
+    fn update_bloom_filter(&mut self, array: &dyn Array) -> DataFusionResult<()> {
+        let Some(bloom_filter) = &mut self.bloom_filter else {
+            return Ok(());
+        };
+
+        // The Cayenne rewriter only enables this accumulator for
+        // `NullEqualsNothing`, so build-side NULL keys cannot match probe keys.
+        bloom_filter.insert_array(array)
+    }
+
+    fn add_interval(&mut self, interval: RangeInterval) -> bool {
+        self.intervals.push(interval);
+        self.intervals.sort_by(|left, right| {
+            left.min_value
+                .partial_cmp(&right.min_value)
+                .unwrap_or(Ordering::Equal)
+        });
+
+        let mut merged_intervals: Vec<RangeInterval> = Vec::with_capacity(self.intervals.len());
+        for interval in self.intervals.drain(..) {
+            let Some(previous) = merged_intervals.last_mut() else {
+                merged_intervals.push(interval);
+                continue;
+            };
+
+            if previous.overlaps(&interval) {
+                if !previous.merge(interval) {
+                    return false;
+                }
+            } else {
+                merged_intervals.push(interval);
+            }
+        }
+
+        if merged_intervals.len() > MAXIMUM_RANGE_INTERVALS {
+            let Some(mut global_range) = merged_intervals.first().cloned() else {
+                self.intervals.clear();
+                return true;
+            };
+
+            for interval in merged_intervals.into_iter().skip(1) {
+                if !global_range.merge(interval) {
+                    return false;
+                }
+            }
+
+            self.intervals.push(global_range);
+        } else {
+            self.intervals = merged_intervals;
+        }
+
+        true
+    }
+
+    fn physical_expr(&self, left_expr: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
+        if !self.supports_range_filter {
+            tracing::debug!(
+                supports_range_filter = self.supports_range_filter,
+                "ExactLeftAccumulator could not create range fallback, returning no-op filter."
+            );
+            return literal_true();
+        }
+
+        if self.intervals.is_empty() {
+            tracing::debug!(
+                "ExactLeftAccumulator range fallback has no non-null values, returning always-false filter."
+            );
+            return literal_false();
+        }
+
+        let mut range_expr = self
+            .intervals
+            .iter()
+            .map(|interval| interval.physical_expr(Arc::clone(&left_expr)))
+            .reduce(|left, right| Arc::new(BinaryExpr::new(left, Operator::Or, right)) as _)
+            .unwrap_or_else(literal_true);
+
+        if let Some(bloom_filter) = &self.bloom_filter
+            && bloom_filter.has_values()
+        {
+            let bloom_expr = Arc::new(BloomFilterExpr::new(
+                left_expr,
+                Arc::new(bloom_filter.clone()),
+            )) as Arc<dyn PhysicalExpr>;
+            range_expr = Arc::new(BinaryExpr::new(range_expr, Operator::And, bloom_expr));
+        }
+
+        tracing::debug!(
+            interval_count = self.intervals.len(),
+            has_bloom_filter = self
+                .bloom_filter
+                .as_ref()
+                .is_some_and(BloomFilter::has_values),
+            "ExactLeftAccumulator created range fallback."
+        );
+
+        range_expr
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RangeInterval {
+    min_value: ScalarValue,
+    max_value: ScalarValue,
+}
+
+impl RangeInterval {
+    fn new(min_value: ScalarValue, max_value: ScalarValue) -> Self {
+        Self {
+            min_value,
+            max_value,
+        }
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        matches!(
+            other.min_value.partial_cmp(&self.max_value),
+            Some(Ordering::Less | Ordering::Equal)
+        )
+    }
+
+    fn merge(&mut self, other: Self) -> bool {
+        let min_value = match other.min_value.partial_cmp(&self.min_value) {
+            Some(Ordering::Less) => other.min_value,
+            Some(_) => self.min_value.clone(),
+            None => return false,
+        };
+        let max_value = match other.max_value.partial_cmp(&self.max_value) {
+            Some(Ordering::Greater) => other.max_value,
+            Some(_) => self.max_value.clone(),
+            None => return false,
+        };
+
+        self.min_value = min_value;
+        self.max_value = max_value;
+        true
+    }
+
+    fn physical_expr(&self, left_expr: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
+        let lower_bound = Arc::new(BinaryExpr::new(
+            Arc::clone(&left_expr),
+            Operator::GtEq,
+            Arc::new(Literal::new(self.min_value.clone())),
+        ));
+        let upper_bound = Arc::new(BinaryExpr::new(
+            left_expr,
+            Operator::LtEq,
+            Arc::new(Literal::new(self.max_value.clone())),
+        ));
+
+        Arc::new(BinaryExpr::new(lower_bound, Operator::And, upper_bound))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BloomFilter {
+    bits: Vec<u64>,
+    bit_count: usize,
+    inserted_values: usize,
+}
+
+impl BloomFilter {
+    const HASH_COUNT: u64 = 7;
+    const HASH_STEP_SALT: u64 = 0x9E37_79B9_7F4A_7C15;
+
+    fn try_new(memory_bytes: usize) -> Option<Self> {
+        let word_count = memory_bytes / size_of::<u64>();
+        if word_count == 0 {
+            return None;
+        }
+
+        Some(Self {
+            bits: vec![0; word_count],
+            bit_count: word_count * u64::BITS as usize,
+            inserted_values: 0,
+        })
+    }
+
+    fn insert_hash(&mut self, hash: u64) {
+        let (hash_one, hash_two) = bloom_hashes(hash);
+        self.insert_hashes(hash_one, hash_two);
+    }
+
+    fn insert_hashes(&mut self, hash_one: u64, hash_two: u64) {
+        for hash_index in 0..Self::HASH_COUNT {
+            let bit_index = self.bit_index(hash_one, hash_two, hash_index);
+            self.bits[bit_index / u64::BITS as usize] |= 1 << (bit_index % u64::BITS as usize);
+        }
+        self.inserted_values = self.inserted_values.saturating_add(1);
+    }
+
+    fn might_contain_hash(&self, hash: u64) -> bool {
+        let (hash_one, hash_two) = bloom_hashes(hash);
+        self.might_contain_hashes(hash_one, hash_two)
+    }
+
+    fn might_contain_hashes(&self, hash_one: u64, hash_two: u64) -> bool {
+        (0..Self::HASH_COUNT).all(|hash_index| {
+            let bit_index = self.bit_index(hash_one, hash_two, hash_index);
+            let word = self.bits[bit_index / u64::BITS as usize];
+            (word & (1 << (bit_index % u64::BITS as usize))) != 0
+        })
+    }
+
+    fn insert_array(&mut self, array: &dyn Array) -> DataFusionResult<()> {
+        match array.data_type() {
+            DataType::Float16 => self.insert_float_array::<Float16Type>(array),
+            DataType::Float32 => self.insert_float_array::<Float32Type>(array),
+            DataType::Float64 => self.insert_float_array::<Float64Type>(array),
+            _ => self.insert_datafusion_hashes(array),
+        }
+    }
+
+    fn evaluate_array(&self, array: &dyn Array) -> DataFusionResult<BooleanArray> {
+        match array.data_type() {
+            DataType::Float16 => self.evaluate_float_array::<Float16Type>(array),
+            DataType::Float32 => self.evaluate_float_array::<Float32Type>(array),
+            DataType::Float64 => self.evaluate_float_array::<Float64Type>(array),
+            _ => self.evaluate_datafusion_hashes(array),
+        }
+    }
+
+    fn insert_float_array<T>(&mut self, array: &dyn Array) -> DataFusionResult<()>
+    where
+        T: BloomFloatType,
+    {
+        let array = downcast_array::<PrimitiveArray<T>>(array)?;
+        let zero_hashes = float_zero_hashes::<T>()?;
+        for_each_datafusion_hash(array, |row_index, hash| {
+            if array.is_valid(row_index) {
+                let value = array.value(row_index);
+                if T::is_nan(value) {
+                    return;
+                }
+
+                self.insert_hash(hash);
+                if T::is_zero(value) {
+                    self.insert_hash(zero_hashes.0);
+                    self.insert_hash(zero_hashes.1);
+                }
+            }
+        })
+    }
+
+    fn evaluate_float_array<T>(&self, array: &dyn Array) -> DataFusionResult<BooleanArray>
+    where
+        T: BloomFloatType,
+    {
+        let array = downcast_array::<PrimitiveArray<T>>(array)?;
+        let mut builder = BooleanBuilder::with_capacity(array.len());
+        for_each_datafusion_hash(array, |row_index, hash| {
+            builder.append_value(if array.is_valid(row_index) {
+                let value = array.value(row_index);
+                !T::is_nan(value) && self.might_contain_hash(hash)
+            } else {
+                false
+            });
+        })?;
+        Ok(builder.finish())
+    }
+
+    fn insert_datafusion_hashes(&mut self, array: &dyn Array) -> DataFusionResult<()> {
+        for_each_datafusion_hash(array, |row_index, hash| {
+            if array.is_valid(row_index) {
+                self.insert_hash(hash);
+            }
+        })
+    }
+
+    fn evaluate_datafusion_hashes(&self, array: &dyn Array) -> DataFusionResult<BooleanArray> {
+        let mut builder = BooleanBuilder::with_capacity(array.len());
+        for_each_datafusion_hash(array, |row_index, hash| {
+            builder.append_value(array.is_valid(row_index) && self.might_contain_hash(hash));
+        })?;
+        Ok(builder.finish())
+    }
+
+    fn has_values(&self) -> bool {
+        self.inserted_values > 0
+    }
+
+    fn bit_index(&self, hash_one: u64, hash_two: u64, hash_index: u64) -> usize {
+        let hash = hash_one.wrapping_add(hash_index.wrapping_mul(hash_two | 1));
+        usize::try_from(hash % self.bit_count as u64).unwrap_or(0)
+    }
+}
+
+fn datafusion_hash_join_random_state() -> SeededRandomState {
+    SeededRandomState::with_seeds('J' as u64, 'O' as u64, 'I' as u64, 'N' as u64)
+}
+
+fn for_each_datafusion_hash(
+    array: &dyn Array,
+    mut f: impl FnMut(usize, u64),
+) -> DataFusionResult<()> {
+    with_hashes(
+        [array],
+        datafusion_hash_join_random_state().random_state(),
+        |hashes| {
+            for (row_index, hash) in hashes.iter().copied().enumerate() {
+                f(row_index, hash);
+            }
+            Ok(())
+        },
+    )
+}
+
+fn float_zero_hashes<T>() -> DataFusionResult<(u64, u64)>
+where
+    T: BloomFloatType,
+{
+    let array = PrimitiveArray::<T>::from_iter_values([T::positive_zero(), T::negative_zero()]);
+    let mut zero_hashes = (0, 0);
+    with_hashes(
+        [&array as &dyn Array],
+        datafusion_hash_join_random_state().random_state(),
+        |hashes| {
+            zero_hashes = (hashes[0], hashes[1]);
+            Ok(())
+        },
+    )?;
+    Ok(zero_hashes)
+}
+
+fn bloom_hashes(datafusion_hash: u64) -> (u64, u64) {
+    (
+        datafusion_hash,
+        combine_hashes(datafusion_hash, BloomFilter::HASH_STEP_SALT),
+    )
+}
+
+trait BloomFloatType: ArrowPrimitiveType {
+    fn positive_zero() -> Self::Native;
+
+    fn negative_zero() -> Self::Native;
+
+    fn is_zero(value: Self::Native) -> bool;
+
+    fn is_nan(value: Self::Native) -> bool;
+}
+
+impl BloomFloatType for Float16Type {
+    fn positive_zero() -> Self::Native {
+        <Self as ArrowPrimitiveType>::Native::from_f32(0.0)
+    }
+
+    fn negative_zero() -> Self::Native {
+        <Self as ArrowPrimitiveType>::Native::from_f32(-0.0)
+    }
+
+    fn is_zero(value: Self::Native) -> bool {
+        value == Self::positive_zero()
+    }
+
+    fn is_nan(value: Self::Native) -> bool {
+        value.is_nan()
+    }
+}
+
+impl BloomFloatType for Float32Type {
+    fn positive_zero() -> Self::Native {
+        0.0
+    }
+
+    fn negative_zero() -> Self::Native {
+        -0.0
+    }
+
+    fn is_zero(value: Self::Native) -> bool {
+        value == 0.0
+    }
+
+    fn is_nan(value: Self::Native) -> bool {
+        value.is_nan()
+    }
+}
+
+impl BloomFloatType for Float64Type {
+    fn positive_zero() -> Self::Native {
+        0.0
+    }
+
+    fn negative_zero() -> Self::Native {
+        -0.0
+    }
+
+    fn is_zero(value: Self::Native) -> bool {
+        value == 0.0
+    }
+
+    fn is_nan(value: Self::Native) -> bool {
+        value.is_nan()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BloomFilterExpr {
+    expr: Arc<dyn PhysicalExpr>,
+    bloom_filter: Arc<BloomFilter>,
+}
+
+impl BloomFilterExpr {
+    fn new(expr: Arc<dyn PhysicalExpr>, bloom_filter: Arc<BloomFilter>) -> Self {
+        Self { expr, bloom_filter }
+    }
+}
+
+impl PartialEq for BloomFilterExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.expr.eq(&other.expr) && self.bloom_filter.eq(&other.bloom_filter)
+    }
+}
+
+impl Eq for BloomFilterExpr {}
+
+impl Hash for BloomFilterExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.expr.hash(state);
+        self.bloom_filter.hash(state);
+    }
+}
+
+impl Display for BloomFilterExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "bloom_filter({})", self.expr)
+    }
+}
+
+impl PhysicalExpr for BloomFilterExpr {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn data_type(&self, _input_schema: &Schema) -> DataFusionResult<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    fn nullable(&self, _input_schema: &Schema) -> DataFusionResult<bool> {
+        Ok(false)
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> DataFusionResult<ColumnarValue> {
+        let array = self.expr.evaluate(batch)?.into_array(batch.num_rows())?;
+        Ok(ColumnarValue::Array(
+            Arc::new(self.bloom_filter.evaluate_array(array.as_ref())?) as ArrayRef,
+        ))
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![&self.expr]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let Some(expr) = children.into_iter().next() else {
+            return Err(DataFusionError::Internal(
+                "BloomFilterExpr expected one child expression".to_string(),
+            ));
+        };
+
+        Ok(Arc::new(Self::new(expr, Arc::clone(&self.bloom_filter))))
+    }
+
+    fn fmt_sql(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "bloom_filter({})", self.expr)
+    }
+}
+
+enum RangeBatchBounds {
+    Values {
+        min_value: ScalarValue,
+        max_value: ScalarValue,
+    },
+    NoValues,
+    Unsupported,
+}
+
+fn min_max_values(array: &dyn Array) -> DataFusionResult<RangeBatchBounds> {
+    match array.data_type() {
+        DataType::Int8 => primitive_min_max::<Int8Type, _>(array, ScalarValue::Int8),
+        DataType::Int16 => primitive_min_max::<Int16Type, _>(array, ScalarValue::Int16),
+        DataType::Int32 => primitive_min_max::<Int32Type, _>(array, ScalarValue::Int32),
+        DataType::Int64 => primitive_min_max::<Int64Type, _>(array, ScalarValue::Int64),
+        DataType::UInt8 => primitive_min_max::<UInt8Type, _>(array, ScalarValue::UInt8),
+        DataType::UInt16 => primitive_min_max::<UInt16Type, _>(array, ScalarValue::UInt16),
+        DataType::UInt32 => primitive_min_max::<UInt32Type, _>(array, ScalarValue::UInt32),
+        DataType::UInt64 => primitive_min_max::<UInt64Type, _>(array, ScalarValue::UInt64),
+        DataType::Float16 => float_min_max::<Float16Type, _>(array, ScalarValue::Float16),
+        DataType::Float32 => float_min_max::<Float32Type, _>(array, ScalarValue::Float32),
+        DataType::Float64 => float_min_max::<Float64Type, _>(array, ScalarValue::Float64),
+        DataType::Decimal32(precision, scale) => {
+            let precision = *precision;
+            let scale = *scale;
+            primitive_min_max::<Decimal32Type, _>(array, |value| {
+                ScalarValue::Decimal32(value, precision, scale)
+            })
+        }
+        DataType::Decimal64(precision, scale) => {
+            let precision = *precision;
+            let scale = *scale;
+            primitive_min_max::<Decimal64Type, _>(array, |value| {
+                ScalarValue::Decimal64(value, precision, scale)
+            })
+        }
+        DataType::Decimal128(precision, scale) => {
+            let precision = *precision;
+            let scale = *scale;
+            primitive_min_max::<Decimal128Type, _>(array, |value| {
+                ScalarValue::Decimal128(value, precision, scale)
+            })
+        }
+        DataType::Decimal256(precision, scale) => {
+            let precision = *precision;
+            let scale = *scale;
+            primitive_min_max::<Decimal256Type, _>(array, |value| {
+                ScalarValue::Decimal256(value, precision, scale)
+            })
+        }
+        DataType::Date32 => primitive_min_max::<Date32Type, _>(array, ScalarValue::Date32),
+        DataType::Date64 => primitive_min_max::<Date64Type, _>(array, ScalarValue::Date64),
+        DataType::Time32(TimeUnit::Second) => {
+            primitive_min_max::<Time32SecondType, _>(array, ScalarValue::Time32Second)
+        }
+        DataType::Time32(TimeUnit::Millisecond) => {
+            primitive_min_max::<Time32MillisecondType, _>(array, ScalarValue::Time32Millisecond)
+        }
+        DataType::Time64(TimeUnit::Microsecond) => {
+            primitive_min_max::<Time64MicrosecondType, _>(array, ScalarValue::Time64Microsecond)
+        }
+        DataType::Time64(TimeUnit::Nanosecond) => {
+            primitive_min_max::<Time64NanosecondType, _>(array, ScalarValue::Time64Nanosecond)
+        }
+        DataType::Timestamp(TimeUnit::Second, timezone) => {
+            let timezone = timezone.clone();
+            primitive_min_max::<TimestampSecondType, _>(array, |value| {
+                ScalarValue::TimestampSecond(value, timezone.clone())
+            })
+        }
+        DataType::Timestamp(TimeUnit::Millisecond, timezone) => {
+            let timezone = timezone.clone();
+            primitive_min_max::<TimestampMillisecondType, _>(array, |value| {
+                ScalarValue::TimestampMillisecond(value, timezone.clone())
+            })
+        }
+        DataType::Timestamp(TimeUnit::Microsecond, timezone) => {
+            let timezone = timezone.clone();
+            primitive_min_max::<TimestampMicrosecondType, _>(array, |value| {
+                ScalarValue::TimestampMicrosecond(value, timezone.clone())
+            })
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, timezone) => {
+            let timezone = timezone.clone();
+            primitive_min_max::<TimestampNanosecondType, _>(array, |value| {
+                ScalarValue::TimestampNanosecond(value, timezone.clone())
+            })
+        }
+        DataType::Utf8 => string_min_max::<i32, _>(array, ScalarValue::Utf8),
+        DataType::LargeUtf8 => string_min_max::<i64, _>(array, ScalarValue::LargeUtf8),
+        DataType::Utf8View => string_view_min_max(array),
+        _ => Ok(RangeBatchBounds::Unsupported),
+    }
+}
+
+fn primitive_min_max<T, F>(array: &dyn Array, scalar_value: F) -> DataFusionResult<RangeBatchBounds>
+where
+    T: ArrowPrimitiveType,
+    T::Native: PartialOrd,
+    F: Fn(Option<T::Native>) -> ScalarValue,
+{
+    let array = downcast_array::<PrimitiveArray<T>>(array)?;
+    let (Some(min_value), Some(max_value)) = (min::<T>(array), max::<T>(array)) else {
+        return Ok(RangeBatchBounds::NoValues);
+    };
+
+    Ok(RangeBatchBounds::Values {
+        min_value: scalar_value(Some(min_value)),
+        max_value: scalar_value(Some(max_value)),
+    })
+}
+
+fn float_min_max<T, F>(array: &dyn Array, scalar_value: F) -> DataFusionResult<RangeBatchBounds>
+where
+    T: BloomFloatType,
+    T::Native: PartialOrd,
+    F: Fn(Option<T::Native>) -> ScalarValue,
+{
+    let array = downcast_array::<PrimitiveArray<T>>(array)?;
+    if array.iter().flatten().any(T::is_nan) {
+        return Ok(RangeBatchBounds::Unsupported);
+    }
+
+    let (Some(min_value), Some(max_value)) = (min::<T>(array), max::<T>(array)) else {
+        return Ok(RangeBatchBounds::NoValues);
+    };
+
+    Ok(RangeBatchBounds::Values {
+        min_value: scalar_value(Some(min_value)),
+        max_value: scalar_value(Some(max_value)),
+    })
+}
+
+fn string_min_max<T, F>(array: &dyn Array, scalar_value: F) -> DataFusionResult<RangeBatchBounds>
+where
+    T: OffsetSizeTrait,
+    F: Fn(Option<String>) -> ScalarValue,
+{
+    let array = downcast_array::<GenericStringArray<T>>(array)?;
+    let (Some(min_value), Some(max_value)) = (min_string(array), max_string(array)) else {
+        return Ok(RangeBatchBounds::NoValues);
+    };
+
+    Ok(RangeBatchBounds::Values {
+        min_value: scalar_value(Some(min_value.to_string())),
+        max_value: scalar_value(Some(max_value.to_string())),
+    })
+}
+
+fn string_view_min_max(array: &dyn Array) -> DataFusionResult<RangeBatchBounds> {
+    let array = downcast_array::<StringViewArray>(array)?;
+    let (Some(min_value), Some(max_value)) = (min_string_view(array), max_string_view(array))
+    else {
+        return Ok(RangeBatchBounds::NoValues);
+    };
+
+    Ok(RangeBatchBounds::Values {
+        min_value: ScalarValue::Utf8View(Some(min_value.to_string())),
+        max_value: ScalarValue::Utf8View(Some(max_value.to_string())),
+    })
+}
+
+fn downcast_array<T: 'static>(array: &dyn Array) -> DataFusionResult<&T> {
+    array.as_any().downcast_ref::<T>().ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "Failed to downcast join filter array with type {} to {}",
+            array.data_type(),
+            type_name::<T>()
+        ))
+    })
+}
+
+fn supports_range_comparison(value: &ScalarValue) -> bool {
+    match value {
+        ScalarValue::Float16(Some(value)) => !value.is_nan(),
+        ScalarValue::Float32(Some(value)) => !value.is_nan(),
+        ScalarValue::Float64(Some(value)) => !value.is_nan(),
+        _ => matches!(
+            value.data_type(),
+            DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Float16
+                | DataType::Float32
+                | DataType::Float64
+                | DataType::Decimal32(_, _)
+                | DataType::Decimal64(_, _)
+                | DataType::Decimal128(_, _)
+                | DataType::Decimal256(_, _)
+                | DataType::Date32
+                | DataType::Date64
+                | DataType::Time32(_)
+                | DataType::Time64(_)
+                | DataType::Timestamp(_, _)
+                | DataType::Utf8
+                | DataType::LargeUtf8
+                | DataType::Utf8View
+        ),
+    }
+}
+
+fn literal_true() -> Arc<dyn PhysicalExpr> {
+    Arc::new(Literal::new(ScalarValue::Boolean(Some(true))))
+}
+
+fn literal_false() -> Arc<dyn PhysicalExpr> {
+    Arc::new(Literal::new(ScalarValue::Boolean(Some(false))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, Int32Array, StringArray, UInt64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::Column;
+    use datafusion::physical_plan::expressions::col;
+    use datafusion_pruning::{PruningPredicate, PruningStatistics};
+    use std::sync::Mutex;
+
+    static INLIST_MEMORY_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn create_test_batch() -> RecordBatch {
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let a: ArrayRef = Arc::new(Int32Array::from((0..10).collect::<Vec<i32>>()));
+        RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+    }
+
+    fn create_uint64_batch(values: Vec<u64>) -> RecordBatch {
+        let schema = Schema::new(vec![Field::new("a", DataType::UInt64, false)]);
+        let a: ArrayRef = Arc::new(UInt64Array::from(values));
+        RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+    }
+
+    fn create_nullable_uint64_batch(values: Vec<Option<u64>>) -> RecordBatch {
+        let schema = Schema::new(vec![Field::new("a", DataType::UInt64, true)]);
+        let a: ArrayRef = Arc::new(UInt64Array::from(values));
+        RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+    }
+
+    fn assert_literal_true(physical_expr: &Arc<dyn PhysicalExpr>) {
+        let literal_expr = physical_expr
+            .as_any()
+            .downcast_ref::<Literal>()
+            .expect("Should downcast to Literal");
+        let expected_value = ScalarValue::Boolean(Some(true));
+        assert_eq!(literal_expr.value(), &expected_value);
+    }
+
+    fn assert_literal_false(physical_expr: &Arc<dyn PhysicalExpr>) {
+        let literal_expr = physical_expr
+            .as_any()
+            .downcast_ref::<Literal>()
+            .expect("Should downcast to Literal");
+        let expected_value = ScalarValue::Boolean(Some(false));
+        assert_eq!(literal_expr.value(), &expected_value);
+    }
+
+    fn evaluate_boolean_expression(
+        physical_expr: &Arc<dyn PhysicalExpr>,
+        batch: &RecordBatch,
+    ) -> Vec<Option<bool>> {
+        let result = physical_expr
+            .evaluate(batch)
+            .expect("Should evaluate expression")
+            .into_array(batch.num_rows())
+            .expect("Should produce boolean array");
+        let bool_result = result
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("Should downcast to BooleanArray");
+
+        (0..bool_result.len())
+            .map(|row_index| {
+                if bool_result.is_null(row_index) {
+                    None
+                } else {
+                    Some(bool_result.value(row_index))
+                }
+            })
+            .collect()
+    }
+
+    #[derive(Debug)]
+    struct TestPruningStats {
+        min_values: ArrayRef,
+        max_values: ArrayRef,
+    }
+
+    impl PruningStatistics for TestPruningStats {
+        fn min_values(&self, _column: &Column) -> Option<ArrayRef> {
+            Some(Arc::clone(&self.min_values))
+        }
+
+        fn max_values(&self, _column: &Column) -> Option<ArrayRef> {
+            Some(Arc::clone(&self.max_values))
+        }
+
+        fn num_containers(&self) -> usize {
+            self.min_values.len()
+        }
+
+        fn null_counts(&self, _column: &Column) -> Option<ArrayRef> {
+            None
+        }
+
+        fn row_counts(&self, _column: &Column) -> Option<ArrayRef> {
+            None
+        }
+
+        fn contained(
+            &self,
+            _column: &Column,
+            _values: &HashSet<ScalarValue>,
+        ) -> Option<BooleanArray> {
+            None
+        }
+    }
+
+    #[test]
+    fn test_exact_left_accumulator() {
+        // Test the ExactLeftAccumulator implementation. Define a sample PhysicalExpr with a projection for a column to be scanned into a dynamic filter
+        // In this scenario, we pass through a record batch with 10 values. We then build the column bounds, and verify the returned PhysicalExpr is an InListExpr with the expected values.
+        let batch = create_test_batch();
+        let schema = batch.schema();
+
+        let left_expr = col("a", &schema).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update batches");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let in_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        // Validate the expression is an InListExpr with the expected values
+        let in_list_expr = in_expr.as_any().downcast_ref::<InListExpr>();
+        let in_list_expr = in_list_expr.expect("Should downcast to InListExpr");
+        let expected_values: Vec<ScalarValue> =
+            (0..10).map(|i| ScalarValue::Int32(Some(i))).collect();
+        let mut actual_values: Vec<ScalarValue> = in_list_expr
+            .list()
+            .iter()
+            .map(|expr| {
+                let literal = expr
+                    .as_any()
+                    .downcast_ref::<Literal>()
+                    .expect("Should be a literal");
+                literal.value().clone()
+            })
+            .collect();
+        actual_values.sort_by(|a, b| a.partial_cmp(b).expect("Should be comparable"));
+        assert_eq!(expected_values, actual_values);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_empty_batch() {
+        // Test that updating with an empty batch does not cause errors and produces an always-false filter.
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let empty_batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(Int32Array::from(Vec::<i32>::new()))],
+        )
+        .expect("Should create empty record batch");
+
+        let left_expr = col("a", &empty_batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &empty_batch.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch(&empty_batch)
+            .expect("Should update with empty batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        assert_literal_false(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_uses_exact_values_at_memory_limit() {
+        let batch = create_uint64_batch(vec![1, 3, 5]);
+        let max_memory_size = batch.column(0).get_array_memory_size();
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), max_memory_size);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+        assert_eq!(1, accumulator.arrays.len());
+        assert!(!accumulator.exact_values_exceeded_memory_limit);
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        physical_expr
+            .as_any()
+            .downcast_ref::<InListExpr>()
+            .expect("Should downcast to InListExpr");
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_exceeds_memory() {
+        let batch = create_uint64_batch(vec![1, 3, 5]);
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 1);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+        assert!(accumulator.arrays.is_empty());
+        assert!(accumulator.exact_values_exceeded_memory_limit);
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let result =
+            evaluate_boolean_expression(&physical_expr, &create_uint64_batch(vec![0, 1, 3, 5, 6]));
+        assert_eq!(
+            vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
+            result
+        );
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_memory_fallback_with_nulls_and_mixed_values() {
+        // Edge case: memory limit exceeded while accumulating a column that contains NULLs.
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, true)]);
+        let values: Vec<Option<i32>> = vec![Some(5), None, Some(10), Some(15), None, Some(20)];
+        let array: ArrayRef = Arc::new(Int32Array::from(values));
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![array])
+            .expect("Should create batch with NULLs");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        // Extremely small memory limit to force immediate fallback.
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 1);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update batch with NULLs and values");
+
+        assert!(accumulator.exact_values_exceeded_memory_limit);
+        assert!(accumulator.arrays.is_empty());
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(Arc::clone(&left_expr))
+            .expect("Should create physical expr");
+
+        let result = evaluate_boolean_expression(&physical_expr, &batch);
+        assert_eq!(
+            vec![Some(true), None, Some(true), Some(true), None, Some(true)],
+            result
+        );
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_defers_range_bounds_until_memory_limit_exceeded() {
+        let first_batch = create_uint64_batch(vec![10, 20]);
+        let second_batch = create_uint64_batch(vec![1, 30]);
+        let max_memory_size = first_batch.column(0).get_array_memory_size();
+
+        let left_expr = col("a", &first_batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), max_memory_size);
+
+        accumulator
+            .update_batch(&first_batch)
+            .expect("Should update first batch");
+        assert_eq!(1, accumulator.arrays.len());
+        assert!(accumulator.range_bounds.intervals.is_empty());
+        assert!(!accumulator.exact_values_exceeded_memory_limit);
+
+        accumulator
+            .update_batch(&second_batch)
+            .expect("Should update second batch");
+        assert!(accumulator.arrays.is_empty());
+        assert!(accumulator.exact_values_exceeded_memory_limit);
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let result = evaluate_boolean_expression(
+            &physical_expr,
+            &create_uint64_batch(vec![0, 1, 15, 30, 31]),
+        );
+        assert_eq!(
+            vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
+            result
+        );
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_updates_range_after_limit_exceeded() {
+        let first_batch = create_uint64_batch(vec![10, 20]);
+        let second_batch = create_uint64_batch(vec![1, 30]);
+
+        let left_expr = col("a", &first_batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 1);
+
+        accumulator
+            .update_batch(&first_batch)
+            .expect("Should update first batch");
+        accumulator
+            .update_batch(&second_batch)
+            .expect("Should update second batch");
+        assert!(accumulator.arrays.is_empty());
+        assert!(accumulator.exact_values_exceeded_memory_limit);
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let result = evaluate_boolean_expression(
+            &physical_expr,
+            &create_uint64_batch(vec![0, 1, 15, 30, 31]),
+        );
+        assert_eq!(
+            vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
+            result
+        );
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_tracks_disjoint_ranges_after_limit_exceeded() {
+        let first_batch = create_uint64_batch(vec![10, 20]);
+        let second_batch = create_uint64_batch(vec![100, 110]);
+        let max_memory_size = first_batch.column(0).get_array_memory_size();
+
+        let left_expr = col("a", &first_batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), max_memory_size);
+
+        accumulator
+            .update_batch(&first_batch)
+            .expect("Should update first batch");
+        accumulator
+            .update_batch(&second_batch)
+            .expect("Should update second batch");
+
+        assert!(accumulator.exact_values_exceeded_memory_limit);
+        assert_eq!(2, accumulator.range_bounds.intervals.len());
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let result = evaluate_boolean_expression(
+            &physical_expr,
+            &create_uint64_batch(vec![5, 10, 50, 100, 120]),
+        );
+        assert_eq!(
+            vec![
+                Some(false),
+                Some(true),
+                Some(false),
+                Some(true),
+                Some(false)
+            ],
+            result
+        );
+    }
+
+    #[test]
+    fn test_shared_inlist_budget_rejects_reservations_above_limit() {
+        let _guard = INLIST_MEMORY_TEST_LOCK
+            .lock()
+            .expect("memory budget test lock should not be poisoned");
+
+        let current_usage = CURRENT_INLIST_MEMORY_BYTES.load(AtomicOrdering::Relaxed);
+        let reservation_size = 16;
+        assert!(reserve_inlist_memory_with_limit(
+            reservation_size,
+            usize::MAX
+        ));
+        let reservation = InListMemoryReservation {
+            bytes: reservation_size,
+        };
+
+        let saturated_limit = CURRENT_INLIST_MEMORY_BYTES.load(AtomicOrdering::Relaxed);
+        assert!(saturated_limit >= current_usage + reservation_size);
+        assert!(!reserve_inlist_memory_with_limit(1, saturated_limit));
+
+        drop(reservation);
+    }
+
+    #[test]
+    fn test_bloom_filter_expression_excludes_definitely_absent_values() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::UInt64, true)]));
+        let a: ArrayRef = Arc::new(UInt64Array::from(vec![Some(1), Some(3), None, Some(5)]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![a])
+            .expect("Should create probe record batch");
+        let left_expr = col("a", &schema).expect("Should create column expr");
+
+        let mut bloom_filter = BloomFilter::try_new(1_024).expect("Bloom filter should be created");
+        let build_array = UInt64Array::from(vec![1, 5]);
+        bloom_filter
+            .insert_array(&build_array)
+            .expect("Should insert build values");
+
+        let physical_expr = Arc::new(BloomFilterExpr::new(left_expr, Arc::new(bloom_filter)))
+            as Arc<dyn PhysicalExpr>;
+        let actual_values = evaluate_boolean_expression(&physical_expr, &batch);
+
+        assert_eq!(
+            vec![Some(true), Some(false), Some(false), Some(true)],
+            actual_values
+        );
+    }
+
+    #[test]
+    fn test_bloom_filter_normalizes_float_zero() {
+        let mut bloom_filter = BloomFilter::try_new(1_024).expect("Bloom filter should be created");
+        let build_array = Float64Array::from(vec![0.0]);
+        bloom_filter
+            .insert_array(&build_array)
+            .expect("Should insert float zero");
+
+        let probe_array = Float64Array::from(vec![-0.0, 1.0]);
+        let result = bloom_filter
+            .evaluate_array(&probe_array)
+            .expect("Should evaluate float bloom filter");
+
+        assert!(result.value(0));
+        assert!(!result.value(1));
+    }
+
+    #[test]
+    fn test_bloom_filter_skips_float_nan() {
+        let mut bloom_filter = BloomFilter::try_new(1_024).expect("Bloom filter should be created");
+        let build_array = Float64Array::from(vec![f64::NAN, 1.0]);
+        bloom_filter
+            .insert_array(&build_array)
+            .expect("Should insert non-NaN float values");
+
+        let probe_array = Float64Array::from(vec![f64::NAN, 1.0]);
+        let result = bloom_filter
+            .evaluate_array(&probe_array)
+            .expect("Should evaluate float bloom filter");
+
+        assert!(!result.value(0));
+        assert!(result.value(1));
+    }
+
+    #[test]
+    fn range_interval_merge_rejects_incomparable_bounds() {
+        let mut interval =
+            RangeInterval::new(ScalarValue::Int64(Some(1)), ScalarValue::Int64(Some(2)));
+        let incomparable = RangeInterval::new(
+            ScalarValue::Utf8(Some("a".to_string())),
+            ScalarValue::Utf8(Some("z".to_string())),
+        );
+
+        assert!(!interval.merge(incomparable));
+        assert_eq!(interval.min_value, ScalarValue::Int64(Some(1)));
+        assert_eq!(interval.max_value, ScalarValue::Int64(Some(2)));
+    }
+
+    #[test]
+    fn test_range_fallback_expression_prunes_row_group_statistics() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::UInt64, false)]));
+        let left_expr = col("a", &schema).expect("Should create column expr");
+        let mut range_bounds = RangeBounds::new(1_024);
+
+        range_bounds
+            .update(create_uint64_batch(vec![10, 20]).column(0).as_ref())
+            .expect("Should update first range");
+        range_bounds
+            .update(create_uint64_batch(vec![100, 110]).column(0).as_ref())
+            .expect("Should update second range");
+
+        let physical_expr = range_bounds.physical_expr(left_expr);
+        let pruning_predicate = PruningPredicate::try_new(physical_expr, Arc::clone(&schema))
+            .expect("Range fallback should produce a pruning predicate");
+        let pruning_stats = TestPruningStats {
+            min_values: Arc::new(UInt64Array::from(vec![0, 30, 105, 200])) as ArrayRef,
+            max_values: Arc::new(UInt64Array::from(vec![5, 40, 106, 220])) as ArrayRef,
+        };
+
+        let should_keep = pruning_predicate
+            .prune(&pruning_stats)
+            .expect("Pruning predicate should evaluate");
+
+        assert_eq!(vec![false, false, true, false], should_keep);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_memory_range_with_nulls() {
+        let batch = create_nullable_uint64_batch(vec![Some(1), None, Some(3)]);
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 1);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(Arc::clone(&left_expr))
+            .expect("Should create physical expr");
+
+        let result = evaluate_boolean_expression(&physical_expr, &batch);
+        assert_eq!(vec![Some(true), None, Some(true)], result);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_memory_false_with_only_nulls() {
+        let batch = create_nullable_uint64_batch(vec![None, None]);
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 0);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        assert_literal_false(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_memory_noop_with_unsupported_type() {
+        let schema = Schema::new(vec![Field::new("a", DataType::Boolean, false)]);
+        let a: ArrayRef = Arc::new(BooleanArray::from(vec![true, false]));
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 0);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        assert_literal_true(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_memory_noop_with_nan() {
+        let schema = Schema::new(vec![Field::new("a", DataType::Float64, false)]);
+        let a: ArrayRef = Arc::new(Float64Array::from(vec![1.0, f64::NAN, 3.0]));
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 0);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        assert_literal_true(&physical_expr);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_memory_range_with_strings() {
+        let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
+        let a: ArrayRef = Arc::new(StringArray::from(vec!["delta", "bravo", "charlie"]));
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+        let mut accumulator =
+            ExactLeftAccumulator::new_with_memory_limit(Arc::clone(&left_expr), 0);
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let physical_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        let eval_schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
+        let eval_batch = RecordBatch::try_new(
+            Arc::new(eval_schema),
+            vec![Arc::new(StringArray::from(vec![
+                "alpha", "bravo", "charlie", "delta", "echo",
+            ]))],
+        )
+        .expect("Should create evaluation batch");
+        let result = evaluate_boolean_expression(&physical_expr, &eval_batch);
+        assert_eq!(
+            vec![Some(false), Some(true), Some(true), Some(true), Some(false)],
+            result
+        );
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_duplicate_values() {
+        // Test that duplicate values are correctly handled and only unique values are included in the InListExpr
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 2, 3, 3, 3]));
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch");
+
+        let left_expr = col("a", &batch.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch(&batch)
+            .expect("Should update with batch");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let in_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        // Validate the expression is an InListExpr with the expected unique values
+        let in_list_expr = in_expr.as_any().downcast_ref::<InListExpr>();
+        let in_list_expr = in_list_expr.expect("Should downcast to InListExpr");
+        let expected_values: Vec<ScalarValue> = vec![1, 2, 3]
+            .into_iter()
+            .map(|i| ScalarValue::Int32(Some(i)))
+            .collect();
+        let mut actual_values: Vec<ScalarValue> = in_list_expr
+            .list()
+            .iter()
+            .map(|expr| {
+                let literal = expr
+                    .as_any()
+                    .downcast_ref::<Literal>()
+                    .expect("Should be a literal");
+                literal.value().clone()
+            })
+            .collect();
+        actual_values.sort_by(|a, b| a.partial_cmp(b).expect("Should be comparable"));
+
+        assert_eq!(expected_values, actual_values);
+    }
+
+    #[test]
+    fn test_exact_left_accumulator_multiple_batches() {
+        // Test that multiple batches can be accumulated correctly
+        let batch1 = {
+            let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+            let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+        };
+
+        let batch2 = {
+            let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+            let a: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
+            RecordBatch::try_new(Arc::new(schema), vec![a]).expect("Should create record batch")
+        };
+
+        let left_expr = col("a", &batch1.schema()).expect("Should create column expr");
+
+        let mut accumulator =
+            ExactLeftAccumulator::try_new(Arc::clone(&left_expr), &batch1.schema())
+                .expect("Should create accumulator");
+
+        accumulator
+            .update_batch(&batch1)
+            .expect("Should update with batch 1");
+        accumulator
+            .update_batch(&batch2)
+            .expect("Should update with batch 2");
+        accumulator
+            .update_batch(&batch1)
+            .expect("Should update with batch 1 a second time");
+
+        let column_bounds = accumulator.evaluate().expect("Should evaluate bounds");
+        let in_expr = column_bounds
+            .physical_expr(left_expr)
+            .expect("Should create physical expr");
+
+        // Validate the expression is an InListExpr with the expected values
+        let in_list_expr = in_expr.as_any().downcast_ref::<InListExpr>();
+        let in_list_expr = in_list_expr.expect("Should downcast to InListExpr");
+        let expected_values: Vec<ScalarValue> =
+            (1..=6).map(|i| ScalarValue::Int32(Some(i))).collect();
+        let mut actual_values: Vec<ScalarValue> = in_list_expr
+            .list()
+            .iter()
+            .map(|expr| {
+                let literal = expr
+                    .as_any()
+                    .downcast_ref::<Literal>()
+                    .expect("Should be a literal");
+                literal.value().clone()
+            })
+            .collect();
+        actual_values.sort_by(|a, b| a.partial_cmp(b).expect("Should be comparable"));
+        assert_eq!(expected_values, actual_values);
+    }
+}

--- a/crates/runtime-datafusion/src/lib.rs
+++ b/crates/runtime-datafusion/src/lib.rs
@@ -22,6 +22,7 @@ pub mod dialect;
 pub mod error;
 pub mod execution_plan;
 pub mod extension;
+pub mod join_accumulator;
 pub mod managed_runtime;
 pub mod optimizer_rule;
 pub mod param_utils;

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -1040,12 +1040,14 @@ fn parse_cayenne_optimizer_rules(
             "anti_join_sort_merge" | "anti_sort_merge" => {
                 rules.set_anti_join_sort_merge(true);
             }
-            // The former Cayenne `ExactLeftAccumulator` rewrite is now handled by
+            // Opt-in: restores the Cayenne `ExactLeftAccumulator` join rewrite
+            // (`CayenneJoinRewriter`). Off by default — the default path uses
             // DataFusion 53's native inner-join hash-join dynamic-filter pushdown
-            // (min/max bounds + InList/hash-table membership), which is always on.
-            // Accept the historical rule tokens as a no-op so existing spicepods
-            // that list them keep working without an "unknown rule" warning.
-            "exact_join_filter" | "join_rewriter" | "exact_accumulator" => {}
+            // (min/max bounds + InList/hash-table membership). Naming this rule
+            // re-enables the forked exact in-list accumulator alongside it.
+            "exact_join_filter" | "join_rewriter" | "exact_accumulator" => {
+                rules.set_exact_join_filter(true);
+            }
             _ => {
                 // Don't discard the rest of an explicit list because of one bad
                 // token; collect the unknown ones, keep the recognized rules,
@@ -1286,12 +1288,13 @@ mod test {
             CayenneOptimizerRules::all_enabled()
         );
 
-        // `join_rewriter` is accepted as a recognized no-op (the native
-        // DataFusion inner-join dynamic-filter pushdown replaced it), so it does
-        // not enable any rule but also does not trigger the unknown-rule path.
+        // `join_rewriter` is an opt-in alias that enables the Cayenne
+        // `ExactLeftAccumulator` rewrite (`exact_join_filter`) alongside any
+        // other named rules, and does not trigger the unknown-rule path.
         let mut selected_rules = CayenneOptimizerRules::none();
         selected_rules.set_filter_propagation(true);
         selected_rules.set_cross_join_reassociation(true);
+        selected_rules.set_exact_join_filter(true);
         assert_eq!(
             parse_cayenne_optimizer_rules(
                 &HashMap::from([(

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -35,7 +35,8 @@ use crate::{dataaccelerator::AcceleratorEngineRegistry, datafusion::SPICE_SCP_SC
 use cache::Caching;
 #[cfg(not(windows))]
 use cayenne::optimizer_rules::{
-    CayenneAntiJoinSortMergeRewriter, CayenneDynamicFilterSharing, CayenneOptimizerConfig,
+    CayenneAntiJoinSortMergeRewriter, CayenneDynamicFilterSharing, CayenneJoinRewriter,
+    CayenneOptimizerConfig,
 };
 #[cfg(not(windows))]
 use cayenne::{
@@ -95,6 +96,8 @@ use datafusion_optimizer_rules::{
         flightsql::aggregate_pushdown::FlightSQLPartialAggregatePushdown,
     },
 };
+#[cfg(not(windows))]
+use runtime_datafusion::join_accumulator::clamp_maximum_shared_inlist_memory_bytes;
 use runtime_datafusion::{
     extension::{
         ExtensionPlanQueryPlanner, bytes_processed::BytesProcessedPhysicalOptimizer,
@@ -166,6 +169,7 @@ struct CayenneLogicalOptimizerRules {
 struct CayennePhysicalOptimizerRules {
     dynamic_filter_sharing: bool,
     anti_join_sort_merge: bool,
+    exact_join_filter: bool,
 }
 
 impl CayenneOptimizerRules {
@@ -181,6 +185,7 @@ impl CayenneOptimizerRules {
             physical: CayennePhysicalOptimizerRules {
                 dynamic_filter_sharing: true,
                 anti_join_sort_merge: true,
+                exact_join_filter: false,
             },
         }
     }
@@ -197,6 +202,7 @@ impl CayenneOptimizerRules {
             physical: CayennePhysicalOptimizerRules {
                 dynamic_filter_sharing: true,
                 anti_join_sort_merge: true,
+                exact_join_filter: true,
             },
         }
     }
@@ -213,6 +219,7 @@ impl CayenneOptimizerRules {
             physical: CayennePhysicalOptimizerRules {
                 dynamic_filter_sharing: false,
                 anti_join_sort_merge: false,
+                exact_join_filter: false,
             },
         }
     }
@@ -269,6 +276,15 @@ impl CayenneOptimizerRules {
 
     pub fn set_anti_join_sort_merge(&mut self, enabled: bool) {
         self.physical.anti_join_sort_merge = enabled;
+    }
+
+    #[must_use]
+    pub const fn exact_join_filter(self) -> bool {
+        self.physical.exact_join_filter
+    }
+
+    pub fn set_exact_join_filter(&mut self, enabled: bool) {
+        self.physical.exact_join_filter = enabled;
     }
 }
 
@@ -608,12 +624,19 @@ impl DataFusionBuilder {
         // forked `ExactLeftAccumulator` seam.
         configure_hash_join_memory_limits(&mut config, effective_memory_limit);
 
+        // Per-query budget for the opt-in `CayenneJoinRewriter` exact in-list
+        // accumulator. Independent of the default-path
+        // `configure_hash_join_memory_limits` cap-raise above; only consumed when
+        // the `exact_join_filter` rule is registered below.
+        let exact_join_filter_memory_limit = exact_join_filter_memory_limit(effective_memory_limit);
+
         #[cfg(not(windows))]
         {
             config = config.with_option_extension(cayenne_optimizer_config(
                 self.cayenne_sort_merge_min_rows,
                 self.cayenne_sort_merge_memory_pool_fraction,
                 effective_memory_limit,
+                exact_join_filter_memory_limit,
             ));
         }
 
@@ -668,11 +691,14 @@ impl DataFusionBuilder {
         #[cfg(not(windows))]
         {
             // Cayenne is not built on Windows, so its physical optimizer rules
-            // are only configured for supported targets. The ordinary inner-join
-            // probe filter is handled by DataFusion 53's native hash-join
-            // dynamic-filter pushdown (no Cayenne-specific physical rule); the
-            // InList budget for it is sized in `configure_hash_join_memory_limits`
-            // above. Windows keeps DataFusion's standard hash-join dynamic filters.
+            // are only configured for supported targets. By default the ordinary
+            // inner-join probe filter is handled by DataFusion 53's native
+            // hash-join dynamic-filter pushdown (no Cayenne-specific physical
+            // rule); the InList budget for it is sized in
+            // `configure_hash_join_memory_limits` above. The opt-in
+            // `CayenneJoinRewriter` below (gated on `exact_join_filter`) restores
+            // the forked exact in-list accumulator path on top of that default.
+            // Windows keeps DataFusion's standard hash-join dynamic filters.
             state = with_cayenne_logical_optimizers(state, self.cayenne_optimizer_rules);
             if self.cayenne_optimizer_rules.dynamic_filter_sharing() {
                 state = state
@@ -683,7 +709,22 @@ impl DataFusionBuilder {
                     CayenneAntiJoinSortMergeRewriter::new(),
                 ));
             }
+            // Opt-in: restores the forked exact in-list join accumulator seam
+            // (`ExactLeftAccumulator`). Off by default — the default path uses
+            // DataFusion 53's native hash-join dynamic-filter pushdown sized by
+            // `configure_hash_join_memory_limits` above. When enabled, clamp the
+            // process-wide shared in-list reservation and register the rewriter
+            // after the sort-merge rewrite so it only touches remaining
+            // `HashJoinExec` nodes.
+            if self.cayenne_optimizer_rules.exact_join_filter() {
+                clamp_maximum_shared_inlist_memory_bytes(exact_join_filter_memory_limit);
+                state = state.with_physical_optimizer_rule(Arc::new(CayenneJoinRewriter::new()));
+            } else {
+                let _ = exact_join_filter_memory_limit;
+            }
         }
+        #[cfg(windows)]
+        let _ = exact_join_filter_memory_limit;
 
         state = state
             .with_physical_optimizer_rule(Arc::new(BytesProcessedPhysicalOptimizer::new(Arc::new(
@@ -1152,6 +1193,7 @@ fn cayenne_optimizer_config(
     sort_merge_min_rows: Option<usize>,
     sort_merge_memory_pool_fraction: Option<f64>,
     effective_memory_limit: u64,
+    exact_join_filter_memory_limit: usize,
 ) -> CayenneOptimizerConfig {
     let mut config = CayenneOptimizerConfig::default();
     if let Some(sort_merge_min_rows) = sort_merge_min_rows {
@@ -1164,7 +1206,25 @@ fn cayenne_optimizer_config(
         Ok(limit) => limit,
         Err(_) => usize::MAX,
     });
+    config.exact_join_filter_max_bytes = exact_join_filter_memory_limit;
     config
+}
+
+/// Fraction (1/N) of the runtime memory limit budgeted for the opt-in
+/// `CayenneJoinRewriter` exact in-list join accumulator.
+const EXACT_JOIN_FILTER_MEMORY_POOL_FRACTION_DENOMINATOR: u64 = 8;
+
+/// Per-query byte budget for the opt-in exact in-list join accumulator, derived
+/// from the runtime memory limit. Only consumed when the `exact_join_filter`
+/// rule is enabled; the default-path native-pushdown cap is sized separately in
+/// `configure_hash_join_memory_limits`.
+fn exact_join_filter_memory_limit(effective_memory_limit: u64) -> usize {
+    let limit = effective_memory_limit / EXACT_JOIN_FILTER_MEMORY_POOL_FRACTION_DENOMINATOR;
+
+    match usize::try_from(limit) {
+        Ok(limit) => limit,
+        Err(_) => usize::MAX,
+    }
 }
 
 fn hash_join_inlist_memory_limit_per_partition(
@@ -1529,6 +1589,8 @@ mod tests {
         assert_eq!(config.sort_merge_min_rows, 100_000_000);
         assert!((config.sort_merge_memory_pool_fraction - 0.25).abs() < f64::EPSILON);
         assert_eq!(config.sort_merge_memory_pool_bytes, Some(1_024));
+        // memory_limit 1_024 / EXACT_JOIN_FILTER_MEMORY_POOL_FRACTION_DENOMINATOR (8) = 128.
+        assert_eq!(config.exact_join_filter_max_bytes, 128);
     }
 
     #[test]
@@ -1773,6 +1835,8 @@ mod tests {
         dynamic_filter_sharing.set_dynamic_filter_sharing(true);
         let mut anti_join_sort_merge = CayenneOptimizerRules::none();
         anti_join_sort_merge.set_anti_join_sort_merge(true);
+        let mut exact_join_filter = CayenneOptimizerRules::none();
+        exact_join_filter.set_exact_join_filter(true);
 
         let cases = [
             (
@@ -1805,6 +1869,7 @@ mod tests {
                 vec![],
                 vec!["CayenneAntiJoinSortMergeRewriter"],
             ),
+            (exact_join_filter, vec![], vec!["CayenneJoinRewriter"]),
         ];
 
         for (rules, expected_logical_rules, expected_physical_rules) in cases {
@@ -2263,6 +2328,10 @@ mod tests {
             .iter()
             .position(|name| *name == "CayenneAntiJoinSortMergeRewriter")
             .expect("Cayenne anti join sort-merge rewriter should be registered");
+        let cayenne_join_rewriter_position = rule_names
+            .iter()
+            .position(|name| *name == "CayenneJoinRewriter")
+            .expect("Cayenne join rewriter should be registered when exact_join_filter is on");
 
         assert!(
             sanity_check_position < cayenne_filter_sharing_position,
@@ -2271,6 +2340,10 @@ mod tests {
         assert!(
             cayenne_filter_sharing_position < cayenne_anti_sort_merge_position,
             "CayenneDynamicFilterSharing must run before CayenneAntiJoinSortMergeRewriter so same-source joins can receive shared scan filters before any sort-merge rewrite"
+        );
+        assert!(
+            cayenne_anti_sort_merge_position < cayenne_join_rewriter_position,
+            "CayenneJoinRewriter must run after same-source sort-merge rewrites so it only touches remaining HashJoinExec nodes"
         );
     }
 

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -1240,39 +1240,22 @@ fn hash_join_inlist_memory_limit_per_partition(
     }
 }
 
-/// Per-partition byte ceiling + distinct-key ceiling for DataFusion's native
-/// hash-join `InList` dynamic filter on analytical (Cayenne) joins. DF's defaults
-/// (`hash_join_inlist_pushdown_max_size` 128 KiB, `_max_distinct_values` 150) are
-/// tuned for PK point-lookups and DISABLE the in-list for the dimension->fact
-/// joins Cayenne targets, leaving only min/max range bounds — a QPH regression vs
-/// the forked `ExactLeftAccumulator` that the DF53 reconciliation dropped. These
-/// match that accumulator's budget so the exact-membership in-list is pushed into
-/// the Cayenne probe scan for analytical build sides; genuinely huge builds still
-/// fall back to hash-table membership.
-const ANALYTICAL_INLIST_PUSHDOWN_MAX_BYTES: usize = 128 * 1024 * 1024; // 128 MiB / partition
-const ANALYTICAL_INLIST_PUSHDOWN_MAX_DISTINCT: usize = 32 * 1024 * 1024; // ~32M keys (byte cap governs)
-
-/// RAISES (never lowers) DataFusion's native hash-join `InList` dynamic-filter
-/// budget so analytical dimension->fact joins push an exact-membership in-list
-/// into the Cayenne probe scan instead of degrading to min/max bounds. Bounded by
-/// the runtime memory limit per partition; larger build sides fall back to the
-/// hash-table membership strategy.
+/// Sizes `DataFusion`'s native hash-join `InList` dynamic-filter budget
+/// (`optimizer.hash_join_inlist_pushdown_max_size`) down to the runtime memory
+/// limit divided across `target_partitions`, never raising `DataFusion`'s own
+/// default. This bounds the per-partition memory the native inner-join dynamic
+/// filter can spend materializing build-side keys as an `InList`; larger build
+/// sides automatically fall back to the hash-table membership strategy.
 fn configure_hash_join_memory_limits(config: &mut SessionConfig, effective_memory_limit: u64) {
     let runtime_memory_limit_per_partition = hash_join_inlist_memory_limit_per_partition(
         effective_memory_limit,
         config.options().execution.target_partitions,
     );
 
-    let analytical_max_bytes =
-        runtime_memory_limit_per_partition.min(ANALYTICAL_INLIST_PUSHDOWN_MAX_BYTES);
-
     let optimizer = &mut config.options_mut().optimizer;
     optimizer.hash_join_inlist_pushdown_max_size = optimizer
         .hash_join_inlist_pushdown_max_size
-        .max(analytical_max_bytes);
-    optimizer.hash_join_inlist_pushdown_max_distinct_values = optimizer
-        .hash_join_inlist_pushdown_max_distinct_values
-        .max(ANALYTICAL_INLIST_PUSHDOWN_MAX_DISTINCT);
+        .min(runtime_memory_limit_per_partition);
 }
 
 fn runtime_env_with_effective_memory_limit_and_object_store_registry(

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -1180,22 +1180,39 @@ fn hash_join_inlist_memory_limit_per_partition(
     }
 }
 
-/// Sizes `DataFusion`'s native hash-join `InList` dynamic-filter budget
-/// (`optimizer.hash_join_inlist_pushdown_max_size`) down to the runtime memory
-/// limit divided across `target_partitions`, never raising `DataFusion`'s own
-/// default. This bounds the per-partition memory the native inner-join dynamic
-/// filter can spend materializing build-side keys as an `InList`; larger build
-/// sides automatically fall back to the hash-table membership strategy.
+/// Per-partition byte ceiling + distinct-key ceiling for DataFusion's native
+/// hash-join `InList` dynamic filter on analytical (Cayenne) joins. DF's defaults
+/// (`hash_join_inlist_pushdown_max_size` 128 KiB, `_max_distinct_values` 150) are
+/// tuned for PK point-lookups and DISABLE the in-list for the dimension->fact
+/// joins Cayenne targets, leaving only min/max range bounds — a QPH regression vs
+/// the forked `ExactLeftAccumulator` that the DF53 reconciliation dropped. These
+/// match that accumulator's budget so the exact-membership in-list is pushed into
+/// the Cayenne probe scan for analytical build sides; genuinely huge builds still
+/// fall back to hash-table membership.
+const ANALYTICAL_INLIST_PUSHDOWN_MAX_BYTES: usize = 128 * 1024 * 1024; // 128 MiB / partition
+const ANALYTICAL_INLIST_PUSHDOWN_MAX_DISTINCT: usize = 32 * 1024 * 1024; // ~32M keys (byte cap governs)
+
+/// RAISES (never lowers) DataFusion's native hash-join `InList` dynamic-filter
+/// budget so analytical dimension->fact joins push an exact-membership in-list
+/// into the Cayenne probe scan instead of degrading to min/max bounds. Bounded by
+/// the runtime memory limit per partition; larger build sides fall back to the
+/// hash-table membership strategy.
 fn configure_hash_join_memory_limits(config: &mut SessionConfig, effective_memory_limit: u64) {
     let runtime_memory_limit_per_partition = hash_join_inlist_memory_limit_per_partition(
         effective_memory_limit,
         config.options().execution.target_partitions,
     );
 
+    let analytical_max_bytes =
+        runtime_memory_limit_per_partition.min(ANALYTICAL_INLIST_PUSHDOWN_MAX_BYTES);
+
     let optimizer = &mut config.options_mut().optimizer;
     optimizer.hash_join_inlist_pushdown_max_size = optimizer
         .hash_join_inlist_pushdown_max_size
-        .min(runtime_memory_limit_per_partition);
+        .max(analytical_max_bytes);
+    optimizer.hash_join_inlist_pushdown_max_distinct_values = optimizer
+        .hash_join_inlist_pushdown_max_distinct_values
+        .max(ANALYTICAL_INLIST_PUSHDOWN_MAX_DISTINCT);
 }
 
 fn runtime_env_with_effective_memory_limit_and_object_store_registry(


### PR DESCRIPTION
## Summary

Restores the gated **`ExactLeftAccumulator`** + `CayenneJoinRewriter` on DF53, behind `cayenne_optimizer_rules.exact_join_filter` (**off by default**). When enabled, `CayenneJoinRewriter` swaps an exact build-key in-list into large-probe analytical joins (probe ≥100K rows, probe:build ratio ≥10) and plants it as a **scan-level pruning predicate** — the precise pruning the DF52 line had, via the forked accumulator (not DF53's native point-lookup InList).

## Depends on

- **spiceai/datafusion#163** — the fork seam (re-genericized `HashJoinExec<A: CollectLeftAccumulator>`, `recreate_with_accumulator`, public traits + config bridge; additive, native default unchanged). The datafusion pin is bumped to the seam rev `506dabefd`; **re-pin to the merged rev once #163 lands.**

## Note — the cap-raise approach was dropped

This PR originally raised DF53's native InList caps (`hash_join_inlist_pushdown_max_distinct_values` / `_max_size`). Testing showed that is **10–100× slower** than stock DF53: the native InList pushdown is built for small (point-lookup) build sides, so forcing giant in-lists for analytical joins degrades to a near-linear per-row membership eval. That commit is reverted here — the diff nets to the gated accumulator only.

## Changes

- `Cargo.toml`/`Cargo.lock` — 35 datafusion pins → the fork seam rev.
- `crates/runtime-datafusion/` — restore `join_accumulator` (`ExactLeftAccumulator`); the one seam delta (`ColumnBounds::as_any`) is implemented.
- `crates/cayenne/src/optimizer_rules.rs` — restore `CayenneJoinRewriter` + gate helpers alongside the existing `CayenneDynamicFilterSharing` (kept).
- `crates/runtime/src/datafusion/builder.rs` — register `CayenneJoinRewriter` gated on `exact_join_filter`.
- `crates/runtime/src/builder.rs` — wire the `exact_join_filter` user-config token (was a no-op).

## Validation

- All three scoped `cargo check`s green; minimal release build green.
- **A/B DEFERRED** — remote benchmark host down. Because the accumulator also materializes an in-list, the A/B must confirm it's genuinely fast (scan-level pruning, not native-InList-style slow) **before enabling** — so it stays gated-off / draft until validated.
