### PR TITLE
fix: Query Redshift schema details from svv_redshift tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=e8d8b3742b280949efe5238f4d864a9c0fa1a501#e8d8b3742b280949efe5238f4d864a9c0fa1a501"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=cbcfdd0c3e33707d57bf7540ac8c0af893900cbe#cbcfdd0c3e33707d57bf7540ac8c0af893900cbe"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ datafusion-proto-common = "53.0.0"
 datafusion-pruning = "53.0.0"
 datafusion-spark = "53.0.0"
 datafusion-substrait = "53.0.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "e8d8b3742b280949efe5238f4d864a9c0fa1a501" } # spiceai-53
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "cbcfdd0c3e33707d57bf7540ac8c0af893900cbe" } # sgrebnov/spiceai-53
 
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates `datafusion-table-providers` to bring in a fix for schema inference of Redshift Datashare tables
* See https://github.com/spiceai/datafusion-table-providers/pull/18 for details