### PR TITLE
feat(chbench): report Cayenne compaction & read-amp metrics

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -9832,6 +9832,7 @@ impl CayenneTableProvider {
             pass_start.elapsed(),
             &[
                 telemetry::KeyValue::new("table", table.clone()),
+                telemetry::KeyValue::new("kind", "full"),
                 telemetry::KeyValue::new("result", result_label),
             ],
         );
@@ -9842,9 +9843,10 @@ impl CayenneTableProvider {
                     if matches!(source, datafusion_common::DataFusionError::ResourcesExhausted(_))
             )
         {
-            telemetry::track_cayenne_compaction_memory_exhausted(&[telemetry::KeyValue::new(
-                "table", table,
-            )]);
+            telemetry::track_cayenne_compaction_memory_exhausted(&[
+                telemetry::KeyValue::new("table", table),
+                telemetry::KeyValue::new("kind", "full"),
+            ]);
         }
         result
     }
@@ -10046,8 +10048,57 @@ impl CayenneTableProvider {
     /// Returns `Ok(true)` if a merge was committed, `Ok(false)` if there was
     /// nothing to do (fewer than two protected snapshots, no qualifying tier,
     /// or the CAS lost a race).
+    ///
+    /// Records compaction telemetry under `kind="subset"`: a pass that actually
+    /// merged (`Ok(true)`) or attempted and failed (`Err`) emits
+    /// `cayenne_compaction_duration_ms` (whose count is the subset-pass counter),
+    /// mirroring the full-path [`rewrite_current_snapshot_for_compaction_tracked`].
+    /// The no-op early-outs (`Ok(false)`: < 2 snapshots, no qualifying tier, lost
+    /// CAS, writer/lock busy) are intentionally not counted, so the subset
+    /// pass count aligns with the `cayenne_compaction_merged_bytes` count.
     #[doc(hidden)]
     pub async fn compact_protected_snapshots_subset(&self, max_inputs: usize) -> Result<bool> {
+        let pass_start = std::time::Instant::now();
+        let result = self
+            .compact_protected_snapshots_subset_inner(max_inputs)
+            .await;
+
+        // Count only passes that did real work (committed a merge) or attempted
+        // one and failed; skip the trivial no-op early-outs so the subset pass
+        // count matches the merged-bytes count emitted on a committed merge.
+        if matches!(result, Ok(true) | Err(_)) {
+            let table = self.table_metadata.table_name.clone();
+            let result_label = if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            };
+            telemetry::track_cayenne_compaction_duration(
+                pass_start.elapsed(),
+                &[
+                    telemetry::KeyValue::new("table", table.clone()),
+                    telemetry::KeyValue::new("kind", "subset"),
+                    telemetry::KeyValue::new("result", result_label),
+                ],
+            );
+            if let Err(e) = &result
+                && matches!(
+                    e,
+                    Error::DataFusion { source }
+                        if matches!(source, datafusion_common::DataFusionError::ResourcesExhausted(_))
+                )
+            {
+                telemetry::track_cayenne_compaction_memory_exhausted(&[
+                    telemetry::KeyValue::new("table", table),
+                    telemetry::KeyValue::new("kind", "subset"),
+                ]);
+            }
+        }
+
+        result
+    }
+
+    async fn compact_protected_snapshots_subset_inner(&self, max_inputs: usize) -> Result<bool> {
         // Position deletes are file-path scoped. If a protected-snapshot rewrite
         // races a writer that adds a position tombstone for one of the input
         // files, the old file can be swapped away before that tombstone is
@@ -10437,10 +10488,10 @@ impl CayenneTableProvider {
         };
         telemetry::track_cayenne_compaction_merged_bytes(
             merged_output_bytes,
-            &[telemetry::KeyValue::new(
-                "table",
-                self.table_metadata.table_name.clone(),
-            )],
+            &[
+                telemetry::KeyValue::new("table", self.table_metadata.table_name.clone()),
+                telemetry::KeyValue::new("kind", "subset"),
+            ],
         );
 
         Ok(true)

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -491,16 +491,19 @@ fn cayenne_compaction_duration_ms() -> &'static Histogram<f64> {
     CAYENNE_COMPACTION_DURATION_MS.get_or_init(|| {
         cayenne_operational_meter()
             .f64_histogram("cayenne_compaction_duration_ms")
-            .with_description("Wall-clock time of Cayenne background compaction passes.")
+            .with_description(
+                "Wall-clock time of Cayenne compaction passes (kind=full current-snapshot rewrite | subset protected-snapshot merge).",
+            )
             .with_unit("ms")
             .with_boundaries(DURATION_MS_HISTOGRAM_BUCKETS.to_vec())
             .build()
     })
 }
 
