### PR TITLE
fix(runtime): retry object-store dataset load when source files are not yet available (#11342)

### DIFF
--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -1562,11 +1562,16 @@ async fn get_last_modified(
     }
 
     if found_extensions.is_empty() {
-        return Err(DataConnectorError::InvalidConfigurationNoSource {
+        // No files at all at the path. This is treated as a transient
+        // (retriable) condition rather than a permanent configuration error:
+        // the source data may not have been written yet (e.g. the object store
+        // is still being populated at startup), so the dataset load keeps
+        // retrying until files appear. Restores pre-#10246 eventual-readiness.
+        return Err(DataConnectorError::ObjectStoreNoFilesAvailable {
             dataconnector: dataconnector.clone(),
             connector_component: ConnectorComponent::from(dataset),
             message: format!(
-                "Failed to find any files matching the extension '{extension}'. Spice could not find any files with extensions at the specified path. Check the path and try again."
+                "Spice could not find any files matching the extension '{extension}' at the specified path."
             ),
         });
     }
@@ -2643,6 +2648,50 @@ mod tests {
         .await;
 
         result.expect_err("should error on no matching extension");
+    }
+
+    #[tokio::test]
+    async fn test_get_last_modified_no_files_is_retriable() {
+        // Regression test for the v2.0.0 dataset-init regression: when an
+        // object-store path has no files yet (e.g. the source has not been
+        // written at startup), get_last_modified must return a RETRIABLE error
+        // so the dataset load keeps retrying until the data appears, rather than
+        // permanently failing and never retrying. (Restores pre-#10246
+        // eventual-readiness for object-store sources.)
+        let url = Url::parse("s3://bucket/").expect("to parse url");
+        let table_path = ListingTableUrl::parse(url.clone()).expect("to parse url");
+        let ctx = SessionContext::new();
+        let app = app::AppBuilder::new("test").build();
+        let rt = crate::Runtime::builder().build().await;
+        let dataset = DatasetBuilder::try_new("s3://bucket/".to_string(), "test")
+            .expect("Failed to create builder")
+            .with_app(Arc::new(app))
+            .with_runtime(Arc::new(rt))
+            .build()
+            .expect("Failed to build dataset");
+
+        // Empty store: no files at all at the path.
+        let test_store = Arc::new(TestObjectStore::new(vec![])) as Arc<dyn ObjectStore>;
+
+        let result = get_last_modified(
+            "TestListingConnector".to_string(),
+            &dataset,
+            ".parquet",
+            table_path,
+            &ctx,
+            &test_store,
+        )
+        .await;
+
+        let err = result.expect_err("should error when no files are present at the path");
+        assert!(
+            matches!(err, DataConnectorError::ObjectStoreNoFilesAvailable { .. }),
+            "no-files-at-path should map to ObjectStoreNoFilesAvailable, got: {err:?}"
+        );
+        assert!(
+            err.is_retriable(),
+            "no-files-at-path must be retriable so the dataset load keeps retrying until data appears"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -272,6 +272,20 @@ pub enum DataConnectorError {
         message: String,
     },
 
+    // Unlike the InvalidConfiguration* variants, this is a transient (retriable)
+    // condition: an object-store source has no data files at the path yet. Object
+    // stores are eventually consistent and data is frequently written after the
+    // runtime starts, so the dataset load must keep retrying until the files
+    // appear rather than failing permanently. See `is_retriable`.
+    #[snafu(display(
+        "No data files are yet available for the {connector_component} ({dataconnector}). {message} The runtime will keep retrying until the source data becomes available."
+    ))]
+    ObjectStoreNoFilesAvailable {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+        message: String,
+    },
+
     #[snafu(display(
         "Cannot setup the {connector_component} ({dataconnector}). The connector '{dataconnector}' is not a valid connector. For details, visit: https://spiceai.org/docs/components/data-connectors"
     ))]


### PR DESCRIPTION
Backport of #11342 to `release/2.0` (for 2.0.1). Cherry-pick is identical to the trunk change.

## Summary

Restores the runtime's pre-#10246 "eventual readiness" behavior for object-store datasets whose source files are not present yet when the runtime starts.

When an object-store dataset (S3, ABFS, GCS, local file, etc.) is loaded and the source path has **no files yet**, schema inference (`get_last_modified`) returned `InvalidConfigurationNoSource`. `DataConnectorError::is_retriable()` classifies that as permanent, and since #10246 the dataset-load retry loop converts permanent failures into `PermanentDatasetFailure` and **stops retrying**. As a result, a dataset whose data is written shortly after the runtime starts fails permanently and never recovers.

Before #10246, every initial-load failure was retried (transient), so the runtime kept retrying until the data appeared and the dataset eventually became `Ready`.

## Fix

Introduce a new **retriable** `DataConnectorError::ObjectStoreNoFilesAvailable` and return it from the empty-path branch of `get_last_modified` instead of the permanent `InvalidConfigurationNoSource`. The dataset-load loop already retries transient errors with Fibonacci backoff, so the dataset becomes ready once the source files appear — without a runtime restart. `is_retriable()` is unchanged (the new variant is simply not in the permanent list); `InvalidConfigurationNoSource` remains permanent for genuine configuration errors.

## Scope

Intentionally narrow: only the empty-path case in `get_last_modified`. Files-present-but-wrong-extension and explicit `schema_source_path` with no matches remain permanent.

## Testing

- New unit test `test_get_last_modified_no_files_is_retriable` (empty store → `ObjectStoreNoFilesAvailable`, `is_retriable() == true`).
- `cargo test -p runtime --lib get_last_modified` → 4/4 pass.
