### PR TITLE
feat(flightsql): fall back to original connection when endpoint location is unreachable

### DIFF
--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -917,9 +917,18 @@ pub async fn get_client_for_flight_endpoint(
     if ep.location.is_empty() {
         Ok(client.clone())
     } else {
-        let channel = new_tls_flight_channel(&ep.location[0].uri, None).await?;
-        let channel = CookieService::new(channel, Arc::clone(cookie_store));
-        Ok(FlightSqlServiceClient::new(channel))
+        // Some Flight SQL servers (e.g. StarRocks) advertise an internal/cluster-only address
+        // in the endpoint location that's unreachable from external clients. Per the Flight SQL
+        // spec, data served at the same address as the FlightInfo may carry an empty location;
+        // StarRocks instead returns its internal FE address. If we can't reach the advertised
+        // location, fall back to the original connection that served the FlightInfo.
+        match new_tls_flight_channel(&ep.location[0].uri, None).await {
+            Ok(channel) => {
+                let channel = CookieService::new(channel, Arc::clone(cookie_store));
+                Ok(FlightSqlServiceClient::new(channel))
+            }
+            Err(_) => Ok(client.clone()),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`get_client_for_flight_endpoint` reuses the original connection only when `FlightEndpoint.location` is empty; otherwise it reconnects to the advertised location. Some servers advertise an internal/cluster-only address there (instead of leaving it empty, which the spec allows when the data is served at the same address as the FlightInfo). For external clients that address is unreachable, so `do_get` fails with a transport error even though the original connection could serve the data. StarRocks, for example, advertises its internal FE pod address.

## Changes

If connecting to the advertised location fails, fall back to the connection that served the `FlightInfo`. Multi-endpoint behavior is preserved when the advertised location is reachable.

## Testing

Verified against a StarRocks 4.0.10 Arrow Flight SQL endpoint: federated and accelerated reads over Flight SQL now succeed where they previously failed with a transport error.

## Notes for Reviewer

The fallback engages only after the connection attempt to the advertised location fails, which can take up to the connect timeout. A reasonable follow-up is to set a short connect timeout on this path so the fallback engages quickly; this PR keeps the existing timeout behavior.

### References

| Type | Link |
|---|---|
| Context | Surfaced while integrating Spice with StarRocks' experimental Arrow Flight SQL |
