### PR TITLE
fix(cayenne): honor cayenne_metastore: turso for partitioned tables and the dataset checkpoint

### DIFF
--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -2196,8 +2196,21 @@ impl DataAccelerator for CayenneAccelerator {
             // the MetadataCatalog API), while the concrete handle is needed by
             // `CayennePartitionedInsertStrategy` to open a shared
             // MetastoreTransaction across all partitions (issue #10125).
+            // Honor the configured `cayenne_metastore` backend (Turso uses the
+            // `libsql://` scheme) rather than hardcoding SQLite. The unpartitioned
+            // path (`get_or_create_catalog`) already selects the scheme from this
+            // param; without the same logic here, partitioned tables silently
+            // ignore `cayenne_metastore: turso` and fall back to SQLite.
+            let metastore_type = source
+                .acceleration()
+                .and_then(|a| a.params.get("cayenne_metastore"))
+                .map_or("sqlite", String::as_str);
+            let catalog_connection_string = match metastore_type {
+                "turso" => format!("libsql://{metadata_dir}/cayenne.db"),
+                _ => format!("sqlite://{metadata_dir}/cayenne.db"),
+            };
             let catalog_concrete: Arc<cayenne::CayenneCatalog> = Arc::new(
-                cayenne::CayenneCatalog::new(format!("sqlite://{metadata_dir}/cayenne.db"))
+                cayenne::CayenneCatalog::new(catalog_connection_string)
                     .boxed()
                     .context(AccelerationInitializationFailedSnafu)?,
             );

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -412,7 +412,20 @@ async fn acceleration_connection(
             // Derive metadata directory using shared resolution logic
             let metadata_dir = CayenneAccelerator::resolve_metadata_dir(source.acceleration());
 
-            let metadata_db_path = format!("{metadata_dir}/cayenne.db");
+            // The dataset checkpoint stores its `spice_checkpoint` table in a SQLite
+            // pool. When the Cayenne metastore backend is Turso it owns `cayenne.db`
+            // as a libSQL/MVCC database; opening that same file as a raw SQLite WAL
+            // pool here would re-stamp it SQLite-WAL and conflict with the metastore.
+            // Keep the checkpoint in a separate SQLite file in that case.
+            let metastore_type = source
+                .acceleration()
+                .and_then(|a| a.params.get("cayenne_metastore"))
+                .map_or("sqlite", String::as_str);
+            let metadata_db_path = if metastore_type == "turso" {
+                format!("{metadata_dir}/cayenne-checkpoint.db")
+            } else {
+                format!("{metadata_dir}/cayenne.db")
+            };
 
             if open_option == OpenOption::OpenExisting && !Path::new(&metadata_db_path).exists() {
                 return CayenneMetadataMissingSnafu {

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -412,20 +412,7 @@ async fn acceleration_connection(
             // Derive metadata directory using shared resolution logic
             let metadata_dir = CayenneAccelerator::resolve_metadata_dir(source.acceleration());
 
-            // The dataset checkpoint stores its `spice_checkpoint` table in a SQLite
-            // pool. When the Cayenne metastore backend is Turso it owns `cayenne.db`
-            // as a libSQL/MVCC database; opening that same file as a raw SQLite WAL
-            // pool here would re-stamp it SQLite-WAL and conflict with the metastore.
-            // Keep the checkpoint in a separate SQLite file in that case.
-            let metastore_type = source
-                .acceleration()
-                .and_then(|a| a.params.get("cayenne_metastore"))
-                .map_or("sqlite", String::as_str);
-            let metadata_db_path = if metastore_type == "turso" {
-                format!("{metadata_dir}/cayenne-checkpoint.db")
-            } else {
-                format!("{metadata_dir}/cayenne.db")
-            };
+            let metadata_db_path = format!("{metadata_dir}/cayenne.db");
 
             if open_option == OpenOption::OpenExisting && !Path::new(&metadata_db_path).exists() {
                 return CayenneMetadataMissingSnafu {
@@ -441,6 +428,26 @@ async fn acceleration_connection(
                     .map_err(|e| Error::CayennePool {
                         source: Box::new(e),
                     })?;
+            }
+
+            // When the Cayenne metastore backend is Turso, it owns `cayenne.db` as a
+            // libSQL/MVCC database. Route the checkpoint through a Turso connection
+            // on that same file rather than opening it as a raw SQLite pool, which
+            // would re-stamp it SQLite-WAL and conflict with the metastore.
+            #[cfg(feature = "turso")]
+            {
+                let metastore_type = source
+                    .acceleration()
+                    .and_then(|a| a.params.get("cayenne_metastore"))
+                    .map_or("sqlite", String::as_str);
+                if metastore_type == "turso" {
+                    let pool = super::turso::TursoConnectionPool::new(&metadata_db_path)
+                        .await
+                        .map_err(|e| Error::CayennePool {
+                            source: Box::new(e),
+                        })?;
+                    return Ok(AccelerationConnection::Turso(Arc::new(pool)));
+                }
             }
 
             // Create SQLite connection pool for cayenne metadata using the factory


### PR DESCRIPTION
## Summary

`cayenne_metastore: turso` was silently ignored for **partitioned** Cayenne tables and for the per-dataset **checkpoint**. Both kept using SQLite, so the Turso / `BEGIN CONCURRENT` MVCC metastore never engaged on the high-volume tables where it matters — with no log line and no warning.

The metastore backend is chosen purely from the connection-string scheme (`cayenne_catalog.rs`: `libsql://` → Turso, otherwise SQLite). Two separate sites bypassed `cayenne_metastore` and forced SQLite onto the metastore file `<metadata_dir>/cayenne.db`. This PR fixes both.

## Flow

```text
Before  (cayenne_metastore: turso)
----------------------------------
unpartitioned table  -> get_or_create_catalog          -> libsql://cayenne.db   (Turso, correct)
partitioned table    -> CayennePartitionedInsertStrategy -> sqlite://cayenne.db (SQLite, wrong)
dataset checkpoint   -> raw SQLite WAL pool on cayenne.db (re-stamps file WAL,  wrong)

After
-----
unpartitioned table  -> libsql://cayenne.db
partitioned table    -> libsql://cayenne.db
dataset checkpoint   -> Turso connection on cayenne.db
                        => one file, one backend
```

## Changes

- **Partitioned-insert catalog** (`dataaccelerator/cayenne/mod.rs`): the `CayennePartitionedInsertStrategy` path (issue #10125) hardcoded `sqlite://{metadata_dir}/cayenne.db`. It now builds the scheme from `cayenne_metastore` (`libsql://` for turso, `sqlite://` otherwise), matching the unpartitioned `get_or_create_catalog` path.
- **Dataset checkpoint** (`dataaccelerator/spice_sys.rs`, `Engine::Cayenne` arm): opened `cayenne.db` as a raw SQLite WAL pool regardless of backend, which re-stamped the libSQL/MVCC metastore file and contended with it. When `cayenne_metastore: turso`, the checkpoint now routes through a Turso connection on the same `cayenne.db` (reusing the existing `AccelerationConnection::Turso`, already driven by `init_turso`/`migrate_turso`), so `spice_checkpoint` lives inside the libSQL metastore db. Gated behind the `turso` feature.

## Notes

- No behavior change for the default SQLite metastore.
- Surfaced on an SF100 CH-benCHmark HTAP run (every table `cayenne_metastore: turso`): only the tiny **unpartitioned** `district` table came up on Turso; every **partitioned** high-volume table (`customer`, `order_line`, `stock`, `new_order`, `oorder`) ran SQLite. Fixing the catalog alone was insufficient — the checkpoint re-stamped the file SQLite.
- Branch history has an interim commit (separate checkpoint file) superseded by the libSQL-backed approach; the net diff is the two source changes above.

## Test plan

- [x] CI: Rust Lint, Build and Test, integration tests, and E2E (including cayenne + turso acceleration) all green.
- [ ] SF100 A/B (Turso vs SQLite, same binary): confirm all partitioned tables come up on Turso (libSQL/MVCC), then measure metastore-commit impact. Will update with results.
