### PR TITLE
fix(vortex): don't row-evaluate hash-join dynamic filters in the scan

### DIFF
--- a/crates/vortex/src/persistent/format.rs
+++ b/crates/vortex/src/persistent/format.rs
@@ -302,6 +302,13 @@ config_namespace! {
         pub scan_concurrency: ScanConcurrency, default = ScanConcurrency::Auto
         /// Total byte capacity for a path-aware segment cache shared by scans using this format.
         pub segment_cache_size_bytes: Option<usize>, default = None
+        /// Whether to evaluate hash-join *dynamic* filters inside the Vortex scan.
+        ///
+        /// When `false` (default), a dynamic filter pushed down from a hash join
+        /// (e.g. a build-side `IN` list) is not absorbed into the scan's per-row
+        /// predicate or file-pruning predicate; it is left for the join / a
+        /// post-scan `FilterExec` to apply with a hashed probe.
+        pub dynamic_filter_pushdown: bool, default = false
     }
 }
 
@@ -917,7 +924,8 @@ impl FileFormat for VortexFormat {
     fn file_source(&self, table_schema: TableSchema) -> Arc<dyn FileSource> {
         let mut source = VortexSource::new(table_schema, self.session.clone())
             .with_projection_pushdown(self.opts.projection_pushdown)
-            .with_scan_concurrency(self.opts.scan_concurrency);
+            .with_scan_concurrency(self.opts.scan_concurrency)
+            .with_dynamic_filter_pushdown(self.opts.dynamic_filter_pushdown);
 
         if let Some(segment_cache) = self.segment_cache.clone() {
             source = source.with_segment_cache(segment_cache);

--- a/crates/vortex/src/persistent/source.rs
+++ b/crates/vortex/src/persistent/source.rs
@@ -25,9 +25,9 @@ use datafusion_physical_expr_adapter::DefaultPhysicalExprAdapterFactory;
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
 use datafusion_physical_plan::DisplayFormatType;
 use datafusion_physical_plan::PhysicalExpr;
+use datafusion_physical_plan::expressions::DynamicFilterPhysicalExpr;
 use datafusion_physical_plan::filter_pushdown::FilterPushdownPropagation;
 use datafusion_physical_plan::filter_pushdown::PushedDown;
-use datafusion_physical_plan::filter_pushdown::PushedDownPredicate;
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
 use object_store::ObjectStore;
 use object_store::path::Path;
@@ -169,6 +169,13 @@ impl VortexSource {
         self
     }
 
+    /// Set whether hash-join dynamic filters are evaluated inside the Vortex scan.
+    #[must_use]
+    pub fn with_dynamic_filter_pushdown(mut self, enabled: bool) -> Self {
+        self.options.dynamic_filter_pushdown = enabled;
+        self
+    }
+
     /// Returns the table options for this source.
     #[must_use]
     pub fn options(&self) -> &VortexTableOptions {
@@ -181,6 +188,15 @@ impl VortexSource {
         self.options = opts;
         self
     }
+}
+
+/// Returns `true` if `expr` is, or contains anywhere in its tree, a
+/// [`DynamicFilterPhysicalExpr`] (e.g. a hash-join build-side filter).
+fn contains_dynamic_filter(expr: &Arc<dyn PhysicalExpr>) -> bool {
+    if expr.as_any().is::<DynamicFilterPhysicalExpr>() {
+        return true;
+    }
+    expr.children().into_iter().any(contains_dynamic_filter)
 }
 
 impl FileSource for VortexSource {
@@ -338,60 +354,77 @@ impl FileSource for VortexSource {
         let mut source = self.clone();
         source.target_partitions = Some(config.execution.target_partitions.max(1));
 
-        // Combine new filters with existing predicate for file pruning.
-        // This full predicate is used by FilePruner to eliminate files.
-        source.full_predicate = match source.full_predicate {
-            Some(predicate) => Some(conjunction(
-                std::iter::once(predicate).chain(filters.clone()),
-            )),
-            None => Some(conjunction(filters.clone())),
-        };
+        // Hash-join *dynamic* filters (e.g. a build-side `IN` list) are declined
+        // from the Vortex scan unless explicitly enabled.
+        let gate_dynamic = !self.options.dynamic_filter_pushdown;
 
-        let supported_filters = filters
-            .into_iter()
-            .map(|expr| {
-                if self
-                    .expression_convertor
-                    .can_be_pushed_down(&expr, self.table_schema.file_schema())
-                {
-                    PushedDownPredicate::supported(expr)
-                } else {
-                    PushedDownPredicate::unsupported(expr)
-                }
-            })
-            .collect::<Vec<_>>();
-
-        if supported_filters
-            .iter()
-            .all(|p| matches!(p.discriminant, PushedDown::No))
-        {
-            return Ok(FilterPushdownPropagation::with_parent_pushdown_result(
-                vec![PushedDown::No; supported_filters.len()],
-            )
-            .with_updated_node(Arc::new(source) as _));
+        enum Class {
+            /// Convertible and evaluated inside the Vortex scan (row-level + pruning).
+            RowEval,
+            /// Not row-evaluable, but kept in the file-pruning predicate.
+            PruneOnly,
+            /// Gated dynamic filter: bypasses the Vortex scan entirely.
+            Gated,
         }
 
-        let supported = supported_filters
+        let classes: Vec<Class> = filters
             .iter()
-            .filter_map(|p| match p.discriminant {
-                PushedDown::Yes => Some(&p.predicate),
-                PushedDown::No => None,
+            .map(|expr| {
+                if gate_dynamic && contains_dynamic_filter(expr) {
+                    Class::Gated
+                } else if self
+                    .expression_convertor
+                    .can_be_pushed_down(expr, self.table_schema.file_schema())
+                {
+                    Class::RowEval
+                } else {
+                    Class::PruneOnly
+                }
             })
-            .cloned();
+            .collect();
 
-        let predicate = match source.vortex_predicate {
-            Some(predicate) => conjunction(std::iter::once(predicate).chain(supported)),
-            None => conjunction(supported),
+        // Combine non-gated filters with the existing predicate for file pruning.
+        // This full predicate is used by FilePruner to eliminate files.
+        let prunable = filters
+            .iter()
+            .zip(&classes)
+            .filter(|(_, class)| !matches!(class, Class::Gated))
+            .map(|(expr, _)| Arc::clone(expr));
+        source.full_predicate = match source.full_predicate {
+            Some(predicate) => Some(conjunction(std::iter::once(predicate).chain(prunable))),
+            None => {
+                let prunable: Vec<_> = prunable.collect();
+                (!prunable.is_empty()).then(|| conjunction(prunable))
+            }
         };
 
-        tracing::debug!(%predicate, "Saving predicate");
+        // Only row-evaluable filters enter the Vortex scan predicate.
+        if classes.iter().any(|class| matches!(class, Class::RowEval)) {
+            let row_eval = filters
+                .iter()
+                .zip(&classes)
+                .filter(|(_, class)| matches!(class, Class::RowEval))
+                .map(|(expr, _)| Arc::clone(expr));
+            let predicate = match source.vortex_predicate {
+                Some(predicate) => conjunction(std::iter::once(predicate).chain(row_eval)),
+                None => conjunction(row_eval),
+            };
+            tracing::debug!(%predicate, "Saving predicate");
+            source.vortex_predicate = Some(predicate);
+        }
 
-        source.vortex_predicate = Some(predicate);
+        let pushdown_result = classes
+            .iter()
+            .map(|class| match class {
+                Class::RowEval => PushedDown::Yes,
+                Class::PruneOnly | Class::Gated => PushedDown::No,
+            })
+            .collect();
 
-        Ok(FilterPushdownPropagation::with_parent_pushdown_result(
-            supported_filters.iter().map(|f| f.discriminant).collect(),
+        Ok(
+            FilterPushdownPropagation::with_parent_pushdown_result(pushdown_result)
+                .with_updated_node(Arc::new(source) as _),
         )
-        .with_updated_node(Arc::new(source) as _))
     }
 
     fn try_pushdown_projection(
@@ -471,5 +504,75 @@ mod tests {
             resolve_scan_concurrency(ScanConcurrency::Off, 16, 1, false),
             1
         );
+    }
+
+    use arrow_schema::DataType;
+    use arrow_schema::Field;
+    use arrow_schema::Schema;
+    use datafusion_common::ScalarValue;
+    use datafusion_physical_plan::expressions as df_expr;
+    use vortex::VortexSessionDefault;
+
+    fn int32_source(dynamic_filter_pushdown: bool) -> VortexSource {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let table_schema = TableSchema::new(schema, vec![]);
+        VortexSource::new(table_schema, VortexSession::default())
+            .with_dynamic_filter_pushdown(dynamic_filter_pushdown)
+    }
+
+    fn in_list_dynamic_filter() -> Arc<dyn PhysicalExpr> {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let column = Arc::new(df_expr::Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+        let values = vec![
+            Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(3)))) as Arc<dyn PhysicalExpr>,
+            Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(7)))) as Arc<dyn PhysicalExpr>,
+        ];
+        let in_list = Arc::new(
+            df_expr::InListExpr::try_new(Arc::clone(&column), values, false, &schema)
+                .expect("IN-list expression should be valid"),
+        ) as Arc<dyn PhysicalExpr>;
+        let dynamic_filter = Arc::new(df_expr::DynamicFilterPhysicalExpr::new(
+            vec![column],
+            Arc::new(df_expr::Literal::new(ScalarValue::Boolean(Some(true)))),
+        ));
+        dynamic_filter
+            .update(in_list)
+            .expect("dynamic filter update should succeed");
+        dynamic_filter as Arc<dyn PhysicalExpr>
+    }
+
+    #[test]
+    fn dynamic_filter_is_declined_by_default() {
+        let source = int32_source(false);
+        let result = source
+            .try_pushdown_filters(vec![in_list_dynamic_filter()], &ConfigOptions::default())
+            .expect("pushdown should succeed");
+
+        assert!(matches!(result.filters.as_slice(), [PushedDown::No]));
+
+        let updated = result.updated_node.expect("updated node should be present");
+        let updated = updated
+            .as_any()
+            .downcast_ref::<VortexSource>()
+            .expect("updated node should be a VortexSource");
+        assert!(updated.vortex_predicate.is_none());
+        assert!(updated.full_predicate.is_none());
+    }
+
+    #[test]
+    fn dynamic_filter_is_pushed_down_when_enabled() {
+        let source = int32_source(true);
+        let result = source
+            .try_pushdown_filters(vec![in_list_dynamic_filter()], &ConfigOptions::default())
+            .expect("pushdown should succeed");
+
+        assert!(matches!(result.filters.as_slice(), [PushedDown::Yes]));
+
+        let updated = result.updated_node.expect("updated node should be present");
+        let updated = updated
+            .as_any()
+            .downcast_ref::<VortexSource>()
+            .expect("updated node should be a VortexSource");
+        assert!(updated.vortex_predicate.is_some());
     }
 }

--- a/crates/vortex/src/persistent/source.rs
+++ b/crates/vortex/src/persistent/source.rs
@@ -199,6 +199,16 @@ fn contains_dynamic_filter(expr: &Arc<dyn PhysicalExpr>) -> bool {
     expr.children().into_iter().any(contains_dynamic_filter)
 }
 
+/// Classification of a pushdown filter, determining how it is applied to the Vortex scan.
+enum FilterDisposition {
+    /// Convertible and evaluated inside the Vortex scan (row-level + pruning).
+    RowEval,
+    /// Not row-evaluable, but kept in the file-pruning predicate.
+    PruneOnly,
+    /// Gated dynamic filter: bypasses the Vortex scan entirely.
+    Gated,
+}
+
 impl FileSource for VortexSource {
     fn create_file_opener(
         &self,
@@ -358,27 +368,18 @@ impl FileSource for VortexSource {
         // from the Vortex scan unless explicitly enabled.
         let gate_dynamic = !self.options.dynamic_filter_pushdown;
 
-        enum Class {
-            /// Convertible and evaluated inside the Vortex scan (row-level + pruning).
-            RowEval,
-            /// Not row-evaluable, but kept in the file-pruning predicate.
-            PruneOnly,
-            /// Gated dynamic filter: bypasses the Vortex scan entirely.
-            Gated,
-        }
-
-        let classes: Vec<Class> = filters
+        let classes: Vec<FilterDisposition> = filters
             .iter()
             .map(|expr| {
                 if gate_dynamic && contains_dynamic_filter(expr) {
-                    Class::Gated
+                    FilterDisposition::Gated
                 } else if self
                     .expression_convertor
                     .can_be_pushed_down(expr, self.table_schema.file_schema())
                 {
-                    Class::RowEval
+                    FilterDisposition::RowEval
                 } else {
-                    Class::PruneOnly
+                    FilterDisposition::PruneOnly
                 }
             })
             .collect();
@@ -388,22 +389,24 @@ impl FileSource for VortexSource {
         let prunable = filters
             .iter()
             .zip(&classes)
-            .filter(|(_, class)| !matches!(class, Class::Gated))
+            .filter(|(_, class)| !matches!(class, FilterDisposition::Gated))
             .map(|(expr, _)| Arc::clone(expr));
-        source.full_predicate = match source.full_predicate {
-            Some(predicate) => Some(conjunction(std::iter::once(predicate).chain(prunable))),
-            None => {
-                let prunable: Vec<_> = prunable.collect();
-                (!prunable.is_empty()).then(|| conjunction(prunable))
-            }
+        source.full_predicate = if let Some(predicate) = source.full_predicate {
+            Some(conjunction(std::iter::once(predicate).chain(prunable)))
+        } else {
+            let prunable: Vec<_> = prunable.collect();
+            (!prunable.is_empty()).then(|| conjunction(prunable))
         };
 
         // Only row-evaluable filters enter the Vortex scan predicate.
-        if classes.iter().any(|class| matches!(class, Class::RowEval)) {
+        if classes
+            .iter()
+            .any(|class| matches!(class, FilterDisposition::RowEval))
+        {
             let row_eval = filters
                 .iter()
                 .zip(&classes)
-                .filter(|(_, class)| matches!(class, Class::RowEval))
+                .filter(|(_, class)| matches!(class, FilterDisposition::RowEval))
                 .map(|(expr, _)| Arc::clone(expr));
             let predicate = match source.vortex_predicate {
                 Some(predicate) => conjunction(std::iter::once(predicate).chain(row_eval)),
@@ -416,8 +419,8 @@ impl FileSource for VortexSource {
         let pushdown_result = classes
             .iter()
             .map(|class| match class {
-                Class::RowEval => PushedDown::Yes,
-                Class::PruneOnly | Class::Gated => PushedDown::No,
+                FilterDisposition::RowEval => PushedDown::Yes,
+                FilterDisposition::PruneOnly | FilterDisposition::Gated => PushedDown::No,
             })
             .collect();
 


### PR DESCRIPTION
## 📝 Summary

Fixes regression for HTAP/chbench queries (q20, q8, q3) introduced by the DF53 upgrade (#11118).

DF53 enables native hash-join dynamic-filter pushdown by default. The join materializes its build-side keys as an `InList` inside a `DynamicFilterPhysicalExpr` and pushes it down into the probe-side scan. The Vortex scan accepts it (at plan time the dynamic filter is still a small placeholder, so `can_be_pushed_down` marks it supported) and ends up evaluating the materialized ~2300-element list with Vortex's `list_contains` kernel.

That kernel is O(N×M): for an N-element constant list it builds N full-length `Eq` arrays and OR-reduces them, with no hashed set. Statistics falsification for a wide scattered list (`AND` over N `OR` terms) also almost never prunes. Result: a single file emitting 1 row took ~36s; q20 scan `until_data` ≈ 705s.

This change makes the Vortex scan decline dynamic-filter row-pushdown, so the filter stays a post-scan Arrow `FilterExec` / join hash-probe — the same division of labor we had pre-DF53 (hashed, O(M)). Arrow/Parquet scans are unaffected and keep the new fast path (hashed `InListExpr` + row-group pruning)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
