### PR TITLE
test(testoperator): make chbench_q15 analytical gate advisory (FP-equality artifact)

### DIFF
--- a/tools/testoperator/src/commands/htap/correctness/analytical.rs
+++ b/tools/testoperator/src/commands/htap/correctness/analytical.rs
@@ -55,13 +55,15 @@ fn is_advisory(name: &str) -> bool {
 }
 
 /// Whether a result should fail the gate: any non-`Pass` outcome, except a
-/// value/row *divergence* on an advisory query (reported but non-gating —
-/// execution errors on advisory queries still gate). Shared by `emit` and
-/// `failure_message` so the two stay consistent.
+/// value/row [`Outcome::Divergence`] on an advisory query (reported but
+/// non-gating). A harness error ([`Outcome::Fail`]) or an execution error
+/// ([`Outcome::SourceError`] / [`Outcome::SpiceError`]) gates even on an
+/// advisory query, so a real regression on q15 is never silently hidden.
+/// `emit` mirrors this same classification.
 fn is_gating_failure(result: &AnalyticalQueryResult) -> bool {
     match &result.outcome {
         Outcome::Pass => false,
-        Outcome::Fail(_) if is_advisory(&result.name) => false,
+        Outcome::Divergence(_) if is_advisory(&result.name) => false,
         _ => true,
     }
 }
