### PR TITLE
fix: detect dual-write accelerated tables behind the metadata-enrichment wrapper

### DIFF
--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -46,6 +46,7 @@ mod update;
 
 use std::sync::Arc;
 
+use data_components::MetadataEnrichedTableProvider;
 use datafusion::catalog::TableProvider;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::SessionState;
@@ -285,22 +286,129 @@ async fn is_distributed_insert_table(session: &SessionState, table_name: &TableR
 }
 
 fn is_dual_write_table_provider(table_provider: &Arc<dyn TableProvider>) -> bool {
-    if let Some(accelerated) = table_provider.as_any().downcast_ref::<AcceleratedTable>() {
-        return accelerated.is_dual_write();
-    }
-
-    if let Some(adaptor) = table_provider
+    peel_table_provider_wrappers(table_provider)
         .as_any()
-        .downcast_ref::<FederatedTableProviderAdaptor>()
-        && let Some(inner_provider) = adaptor.table_provider.as_ref()
-        && let Some(accelerated) = inner_provider.as_any().downcast_ref::<AcceleratedTable>()
-    {
-        return accelerated.is_dual_write();
-    }
+        .downcast_ref::<AcceleratedTable>()
+        .is_some_and(AcceleratedTable::is_dual_write)
+}
 
-    false
+/// Peel the wrapper providers that dataset registration can insert between the
+/// catalog entry and the inner `AcceleratedTable`, so callers can downcast to it.
+///
+/// `PolyTableProvider`-backed accelerators are wrapped in a
+/// `FederatedTableProviderAdaptor`, and datasets that declare table- or
+/// column-level metadata are wrapped in a `MetadataEnrichedTableProvider` by
+/// `register_accelerated_table`. Both wrappers return themselves from `as_any`,
+/// and they can nest in either order, so a single direct downcast silently misses
+/// the inner provider — which is how an accelerated table with metadata used to be
+/// misclassified as not-dual-write (the same wrapper-hiding-a-downcast class as
+/// #11339 / #11345). Loop until neither wrapper matches.
+fn peel_table_provider_wrappers(table_provider: &Arc<dyn TableProvider>) -> Arc<dyn TableProvider> {
+    let mut current = Arc::clone(table_provider);
+    loop {
+        if let Some(adaptor) = current
+            .as_any()
+            .downcast_ref::<FederatedTableProviderAdaptor>()
+        {
+            let Some(inner) = adaptor.table_provider.clone() else {
+                break;
+            };
+            current = inner;
+            continue;
+        }
+
+        if let Some(enriched) = current
+            .as_any()
+            .downcast_ref::<MetadataEnrichedTableProvider>()
+        {
+            current = Arc::clone(enriched.get_inner_ref());
+            continue;
+        }
+
+        break;
+    }
+    current
 }
 
 fn matches_write_op(actual: &WriteOp, expected: &WriteOp) -> bool {
     std::mem::discriminant(actual) == std::mem::discriminant(expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::catalog::TableProvider;
+    use datafusion::datasource::MemTable;
+
+    use super::{MetadataEnrichedTableProvider, peel_table_provider_wrappers};
+
+    fn mem_table() -> Arc<dyn TableProvider> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        Arc::new(MemTable::try_new(schema, vec![vec![]]).expect("mem table should be created"))
+    }
+
+    fn enrich(inner: Arc<dyn TableProvider>) -> Arc<dyn TableProvider> {
+        let mut metadata = HashMap::new();
+        metadata.insert("source_owner".to_string(), "analytics".to_string());
+        Arc::new(MetadataEnrichedTableProvider::new(inner, metadata))
+    }
+
+    #[test]
+    fn peel_reaches_inner_through_metadata_wrapper() {
+        // Regression: a dataset that declares table-/column-level metadata is
+        // registered behind a `MetadataEnrichedTableProvider`. `is_dual_write_table_provider`
+        // (via `peel_table_provider_wrappers`) must see through that wrapper to reach the
+        // inner provider; otherwise a dual-write accelerated table with metadata is wrongly
+        // classified as not-dual-write and its INSERTs skip the distributed-insert rewrite.
+        let inner = mem_table();
+        let wrapped = enrich(Arc::clone(&inner));
+        assert!(
+            wrapped
+                .as_any()
+                .downcast_ref::<MetadataEnrichedTableProvider>()
+                .is_some(),
+            "precondition: provider is wrapped in MetadataEnrichedTableProvider"
+        );
+
+        let peeled = peel_table_provider_wrappers(&wrapped);
+        assert!(
+            peeled.as_any().downcast_ref::<MemTable>().is_some(),
+            "peel must reach the inner provider through the metadata wrapper"
+        );
+    }
+
+    #[test]
+    fn peel_reaches_inner_through_nested_metadata_wrappers() {
+        // The wrappers can nest (e.g. metadata-over-federated-over-metadata); the loop
+        // must keep peeling until no known wrapper matches.
+        let inner = mem_table();
+        let wrapped = enrich(enrich(Arc::clone(&inner)));
+
+        let peeled = peel_table_provider_wrappers(&wrapped);
+        assert!(
+            peeled.as_any().downcast_ref::<MemTable>().is_some(),
+            "peel must unwrap every nested metadata wrapper"
+        );
+    }
+
+    #[test]
+    fn peel_is_identity_for_unwrapped_provider() {
+        let inner = mem_table();
+        let peeled = peel_table_provider_wrappers(&inner);
+        assert!(
+            peeled.as_any().downcast_ref::<MemTable>().is_some(),
+            "an unwrapped provider must be returned unchanged"
+        );
+    }
+
+    #[test]
+    fn non_accelerated_metadata_wrapped_table_is_not_dual_write() {
+        // A wrapped non-accelerated table must not be misclassified as dual-write — the
+        // peel only routes the downcast, it does not invent an AcceleratedTable.
+        let wrapped = enrich(mem_table());
+        assert!(!super::is_dual_write_table_provider(&wrapped));
+    }
 }