-/// Records the wall-clock duration of a Cayenne background compaction pass.
-/// `dimensions` should carry `table` and `result` (`"completed"` | `"failed"`).
-/// The histogram's count doubles as the compaction-pass counter.
+/// Records the wall-clock duration of a Cayenne compaction pass. `dimensions`
+/// should carry `table`, `kind` (`"full"` current-snapshot rewrite | `"subset"`
+/// protected-snapshot merge), and `result` (`"completed"` | `"failed"`). The
+/// histogram's count doubles as the per-kind compaction-pass counter.
 pub fn track_cayenne_compaction_duration(duration: Duration, dimensions: &[KeyValue]) {
     cayenne_compaction_duration_ms().record(duration.as_secs_f64() * 1000.0, dimensions);
 }
@@ -543,6 +546,7 @@ fn cayenne_compaction_memory_exhausted() -> &'static Counter<u64> {
 /// Counts compaction passes that failed because the dedicated compaction memory
 /// pool could not satisfy a reservation (`ResourcesExhausted`). A non-zero rate
 /// means the carve fraction is too small for the rewrite working set.
+/// `dimensions` should carry `table` and `kind` (`"full"` | `"subset"`).
 pub fn track_cayenne_compaction_memory_exhausted(dimensions: &[KeyValue]) {
     cayenne_compaction_memory_exhausted().add(1, dimensions);
 }
@@ -880,7 +884,9 @@ static CAYENNE_COMPACTION_MERGED_BYTES: OnceLock<Histogram<u64>> = OnceLock::new
 /// output (≈ the resulting compacted file size). Compare its distribution
 /// against `cayenne_autotune_target_file_size_mb` to see whether compaction is
 /// trending to the target file size or stalling below it (a read-amplification
-/// signal the adaptive tuner cares about). `dimensions` should carry `table`.
+/// signal the adaptive tuner cares about). `dimensions` should carry `table`
+/// and `kind` (currently always `"subset"` — the full current-snapshot rewrite
+/// path does not yet emit this metric).
 pub fn track_cayenne_compaction_merged_bytes(bytes: u64, dimensions: &[KeyValue]) {
     const MIB: f64 = 1024.0 * 1024.0;
     CAYENNE_COMPACTION_MERGED_BYTES

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -18,6 +18,7 @@ limitations under the License.
 //! Postgres database while executing CH-benCH analytical queries through spiced.
 
 mod correctness;
+mod reporting;
 mod spice;
 mod staleness;
 
@@ -268,7 +269,9 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     }
 
     if let Some(metrics) = spiced_metrics {
-        emit_replication_metrics(&metrics, "under load", true);
+        reporting::emit_replication_metrics(&metrics, "under load", true);
+        // For Cayenne backend report additional metrics
+        reporting::emit_cayenne_read_amp_percentiles(&metrics);
     }
 
     // 10. Data-correctness gate: OLTP has stopped, so wait for replication to