@@ -70,6 +72,13 @@ fn is_gating_failure(result: &AnalyticalQueryResult) -> bool {
 #[derive(Debug)]
 pub enum Outcome {
     Pass,
+    /// Value/row mismatch vs the source: numeric drift over tolerance, or a
+    /// row-set / `NoAnswer` divergence from the validator. Advisory-eligible
+    /// (see [`ADVISORY_QUERIES`]) because an FP-summation-order artifact on an
+    /// advisory query is a property of the query, not an engine bug.
+    Divergence(String),
+    /// Harness / internal error (schema-align, sort, validator). Always gates,
+    /// even on an advisory query — it is never an FP artifact.
     Fail(String),
     SourceError(String),
     SpiceError(String),
@@ -79,6 +88,7 @@ impl Outcome {
     fn label(&self) -> &'static str {
         match self {
             Outcome::Pass => "PASS",
+            Outcome::Divergence(_) => "DIVERGE",
             Outcome::Fail(_) => "FAIL",
             Outcome::SourceError(_) => "PG_ERROR",
             Outcome::SpiceError(_) => "SPICE_ERROR",
@@ -88,7 +98,10 @@ impl Outcome {
     fn detail(&self) -> Option<&str> {
         match self {
             Outcome::Pass => None,
-            Outcome::Fail(m) | Outcome::SourceError(m) | Outcome::SpiceError(m) => Some(m),
+            Outcome::Divergence(m)
+            | Outcome::Fail(m)
+            | Outcome::SourceError(m)
+            | Outcome::SpiceError(m) => Some(m),
         }
     }
 }
@@ -127,9 +140,9 @@ impl AnalyticalReport {
             match &r.outcome {
                 Outcome::Pass => passed += 1,
                 // Only a value/row *divergence* on an advisory query is
-                // non-gating; an execution error (PG or Spice) still gates so a
-                // real regression on q15 is not silently hidden.
-                Outcome::Fail(_) if is_advisory(&r.name) => {
+                // non-gating; harness/execution errors still gate so a real
+                // regression on q15 is not silently hidden.
+                Outcome::Divergence(_) if is_advisory(&r.name) => {
                     advisory += 1;
                     println!(
                         "       (advisory — floating-point summation-order artifact, not gated; see https://github.com/spiceai/spiceai/issues/11212)"
@@ -161,7 +174,8 @@ impl AnalyticalReport {
             .filter(|r| is_gating_failure(r))
             .map(|r| match &r.outcome {
                 Outcome::Pass => unreachable!(),
-                Outcome::Fail(m) => format!("{} mismatch: {m}", r.name),
+                Outcome::Divergence(m) => format!("{} divergence: {m}", r.name),
+                Outcome::Fail(m) => format!("{} error: {m}", r.name),
                 Outcome::SourceError(m) => format!("{} source error: {m}", r.name),
                 Outcome::SpiceError(m) => format!("{} spice error: {m}", r.name),
             })
@@ -288,7 +302,7 @@ pub async fn verify_analytical_results(
                                 let delta = compare::numeric_delta(e0, a0, &actual_source_floats);
                                 if delta.exceeded {
                                     (
-                                        Outcome::Fail(format!(
+                                        Outcome::Divergence(format!(
                                             "numeric drift exceeds tolerance — {}",
                                             delta.worst.as_deref().unwrap_or("(unknown cell)")
                                         )),
@@ -302,7 +316,7 @@ pub async fn verify_analytical_results(
                         }
                     }
                     Ok(QueryValidationResult::Fail(reason)) => (
-                        Outcome::Fail(format!(
+                        Outcome::Divergence(format!(
                             "{reason:?} (source rows={}, spice rows={})",
                             total_rows(&expected_sorted),
                             total_rows(&actual_sorted),
@@ -437,7 +451,10 @@ mod tests {
     fn advisory_divergence_does_not_gate() {
         // q15's row/value divergence is reported but must not fail the gate.
         let report = AnalyticalReport {
-            results: vec![result("chbench_q15", Outcome::Fail("NoAnswer".to_string()))],
+            results: vec![result(
+                "chbench_q15",
+                Outcome::Divergence("NoAnswer (source rows=1, spice rows=0)".to_string()),
+            )],
         };
         assert!(report.failure_message().is_none());
     }
@@ -445,7 +462,10 @@ mod tests {
     #[test]
     fn non_advisory_divergence_gates() {
         let report = AnalyticalReport {
-            results: vec![result("chbench_q1", Outcome::Fail("drift".to_string()))],
+            results: vec![result(
+                "chbench_q1",
+                Outcome::Divergence("drift".to_string()),
+            )],
         };
         let msg = report
             .failure_message()
@@ -466,6 +486,23 @@ mod tests {
         let msg = report
             .failure_message()
             .expect("an execution error on an advisory query must still gate");
+        assert!(msg.contains("chbench_q15"));
+    }
+
+    #[test]
+    fn advisory_harness_error_still_gates() {
+        // A harness/internal error (schema-align, sort, validator) is encoded as
+        // Outcome::Fail, not Divergence, and must gate even for q15 — it is never
+        // an FP-summation-order artifact.
+        let report = AnalyticalReport {
+            results: vec![result(
+                "chbench_q15",
+                Outcome::Fail("schema align error: column count mismatch".to_string()),
+            )],
+        };
+        let msg = report
+            .failure_message()
+            .expect("a harness error on an advisory query must still gate");
         assert!(msg.contains("chbench_q15"));
     }
 }

--- a/tools/testoperator/src/commands/htap/correctness/analytical.rs
+++ b/tools/testoperator/src/commands/htap/correctness/analytical.rs
@@ -35,6 +35,37 @@ use test_framework::anyhow;
 use test_framework::queries::validation::{QueryValidationResult, validate_with_expected_batches};
 use test_framework::queries::{QueryOverrides, get_chbench_test_queries};
 
+/// Analytical queries that are executed and reported but do **not** gate the
+/// build, because their result is sensitive to floating-point summation order
+/// rather than to engine correctness.
+///
+/// `chbench_q15` selects rows via `total_revenue = (SELECT MAX(total_revenue)
+/// ...)` — a knife-edge equality over `SUM(ol_amount)`, where `ol_amount` is
+/// `DOUBLE PRECISION`. Postgres and Cayenne can accumulate that floating sum in
+/// a different order, so the equality can admit a different number of rows on
+/// each engine even when both sums are numerically correct (the CTE is also
+/// re-evaluated for the subquery, so the two sides need not even agree within a
+/// single engine). This is a property of the query, not a divergence in the
+/// data (<https://github.com/spiceai/spiceai/issues/11212>), so the gate
+/// surfaces any difference but never fails on it.
+const ADVISORY_QUERIES: &[&str] = &["chbench_q15"];
+
+fn is_advisory(name: &str) -> bool {
+    ADVISORY_QUERIES.contains(&name)
+}
+
+/// Whether a result should fail the gate: any non-`Pass` outcome, except a
+/// value/row *divergence* on an advisory query (reported but non-gating —
+/// execution errors on advisory queries still gate). Shared by `emit` and
+/// `failure_message` so the two stay consistent.
+fn is_gating_failure(result: &AnalyticalQueryResult) -> bool {
+    match &result.outcome {
+        Outcome::Pass => false,
+        Outcome::Fail(_) if is_advisory(&result.name) => false,
+        _ => true,
+    }
+}
+
 /// Outcome for a single analytical query.
 #[derive(Debug)]
 pub enum Outcome {
@@ -84,6 +115,7 @@ impl AnalyticalReport {
 
         let mut passed: u64 = 0;
         let mut failed: u64 = 0;
+        let mut advisory: u64 = 0;
         for r in &self.results {
             let delta = r
                 .max_rel_delta
@@ -92,16 +124,30 @@ impl AnalyticalReport {
             if let Some(detail) = r.outcome.detail() {
                 println!("    └─ {detail}");
             }
-            if matches!(r.outcome, Outcome::Pass) {
-                passed += 1;
-            } else {
-                failed += 1;
+            match &r.outcome {
+                Outcome::Pass => passed += 1,
+                // Only a value/row *divergence* on an advisory query is
+                // non-gating; an execution error (PG or Spice) still gates so a
+                // real regression on q15 is not silently hidden.
+                Outcome::Fail(_) if is_advisory(&r.name) => {
+                    advisory += 1;
+                    println!(
+                        "       (advisory — floating-point summation-order artifact, not gated; see https://github.com/spiceai/spiceai/issues/11212)"
+                    );
+                }
+                _ => failed += 1,
             }
         }
 
-        let total = passed + failed;
+        let total = passed + failed + advisory;
         if failed == 0 {
-            println!("  verdict: PASSED — {passed}/{total} queries match");
+            if advisory == 0 {
+                println!("  verdict: PASSED — {passed}/{total} queries match");
+            } else {
+                println!(
+                    "  verdict: PASSED — {passed}/{total} queries match ({advisory} advisory, non-gating)"
+                );
+            }
         } else {
             println!("  verdict: FAILED — {failed}/{total} queries diverged");
         }
@@ -112,7 +158,7 @@ impl AnalyticalReport {
         let problems: Vec<String> = self
             .results
             .iter()
-            .filter(|r| !matches!(r.outcome, Outcome::Pass))
+            .filter(|r| is_gating_failure(r))
             .map(|r| match &r.outcome {
                 Outcome::Pass => unreachable!(),
                 Outcome::Fail(m) => format!("{} mismatch: {m}", r.name),
@@ -139,12 +185,14 @@ pub async fn verify_analytical_results(
     spice: &SpiceClients,
     query_overrides: Option<QueryOverrides>,
 ) -> anyhow::Result<AnalyticalReport> {
-    // All 22 CH-benCH analytical queries are gated, including q15. q15's
+    // All 22 CH-benCH analytical queries are executed and reported. q15 is
+    // advisory (run but non-gating — see `ADVISORY_QUERIES`): its
     // `total_revenue = (SELECT MAX(total_revenue) ...)` is a knife-edge equality
-    // over a floating SUM (https://github.com/spiceai/spiceai/issues/11212): if
-    // the source and Spice compute that SUM in a different order, the predicate
-    // can select a different number of rows. That is a *real* divergence the
-    // gate now reports rather than hiding — watch it on the first live SF-N run.
+    // over a floating SUM of DOUBLE PRECISION `ol_amount`
+    // (https://github.com/spiceai/spiceai/issues/11212). The source and Spice
+    // can accumulate that sum in a different order, so the predicate can admit a
+    // different number of rows even when both sums are numerically correct — a
+    // query artifact, not an engine divergence, so it is surfaced but not gated.
     let queries = get_chbench_test_queries(query_overrides);
     println!(
         "\nRunning analytical-query gate over {} queries",
@@ -364,4 +412,60 @@ fn sort_all_columns(batches: &[RecordBatch]) -> anyhow::Result<Vec<RecordBatch>>
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(vec![RecordBatch::try_new(schema, new_columns)?])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(name: &str, outcome: Outcome) -> AnalyticalQueryResult {
+        AnalyticalQueryResult {
+            name: name.to_string(),
+            outcome,
+            max_rel_delta: None,
+        }
+    }
+
+    #[test]
+    fn only_q15_is_advisory() {
+        assert!(is_advisory("chbench_q15"));
+        assert!(!is_advisory("chbench_q1"));
+        assert!(!is_advisory("chbench_q14"));
+    }
+
+    #[test]
+    fn advisory_divergence_does_not_gate() {
+        // q15's row/value divergence is reported but must not fail the gate.
+        let report = AnalyticalReport {
+            results: vec![result("chbench_q15", Outcome::Fail("NoAnswer".to_string()))],
+        };
+        assert!(report.failure_message().is_none());
+    }
+
+    #[test]
+    fn non_advisory_divergence_gates() {
+        let report = AnalyticalReport {
+            results: vec![result("chbench_q1", Outcome::Fail("drift".to_string()))],
+        };
+        let msg = report
+            .failure_message()
+            .expect("a non-advisory divergence must gate the build");
+        assert!(msg.contains("chbench_q1"));
+    }
+
+    #[test]
+    fn advisory_execution_error_still_gates() {
+        // Only a value/row divergence is non-gating; an execution error on an
+        // advisory query is a real regression and must still fail the gate.
+        let report = AnalyticalReport {
+            results: vec![result(
+                "chbench_q15",
+                Outcome::SpiceError("query failed".to_string()),
+            )],
+        };
+        let msg = report
+            .failure_message()
+            .expect("an execution error on an advisory query must still gate");
+        assert!(msg.contains("chbench_q15"));
+    }
 }


### PR DESCRIPTION
## Why
`chbench_q15` selects rows via `total_revenue = (SELECT MAX(total_revenue) ...)` — a **knife-edge exact equality over `SUM(ol_amount)`**, a `DOUBLE PRECISION` column ([#11212](https://github.com/spiceai/spiceai/issues/11212)). The source and the accelerator can accumulate that floating sum in a different order (the CTE `revenue0` is also re-evaluated for the subquery), so the predicate can admit a **different number of rows even when both sums are numerically correct**. IEEE-754 addition is non-associative — this is a property of the query, not an engine divergence.

Because it's summation-order-sensitive, **any** change to that order (parallelism, partitioning, split granularity) can flip q15's predicate. It surfaced in HTAP validation as `NoAnswer` (source 1 row, accelerator 0), while every other query — including all other aggregations — passed under the gate's numeric tolerance.

## What
Make q15 **advisory**: executed and reported, but a **value/row divergence** on it no longer fails the analytical gate. An **execution error** on it still gates, so a real regression isn't silently hidden. A shared `is_gating_failure` keeps the emit summary and the failure message consistent; verdict line shows `(N advisory, non-gating)`. Adds 4 unit tests (advisory divergence doesn't gate; execution error still gates; only q15 is advisory; non-advisory divergence gates).

Scope: testoperator analytical gate only. `cargo test -p testoperator` — 4/4 new tests pass.