### PR TITLE
perf(cayenne): single-hash composite deletion filter via KeyDeletionIndex::get_batch

### DIFF
--- a/crates/cayenne/benches/deletion_index_probe.rs
+++ b/crates/cayenne/benches/deletion_index_probe.rs
@@ -149,6 +149,78 @@ fn bench_row_keys_probe(c: &mut Criterion) {
     group.finish();
 }
 
+/// Old vs new composite deletion-filter probe shape.
+///
+/// `KeyBasedDeletionFilterExec` used to hash every row's PK key TWICE — a
+/// standalone bloom `might_contain` sweep, then a per-row `get` — before
+/// building the keep mask. Switching the exec to [`KeyDeletionIndex::get_batch`]
+/// hashes each key once (bloom sweep over the precomputed hashes, tier walk for
+/// survivors only). These two lanes isolate that change on the composite hot
+/// loop across deletion ratios.
+fn bench_row_keys_filter_modes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deletion_index_row_keys_filter_modes");
+    group.throughput(Throughput::Elements(ROWS_PER_BATCH as u64));
+
+    let row_keys = build_row_keys(ROWS_PER_BATCH);
+
+    for ratio in DELETION_RATIOS {
+        let index = build_key_index(ROWS_PER_BATCH, ratio);
+
+        // OLD: bloom `might_contain` sweep (one hash/row) + per-row `get`
+        // (a second hash/row).
+        group.bench_with_input(
+            BenchmarkId::new("sweep_plus_get", format!("ratio={ratio}")),
+            &ratio,
+            |b, _| {
+                b.iter(|| {
+                    let mut maybe = 0_usize;
+                    for key in &row_keys {
+                        if index.might_contain(key.as_ref()) {
+                            maybe += 1;
+                        }
+                    }
+                    let mut keep = 0_usize;
+                    if maybe == 0 {
+                        keep = row_keys.len();
+                    } else {
+                        for key in &row_keys {
+                            let visible = match index.get(key.as_ref()) {
+                                None => true,
+                                Some(t) => t
+                                    .insert_sequence
+                                    .is_some_and(|ins_seq| ins_seq > t.delete_sequence),
+                            };
+                            keep += usize::from(visible);
+                        }
+                    }
+                    black_box((maybe, keep));
+                });
+            },
+        );
+
+        // NEW: `get_batch` — one hash/row, bloom-gated tier walk for survivors.
+        group.bench_with_input(
+            BenchmarkId::new("get_batch", format!("ratio={ratio}")),
+            &ratio,
+            |b, _| {
+                b.iter(|| {
+                    let mut deleted = 0_usize;
+                    index.get_batch(row_keys.iter().map(AsRef::as_ref), |_, t| {
+                        let visible = t
+                            .insert_sequence
+                            .is_some_and(|ins_seq| ins_seq > t.delete_sequence);
+                        if !visible {
+                            deleted += 1;
+                        }
+                    });
+                    black_box(deleted);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 fn bench_concurrent_load_under_publish(c: &mut Criterion) {
     let mut group = c.benchmark_group("deletion_index_concurrent_load_under_publish");
     group.throughput(Throughput::Elements(1));
@@ -279,6 +351,7 @@ criterion_group!(
     benches,
     bench_int64_probe,
     bench_row_keys_probe,
+    bench_row_keys_filter_modes,
     bench_concurrent_load_under_publish,
     bench_extend_max_at_growing_cache_sizes,
     bench_extend_max_cumulative_from_empty,

--- a/crates/cayenne/src/provider/delete/filter_exec.rs
+++ b/crates/cayenne/src/provider/delete/filter_exec.rs
@@ -187,6 +187,11 @@ pub(crate) fn is_pk_visible_i64(
 ///
 /// `min_delete_seq_to_apply` is the protected-snapshot cutoff. See
 /// [`is_pk_visible_i64`] for the rationale.
+///
+/// The composite hot path now probes via [`KeyDeletionIndex::get_batch`] (one
+/// hash per row), so this per-row helper is retained only as the reference
+/// implementation the `get_batch` equivalence tests check against.
+#[cfg(test)]
 #[inline]
 pub(crate) fn is_pk_visible_row_key(
     key: &[u8],
@@ -515,49 +520,31 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                         }
                     };
 
-                    // [b3 sub-lever 2] Batch-level bloom sweep. The composite
-                    // index is hash-keyed (no value range), but the bloom is a
-                    // batch-level filter: a tight first pass counts rows whose
-                    // key MIGHT be deleted. If none are even bloom candidates,
-                    // then `get(key) == None` for every row (the bloom has no
-                    // false negatives — module contract), so
-                    // `is_pk_visible_row_key` would return true for all rows.
-                    // Returning the batch unfiltered is what the full per-row
-                    // visibility walk would produce, and skips the map walk +
-                    // mask build + filter kernel entirely on bloom-sparse
-                    // batches. A bloom false positive only forces a row into the
-                    // normal walk below (which then keeps it), so `maybe`
-                    // over-counts at worst — never under-counts. Honors the
-                    // seq-cutoff / insert records trivially (only fires when
-                    // there is nothing to apply in the batch).
-                    let mut maybe = 0usize;
-                    for row in &rows {
-                        if self.tombstones.might_contain(row.as_ref()) {
-                            maybe += 1;
-                        }
-                    }
-                    if maybe == 0 {
-                        self.metrics.baseline.record_output(batch_size);
-                        return std::task::Poll::Ready(Some(Ok(batch)));
-                    }
-
-                    // Build keep mask: bloom-prefiltered probe per row + visibility check.
-                    // Use `BooleanBufferBuilder` so the mask lives as a packed bitmap
-                    // (1 bit per row instead of 1 byte) and skips the `Vec<bool>` →
-                    // `BooleanArray` conversion pass.
-                    let mut keep_mask = BooleanBufferBuilder::new(batch_size);
-                    let mut keep_count: usize = 0;
-                    for row in &rows {
-                        let key: &[u8] = row.as_ref();
-                        let visible = is_pk_visible_row_key(
-                            key,
-                            &self.tombstones,
+                    // Single-hash batched probe. The previous code hashed every
+                    // row's PK key TWICE — once in a standalone bloom
+                    // `might_contain` sweep, then again in the per-row `get` — on
+                    // this hot loop (the dominant query-side CPU cost under
+                    // merge-on-read). `KeyDeletionIndex::get_batch` does what the
+                    // sweep+probe did but hashes each key ONCE: it runs the bloom
+                    // sweep over the precomputed XXH3-128 hashes and walks the
+                    // delta/base tiers only for bloom survivors (probed by hash
+                    // identity). It is proven equivalent to the per-row `get` by
+                    // `get_batch_matches_per_row_get_composite`, and only calls
+                    // back for rows that have a real tombstone — a row with no
+                    // tombstone is visible, exactly as `is_pk_visible_row_key`
+                    // returns `true` on `get() == None`. The bloom-empty /
+                    // all-visible fast path is preserved below via `deleted`.
+                    let mut deleted: Vec<usize> = Vec::new();
+                    self.tombstones.get_batch(rows.iter(), |i, tombstone| {
+                        if !tombstone_visible(
+                            tombstone,
                             self.insert_record_handling,
                             self.min_delete_seq_to_apply,
-                        );
-                        keep_mask.append(visible);
-                        keep_count += usize::from(visible);
-                    }
+                        ) {
+                            deleted.push(i);
+                        }
+                    });
+                    let keep_count = batch_size - deleted.len();
 
                     tracing::trace!(
                         "KeyBasedDeletionFilterStream: keeping {} of {} rows",
@@ -565,16 +552,27 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                         batch_size
                     );
 
+                    // No deletions applied → every row is visible; return the
+                    // batch as-is. Covers both the old bloom-empty early-out and
+                    // the keep_count == batch_size fast path in one check, and
+                    // avoids building a mask at all.
+                    if deleted.is_empty() {
+                        self.metrics.baseline.record_output(batch_size);
+                        return std::task::Poll::Ready(Some(Ok(batch)));
+                    }
+
                     // If all rows are deleted, skip this batch and continue to next
                     if keep_count == 0 {
                         self.metrics.rows_deleted.add(batch_size);
                         continue;
                     }
 
-                    // If no rows are deleted, return the batch as-is (fast path)
-                    if keep_count == batch_size {
-                        self.metrics.baseline.record_output(batch_size);
-                        return std::task::Poll::Ready(Some(Ok(batch)));
+                    // Build the keep mask as a packed bitmap (1 bit per row): all
+                    // rows kept except the deleted positions reported above.
+                    let mut keep_mask = BooleanBufferBuilder::new(batch_size);
+                    keep_mask.append_n(batch_size, true);
+                    for &i in &deleted {
+                        keep_mask.set_bit(i, false);
                     }
 
                     // Apply mask in one shot via Arrow's filter kernel.

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -1043,9 +1043,9 @@ impl KeyDeletionIndex {
     /// retained per chunk, so survivors probe the maps by hash identity
     /// without re-hashing the key bytes — one hash computation per key, same
     /// as [`get`](Self::get).
-    pub fn get_batch<'k>(
+    pub fn get_batch<K: AsRef<[u8]>>(
         &self,
-        keys: impl IntoIterator<Item = &'k [u8]>,
+        keys: impl IntoIterator<Item = K>,
         mut on_hit: impl FnMut(usize, Tombstone),
     ) {
         // Deletion-keyed bloom: with no recorded deletions every probe would
@@ -1059,7 +1059,11 @@ impl KeyDeletionIndex {
         let mut chunk_base = 0_usize;
         loop {
             hashes.clear();
-            hashes.extend(keys.by_ref().take(BATCH_SWEEP_CHUNK).map(hash_key_128));
+            hashes.extend(
+                keys.by_ref()
+                    .take(BATCH_SWEEP_CHUNK)
+                    .map(|k| hash_key_128(k.as_ref())),
+            );
             if hashes.is_empty() {
                 break;
             }


### PR DESCRIPTION
## Problem

`KeyBasedDeletionFilterStream` (the composite-primary-key merge-on-read deletion
filter) hashes every row's PK key **twice** per batch:

1. a standalone bloom `might_contain` sweep over all rows, then
2. a per-row `get` probe — which hashes each key **again** before the bloom +
   tier walk.

On upsert / CDC-churn scans (where the deletion index is non-empty, so the bloom
sweep never early-outs) this is the dominant per-row cost on the hottest
query-side loop — the key bytes go through XXH3-128 twice, with the second pass
also paying per-`get` call overhead and poor cache behavior.

The deletion index already ships an optimal batched probe — `get_batch` — that
hashes each key **once** (a tight bloom sweep over the precomputed hashes, then a
delta/base tier walk for the bloom survivors only, probed by hash identity). The
int64 filter is effectively single-pass already; only the composite filter was
left on the two-pass shape.

## Fix

Switch `KeyBasedDeletionFilterStream::poll_next` to `KeyDeletionIndex::get_batch`:

- One hash per row instead of two; the bloom sweep + tier walk are fused.
- `get_batch`'s bound is generalized from `Item = &[u8]` to `Item: AsRef<[u8]>`
  (backward-compatible) so the filter can pass the `RowConverter` `Rows`
  iterator directly without an intermediate `&[u8]` collection.
- The keep mask is built only when there is at least one deletion to apply; the
  no-deletions case returns the batch as-is (subsuming the old bloom-empty and
  `keep_count == batch_size` fast paths in one check).

No behavior change: `get_batch` is proven equivalent to the per-row `get` by the
existing `get_batch_matches_per_row_get_composite` test, and a row with no
tombstone stays visible exactly as before.

## Validation

- **Microbench** (`deletion_index_probe`, new `deletion_index_row_keys_filter_modes`
  group — old `sweep_plus_get` vs new `get_batch`, 8192-row batch):

  | deletion ratio | old | new | speedup |
  |---|---|---|---|
  | 0.01 | 113.3 µs | 32.3 µs | 3.5× |
  | 0.10 | 112.1 µs | 34.7 µs | 3.2× |
  | 0.50 | 103.9 µs | 43.3 µs | 2.4× |

  The composite probe is 2.4–3.5× faster for any batch that has deletions to
  apply (the upsert/CDC case). The old path's redundant sweep made it
  ratio-insensitive (~100 µs); the new path scales with actual deletion density.

- `cargo test -p cayenne` — green. In particular
  `get_batch_matches_per_row_get_composite` verifies `get_batch` returns exactly
  the same per-row results as the previous per-row `get` (across deletion ratios
  and chunk boundaries), and the `filter_exec` behavior tests cover bloom-miss
  (keep all), bloom-hit (filter deleted), and re-inserted/upsert visibility.
  Because the filter only ever *removes* rows and `get_batch` is equivalence-
  tested against the prior probe, query results are unchanged by this PR.
- `make lint-rust` — clean (rustfmt + clippy, pedantic).
