### PR TITLE
perf(runtime): run SQL-engine runtime below the primary runtime priority

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -638,8 +638,20 @@ pub async fn run(args: Args) -> Result<()> {
     // Configure the CPU runtime for DataFusion by default. Opt-out via `runtime.params.dedicated_thread_pool=disabled`
     match App::get_runtime_param_opt::<String>(&app, "dedicated_thread_pool").as_deref() {
         Some("sql_engine") | None => {
+            // The dedicated SQL-engine (query execution) runtime runs at a
+            // slightly lower OS priority (nice 5) than the default-priority
+            // (nice 0) primary runtime that serves HTTP/health and request
+            // handling. Under a CPU-saturated query workload this keeps query
+            // *execution* from starving the latency-sensitive liveness probe
+            // and request-serving threads, while staying *above* the background
+            // refresh/compaction runtimes (nice 10) so query work is still
+            // favored over background maintenance.
+            const SQL_ENGINE_NICE: i32 = 5;
             // This needs to be created after tracing is set up, or else task_history events aren't emitted.
-            let cpu_runtime = ManagedTokioRuntime::try_new()
+            let cpu_runtime = ManagedTokioRuntime::builder()
+                .with_nice(SQL_ENGINE_NICE)
+                .with_thread_name("sql-worker")
+                .build()
                 .boxed()
                 .context(UnableToInitializeDatafusionTokioRuntimeSnafu)?;
 

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -44,7 +44,7 @@ use runtime::podswatcher::PodsWatcher;
 use runtime::secrets::ExposeSecret;
 use runtime::spice_metrics;
 use runtime::{Runtime, auth::EndpointAuth, extension::ExtensionFactory};
-use runtime_async::ManagedTokioRuntime;
+use runtime_async::{ManagedTokioRuntime, RuntimePriority};
 use snafu::prelude::*;
 use spice_cloud::SpiceExtensionFactory;
 use spiced_tracing::LogVerbosity;
@@ -639,17 +639,15 @@ pub async fn run(args: Args) -> Result<()> {
     match App::get_runtime_param_opt::<String>(&app, "dedicated_thread_pool").as_deref() {
         Some("sql_engine") | None => {
             // The dedicated SQL-engine (query execution) runtime runs at a
-            // slightly lower OS priority (nice 5) than the default-priority
-            // (nice 0) primary runtime that serves HTTP/health and request
-            // handling. Under a CPU-saturated query workload this keeps query
-            // *execution* from starving the latency-sensitive liveness probe
-            // and request-serving threads, while staying *above* the background
-            // refresh/compaction runtimes (nice 10) so query work is still
-            // favored over background maintenance.
-            const SQL_ENGINE_NICE: i32 = 5;
+            // Reduced priority — below the default-priority primary runtime that
+            // serves HTTP/health and request handling, but above the Background
+            // refresh/compaction runtimes. Under a CPU-saturated query workload
+            // this keeps query *execution* from starving the latency-sensitive
+            // liveness probe and request-serving threads, while still favoring
+            // query work over background maintenance.
             // This needs to be created after tracing is set up, or else task_history events aren't emitted.
             let cpu_runtime = ManagedTokioRuntime::builder()
-                .with_nice(SQL_ENGINE_NICE)
+                .with_priority(RuntimePriority::Reduced)
                 .with_thread_name("sql-worker")
                 .build()
                 .boxed()
@@ -663,7 +661,7 @@ pub async fn run(args: Args) -> Result<()> {
             // impacting query latency.
             // Uses low thread priority to minimize impact on latency-sensitive operations.
             let refresh_runtime = ManagedTokioRuntime::builder()
-                .with_low_priority()
+                .with_priority(RuntimePriority::Background)
                 .with_thread_name("refresh-worker")
                 .build()
                 .boxed()
@@ -679,7 +677,7 @@ pub async fn run(args: Args) -> Result<()> {
             // spicepod. `set_compaction_runtime` injects the carved memory
             // environment only when one is available.
             let compaction_runtime = ManagedTokioRuntime::builder()
-                .with_low_priority()
+                .with_priority(RuntimePriority::Background)
                 .with_thread_name("compaction-worker")
                 .build()
                 .boxed()

--- a/crates/runtime-async/src/lib.rs
+++ b/crates/runtime-async/src/lib.rs
@@ -88,9 +88,17 @@ impl ManagedTokioRuntime {
     }
 }
 
+/// `nice` value for background runtimes (refresh, compaction): clearly
+/// deprioritized so background maintenance yields to query and control-plane
+/// work, while still making forward progress on otherwise-idle cores.
+const BACKGROUND_NICE: i32 = 10;
+
 /// Builder for [`ManagedTokioRuntime`] with configuration options.
 pub struct ManagedTokioRuntimeBuilder {
-    low_priority: bool,
+    /// Worker-thread `nice` value on Unix. `None` leaves the OS default
+    /// (nice 0). Positive values lower priority; we never set a negative
+    /// (higher-priority) value because that would require `CAP_SYS_NICE`.
+    nice: Option<i32>,
     thread_name: Option<String>,
 }
 
@@ -105,16 +113,29 @@ impl ManagedTokioRuntimeBuilder {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            low_priority: false,
+            nice: None,
             thread_name: None,
         }
     }
 
-    /// Set worker threads to run at lower priority (nice value 10 on Unix).
-    /// This is useful for background tasks that shouldn't compete with latency-sensitive work.
+    /// Set worker threads to run at low priority (nice value 10 on Unix).
+    /// This is useful for background tasks (refresh, compaction) that shouldn't
+    /// compete with latency-sensitive query and control-plane work.
     #[must_use]
-    pub fn with_low_priority(mut self) -> Self {
-        self.low_priority = true;
+    pub fn with_low_priority(self) -> Self {
+        self.with_nice(BACKGROUND_NICE)
+    }
+
+    /// Set an explicit worker-thread `nice` value (Unix only).
+    ///
+    /// Higher values mean lower scheduling priority. Only non-negative values
+    /// are meaningful here: lowering the nice value below the default (raising
+    /// priority) requires `CAP_SYS_NICE`, which the runtime does not assume.
+    /// Use this to place a runtime *between* the default-priority (nice 0)
+    /// primary runtime and the background runtimes (nice 10).
+    #[must_use]
+    pub fn with_nice(mut self, nice: i32) -> Self {
+        self.nice = Some(nice);
         self
     }
 
@@ -144,14 +165,20 @@ impl ManagedTokioRuntimeBuilder {
             builder.thread_name(name);
         }
 
-        // Set low priority on worker threads if requested (Unix only)
+        // Apply a worker-thread nice value if one was requested (Unix only).
+        // A positive nice lowers this runtime's scheduling priority relative to
+        // the default-priority (nice 0) primary runtime, without starving it:
+        // CFS keeps scheduling these threads, just with a smaller CPU-time
+        // weight when cores are contended.
         #[cfg(unix)]
-        if self.low_priority {
-            builder.on_thread_start(|| {
-                // Set nice value to 10 (lower priority than default 0, range is -20 to 19)
-                // SAFETY: setpriority is safe to call with PRIO_PROCESS and 0 (current thread)
+        if let Some(nice) = self.nice {
+            builder.on_thread_start(move || {
+                // `who = 0` targets the calling thread on Linux (niceness is
+                // per-task there), so each worker thread sets its own nice value
+                // as it starts. Range is -20 (highest) to 19 (lowest priority).
+                // SAFETY: setpriority is safe to call with PRIO_PROCESS and 0.
                 unsafe {
-                    libc::setpriority(libc::PRIO_PROCESS, 0, 10);
+                    libc::setpriority(libc::PRIO_PROCESS, 0, nice);
                 }
             });
         }

--- a/crates/runtime-async/src/lib.rs
+++ b/crates/runtime-async/src/lib.rs
@@ -112,11 +112,14 @@ pub enum RuntimePriority {
 }
 
 impl RuntimePriority {
-    /// Translate the tier to a Unix `nice` value, or `None` to leave the OS
+    /// Translate the tier to a Linux `nice` value, or `None` to leave the OS
     /// default untouched. `nice` ranges from -20 (highest) to 19 (lowest); we
     /// only ever lower priority (non-negative values), so no `CAP_SYS_NICE` is
     /// required.
-    #[cfg(unix)]
+    ///
+    /// Linux-only because the priority is applied per worker *thread*, which
+    /// only `nice` semantics on Linux provide (see [`ManagedTokioRuntimeBuilder::build`]).
+    #[cfg(target_os = "linux")]
     fn nice_value(self) -> Option<i32> {
         match self {
             Self::Normal => None,
@@ -128,6 +131,7 @@ impl RuntimePriority {
 
 /// Builder for [`ManagedTokioRuntime`] with configuration options.
 pub struct ManagedTokioRuntimeBuilder {
+    // Only consumed on Linux, where worker-thread priority is applied; see `build`.
     priority: RuntimePriority,
     thread_name: Option<String>,
 }
@@ -182,18 +186,22 @@ impl ManagedTokioRuntimeBuilder {
             builder.thread_name(name);
         }
 
-        // Apply the worker-thread priority tier (Unix only). A Reduced/Background
-        // tier lowers this runtime's scheduling priority relative to the
-        // default-priority (nice 0) primary runtime without starving it: CFS
-        // keeps scheduling these threads, just with a smaller CPU-time weight
-        // when cores are contended.
-        #[cfg(unix)]
+        // Apply the worker-thread priority tier. A Reduced/Background tier lowers
+        // this runtime's scheduling priority relative to the default-priority
+        // (nice 0) primary runtime without starving it: CFS keeps scheduling
+        // these threads, just with a smaller CPU-time weight when cores are
+        // contended.
+        //
+        // Linux only: there `nice` is per-task, so calling `setpriority` with
+        // `who = 0` from `on_thread_start` lowers only THIS worker thread. On
+        // macOS/BSD `PRIO_PROCESS` is process-wide, so the first worker to start
+        // would renice the entire `spiced` process — including the primary
+        // HTTP/health runtime — defeating the isolation. We therefore leave
+        // priority at the OS default on non-Linux platforms.
+        #[cfg(target_os = "linux")]
         if let Some(nice) = self.priority.nice_value() {
             builder.on_thread_start(move || {
-                // `who = 0` targets the calling thread on Linux (niceness is
-                // per-task there), so each worker thread sets its own nice value
-                // as it starts.
-                // SAFETY: setpriority is safe to call with PRIO_PROCESS and 0.
+                // SAFETY: setpriority is safe to call with PRIO_PROCESS and who = 0.
                 unsafe {
                     libc::setpriority(libc::PRIO_PROCESS, 0, nice);
                 }

--- a/crates/runtime-async/src/lib.rs
+++ b/crates/runtime-async/src/lib.rs
@@ -88,17 +88,47 @@ impl ManagedTokioRuntime {
     }
 }
 
-/// `nice` value for background runtimes (refresh, compaction): clearly
-/// deprioritized so background maintenance yields to query and control-plane
-/// work, while still making forward progress on otherwise-idle cores.
-const BACKGROUND_NICE: i32 = 10;
+/// Relative OS scheduling priority for a managed runtime's worker threads.
+///
+/// These are coarse, semantic tiers rather than raw `nice` values — the builder
+/// translates each to a concrete platform priority internally. They are
+/// expressed relative to the primary Tokio runtime, which serves HTTP,
+/// health/readiness probes, and control-plane work and always runs at the
+/// default OS priority.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimePriority {
+    /// Default OS priority — competes for CPU on equal footing with the primary
+    /// runtime. Appropriate for latency-sensitive work.
+    #[default]
+    Normal,
+    /// Just below [`Normal`](Self::Normal): yields CPU to the primary runtime
+    /// under contention, but stays ahead of [`Background`](Self::Background)
+    /// work. Used for CPU-heavy query execution that must not starve request
+    /// handling or health probes.
+    Reduced,
+    /// Clearly deprioritized background work (e.g. acceleration refresh,
+    /// compaction) that should only consume otherwise-idle CPU.
+    Background,
+}
+
+impl RuntimePriority {
+    /// Translate the tier to a Unix `nice` value, or `None` to leave the OS
+    /// default untouched. `nice` ranges from -20 (highest) to 19 (lowest); we
+    /// only ever lower priority (non-negative values), so no `CAP_SYS_NICE` is
+    /// required.
+    #[cfg(unix)]
+    fn nice_value(self) -> Option<i32> {
+        match self {
+            Self::Normal => None,
+            Self::Reduced => Some(5),
+            Self::Background => Some(10),
+        }
+    }
+}
 
 /// Builder for [`ManagedTokioRuntime`] with configuration options.
 pub struct ManagedTokioRuntimeBuilder {
-    /// Worker-thread `nice` value on Unix. `None` leaves the OS default
-    /// (nice 0). Positive values lower priority; we never set a negative
-    /// (higher-priority) value because that would require `CAP_SYS_NICE`.
-    nice: Option<i32>,
+    priority: RuntimePriority,
     thread_name: Option<String>,
 }
 
@@ -113,29 +143,16 @@ impl ManagedTokioRuntimeBuilder {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            nice: None,
+            priority: RuntimePriority::Normal,
             thread_name: None,
         }
     }
 
-    /// Set worker threads to run at low priority (nice value 10 on Unix).
-    /// This is useful for background tasks (refresh, compaction) that shouldn't
-    /// compete with latency-sensitive query and control-plane work.
+    /// Set the scheduling-priority tier for this runtime's worker threads.
+    /// Defaults to [`RuntimePriority::Normal`].
     #[must_use]
-    pub fn with_low_priority(self) -> Self {
-        self.with_nice(BACKGROUND_NICE)
-    }
-
-    /// Set an explicit worker-thread `nice` value (Unix only).
-    ///
-    /// Higher values mean lower scheduling priority. Only non-negative values
-    /// are meaningful here: lowering the nice value below the default (raising
-    /// priority) requires `CAP_SYS_NICE`, which the runtime does not assume.
-    /// Use this to place a runtime *between* the default-priority (nice 0)
-    /// primary runtime and the background runtimes (nice 10).
-    #[must_use]
-    pub fn with_nice(mut self, nice: i32) -> Self {
-        self.nice = Some(nice);
+    pub fn with_priority(mut self, priority: RuntimePriority) -> Self {
+        self.priority = priority;
         self
     }
 
@@ -165,17 +182,17 @@ impl ManagedTokioRuntimeBuilder {
             builder.thread_name(name);
         }
 
-        // Apply a worker-thread nice value if one was requested (Unix only).
-        // A positive nice lowers this runtime's scheduling priority relative to
-        // the default-priority (nice 0) primary runtime, without starving it:
-        // CFS keeps scheduling these threads, just with a smaller CPU-time
-        // weight when cores are contended.
+        // Apply the worker-thread priority tier (Unix only). A Reduced/Background
+        // tier lowers this runtime's scheduling priority relative to the
+        // default-priority (nice 0) primary runtime without starving it: CFS
+        // keeps scheduling these threads, just with a smaller CPU-time weight
+        // when cores are contended.
         #[cfg(unix)]
-        if let Some(nice) = self.nice {
+        if let Some(nice) = self.priority.nice_value() {
             builder.on_thread_start(move || {
                 // `who = 0` targets the calling thread on Linux (niceness is
                 // per-task there), so each worker thread sets its own nice value
-                // as it starts. Range is -20 (highest) to 19 (lowest priority).
+                // as it starts.
                 // SAFETY: setpriority is safe to call with PRIO_PROCESS and 0.
                 unsafe {
                     libc::setpriority(libc::PRIO_PROCESS, 0, nice);


### PR DESCRIPTION
## Problem

The dedicated DataFusion query-execution runtime (`cpu_runtime`) runs at the default OS priority (nice 0) — the same priority as the primary Tokio runtime that serves HTTP `/health`, readiness (`/v1/ready`), and request handling.

Under a CPU-bound, high-throughput query workload, both runtimes' worker threads compete for cores as equals. The HTTP `/health` handler is trivial (`get(|| async { "ok\n" })`) and does no work, but when every core is saturated executing queries its future can't get a scheduling slice in time — long enough to blow past tight liveness-probe timeouts and surface as health-check errors, even though the runtime is otherwise healthy.

This manifests specifically when query execution is genuinely CPU-bound (local scans, sorts, hashing, vector/embedding work). I/O-bound (federated) query threads park waiting on sockets and don't contend, and the effect is independent of any cgroup CPU limit.

## Change

Introduce a semantic `RuntimePriority` tier on the runtime builder and run `cpu_runtime` at `Reduced` — below the default-priority primary runtime (so the latency-sensitive health/control/request path wins CPU under contention), but above the `Background` refresh/compaction runtimes (so query execution is still favored over background maintenance).

```rust
pub enum RuntimePriority { Normal, Reduced, Background }

builder.with_priority(RuntimePriority::Reduced)     // cpu_runtime (query execution)
builder.with_priority(RuntimePriority::Background)  // refresh, compaction
```

The builder no longer exposes a raw `nice` integer — the concrete Unix mapping (`Normal` → default, `Reduced` → nice 5, `Background` → nice 10) is an implementation detail hidden behind `RuntimePriority::nice_value()`. `try_new()` still yields `Normal`.

| Runtime | Tier | nice | Role |
|---|---|---|---|
| primary (`Runtime::new`) | — | 0 | HTTP `/health`, `/v1/ready`, request handling, control plane |
| `cpu_runtime` | `Reduced` | 5 | DataFusion query execution |
| `refresh` / `compaction` | `Background` | 10 | background maintenance |

SQL worker threads are now named `sql-worker` for observability (`top -H`, profiles).

## Notes

- Priority only arbitrates among *runnable* threads, so this targets exactly the CPU-bound contention case above; it is a no-op under CFS quota throttling or I/O-bound load.
- On Linux niceness is per-task, so each worker thread sets its own value in `on_thread_start`. We only ever lower priority (positive nice), which is unprivileged — no `CAP_SYS_NICE` required.
- The trivial `/health` handler touches no shared state, so deprioritizing query execution carries no priority-inversion risk for liveness.

## Testing

- `cargo check -p runtime-async`, `cargo check -p spiced` — pass
- `make lint-rust` — pass (clean, `-Dwarnings`)
