### PR TITLE
fix: restore federation deny-list enforcement regressed by the DataFusion 53 upgrade

### DIFF
--- a/crates/data_components/src/function_support.rs
+++ b/crates/data_components/src/function_support.rs
@@ -94,26 +94,31 @@ fn supports_name(restriction: Option<&FunctionRestriction>, name: &str) -> bool 
     }
 }
 
+/// Returns `true` if any expression anywhere in `plan` — including child plan
+/// nodes and subquery plans (`IN`/`EXISTS`/scalar subqueries) — references a
+/// function the `function_support` restriction rejects.
+///
+/// The walk must cover the whole plan tree, not just `plan.expressions()` on
+/// the root node: callers pass the root of an entire federated subtree (e.g.
+/// `Projection → Filter → TableScan`), so a denied function in a `WHERE`
+/// predicate or subquery would otherwise escape the check and be unparsed into
+/// the remote engine's SQL.
 pub fn contains_unsupported_functions(
     plan: &LogicalPlan,
     function_support: &FunctionSupport,
 ) -> Result<bool> {
     let mut unsupported = false;
-    for expr in plan.expressions() {
-        expr.apply(|expr| {
-            if !function_support.supports(expr) {
+    plan.apply_with_subqueries(|plan| {
+        for expr in plan.expressions() {
+            if !function_support.supports(&expr) {
                 unsupported = true;
                 return Ok(TreeNodeRecursion::Stop);
             }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
-
-        if unsupported {
-            return Ok(true);
         }
-    }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
 
-    Ok(false)
+    Ok(unsupported)
 }
 
 pub fn unfederate_plan_with_unsupported_functions(
@@ -128,4 +133,122 @@ pub fn unfederate_plan_with_unsupported_functions(
     }
 
     Ok(plan)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::logical_expr::{
+        ColumnarValue, LogicalPlanBuilder, ScalarUDF, TableSource, Volatility,
+        builder::LogicalTableSource, create_udf, expr::ScalarFunction, expr_fn::in_subquery,
+    };
+    use datafusion::prelude::{col, lit};
+
+    use super::*;
+
+    fn stub_udf(name: &str) -> Arc<ScalarUDF> {
+        Arc::new(create_udf(
+            name,
+            vec![DataType::Utf8],
+            DataType::Utf8,
+            Volatility::Immutable,
+            Arc::new(|args: &[ColumnarValue]| Ok(args[0].clone())),
+        ))
+    }
+
+    fn udf_expr(name: &str) -> Expr {
+        Expr::ScalarFunction(ScalarFunction::new_udf(stub_udf(name), vec![col("val")]))
+    }
+
+    fn scan(table: &str) -> LogicalPlanBuilder {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("val", DataType::Utf8, true),
+        ]));
+        let source = Arc::new(LogicalTableSource::new(schema)) as Arc<dyn TableSource>;
+        LogicalPlanBuilder::scan(table, source, None).expect("scan")
+    }
+
+    fn deny(names: &[&str]) -> FunctionSupport {
+        FunctionSupport::new(
+            Some(FunctionRestriction::Deny(
+                names.iter().map(|s| (*s).to_string()).collect(),
+            )),
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn detects_denied_function_in_root_node() {
+        let plan = scan("t")
+            .project(vec![udf_expr("json_get_str")])
+            .expect("project")
+            .build()
+            .expect("build");
+
+        assert!(
+            contains_unsupported_functions(&plan, &deny(&["json_get_str"])).expect("walk plan"),
+            "denied function in the root projection must be detected"
+        );
+    }
+
+    #[test]
+    fn detects_denied_function_below_root_node() {
+        // The denied function sits in a `Filter` BELOW the root `Projection`,
+        // whose own expressions are clean. A root-only check misses it and the
+        // predicate would be unparsed into the remote engine's SQL.
+        let plan = scan("t")
+            .filter(udf_expr("json_get_str").eq(lit("x")))
+            .expect("filter")
+            .project(vec![col("id")])
+            .expect("project")
+            .build()
+            .expect("build");
+
+        assert!(
+            contains_unsupported_functions(&plan, &deny(&["json_get_str"])).expect("walk plan"),
+            "denied function in a filter below the root must be detected"
+        );
+    }
+
+    #[test]
+    fn detects_denied_function_inside_subquery() {
+        // The denied function lives only inside the `IN (<subquery>)` plan.
+        // `Expr::apply` does not descend into subquery plans, so the walk must
+        // use `apply_with_subqueries` to see it.
+        let subquery = scan("u")
+            .project(vec![udf_expr("json_get_str")])
+            .expect("project")
+            .build()
+            .expect("build");
+        let plan = scan("t")
+            .filter(in_subquery(col("val"), Arc::new(subquery)))
+            .expect("filter")
+            .build()
+            .expect("build");
+
+        assert!(
+            contains_unsupported_functions(&plan, &deny(&["json_get_str"])).expect("walk plan"),
+            "denied function inside a subquery must be detected"
+        );
+    }
+
+    #[test]
+    fn allows_plan_without_denied_functions() {
+        let plan = scan("t")
+            .filter(udf_expr("upper").eq(lit("x")))
+            .expect("filter")
+            .project(vec![col("id")])
+            .expect("project")
+            .build()
+            .expect("build");
+
+        assert!(
+            !contains_unsupported_functions(&plan, &deny(&["json_get_str"])).expect("walk plan"),
+            "plan with no denied functions must stay federated"
+        );
+    }
 }

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -29,7 +29,9 @@ use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
 use crate::{
-    component::dataset::acceleration::Engine, parameters::ParameterSpec, register_data_accelerator,
+    component::dataset::acceleration::Engine,
+    datafusion::udf::deny_spice_specific_functions_table_providers, parameters::ParameterSpec,
+    register_data_accelerator,
 };
 
 use super::{AccelerationSource, DataAccelerator, upsert_dedup};
@@ -68,7 +70,11 @@ impl PostgresAccelerator {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            postgres_factory: PostgresTableProviderFactory::new(),
+            // Keep plans referencing Spice-only functions (e.g. `json_get_str`)
+            // evaluating locally instead of failing in `Postgres`. Wired before
+            // the `DataFusion` 53 upgrade (#11118) dropped it; see issue #10703.
+            postgres_factory: PostgresTableProviderFactory::new()
+                .with_function_support(deny_spice_specific_functions_table_providers()),
         }
     }
 }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -23,6 +23,7 @@ use crate::{
         snapshots::{download_snapshot_if_needed, snapshot_before_recreate},
         storage::{ResolvedAccelerationStorage, resolve_acceleration_storage_async},
     },
+    datafusion::udf::deny_spice_specific_functions_table_providers,
     make_spice_data_directory,
     parameters::ParameterSpec,
     register_data_accelerator, spice_data_base_path,
@@ -122,8 +123,17 @@ impl SqliteAccelerator {
             sqlite3_auto_extension(Some(Self::sqlite3_decimal_init_wrapper));
         }
         Self {
+            // `decimal_between` rewrites federated `BETWEEN` comparisons over
+            // decimal columns (stored as TEXT in `SQLite`) so they compare
+            // numerically instead of lexically — without it those queries
+            // silently return wrong rows. The deny-list keeps plans referencing
+            // Spice-only functions (e.g. `json_get_str`) evaluating locally
+            // instead of failing in `SQLite`. Both were wired before the
+            // `DataFusion` 53 upgrade (#11118) dropped them; see issue #10703.
             sqlite_factory: SqliteTableProviderFactory::new()
-                .with_batch_insert_use_prepared_statements(true),
+                .with_batch_insert_use_prepared_statements(true)
+                .with_decimal_between(true)
+                .with_function_support(deny_spice_specific_functions_table_providers()),
         }
     }
 

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -823,6 +823,21 @@ pub fn deny_spice_functions_for_duckdb_table_providers() -> TpFunctionSupport {
 }
 
 /// Same deny-list as [`deny_spice_specific_functions`], but expressed in the
+/// `datafusion-table-providers` [`TpFunctionSupport`] type that the fork's
+/// factory `with_function_support` seams expect (`SqliteTableProviderFactory`,
+/// `PostgresTableProviderFactory`, `MySQLTableFactory`).
+///
+/// For backends whose unparser dialect has no Spice-function carve-out (unlike
+/// `DuckDB`), this is the full default deny-list: every built-in Spice UDF plus
+/// any user-registered function. See issue #10703.
+#[must_use]
+pub fn deny_spice_specific_functions_table_providers() -> TpFunctionSupport {
+    let mut denied = BUILTIN_DENIED_SPICE_FUNCTION_NAMES.as_slice().to_vec();
+    denied.extend(USER_FUNCTION_NAMES.read().iter().cloned());
+    TpFunctionSupport::new(Some(TpFunctionRestriction::Deny(denied)), None, None)
+}
+
+/// Same deny-list as [`deny_spice_specific_functions`], but expressed in the
 /// `datafusion-table-providers` [`TpFunctionSupport`] type that
 /// `MySQLTableFactory::with_function_support` expects.
 ///
@@ -831,9 +846,7 @@ pub fn deny_spice_functions_for_duckdb_table_providers() -> TpFunctionSupport {
 /// user-registered function. See issue #10703.
 #[must_use]
 pub fn deny_spice_functions_for_mysql_table_providers() -> TpFunctionSupport {
-    let mut denied = BUILTIN_DENIED_SPICE_FUNCTION_NAMES.as_slice().to_vec();
-    denied.extend(USER_FUNCTION_NAMES.read().iter().cloned());
-    TpFunctionSupport::new(Some(TpFunctionRestriction::Deny(denied)), None, None)
+    deny_spice_specific_functions_table_providers()
 }
 
 fn json_functions() -> Vec<String> {
@@ -1073,6 +1086,26 @@ mod tests {
             Arc::new(stub_scalar_udf(name)),
             vec![],
         ))
+    }
+
+    #[test]
+    fn table_providers_default_deny_list_denies_spice_functions() {
+        // The default table-providers-typed deny-list (wired into the SQLite
+        // and Postgres accelerator factories and the MySQL connector factory)
+        // has no dialect carve-out: every built-in Spice UDF must be denied
+        // while ordinary functions still federate.
+        let support = deny_spice_specific_functions_table_providers();
+        let json_name = json_get_str_udf().name().to_string();
+        for name in [EMBED_UDF_NAME, COSINE_DISTANCE_UDF_NAME, json_name.as_str()] {
+            assert!(
+                !support.supports(&make_named_expr(name)),
+                "{name} is a Spice-only function and must be denied"
+            );
+        }
+        assert!(
+            support.supports(&make_named_expr("upper")),
+            "non-Spice functions must not be denied"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The DataFusion v53.1 upgrade (#11118) regressed the Spice-function federation deny-list (issue #10703) in two independent ways, plus dropped the SQLite decimal `BETWEEN` rewrite. All three silently change query behavior.

## Root causes and user-visible symptoms

**1. SQLite and Postgres accelerator factories lost their deny-list (and SQLite its `decimal_between`).**
The upgrade migrated the DuckDB accelerator and MySQL connector to the new table-providers-typed `FunctionSupport` seam (`deny_spice_functions_for_*_table_providers`), but the SQLite and Postgres accelerator factories' builder calls were dropped outright instead of migrated — the fork APIs (`SqliteTableProviderFactory::with_function_support`/`with_decimal_between`, `PostgresTableProviderFactory::with_function_support`) still exist at the pinned rev:

- `with_decimal_between(true)` enables the `SQLiteBetweenVisitor`, which rewrites federated `BETWEEN` comparisons over decimal columns (stored as TEXT in SQLite) to compare numerically. Without it, `WHERE price BETWEEN 0.07 AND 0.10` against a `sqlite`-accelerated decimal column can silently return wrong rows (lexical TEXT comparison).
- Without `function_support`, plans referencing Spice-only functions (`json_get_str`, `embed`, user UDFs) are federated into SQLite/Postgres accelerator SQL instead of falling back to local evaluation — failing with "no such function", where names colliding with remote builtins of different semantics could silently return different results.

Fix: add `deny_spice_specific_functions_table_providers()` (the full default deny-list expressed in the fork's `TpFunctionSupport` type; the MySQL helper now delegates to it) and restore the wiring in both accelerator factories.

**2. `contains_unsupported_functions` only inspected the root plan node.**
The upgrade replaced the fork's `datafusion_table_providers::util::supported_functions::contains_unsupported_functions` — which walks the entire plan including subqueries via `plan.apply_with_subqueries` — with a local reimplementation in `data_components::function_support` that iterates only `plan.expressions()` on the single node it is handed. Callers pass the root of an entire federated subtree (`unfederate_plan_with_unsupported_functions` passes `federated.plan()`; flight/flightsql pass the plan given to `can_execute_plan`), so a denied function in a `WHERE` predicate below the root projection — or inside an `IN`/`EXISTS`/scalar subquery at any depth — escaped the check and was unparsed into the remote engine's SQL. This affected every consumer of the local check: the generic SQL federation wrapper (Snowflake, ClickHouse, ODBC, Dremio, Postgres connectors), Turso, Flight, and FlightSQL.

Fix: walk the plan with `apply_with_subqueries`, matching the fork implementation this replaced.

## Test plan
- [x] Added regression tests for the deep plan walk: denied function in a `Filter` below the root node, and denied function inside an `IN (<subquery>)` plan (both fail against the previous root-only implementation), plus a root-node and a no-denied-function control case (`data_components::function_support::tests`)
- [x] Added regression test that the new table-providers-typed default deny-list denies Spice-only functions (`embed`, `cosine_distance`, `json_get_str`) and allows ordinary functions (`runtime::datafusion::udf::tests`)
- [x] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full workspace clippy, not per-crate)
- [x] `make test` run (as `cargo test --all --lib --no-fail-fast` for full coverage) — 88 suites green; the only failures are pre-existing/environmental and unrelated to this diff: 28 `cayenne_catalog` tests that hardcode `/tmp/cayenne_test` (owned by a different user on this shared runner → `PermissionDenied`; no cayenne code touched here), the known external `test_integration_httpbin_500_server_error` flake, and `test_refresh_status_change_to_ready` which timed out under full-workspace load and passes when run solo.
