### PR TITLE
chore(deps): bump iceberg-rust to parallel file scanning fork (release/2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8257,8 +8257,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -9479,7 +9479,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -9557,7 +9557,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9572,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422#ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -9626,7 +9626,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422#ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422#ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9667,7 +9667,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422#ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422#ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9701,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "iceberg_test_utils"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422#ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422"
 dependencies = [
  "iceberg",
  "tracing-subscriber",
@@ -14742,7 +14742,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14780,7 +14780,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -22524,7 +22524,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8257,8 +8257,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -9479,7 +9479,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -9557,7 +9557,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -14742,7 +14742,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14780,7 +14780,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -22524,7 +22524,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9572,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a24ad5d40cccc914e47762ab6c4023f01b606b47#a24ad5d40cccc914e47762ab6c4023f01b606b47"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -9626,7 +9626,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a24ad5d40cccc914e47762ab6c4023f01b606b47#a24ad5d40cccc914e47762ab6c4023f01b606b47"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a24ad5d40cccc914e47762ab6c4023f01b606b47#a24ad5d40cccc914e47762ab6c4023f01b606b47"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9667,7 +9667,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a24ad5d40cccc914e47762ab6c4023f01b606b47#a24ad5d40cccc914e47762ab6c4023f01b606b47"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a24ad5d40cccc914e47762ab6c4023f01b606b47#a24ad5d40cccc914e47762ab6c4023f01b606b47"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9701,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "iceberg_test_utils"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a24ad5d40cccc914e47762ab6c4023f01b606b47#a24ad5d40cccc914e47762ab6c4023f01b606b47"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=65463fe69575860d53f047e8b5ec9b0922dc7c78#65463fe69575860d53f047e8b5ec9b0922dc7c78"
 dependencies = [
  "iceberg",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,12 +443,12 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" }              # spiceai-52
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" } # spiceai-52
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" } # spiceai-52
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" }   # spiceai-52
-iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" } # spiceai-52
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" }   # spiceai-52
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" }              # spiceai-52
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # spiceai-52
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # spiceai-52
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" }   # spiceai-52
+iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # spiceai-52
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" }   # spiceai-52
 
 # candle-* crates are already redirected to the spiceai/candle fork via the
 # [patch.crates-io] block higher up in this file. Keeping those here would be

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,12 +443,12 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a24ad5d40cccc914e47762ab6c4023f01b606b47" }              # spiceai-52
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a24ad5d40cccc914e47762ab6c4023f01b606b47" } # spiceai-52
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a24ad5d40cccc914e47762ab6c4023f01b606b47" } # spiceai-52
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a24ad5d40cccc914e47762ab6c4023f01b606b47" }   # spiceai-52
-iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a24ad5d40cccc914e47762ab6c4023f01b606b47" } # spiceai-52
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a24ad5d40cccc914e47762ab6c4023f01b606b47" }   # spiceai-52
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" }              # spiceai-52
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" } # spiceai-52
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" } # spiceai-52
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" }   # spiceai-52
+iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" } # spiceai-52
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "65463fe69575860d53f047e8b5ec9b0922dc7c78" }   # spiceai-52
 
 # candle-* crates are already redirected to the spiceai/candle fork via the
 # [patch.crates-io] block higher up in this file. Keeping those here would be

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,12 +443,12 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "3d1f5f6f6d6
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" }              # spiceai-52
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # spiceai-52
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # spiceai-52
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" }   # spiceai-52
-iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # spiceai-52
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" }   # spiceai-52
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # branch: spiceai-0.9.1-df-52
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # branch: spiceai-0.9.1-df-52
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # branch: spiceai-0.9.1-df-52
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # branch: spiceai-0.9.1-df-52
+iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # branch: spiceai-0.9.1-df-52
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ff09ec55bd49effe01ed9d4dafc5c8a6e10fd422" } # branch: spiceai-0.9.1-df-52
 
 # candle-* crates are already redirected to the spiceai/candle fork via the
 # [patch.crates-io] block higher up in this file. Keeping those here would be


### PR DESCRIPTION
release/2.0 backport of #11328. Re-pins `spiceai/iceberg-rust` to the eager task-bucketing parallel-scan change on the DF52 line.

- Fork PR: spiceai/iceberg-rust#44 (port of apache/iceberg-rust#2298)
- Pins `spiceai-0.9.1-df-52` @ `65463fe6` (was `spiceai-52` @ `a24ad5d4`)

Not a literal cherry-pick of #11328 — that pins the DF53 line (`spiceai-0.9.1-df-53`); this pins the DF52 line `release/2.0` builds against. The `spiceai-52` branch is renamed `spiceai-0.9.1-df-52` per the `spiceai-<iceberg>-df-<datafusion>` convention (alias retained); the version requirement stays caret `"0.9.0"` (satisfied by the fork's 0.9.1).

## Effect on Spice

`IcebergTableProvider::scan()` now plans files eagerly and distributes file scan tasks across `min(target_partitions, n_files)` DataFusion partitions, so Iceberg file reads are scheduled concurrently. **No Spice code changes** — Spice consumes the provider only via `IcebergTableProvider::try_new`; the fork preserves Spice's Iceberg limit-pushdown.

## Validation

- `cargo check -p data_components` clean against the bumped rev (Spice **DataFusion 52** fork), based on current `release/2.0` (`d16271c8`).
- Fork validated independently: 86 lib tests + all 9 `df_*` sqllogictest schedules + integration test; clippy/fmt clean (DataFusion 52.2).
