### PR TITLE
feat(s3): default to path-style for dotted bucket names on standard AWS

### DIFF
--- a/crates/runtime-object-store/src/registry/mod.rs
+++ b/crates/runtime-object-store/src/registry/mod.rs
@@ -189,13 +189,34 @@ impl SpiceObjectStoreRegistry {
                     // Non-IP custom endpoint — cached result or DNS probe.
                     Self::resolve_s3_url_style(bucket_name, ep)
                 } else {
-                    // No custom endpoint (standard AWS) — vhost.
-                    S3UrlStyle::VirtualHosted
+                    // No custom endpoint (standard AWS).
+                    Self::default_aws_url_style(bucket_name)
                 }
             }
         };
 
         self.build_s3_object_store(bucket_name, &params, url_style)
+    }
+
+    /// Default URL style for standard AWS S3 (no custom endpoint) when the user
+    /// did not set `s3_url_style`.
+    ///
+    /// Virtual-hosted style is AWS's default, but a bucket name containing dots
+    /// cannot use it over HTTPS: the wildcard certificate
+    /// (`*.s3.<region>.amazonaws.com`) only matches a single label, so the
+    /// multi-label virtual-hosted host (`my.dotted.bucket.s3.<region>...`) fails
+    /// TLS validation. AWS recommends path style for dotted bucket names, so fall
+    /// back to it automatically. An explicit `s3_url_style` always takes
+    /// precedence over this default.
+    fn default_aws_url_style(bucket_name: &str) -> S3UrlStyle {
+        if bucket_name.contains('.') {
+            tracing::debug!(
+                "s3_url_style not set and bucket '{bucket_name}' contains dots; using path style to avoid the virtual-hosted TLS certificate mismatch on standard AWS"
+            );
+            S3UrlStyle::Path
+        } else {
+            S3UrlStyle::VirtualHosted
+        }
     }
 
     /// Resolve the S3 URL style for a non-IP custom endpoint, using the cache
@@ -790,6 +811,31 @@ mod tests {
         let params = HashMap::from([("url_style".to_string(), "invalid".to_string())]);
         let _ = SpiceObjectStoreRegistry::parse_s3_url_style(&params)
             .expect_err("invalid url_style should error");
+    }
+
+    #[test]
+    fn test_default_aws_url_style_plain_bucket_is_vhost() {
+        assert_eq!(
+            SpiceObjectStoreRegistry::default_aws_url_style("my-bucket"),
+            S3UrlStyle::VirtualHosted
+        );
+    }
+
+    #[test]
+    fn test_default_aws_url_style_dotted_bucket_falls_back_to_path() {
+        // A dotted bucket name cannot use virtual-hosted style over HTTPS on
+        // standard AWS (wildcard TLS cert matches a single label only), so it
+        // must default to path style.
+        assert_eq!(
+            SpiceObjectStoreRegistry::default_aws_url_style(
+                "com.twilio.dev.us-east-1.amazonaws.com"
+            ),
+            S3UrlStyle::Path
+        );
+        assert_eq!(
+            SpiceObjectStoreRegistry::default_aws_url_style("a.b"),
+            S3UrlStyle::Path
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Makes S3 buckets with dots in their name (e.g. `com.twilio.dev.us-east-1.amazonaws.com`) work on standard AWS **without** requiring a manual `s3_url_style: path`.

## Background

In 1.x the S3 object-store builder set no addressing style, so it inherited `object_store`'s default of **path-style** — and dotted bucket names worked transparently. v2.0 added explicit `S3UrlStyle` resolution that defaults standard AWS (no custom endpoint, no explicit `s3_url_style`) to **virtual-hosted style**.

Virtual-hosted style puts the bucket in the hostname (`<bucket>.s3.<region>.amazonaws.com`). For a dotted bucket name the host becomes multi-label (`com.twilio.dev….s3.<region>.amazonaws.com`), which the AWS wildcard certificate `*.s3.<region>.amazonaws.com` **cannot** match (a TLS wildcard matches a single label only) → the HTTPS handshake fails. The only workaround was setting `s3_url_style: path` manually. AWS itself documents this and recommends path-style for dotted bucket names.

## Fix

When `s3_url_style` is not set and there is no custom endpoint (standard AWS), default to **path style** if the bucket name contains a dot; otherwise keep virtual-hosted style. This is the one case where virtual-hosted can never succeed over HTTPS, so the fallback is safe and removes the manual step.

- An explicit `s3_url_style` always takes precedence (unchanged).
- Custom endpoints continue to use the existing DNS-based detection (unchanged).
- Non-dotted buckets still default to virtual-hosted (unchanged).

## Testing

- New `test_default_aws_url_style_dotted_bucket_falls_back_to_path` and `test_default_aws_url_style_plain_bucket_is_vhost`.
- `cargo test -p runtime-object-store --lib url_style` → 11/11 pass.
- CI runs the full `make lint-rust`.

## Backport

Restores the 1.x outcome for dotted buckets, so proposing a cherry-pick to `release/2.0` for 2.0.1.