@@ -307,7 +310,11 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
             if report.converged_at.is_none() {
                 match crate::spiced_metrics::MetricsScraper::scrape_once().await {
                     Ok(metrics) => {
-                        emit_replication_metrics(&metrics, "post-drain re-scrape", false);
+                        reporting::emit_replication_metrics(
+                            &metrics,
+                            "post-drain re-scrape",
+                            false,
+                        );
                     }
                     Err(e) => {
                         eprintln!(
@@ -355,7 +362,30 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         }
     }
 
+    // For Cayenne backend report additional metrics
+    match crate::spiced_metrics::MetricsScraper::scrape_once().await {
+        Ok(final_metrics) => reporting::emit_cayenne_compaction_metrics(&final_metrics),
+        Err(e) => eprintln!("Failed to scrape final Cayenne compaction metrics: {e}"),
+    }
+
     telemetry.emit().await?;
+
+    // Optional: hold spiced alive after the benchmark so you can run ad-hoc
+    // queries against it. Set SPICED_KEEP_ALIVE to block here until you press
+    // Enter; spiced is still serving on its usual HTTP (8090) / Flight ports.
+    if std::env::var_os("SPICED_KEEP_ALIVE").is_some() {
+        let workdir = spiced_instance
+            .get_tempdir_path()
+            .map_or_else(|_| "<unknown>".to_string(), |p| p.display().to_string());
+        println!(
+            "\nSPICED_KEEP_ALIVE set — spiced is still running for manual queries \
+             spiced working dir: {workdir}\n\
+             Press Enter to stop spiced and finish the run..."
+        );
+        let mut line = String::new();
+        std::io::stdin().read_line(&mut line)?;
+    }
+
     spiced_instance.stop()?;
 
     let health_report = health_report?;
@@ -376,145 +406,4 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-/// Emits replication metrics scraped from spiced's `/metrics` endpoint.
-///
-/// `phase` labels the scrape context (e.g. "under load", "post-drain re-scrape").
-/// `record_telemetry` controls whether the values are recorded to OpenTelemetry —
-/// only the primary under-load scrape should be recorded so diagnostic re-scrapes
-/// don't overwrite the headline lag metric.
-fn emit_replication_metrics(
-    metrics: &crate::spiced_metrics::SpicedMetrics,
-    phase: &str,
-    record_telemetry: bool,
-) {
-    use std::collections::{BTreeMap, BTreeSet};
-
-    // Collect replication metrics per dataset from scraped samples.
-    // Gauges (lag_ms, lag_bytes): use the last observed value — represents the
-    // pipeline state when the scraper stopped (while OLTP was still active).
-    // Counters (inserts, updates, deletes): use the last value (monotonic total).
-    let mut lag_ms: BTreeMap<String, f64> = BTreeMap::new();
-    let mut lag_bytes: BTreeMap<String, f64> = BTreeMap::new();
-    let mut inserts: BTreeMap<String, f64> = BTreeMap::new();
-    let mut updates: BTreeMap<String, f64> = BTreeMap::new();
-    let mut deletes: BTreeMap<String, f64> = BTreeMap::new();
-    let mut recv_errors: BTreeMap<String, f64> = BTreeMap::new();
-    let mut reconnects: BTreeMap<String, f64> = BTreeMap::new();
-
-    let gauge_metrics = [
-        (
-            "dataset_postgres_replication_lag_ms",
-            &mut lag_ms as &mut BTreeMap<String, f64>,
-        ),
-        ("dataset_postgres_replication_lag_bytes", &mut lag_bytes),
-    ];
-    let counter_metrics = [
-        (
-            "dataset_postgres_replication_inserts_total",
-            &mut inserts as &mut BTreeMap<String, f64>,
-        ),
-        ("dataset_postgres_replication_updates_total", &mut updates),
-        ("dataset_postgres_replication_deletes_total", &mut deletes),
-        (
-            "dataset_postgres_replication_recv_errors_total",
-            &mut recv_errors,
-        ),
-        (
-            "dataset_postgres_replication_reconnects_total",
-            &mut reconnects,
-        ),
-    ];
-
-    for (metric_name, map) in gauge_metrics {
-        if let Some(samples) = metrics.samples.get(metric_name) {
-            for sample in samples {
-                let dataset = sample
-                    .labels
-                    .get("name")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                // Gauge: last value wins (overwrites previous).
-                map.insert(dataset, sample.value);
-            }
-        }
-    }
-
-    for (metric_name, map) in counter_metrics {
-        if let Some(samples) = metrics.samples.get(metric_name) {
-            for sample in samples {
-                let dataset = sample
-                    .labels
-                    .get("name")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                // Counter: last observed value is the total.
-                map.insert(dataset, sample.value);
-            }
-        }
-    }
-
-    if lag_ms.is_empty()
-        && lag_bytes.is_empty()
-        && inserts.is_empty()
-        && updates.is_empty()
-        && deletes.is_empty()
-        && recv_errors.is_empty()
-        && reconnects.is_empty()
-    {
-        return;
-    }
-
-    println!("\nReplication Metrics ({phase})");
-    // Header
-    println!(
-        "  {:<14} {:>10} {:>12} {:>10} {:>10} {:>10} {:>10} {:>10}",
-        "dataset",
-        "lag_ms",
-        "lag_bytes",
-        "inserts",
-        "updates",
-        "deletes",
-        "recv_errs",
-        "reconnects"
-    );
-
-    let all_datasets: BTreeSet<&String> = lag_ms
-        .keys()
-        .chain(lag_bytes.keys())
-        .chain(inserts.keys())
-        .chain(updates.keys())
-        .chain(deletes.keys())
-        .chain(recv_errors.keys())
-        .chain(reconnects.keys())
-        .collect();
-
-    let mut worst_lag_ms: f64 = 0.0;
-    for dataset in &all_datasets {
-        let l_ms = lag_ms.get(*dataset).copied().unwrap_or(0.0);
-        let l_bytes = lag_bytes.get(*dataset).copied().unwrap_or(0.0);
-        let ins = inserts.get(*dataset).copied().unwrap_or(0.0);
-        let upd = updates.get(*dataset).copied().unwrap_or(0.0);
-        let del = deletes.get(*dataset).copied().unwrap_or(0.0);
-        let recv = recv_errors.get(*dataset).copied().unwrap_or(0.0);
-        let reconn = reconnects.get(*dataset).copied().unwrap_or(0.0);
-        println!(
-            "  {dataset:<14} {l_ms:>10.0} {l_bytes:>12.0} {ins:>10.0} {upd:>10.0} {del:>10.0} {recv:>10.0} {reconn:>10.0}",
-        );
-
-        if record_telemetry {
-            crate::metrics::REPLICATION_LAG_MS
-                .record(l_ms, &[KeyValue::new("dataset", (*dataset).clone())]);
-        }
-        if l_ms > worst_lag_ms {
-            worst_lag_ms = l_ms;
-        }
-    }
-    println!();
-
-    // Headline: worst replication lag across all datasets.
-    if record_telemetry {
-        crate::metrics::REPLICATION_LAG_MS.record(worst_lag_ms, &[]);
-    }
 }

--- a/tools/testoperator/src/commands/htap/reporting.rs
+++ b/tools/testoperator/src/commands/htap/reporting.rs
@@ -1,0 +1,415 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Reporting helpers for the HTAP command: parse the metrics scraped from
+//! spiced's `/metrics` endpoint and emit per-run summaries (printed tables +
+//! OpenTelemetry gauges). Replication metrics are accelerator-agnostic; the
+//! Cayenne sections are emitted only when the corresponding `cayenne_*` series
+//! are present, so a non-Cayenne accelerator (e.g. `DuckDB`) cleanly skips them.
+
+use test_framework::opentelemetry::KeyValue;
+
+/// Emits replication metrics scraped from spiced's `/metrics` endpoint.
+///
+/// `phase` labels the scrape context (e.g. "under load", "post-drain re-scrape").
+/// `record_telemetry` controls whether the values are recorded to OpenTelemetry —
+/// only the primary under-load scrape should be recorded so diagnostic re-scrapes
+/// don't overwrite the headline lag metric.
+pub(super) fn emit_replication_metrics(
+    metrics: &crate::spiced_metrics::SpicedMetrics,
+    phase: &str,
+    record_telemetry: bool,
+) {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    // Collect replication metrics per dataset from scraped samples.
+    // Gauges (lag_ms, lag_bytes): use the last observed value — represents the
+    // pipeline state when the scraper stopped (while OLTP was still active).
+    // Counters (inserts, updates, deletes): use the last value (monotonic total).
+    let mut lag_ms: BTreeMap<String, f64> = BTreeMap::new();
+    let mut lag_bytes: BTreeMap<String, f64> = BTreeMap::new();
+    let mut inserts: BTreeMap<String, f64> = BTreeMap::new();
+    let mut updates: BTreeMap<String, f64> = BTreeMap::new();
+    let mut deletes: BTreeMap<String, f64> = BTreeMap::new();
+    let mut recv_errors: BTreeMap<String, f64> = BTreeMap::new();
+    let mut reconnects: BTreeMap<String, f64> = BTreeMap::new();
+
+    let gauge_metrics = [
+        (
+            "dataset_postgres_replication_lag_ms",
+            &mut lag_ms as &mut BTreeMap<String, f64>,
+        ),
+        ("dataset_postgres_replication_lag_bytes", &mut lag_bytes),
+    ];
+    let counter_metrics = [
+        (
+            "dataset_postgres_replication_inserts_total",
+            &mut inserts as &mut BTreeMap<String, f64>,
+        ),
+        ("dataset_postgres_replication_updates_total", &mut updates),
+        ("dataset_postgres_replication_deletes_total", &mut deletes),
+        (
+            "dataset_postgres_replication_recv_errors_total",
+            &mut recv_errors,
+        ),
+        (
+            "dataset_postgres_replication_reconnects_total",
+            &mut reconnects,
+        ),
+    ];
+
+    for (metric_name, map) in gauge_metrics {
+        if let Some(samples) = metrics.samples.get(metric_name) {
+            for sample in samples {
+                let dataset = sample
+                    .labels
+                    .get("name")
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
+                // Gauge: last value wins (overwrites previous).
+                map.insert(dataset, sample.value);
+            }
+        }
+    }
+
+    for (metric_name, map) in counter_metrics {
+        if let Some(samples) = metrics.samples.get(metric_name) {
+            for sample in samples {
+                let dataset = sample
+                    .labels
+                    .get("name")
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
+                // Counter: last observed value is the total.
+                map.insert(dataset, sample.value);
+            }
+        }
+    }
+
+    if lag_ms.is_empty()
+        && lag_bytes.is_empty()
+        && inserts.is_empty()
+        && updates.is_empty()
+        && deletes.is_empty()
+        && recv_errors.is_empty()
+        && reconnects.is_empty()
+    {
+        return;
+    }
+
+    println!("\nReplication Metrics ({phase})");
+    // Header
+    println!(
+        "  {:<14} {:>10} {:>12} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "dataset",
+        "lag_ms",
+        "lag_bytes",
+        "inserts",
+        "updates",
+        "deletes",
+        "recv_errs",
+        "reconnects"
+    );
+
+    let all_datasets: BTreeSet<&String> = lag_ms
+        .keys()
+        .chain(lag_bytes.keys())
+        .chain(inserts.keys())
+        .chain(updates.keys())
+        .chain(deletes.keys())
+        .chain(recv_errors.keys())
+        .chain(reconnects.keys())
+        .collect();
+
+    let mut worst_lag_ms: f64 = 0.0;
+    for dataset in &all_datasets {
+        let l_ms = lag_ms.get(*dataset).copied().unwrap_or(0.0);
+        let l_bytes = lag_bytes.get(*dataset).copied().unwrap_or(0.0);
+        let ins = inserts.get(*dataset).copied().unwrap_or(0.0);
+        let upd = updates.get(*dataset).copied().unwrap_or(0.0);
+        let del = deletes.get(*dataset).copied().unwrap_or(0.0);
+        let recv = recv_errors.get(*dataset).copied().unwrap_or(0.0);
+        let reconn = reconnects.get(*dataset).copied().unwrap_or(0.0);
+        println!(
+            "  {dataset:<14} {l_ms:>10.0} {l_bytes:>12.0} {ins:>10.0} {upd:>10.0} {del:>10.0} {recv:>10.0} {reconn:>10.0}",
+        );
+
+        if record_telemetry {
+            crate::metrics::REPLICATION_LAG_MS
+                .record(l_ms, &[KeyValue::new("dataset", (*dataset).clone())]);
+        }
+        if l_ms > worst_lag_ms {
+            worst_lag_ms = l_ms;
+        }
+    }
+    println!();
+
+    // Headline: worst replication lag across all datasets.
+    if record_telemetry {
+        crate::metrics::REPLICATION_LAG_MS.record(worst_lag_ms, &[]);
+    }
+}
+
+/// Emits the p90 and p99 of Cayenne read amplification (`cayenne_ingest_read_amp`)
+/// per table, computed from the gauge time series the background scraper collected
+/// while the OLTP load was running.
+pub(super) fn emit_cayenne_read_amp_percentiles(metrics: &crate::spiced_metrics::SpicedMetrics) {
+    use std::collections::BTreeMap;
+
+    let Some(samples) = metrics.samples.get("cayenne_ingest_read_amp") else {
+        return;
+    };
+
+    let mut per_table: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    for sample in samples {
+        if sample.value.is_nan() {
+            continue;
+        }
+        let table = sample
+            .labels
+            .get("table")
+            .or_else(|| sample.labels.get("name"))
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        per_table.entry(table).or_default().push(sample.value);
+    }
+
+    if per_table.is_empty() {
+        return;
+    }
+
+    println!("\nCayenne Read Amplification (under load)");
+    println!("  {:<20} {:>8} {:>8} {:>8}", "table", "p90", "p99", "max");
+    for (table, mut values) in per_table {
+        values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let p90 = percentile(&values, 0.90);
+        let p99 = percentile(&values, 0.99);
+        let max = *values.last().unwrap_or(&0.0);
+        println!("  {table:<20} {p90:>8.0} {p99:>8.0} {max:>8.0}");
+
+        let attributes = [KeyValue::new("table", table)];
+        crate::metrics::CAYENNE_INGEST_READ_AMP_P90.record(p90, &attributes);
+        crate::metrics::CAYENNE_INGEST_READ_AMP_P99.record(p99, &attributes);
+    }
+    println!();
+}
+
+/// Emits Cayenne compaction metrics scraped from spiced's `/metrics` endpoint,
+/// reported per `table` and compaction `kind`
+pub(super) fn emit_cayenne_compaction_metrics(metrics: &crate::spiced_metrics::SpicedMetrics) {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    // Counter / histogram count+sum series are cumulative, so the latest value of
+    // each distinct label-set is its max. Collapse to (table, kind), summing the
+    // `result` dimension (e.g. completed + failed passes) — the native granularity
+    // cayenne exposes, with no cross-table aggregation.
+    let latest_per_table_kind = |name: &str| -> BTreeMap<(String, String), f64> {
+        // Full label set identifies a series; track its max (= latest cumulative).
+        let mut series_max: BTreeMap<String, (String, String, f64)> = BTreeMap::new();
+        if let Some(samples) = metrics.samples.get(name) {
+            for sample in samples {
+                let table = sample
+                    .labels
+                    .get("table")
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
+                let kind = sample
+                    .labels
+                    .get("kind")
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
+                let mut fingerprint: Vec<String> = sample
+                    .labels
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect();
+                fingerprint.sort();
+                let entry =
+                    series_max
+                        .entry(fingerprint.join(","))
+                        .or_insert((table, kind, f64::MIN));
+                if sample.value > entry.2 {
+                    entry.2 = sample.value;
+                }
+            }
+        }
+        let mut out: BTreeMap<(String, String), f64> = BTreeMap::new();
+        for (_series, (table, kind, value)) in series_max {
+            *out.entry((table, kind)).or_insert(0.0) += value;
+        }
+        out
+    };
+
+    let passes = latest_per_table_kind("cayenne_compaction_duration_ms_count");
+    let merged_bytes = latest_per_table_kind("cayenne_compaction_merged_bytes_sum");
+
+    // p90/p99 pass duration per (table, kind), via Prometheus-style
+    // histogram_quantile over the cumulative `_bucket` series (summing the
+    // `result` dimension). A single end scrape suffices — the histogram is
+    // cumulative for the run.
+    let duration_pcts = compaction_duration_percentiles_per_table_kind(metrics);
+
+    if passes.is_empty() && merged_bytes.is_empty() {
+        return;
+    }
+
+    let all_keys: BTreeSet<&(String, String)> = passes.keys().chain(merged_bytes.keys()).collect();
+
+    println!("\nCayenne Compaction Metrics");
+    println!(
+        "  {:<20} {:<8} {:>8} {:>12} {:>12} {:>16}",
+        "table", "kind", "passes", "dur_p90_ms", "dur_p99_ms", "merged_bytes"
+    );
+    for key in &all_keys {
+        let (table, kind) = (&key.0, &key.1);
+        let p = passes.get(*key).copied().unwrap_or(0.0);
+        let b = merged_bytes.get(*key).copied().unwrap_or(0.0);
+        let pcts = duration_pcts.get(*key).copied();
+        let (p90_display, p99_display) = pcts.unwrap_or((0.0, 0.0));
+        println!(
+            "  {table:<20} {kind:<8} {p:>8.0} {p90_display:>12.1} {p99_display:>12.1} {b:>16.0}"
+        );
+
+        let attributes = [
+            KeyValue::new("table", table.clone()),
+            KeyValue::new("kind", kind.clone()),
+        ];
+        crate::metrics::CAYENNE_COMPACTION_PASSES.record(to_u64(p), &attributes);
+        if let Some((p90, p99)) = pcts {
+            crate::metrics::CAYENNE_COMPACTION_DURATION_P90_MS.record(p90, &attributes);
+            crate::metrics::CAYENNE_COMPACTION_DURATION_P99_MS.record(p99, &attributes);
+        }
+        // merged_bytes is only populated for kinds that emit the merged-bytes
+        // histogram (currently `subset`); skip recording a misleading zero for
+        // series that never report it.
+        if merged_bytes.contains_key(*key) {
+            crate::metrics::CAYENNE_COMPACTION_MERGED_BYTES.record(to_u64(b), &attributes);
+        }
+    }
+    println!();
+}
+
+/// Computes the p90 and p99 Cayenne compaction-pass duration (ms) per
+/// `(table, kind)` from the cumulative `cayenne_compaction_duration_ms_bucket`
+fn compaction_duration_percentiles_per_table_kind(
+    metrics: &crate::spiced_metrics::SpicedMetrics,
+) -> std::collections::BTreeMap<(String, String), (f64, f64)> {
+    use std::collections::BTreeMap;
+
+    // (table, kind) -> (le -> cumulative count), summed across `result`.
+    let mut buckets: BTreeMap<(String, String), BTreeMap<u64, f64>> = BTreeMap::new();
+    if let Some(samples) = metrics.samples.get("cayenne_compaction_duration_ms_bucket") {
+        for sample in samples {
+            let Some(le_raw) = sample.labels.get("le") else {
+                continue;
+            };
+            let le = if le_raw.eq_ignore_ascii_case("+inf") || le_raw.eq_ignore_ascii_case("inf") {
+                f64::INFINITY
+            } else {
+                match le_raw.parse::<f64>() {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                }
+            };
+            let table = sample
+                .labels
+                .get("table")
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            let kind = sample
+                .labels
+                .get("kind")
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            // Bucket boundaries are stable integers in this histogram; key on the
+            // bit pattern so +Inf sorts last and identical boundaries coalesce.
+            let le_key = le.to_bits();
+            *buckets
+                .entry((table, kind))
+                .or_default()
+                .entry(le_key)
+                .or_insert(0.0) += sample.value;
+        }
+    }
+
+    let mut out: BTreeMap<(String, String), (f64, f64)> = BTreeMap::new();
+    for (key, le_counts) in buckets {
+        // Sort boundaries ascending (f64::INFINITY bits sort above finite values).
+        let mut bounds: Vec<(f64, f64)> = le_counts
+            .into_iter()
+            .map(|(bits, count)| (f64::from_bits(bits), count))
+            .collect();
+        bounds.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+        if bounds.last().is_none_or(|&(_, total)| total <= 0.0) {
+            continue;
+        }
+        out.insert(
+            key,
+            (
+                histogram_quantile(&bounds, 0.90),
+                histogram_quantile(&bounds, 0.99),
+            ),
+        );
+    }
+    out
+}
+
+/// Nearest-rank percentile `q` (0.0–1.0) of a sorted, non-empty slice.
+#[expect(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    let idx = (((sorted.len() as f64) * q).ceil() as usize)
+        .saturating_sub(1)
+        .min(sorted.len() - 1);
+    sorted[idx]
+}
+
+/// Clamps a non-negative float metric value to `u64` for gauge recording.
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn to_u64(value: f64) -> u64 {
+    if value <= 0.0 { 0 } else { value as u64 }
+}
+
+/// Standard Prometheus `histogram_quantile` over ascending `(le, cumulative)`
+/// bounds; `bounds.last()` is the +Inf bucket whose count is the total.
+fn histogram_quantile(bounds: &[(f64, f64)], q: f64) -> f64 {
+    let total = bounds.last().map_or(0.0, |&(_, c)| c);
+    if total <= 0.0 {
+        return 0.0;
+    }
+    let rank = q * total;
+    let mut lower_le = 0.0_f64;
+    let mut lower_cum = 0.0_f64;
+    for &(le, cum) in bounds {
+        if cum >= rank {
+            if le.is_infinite() {
+                // The quantile sits in the open-ended top bucket — report the
+                // highest finite boundary (Prometheus convention).
+                return lower_le;
+            } else if cum > lower_cum {
+                return lower_le + (le - lower_le) * (rank - lower_cum) / (cum - lower_cum);
+            }
+            return le;
+        }
+        lower_le = le;
+        lower_cum = cum;
+    }
+    bounds.last().map_or(0.0, |&(le, _)| le)
+}

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -561,3 +561,61 @@ pub static QPH: LazyLock<Gauge<f64>> = LazyLock::new(|| {
         .with_unit("queries/hour")
         .build()
 });
+
+pub static CAYENNE_INGEST_READ_AMP_P99: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("cayenne_ingest_read_amp_p99")
+        .with_description(
+            "p99 Cayenne read amplification (protected snapshots a scan must merge) per table over the under-load window — the query-impact signal of compaction keeping up.",
+        )
+        .with_unit("snapshots")
+        .build()
+});
+
+pub static CAYENNE_INGEST_READ_AMP_P90: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("cayenne_ingest_read_amp_p90")
+        .with_description(
+            "p90 Cayenne read amplification (protected snapshots a scan must merge) per table over the under-load window.",
+        )
+        .with_unit("snapshots")
+        .build()
+});
+
+pub static CAYENNE_COMPACTION_PASSES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    meter()
+        .u64_gauge("cayenne_compaction_passes")
+        .with_description("Cayenne compaction passes during the test, per table and kind.")
+        .with_unit("passes")
+        .build()
+});
+
+pub static CAYENNE_COMPACTION_MERGED_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    meter()
+        .u64_gauge("cayenne_compaction_merged_bytes")
+        .with_description(
+            "Total output bytes written by Cayenne compaction during the test, per table and kind.",
+        )
+        .with_unit("bytes")
+        .build()
+});
+
+pub static CAYENNE_COMPACTION_DURATION_P99_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("cayenne_compaction_duration_p99_ms")
+        .with_description(
+            "p99 wall-clock time of a Cayenne compaction pass, per table and kind — high p99 means each pass is slow, so compaction can't drain files faster than CDC creates them and read amplification climbs.",
+        )
+        .with_unit("ms")
+        .build()
+});
+
+pub static CAYENNE_COMPACTION_DURATION_P90_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("cayenne_compaction_duration_p90_ms")
+        .with_description(
+            "p90 wall-clock time of a Cayenne compaction pass, per table and kind — the typical pass cost (pair with p99 to spot tail stalls).",
+        )
+        .with_unit("ms")
+        .build()
+});


