### PR TITLE
fix(ci): key testoperator & validator artifacts by checked-out commit

### DIFF
--- a/.github/actions/build-spicepod-validator/action.yml
+++ b/.github/actions/build-spicepod-validator/action.yml
@@ -69,8 +69,13 @@ runs:
         # github.sha. The scheduled dispatch builds a branch matrix (trunk +
         # release/x.y) where every leg shares one github.sha (the trigger SHA),
         # so keying by github.sha makes the release/x.y leg publish its binary
-        # under trunk's SHA
-        sha="$(git rev-parse HEAD 2>/dev/null || echo "${{ github.sha }}")"
+        # under trunk's SHA and overwrite the trunk build (last-writer-wins).
+        # Fail fast rather than falling back to github.sha: the fallback would
+        # silently reintroduce the cross-branch collision this fix prevents.
+        sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD 2>/dev/null)" || {
+          echo "Failed to determine checked-out commit SHA. Ensure actions/checkout has run before build-spicepod-validator." >&2
+          exit 1
+        }
         echo "sha=$sha" >> $GITHUB_OUTPUT
 
     - name: Download spicepod-validator from MinIO

--- a/.github/actions/build-spicepod-validator/action.yml
+++ b/.github/actions/build-spicepod-validator/action.yml
@@ -65,7 +65,13 @@ runs:
       id: commit-sha
       shell: bash
       run: |
-        echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+        # Key the cache/MinIO artifact by the actually checked-out commit, not
+        # github.sha. The scheduled dispatch builds a branch matrix (trunk +
+        # release/x.y) where every leg shares one github.sha (the trigger SHA),
+        # so keying by github.sha makes the release/x.y leg publish its binary
+        # under trunk's SHA
+        sha="$(git rev-parse HEAD 2>/dev/null || echo "${{ github.sha }}")"
+        echo "sha=$sha" >> $GITHUB_OUTPUT
 
     - name: Download spicepod-validator from MinIO
       if: inputs.download_from_minio == 'true' && inputs.force_rebuild != 'true'

--- a/.github/actions/build-testoperator/action.yml
+++ b/.github/actions/build-testoperator/action.yml
@@ -69,7 +69,18 @@ runs:
       id: commit-sha
       shell: bash
       run: |
-        echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+        # Key the cache/MinIO artifact by the actually checked-out commit, not
+        # github.sha. The scheduled dispatch builds a branch matrix (trunk +
+        # release/x.y) where every leg shares one github.sha (the trigger SHA),
+        # so keying by github.sha makes the release/x.y leg publish its binary
+        # under trunk's SHA and overwrite the trunk build (last-writer-wins).
+        # Fail fast rather than falling back to github.sha: the fallback would
+        # silently reintroduce the cross-branch collision this fix prevents.
+        sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD 2>/dev/null)" || {
+          echo "Failed to determine checked-out commit SHA. Ensure actions/checkout has run before build-testoperator." >&2
+          exit 1
+        }
+        echo "sha=$sha" >> $GITHUB_OUTPUT
 
     - name: Download testoperator from MinIO
       if: inputs.download_from_minio == 'true' && inputs.force_rebuild != 'true'


### PR DESCRIPTION
## 📝 Summary

The scheduled `testoperator dispatch` runs a branch matrix (`trunk` + `release/2.0`) in parallel. Each leg checks out its own branch, but `build-testoperator` and `build-spicepod-validator` key their MinIO/GitHub cache artifacts by `github.sha` — which is the trigger SHA (trunk HEAD), identical across both legs.

So the `release/2.0` leg builds `testoperator`/`spicepod-validator` from **v2.0.0** source and publishes them under **trunk's SHA**. Both legs race to write the same path (last-writer-wins); when release/2.0 wins, trunk's SHA ends up serving a v2.0.0 binary.

## Fix

Key both build actions by the actually checked-out commit (`git rev-parse HEAD`) instead of `github.sha`, so each branch writes its own collision-free path. 


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
