### PR TITLE
fix: scope SQL UDF arg inlining to args-table columns (fixes #11273)

### DIFF
--- a/crates/runtime-datafusion-udfs/src/user_functions/args_inliner.rs
+++ b/crates/runtime-datafusion-udfs/src/user_functions/args_inliner.rs
@@ -38,7 +38,7 @@ use std::collections::HashMap;
 use arrow::datatypes::Schema;
 use datafusion::{
     common::{
-        Column, Result as DataFusionResult,
+        Column, DFSchema, Result as DataFusionResult,
         tree_node::{Transformed, TreeNode},
     },
     logical_expr::{LogicalPlan, Projection, TableScan, expr::Alias},
@@ -53,6 +53,31 @@ fn is_args_table_ref(table_name: &datafusion::sql::TableReference) -> bool {
     table_name
         .table()
         .eq_ignore_ascii_case(SQL_TABLE_ARGS_TABLE_NAME)
+}
+
+/// Returns `true` if an *unqualified* column named `name` resolves uniquely to
+/// a field qualified by the `args` table within `input_schema`.
+///
+/// Derived output columns — aggregate aliases, projection aliases, subquery
+/// outputs, `ORDER BY`/`HAVING` references — are unqualified `Column`s too.
+/// Matching them by name alone (the previous behavior) stomped any such column
+/// whose name happened to collide with a scalar arg, replacing e.g. an
+/// aggregate result with the constant argument value. Resolving the name
+/// against the node's input schema ensures we only inline columns that actually
+/// originate from the `args` table. When the name is absent or ambiguous we are
+/// conservative and do not inline (this only forgoes a pushdown optimization,
+/// never changes results).
+fn unqualified_resolves_to_args(input_schema: &DFSchema, name: &str) -> bool {
+    let mut matches = input_schema
+        .iter()
+        .filter(|(_, field)| field.name().eq_ignore_ascii_case(name))
+        .map(|(qualifier, _)| qualifier);
+    match (matches.next(), matches.next()) {
+        // Unique match: inline only when it is qualified by `args`.
+        (Some(qualifier), None) => qualifier.is_some_and(is_args_table_ref),
+        // No match, or ambiguous across qualifiers: do not inline.
+        _ => false,
+    }
 }
 
 /// If `plan` is `Projection([single_expr], TableScan("args"))` and
@@ -175,6 +200,21 @@ pub(super) fn inline_args_into_plan(
     // all plans (including subquery plans).
     let plan = plan
         .transform_up_with_subqueries(|plan| {
+            // The schema a node's expressions resolve against is the merged
+            // schema of its inputs. Leaf nodes (e.g. `TableScan`) have no
+            // inputs, so fall back to the node's own schema. We use this to
+            // decide whether an *unqualified* column actually refers to the
+            // `args` table rather than to a derived column of the same name.
+            let mut input_schema = DFSchema::empty();
+            let inputs = plan.inputs();
+            if inputs.is_empty() {
+                input_schema.merge(plan.schema());
+            } else {
+                for input in inputs {
+                    input_schema.merge(input.schema());
+                }
+            }
+
             plan.map_expressions(|expr| {
                 expr.transform_up(|e| {
                     if let Expr::Column(Column {
@@ -185,8 +225,8 @@ pub(super) fn inline_args_into_plan(
                     {
                         let key = name.to_ascii_lowercase();
                         let should_replace = match relation {
-                            Some(r) => is_args_table_ref(r) && arg_map.contains_key(&key),
-                            None => arg_map.contains_key(&key),
+                            Some(r) => is_args_table_ref(r),
+                            None => unqualified_resolves_to_args(&input_schema, name),
                         };
                         if should_replace && let Some(value) = arg_map.get(&key) {
                             return Ok(Transformed::yes(Expr::Literal(value.clone(), None)));
@@ -374,6 +414,71 @@ mod tests {
         let original = plan_str(&plan);
         let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
         assert_eq!(original, plan_str(&rewritten));
+    }
+
+    /// Regression for the bug where a scalar arg whose name collides with a
+    /// derived (aggregate/projection-alias) output column stomped that column
+    /// with the arg literal. The body below never references `args`, so the
+    /// arg literal must NOT appear in the rewritten plan — the outer `total`
+    /// is the aggregate alias, not the argument.
+    #[tokio::test]
+    async fn inline_does_not_stomp_derived_column_with_arg_name() {
+        let schema = Schema::new(vec![ArrowField::new(
+            "total",
+            arrow::datatypes::DataType::Int64,
+            true,
+        )]);
+        let values = vec![ScalarValue::Int64(Some(999))];
+        let body = "SELECT total FROM (SELECT sum(id) AS total FROM t) sub";
+        let plan = plan_body(body, &schema, &values).await;
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        let s = plan_str(&rewritten);
+        assert!(
+            !s.contains("Int64(999)"),
+            "Derived column `total` must not be replaced by the arg literal: {s}"
+        );
+        assert!(
+            s.contains("sum(t.id)") || s.contains("sum("),
+            "Aggregate over t.id should be preserved: {s}"
+        );
+    }
+
+    /// A scalar arg referenced as a bare (unqualified) column via
+    /// `CROSS JOIN args` must still be inlined — the fix resolves the name
+    /// against the input schema and finds it uniquely owned by `args`.
+    #[tokio::test]
+    async fn inline_replaces_unqualified_arg_via_cross_join() {
+        let schema = Schema::new(vec![ArrowField::new(
+            "offset",
+            arrow::datatypes::DataType::Int64,
+            true,
+        )]);
+        let values = vec![ScalarValue::Int64(Some(5))];
+        let body = "SELECT id + offset AS r FROM t CROSS JOIN args";
+        let plan = plan_body(body, &schema, &values).await;
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        let s = plan_str(&rewritten);
+        assert!(
+            s.contains("Int64(5)"),
+            "Unqualified arg `offset` should be inlined: {s}"
+        );
+    }
+
+    /// A non-`args` table column that collides with an arg name must not be
+    /// inlined even when referenced unqualified (here `t.name` vs arg `name`).
+    #[tokio::test]
+    async fn inline_does_not_stomp_unqualified_base_table_column() {
+        let schema = utf8_schema(&["name"]);
+        let values = vec![ScalarValue::Utf8(Some("inlined".into()))];
+        // `name` here is `t.name`; `args` is not in scope for this query.
+        let body = "SELECT name FROM t WHERE id > 0";
+        let plan = plan_body(body, &schema, &values).await;
+        let rewritten = inline_args_into_plan(plan, &schema, &values).expect("rewrite");
+        let s = plan_str(&rewritten);
+        assert!(
+            !s.contains("Utf8(\"inlined\")"),
+            "Base-table column `name` must not be replaced by the arg literal: {s}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`crates/runtime-datafusion-udfs/src/user_functions/args_inliner.rs` inlines a SQL table/scalar function's literal arguments into its body plan so the optimizer can fold and push them down. The replacement step matched **unqualified** columns by name alone:

```rust
None => arg_map.contains_key(&key),
```

Derived output columns — aggregate aliases, projection aliases, unaliased subquery outputs, and `ORDER BY`/`HAVING` references — are also unqualified `Column`s (`relation = None`). So a function whose scalar arg name collided with one of those columns had the column silently replaced by the constant argument value. For example, with a scalar arg `total`:

```sql
SELECT total FROM (SELECT sum(value) AS total FROM input)
```

returned the argument constant for every row instead of the aggregate. No error — the plan stayed valid. `ORDER BY <alias>` / `HAVING <alias>` colliding with an arg name were affected the same way.

## Root cause

Name-only matching for unqualified columns cannot distinguish a reference to the `args` table from a same-named derived column in an outer scope.

## Changes

- Resolve each unqualified column against the **input schema** of the plan node it appears in, and inline only when the name resolves *uniquely* to an `args`-qualified field. Absent or ambiguous → leave untouched (this only forgoes a pushdown optimization, never changes results).
- Qualified `args.*` columns continue to inline directly; columns owned by a base table or a derived scope are never replaced.
- Bare arg references via `CROSS JOIN args` still inline correctly (the name resolves uniquely to `args` in the join's input schema).

## Test plan

- `make lint`
- `make test`

New regression tests in `args_inliner.rs`:
- `inline_does_not_stomp_derived_column_with_arg_name` — the reported bug; fails on old code (arg literal stomped the aggregate alias), passes now.
- `inline_replaces_unqualified_arg_via_cross_join` — confirms legitimate bare arg references still inline.
- `inline_does_not_stomp_unqualified_base_table_column` — a base-table column colliding with an arg name is left alone.

All existing `user_functions` tests (45) continue to pass, including the `CROSS JOIN args` integration tests.

## Performance impact

None for correct queries. The fix can only *reduce* inlining in the ambiguous/derived-name case, where the previous behavior was incorrect; normal qualified and uniquely-resolved args references inline and push down exactly as before.

## Checklist

- [x] Root cause identified and fixed at the shared inliner, not a single call site
- [x] Regression test fails on old code, passes on new
- [x] Existing tests pass (`cargo test -p runtime-datafusion-udfs`)
- [x] `cargo clippy -p runtime-datafusion-udfs --all-targets` clean
- [x] `rustfmt --check` clean

Fixes #11273