### PR TITLE
feat(connectors): support `format: vortex` everywhere `format: parquet` is supported

### DIFF
--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -157,6 +157,13 @@ impl Https {
             return true;
         }
 
+        // Vortex is a structured columnar format handled by the listing connector.
+        // It is only built on non-Windows targets (see `get_file_format_and_extension`).
+        #[cfg(not(windows))]
+        if file_format == "vortex" {
+            return true;
+        }
+
         // JSON format is structured only for static file endpoints.
         // Dynamic API endpoints (with allowed_request_paths, request_query_filters, etc.)
         // should use HttpTableProvider instead.
@@ -179,6 +186,12 @@ impl Https {
                 extension.as_deref(),
                 Some("parquet" | "csv" | "tsv" | "arrow" | "avro" | "jsonl" | "ndjson" | "ldjson")
             ) {
+                return true;
+            }
+
+            // Vortex is only built on non-Windows targets.
+            #[cfg(not(windows))]
+            if extension.as_deref() == Some("vortex") {
                 return true;
             }
 
@@ -2352,6 +2365,26 @@ uGgYIHbi/F+GaiUPzDyqe5p9
     async fn test_http_auto_structured_format_detects_compressed_file_extension_param() {
         let connector = test_connector_with(&[("file_extension", ".csv.zst")]).await;
         let dataset = test_dataset("https://example.com/download", RefreshMode::Full, None).await;
+
+        assert!(connector.is_structured_format(&dataset));
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_http_structured_format_detects_explicit_vortex() {
+        let connector = test_connector(Some("vortex")).await;
+        let dataset =
+            test_dataset("https://example.com/data.vortex", RefreshMode::Full, None).await;
+
+        assert!(connector.is_structured_format(&dataset));
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_http_auto_structured_format_detects_vortex_extension() {
+        let connector = test_connector(None).await;
+        let dataset =
+            test_dataset("https://example.com/data.vortex", RefreshMode::Full, None).await;
 
         assert!(connector.is_structured_format(&dataset));
     }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -573,6 +573,7 @@ pub trait ListingTableConnector: DataConnector {
     /// to infer the format from the dataset's file extension. It supports both tabular and
     /// unstructured formats. It supports the following tabular formats:
     ///  - parquet
+    ///  - vortex (not available on Windows)
     ///  - csv
     ///
     /// For tabular formats, file options can also be specified in the [`Dataset`]'s `param`s.
@@ -784,6 +785,16 @@ pub trait ListingTableConnector: DataConnector {
                             configured_extension.as_ref(),
                             path_extension.as_ref(),
                             ".parquet",
+                            FileCompressionType::UNCOMPRESSED,
+                        ),
+                    )),
+                    #[cfg(not(windows))]
+                    Some("vortex") => Ok((
+                        Some(VortexFormatFactory::new().default()),
+                        listing_extension(
+                            configured_extension.as_ref(),
+                            path_extension.as_ref(),
+                            ".vortex",
                             FileCompressionType::UNCOMPRESSED,
                         ),
                     )),
@@ -1918,6 +1929,37 @@ mod tests {
             connector.get_file_format_and_extension(&dataset).await
         {
             assert_eq!(extension, ".parquet");
+        } else {
+            panic!("Unexpected error");
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_get_file_format_and_extension_detect_vortex_extension() {
+        let (connector, dataset) =
+            setup_connector("test:test.vortex".to_string(), HashMap::new()).await;
+
+        if let Ok((Some(_file_format), extension)) =
+            connector.get_file_format_and_extension(&dataset).await
+        {
+            assert_eq!(extension, ".vortex");
+        } else {
+            panic!("Unexpected error");
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_get_file_format_and_extension_auto_detects_vortex() {
+        let mut params = HashMap::new();
+        params.insert("file_format".to_string(), "auto".to_string());
+        let (connector, dataset) = setup_connector("test:test.vortex".to_string(), params).await;
+
+        if let Ok((Some(_file_format), extension)) =
+            connector.get_file_format_and_extension(&dataset).await
+        {
+            assert_eq!(extension, ".vortex");
         } else {
             panic!("Unexpected error");
         }


### PR DESCRIPTION
## What

Adds `format: vortex` support to the file/object data connectors **everywhere `format: parquet` is supported**. S3, file, GCS, ABFS, and HTTPS all implement `ListingTableConnector` and share `get_file_format_and_extension`, so the fixes below cover all of them at once.

Trunk already supports the explicit `file_format: vortex` case and the bare `.vortex`-extension case. This PR closes the remaining gaps where parquet worked but vortex silently fell back to the JSON/text reader.

## Changes

- **`listing/connector.rs`** — handle `file_format: auto` + a `.vortex` file. Parquet had an `auto` sub-case; vortex didn't, so an `auto`-configured vortex dataset fell through to the JSON reader. Added a `Some("vortex")` arm mirroring parquet.
- **`https.rs`** — include vortex in `is_structured_format` (both the explicit-format allowlist and the auto extension-detection allowlist). Without this, `file_format: vortex` (or a `.vortex` URL) over HTTPS routed to the JSON/text `HttpTableProvider` instead of the listing path.
- Doc-comment update + **4 new unit tests** (extension inference, `auto` inference, HTTPS explicit + auto routing).

All new code is gated `#[cfg(not(windows))]`, matching the existing vortex wiring (vortex isn't built on Windows).

## Testing

- `cargo test -p runtime --lib` (connector + https suites): **94 passed, 0 failed**, including the 4 new vortex tests.
- `cargo clippy -p runtime --lib --tests`: clean on the changed files.

## Out of scope

`COPY TO '…' (FORMAT vortex)` / `CREATE EXTERNAL TABLE … STORED AS vortex` is **not** included — the runtime session registers DataFusion's default format factories via `.with_default_features()` but never registers `VortexFormatFactory` globally. That's a separate SQL write/DDL surface, distinct from the connector `format:` param this PR targets.
