### PR TITLE
feat(postgres): share generated replication slots per instance

### DIFF
--- a/crates/data-connectors/connector-postgres/src/lib.rs
+++ b/crates/data-connectors/connector-postgres/src/lib.rs
@@ -157,14 +157,28 @@ const PARAMETERS: &[ParameterSpec] = &[
         "Name of the Postgres replication slot to create/reuse for this dataset. \
          Defaults to `spice_<dataset>_<dataset-hash>_<instance-hash>`. Datasets on the \
          same connection that name the same slot SHARE it: one replication connection, \
-         one publication, with decoded changes routed per table. Each Spice replica \
-         MUST have its own unique slot.",
+         one publication, with decoded changes routed per table. An explicit name is used \
+         verbatim, so each Spice replica MUST set a unique slot — or omit this and set \
+         `pg_replication_slot_scope: instance` to share one auto-named slot per replica.",
     ),
+    ParameterSpec::component("replication_slot_scope")
+        .description(
+            "Scope of the auto-generated replication slot when `pg_replication_slot` is not \
+             set. `dataset` (default): one slot per dataset \
+             (`spice_<dataset>_<dataset-hash>_<instance-hash>`). `instance`: one slot per \
+             Spice replica per source connection (`spice_inst_<instance-hash>_<source-hash>`), \
+             shared by every `refresh_mode: changes` dataset on that source via the \
+             replication multiplexer — cutting slot/walsender usage from datasets×replicas to \
+             replicas. Ignored when `pg_replication_slot` is set.",
+        )
+        .one_of(&["dataset", "instance"])
+        .default("dataset")
+        .help_link(POSTGRES_DOCS),
     ParameterSpec::component("publication").description(
         "Name of the Postgres publication to create/reuse for this dataset. \
          Defaults to `spice_<dataset>_<dataset-hash>_pub`, or `<slot>_pub` when \
-         `pg_replication_slot` is set. Shared across replicas for the same dataset; \
-         datasets sharing a slot must use the same publication.",
+         `pg_replication_slot` is set or an instance-scoped slot is used. Shared across \
+         replicas for the same dataset; datasets sharing a slot must use the same publication.",
     ),
     ParameterSpec::component("replication_initial_snapshot")
         .description(

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -495,18 +495,43 @@ fn replication_params_from_connector_params(
     // connection (see `data_components::postgres_replication::shared`). The
     // default publication is then derived from the slot — not the dataset —
     // so all members land on the same publication.
+    //
+    // `pg_replication_slot_scope: instance` opts into the same multiplexer with
+    // a *generated* instance-scoped slot name (`spice_inst_<instance>_<source>`)
+    // shared across every changes-mode dataset on this source — collapsing
+    // `datasets × replicas` slots down to `replicas` (one per replica per
+    // source), while staying distinct per replica via the instance hash. An
+    // explicit `pg_replication_slot` takes precedence and is used verbatim.
     let explicit_slot = optional_string(params, "replication_slot");
-    let shared = explicit_slot.is_some();
-    let (slot_name, publication_name) = match explicit_slot {
+    let instance_scoped = matches!(
+        optional_string(params, "replication_slot_scope").as_deref(),
+        Some("instance")
+    );
+    let explicit_publication = optional_string(params, "publication");
+    let (slot_name, publication_name, shared) = match explicit_slot {
         Some(slot) => {
-            let publication = optional_string(params, "publication")
-                .unwrap_or_else(|| config::publication_name_for_slot(&slot));
-            (slot, publication)
+            if instance_scoped {
+                tracing::warn!(
+                    dataset = %dataset_name,
+                    "both `pg_replication_slot` and `pg_replication_slot_scope: instance` are \
+                     set; using the explicit slot name verbatim and ignoring the scope. Remove \
+                     `pg_replication_slot` to get an instance-scoped (per-replica) slot."
+                );
+            }
+            let publication =
+                explicit_publication.unwrap_or_else(|| config::publication_name_for_slot(&slot));
+            (slot, publication, true)
+        }
+        None if instance_scoped => {
+            let slot = config::instance_slot_name(&host, port, &database, &user);
+            let publication =
+                explicit_publication.unwrap_or_else(|| config::publication_name_for_slot(&slot));
+            (slot, publication, true)
         }
         None => (
             config::default_slot_name(dataset_name),
-            optional_string(params, "publication")
-                .unwrap_or_else(|| config::default_publication_name(dataset_name)),
+            explicit_publication.unwrap_or_else(|| config::default_publication_name(dataset_name)),
+            false,
         ),
     };
     let initial_snapshot = optional_string(params, "replication_initial_snapshot")
@@ -678,5 +703,110 @@ mod tests {
                     "parameter `pg_replication_bootstrap_batch_size` must be a positive integer, got \"many\""
                 )
         );
+    }
+
+    /// Build a full connector param set (the connection params are required by
+    /// `replication_params_from_connector_params`) plus any extra entries.
+    fn conn_params(db: &str, extra: &[(&str, &str)]) -> Parameters {
+        let mut kv: Vec<(String, SecretString)> = vec![
+            ("host".to_string(), SecretString::from("db.example.com")),
+            ("port".to_string(), SecretString::from("5432")),
+            ("user".to_string(), SecretString::from("spice")),
+            ("pass".to_string(), SecretString::from("secret")),
+            ("db".to_string(), SecretString::from(db.to_string())),
+        ];
+        for (k, v) in extra {
+            kv.push(((*k).to_string(), SecretString::from((*v).to_string())));
+        }
+        Parameters::new(kv, "pg", crate::PARAMETERS)
+    }
+
+    #[test]
+    fn default_scope_is_per_dataset_and_unshared() {
+        let p = replication_params_from_connector_params(&conn_params("appdb", &[]), "public.apps")
+            .expect("params build");
+        assert!(
+            !p.shared,
+            "default scope must keep a dedicated per-dataset stream"
+        );
+        assert_eq!(p.slot_name, config::default_slot_name("public.apps"));
+        assert_eq!(
+            p.publication_name,
+            config::default_publication_name("public.apps")
+        );
+    }
+
+    #[test]
+    fn scope_instance_produces_a_shared_instance_slot() {
+        let p = replication_params_from_connector_params(
+            &conn_params("appdb", &[("replication_slot_scope", "instance")]),
+            "public.apps",
+        )
+        .expect("params build");
+        assert!(p.shared, "instance scope must use the shared multiplexer");
+        assert!(
+            p.slot_name.starts_with("spice_inst_"),
+            "got slot `{}`",
+            p.slot_name
+        );
+        // Publication is derived from the (shared) slot, not the dataset, so
+        // every member lands on the same publication.
+        assert_eq!(
+            p.publication_name,
+            config::publication_name_for_slot(&p.slot_name)
+        );
+    }
+
+    #[test]
+    fn scope_instance_shares_one_slot_across_datasets_on_the_same_source() {
+        let apps = replication_params_from_connector_params(
+            &conn_params("appdb", &[("replication_slot_scope", "instance")]),
+            "public.apps",
+        )
+        .expect("params build");
+        let orgs = replication_params_from_connector_params(
+            &conn_params("appdb", &[("replication_slot_scope", "instance")]),
+            "public.orgs",
+        )
+        .expect("params build");
+        // Identical slot + publication → the multiplexer collapses them onto one
+        // replication connection (datasets × replicas → replicas).
+        assert_eq!(apps.slot_name, orgs.slot_name);
+        assert_eq!(apps.publication_name, orgs.publication_name);
+    }
+
+    #[test]
+    fn scope_instance_distinguishes_different_sources() {
+        let appdb = replication_params_from_connector_params(
+            &conn_params("appdb", &[("replication_slot_scope", "instance")]),
+            "public.apps",
+        )
+        .expect("params build");
+        let otherdb = replication_params_from_connector_params(
+            &conn_params("otherdb", &[("replication_slot_scope", "instance")]),
+            "public.apps",
+        )
+        .expect("params build");
+        // Logical slot names are unique cluster-wide; two databases on the same
+        // server must not collide on one physical slot.
+        assert_ne!(appdb.slot_name, otherdb.slot_name);
+    }
+
+    #[test]
+    fn explicit_slot_overrides_instance_scope() {
+        let p = replication_params_from_connector_params(
+            &conn_params(
+                "appdb",
+                &[
+                    ("replication_slot", "my_slot"),
+                    ("replication_slot_scope", "instance"),
+                ],
+            ),
+            "public.apps",
+        )
+        .expect("params build");
+        assert!(p.shared);
+        assert_eq!(p.slot_name, "my_slot", "explicit slot is used verbatim");
+        assert_eq!(p.publication_name, "my_slot_pub");
     }
 }