### PR DESCRIPTION
## Problem

`is_distributed_insert_table` (via `is_dual_write_table_provider` in `crates/runtime/src/datafusion/planner/mod.rs`) decides whether an `INSERT` is rewritten into the distributed-insert path that forwards writes remotely for **dual-write** accelerated tables (the Iceberg federated-catalog cache).

It downcast the catalog's table provider directly to `AcceleratedTable`, or through a single `FederatedTableProviderAdaptor`. But `FederatedTable::new` wraps a provider in a `MetadataEnrichedTableProvider` whenever the dataset declares **table- or column-level metadata** (the same wrapper called out in #11345 and #11339). That wrapper returns itself from `as_any`, and the two wrappers can nest in either order, so a dual-write accelerated table with metadata was hidden behind the wrapper and classified as **not** dual-write.

**User-visible effect:** in scheduler mode, `INSERT` into a dual-write accelerated table that declares metadata silently skipped the distributed-insert rewrite, so the write could be applied only to the local accelerator instead of being dual-written to the federated source — a data-correctness bug that depended on whether the dataset happened to declare metadata. A dataset without metadata worked; adding a column description changed write routing.

## Fix

Peel the known wrapper providers (`FederatedTableProviderAdaptor` and `MetadataEnrichedTableProvider`, which can nest in either order) in a loop before the downcast — matching the canonical peel loop already used in `crates/runtime/src/search/util.rs` and the per-call peeling just added in #11345 / #11339. The peel only routes the downcast; it cannot invent an `AcceleratedTable`, so a non-accelerated wrapped table is still correctly classified as not-dual-write.

This is the same wrapper-hiding-a-downcast class as #11339 and #11345; this sibling call site was missed by those fixes.

## Test plan
- [x] Added regression test `peel_reaches_inner_through_metadata_wrapper` (dual-write detection must see through the metadata wrapper)
- [x] Added edge-case tests: nested metadata wrappers, identity for an unwrapped provider, and a non-accelerated wrapped table not misclassified as dual-write
- [x] `cargo check -p runtime` passes (clean)
- [x] `cargo clippy -p runtime --no-deps` clean on changed code (one pre-existing `needless_return` warning in untouched `builder.rs`)
- [x] `cargo test -p runtime --lib datafusion::planner::tests` — 4 passed, 0 failed
- [x] `rustfmt --edition 2024` applied
- [ ] Note: this is a nested git worktree where workspace-wide `make lint` / `make test` walk up to the parent `Cargo.toml`; the workspace lint/test gates run in CI (Rust Lint / Build and Test).