### PR TITLE
fix(Vortex): decline only the `InList` membership conjunct of hash-join dynamic filters

### DIFF
--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -670,11 +670,6 @@ impl CayenneContext {
         VortexTableOptions {
             target_file_size_mb: config.target_vortex_file_size_mb,
             projection_pushdown: ProjectionPushdown::On,
-            // `dynamic_filter_pushdown` is left at its default (off): Vortex's
-            // IN-list / `list_contains` evaluation has no hashset (O(K×N)), so
-            // absorbing a hash-join build-side dynamic filter into the Vortex
-            // scan is slower than letting DataFusion's hashed join probe apply
-            // it. See #11307 and `mem_tier_join_does_not_push_dynamic_filter_into_vortex_scan`.
             segment_cache_size_bytes,
             ..VortexTableOptions::default()
         }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -22828,16 +22828,8 @@ mod tests {
         );
     }
 
-    /// Pins that a DF53 hash-join DYNAMIC filter is NOT absorbed into the Vortex
-    /// scan, even when the fact table has a resident in-memory CDC tier (the
-    /// scan is then union(file branch, bare memory branch)). Vortex's IN-list /
-    /// `list_contains` evaluation has no hashset (O(K×N)) and is slower than
-    /// `DataFusion`'s hashed join probe, so `dynamic_filter_pushdown` is left
-    /// default-off (#11307) and the hash join applies the filter. This guards
-    /// against a regression that re-absorbs the dynamic filter into the Vortex
-    /// scan — the slower path.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn mem_tier_join_does_not_push_dynamic_filter_into_vortex_scan() {
+    async fn mem_tier_join_probe_keeps_dynamic_filter_pushdown() {
         use arrow::array::Int64Array;
         use datafusion::datasource::MemTable;
 
@@ -22911,20 +22903,16 @@ mod tests {
         let display = datafusion_physical_plan::displayable(physical.as_ref())
             .indent(true)
             .to_string();
-        // #11307 keeps `dynamic_filter_pushdown` off: the build-side dynamic
-        // filter must NOT be absorbed into the Vortex scan (its DataSourceExec
-        // predicate). Vortex IN-list eval is slower than DataFusion's hashed
-        // join probe, which applies the filter instead. Guard against
-        // re-enabling the slower path.
-        let pushed_into_vortex_scan = display.lines().any(|line| {
+        let probe_side_installed = display.lines().any(|line| {
             let l = line.to_lowercase();
-            l.contains("datasourceexec") && l.contains("dynamicfilter")
+            (l.contains("datasourceexec") || l.contains("filterexec"))
+                && l.contains("dynamicfilter")
         });
         assert!(
-            !pushed_into_vortex_scan,
-            "dynamic filter must NOT be pushed into the Vortex scan (DataSourceExec); \
-             it is left to the hash join because Vortex IN-list eval is slower than \
-             DataFusion's hashed probe. Plan:\n{display}"
+            probe_side_installed,
+            "dimension->fact dynamic filter must install on the PROBE side (a scan or \
+             absorber FilterExec line), not merely display on the join, even with a \
+             resident mem tier (bare memory branch blocks pushdown). Plan:\n{display}"
         );
     }
 

--- a/crates/vortex/src/persistent/format.rs
+++ b/crates/vortex/src/persistent/format.rs
@@ -302,13 +302,6 @@ config_namespace! {
         pub scan_concurrency: ScanConcurrency, default = ScanConcurrency::Auto
         /// Total byte capacity for a path-aware segment cache shared by scans using this format.
         pub segment_cache_size_bytes: Option<usize>, default = None
-        /// Whether to evaluate hash-join *dynamic* filters inside the Vortex scan.
-        ///
-        /// When `false` (default), a dynamic filter pushed down from a hash join
-        /// (e.g. a build-side `IN` list) is not absorbed into the scan's per-row
-        /// predicate or file-pruning predicate; it is left for the join / a
-        /// post-scan `FilterExec` to apply with a hashed probe.
-        pub dynamic_filter_pushdown: bool, default = false
     }
 }
 
@@ -924,8 +917,7 @@ impl FileFormat for VortexFormat {
     fn file_source(&self, table_schema: TableSchema) -> Arc<dyn FileSource> {
         let mut source = VortexSource::new(table_schema, self.session.clone())
             .with_projection_pushdown(self.opts.projection_pushdown)
-            .with_scan_concurrency(self.opts.scan_concurrency)
-            .with_dynamic_filter_pushdown(self.opts.dynamic_filter_pushdown);
+            .with_scan_concurrency(self.opts.scan_concurrency);
 
         if let Some(segment_cache) = self.segment_cache.clone() {
             source = source.with_segment_cache(segment_cache);

--- a/crates/vortex/src/persistent/opener.rs
+++ b/crates/vortex/src/persistent/opener.rs
@@ -527,6 +527,14 @@ fn collect_vortex_pushdown_conjunct(
         return Ok(());
     }
 
+    // Decline the *membership* (`InList`) conjunct of a hash-join dynamic filter.
+    // Vortex evaluates an `InList` with the O(N×M) `list_contains` kernel per row, which
+    // dominates scan time for large build-side lists.
+    if from_dynamic_filter && expr.as_any().is::<df_expr::InListExpr>() {
+        conjuncts.skipped_dynamic.push(expr);
+        return Ok(());
+    }
+
     if expr_convertor.can_be_pushed_down(&expr, schema) {
         conjuncts.pushed.push(expr);
     } else if from_dynamic_filter || is_dynamic_physical_expr(&expr) {
@@ -1468,5 +1476,77 @@ mod tests {
             "Struct(Dictionary) type should be preserved"
         );
         Ok(())
+    }
+
+    /// Builds a hash-join style dynamic filter `(id >= 3 AND id <= 7) AND id IN (3, 7)`
+    /// — the min/max bounds conjuncts AND the `InList` membership.
+    fn bounds_and_inlist_dynamic_filter() -> PhysicalExprRef {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let column = Arc::new(df_expr::Column::new("id", 0)) as PhysicalExprRef;
+
+        let ge = Arc::new(df_expr::BinaryExpr::new(
+            Arc::clone(&column),
+            Operator::GtEq,
+            Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(3)))),
+        )) as PhysicalExprRef;
+        let le = Arc::new(df_expr::BinaryExpr::new(
+            Arc::clone(&column),
+            Operator::LtEq,
+            Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(7)))),
+        )) as PhysicalExprRef;
+        let bounds = Arc::new(df_expr::BinaryExpr::new(ge, Operator::And, le)) as PhysicalExprRef;
+
+        let in_list = Arc::new(
+            df_expr::InListExpr::try_new(
+                Arc::clone(&column),
+                vec![
+                    Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(3)))) as PhysicalExprRef,
+                    Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(7)))) as PhysicalExprRef,
+                ],
+                false,
+                &schema,
+            )
+            .expect("IN-list expression should be valid"),
+        ) as PhysicalExprRef;
+
+        let combined =
+            Arc::new(df_expr::BinaryExpr::new(bounds, Operator::And, in_list)) as PhysicalExprRef;
+
+        let dynamic_filter = Arc::new(df_expr::DynamicFilterPhysicalExpr::new(
+            vec![column],
+            Arc::new(df_expr::Literal::new(ScalarValue::Boolean(Some(true)))),
+        ));
+        dynamic_filter
+            .update(combined)
+            .expect("dynamic filter update should succeed");
+        dynamic_filter as PhysicalExprRef
+    }
+
+    #[test]
+    fn dynamic_filter_inlist_membership_is_declined() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let convertor = DefaultExpressionConvertor::default();
+        let filter = bounds_and_inlist_dynamic_filter();
+
+        // The cheap min/max bounds conjuncts enter the scan (driving zone pruning) while
+        // the expensive `InList` membership is declined and left to the join hash-probe.
+        let conjuncts = split_vortex_pushdown_conjuncts(&convertor, &filter, &schema)
+            .expect("split should succeed");
+        assert_eq!(
+            conjuncts.pushed.len(),
+            2,
+            "both min/max bounds conjuncts are pushed into the scan"
+        );
+        assert!(conjuncts.unpushed.is_empty());
+        assert_eq!(
+            conjuncts.skipped_dynamic.len(),
+            1,
+            "the InList membership conjunct is declined"
+        );
+        assert!(
+            conjuncts.skipped_dynamic[0]
+                .as_any()
+                .is::<df_expr::InListExpr>()
+        );
     }
 }

