### PR TITLE
fix(lint): backtick refresh_mode in cayenne test doc comment

### DIFF
--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -3320,7 +3320,7 @@ mod tests {
         assert_eq!(config.cdc_mem_tier_min_flush_bytes, 32 * MIB);
     }
 
-    /// `deletion_mode: auto` resolves to `key` ONLY for refresh_mode: changes
+    /// `deletion_mode: auto` resolves to `key` ONLY for `refresh_mode`: changes
     /// datasets whose workload has a primary key; explicit configs and every
     /// other profile keep their value (and Auto's downstream position
     /// resolution) untouched.


### PR DESCRIPTION
## Problem

`Rust Lint` is failing on **every** open PR that merges current `trunk`. The merge commits pick up a `clippy::doc_markdown` (pedantic, `-D warnings`) violation that landed on trunk via #11278:

```
error: item in documentation is missing backticks
    --> crates/runtime/src/dataaccelerator/cayenne/mod.rs:3323:58
3323 |     /// `deletion_mode: auto` resolves to `key` ONLY for refresh_mode: changes
     |                                                          ^^^^^^^^^^^^
error: could not compile `runtime` (lib test) due to 1 previous error
```

The `build_and_release` pipeline that runs on push to `trunk` does **not** include a Rust Lint job, so the violation was not caught when #11278 merged — it only surfaces in per-PR `Rust Lint` runs.

## Fix

Backtick `refresh_mode` in the doc comment for `test_deletion_mode_auto_resolves_to_key_for_cdc_pk_tables`, exactly as clippy's own suggestion proposes. Doc-comment-only change; no behavior impact.

Unblocks Rust Lint on #11252 and any other PR currently rebased on trunk.