### PR TITLE
ci(spiced_docker_dev): show tag, branch, and commit SHA in run name

### DIFF
--- a/.github/workflows/spiced_docker_dev.yml
+++ b/.github/workflows/spiced_docker_dev.yml
@@ -1,4 +1,5 @@
 name: spiced_docker_dev
+run-name: 'spiced_docker_dev: ${{ inputs.tag }} (branch ${{ github.ref_name }} @ ${{ github.sha }})'
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Adds a top-level `run-name` to the `spiced_docker_dev` workflow so each manually dispatched build is identifiable in the Actions runs list.

Today every dispatched run shows the generic `spiced_docker_dev` title, so you can't tell which image tag / branch / commit a run built without clicking into it. With this change the run title reads, e.g.:

```
spiced_docker_dev: my-feature (branch phillip/foo @ 79f8cb60...)
```

## Details

```yaml
run-name: 'spiced_docker_dev: ${{ inputs.tag }} (branch ${{ github.ref_name }} @ ${{ github.sha }})'
```

- **tag** → `inputs.tag` (the image tag being published)
- **branch** → `github.ref_name` (branch the run was dispatched on)
- **commit SHA** → `github.sha`

`run-name` only resolves the `github`/`inputs`/`vars` contexts (not `needs`/`steps` outputs), so the job-computed short SHA isn't available there — this uses the full `github.sha`. GitHub Actions expressions have no substring function to shorten it inline.

## Testing

No build/logic change — workflow metadata only. YAML validated locally; takes effect on the next `workflow_dispatch` run.