### PR TITLE
fix(refresh): restore S3 ETag/Version refresh-skip behind provider wrappers (cherry-pick #11339)

### DIFF
--- a/crates/data_components/src/refresh_skip.rs
+++ b/crates/data_components/src/refresh_skip.rs
@@ -18,6 +18,7 @@ limitations under the License.
 
 use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, error::Result as DataFusionResult};
+use datafusion_federation::FederatedTableProviderAdaptor;
 
 /// A trait for table providers that can determine if a refresh operation should be skipped.
 ///
@@ -68,6 +69,14 @@ impl<T: RefreshSkipTableProvider> AsRefreshSkipProvider for T {
 /// This function uses `Any::downcast_ref` to check if the concrete type implements both
 /// `AsRefreshSkipProvider` and can be used to call the refresh skip logic without requiring
 /// the caller to know the concrete type.
+///
+/// The inner refresh-skip provider can be hidden behind wrappers inserted during dataset
+/// registration — most notably schema-metadata enrichment ([`crate::MetadataEnrichedTableProvider`],
+/// applied by `FederatedTable::new` whenever a dataset declares table- or column-level metadata) and
+/// federation adaptors ([`FederatedTableProviderAdaptor`]). Those wrappers return themselves from
+/// `as_any`, so a single direct downcast would silently miss the inner provider and the refresh would
+/// never be skipped. Unwrap the wrappers we know about and recurse so the skip check still reaches the
+/// inner [`RefreshSkipTableProvider`].
 pub async fn should_skip_refresh_for_table_provider(
     table_provider: &(dyn TableProvider + Send + Sync),
 ) -> DataFusionResult<Option<bool>> {
@@ -83,6 +92,20 @@ pub async fn should_skip_refresh_for_table_provider(
     // if let Some(provider) = any.downcast_ref::<SomeOtherType>() {
     //     return provider.should_skip_refresh().await.map(Some);
     // }
+
+    // Unwrap known wrapper providers so the inner refresh-skip provider is still reached.
+    if let Some(enriched) = any.downcast_ref::<crate::MetadataEnrichedTableProvider>() {
+        return Box::pin(should_skip_refresh_for_table_provider(
+            enriched.get_inner_ref().as_ref(),
+        ))
+        .await;
+    }
+
+    if let Some(adaptor) = any.downcast_ref::<FederatedTableProviderAdaptor>()
+        && let Some(inner) = adaptor.table_provider.as_ref()
+    {
+        return Box::pin(should_skip_refresh_for_table_provider(inner.as_ref())).await;
+    }
 
     Ok(None)
 }

--- a/crates/data_components/src/s3_single_file_cached.rs
+++ b/crates/data_components/src/s3_single_file_cached.rs
@@ -506,4 +506,36 @@ mod tests {
                 .expect("second attempt")
         );
     }
+
+    /// Regression test for the lost S3 `ETag`/Version refresh-skip check.
+    ///
+    /// `FederatedTable::new` wraps the connector's provider in a
+    /// [`crate::MetadataEnrichedTableProvider`] whenever the dataset declares table- or
+    /// column-level metadata. That wrapper returns itself from `as_any`, so the previous
+    /// single-level downcast in `should_skip_refresh_for_table_provider` missed the inner
+    /// `S3SingleFileCached`, returned `Ok(None)`, and forced a full S3 fetch on every refresh.
+    /// The skip check must now see through the wrapper.
+    #[tokio::test]
+    async fn test_should_skip_refresh_through_metadata_enriched_wrapper() {
+        let meta = make_meta("file", 128, 10, Some("etag"), Some("v1"));
+        let store = Arc::new(HeadOnlyObjectStore::new(vec![meta.clone()])) as Arc<dyn ObjectStore>;
+        let cached_table = build_cached_table(store, Some(meta));
+
+        let mut extra_metadata = std::collections::HashMap::new();
+        extra_metadata.insert("schema.key".to_string(), "value".to_string());
+        let wrapped: Arc<dyn TableProvider> = Arc::new(crate::MetadataEnrichedTableProvider::new(
+            Arc::new(cached_table) as Arc<dyn TableProvider>,
+            extra_metadata,
+        ));
+
+        let result = crate::refresh_skip::should_skip_refresh_for_table_provider(wrapped.as_ref())
+            .await
+            .expect("skip check should not error");
+
+        assert_eq!(
+            result,
+            Some(true),
+            "refresh-skip must be reached through the metadata-enriched wrapper"
+        );
+    }
 }


### PR DESCRIPTION
Cherry-pick of #11339 onto `release/2.0`. This regression shipped in v2.0.0.

## Problem

For accelerated S3 single-file datasets, the runtime checks the file's
`ETag`/Version ID (and size/`last_modified`) on each refresh and skips the
data fetch when the file is unchanged (`S3SingleFileCached`, surfaced via
`should_skip_refresh_for_table_provider`). That skip was silently lost: the
file was re-fetched from S3 on **every** refresh even when unchanged,
spiking S3 GET requests and continuously "refreshing" the data.

## Root cause

`FederatedTable::new` wraps the connector's provider in a
`MetadataEnrichedTableProvider` whenever a dataset declares table- or
column-level metadata. That wrapper returns itself from `as_any()`, so the
single-level downcast in `should_skip_refresh_for_table_provider` no longer
found the inner `S3SingleFileCached`, returned `Ok(None)`, and the refresh
task fell through to a full fetch every time.

## Fix

Unwrap the known wrapper providers (`MetadataEnrichedTableProvider` →
`get_inner_ref()`, `FederatedTableProviderAdaptor` → `.table_provider`) and
recurse so the skip check reaches the inner `RefreshSkipTableProvider`
again. Preserves metadata enrichment and federation pushdown. Includes a
regression test.

See #11339 for the full description.