### PR TITLE
feat(cayenne): broadcast small-dimension joins to executors

### DIFF
--- a/crates/cayenne/src/catalog_provider.rs
+++ b/crates/cayenne/src/catalog_provider.rs
@@ -75,6 +75,17 @@ pub struct CayenneCatalogProviderConfig {
     pub inline_flush_max_bytes: Option<i64>,
     /// Primary-key conflict detection behavior for inserts.
     pub pk_conflict_detection: Option<PkConflictDetection>,
+    /// Enable the closed-loop adaptive tuner (`cayenne_tuning: adaptive`). When
+    /// `true`, the per-table controller in `provider::context` adapts the
+    /// inline-flush caps, compaction cadence/trigger, and write concurrency over
+    /// time, anchored to the seeded knob values below.
+    pub dynamic_tuning: bool,
+    /// Hardware-seeded background compaction interval (ms). Seeds the adaptive
+    /// controller's starting point; `None` keeps the engine default.
+    pub compaction_background_interval_ms: Option<u64>,
+    /// Hardware-seeded small-file compaction trigger. Seeds the adaptive
+    /// controller's starting point; `None` keeps the engine default.
+    pub compaction_trigger_files: Option<usize>,
 }
 
 /// Errors that can occur when interacting with a Cayenne catalog.
@@ -301,6 +312,15 @@ impl CayenneCatalogProvider {
         if let Some(v) = provider_config.pk_conflict_detection {
             config.pk_conflict_detection = v;
         }
+        if let Some(v) = provider_config.compaction_background_interval_ms {
+            config.compaction_background_interval_ms = v;
+        }
+        if let Some(v) = provider_config.compaction_trigger_files {
+            config.compaction_trigger_files = v;
+        }
+        // Enable the closed loop last so it anchors to the seeded knob values
+        // above (the controller bounds derive from `[floor, 4×seed]`).
+        config.dynamic_tuning = provider_config.dynamic_tuning;
         config
     }
 }
