### PR TITLE
fix(ci): key testoperator & validator artifacts by checked-out commit (#11281) [release/2.0]

### DIFF
--- a/.github/actions/build-spicepod-validator/action.yml
+++ b/.github/actions/build-spicepod-validator/action.yml
@@ -65,7 +65,18 @@ runs:
       id: commit-sha
       shell: bash
       run: |
-        echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+        # Key the cache/MinIO artifact by the actually checked-out commit, not
+        # github.sha. The scheduled dispatch builds a branch matrix (trunk +
+        # release/x.y) where every leg shares one github.sha (the trigger SHA),
+        # so keying by github.sha makes the release/x.y leg publish its binary
+        # under trunk's SHA and overwrite the trunk build (last-writer-wins).
+        # Fail fast rather than falling back to github.sha: the fallback would
+        # silently reintroduce the cross-branch collision this fix prevents.
+        sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD 2>/dev/null)" || {
+          echo "Failed to determine checked-out commit SHA. Ensure actions/checkout has run before build-spicepod-validator." >&2
+          exit 1
+        }
+        echo "sha=$sha" >> $GITHUB_OUTPUT
 
     - name: Download spicepod-validator from MinIO
       if: inputs.download_from_minio == 'true' && inputs.force_rebuild != 'true'

--- a/.github/actions/build-testoperator/action.yml
+++ b/.github/actions/build-testoperator/action.yml
@@ -69,7 +69,18 @@ runs:
       id: commit-sha
       shell: bash
       run: |
-        echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+        # Key the cache/MinIO artifact by the actually checked-out commit, not
+        # github.sha. The scheduled dispatch builds a branch matrix (trunk +
+        # release/x.y) where every leg shares one github.sha (the trigger SHA),
+        # so keying by github.sha makes the release/x.y leg publish its binary
+        # under trunk's SHA and overwrite the trunk build (last-writer-wins).
+        # Fail fast rather than falling back to github.sha: the fallback would
+        # silently reintroduce the cross-branch collision this fix prevents.
+        sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD 2>/dev/null)" || {
+          echo "Failed to determine checked-out commit SHA. Ensure actions/checkout has run before build-testoperator." >&2
+          exit 1
+        }
+        echo "sha=$sha" >> $GITHUB_OUTPUT
 
     - name: Download testoperator from MinIO
       if: inputs.download_from_minio == 'true' && inputs.force_rebuild != 'true'


### PR DESCRIPTION
## 📝 Summary

Cherry-pick of #11281 into `release/2.0`.

The scheduled `testoperator dispatch` runs a branch matrix (`trunk` + `release/2.0`) in parallel. Each leg checks out its own branch via `ref: ${{ matrix.branch }}` and then invokes the **local** composite actions `./.github/actions/build-testoperator` and `./.github/actions/build-spicepod-validator` — which are read from the checked-out branch's tree.

This means the `release/2.0` leg runs **release/2.0's** copy of those actions. Since they keyed their MinIO/GitHub cache artifacts by `github.sha` (the trigger SHA = trunk HEAD, identical across both legs), the `release/2.0` leg published its v2.0.0 binary under trunk's SHA. Both legs raced to write the same path (last-writer-wins); when `release/2.0` won, trunk's SHA served a v2.0.0 binary.

Fixing this only on `trunk` (#11281) is insufficient — the `release/2.0` leg keeps running release/2.0's buggy action until the fix lands here too.

## Fix

Key both build actions by the actually checked-out commit (`git rev-parse HEAD`) instead of `github.sha`, so each branch writes its own collision-free path.

## 🔗 Related

Cherry-pick of #11281 (trunk).