### PR TITLE
fix(kafka): harden fetch_latest_message for multi-partition topics

### DIFF
--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -54,6 +54,11 @@ pub use rdkafka;
 // the local buffer, eliminating per-tombstone seek overhead.
 const TOMBSTONE_SCAN_WINDOW: i64 = 100;
 
+// Brief pause before retrying a transient poll error during schema peek
+// (`fetch_latest_message`). Long enough to avoid tight spin on a reconnecting
+// broker; short enough to stay within the peek timeout budget.
+const PEEK_TRANSIENT_POLL_BACKOFF: Duration = Duration::from_millis(100);
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Unable to create Kafka consumer: {source}"))]
@@ -117,6 +122,22 @@ pub fn is_unknown_topic_or_partition(e: &Error) -> bool {
         Error::UnableToReceiveMessage {
             source: RdKafkaError::MessageConsumption(RDKafkaErrorCode::UnknownTopicOrPartition)
         }
+    )
+}
+
+/// Returns `true` for Kafka consumption errors that are typically transient during
+/// assign/seek polling (e.g. broker reconnect or partition leader election).
+#[must_use]
+fn is_transient_kafka_consumption_error(error: &rdkafka::error::KafkaError) -> bool {
+    use rdkafka::error::KafkaError as RdKafkaError;
+    use rdkafka::types::RDKafkaErrorCode;
+    matches!(
+        error,
+        RdKafkaError::MessageConsumption(
+            RDKafkaErrorCode::BrokerTransportFailure
+                | RDKafkaErrorCode::AllBrokersDown
+                | RDKafkaErrorCode::OperationTimedOut
+        )
     )
 }
 
@@ -801,6 +822,11 @@ impl KafkaConsumer {
                         }
                     }
                 }
+                Ok(Some(Err(e)))
+                    if is_transient_kafka_consumption_error(&e) && Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(PEEK_TRANSIENT_POLL_BACKOFF).await;
+                }
                 Ok(Some(Err(e))) => {
                     return Err(Error::UnableToReceiveMessage { source: e });
                 }
@@ -951,6 +977,13 @@ impl KafkaConsumer {
             .await?
             {
                 best_message = merge_latest_by_timestamp(best_message, candidate);
+            }
+
+            // Reset manual assignment before scanning the next partition.
+            if let Err(e) = temp_consumer.consumer.unassign() {
+                tracing::debug!(
+                    "Failed to unassign Kafka consumer after peeking partition {partition_id}: {e}"
+                );
             }
         }
 

--- a/crates/runtime/tests/kafka/bootstrap.rs
+++ b/crates/runtime/tests/kafka/bootstrap.rs
@@ -390,7 +390,10 @@ async fn wait_for_topic_partitions(
     const METADATA_TIMEOUT: Duration = Duration::from_secs(5);
 
     for attempt in 1..=MAX_RETRIES {
-        match producer.client().fetch_metadata(Some(topic), METADATA_TIMEOUT) {
+        match producer
+            .client()
+            .fetch_metadata(Some(topic), METADATA_TIMEOUT)
+        {
             Ok(metadata) => {
                 let partition_count = metadata
                     .topics()

--- a/crates/runtime/tests/kafka/bootstrap.rs
+++ b/crates/runtime/tests/kafka/bootstrap.rs
@@ -390,15 +390,7 @@ async fn wait_for_topic_partitions(
     const METADATA_TIMEOUT: Duration = Duration::from_secs(5);
 
     for attempt in 1..=MAX_RETRIES {
-        let client = producer.client();
-        let topic_name = topic.to_string();
-        let metadata_result = tokio::task::spawn_blocking(move || {
-            client.fetch_metadata(Some(topic_name.as_str()), METADATA_TIMEOUT)
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("Kafka metadata fetch task failed: {e}"))?;
-
-        match metadata_result {
+        match producer.client().fetch_metadata(Some(topic), METADATA_TIMEOUT) {
             Ok(metadata) => {
                 let partition_count = metadata
                     .topics()

--- a/crates/runtime/tests/kafka/bootstrap.rs
+++ b/crates/runtime/tests/kafka/bootstrap.rs
@@ -368,7 +368,68 @@ pub async fn create_kafka_topic_with_partitions(
         ))
         .await?;
     tracing::debug!("Created topic '{topic}' with {partitions} partitions: {output}");
+
+    let producer = create_kafka_producer(
+        &format!("localhost:{port}"),
+        Some(KAFKA_SASL_USERNAME),
+        Some(KAFKA_SASL_PASSWORD),
+    )?;
+    wait_for_topic_partitions(&producer, topic, partitions).await?;
+
     Ok(())
+}
+
+/// Wait until topic metadata reports the expected partition count.
+async fn wait_for_topic_partitions(
+    producer: &FutureProducer,
+    topic: &str,
+    expected_partitions: i32,
+) -> Result<(), anyhow::Error> {
+    const MAX_RETRIES: u32 = 10;
+    const RETRY_DELAY: Duration = Duration::from_millis(250);
+    const METADATA_TIMEOUT: Duration = Duration::from_secs(5);
+
+    for attempt in 1..=MAX_RETRIES {
+        let client = producer.client();
+        let topic_name = topic.to_string();
+        let metadata_result = tokio::task::spawn_blocking(move || {
+            client.fetch_metadata(Some(topic_name.as_str()), METADATA_TIMEOUT)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Kafka metadata fetch task failed: {e}"))?;
+
+        match metadata_result {
+            Ok(metadata) => {
+                let partition_count = metadata
+                    .topics()
+                    .iter()
+                    .find(|t| t.name() == topic)
+                    .map_or(0, |t| t.partitions().len());
+
+                if i32::try_from(partition_count).unwrap_or(0) == expected_partitions {
+                    tracing::debug!("Topic '{topic}' ready with {expected_partitions} partitions");
+                    return Ok(());
+                }
+
+                tracing::debug!(
+                    "Topic '{topic}' has {partition_count} partitions, expected {expected_partitions} (attempt {attempt}/{MAX_RETRIES})"
+                );
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "Failed to fetch metadata for topic '{topic}' (attempt {attempt}/{MAX_RETRIES}): {e}"
+                );
+            }
+        }
+
+        if attempt < MAX_RETRIES {
+            tokio::time::sleep(RETRY_DELAY).await;
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "Topic '{topic}' did not become ready with {expected_partitions} partitions after {MAX_RETRIES} attempts"
+    ))
 }
 
 pub fn make_kafka_dataset(


### PR DESCRIPTION
## Summary
- Fix flaky `kafka_fetch_latest_message_multi_partition_test` CI failures caused by transient `BrokerTransportFailure` when `fetch_latest_message` scans across multiple partitions
- Retry transient Kafka consumption errors during assign/seek polling and `unassign()` the peek consumer between partitions
- Wait for multi-partition topic metadata in the Kafka integration test bootstrap before producing/consuming

## Test plan
- [x] `cargo test -p runtime --features kafka --test integration kafka::kafka_fetch_latest_message`
- [x] `cargo test -p runtime --features kafka --test integration kafka::kafka_fetch_latest_message_multi_partition_test`