@@ -482,6 +502,15 @@ impl CayenneSchemaProvider {
 
     fn tables_snapshot(&self) -> HashMap<String, Arc<dyn TableProvider>> {
         self.tables.read().clone()
+    }
+
+    /// Synchronous lookup of a cached table provider by name. Unlike the async
+    /// [`SchemaProvider::table`], this reads the in-memory table cache directly,
+    /// so callers that need a table's schema from a sync context (e.g. the
+    /// `executor_table` UDTF's `TableFunctionImpl::call`) can avoid blocking.
+    #[must_use]
+    pub fn table_sync(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        self.tables.read().get(name).cloned()
     }
 
     fn replace_tables(&self, tables: HashMap<String, Arc<dyn TableProvider>>) {

--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/aggregate_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/aggregate_pushdown.rs
@@ -110,6 +110,16 @@ fn try_rewrite_partial_aggregate(
     // original expressions during SQL generation.
     let (scan_child, column_substitutions) = skip_projection(child);
 
+    // A RoundRobin RepartitionExec can also sit BELOW the CSE projection
+    // (Aggregate → Projection → Repartition → Union → …Flight). This is the
+    // common shape for aggregates over computed arguments — e.g.
+    // `sum(l_extendedprice * (1 - l_discount))` (TPC-H Q1) — where CSE pulls the
+    // computed expression into a projection that lands above the repartition.
+    // Skip it here too so `collect_flight_execs` sees the `UnionExec` directly
+    // instead of bailing on a multi-input node mid-walk. The repartition
+    // preserves the scan schema, so the projection substitutions stay valid.
+    let scan_child = skip_repartition_roundrobin(scan_child);
+
     let flight_execs = collect_flight_execs(scan_child);
     let Some(flight_execs) = flight_execs else {
         return Ok(Transformed::no(plan));

--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/broadcast_join.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/broadcast_join.rs
@@ -1,0 +1,634 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Physical optimizer rule that distributes a `HashJoinExec` between a
+//! partitioned fact table and a SMALL dimension table onto the executors,
+//! instead of pulling every fact row up to the scheduler and joining centrally.
+//!
+//! Today, a distributed-acceleration join federates only the scans:
+//! ```text
+//! HashJoinExec
+//!   UnionExec[ FlightSqlExec(fact part 0), ..., FlightSqlExec(fact part N) ]   -- 6M rows shipped up
+//!   UnionExec[ FlightSqlExec(dim part 0),  ..., FlightSqlExec(dim part M)  ]
+//! ```
+//! The scheduler repartitions and joins. This rule rewrites it to a per-executor
+//! join pushed back down — each fact-partition executor joins its local fact
+//! slice against the FULL dimension, which it gathers from its peers via the
+//! `executor_table` UDTF, and ships only the joined rows:
+//! ```text
+//! UnionExec[
+//!   BroadcastJoinFlightSqlExec(exec0): SELECT ... FROM (fact) f
+//!       JOIN (SELECT * FROM executor_table('e0',dim) UNION ALL ...) d ON ...
+//!   BroadcastJoinFlightSqlExec(exec1): <same SQL, run on exec1>
+//!   ...
+//! ]
+//! ```
+//! The per-executor SQL is identical (each executor's `FROM dim_or_fact` resolves
+//! to its own partition; the `executor_table` UNION addresses are the same), so
+//! it is built once and run against each fact-partition executor's client.
+//!
+//! Correctness: for an inner equi-join keyed on the fact, the union of
+//! `(fact_partitionᵢ ⋈ full_dim)` equals `full_fact ⋈ full_dim` (each fact row
+//! lives in exactly one partition and joins independently). Validated on SF1.
+//!
+//! Gating: only fires when the dimension side's statistics report a row count
+//! below `broadcast_threshold_rows` — broadcasting a large table would move
+//! `N_executors × dim_size` rows and lose.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use datafusion::arrow::compute::cast;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::{DataFusionError, Result, Statistics};
+use datafusion::config::ConfigOptions;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::JoinType;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::joins::HashJoinExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::union::UnionExec;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+};
+use futures::StreamExt;
+
+use data_components::flightsql::{FlightSqlClient, FlightSqlExec, query_to_stream};
+use data_components::sql_expr::to_sql_preserving_precedence;
+use flight_client::cookie::CookieStore;
+
+/// Pass-through nodes that may sit between a `HashJoinExec` and the federated
+/// scan union without changing the data (same set the agg-pushdown rule uses).
+const PASS_THROUGH_EXEC_NAMES: &[&str] = &["CooperativeExec", "BytesProcessedExec"];
+
+/// The fact side must exceed the broadcast cost (`dim_rows × num_executors`) by
+/// at least this factor for a broadcast to be worthwhile. Validated against
+/// SF10: genuine wins (lineitem facts) have a fact/cost ratio ≥7.5, while
+/// marginal joins that regressed (orders/customer-class) sit around ~2.5, so a
+/// factor of 4 separates them with headroom on both sides.
+const BROADCAST_FACT_MARGIN: usize = 4;
+
+/// Returns live peer executor addresses (`host:port`, no scheme) for the
+/// `executor_table` UNION. Supplied by the runtime (cluster) layer so this
+/// crate need not depend on `runtime-cluster`.
+pub type ExecutorAddressProvider = Arc<dyn Fn() -> Vec<String> + Send + Sync>;
+
+/// A leaf `ExecutionPlan` that runs a pre-built join SQL against ONE executor's
+/// Flight SQL endpoint (the executor owning a fact partition). The SQL gathers
+/// the broadcast dimension from all peers via `executor_table`.
+#[derive(Clone)]
+pub struct BroadcastJoinFlightSqlExec {
+    sql: String,
+    client: FlightSqlClient,
+    cookie_store: Arc<CookieStore>,
+    output_schema: SchemaRef,
+    trace_parent: Option<String>,
+    properties: PlanProperties,
+    statistics: Statistics,
+}
+
+impl BroadcastJoinFlightSqlExec {
+    fn new(
+        sql: String,
+        client: FlightSqlClient,
+        cookie_store: Arc<CookieStore>,
+        output_schema: SchemaRef,
+        trace_parent: Option<String>,
+        statistics: Statistics,
+    ) -> Self {
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&output_schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        Self {
+            sql,
+            client,
+            cookie_store,
+            output_schema,
+            trace_parent,
+            properties,
+            statistics,
+        }
+    }
+}
+
+impl fmt::Debug for BroadcastJoinFlightSqlExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BroadcastJoinFlightSqlExec: sql={}", self.sql)
+    }
+}
+
+impl DisplayAs for BroadcastJoinFlightSqlExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BroadcastJoinFlightSqlExec: sql={}", self.sql)
+    }
+}
+
+impl ExecutionPlan for BroadcastJoinFlightSqlExec {
+    fn name(&self) -> &'static str {
+        "BroadcastJoinFlightSqlExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let mut client = self.client.clone();
+        if let Some(tp) = &self.trace_parent {
+            client.set_header("traceparent", tp.clone());
+        }
+        // Coerce each returned batch to the expected output schema. The remote
+        // executor returns its native string types (e.g. LargeUtf8) but the
+        // parent plan expects the join's schema (e.g. Utf8View); cast to match,
+        // mirroring `FlightSqlExec`'s own schema alignment.
+        let target = Arc::clone(&self.output_schema);
+        let target_for_map = Arc::clone(&target);
+        let stream = query_to_stream(client, self.sql.clone(), Arc::clone(&self.cookie_store))
+            .map(move |res| res.and_then(|batch| coerce_batch(batch, &target_for_map)));
+        Ok(Box::pin(RecordBatchStreamAdapter::new(target, stream)))
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        Ok(self.statistics.clone())
+    }
+
+    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Statistics> {
+        Ok(self.statistics.clone())
+    }
+}
+
+/// Physical optimizer rule: distribute small-dimension joins onto executors.
+#[derive(Clone)]
+pub struct FlightSQLBroadcastJoinPushdown {
+    addresses: ExecutorAddressProvider,
+    broadcast_threshold_rows: usize,
+}
+
+impl fmt::Debug for FlightSQLBroadcastJoinPushdown {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlightSQLBroadcastJoinPushdown")
+            .field("broadcast_threshold_rows", &self.broadcast_threshold_rows)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FlightSQLBroadcastJoinPushdown {
+    #[must_use]
+    pub fn new(addresses: ExecutorAddressProvider, broadcast_threshold_rows: usize) -> Arc<Self> {
+        Arc::new(Self {
+            addresses,
+            broadcast_threshold_rows,
+        })
+    }
+}
+
+impl PhysicalOptimizerRule for FlightSQLBroadcastJoinPushdown {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let addresses = (self.addresses)();
+        if addresses.is_empty() {
+            return Ok(plan);
+        }
+        let threshold = self.broadcast_threshold_rows;
+        plan.transform_up(|p| try_rewrite(p, &addresses, threshold))
+            .map(|t| t.data)
+    }
+
+    fn name(&self) -> &'static str {
+        "FlightSQLBroadcastJoinPushdown"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+/// One side of the join, resolved to a federated scan: the per-partition
+/// `FlightSqlExec`s and the table/filter/schema info (shared across partitions).
+struct FederatedSide<'a> {
+    flight_execs: Vec<&'a FlightSqlExec>,
+    schema: SchemaRef,
+}
+
+fn try_rewrite(
+    plan: Arc<dyn ExecutionPlan>,
+    addresses: &[String],
+    max_broadcast_rows: usize,
+) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
+    let Some(join) = plan.as_any().downcast_ref::<HashJoinExec>() else {
+        return Ok(Transformed::no(plan));
+    };
+    // Only inner equi-joins with no residual filter (the common cayenne shape).
+    if *join.join_type() != JoinType::Inner || join.filter().is_some() || join.on().is_empty() {
+        return Ok(Transformed::no(plan));
+    }
+
+    let Some(left) = resolve_federated_side(join.left()) else {
+        return Ok(Transformed::no(plan));
+    };
+    let Some(right) = resolve_federated_side(join.right()) else {
+        return Ok(Transformed::no(plan));
+    };
+
+    // Pick the smaller side (by stats) as the broadcast dimension; it must be
+    // below the threshold. The other side is the partitioned fact.
+    let left_rows = side_num_rows(&left);
+    let right_rows = side_num_rows(&right);
+    let num_executors = addresses.len();
+    // Choose the broadcast (dimension) side: the smaller input. Broadcasting it
+    // gathers `dim_rows × num_executors` rows across the cluster, so only do it
+    // when the fact is large enough that NOT shipping it to the coordinator is a
+    // clear win — i.e. the fact must exceed the broadcast cost by a safety
+    // factor: `dim_rows × N × BROADCAST_FACT_MARGIN < fact_rows`. This is a
+    // scale-invariant broadcast-vs-shuffle cost test (fires for small dims at any
+    // scale factor). A plain `dim × N < fact` is too loose: it fired on
+    // moderate-ratio joins (e.g. tpch q3's orders⋈customer, fact/cost ratio ~2.5)
+    // where the executor_table round-trips outweigh the savings, while the genuine
+    // wins (lineitem facts, ratio ≥7.5) clear the margin comfortably. Also cap the
+    // dim size to bound per-executor memory. Requires row-count stats on both
+    // sides (else we cannot tell which side is small, so leave the plan alone).
+    let dim_is_left = match (left_rows, right_rows) {
+        (Some(l), Some(r)) => {
+            let (dim_rows, fact_rows, is_left) = if l <= r { (l, r, true) } else { (r, l, false) };
+            if dim_rows > max_broadcast_rows
+                || dim_rows
+                    .saturating_mul(num_executors)
+                    .saturating_mul(BROADCAST_FACT_MARGIN)
+                    >= fact_rows
+            {
+                return Ok(Transformed::no(plan));
+            }
+            is_left
+        }
+        _ => return Ok(Transformed::no(plan)),
+    };
+    let (fact, dim, fact_is_left) = if dim_is_left {
+        (&right, &left, false)
+    } else {
+        (&left, &right, true)
+    };
+
+    let Some(sql) = build_join_sql(join, fact, dim, fact_is_left, addresses) else {
+        return Ok(Transformed::no(plan));
+    };
+
+    // One BroadcastJoinFlightSqlExec per fact-partition executor, all running
+    // the identical join SQL against that executor's client.
+    let output_schema = join.schema();
+    let statistics = Statistics::new_unknown(&output_schema);
+    let mut children: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(fact.flight_execs.len());
+    for fe in &fact.flight_execs {
+        children.push(Arc::new(BroadcastJoinFlightSqlExec::new(
+            sql.clone(),
+            fe.client().clone(),
+            Arc::clone(fe.cookie_store()),
+            Arc::clone(&output_schema),
+            fe.trace_parent().map(str::to_string),
+            statistics.clone(),
+        )));
+    }
+
+    let union: Arc<dyn ExecutionPlan> = if children.len() == 1 {
+        children.remove(0)
+    } else {
+        UnionExec::try_new(children)?
+    };
+    // Preserve the replaced join's output partitioning. This rule runs AFTER
+    // EnforceDistribution, so a parent `HashJoinExec(mode=Partitioned)` still
+    // expects matching partition counts on its inputs; our union has one
+    // partition per executor and would otherwise trip a "partition count
+    // mismatch N!=M" assertion. Re-establishing the partitioning is cheap — it
+    // repartitions only the small joined result, not the raw fact table — so the
+    // broadcast win is preserved.
+    //
+    // IMPORTANT: the join's reported `Hash([..])` partitioning may reference
+    // columns that its own embedded projection dropped (a Partitioned hash join
+    // whose key is not in the output schema reports `Hash([UnKnownColumn])` — an
+    // internally inconsistent partitioning). Blindly reusing it makes the
+    // `RepartitionExec` evaluate that bogus hash and fail at runtime with
+    // "UnKnownColumn::evaluate() should not be called" (hit by tpch q3/q5/q8/q14,
+    // whose join feeds an aggregate that doesn't reference the keys). So remap the
+    // hash columns onto our output schema by name and fall back to round-robin
+    // when a key was dropped — a parent that needs hash co-location only
+    // references columns that ARE in the output, so its keys always remap.
+    let result: Arc<dyn ExecutionPlan> =
+        match safe_output_partitioning(join.properties().output_partitioning(), &output_schema) {
+            Some(part) => Arc::new(RepartitionExec::try_new(union, part)?),
+            None => union,
+        };
+    Ok(Transformed::yes(result))
+}
+
+/// Total estimated row count of a federated side = the SUM of its per-partition
+/// `FlightSqlExec` statistics (each scan reports only its own partition's rows).
+/// `None` if no partition carries a row-count estimate.
+fn side_num_rows(side: &FederatedSide) -> Option<usize> {
+    let mut total = 0usize;
+    let mut any = false;
+    for fe in &side.flight_execs {
+        if let Ok(stats) = fe.partition_statistics(None)
+            && let Some(n) = stats.num_rows.get_value()
+        {
+            total += *n;
+            any = true;
+        }
+    }
+    any.then_some(total)
+}
+
+/// Produce a partitioning for the broadcast result that is VALID for `out_schema`
+/// (the broadcast output schema), re-establishing the replaced join's partition
+/// count for any parent that requires it.
+///
+/// `Hash([..])` keys are remapped onto `out_schema` by name; if any key is not a
+/// plain `Column` present in the output (i.e. the join dropped it, leaving a
+/// bogus `Hash([UnKnownColumn])`), we fall back to round-robin to the same
+/// partition count — which satisfies a parent that only needs the count (e.g. a
+/// partial aggregate), while a parent needing hash co-location only references
+/// columns that are present and so always remaps cleanly. Returns `None` to leave
+/// the union unwrapped (unknown partitioning carries no count contract).
+fn safe_output_partitioning(part: &Partitioning, out_schema: &SchemaRef) -> Option<Partitioning> {
+    match part {
+        Partitioning::Hash(exprs, n) => {
+            let mut mapped: Vec<Arc<dyn PhysicalExpr>> = Vec::with_capacity(exprs.len());
+            for e in exprs {
+                let Some(col) = e.as_any().downcast_ref::<Column>() else {
+                    return Some(Partitioning::RoundRobinBatch(*n));
+                };
+                match out_schema.index_of(col.name()) {
+                    Ok(idx) => mapped.push(Arc::new(Column::new(col.name(), idx))),
+                    Err(_) => return Some(Partitioning::RoundRobinBatch(*n)),
+                }
+            }
+            Some(Partitioning::Hash(mapped, *n))
+        }
+        Partitioning::RoundRobinBatch(n) => Some(Partitioning::RoundRobinBatch(*n)),
+        Partitioning::UnknownPartitioning(_) => None,
+    }
+}
+
+/// Resolve a join input to a federated scan: a `UnionExec` (or single node) of
+/// `FlightSqlExec` leaves, walking through repartition / pass-through nodes.
+fn resolve_federated_side(plan: &Arc<dyn ExecutionPlan>) -> Option<FederatedSide<'_>> {
+    // A join input is typically `RepartitionExec(Hash) -> UnionExec ->
+    // [pass-through -> FlightSqlExec]`. Descend through single-input wrapper
+    // nodes (repartition / coalesce / filter / cooperative) to reach the
+    // `UnionExec` (or a bare `FlightSqlExec`) before collecting the per-partition
+    // scans — otherwise `collect_flight_execs` hits the multi-input `UnionExec`
+    // mid-walk and bails.
+    let mut scan_root = plan;
+    while scan_root.as_any().downcast_ref::<UnionExec>().is_none()
+        && scan_root.as_any().downcast_ref::<FlightSqlExec>().is_none()
+    {
+        if !is_single_input_wrapper(scan_root.as_ref()) {
+            return None;
+        }
+        let children = scan_root.children();
+        if children.len() != 1 {
+            return None;
+        }
+        scan_root = children[0];
+    }
+    let flight_execs = collect_flight_execs(scan_root)?;
+    if flight_execs.is_empty() {
+        return None;
+    }
+    let schema = Arc::clone(flight_execs[0].projected_schema());
+    // All partitions must scan the same table for the broadcast to be well-defined.
+    let table = flight_execs[0].table_reference();
+    if flight_execs.iter().any(|fe| fe.table_reference() != table) {
+        return None;
+    }
+    Some(FederatedSide {
+        flight_execs,
+        schema,
+    })
+}
+
+fn collect_flight_execs(plan: &Arc<dyn ExecutionPlan>) -> Option<Vec<&FlightSqlExec>> {
+    if let Some(union) = plan.as_any().downcast_ref::<UnionExec>() {
+        let mut out = Vec::with_capacity(union.inputs().len());
+        for child in union.inputs() {
+            out.push(walk_to_flight_exec(child)?);
+        }
+        Some(out)
+    } else {
+        Some(vec![walk_to_flight_exec(plan)?])
+    }
+}
+
+fn walk_to_flight_exec(plan: &Arc<dyn ExecutionPlan>) -> Option<&FlightSqlExec> {
+    let mut current = plan;
+    loop {
+        if let Some(fe) = current.as_any().downcast_ref::<FlightSqlExec>() {
+            return Some(fe);
+        }
+        let children = current.children();
+        if children.len() != 1 {
+            return None;
+        }
+        if !is_single_input_wrapper(current.as_ref()) {
+            return None;
+        }
+        current = children[0];
+    }
+}
+
+/// A single-input node that passes data through unchanged for the purposes of
+/// resolving a federated scan: repartition, coalesce-batches, filter (the
+/// underlying `FlightSqlExec` already carries the predicate in its SQL), and the
+/// name-identified `CooperativeExec` / `BytesProcessedExec` wrappers.
+fn is_single_input_wrapper(plan: &dyn ExecutionPlan) -> bool {
+    plan.as_any().downcast_ref::<RepartitionExec>().is_some()
+        || plan
+            .as_any()
+            .downcast_ref::<CoalesceBatchesExec>()
+            .is_some()
+        || plan.as_any().downcast_ref::<FilterExec>().is_some()
+        || PASS_THROUGH_EXEC_NAMES.contains(&plan.name())
+}
+
+/// Build the per-executor join SQL. Returns `None` (bail) on any shape we can't
+/// faithfully render.
+fn build_join_sql(
+    join: &HashJoinExec,
+    fact: &FederatedSide,
+    dim: &FederatedSide,
+    fact_is_left: bool,
+    addresses: &[String],
+) -> Option<String> {
+    let fact_fe = *fact.flight_execs.first()?;
+    let dim_fe = *dim.flight_execs.first()?;
+
+    // Fact subquery: the executor's own local scan (its partition), filters incl.
+    let fact_sql = fact_fe.sql().ok()?;
+
+    // Dimension gathered from every peer via executor_table, UNION ALL.
+    let dim_table = dim_fe.table_reference().to_string();
+    let dim_cols = dim
+        .schema
+        .fields()
+        .iter()
+        .map(|f| quote_ident(f.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let dim_where = render_filters(dim_fe.filters())?;
+    let dim_union = addresses
+        .iter()
+        .map(|addr| {
+            format!(
+                "SELECT {dim_cols} FROM executor_table('https://{addr}', '{dim_table}'){dim_where}"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" UNION ALL ");
+
+    // ON clause: each equi-key pair is (left_col, right_col); assign to f/d by
+    // which physical side is the fact.
+    let mut on_terms = Vec::with_capacity(join.on().len());
+    for (l, r) in join.on() {
+        let l_name = l.as_any().downcast_ref::<Column>()?.name();
+        let r_name = r.as_any().downcast_ref::<Column>()?.name();
+        let (fact_col, dim_col) = if fact_is_left {
+            (l_name, r_name)
+        } else {
+            (r_name, l_name)
+        };
+        on_terms.push(format!(
+            "f.{} = d.{}",
+            quote_ident(fact_col),
+            quote_ident(dim_col)
+        ));
+    }
+    let on_clause = on_terms.join(" AND ");
+
+    // Output projection: map each output field to f.<col> or d.<col> by name
+    // (cayenne/TPCH join columns are uniquely named across the two inputs).
+    let fact_names: std::collections::HashSet<&str> = fact
+        .schema
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+    let dim_names: std::collections::HashSet<&str> = dim
+        .schema
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+    let mut select_items = Vec::with_capacity(join.schema().fields().len());
+    for field in join.schema().fields() {
+        let name = field.name();
+        let qualified = if fact_names.contains(name.as_str()) {
+            format!("f.{}", quote_ident(name))
+        } else if dim_names.contains(name.as_str()) {
+            format!("d.{}", quote_ident(name))
+        } else {
+            // Output column we can't attribute to a side — bail rather than
+            // produce a wrong schema.
+            return None;
+        };
+        select_items.push(format!("{qualified} AS {}", quote_ident(name)));
+    }
+    let select_list = select_items.join(", ");
+
+    Some(format!(
+        "SELECT {select_list} FROM ({fact_sql}) f INNER JOIN ({dim_union}) d ON {on_clause}"
+    ))
+}
+
+fn render_filters(filters: &[datafusion::logical_expr::Expr]) -> Option<String> {
+    if filters.is_empty() {
+        return Some(String::new());
+    }
+    let parts = filters
+        .iter()
+        .map(|f| to_sql_preserving_precedence(f).map(|s| format!("({s})")))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .ok()?;
+    Some(format!(" WHERE {}", parts.join(" AND ")))
+}
+
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Cast a batch returned by the remote executor to the expected output schema.
+/// Column count and order already match the generated `SELECT`; only types may
+/// differ (e.g. the executor returns `LargeUtf8` where the plan expects
+/// `Utf8View`), so cast column-by-column.
+fn coerce_batch(batch: RecordBatch, target: &SchemaRef) -> Result<RecordBatch> {
+    if batch.schema().as_ref() == target.as_ref() {
+        return Ok(batch);
+    }
+    if batch.num_columns() != target.fields().len() {
+        return Err(DataFusionError::Internal(format!(
+            "BroadcastJoinFlightSqlExec: result has {} columns, expected {}",
+            batch.num_columns(),
+            target.fields().len()
+        )));
+    }
+    let columns = target
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let col = batch.column(i);
+            if col.data_type() == field.data_type() {
+                Ok(Arc::clone(col))
+            } else {
+                cast(col, field.data_type())
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+    RecordBatch::try_new(Arc::clone(target), columns)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}

--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/mod.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/mod.rs
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 pub mod aggregate_pushdown;
+pub mod broadcast_join;
 mod exec;

--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -523,6 +523,19 @@ impl ExecutorRegistry {
         connections.keys().cloned().collect()
     }
 
+    /// Best-effort SYNCHRONOUS snapshot of ready executor IDs (`host:port`, no
+    /// scheme — the same form `executor_table` expects after prepending a
+    /// scheme). Returns empty if the lock is momentarily contended. Used by the
+    /// broadcast-join physical optimizer rule, which runs in a sync planning
+    /// context and cannot await.
+    #[must_use]
+    pub fn ready_executor_ids_sync(&self) -> Vec<String> {
+        match self.flight_sql_clients.try_read() {
+            Ok(clients) => clients.keys().cloned().collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
     /// Sends a control message to a specific executor and waits for an Ack
     /// correlated by `request_id`.
     ///

--- a/crates/runtime/src/catalogconnector/cayenne/mod.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/mod.rs
@@ -77,6 +77,10 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("inline_flush_max_bytes")
         .description("Maximum inline IPC bytes before checkpointing inline data to Vortex. Default: 8388608.")
         .default("8388608"),
+    ParameterSpec::component("tuning")
+        .description("Auto-tuning mode. 'auto' (default): use static, hardware-derived defaults. 'adaptive': additionally run a per-table closed-feedback controller that measures the live CDC ingest rate AND the runtime's whole-system response (apply latency vs offered load, read amplification, cgroup-aware memory pressure) and adjusts the inline-memtable flush caps, compaction cadence/trigger, and write concurrency over time, within a hardware-derived [floor, ceiling]. The controller's bounds anchor to the seeded knob values, which are derived from the detected host (cores + cgroup-aware memory + storage class) — no schema inference is needed on the catalog path. An explicit per-knob value (e.g. cayenne_inline_flush_max_bytes) overrides the seed and is pinned under 'adaptive'.")
+        .one_of(&["auto", "adaptive"])
+        .default("auto"),
 ];
 
 /// A catalog connector for Cayenne lakehouse catalogs.
@@ -100,7 +104,7 @@ impl CayenneCatalogConnector {
         })
     }
 
-    fn parse_provider_config(&self) -> CayenneCatalogProviderConfig {
+    async fn parse_provider_config(&self) -> CayenneCatalogProviderConfig {
         // Parse a numeric catalog parameter, warning (and ignoring) on a value
         // that does not parse, so a typo surfaces instead of being silently
         // dropped — matching the acceleration-param path's behavior.
@@ -221,6 +225,80 @@ impl CayenneCatalogConnector {
             .and_then(|v| parse_num_param::<i64>(v, "inline_flush_max_bytes"))
             .map(|v| v.max(0));
 
+        // Tuning mode (`cayenne_tuning`): `auto` (default) keeps the static,
+        // hardware-derived knobs; `adaptive` additionally runs the closed-loop
+        // controller in `cayenne::provider::context`. Unlike the accelerator
+        // path, the catalog path has no schema inference, so `adaptive` is seeded
+        // purely from the detected `HardwareProfile` — the controller's bounds
+        // anchor to `[floor, 4×seed]`, so a host-appropriate seed is essential.
+        let tuning_mode = self
+            .params
+            .get("tuning")
+            .expose()
+            .ok()
+            .map(|v| v.trim().to_ascii_lowercase());
+        if let Some(mode) = &tuning_mode
+            && mode != "auto"
+            && mode != "adaptive"
+        {
+            tracing::warn!(
+                "Invalid Cayenne catalog parameter `tuning` value `{mode}`; expected `auto` or `adaptive`, defaulting to `auto`."
+            );
+        }
+        let dynamic_tuning = tuning_mode.as_deref() == Some("adaptive");
+
+        // Seed the adaptive-tunable knobs from the host hardware profile (only
+        // when adaptive is requested — `auto` keeps the engine defaults so the
+        // static path is byte-identical to prior behavior). The seed values are
+        // ONLY applied where the operator did not pin the knob explicitly, so an
+        // explicit `cayenne_*` value still wins.
+        let (
+            seed_compaction_background_interval_ms,
+            seed_compaction_trigger_files,
+            seed_inline_flush_max_rows,
+            seed_inline_flush_max_segments,
+            seed_inline_flush_max_bytes,
+            seed_write_concurrency,
+        ) = if dynamic_tuning {
+            use crate::dataaccelerator::cayenne::autotune::{HardwareProfile, WorkloadProfile};
+            // Probe storage under the resolved data/metadata dirs (falling back to
+            // the spice data base path), mirroring the accelerator's detection.
+            let base = crate::spice_data_base_path();
+            let data_path = data_dir.clone().unwrap_or_else(|| base.clone());
+            let metastore_path = metadata_dir.clone().unwrap_or(base);
+            // No StorageProfile override is plumbed on the catalog path; auto-detect.
+            let hw = HardwareProfile::detect(
+                crate::component::dataset::acceleration::StorageProfile::Auto,
+                &data_path,
+                &metastore_path,
+            )
+            .await;
+            // Hardware-only workload profile (no inferred row_count / row width).
+            let wl = WorkloadProfile::default();
+            let caps = hw.inline_flush_caps(&wl);
+            (
+                // Small-write/CDC cadence so the controller has a tick to ride.
+                Some(10_000_u64),
+                Some(4_usize),
+                Some(caps.max_rows),
+                Some(caps.max_segments),
+                Some(caps.max_bytes),
+                // Seed write concurrency to the host core count so the controller's
+                // [1, cores] window is host-appropriate.
+                Some(hw.cores),
+            )
+        } else {
+            (None, None, None, None, None, None)
+        };
+
+        // The seed only applies where the operator did not set the knob; an
+        // explicit catalog param always wins.
+        let inline_flush_max_rows = inline_flush_max_rows.or(seed_inline_flush_max_rows);
+        let inline_flush_max_segments =
+            inline_flush_max_segments.or(seed_inline_flush_max_segments);
+        let inline_flush_max_bytes = inline_flush_max_bytes.or(seed_inline_flush_max_bytes);
+        let write_concurrency = write_concurrency.or(seed_write_concurrency);
+
         CayenneCatalogProviderConfig {
             data_dir,
             metadata_dir,
@@ -238,6 +316,9 @@ impl CayenneCatalogConnector {
             inline_flush_max_rows,
             inline_flush_max_segments,
             inline_flush_max_bytes,
+            dynamic_tuning,
+            compaction_background_interval_ms: seed_compaction_background_interval_ms,
+            compaction_trigger_files: seed_compaction_trigger_files,
         }
     }
 }
@@ -267,7 +348,7 @@ impl CatalogConnector for CayenneCatalogConnector {
         }
 
         let runtime_env = runtime.datafusion().ctx.runtime_env();
-        let provider_config = self.parse_provider_config();
+        let provider_config = self.parse_provider_config().await;
         let refreshable_provider = Arc::new(
             CayenneCatalogProvider::try_new(provider_config, runtime_env)
                 .await
@@ -356,7 +437,7 @@ mod tests {
         .expect("single-prefixed Cayenne catalog params should validate");
         let connector = CayenneCatalogConnector { params };
 
-        let config = connector.parse_provider_config();
+        let config = connector.parse_provider_config().await;
 
         assert_eq!(config.data_dir.as_deref(), Some("/tmp/cayenne-data"));
         assert_eq!(config.upload_concurrency, Some(1));

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-mod autotune;
+// `pub(crate)` (not private) so the Cayenne *catalog* connector
+// (`crate::catalogconnector::cayenne`) can seed the adaptive-tuning knobs from
+// the same hardware-derived profile this accelerator path uses.
+pub(crate) mod autotune;
 pub mod partitioned_insert_strategy;
 pub mod s3;
 pub mod snapshot_engine;

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -722,12 +722,7 @@ impl DataFusionBuilder {
             // scheduler stops pulling whole fact tables up to join centrally.
             // Gated on the dim's row-count stats; only fires for genuinely small
             // dimensions. Live executor addresses are read sync at plan time.
-            // Enabled by default; set SPICE_BROADCAST_JOIN=0 (or false) to
-            // disable it for an A/B perf comparison.
-            let broadcast_enabled = std::env::var("SPICE_BROADCAST_JOIN")
-                .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-                .unwrap_or(true);
-            if broadcast_enabled && let Some(registry) = &self.executor_registry {
+            if let Some(registry) = &self.executor_registry {
                 let reg = Arc::clone(registry);
                 let addresses: ExecutorAddressProvider =
                     Arc::new(move || reg.ready_executor_ids_sync());

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -93,6 +93,7 @@ use datafusion_optimizer_rules::{
     physical_plan::{
         EmptyHashJoinExecPhysicalOptimization, HttpParamsPushdown,
         flightsql::aggregate_pushdown::FlightSQLPartialAggregatePushdown,
+        flightsql::broadcast_join::{ExecutorAddressProvider, FlightSQLBroadcastJoinPushdown},
     },
 };
 #[cfg(not(windows))]
@@ -715,6 +716,29 @@ impl DataFusionBuilder {
             Some(ClusterRole::Scheduler)
         ) {
             state = state.with_physical_optimizer_rule(FlightSQLPartialAggregatePushdown::new());
+
+            // Distribute small-dimension joins onto executors (broadcast the
+            // dim via `executor_table`, join each fact partition locally) so the
+            // scheduler stops pulling whole fact tables up to join centrally.
+            // Gated on the dim's row-count stats; only fires for genuinely small
+            // dimensions. Live executor addresses are read sync at plan time.
+            // Enabled by default; set SPICE_BROADCAST_JOIN=0 (or false) to
+            // disable it for an A/B perf comparison.
+            let broadcast_enabled = std::env::var("SPICE_BROADCAST_JOIN")
+                .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+                .unwrap_or(true);
+            if broadcast_enabled && let Some(registry) = &self.executor_registry {
+                let reg = Arc::clone(registry);
+                let addresses: ExecutorAddressProvider =
+                    Arc::new(move || reg.ready_executor_ids_sync());
+                // The primary gate is the scale-invariant cost test
+                // (dim_rows × executors < fact_rows); this is the absolute cap
+                // on the broadcast dimension's row count to bound per-executor
+                // memory regardless of that comparison.
+                state = state.with_physical_optimizer_rule(FlightSQLBroadcastJoinPushdown::new(
+                    addresses, /* max_broadcast_dim_rows */ 25_000_000,
+                ));
+            }
         }
 
         let mut state = state.build();

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -28,6 +28,7 @@ use crate::datafusion::udtf::json_properties::{
 };
 use crate::datafusion::udtf::json_tree::{JSON_TREE_UDTF_NAME, JsonTreeScalar, JsonTreeTableFunc};
 use crate::embeddings::udtf::{VECTOR_SEARCH_UDTF_NAME, VectorSearchTableFunc};
+use crate::executor_table::{EXECUTOR_TABLE_UDTF_NAME, ExecutorTableFunc};
 use crate::search::full_text::udtf::{TEXT_SEARCH_UDTF_NAME, TextSearchTableFunc};
 use crate::search::rerank::{RERANK_UDTF_NAME, RerankTableFunc};
 use crate::search::rrf;
@@ -89,6 +90,13 @@ pub async fn register_udfs(runtime: &crate::Runtime) {
     ctx.register_udtf(
         TEXT_SEARCH_UDTF_NAME,
         Arc::new(TextSearchTableFunc::new(Arc::downgrade(&runtime.df))),
+    );
+
+    // `executor_table('endpoint','table')` — fetch a peer executor's partition
+    // of a table over Flight SQL (the distributed broadcast-join primitive).
+    ctx.register_udtf(
+        EXECUTOR_TABLE_UDTF_NAME,
+        Arc::new(ExecutorTableFunc::new(Arc::downgrade(&runtime.df))),
     );
 
     let explicit_pks = parse_explicit_primary_keys(runtime.app()).await;

--- a/crates/runtime/src/executor_table.rs
+++ b/crates/runtime/src/executor_table.rs
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `executor_table('endpoint', 'table')` — a table-valued function that fetches
+//! a single peer executor's partition of a table over Flight SQL.
+//!
+//! This is the primitive behind distributed broadcast joins on the
+//! distributed-acceleration (Cayenne catalog) path. Each executor physically
+//! holds only its assigned partition of a table, so a plain `SELECT * FROM t`
+//! issued to one executor returns just that executor's slice. A small dimension
+//! table can therefore be reconstructed in full on ANY node by UNION-ing
+//! `executor_table(eᵢ, 't')` over the live executors:
+//!
+//! ```sql
+//! SELECT * FROM executor_table('https://e0:50052', 'spicebench.bench.nation')
+//! UNION ALL
+//! SELECT * FROM executor_table('https://e1:50052', 'spicebench.bench.nation')
+//! ...
+//! ```
+//!
+//! The broadcast-join rewrite rule pushes a per-executor join SQL down to each
+//! fact-partition executor, where the small dimension is gathered via this
+//! UNION and the join runs locally — instead of shipping the whole fact table
+//! up to the scheduler. The schema is resolved from the LOCAL catalog (every
+//! node shares the table definition; only the data is partitioned), so no
+//! remote schema round-trip is needed, and the wrapped [`FlightSQLTable`]
+//! pushes the dimension's own filters/projection into the peer `SELECT` for
+//! free.
+
+use std::sync::{Arc, Weak};
+
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::sql::client::FlightSqlServiceClient;
+use arrow_schema::SchemaRef;
+use datafusion::catalog::{TableFunctionImpl, TableProvider};
+use datafusion::common::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::Expr;
+use datafusion::scalar::ScalarValue;
+use datafusion::sql::TableReference;
+use flight_client::cookie::{CookieService, CookieStore};
+use tonic::transport::{ClientTlsConfig, Endpoint};
+
+use cayenne::catalog_provider::CayenneSchemaProvider;
+use data_components::flightsql::{FlightSQLTable, FlightSqlClient};
+
+use crate::datafusion::DataFusion;
+
+/// UDTF name for `executor_table`.
+pub const EXECUTOR_TABLE_UDTF_NAME: &str = "executor_table";
+
+const MAX_FLIGHT_MESSAGE_SIZE: usize = 100 * 1024 * 1024;
+
+/// `executor_table('endpoint', 'table')` table function.
+pub struct ExecutorTableFunc {
+    df: Weak<DataFusion>,
+}
+
+impl std::fmt::Debug for ExecutorTableFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExecutorTableFunc").finish()
+    }
+}
+
+impl ExecutorTableFunc {
+    #[must_use]
+    pub fn new(df: Weak<DataFusion>) -> Self {
+        Self { df }
+    }
+}
+
+fn literal_string(arg: Option<&Expr>, what: &str) -> DataFusionResult<String> {
+    match arg {
+        Some(Expr::Literal(ScalarValue::Utf8(Some(s)) | ScalarValue::Utf8View(Some(s)), _)) => {
+            Ok(s.clone())
+        }
+        other => Err(DataFusionError::Plan(format!(
+            "executor_table: expected a string literal for the {what}, got {other:?}"
+        ))),
+    }
+}
+
+/// Build a Flight SQL client to a peer executor's endpoint, applying the node's
+/// cluster mTLS config. Mirrors `cluster::service::create_executor_flight_client`.
+fn build_peer_client(
+    endpoint: &str,
+    client_tls_config: Option<ClientTlsConfig>,
+) -> DataFusionResult<FlightSqlClient> {
+    let address = if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        endpoint.to_string()
+    } else {
+        format!("http://{endpoint}")
+    };
+    let mut channel = Endpoint::from_shared(address)
+        .map_err(|e| DataFusionError::Execution(format!("executor_table: bad endpoint: {e}")))?;
+    if let Some(tls_config) = client_tls_config {
+        channel = channel
+            .tls_config(tls_config)
+            .map_err(|e| DataFusionError::Execution(format!("executor_table: tls: {e}")))?;
+    }
+    let channel = CookieService::new(channel.connect_lazy(), Arc::new(CookieStore::new()));
+    Ok(FlightSqlServiceClient::new_from_inner(
+        FlightServiceClient::new(channel)
+            .max_encoding_message_size(MAX_FLIGHT_MESSAGE_SIZE)
+            .max_decoding_message_size(MAX_FLIGHT_MESSAGE_SIZE),
+    ))
+}
+
+impl TableFunctionImpl for ExecutorTableFunc {
+    fn call(&self, args: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
+        let endpoint = literal_string(args.first(), "executor endpoint")?;
+        let table_str = literal_string(args.get(1), "table name")?;
+        let table_ref = TableReference::parse_str(&table_str);
+
+        let df = self.df.upgrade().ok_or_else(|| {
+            DataFusionError::Plan(
+                "executor_table: DataFusion instance has been dropped".to_string(),
+            )
+        })?;
+
+        // Resolve the schema SYNCHRONOUSLY from the LOCAL catalog. `get_table_sync`
+        // only sees `SpiceSchemaProvider` tables (not external catalogs like
+        // Cayenne), and the generic `SchemaProvider::table()` is async — so
+        // resolve the catalog/schema (both sync) and read the Cayenne schema
+        // provider's in-memory table cache directly via `table_sync`.
+        let cat_name = table_ref.catalog().ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "executor_table: table '{table_str}' must be catalog-qualified"
+            ))
+        })?;
+        let sch_name = table_ref.schema().ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "executor_table: table '{table_str}' must be schema-qualified"
+            ))
+        })?;
+        let catalog = df.ctx.catalog(cat_name).ok_or_else(|| {
+            DataFusionError::Plan(format!("executor_table: catalog '{cat_name}' not found"))
+        })?;
+        let schema_provider = catalog.schema(sch_name).ok_or_else(|| {
+            DataFusionError::Plan(format!("executor_table: schema '{sch_name}' not found"))
+        })?;
+        let cayenne_schema = schema_provider
+            .as_any()
+            .downcast_ref::<CayenneSchemaProvider>()
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "executor_table: schema '{cat_name}.{sch_name}' is not a Cayenne catalog schema"
+                ))
+            })?;
+        let provider = cayenne_schema
+            .table_sync(table_ref.table())
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "executor_table: table '{table_str}' not found locally"
+                ))
+            })?;
+        let schema: SchemaRef = provider.schema();
+
+        let client = build_peer_client(&endpoint, df.cluster_config.client_tls_config())?;
+        let cookie_store = Arc::new(CookieStore::new());
+
+        Ok(Arc::new(FlightSQLTable::create_with_schema(
+            EXECUTOR_TABLE_UDTF_NAME,
+            &endpoint,
+            client,
+            table_ref,
+            schema,
+            cookie_store,
+        )))
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -98,6 +98,7 @@ pub mod datasets_health_monitor;
 pub mod dataupdate;
 pub mod embeddings;
 pub mod execution_plan;
