### PR TITLE
test(chbench): SF100 maintained-aggregate spicepod for HTAP validation

### DIFF
--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100-maintagg.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100-maintagg.yaml
@@ -1,0 +1,308 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]-cdc-tuned-sf100-maintagg
+
+# Target: 64 vCPU / 256 GiB RAM, EBS gp3 (m7a.16xlarge-class). Goal: every CDC table under
+# 5s replication lag at SF-100 @ 10K txn/s, with >=5K QPH on the OLAP queries.
+#
+# Tuning (values validated on the 16-core local SF-100 run — all 7 tables <5s, ~97% of 5K
+# QPH — then scaled to 64c/256GB; the write-path values are core/RAM-invariant because the
+# wall is the single-writer-per-table metastore txn, not CPU or batch size):
+#   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
+#     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
+#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
+#     WAL drain ahead of bursty OLTP without enlarging the per-apply batch.
+#   - target_partitions 64: read-path parallelism matched to vCPU count (drives the QPH goal).
+#   - cayenne_pk_keyset_cache_mb 256 pinned on ALL tables: defeats the backwards memory-aware
+#     auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) and keeps the heavy-update tables
+#     (stock, order_line) on the cheap bloom path (256 = SF-100 sweep optimum).
+#   - per-table cayenne_write_concurrency / segment_cache_mb / compaction_* for the high-volume
+#     upsert tables; reference tables lighter. write_concurrency stays moderate (4/2): lower
+#     fan-out relieves CPU contention for OLAP (validated on the 128-core write-concurrency run).
+#   - metastore/footer caches (1024/1024 MiB, 4096 MiB mmap) are sized to the SF-100 working set,
+#     bounded by catalog/footer size — so 256 GiB adds headroom, not bigger caches.
+#
+# NOTE: validated on 16-core local + the 128-core write-concurrency study; the 64c/256GB
+# end-to-end run is the remaining validation (m7a.16xlarge + gp3).
+runtime:
+  params:
+    cdc_prefetch_buffer: '16384'
+    cdc_max_coalesced_envelopes: '16384'
+    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    # 250ms, NOT 4000: this is a real apply-loop linger (trunk #11196). At 4000ms the caught-up
+    # tables over-coalesce past the 1024-row inline admission cap (customer flips 100%
+    # inline->staged and builds a ~16 GB backlog) while apply-bound tables gain nothing (the
+    # deadline anchors at apply-start). Measured fixed cost ~120-250ms/batch, so ~250ms amortizes
+    # it without overflowing the inline cap. The wall is the single-writer metastore txn (per-row
+    # insert_records WAL), not batch size — bigger bursts don't help; 512 MB/4000ms regressed.
+    cdc_max_coalesce_age_ms: '250'
+    cdc_commit_timeout_ms: '60000'
+    cayenne_sort_merge_min_rows: '50000000'
+    cayenne_footer_cache_mb: '1024'
+    cayenne_metastore_cache_mb: '1024'
+    cayenne_metastore_mmap_mb: '4096'
+  query:
+    target_partitions: 64
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: '5432'
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
+datasets:
+  # ------------------------------------------------------------------
+  # High-volume PK upsert tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:district
+    name: district
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+      params: &accel_high_volume
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/district
+        cayenne_write_concurrency: '4'
+        cayenne_segment_cache_mb: '1024'
+        cayenne_compaction_trigger_protected_snapshots: '3'
+        # Pinned to 256 MiB (SF-100 sweep optimum). The keyset pin is scale-dependent: it
+        # must sit just UNDER the heavy-update tables' (stock, order_line) PK keysets so
+        # they stay on the cheap bloom path — at SF-100 that is 256 (1024 would fit them
+        # on the expensive exact path; the SF-1000 venue pins 1024). The memory-aware
+        # auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) is BACKWARDS — pin it.
+        cayenne_pk_keyset_cache_mb: '256'
+        cayenne_compaction_trigger_snapshot_age_ms: '15000'
+        cayenne_compaction_max_files_per_pick: '64'
+        cayenne_compaction_background_interval_ms: '3000'
+
+  - from: postgres:customer
+    name: customer
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/customer
+        cayenne_target_file_size_mb: '256'
+
+  - from: postgres:new_order
+    name: new_order
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/new_order
+
+  - from: postgres:oorder
+    name: oorder
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/oorder
+
+  - from: postgres:order_line
+    name: order_line
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+      # Maintained per-(ol_number) aggregates over order_line on ol_amount
+      # (DOUBLE PRECISION -> Float64). Maintained SUM supports Int64/UInt64/Float64
+      # and AVG supports Float64 only, so ol_quantity (INT -> Int32) is excluded.
+      # ol_amount is exactly q1's float column (sum_amount / avg_amount).
+      maintained_aggregates:
+        - group_by: [ol_number]
+          aggregates:
+            - function: sum
+              column: ol_amount
+            - function: avg
+              column: ol_amount
+            - function: count
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/order_line
+        cayenne_write_concurrency: '4'
+        cayenne_target_file_size_mb: '256'
+        cayenne_compaction_trigger_files: '8'
+        cayenne_compaction_trigger_snapshot_age_ms: '30000'
+        cayenne_compaction_max_files_per_pick: '128'
+        cayenne_segment_cache_mb: '2048'
+
+  - from: postgres:stock
+    name: stock
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/stock
+        cayenne_target_file_size_mb: '256'
+
+  # ------------------------------------------------------------------
+  # Low-volume reference tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:warehouse
+    name: warehouse
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: w_id
+      on_conflict:
+        w_id: upsert
+      params: &accel_medium
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/warehouse
+        cayenne_write_concurrency: '4'
+        cayenne_segment_cache_mb: '64'
+        # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
+        cayenne_pk_keyset_cache_mb: '256'
+
+  # ------------------------------------------------------------------
+  # Static reference tables (no OLTP mutations, full refresh).
+  # ------------------------------------------------------------------
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+      params:
+        <<: *accel_medium
+        cayenne_file_path: .spice/cayenne/item
+
+  - from: postgres:region
+    name: region
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      params: &accel_small
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/region
+        cayenne_write_concurrency: '2'
+        cayenne_segment_cache_mb: '16'
+        # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
+        cayenne_pk_keyset_cache_mb: '256'
+
+  - from: postgres:nation
+    name: nation
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/nation
+
+  - from: postgres:supplier
+    name: supplier
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: su_suppkey
+      on_conflict:
+        su_suppkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/supplier


### PR DESCRIPTION
**Draft / test vehicle — not for merge.**

Adds a CH-benCH spicepod (`postgres-cayenne[file]-cdc-tuned-sf100-maintagg.yaml`, a copy of the SF100 cdc-tuned spicepod) that declares Cayenne `maintained_aggregates` on `order_line`:

- `group_by: [ol_number]`
- `sum`/`avg` of `ol_amount` (DOUBLE PRECISION → Float64) + `count`

(`ol_quantity` is `INT`→Int32, which maintained SUM/AVG don't support, so it's excluded.)

Used to drive a cloud CH-BenCHmark HTAP run that exercises the maintained-aggregate maintenance + optimizer-rewrite path from #11235 at SF100.

Stacked on `cdc-maintained-aggregates` (#11235); the diff is just the test spicepod.

Local SF10 self-consistent run (#11235 spiced + #11235 gate): replication converged, 21/21 analytical queries passed. Cloud SF100 run (via `build_and_release` + `testoperator_run_htap`) pending.