### PR TITLE
ci(testoperator): add scheduled CH-BenCHmark SF1000 HTAP runs

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -6,6 +6,8 @@ on:
     - cron: '0 9 * * *'
     # htap-sf100, every 3h (0200, 0500, 0800, 1100, 1400, 1700, 2000, 2300) — HTAP CH-benCHmark SF100
     - cron: '0 2,5,8,11,14,17,20,23 * * *'
+    # htap-sf1000, twice daily (0000, 1200) — HTAP CH-benCHmark SF1000
+    - cron: '0 0,12 * * *'
 
   workflow_dispatch:
     inputs:
@@ -101,6 +103,7 @@ jobs:
           case "${{ github.event.schedule }}" in
             '0 9 * * *')               NAME=daily-main ;;
             '0 2,5,8,11,14,17,20,23 * * *') NAME=htap-sf100 ;;
+            '0 0,12 * * *')            NAME=htap-sf1000 ;;
             *)                         NAME=           ;;   # manual / unrecognized cron — match nothing
           esac
           echo "Resolved schedule name: $NAME"
@@ -245,6 +248,15 @@ jobs:
         if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/sf100 --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.branch }}
+
+      - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF1000
+        if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'htap-sf1000' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf1000 --workflow htap
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -60,7 +60,7 @@ jobs:
   run-htap:
     name: Run CH-BenCHmark
     runs-on: ${{ github.event.inputs.runner_type }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
@@ -2,21 +2,13 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned-sf1000
 
-# Target: xlarge-runner — 64 vCPU / 256 GiB RAM, SSD storage.
-#
-# Key tuning:
-#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384 (runtime max after Lever D
-#     raised CDC_PREFETCH_BUFFER_MAX / CDC_MAX_COALESCED_ENVELOPES_MAX 4096->16384):
-#     larger CDC bursts cut metastore round-trips and keep WAL drain ahead of bursty OLTP.
-#   - target_partitions 64: read-path parallelism matched to vCPU count.
-#   - per-table cayenne_write_concurrency / segment_cache_mb / compaction_* for the high-volume
-#     upsert tables; reference tables use lighter settings.
+
 runtime:
   params:
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
-    cdc_max_coalesce_age_ms: '4000'
+    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
     cayenne_footer_cache_mb: '1024'
@@ -61,17 +53,26 @@ datasets:
       params: &accel_high_volume
         cayenne_metastore: sqlite
         cayenne_file_path: .spice/cayenne/district
+        # Explicit: the engine default flipped to `memory`. This pod IS the
+        # file-durability variant (per-batch durable persist before the slot
+        # ack) — its identity must not depend on the build's default. The
+        # memory-durability twin is postgres-cayenne[file]-cdc-memory.yaml.
+        cayenne_cdc_durability: file
+        # KEY deletes even in file mode: deletion_mode auto resolves to
+        # position, which serializes compaction with writers (try_lock
+        # starvation under continuous CDC — measured unbounded file/read-amp
+        # growth on the delete-receiving table). Key-delete compaction runs
+        # concurrently with writers.
+        cayenne_deletion_mode: key
         cayenne_write_concurrency: '4'
         cayenne_segment_cache_mb: '1024'
         cayenne_compaction_trigger_protected_snapshots: '3'
-        # Pinned to 1 GiB (SF-1000 sweep): a small keyset budget keeps the heavy-update
-        # tables (stock, order_line) on the cheap bloom path and hits the <30s lag goal for
-        # all 22 queries. The memory-aware auto-default (total_mem/32 -> ~8 GiB on a 256 GiB
-        # host) is BACKWARDS — it over-sizes the exact keyset and hurts those tables. Pin 1024.
-        cayenne_pk_keyset_cache_mb: '1024'
+        cayenne_pk_keyset_cache_mb: '256'
         cayenne_compaction_trigger_snapshot_age_ms: '15000'
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   - from: postgres:customer
     name: customer
@@ -198,10 +199,14 @@ datasets:
       params: &accel_medium
         cayenne_metastore: sqlite
         cayenne_file_path: .spice/cayenne/warehouse
+        # See &accel_high_volume: explicit file durability + key deletes.
+        cayenne_cdc_durability: file
+        cayenne_deletion_mode: key
         cayenne_write_concurrency: '4'
         cayenne_segment_cache_mb: '64'
-        # Pin 1 GiB explicitly (don't leave to the backwards memory-aware auto-default).
-        cayenne_pk_keyset_cache_mb: '1024'
+        cayenne_pk_keyset_cache_mb: '256'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).
@@ -238,10 +243,12 @@ datasets:
       params: &accel_small
         cayenne_metastore: sqlite
         cayenne_file_path: .spice/cayenne/region
+        # See &accel_high_volume: explicit file durability + key deletes.
+        cayenne_cdc_durability: file
+        cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'
         cayenne_segment_cache_mb: '16'
-        # Pin 1 GiB explicitly (don't leave to the backwards memory-aware auto-default).
-        cayenne_pk_keyset_cache_mb: '1024'
+        cayenne_pk_keyset_cache_mb: '256'
 
   - from: postgres:nation
     name: nation

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-adaptive.yaml
@@ -1,10 +1,9 @@
 tests:
   htap:
-    spicepod_path: accelerated/postgres-duckdb[file].yaml
+    spicepod_path: accelerated/postgres-cayenne[file]-adaptive.yaml
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
     duration: 600
     ready_wait: 900
-    query_overrides: duckdb
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-memory.yaml
@@ -1,10 +1,9 @@
 tests:
   htap:
-    spicepod_path: accelerated/postgres-duckdb[file].yaml
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-memory.yaml
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
     duration: 600
     ready_wait: 900
-    query_overrides: duckdb
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -5,5 +5,5 @@ tests:
     scale_factor: 1000
     terminals: 100
     duration: 600
-    ready_wait: 600
+    ready_wait: 900
     rate: 10000


### PR DESCRIPTION
## 📝 Summary

Add the CH-BenCHmark SF1000 HTAP benchmark to the scheduled testoperator dispatch (twice as day)

## Changes

- New cron `0 0,12 * * *` (`htap-sf1000`) — fires twice daily at 0000/1200 UTC. Times are chosen to avoid the every-3h `htap-sf100` slots and the 0900 `daily-main` run, since SF1000 is 10× the data and runs much longer.
- Update SF1000 test configurations to match latest SF100

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