+pub mod executor_table;
 pub mod extension;
 pub mod federated_table;
 pub mod flight;

--- a/tools/cayenne-flightsql/src/main.rs
+++ b/tools/cayenne-flightsql/src/main.rs
@@ -182,6 +182,9 @@ async fn main() -> Result<()> {
                 inline_flush_max_segments: None,
                 inline_flush_max_bytes: None,
                 pk_conflict_detection: None,
+                dynamic_tuning: false,
+                compaction_background_interval_ms: None,
+                compaction_trigger_files: None,
             },
             ctx.runtime_env(),
         )
@@ -390,6 +393,9 @@ mod tests {
                     inline_flush_max_segments: None,
                     inline_flush_max_bytes: None,
                     pk_conflict_detection: None,
+                    dynamic_tuning: false,
+                    compaction_background_interval_ms: None,
+                    compaction_trigger_files: None,
                 },
                 ctx.runtime_env(),
             )

--- a/tools/spidapter/src/provision/spice_local.rs
+++ b/tools/spidapter/src/provision/spice_local.rs
@@ -411,6 +411,21 @@ pub(crate) async fn teardown_local_run(local_state: &mut LocalRunState) -> anyho
         "[stdio] teardown: stopping local process(es) (sql endpoint: {})",
         local_state.sql_url
     );
