### PR TITLE
feat(chbench): add support for bare metal `htap-benchmark` runner

### DIFF
--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -16,15 +16,17 @@ on:
         description: 'Scale factor (warehouses). Terminals = scale_factor * 10.'
         required: false
         type: string
-        default: '1'
+        default: '100'
       terminals:
         description: 'Override OLTP terminal count (default: scale_factor * 10)'
         required: false
         type: string
+        default: '100'
       rate:
         description: 'Target OLTP transaction rate (txns/sec); empty = unlimited'
         required: false
         type: string
+        default: '10000'
       duration:
         description: 'Duration of the HTAP workload in seconds'
         required: false
@@ -82,12 +84,12 @@ jobs:
           fi
           echo "Spicepod file found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
 
-      - name: Install MinIO
-        uses: ./.github/actions/setup-minio
-        with:
-          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+      # - name: Install MinIO
+      #   uses: ./.github/actions/setup-minio
+      #   with:
+      #     minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+      #     minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+      #     minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
 
       - name: Setup spiced
         uses: ./.github/actions/setup-spiced
@@ -126,12 +128,7 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           CHBENCH_PG_HOST: 127.0.0.1
 
-      # Insurance against a crashed/cancelled run leaving an orphaned logical
-      # replication slot behind: an inactive slot keeps pinning WAL until the
-      # next run's prepare() drops it, which can bloat disk on a static PG that
-      # is not torn down between runs. Drop inactive spice_* slots (and their
-      # publications) here so WAL retention is bounded even when no next run
-      # comes. Never fails the job — best-effort cleanup only.
+      # Ensure a crashed/cancelled run leaves no orphaned logical replication slots and publications
       - name: Clean up orphaned replication slots and publications
         if: always()
         env:

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -51,11 +51,12 @@ on:
       runner_type:
         description: 'Runner type'
         required: true
-        default: 'spiceai-dev-xlarge-runners'
+        default: 'htap-benchmark'
         type: choice
         options:
           - 'spiceai-dev-large-runners'
           - 'spiceai-dev-xlarge-runners'
+          - 'htap-benchmark'
 jobs:
   run-htap:
     name: Run CH-BenCHmark
@@ -100,26 +101,10 @@ jobs:
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
 
+      # The 'htap-benchmark' runner has a static local PostgreSQL
       - name: Setup CH-benCH PostgreSQL
+        if: github.event.inputs.runner_type != 'htap-benchmark'
         uses: ./.github/actions/setup-chbench-postgres
-
-      - name: Start resource monitor
-        run: |
-          echo -e "timestamp\tpg_cpu_pct\tpg_mem\tpg_block_io\tspiced_cpu_pct\tspiced_rss_kb\ttestop_cpu_pct\ttestop_rss_kb" > /tmp/resource-monitor.tsv
-          (while true; do
-            ts=$(date -u +%H:%M:%S)
-            pg=$(docker stats chbench-pg --no-stream --format "{{.CPUPerc}}\t{{.MemUsage}}\t{{.BlockIO}}" 2>/dev/null || echo "0%\t0\t0")
-            spiced_line=$(ps -eo pcpu,rss,comm | grep '[s]piced' | head -1 || true)
-            testop_line=$(ps -eo pcpu,rss,comm | grep '[t]estoperator' | head -1 || true)
-            spiced_cpu=$(echo "$spiced_line" | awk '{print $1+0}')
-            spiced_rss=$(echo "$spiced_line" | awk '{print $2+0}')
-            testop_cpu=$(echo "$testop_line" | awk '{print $1+0}')
-            testop_rss=$(echo "$testop_line" | awk '{print $2+0}')
-            echo -e "${ts}\t${pg}\t${spiced_cpu}\t${spiced_rss}\t${testop_cpu}\t${testop_rss}" >> /tmp/resource-monitor.tsv
-            sleep 10
-          done) &
-          echo $! > /tmp/monitor-pid.txt
-          echo "Resource monitor started (PID: $(cat /tmp/monitor-pid.txt))"
 
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |
@@ -141,17 +126,46 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           CHBENCH_PG_HOST: 127.0.0.1
 