--- a/crates/vortex/src/persistent/source.rs
+++ b/crates/vortex/src/persistent/source.rs
@@ -25,7 +25,6 @@ use datafusion_physical_expr_adapter::DefaultPhysicalExprAdapterFactory;
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
 use datafusion_physical_plan::DisplayFormatType;
 use datafusion_physical_plan::PhysicalExpr;
-use datafusion_physical_plan::expressions::DynamicFilterPhysicalExpr;
 use datafusion_physical_plan::filter_pushdown::FilterPushdownPropagation;
 use datafusion_physical_plan::filter_pushdown::PushedDown;
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
@@ -169,13 +168,6 @@ impl VortexSource {
         self
     }
 
-    /// Set whether hash-join dynamic filters are evaluated inside the Vortex scan.
-    #[must_use]
-    pub fn with_dynamic_filter_pushdown(mut self, enabled: bool) -> Self {
-        self.options.dynamic_filter_pushdown = enabled;
-        self
-    }
-
     /// Returns the table options for this source.
     #[must_use]
     pub fn options(&self) -> &VortexTableOptions {
@@ -188,25 +180,6 @@ impl VortexSource {
         self.options = opts;
         self
     }
-}
-
-/// Returns `true` if `expr` is, or contains anywhere in its tree, a
-/// [`DynamicFilterPhysicalExpr`] (e.g. a hash-join build-side filter).
-fn contains_dynamic_filter(expr: &Arc<dyn PhysicalExpr>) -> bool {
-    if expr.as_any().is::<DynamicFilterPhysicalExpr>() {
-        return true;
-    }
-    expr.children().into_iter().any(contains_dynamic_filter)
-}
-
-/// Classification of a pushdown filter, determining how it is applied to the Vortex scan.
-enum FilterDisposition {
-    /// Convertible and evaluated inside the Vortex scan (row-level + pruning).
-    RowEval,
-    /// Not row-evaluable, but kept in the file-pruning predicate.
-    PruneOnly,
-    /// Gated dynamic filter: bypasses the Vortex scan entirely.
-    Gated,
 }
 
 impl FileSource for VortexSource {
@@ -364,64 +337,46 @@ impl FileSource for VortexSource {
         let mut source = self.clone();
         source.target_partitions = Some(config.execution.target_partitions.max(1));
 
-        // Hash-join *dynamic* filters (e.g. a build-side `IN` list) are declined
-        // from the Vortex scan unless explicitly enabled.
-        let gate_dynamic = !self.options.dynamic_filter_pushdown;
+        // Every filter contributes to the file-pruning predicate used by `FilePruner`
+        // to eliminate whole files via statistics / partition values.
+        source.full_predicate = match source.full_predicate {
+            Some(predicate) => Some(conjunction(
+                std::iter::once(predicate).chain(filters.iter().map(Arc::clone)),
+            )),
+            None => Some(conjunction(filters.iter().map(Arc::clone))),
+        };
 
-        let classes: Vec<FilterDisposition> = filters
+        // A filter is row-evaluated inside the Vortex scan only if the convertor can
+        // translate it. Hash-join *dynamic* filters appear here as a `lit(true)`
+        // placeholder and are accepted; the per-conjunct decision of what actually
+        // enters the scan (cheap min/max bounds vs. the expensive `InList` membership)
+        // is deferred to file-open time in `VortexOpener`, once the dynamic filter has
+        // materialized into its real expression.
+        let row_eval: Vec<bool> = filters
             .iter()
             .map(|expr| {
-                if gate_dynamic && contains_dynamic_filter(expr) {
-                    FilterDisposition::Gated
-                } else if self
-                    .expression_convertor
+                self.expression_convertor
                     .can_be_pushed_down(expr, self.table_schema.file_schema())
-                {
-                    FilterDisposition::RowEval
-                } else {
-                    FilterDisposition::PruneOnly
-                }
             })
             .collect();
 
-        // Combine non-gated filters with the existing predicate for file pruning.
-        // This full predicate is used by FilePruner to eliminate files.
-        let prunable = filters
-            .iter()
-            .zip(&classes)
-            .filter(|(_, class)| !matches!(class, FilterDisposition::Gated))
-            .map(|(expr, _)| Arc::clone(expr));
-        source.full_predicate = if let Some(predicate) = source.full_predicate {
-            Some(conjunction(std::iter::once(predicate).chain(prunable)))
-        } else {
-            let prunable: Vec<_> = prunable.collect();
-            (!prunable.is_empty()).then(|| conjunction(prunable))
-        };
-
-        // Only row-evaluable filters enter the Vortex scan predicate.
-        if classes
-            .iter()
-            .any(|class| matches!(class, FilterDisposition::RowEval))
-        {
-            let row_eval = filters
+        if row_eval.iter().any(|&ok| ok) {
+            let supported = filters
                 .iter()
-                .zip(&classes)
-                .filter(|(_, class)| matches!(class, FilterDisposition::RowEval))
+                .zip(&row_eval)
+                .filter(|&(_, &ok)| ok)
                 .map(|(expr, _)| Arc::clone(expr));
             let predicate = match source.vortex_predicate {
-                Some(predicate) => conjunction(std::iter::once(predicate).chain(row_eval)),
-                None => conjunction(row_eval),
+                Some(predicate) => conjunction(std::iter::once(predicate).chain(supported)),
+                None => conjunction(supported),
             };
             tracing::debug!(%predicate, "Saving predicate");
             source.vortex_predicate = Some(predicate);
         }
 
-        let pushdown_result = classes
+        let pushdown_result = row_eval
             .iter()
-            .map(|class| match class {
-                FilterDisposition::RowEval => PushedDown::Yes,
-                FilterDisposition::PruneOnly | FilterDisposition::Gated => PushedDown::No,
-            })
+            .map(|&ok| if ok { PushedDown::Yes } else { PushedDown::No })
             .collect();
 
         Ok(
@@ -507,75 +462,5 @@ mod tests {
             resolve_scan_concurrency(ScanConcurrency::Off, 16, 1, false),
             1
         );
-    }
-
-    use arrow_schema::DataType;
-    use arrow_schema::Field;
-    use arrow_schema::Schema;
-    use datafusion_common::ScalarValue;
-    use datafusion_physical_plan::expressions as df_expr;
-    use vortex::VortexSessionDefault;
-
-    fn int32_source(dynamic_filter_pushdown: bool) -> VortexSource {
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let table_schema = TableSchema::new(schema, vec![]);
-        VortexSource::new(table_schema, VortexSession::default())
-            .with_dynamic_filter_pushdown(dynamic_filter_pushdown)
-    }
-
-    fn in_list_dynamic_filter() -> Arc<dyn PhysicalExpr> {
-        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
-        let column = Arc::new(df_expr::Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
-        let values = vec![
-            Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(3)))) as Arc<dyn PhysicalExpr>,
-            Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(7)))) as Arc<dyn PhysicalExpr>,
-        ];
-        let in_list = Arc::new(
-            df_expr::InListExpr::try_new(Arc::clone(&column), values, false, &schema)
-                .expect("IN-list expression should be valid"),
-        ) as Arc<dyn PhysicalExpr>;
-        let dynamic_filter = Arc::new(df_expr::DynamicFilterPhysicalExpr::new(
-            vec![column],
-            Arc::new(df_expr::Literal::new(ScalarValue::Boolean(Some(true)))),
-        ));
-        dynamic_filter
-            .update(in_list)
-            .expect("dynamic filter update should succeed");
-        dynamic_filter as Arc<dyn PhysicalExpr>
-    }
-
-    #[test]
-    fn dynamic_filter_is_declined_by_default() {
-        let source = int32_source(false);
-        let result = source
-            .try_pushdown_filters(vec![in_list_dynamic_filter()], &ConfigOptions::default())
-            .expect("pushdown should succeed");
-
-        assert!(matches!(result.filters.as_slice(), [PushedDown::No]));
-
-        let updated = result.updated_node.expect("updated node should be present");
-        let updated = updated
-            .as_any()
-            .downcast_ref::<VortexSource>()
-            .expect("updated node should be a VortexSource");
-        assert!(updated.vortex_predicate.is_none());
-        assert!(updated.full_predicate.is_none());
-    }
-
-    #[test]
-    fn dynamic_filter_is_pushed_down_when_enabled() {
-        let source = int32_source(true);
-        let result = source
-            .try_pushdown_filters(vec![in_list_dynamic_filter()], &ConfigOptions::default())
-            .expect("pushdown should succeed");
-
-        assert!(matches!(result.filters.as_slice(), [PushedDown::Yes]));
-
-        let updated = result.updated_node.expect("updated node should be present");
-        let updated = updated
-            .as_any()
-            .downcast_ref::<VortexSource>()
-            .expect("updated node should be a VortexSource");
-        assert!(updated.vortex_predicate.is_some());
     }
 }


### PR DESCRIPTION
## 📝 Summary

Follow-up to #11307: push the min/max bounds of hash-join dynamic filters into the Vortex scan (zone pruning) while still declining the expensive `InListExpr`. Replaces the `dynamic_filter_pushdown` opt-in flag with a single, unconditional rule applied at file-open time in `VortexOpener`: split the materialized dynamic filter into conjuncts, keep the bounds, drop the `InList`.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