### PR DESCRIPTION
## 📝 Summary

Adds Cayenne compaction and read-amplification metrics in HTAP benchmark runs so runs:
 - cayenne_ingest_read_amp_p90 / cayenne_ingest_read_amp_p99
 - cayenne_compaction_passes
 - cayenne_compaction_duration_p90_ms / cayenne_compaction_duration_p99_ms
 - cayenne_compaction_merged_bytes

Also adds flag `SPICED_KEEP_ALIVE` that can be used to keep `spiced` running after benchmark for additional experimetns and troubleshooting.

### Cayenne telemetry (`crates/cayenne`, `crates/telemetry`)

Unifies the two compaction paths under a `kind` label and closes an instrumentation gap:
- Added `kind="full"` (full current-snapshot rewrite) / `kind="subset"` (protected-snapshot merge) to `cayenne_compaction_duration_ms`, `cayenne_compaction_merged_bytes`
- Added duration tracking to the subset path: previously it emitted only `merged_bytes`, never a pass duration/count. 

### testoperator HTAP reporting (`tools/testoperator`)
Translates the native `/metrics` series into per-run summary scalars. 

| Cayenne-native instrument | What it records & when | `/metrics` series | testoperator translation |
|---|---|---|---|
| `cayenne_ingest_read_amp` — gauge `{table}` | `protected_snapshots.len()` on each autotune tick | the gauge | p90/p99 over under-load window → `cayenne_ingest_read_amp_p90` / `cayenne_ingest_read_amp_p99` `{table}` |
| `cayenne_compaction_duration_ms` — histogram `{table,kind,result}` | one obs per pass (full + subset) | `_count`, `_sum`, `_bucket` | `_count` → `cayenne_compaction_passes{table,kind}`; `_bucket`→p90/p99 → `cayenne_compaction_duration_p90_ms` / `cayenne_compaction_duration_p99_ms` `{table,kind}` |
| `cayenne_compaction_merged_bytes` — histogram `{table,kind}` | one obs per committed merge = output bytes (subset only) | `_count`, `_sum`, `_bucket` | `_sum` → `cayenne_compaction_merged_bytes{table,kind}` |

## Why
`read_amp p90/p99` is the query-impact symptom; `compaction_passes` (how often) + `compaction_duration_p90/p99_ms` (typical vs. tail pass slowness) separate the two root causes of read-amp climbing under CDC load



```

Cayenne Read Amplification (under load)
  table                     p90      p99      max
  customer                    2        2        2
  district                    0        0        0
  item                        0        0        0
  nation                      0        0        0
  new_order                   2        2        2
  oorder                      2        2        2
  order_line                  7        8        8
  region                      0        0        0
  stock                       8        9        9
  supplier                    0        0        0
  warehouse                   0        0        0


Cayenne Compaction Metrics
  table                kind       passes   dur_p90_ms   dur_p99_ms     merged_bytes
  customer             subset          1       2350.0       2485.0       1426434688
  oorder               subset          1        975.0        997.5         20082216
  order_line           subset        142        234.6       3225.0       2664774920
  stock                subset        108        233.3       1960.0       3298526504
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
