### PR TITLE
feat: Update roadmap with new features and adjustments for v2.1 and v2.2

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,12 +21,12 @@ To propose features or report issues, please [file an issue](https://github.com/
 
 **DataFusion:** v53
 
-- **Distributed Search (Alpha)**: Federated vector and full-text search across multiple nodes, with FTS indexes available in distributed query mode.
 - **Schema Registry (Initial)**: Versioning and backward compatibility checks.
 - **Schema Evolution**: Safe, non-breaking schema changes for accelerated datasets (add/drop/rename columns, type widening) with automatic migration.
 - **Cayenne Improvements**: Non-distributed Cayenne catalog, multi-version metadata schema support, and orphaned deletion-vector cleanup during retention.
 - **Distributed Acceleration Hardening**: Continued planner and runtime improvements for distributed acceleration, including partitioning, readiness signaling, and filter/TopK pushdown.
 - **Ballista / Distributed Query**: Shared job state across schedulers and faster partition reassignment on executor failure.
+- **Write-Back Acceleration**: Eventually-consistent write-back, with full DML (UPDATE/DELETE) and `spice refresh`/`refresh_check_interval` on write-through accelerated tables.
 
 ### [v2.2](https://github.com/spiceai/spiceai/milestone/99) (September 2026)
 
@@ -34,10 +34,9 @@ To propose features or report issues, please [file an issue](https://github.com/
 
 **DataFusion:** v54
 
+- **Distributed Search (Alpha)**: Federated vector and full-text search across multiple nodes, with FTS indexes available in distributed query mode.
 - **Webhooks & Event Notifications**: Push-based data change alerts for downstream consumers.
 - **Actions (Drasi-based)**: Reactive event-driven actions triggered by data changes.
-- **Streaming Cayenne Ingest**: `refresh_mode: changes` (Kafka) support for Cayenne-accelerated tables.
-- **Distributed Search Scale-Out**: Search query partitioning and relative score fusion across distributed nodes.
 
 ### [v2.3](https://github.com/spiceai/spiceai/milestone/100) (October 2026)
 
@@ -48,7 +47,7 @@ To propose features or report issues, please [file an issue](https://github.com/
 - **Audit Logging**: Persistent, immutable query and access logs for compliance.
 - **Resource Quotas**: Per-user/tenant query limits and throttling.
 - **Distributed Cayenne Catalog**: Cayenne catalog with full distributed query and acceleration support.
-- **Write-Back Acceleration**: Eventually-consistent write-back, with full DML (UPDATE/DELETE) and `spice refresh`/`refresh_check_interval` on write-through accelerated tables.
+- **Distributed Search Scale-Out**: Search query partitioning and relative score fusion across distributed nodes.
 
 ### [v2.4](https://github.com/spiceai/spiceai/milestone/101) (December 2026)
 
@@ -95,7 +94,7 @@ These are prioritized based on community demand and strategic alignment. Share y
 
 ### Search & Retrieval
 
-- **Faceted Search**: Aggregations, filters, and counts for enterprise search UX.
+- **Faceted Search**: Native facet buckets and counts returned directly in the search API response — beyond today's `GROUP BY` over the `vector_search`/`text_search` SQL functions — for filter-sidebar enterprise search UX.
 
 ### Data Platform
 


### PR DESCRIPTION
This pull request updates the `docs/ROADMAP.md` file to clarify the scope and scheduling of several upcoming features, particularly around distributed search, write-back acceleration, and faceted search. The main changes involve moving features between release milestones and refining feature descriptions for better clarity.

**Roadmap milestone adjustments:**

* Moved "Distributed Search (Alpha)" from v2.1 to v2.2, and "Distributed Search Scale-Out" from v2.2 to v2.3, to better reflect the planned release schedule. [[1]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L24-L40) [[2]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L51-R50)
* Moved "Write-Back Acceleration" from v2.3 to v2.1, indicating an earlier delivery of this capability. [[1]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L24-L40) [[2]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L51-R50)

**Feature description improvements:**

* Expanded the "Faceted Search" description to clarify that native facet buckets and counts will be returned directly in the search API response, improving the enterprise search UX beyond current SQL-based approaches.