--- a/crates/data_components/src/postgres_replication/config.rs
+++ b/crates/data_components/src/postgres_replication/config.rs
@@ -60,13 +60,13 @@ pub struct ReplicationParams {
     pub status_interval: Duration,
     /// Rows per emitted snapshot batch during initial bootstrap.
     pub bootstrap_batch_size: usize,
-    /// `true` when the slot name was explicitly configured
-    /// (`pg_replication_slot`). Explicitly-named slots are served by the
-    /// shared multiplexer ([`super::shared`]): every dataset on the same
-    /// connection naming the same slot shares one replication
-    /// connection/decoder, with changes routed per table. Default
-    /// (per-dataset generated) slot names keep the dedicated per-dataset
-    /// stream.
+    /// `true` when the slot is shared across datasets — either an explicit
+    /// `pg_replication_slot` name, or `pg_replication_slot_scope: instance`
+    /// (an instance-scoped *generated* name). Shared slots are served by the
+    /// multiplexer ([`super::shared`]): every dataset on the same connection
+    /// naming the same slot shares one replication connection/decoder, with
+    /// changes routed per table. The default (per-dataset generated) slot name
+    /// keeps the dedicated per-dataset stream.
     pub shared: bool,
 }
 
@@ -185,6 +185,36 @@ pub fn default_slot_name(dataset_name: &str) -> String {
     let dataset_hash = xxh3_short_hash_prefix(dataset_name, DATASET_HASH_LEN);
     let dataset = truncate_to_bytes(&sanitize(dataset_name), SLOT_DATASET_PORTION_MAX);
     format!("{SLOT_PREFIX}{dataset}_{dataset_hash}_{instance_hash}")
+}
+
+/// Build an instance-scoped slot name shared by every changes-mode dataset on
+/// the same source connection within this spiced instance:
+/// `spice_inst_{instance_hash}_{source_hash}`.
+///
+/// Selected by `pg_replication_slot_scope: instance`. Unlike [`default_slot_name`]
+/// (one slot per dataset) this collapses every dataset on the same source onto a
+/// single replication slot/connection/publication via the shared multiplexer
+/// ([`super::shared`]), cutting the slot count from `datasets × replicas` down to
+/// `replicas` (one slot per replica per source connection).
+///
+/// - `instance_hash` (from `SPICE_INSTANCE_ID`, falling back to the hostname)
+///   keeps the name distinct per replica, so HA replicas never contend over a
+///   single physical slot (which would leave all but one serving stale data).
+/// - `source_hash` disambiguates by `(host, port, database, user)`. Logical slot
+///   names are unique cluster-wide, so two instance-scoped datasets pointing at
+///   different databases on the *same* server would otherwise collide on one
+///   name; folding the source in makes it precisely one slot per source. It is
+///   the same tuple the multiplexer keys on ([`super::shared::SourceKey`]), so
+///   datasets that share a source share the name and multiplex, and datasets on
+///   different sources get distinct slots.
+///
+/// Length: `spice_`(6) + `inst_`(5) + 8 + `_`(1) + 8 = 28 bytes, well under the
+/// 63-byte identifier limit (no truncation needed).
+#[must_use]
+pub fn instance_slot_name(host: &str, port: u16, database: &str, user: &str) -> String {
+    let instance = instance_hash();
+    let source = xxh3_short_hash(&format!("{host}:{port}/{database}#{user}"));
+    format!("{SLOT_PREFIX}inst_{instance}_{source}")
 }
 
 /// Default publication name for a dataset with an explicitly-named
