### PR TITLE
chore(deps): bump git2 to 0.21 (RUSTSEC-2026-0183 — Remote::list unsound)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8429,9 +8429,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.12.1",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ dyn-hash = "1.0.0"
 fundu = "2.0.1"
 futures = "0.3.32"
 gethostname = "1.1.0"
-git2 = { version = "0.20", default-features = false, features = [
+git2 = { version = "0.21", default-features = false, features = [
     "https",
     "ssh",
 ] }


### PR DESCRIPTION
## What
Bump `git2` `0.20` → `0.21` to clear **RUSTSEC-2026-0183**.

## Why
`git2 <0.21.0` passes a null pointer to `slice::from_raw_parts()` in `Remote::list()` when a remote advertises no references — undefined behavior (`unsound`). The workspace `cargo-deny` advisories check ("Check Rust Licenses") now fails on this repo-wide (it affects `trunk` and every open PR), since the advisory was published recently. The advisory's prescribed fix is upgrading to `>=0.21.0`.

## Scope
- **Manifest + lockfile only** (`Cargo.toml` requirement `0.20`→`0.21`, `Cargo.lock` `git2 0.20.4`→`0.21.0`).
- `data_components` is the only `git2` consumer (in `src/git.rs`, 17 call sites); it **compiles unchanged** against the 0.21 API — `cargo check -p data_components` is clean, no code changes required.
- Unblocks the workspace `cargo-deny` advisories gate for all branches.

Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0183