### PR TITLE
ci(chbench): run scheduled CH-benCHmark every 3 hours (8x/day)

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -4,14 +4,14 @@ on:
   schedule:
     # daily-main, 0900 UTC / 0200 PDT  — full bench suite + HTAP CH-benCHmark SF1
     - cron: '0 9 * * *'
-    # htap-sf1, every 4h — extra HTAP CH-benCHmark SF1 runs so SF1 fires every 4
-    # hours (0100, 0500, 0900 via daily-main, 1300, 1700, 2100) without
-    # re-running the full daily-main suite six times a day.
-    - cron: '0 1,5,13,17,21 * * *'
-    # htap-sf10, every 4h (0000, 0400, 0800, 1200, 1600, 2000) — HTAP CH-benCHmark SF10
-    - cron: '0 0,4,8,12,16,20 * * *'
-    # htap-sf100, every 4h (0200, 0600, 1000, 1400, 1800, 2200) — HTAP CH-benCHmark SF100
-    - cron: '0 2,6,10,14,18,22 * * *'
+    # htap-sf1, every 3h — extra HTAP CH-benCHmark SF1 runs so SF1 fires every 3
+    # hours (0000, 0300, 0600, 0900 via daily-main, 1200, 1500, 1800, 2100) without
+    # re-running the full daily-main suite eight times a day.
+    - cron: '0 0,3,6,12,15,18,21 * * *'
+    # htap-sf10, every 3h (0100, 0400, 0700, 1000, 1300, 1600, 1900, 2200) — HTAP CH-benCHmark SF10
+    - cron: '0 1,4,7,10,13,16,19,22 * * *'
+    # htap-sf100, every 3h (0200, 0500, 0800, 1100, 1400, 1700, 2000, 2300) — HTAP CH-benCHmark SF100
+    - cron: '0 2,5,8,11,14,17,20,23 * * *'
 
   workflow_dispatch:
     inputs:
@@ -107,9 +107,9 @@ jobs:
         run: |
           case "${{ github.event.schedule }}" in
             '0 9 * * *')               NAME=daily-main ;;
-            '0 1,5,13,17,21 * * *')    NAME=htap-sf1   ;;
-            '0 0,4,8,12,16,20 * * *')  NAME=htap-sf10  ;;
-            '0 2,6,10,14,18,22 * * *') NAME=htap-sf100 ;;
+            '0 0,3,6,12,15,18,21 * * *')   NAME=htap-sf1   ;;
+            '0 1,4,7,10,13,16,19,22 * * *') NAME=htap-sf10  ;;
+            '0 2,5,8,11,14,17,20,23 * * *') NAME=htap-sf100 ;;
             *)                         NAME=           ;;   # manual / unrecognized cron — match nothing
           esac
           echo "Resolved schedule name: $NAME"
@@ -240,9 +240,9 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
-      # HTAP CH-benCHmark — every SF runs 6x/day (every 4 hours). SF1 rides
-      # with daily-main at 0900 plus the htap-sf1 extras at 0100/0500/1300/1700/2100;
-      # SF10 / SF100 each fire on their own every-4h cron.
+      # HTAP CH-benCHmark — every SF runs 8x/day (every 3 hours). SF1 rides
+      # with daily-main at 0900 plus the htap-sf1 extras at 0000/0300/0600/1200/1500/1800/2100;
+      # SF10 / SF100 each fire on their own every-3h cron.
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF1
         if: ${{ matrix.branch == 'trunk' && (steps.sched.outputs.name == 'daily-main' || steps.sched.outputs.name == 'htap-sf1') }}
         run: |


### PR DESCRIPTION
## Summary

Bumps the scheduled HTAP CH-benCHmark dispatch cadence in `testoperator_dispatch.yml` from **every 4 hours (6×/day)** to **every 3 hours (8×/day)** for all three scale factors (SF1, SF10, SF100).

## Details

The three scale factors stay staggered an hour apart so no two ever fire in the same hour:

| Scale factor | Hours (UTC) | Runs/day |
|---|---|---|
| SF1 | 00, 03, 06, **09** (via daily-main), 12, 15, 18, 21 | 8 |
| SF10 | 01, 04, 07, 10, 13, 16, 19, 22 | 8 |
| SF100 | 02, 05, 08, 11, 14, 17, 20, 23 | 8 |

- **SF1 moves to offset 0** (`0,3,6,12,15,18,21`) so its `daily-main` 0900 run lands exactly on the 3-hour grid — otherwise 0900 would become an off-grid extra.
- **SF10 takes offset 1**, **SF100 keeps offset 2**.
- The exact-match cron strings in the **"Resolve schedule name"** `case` block are updated in lockstep — these must match the `schedule:` crons byte-for-byte or the dispatch silently stops firing.
- All explanatory comments updated (4h→3h, 6x→8x).

## Verification

- Computed each SF's combined schedule: uniform 3-hour gaps, 8 runs/day, **zero cross-SF hour collisions**.
- Confirmed the `schedule:` crons match the `case` patterns exactly.
- YAML parses cleanly.

> Note: this increases dispatched HTAP benchmark load ~33% (6→8 runs/day per scale factor).