-      - name: Stop resource monitor
+      # Insurance against a crashed/cancelled run leaving an orphaned logical
+      # replication slot behind: an inactive slot keeps pinning WAL until the
+      # next run's prepare() drops it, which can bloat disk on a static PG that
+      # is not torn down between runs. Drop inactive spice_* slots (and their
+      # publications) here so WAL retention is bounded even when no next run
+      # comes. Never fails the job — best-effort cleanup only.
+      - name: Clean up orphaned replication slots and publications
         if: always()
+        env:
+          CHBENCH_PG_HOST: 127.0.0.1
+          CHBENCH_PG_PORT: '5432'
+          CHBENCH_PG_USER: bench
+          CHBENCH_PG_PASS: bench
+          CHBENCH_PG_DB: chbench
         run: |
-          if [ -f /tmp/monitor-pid.txt ]; then
-            kill "$(cat /tmp/monitor-pid.txt)" 2>/dev/null || true
-          fi
+          cat > /tmp/chbench-slot-cleanup.sql <<'SQL'
+          DO $$
+          DECLARE r RECORD;
+          BEGIN
+            FOR r IN
+              SELECT slot_name FROM pg_replication_slots
+              WHERE slot_name LIKE 'spice_%' AND NOT active
+            LOOP
+              RAISE NOTICE 'dropping replication slot %', r.slot_name;
+              PERFORM pg_drop_replication_slot(r.slot_name);
+            END LOOP;
+            FOR r IN
+              SELECT pubname FROM pg_publication WHERE pubname LIKE 'spice_%'
+            LOOP
+              RAISE NOTICE 'dropping publication %', r.pubname;
+              EXECUTE format('DROP PUBLICATION IF EXISTS %I', r.pubname);
+            END LOOP;
+          END $$;
+          SQL
 
-      - name: Upload resource monitor
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: resource-monitor
-          path: /tmp/resource-monitor.tsv
-          retention-days: 7
+          if command -v psql >/dev/null 2>&1; then
+            PGPASSWORD="${CHBENCH_PG_PASS}" psql \
+              -h "${CHBENCH_PG_HOST}" -p "${CHBENCH_PG_PORT}" \
+              -U "${CHBENCH_PG_USER}" -d "${CHBENCH_PG_DB}" \
+              -v ON_ERROR_STOP=0 -f /tmp/chbench-slot-cleanup.sql || true
+          else
+            echo "No psql client found; skipping replication cleanup."
+          fi

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -111,13 +111,19 @@ jobs:
 
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |
-          TASKSET=""
+          # Cap spiced CPU on htap-benchmark bare-metal runners
+          SPICED_BIN=/usr/local/bin/spiced
           if [ "${{ github.event.inputs.runner_type }}" = "htap-benchmark" ] && command -v taskset >/dev/null 2>&1; then
-            TASKSET="taskset -c 0-63"
-            echo "Pinning benchmark to CPUs 0-63 via: ${TASKSET}"
+            cat > /tmp/spiced-pinned.sh <<'EOF'
+          #!/usr/bin/env bash
+          exec taskset -c 0-63 /usr/local/bin/spiced "$@"
+          EOF
+            chmod +x /tmp/spiced-pinned.sh
+            SPICED_BIN=/tmp/spiced-pinned.sh
+            echo "Pinning spiced to CPUs 0-63 via wrapper: ${SPICED_BIN}"
           fi
-          ${TASKSET} testoperator run htap \
-            -s /usr/local/bin/spiced \
+          testoperator run htap \
+            -s "${SPICED_BIN}" \
             -p '${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}' \
             --query-set chbench \
             --scale-factor ${{ github.event.inputs.scale_factor }} \

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -84,12 +84,13 @@ jobs:
           fi
           echo "Spicepod file found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
 