+    // Diagnostic hold: keep the loaded cluster alive for SPIDAPTER_HOLD_SECS so
+    // an operator can run EXPLAIN ANALYZE / inspect state before teardown
+    // SIGKILLs it. No-op when unset or zero.
+    if let Ok(raw) = std::env::var("SPIDAPTER_HOLD_SECS")
+        && let Ok(secs) = raw.trim().parse::<u64>()
+        && secs > 0
+    {
+        eprintln!(
+            "[stdio] teardown: HOLDING cluster {secs}s before teardown. sql_endpoint={} api_key={}",
+            local_state.sql_url,
+            local_state.flight_api_key.as_deref().unwrap_or("<none>")
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+        eprintln!("[stdio] teardown: hold elapsed, proceeding with teardown");
+    }
     match &mut local_state.processes {
         LocalProcesses::SingleNode { child } => {
             stop_child_process(child, "spiced").await?;

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -1415,7 +1415,19 @@ async fn generate_initial_spicepod(
     scp: &ScpConfig,
     cayenne: Option<&CayenneConfig>,
 ) -> anyhow::Result<SpicepodDefinition> {
-    let scheduler_state_location = scp.scheduler_state_location.as_deref();
+    // Local-bench fallback: when no scenario `compute.scp` block provides a
+    // scheduler state location, honor the SCHEDULER_STATE_LOCATION env var
+    // (passed by `spicebench run` via --system-adapter-env). spiced refuses to
+    // start in scheduler mode without `runtime.scheduler.state_location`, and
+    // the local backend otherwise leaves it unset.
+    let scheduler_state_location_env = std::env::var("SCHEDULER_STATE_LOCATION")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+    let scheduler_state_location = scp
+        .scheduler_state_location
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .or(scheduler_state_location_env.as_deref());
 
     let mut spicepod = if let Some(path) = setup_config.spicepod_path.as_deref() {
         load_spicepod_from_path(path, run_id).await?


### PR DESCRIPTION
## Summary

This PR reduces query latency for distributed acceleration on Cayenne clusters. Instead of shipping all fact-table partitions to the scheduler and joining centrally, the optimizer can now push eligible inner equi-joins back to the executors.

For eligible plans, each executor joins its local fact partition with the full small dimension table. The dimension is reconstructed on the executor by querying peer partitions through the new `executor_table(...)` table-valued function, so the scheduler receives joined rows instead of the raw fact table.

The rewrite is automatic and stats-gated; no table annotation is required.

## Flow

```text
Before
------
fact partitions ----\
                    +--> scheduler joins full fact + dimension
dimension parts ----/

After
-----
scheduler builds distributed join plan
      |
      +--> executor 0: local fact slice + full dimension from peers -> joined rows
      +--> executor 1: local fact slice + full dimension from peers -> joined rows
      +--> executor N: local fact slice + full dimension from peers -> joined rows
      |
      v
scheduler receives joined rows
```

## Changes

- Adds `FlightSQLBroadcastJoinPushdown`, a physical optimizer rule for inner equi-joins where the small side is below 25M rows and `dim_rows * executors * 4 < fact_rows`.
- Adds `BroadcastJoinFlightSqlExec` to run generated join SQL against each fact-partition executor and align the returned schema and partitioning with the replaced join.
- Adds `executor_table('https://host:port', 'catalog.schema.table')`, a table-valued function that reads one peer executor's local Cayenne partition over Flight SQL using cluster mTLS.
- Fixes Flight SQL partial-aggregate pushdown for the `Aggregate -> Projection -> RoundRobin -> Union -> FlightSqlExec` plan shape used by computed aggregate arguments such as TPC-H Q1.
- Adds Cayenne catalog `tuning: auto | adaptive`; adaptive mode seeds flush, compaction, and write-concurrency knobs from the host hardware profile.
- Updates the spidapter local backend to read `SCHEDULER_STATE_LOCATION` and adds `SPIDAPTER_HOLD_SECS` for diagnostic teardown delays.

## Notes

- Joins without row-count stats, joins where the dimension is too large, and non-inner or residual-filter joins keep the existing scheduler-join path.
- `executor_table(...)` is primarily an optimizer primitive for distributed broadcast joins.
- This supersedes the closed replicated-table directive prototype in #10090.

## Test plan

- [x] Local distributed cluster SF1/SF10 TPC-H validation: all 21 queries passed with broadcast enabled.
- [x] Cloud SF10 TPC-H append benchmark: q9 ~3.5x, q8 ~4-5x, plus q5/q17/q21/q10 improvements on join-heavy queries.
- [ ] CI
