### PR TITLE
fix: scope request context across the managed query runtime

### DIFF
--- a/crates/runtime-datafusion/src/managed_runtime.rs
+++ b/crates/runtime-datafusion/src/managed_runtime.rs
@@ -71,7 +71,18 @@ where
     let driver_span = span.clone();
 
     let driver_task = async move {
-        match future.instrument(driver_span.clone()).await {
+        // Scope the planning/execution future under the originating request
+        // context so task-local reads (`RequestContext::current()`) resolve to
+        // the request's context on this managed runtime task. The streaming
+        // loop below is already scoped; without scoping the future too, code
+        // that reads the task-local context during query planning/execution
+        // (identity UDFs like `current_user_id()`/`current_org_id()`, task
+        // history attribution, per-principal cache namespacing) falls back to
+        // the empty/anonymous context.
+        match Arc::clone(&driver_request_context)
+            .scope(future.instrument(driver_span.clone()))
+            .await
+        {
             Ok((metadata, mut stream)) => {
                 let schema = stream.schema();
 


### PR DESCRIPTION
## Summary

When a dedicated query `cpu_runtime` is configured (the default), queries are
driven on that managed runtime by `run_record_batch_stream_on_runtime`. The
result-streaming loop was scoped under the originating `RequestContext`, but
the query planning/execution future itself was awaited **unscoped**.

As a result, any code that reads the task-local request context during query
planning or execution resolved to an empty context and silently fell back to
the anonymous path, including:

- identity UDFs — `current_user_id()`, `current_org_id()`
- task-history attribution
- per-principal cache namespacing

## Fix

Scope the planning/execution future under the request context, exactly as the
streaming loop already does (one line in `managed_runtime.rs`).

## Test plan

- `cargo test -p runtime`
- Manually verified that `current_org_id()` / `current_user_id()` resolve to
  the request's identity during query execution on the managed runtime after
  the change (they resolved to the anonymous/empty value before it).