-      # - name: Install MinIO
-      #   uses: ./.github/actions/setup-minio
-      #   with:
-      #     minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
-      #     minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-      #     minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+      - name: Install MinIO
+        if: github.event.inputs.runner_type != 'htap-benchmark'
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
 
       - name: Setup spiced
         uses: ./.github/actions/setup-spiced
@@ -110,7 +111,12 @@ jobs:
 
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |
-          testoperator run htap \
+          TASKSET=""
+          if [ "${{ github.event.inputs.runner_type }}" = "htap-benchmark" ] && command -v taskset >/dev/null 2>&1; then
+            TASKSET="taskset -c 0-63"
+            echo "Pinning benchmark to CPUs 0-63 via: ${TASKSET}"
+          fi
+          ${TASKSET} testoperator run htap \
             -s /usr/local/bin/spiced \
             -p '${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}' \
             --query-set chbench \
@@ -127,10 +133,14 @@ jobs:
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           CHBENCH_PG_HOST: 127.0.0.1
+          CHBENCH_PG_PORT: '5432'
+          CHBENCH_PG_USER: bench
+          CHBENCH_PG_PASS: bench
+          CHBENCH_PG_DB: chbench
 
       # Ensure a crashed/cancelled run leaves no orphaned logical replication slots and publications
-      - name: Clean up orphaned replication slots and publications
-        if: always()
+      - name: Clean up PG
+        if: always() && github.event.inputs.runner_type == 'htap-benchmark'
         env:
           CHBENCH_PG_HOST: 127.0.0.1
           CHBENCH_PG_PORT: '5432'

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-adaptive.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-adaptive.yaml
-    runner_type: spiceai-dev-xlarge-runners
+    runner_type: htap-benchmark
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-memory.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-memory.yaml
-    runner_type: spiceai-dev-xlarge-runners
+    runner_type: htap-benchmark
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
-    runner_type: spiceai-dev-xlarge-runners
+    runner_type: htap-benchmark
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
-    runner_type: spiceai-dev-xlarge-runners
+    runner_type: htap-benchmark
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-xlarge-runners
+    runner_type: htap-benchmark
     scale_factor: 100
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
-    runner_type: spiceai-dev-xlarge-runners
+    runner_type: htap-benchmark
     scale_factor: 1000
     terminals: 100
     duration: 600

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -1,7 +1,7 @@
 tests:
   htap:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
-    runner_type: spiceai-dev-xlarge-runners
+    runner_type: htap-benchmark
     scale_factor: 1000
     terminals: 100
     duration: 600

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -306,6 +306,8 @@ pub enum RunnerType {
     DevLarge,
     #[serde(rename = "spiceai-dev-xlarge-runners")]
     DevXLarge,
+    #[serde(rename = "htap-benchmark")]
+    HtapBenchmark,
 }
 
 /// Payload sent to the GitHub Actions workflow request. Should match inputs in `.github/workflows/testoperator_run_texttosql.yml`.
@@ -719,5 +721,30 @@ tests:
         let serialized =
             serde_json::to_value(&test_file.tests.htap[0]).expect("Failed to serialize");
         assert_eq!(serialized["runner_type"], "spiceai-dev-xlarge-runners");
+    }
+
+    #[test]
+    fn test_htap_benchmark_runner_type_round_trip() {
+        let yaml = "
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file].yaml
+    runner_type: htap-benchmark
+    scale_factor: 100
+    duration: 600
+    ready_wait: 300
+";
+
+        let test_file: DispatchTestFile = yaml::from_str(yaml).expect("Failed to deserialize");
+
+        assert!(matches!(
+            test_file.tests.htap[0].runner_type,
+            RunnerType::HtapBenchmark
+        ));
+
+        // Verify it serializes back to the expected workflow input value
+        let serialized =
+            serde_json::to_value(&test_file.tests.htap[0]).expect("Failed to serialize");
+        assert_eq!(serialized["runner_type"], "htap-benchmark");
     }
 }


### PR DESCRIPTION
## 📝 Summary

1. Add support for new `htap-benchmark` runner and switch to it as default for SF100+ HTAP benchmarks
2. Update HTAP `workflow_dispatch` to match SF100 default params

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
