### PR TITLE
fix: Strip inference columns from table schema on query

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4715,14 +4715,7 @@ impl CayenneTableProvider {
         runtime_env: Arc<RuntimeEnv>,
         context: Option<Arc<CayenneContext>>,
     ) -> CatalogResult<Self> {
-        let mut table_metadata = catalog.get_table(table_name).await?;
-        // Extended-inference hints (`spice.inferred_*`) are consumed once, at
-        // acceleration setup, to fill unspecified settings and seed tuning;
-        // retaining them on the metadata would lead to schema mismatch errors
-        // during joins on tables with varying inference states.
-        table_metadata.schema = data_components::inferred_schema::schema_without_inferred_metadata(
-            &table_metadata.schema,
-        );
+        let table_metadata = catalog.get_table(table_name).await?;
 
         // Use the provided context (for partition cache sharing) or build a
         // fresh one from this table's VortexConfig and the shared RuntimeEnv.

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4715,7 +4715,14 @@ impl CayenneTableProvider {
         runtime_env: Arc<RuntimeEnv>,
         context: Option<Arc<CayenneContext>>,
     ) -> CatalogResult<Self> {
-        let table_metadata = catalog.get_table(table_name).await?;
+        let mut table_metadata = catalog.get_table(table_name).await?;
+        // Extended-inference hints (`spice.inferred_*`) are consumed once, at
+        // acceleration setup, to fill unspecified settings and seed tuning;
+        // retaining them on the metadata would lead to schema mismatch errors
+        // during joins on tables with varying inference states.
+        table_metadata.schema = data_components::inferred_schema::schema_without_inferred_metadata(
+            &table_metadata.schema,
+        );
 
         // Use the provided context (for partition cache sharing) or build a
         // fresh one from this table's VortexConfig and the shared RuntimeEnv.

--- a/crates/data_components/src/inferred_schema.rs
+++ b/crates/data_components/src/inferred_schema.rs
@@ -63,7 +63,9 @@ pub const INFERRED_METADATA_KEYS: [&str; 5] = [
 /// output schema no longer equals its input schema and the schema-invariant
 /// check fails. Strip them from the scan schema (only) to keep join schemas
 /// stable while leaving the statistics/tuning consumers untouched.
-pub fn strip_inferred_metadata<S: std::hash::BuildHasher>(metadata: &mut HashMap<String, String, S>) {
+pub fn strip_inferred_metadata<S: std::hash::BuildHasher>(
+    metadata: &mut HashMap<String, String, S>,
+) {
     for key in INFERRED_METADATA_KEYS {
         metadata.remove(key);
     }

--- a/crates/data_components/src/inferred_schema.rs
+++ b/crates/data_components/src/inferred_schema.rs
@@ -28,9 +28,7 @@ limitations under the License.
 //! the consumer (runtime) always agree on the wire format.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use arrow::datatypes::SchemaRef;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{
@@ -41,9 +39,8 @@ use crate::{
 
 /// Every Arrow schema-metadata key written by [`InferredSchema::to_metadata`].
 ///
-/// Centralized here so a consumer can strip the extended-inference hints from a
-/// table's live, queryable schema in one place — see
-/// [`schema_without_inferred_metadata`].
+/// Centralized so the inference hints can be located — and removed from a query
+/// scan's output schema — in one place; see [`strip_inferred_metadata`].
 pub const INFERRED_METADATA_KEYS: [&str; 5] = [
     INFERRED_PRIMARY_KEY_METADATA_KEY,
     INFERRED_INDEXES_METADATA_KEY,
@@ -52,33 +49,24 @@ pub const INFERRED_METADATA_KEYS: [&str; 5] = [
     INFERRED_TABLE_BYTES_METADATA_KEY,
 ];
 
-/// Return `schema` with every extended-inference hint ([`INFERRED_METADATA_KEYS`])
-/// removed from its schema-level metadata, cloning the `Arc` unchanged when it
-/// carries none (the common case, so the hot path allocates nothing). Field-level
-/// metadata (e.g. `source_type`) and all other schema-level keys are preserved.
+/// Remove every extended-inference hint ([`INFERRED_METADATA_KEYS`]) from a
+/// schema-metadata map, in place.
 ///
-/// These hints are produced by extended schema inference and consumed *once*, at
-/// acceleration setup, to fill unspecified acceleration settings and seed tuning.
-/// They must not ride on the live, queryable table schema: their values vary per
-/// table, and DataFusion builds a join's output schema by merging its inputs'
-/// schema-level metadata in input order. When `join_selection` swaps a hash
-/// join's build/probe sides, that merge order flips and the surviving values
-/// change, so the rule's output schema no longer equals its input schema and the
-/// physical-optimizer schema-invariant check fails.
-#[must_use]
-pub fn schema_without_inferred_metadata(schema: &SchemaRef) -> SchemaRef {
-    if !INFERRED_METADATA_KEYS
-        .iter()
-        .any(|key| schema.metadata().contains_key(*key))
-    {
-        return Arc::clone(schema);
-    }
-
-    let mut metadata = schema.metadata().clone();
+/// These hints stay useful on a table provider's *advertised* schema: the runtime
+/// surfaces the inferred row-count / byte-size as table statistics (see
+/// `MetadataEnrichedTableProvider`) and seeds the accelerator's tuning warm-start
+/// from them. They must not, however, ride on a query scan's *output* schema.
+/// Their values vary per table, and DataFusion builds a join's output schema by
+/// merging its inputs' schema-level metadata in input order; when the
+/// `join_selection` physical-optimizer rule swaps a hash join's build/probe
+/// sides, that merge order flips and the surviving values change, so the rule's
+/// output schema no longer equals its input schema and the schema-invariant
+/// check fails. Strip them from the scan schema (only) to keep join schemas
+/// stable while leaving the statistics/tuning consumers untouched.
+pub fn strip_inferred_metadata(metadata: &mut HashMap<String, String>) {
     for key in INFERRED_METADATA_KEYS {
         metadata.remove(key);
     }
-    Arc::new(schema.as_ref().clone().with_metadata(metadata))
 }
 
 /// A secondary index inferred from the source table.
@@ -320,59 +308,40 @@ mod tests {
     }
 
     #[test]
-    fn strip_removes_inferred_keys_preserving_fields_and_other_metadata() {
-        use arrow::datatypes::{DataType, Field, Schema};
+    fn strip_inferred_metadata_removes_only_inferred_keys() {
+        // Every key `to_metadata` can emit, plus unrelated schema-level metadata.
+        let mut metadata = sample().to_metadata();
+        metadata.insert("spice.accelerator".to_string(), "cayenne".to_string());
+        metadata.insert("description".to_string(), "orders".to_string());
 
-        let mut field_md = HashMap::new();
-        field_md.insert("source_type".to_string(), "integer".to_string());
-        let field = Field::new("id", DataType::Int32, false).with_metadata(field_md);
-
-        let mut schema_md = sample().to_metadata();
-        schema_md.insert("spice.accelerator".to_string(), "cayenne".to_string());
-        let schema: SchemaRef = Arc::new(Schema::new_with_metadata(vec![field], schema_md));
-
-        let stripped = schema_without_inferred_metadata(&schema);
+        strip_inferred_metadata(&mut metadata);
 
         for key in INFERRED_METADATA_KEYS {
-            assert!(
-                !stripped.metadata().contains_key(key),
-                "inferred key {key} should be stripped"
-            );
+            assert!(!metadata.contains_key(key), "{key} should be stripped");
         }
-        // Unrelated schema-level metadata is kept.
+        // Unrelated schema-level metadata is preserved.
         assert_eq!(
-            stripped
-                .metadata()
-                .get("spice.accelerator")
-                .map(String::as_str),
+            metadata.get("spice.accelerator").map(String::as_str),
             Some("cayenne")
         );
-        // Fields and their (field-level) metadata are untouched.
-        assert_eq!(stripped.fields().len(), 1);
         assert_eq!(
-            stripped
-                .field(0)
-                .metadata()
-                .get("source_type")
-                .map(String::as_str),
-            Some("integer")
+            metadata.get("description").map(String::as_str),
+            Some("orders")
         );
     }
 
     #[test]
-    fn strip_is_a_noop_arc_clone_without_inferred_metadata() {
-        use arrow::datatypes::{DataType, Field, Schema};
+    fn strip_inferred_metadata_is_a_noop_when_absent() {
+        let mut metadata = HashMap::new();
+        metadata.insert("spice.accelerator".to_string(), "cayenne".to_string());
 
-        let mut schema_md = HashMap::new();
-        schema_md.insert("spice.accelerator".to_string(), "cayenne".to_string());
-        let schema: SchemaRef = Arc::new(Schema::new_with_metadata(
-            vec![Field::new("id", DataType::Int32, false)],
-            schema_md,
-        ));
+        strip_inferred_metadata(&mut metadata);
 
-        let stripped = schema_without_inferred_metadata(&schema);
-        // Nothing to strip → same allocation returned, no rebuild.
-        assert!(Arc::ptr_eq(&schema, &stripped));
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(
+            metadata.get("spice.accelerator").map(String::as_str),
+            Some("cayenne")
+        );
     }
 
     #[test]

--- a/crates/data_components/src/inferred_schema.rs
+++ b/crates/data_components/src/inferred_schema.rs
@@ -28,7 +28,9 @@ limitations under the License.
 //! the consumer (runtime) always agree on the wire format.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use arrow::datatypes::SchemaRef;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{
@@ -36,6 +38,48 @@ use crate::{
     INFERRED_ROW_COUNT_METADATA_KEY, INFERRED_SORT_COLUMNS_METADATA_KEY,
     INFERRED_TABLE_BYTES_METADATA_KEY,
 };
+
+/// Every Arrow schema-metadata key written by [`InferredSchema::to_metadata`].
+///
+/// Centralized here so a consumer can strip the extended-inference hints from a
+/// table's live, queryable schema in one place — see
+/// [`schema_without_inferred_metadata`].
+pub const INFERRED_METADATA_KEYS: [&str; 5] = [
+    INFERRED_PRIMARY_KEY_METADATA_KEY,
+    INFERRED_INDEXES_METADATA_KEY,
+    INFERRED_SORT_COLUMNS_METADATA_KEY,
+    INFERRED_ROW_COUNT_METADATA_KEY,
+    INFERRED_TABLE_BYTES_METADATA_KEY,
+];
+
+/// Return `schema` with every extended-inference hint ([`INFERRED_METADATA_KEYS`])
+/// removed from its schema-level metadata, cloning the `Arc` unchanged when it
+/// carries none (the common case, so the hot path allocates nothing). Field-level
+/// metadata (e.g. `source_type`) and all other schema-level keys are preserved.
+///
+/// These hints are produced by extended schema inference and consumed *once*, at
+/// acceleration setup, to fill unspecified acceleration settings and seed tuning.
+/// They must not ride on the live, queryable table schema: their values vary per
+/// table, and DataFusion builds a join's output schema by merging its inputs'
+/// schema-level metadata in input order. When `join_selection` swaps a hash
+/// join's build/probe sides, that merge order flips and the surviving values
+/// change, so the rule's output schema no longer equals its input schema and the
+/// physical-optimizer schema-invariant check fails.
+#[must_use]
+pub fn schema_without_inferred_metadata(schema: &SchemaRef) -> SchemaRef {
+    if !INFERRED_METADATA_KEYS
+        .iter()
+        .any(|key| schema.metadata().contains_key(*key))
+    {
+        return Arc::clone(schema);
+    }
+
+    let mut metadata = schema.metadata().clone();
+    for key in INFERRED_METADATA_KEYS {
+        metadata.remove(key);
+    }
+    Arc::new(schema.as_ref().clone().with_metadata(metadata))
+}
 
 /// A secondary index inferred from the source table.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -273,6 +317,62 @@ mod tests {
         // Bad PK ignored, good indexes preserved.
         assert!(parsed.primary_key.is_empty());
         assert_eq!(parsed.indexes, sample().indexes);
+    }
+
+    #[test]
+    fn strip_removes_inferred_keys_preserving_fields_and_other_metadata() {
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        let mut field_md = HashMap::new();
+        field_md.insert("source_type".to_string(), "integer".to_string());
+        let field = Field::new("id", DataType::Int32, false).with_metadata(field_md);
+
+        let mut schema_md = sample().to_metadata();
+        schema_md.insert("spice.accelerator".to_string(), "cayenne".to_string());
+        let schema: SchemaRef = Arc::new(Schema::new_with_metadata(vec![field], schema_md));
+
+        let stripped = schema_without_inferred_metadata(&schema);
+
+        for key in INFERRED_METADATA_KEYS {
+            assert!(
+                !stripped.metadata().contains_key(key),
+                "inferred key {key} should be stripped"
+            );
+        }
+        // Unrelated schema-level metadata is kept.
+        assert_eq!(
+            stripped
+                .metadata()
+                .get("spice.accelerator")
+                .map(String::as_str),
+            Some("cayenne")
+        );
+        // Fields and their (field-level) metadata are untouched.
+        assert_eq!(stripped.fields().len(), 1);
+        assert_eq!(
+            stripped
+                .field(0)
+                .metadata()
+                .get("source_type")
+                .map(String::as_str),
+            Some("integer")
+        );
+    }
+
+    #[test]
+    fn strip_is_a_noop_arc_clone_without_inferred_metadata() {
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        let mut schema_md = HashMap::new();
+        schema_md.insert("spice.accelerator".to_string(), "cayenne".to_string());
+        let schema: SchemaRef = Arc::new(Schema::new_with_metadata(
+            vec![Field::new("id", DataType::Int32, false)],
+            schema_md,
+        ));
+
+        let stripped = schema_without_inferred_metadata(&schema);
+        // Nothing to strip → same allocation returned, no rebuild.
+        assert!(Arc::ptr_eq(&schema, &stripped));
     }
 
     #[test]

--- a/crates/data_components/src/inferred_schema.rs
+++ b/crates/data_components/src/inferred_schema.rs
@@ -56,14 +56,14 @@ pub const INFERRED_METADATA_KEYS: [&str; 5] = [
 /// surfaces the inferred row-count / byte-size as table statistics (see
 /// `MetadataEnrichedTableProvider`) and seeds the accelerator's tuning warm-start
 /// from them. They must not, however, ride on a query scan's *output* schema.
-/// Their values vary per table, and DataFusion builds a join's output schema by
+/// Their values vary per table, and `DataFusion` builds a join's output schema by
 /// merging its inputs' schema-level metadata in input order; when the
 /// `join_selection` physical-optimizer rule swaps a hash join's build/probe
 /// sides, that merge order flips and the surviving values change, so the rule's
 /// output schema no longer equals its input schema and the schema-invariant
 /// check fails. Strip them from the scan schema (only) to keep join schemas
 /// stable while leaving the statistics/tuning consumers untouched.
-pub fn strip_inferred_metadata(metadata: &mut HashMap<String, String>) {
+pub fn strip_inferred_metadata<S: std::hash::BuildHasher>(metadata: &mut HashMap<String, String, S>) {
     for key in INFERRED_METADATA_KEYS {
         metadata.remove(key);
     }

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1622,19 +1622,32 @@ impl TableProvider for AcceleratedTable {
         // Compute the target schema based on user's original projection.
         // SchemaCastScanExec strips extra columns (like _fetched_at added for caching)
         // and casts types. The schema should match what the user requested.
+        //
+        // Drop the extended-inference hints (`spice.inferred_*`) from this physical
+        // scan-output schema. They stay on the logical `TableProvider::schema()`
+        // chain — so `MetadataEnrichedTableProvider` still surfaces the inferred
+        // row-count/byte-size as table statistics and an accelerator keeps its
+        // tuning warm-start — but their values vary per table, and DataFusion
+        // builds a join's output schema by merging its inputs' schema-level
+        // metadata in input order. Leaving them here lets `join_selection`'s
+        // build/probe swap flip the surviving values, so the rule's output schema
+        // no longer equals its input and the physical-optimizer schema invariant
+        // fails. See `data_components::inferred_schema`.
+        let full_schema = self.schema();
+        let mut metadata = full_schema.metadata().clone();
+        data_components::inferred_schema::strip_inferred_metadata(&mut metadata);
         let target_schema = match projection {
             Some(indices) => {
-                let full_schema = self.schema();
                 let projected_fields: Vec<_> = indices
                     .iter()
                     .filter_map(|&i| full_schema.fields().get(i).cloned())
                     .collect();
-                Arc::new(Schema::new_with_metadata(
-                    projected_fields,
-                    full_schema.metadata().clone(),
-                ))
+                Arc::new(Schema::new_with_metadata(projected_fields, metadata))
             }
-            None => self.schema(),
+            None => Arc::new(Schema::new_with_metadata(
+                full_schema.fields().clone(),
+                metadata,
+            )),
         };
 
         Ok(Arc::new(SchemaCastScanExec::new(plan, target_schema)))


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Extended schema inference applies `spice.inference_*` columns when detecting extended schema inference. These columns infer some tuning settings for accelerators, and should not be retained for schema comparisons on joins/scans
* Strips `spice.inference_*` columns from accelerated table schemas to avoid expected schema mismatches during joins. Retains the inferred columns for internal table providers to ensure adaptive tuning continues to function as expected for Cayenne.

Failing queries Q2, 15 and 20 that were previously failing are passing in a test run: https://github.com/spiceai/spiceai/actions/runs/27253375591/job/80482407454