@@ -554,6 +584,46 @@ mod tests {
         // 63-byte cap survives long slot names.
         let long = "p".repeat(120);
         assert!(publication_name_for_slot(&long).len() <= PG_IDENTIFIER_MAX_BYTES);
+    }
+
+    #[test]
+    fn instance_slot_name_is_deterministic_and_prefixed() {
+        // Same inputs within a process → same name (so two datasets on the same
+        // source produce the identical slot and therefore multiplex).
+        let a1 = instance_slot_name("db.example.com", 5432, "appdb", "spice");
+        let a2 = instance_slot_name("db.example.com", 5432, "appdb", "spice");
+        assert_eq!(a1, a2);
+        assert!(a1.starts_with("spice_inst_"), "got {a1}");
+        assert!(
+            a1.len() <= PG_IDENTIFIER_MAX_BYTES,
+            "got {} bytes",
+            a1.len()
+        );
+    }
+
+    #[test]
+    fn instance_slot_name_distinguishes_sources() {
+        // Different database, host, port, or user on the same instance must
+        // yield distinct slot names — logical slot names are unique
+        // cluster-wide, so colliding here would make two sources fight over one
+        // physical slot.
+        let base = instance_slot_name("db.example.com", 5432, "appdb", "spice");
+        assert_ne!(
+            base,
+            instance_slot_name("db.example.com", 5432, "otherdb", "spice")
+        );
+        assert_ne!(
+            base,
+            instance_slot_name("other.example.com", 5432, "appdb", "spice")
+        );
+        assert_ne!(
+            base,
+            instance_slot_name("db.example.com", 5433, "appdb", "spice")
+        );
+        assert_ne!(
+            base,
+            instance_slot_name("db.example.com", 5432, "appdb", "other")
+        );
     }
 
     #[test]

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -272,11 +272,11 @@ async fn expect_single_change(
     Ok(())
 }
 
-async fn slot_count(client: &tokio_postgres::Client) -> Result<i64, anyhow::Error> {
+async fn slot_count(client: &tokio_postgres::Client, slot: &str) -> Result<i64, anyhow::Error> {
     Ok(client
         .query_one(
             "SELECT count(*) FROM pg_replication_slots WHERE slot_name = $1",
-            &[&SLOT],
+            &[&slot],
         )
         .await?
         .get(0))
@@ -284,20 +284,22 @@ async fn slot_count(client: &tokio_postgres::Client) -> Result<i64, anyhow::Erro
 
 async fn publication_tables(
     client: &tokio_postgres::Client,
+    publication: &str,
 ) -> Result<HashSet<String>, anyhow::Error> {
     let rows = client
         .query(
             "SELECT tablename FROM pg_publication_tables WHERE pubname = $1",
-            &[&PUBLICATION],
+            &[&publication],
         )
         .await?;
     Ok(rows.iter().map(|r| r.get::<_, String>(0)).collect())
 }
 
-/// Poll until exactly `expected` walsenders serve our slot (reconnects make
+/// Poll until exactly `expected` walsenders serve the slot (reconnects make
 /// the instantaneous count racy).
 async fn wait_for_walsender_count(
     client: &tokio_postgres::Client,
+    slot: &str,
     expected: i64,
 ) -> Result<(), anyhow::Error> {
     let deadline = std::time::Instant::now() + Duration::from_secs(20);
@@ -308,7 +310,7 @@ async fn wait_for_walsender_count(
                 "SELECT count(*) FROM pg_stat_replication r \
                  JOIN pg_replication_slots s ON s.active_pid = r.pid \
                  WHERE s.slot_name = $1",
-                &[&SLOT],
+                &[&slot],
             )
             .await?
             .get(0);
@@ -318,7 +320,7 @@ async fn wait_for_walsender_count(
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
     Err(anyhow::anyhow!(
-        "expected {expected} walsender(s) for slot {SLOT}, last saw {last}"
+        "expected {expected} walsender(s) for slot {slot}, last saw {last}"
     ))
 }
 
@@ -375,13 +377,13 @@ async fn shared_slot_multiplexes_multiple_datasets() -> Result<(), anyhow::Error
     boot_b.commit().await?;
 
     // --- 2. One slot, one publication covering both tables, one walsender. ---
-    assert_eq!(slot_count(&source).await?, 1, "exactly one slot");
+    assert_eq!(slot_count(&source, SLOT).await?, 1, "exactly one slot");
     assert_eq!(
-        publication_tables(&source).await?,
+        publication_tables(&source, PUBLICATION).await?,
         HashSet::from(["shared_repl_a".to_string(), "shared_repl_b".to_string()]),
         "publication covers both member tables"
     );
-    wait_for_walsender_count(&source, 1).await?;
+    wait_for_walsender_count(&source, SLOT, 1).await?;
 
     // --- 3. Interleaved changes route to the right dataset. ---
     source
@@ -461,9 +463,13 @@ async fn shared_slot_multiplexes_multiple_datasets() -> Result<(), anyhow::Error
     );
     boot_c.commit().await?;
 
-    assert_eq!(slot_count(&source).await?, 1, "still exactly one slot");
     assert_eq!(
-        publication_tables(&source).await?.len(),
+        slot_count(&source, SLOT).await?,
+        1,
+        "still exactly one slot"
+    );
+    assert_eq!(
+        publication_tables(&source, PUBLICATION).await?.len(),
         3,
         "publication gained the late-added table"
     );
@@ -686,6 +692,98 @@ async fn shared_slot_multiplexes_multiple_datasets() -> Result<(), anyhow::Error
     drop_replication_slot_when_inactive(&source, SLOT).await?;
     source
         .simple_query(&format!("DROP PUBLICATION IF EXISTS {PUBLICATION}"))
+        .await?;
+    Ok(())
+}
+
+/// `pg_replication_slot_scope: instance` shares one *generated* slot across
+/// every changes-mode dataset on a source — distinct per replica via the
+/// instance hash. This proves the shared multiplexer treats the generated
+/// instance-scoped name (`config::instance_slot_name`) exactly like an explicit
+/// one: two datasets collapse onto one slot / one publication / one walsender.
+#[tokio::test(flavor = "multi_thread")]
+async fn instance_scoped_slot_multiplexes_generated_name() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port = u16::try_from(port).expect("port fits in u16");
+    let source = pg_client(port).await?;
+
+    create_table(&source, "inst_a", &[(1, "a1"), (2, "a2")]).await?;
+    create_table(&source, "inst_b", &[(1, "b1")]).await?;
+
+    // The exact name the connector generates for `pg_replication_slot_scope:
+    // instance` on this (host, port, db, user). Both datasets compute the same
+    // name and must multiplex onto it.
+    let slot = config::instance_slot_name("localhost", port, "postgres", "postgres");
+    assert!(slot.starts_with("spice_inst_"), "got slot `{slot}`");
+    let publication = config::publication_name_for_slot(&slot);
+
+    let input = |table: &str| ReplicationStreamInput {
+        dataset_name: table.to_string(),
+        params: ReplicationParams {
+            host: "localhost".into(),
+            port,
+            user: "postgres".into(),
+            password: SecretString::from(common::PG_PASSWORD.to_string()),
+            database: "postgres".into(),
+            sslmode: config::SslMode::Disable,
+            sslrootcert: None,
+            slot_name: slot.clone(),
+            publication_name: publication.clone(),
+            initial_snapshot: true,
+            snapshot_on_resume: false,
+            temporary_slot: false,
+            status_interval: Duration::from_secs(1),
+            bootstrap_batch_size: 8192,
+            shared: true,
+        },
+        schema: dataset_schema(),
+        primary_keys: vec!["id".into()],
+        schema_name: "public".into(),
+        table_name: table.to_string(),
+        metrics: ReplicationMetricsCollector::new(),
+    };
+
+    let mut stream_a = start_replication_stream(input("inst_a"));
+    let boot_a = next_envelope(&mut stream_a, "bootstrap inst_a").await?;
+    assert_eq!(boot_a.change_batch.record.num_rows(), 2, "bootstrap inst_a");
+    boot_a.commit().await?;
+
+    let mut stream_b = start_replication_stream(input("inst_b"));
+    let boot_b = next_envelope(&mut stream_b, "bootstrap inst_b").await?;
+    assert_eq!(boot_b.change_batch.record.num_rows(), 1, "bootstrap inst_b");
+    boot_b.commit().await?;
+
+    // One slot, one publication covering both tables, one walsender.
+    assert_eq!(
+        slot_count(&source, &slot).await?,
+        1,
+        "two instance-scoped datasets share exactly one slot"
+    );
+    assert_eq!(
+        publication_tables(&source, &publication).await?,
+        HashSet::from(["inst_a".to_string(), "inst_b".to_string()]),
+        "instance-scoped publication covers both member tables"
+    );
+    wait_for_walsender_count(&source, &slot, 1).await?;
+
+    // Per-table routing over the shared generated slot.
+    source
+        .simple_query("INSERT INTO public.inst_a VALUES (10, 'a10')")
+        .await?;
+    expect_single_change(&mut stream_a, "insert inst_a", "c", 10).await?;
+    source
+        .simple_query("INSERT INTO public.inst_b VALUES (20, 'b20')")
+        .await?;
+    expect_single_change(&mut stream_b, "insert inst_b", "c", 20).await?;
+
+    drop(stream_a);
+    drop(stream_b);
+    drop_replication_slot_when_inactive(&source, &slot).await?;
+    source
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {publication}"))
         .await?;
     Ok(())
 }

--- a/docs/features/postgres-replication.md
+++ b/docs/features/postgres-replication.md
@@ -116,7 +116,8 @@ All replication-specific parameters live under `params:` on the dataset and star
 | Parameter                             | Default                                          | Description                                                                                                                                                                                                                            |
 | ------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pg_replication_slot`                 | `spice_<dataset>_<dataset-hash>_<instance-hash>` | Name of the replication slot. Must be unique per replica. The dataset-hash protects against truncation collisions between long dataset names. Datasets on the same connection that name the **same** slot share it — see [Sharing one slot across multiple datasets](#sharing-one-slot-across-multiple-datasets). |
-| `pg_publication`                      | `spice_<dataset>_<dataset-hash>_pub`             | Publication name. Shared across replicas. Auto-created if missing. The short hash disambiguates datasets whose names share a long truncated prefix. When `pg_replication_slot` is set explicitly, the default becomes `<slot>_pub` so datasets sharing a slot land on the same publication.                       |
+| `pg_replication_slot_scope`           | `dataset`                                        | Scope of the **auto-generated** slot name when `pg_replication_slot` is unset. `dataset`: one slot per dataset (default). `instance`: one slot per replica per source connection (`spice_inst_<instance-hash>_<source-hash>`), shared by every `refresh_mode: changes` dataset on that source — see [Instance-scoped slots](#instance-scoped-slots-one-slot-per-replica). Ignored when `pg_replication_slot` is set. |
+| `pg_publication`                      | `spice_<dataset>_<dataset-hash>_pub`             | Publication name. Shared across replicas. Auto-created if missing. The short hash disambiguates datasets whose names share a long truncated prefix. When `pg_replication_slot` is set explicitly (or an instance-scoped slot is used), the default becomes `<slot>_pub` so datasets sharing a slot land on the same publication.                       |
 | `pg_replication_initial_snapshot`     | `true`                                           | If `true`, take an initial snapshot of the table's existing rows before streaming. Set to `false` if you are pre-seeding the accelerator yourself. Non-persistent accelerators (`arrow`, or `duckdb`/`sqlite` with `mode: memory`/`file_create`) snapshot on **every** start — including slot resume — since they boot empty.            |
 | `pg_replication_temporary_slot`       | `false`                                          | If `true`, the slot is dropped when Spice disconnects. Every restart re-bootstraps.                                                                                                                                                    |
 | `pg_replication_status_interval`      | `10s`                                            | How often `StandbyStatusUpdate` (LSN acknowledgement) is sent back to Postgres. Lower values free WAL faster; higher values reduce network chatter. Accepts any [fundu](https://docs.rs/fundu) duration string (`500ms`, `30s`, `2m`). |
@@ -223,7 +224,29 @@ Sharing semantics worth knowing:
 - **One dataset per source table per slot.** Two datasets replicating the same table must use different slots.
 - **All members must use the same publication.** Leave `pg_publication` unset (the `<slot>_pub` default agrees automatically) or set it identically on every member.
 - **Removing a dataset** stops routing its changes but does not remove its table from the publication, and its last-applied LSN keeps pinning WAL until spiced restarts. After a restart the remaining members resume and the slot acknowledges freely again. If you later **re-add a previously removed dataset**, drop its table from the publication first (`ALTER PUBLICATION spice_app_cdc_pub DROP TABLE public.users;`) so Spice re-adds it and takes a fresh snapshot — changes that committed while the dataset was absent across a restart are not replayable from the slot.
-- **Replicas still need distinct slots.** Slots are single-consumer: sharing happens *within* a spiced instance, never across replicas. With explicit slot names, include the replica identity in the name (see [Multi-replica deployments](#multi-replica-deployments)); a second consumer of the same slot fails loudly with "replication slot is active".
+- **Replicas still need distinct slots.** Slots are single-consumer: sharing happens *within* a spiced instance, never across replicas. The simplest way to share one slot across many datasets in a multi-replica deployment is [`pg_replication_slot_scope: instance`](#instance-scoped-slots-one-slot-per-replica), which generates a per-replica shared slot for you. With explicit slot names, include the replica identity in the name (see [Multi-replica deployments](#multi-replica-deployments)); a second consumer of the same slot fails loudly with "replication slot is active".
+
+### Instance-scoped slots (one slot per replica)
+
+The sharing above requires every dataset to name the **same** explicit `pg_replication_slot`, and an explicit name is used verbatim — so in a multi-replica deployment every replica computes the *same* slot name and all but one fail with "replication slot is active" (slots are single-consumer). You then have to invent a per-replica naming scheme by hand.
+
+`pg_replication_slot_scope: instance` removes that friction. Set it on each `refresh_mode: changes` dataset (leaving `pg_replication_slot` unset) and Spice generates one shared slot name automatically:
+
+```yaml
+params: &repl
+  pg_host: db.internal
+  pg_db: app
+  pg_user: spice
+  pg_pass: ${secrets:pg_pass}
+  pg_replication_slot_scope: instance
+```
+
+The generated name is `spice_inst_<instance-hash>_<source-hash>`:
+
+- `<instance-hash>` is the replica identity (`SPICE_INSTANCE_ID`, falling back to `HOSTNAME`), so **each replica gets its own slot with no contention** — exactly like the default per-dataset slots (see [Multi-replica deployments](#multi-replica-deployments)).
+- `<source-hash>` folds in `(host, port, db, user)`, so datasets on the same source share one slot while datasets pointing at a different database or server get their own. (Logical slot names are unique cluster-wide, so this prevents two databases on one server from colliding on a single slot.)
+
+The net effect is **one slot per replica per source** instead of `datasets × replicas` — e.g. six tables mirrored across three replicas drop from 18 slots to 3. All the sharing semantics above still apply (collective acknowledgement, one publication, one walsender). The trade-off versus per-dataset slots is that members share a single replication connection/walsender, so they share throughput and back-pressure; correctness stays isolated — a stalled member only pins WAL, as described above. An explicit `pg_replication_slot` still overrides the scope and is used verbatim.
 
 ## Multi-replica deployments
 


### PR DESCRIPTION
## Summary

Adds an opt-in `pg_replication_slot_scope` parameter for Postgres datasets that use `refresh_mode: changes`. The default `dataset` scope keeps the existing behavior: one generated replication slot per dataset per runtime instance.

The new `instance` scope generates one shared slot name per runtime instance and Postgres source connection: `spice_inst_<instance-hash>_<source-hash>`. Datasets on the same source can share one slot, publication, and walsender without making every runtime replica contend for the same physical Postgres slot.

This reduces replication slot usage from `datasets × replicas` to `sources × replicas`. Explicit `pg_replication_slot` values still take precedence and are used verbatim.

## Example config

Set `pg_replication_slot_scope: instance` on each Postgres dataset that uses `refresh_mode: changes` and should share the generated per-instance slot for the same source connection:

```yaml
version: v1
kind: Spicepod
name: postgres-cdc

datasets:
  - from: postgres:public.orders
    name: orders
    params:
      pg_host: db.internal
      pg_port: 5432
      pg_db: app
      pg_user: spice
      pg_pass: ${secrets:pg_pass}
      pg_replication_slot_scope: instance
    acceleration:
      enabled: true
      refresh_mode: changes

  - from: postgres:public.customers
    name: customers
    params:
      pg_host: db.internal
      pg_port: 5432
      pg_db: app
      pg_user: spice
      pg_pass: ${secrets:pg_pass}
      pg_replication_slot_scope: instance
    acceleration:
      enabled: true
      refresh_mode: changes
```

## Flow

```text
Default: pg_replication_slot_scope: dataset

runtime replica 1
  dataset A -> spice_<dataset-a>_<dataset-hash>_<instance-hash>
  dataset B -> spice_<dataset-b>_<dataset-hash>_<instance-hash>

Instance scope: pg_replication_slot_scope: instance

runtime replica 1
  dataset A --\
  dataset B ----> spice_inst_<instance-hash>_<source-hash> -> shared multiplexer
  dataset C --/

runtime replica 2
  dataset A --\
  dataset B ----> spice_inst_<different-instance-hash>_<same-source-hash>
  dataset C --/
```

## Changes

- Add `pg_replication_slot_scope` with `dataset` as the default and `instance` as the opt-in shared mode.
- Generate instance-scoped slot names from the runtime instance identity (`SPICE_INSTANCE_ID`, falling back to hostname) and the Postgres source tuple `(host, port, database, user)`.
- Route instance-scoped generated slots through the existing shared replication multiplexer.
- Keep explicit `pg_replication_slot` behavior unchanged, including precedence over `pg_replication_slot_scope`.
- Update Postgres replication docs and add coverage for slot naming, source separation, explicit-slot precedence, and generated-slot multiplexing.

## Notes

- Existing deployments are unchanged unless `pg_replication_slot_scope: instance` is set.
- Instance-scoped datasets on the same source share one replication connection/walsender, so they also share throughput and back-pressure.

## Test plan

- [ ] CI

