### PR TITLE
ci(testoperator): add Turso-metastore CH-benCHmark variants (CDC-tuned SF100/SF1000 + adaptive SF1000)

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -45,6 +45,11 @@ jobs:
   dispatch-scheduled:
     name: Dispatch tests - Scheduled
     runs-on: spiceai-dev-runners
+    # Serial chbench htap dispatch (--max-concurrent 1) blocks this job for the sum of the batch's
+    # run durations; the SF1000 batch (6 variants x up to the 120-min htap cap) can run several
+    # hours, so raise the cap well above GitHub's 6h default. Shorter crons (daily-main, htap-sf100)
+    # finish early — this is only an upper bound.
+    timeout-minutes: 720
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.scheduled == 'true') }}
     strategy:
       fail-fast: false

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -234,11 +234,14 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
-      # HTAP CH-benCHmark — SF100 fires on its own every-3h cron.
+      # HTAP CH-benCHmark — SF100 fires on its own every-3h cron. --max-concurrent 1 makes the
+      # dispatcher wait for each run to finish before dispatching the next (true serial, no
+      # supersession); --max-concurrent-wait-timeout-mins 180 covers a full run's wall-clock so
+      # the slot wait doesn't give up early. The htap concurrency group is the backstop.
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF100
         if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'htap-sf100' }}
         run: |
-          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf100 --workflow htap
+          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf100 --workflow htap --max-concurrent 1 --max-concurrent-wait-timeout-mins 180
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
@@ -253,10 +256,13 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
+      # SF1000 fires twice daily. --max-concurrent 1 + the long slot-wait timeout serialize the
+      # whole SF1000 variant batch run-by-run (no supersession), and serialize against any still-
+      # draining SF100 run via the shared htap active-run count.
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF1000
         if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'htap-sf1000' }}
         run: |
-          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf1000 --workflow htap
+          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf1000 --workflow htap --max-concurrent 1 --max-concurrent-wait-timeout-mins 180
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -57,14 +57,18 @@ on:
           - 'spiceai-dev-large-runners'
           - 'spiceai-dev-xlarge-runners'
 
-# Serialize the Turso-metastore CH-benCHmark runs (CDC-tuned SF100 + SF1000 and adaptive SF1000)
-# so only one of them executes at any time: they share one concurrency group. Overlapping heavy
-# Turso CDC runs would contend for the shared xlarge runner pool and skew each other's
-# freshness/QPH numbers. cancel-in-progress is false so an in-flight benchmark is never killed
-# mid-run — a newer dispatch just queues behind it. Every other htap run (sqlite/adaptive/duckdb)
-# gets a unique group (github.run_id) and is unaffected.
+# Serialize ALL SF100 + SF1000 CH-benCHmark runs across every variant (sqlite/turso cdc-tuned,
+# adaptive, cdc-memory, duckdb): they share ONE concurrency group keyed only by scale factor, so
+# only one runs at any time on the shared xlarge runner pool. Overlapping heavy CDC runs would
+# contend for runners and skew each other's freshness/QPH numbers. cancel-in-progress is false so
+# an in-flight benchmark is never killed mid-run. Other scale factors (e.g. manual SF1/SF10 runs)
+# get a unique group (github.run_id) and stay parallel.
+#
+# NOTE: GitHub keeps at most one in-progress + one pending run per group (a newer pending run
+# cancels the older pending one), so when a cron dispatches a batch faster than runs complete,
+# the intermediate dispatches are superseded rather than queued FIFO.
 concurrency:
-  group: ${{ contains(github.event.inputs.spicepod_path, 'turso') && 'chbench-htap-turso' || github.run_id }}
+  group: ${{ (github.event.inputs.scale_factor == '100' || github.event.inputs.scale_factor == '1000') && 'chbench-htap-sf100-sf1000' || github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -56,6 +56,17 @@ on:
         options:
           - 'spiceai-dev-large-runners'
           - 'spiceai-dev-xlarge-runners'
+
+# Serialize the Turso-metastore CH-benCHmark runs (CDC-tuned SF100 + SF1000 and adaptive SF1000)
+# so only one of them executes at any time: they share one concurrency group. Overlapping heavy
+# Turso CDC runs would contend for the shared xlarge runner pool and skew each other's
+# freshness/QPH numbers. cancel-in-progress is false so an in-flight benchmark is never killed
+# mid-run — a newer dispatch just queues behind it. Every other htap run (sqlite/adaptive/duckdb)
+# gets a unique group (github.run_id) and is unaffected.
+concurrency:
+  group: ${{ contains(github.event.inputs.spicepod_path, 'turso') && 'chbench-htap-turso' || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   run-htap:
     name: Run CH-BenCHmark

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-turso.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-turso.yaml
@@ -1,0 +1,168 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]-adaptive-turso
+
+# Turso-metastore variant of postgres-cayenne[file]-adaptive: same adaptive tuning + goal SLOs;
+# only the Cayenne metastore backend differs — cayenne_metastore: turso (libsql MVCC /
+# BEGIN CONCURRENT) instead of the sqlite default. Tracks the Turso metastore under adaptive
+# tuning on the scheduled CH-benCHmark, vs the sqlite adaptive twin (postgres-cayenne[file]-adaptive.yaml).
+#
+# Adaptive-tuning variant of the non-tuned postgres-cayenne[file] baseline. Instead of either
+# the static `auto` derivation (the baseline) or a hand-pinned -cdc-tuned-* config, every Cayenne
+# table runs `cayenne_tuning: adaptive`: the runtime still warm-starts each knob from the detected
+# host + inferred schema, then runs the closed-feedback loop that adapts those knobs over time
+# within the environment-derived [floor, ceiling] as the workload shifts.
+#
+# `schema_inference: extended` (per dataset) does double duty here, so nothing else is hand-set:
+#   - It auto-detects the primary key, secondary indexes, and (non-CDC) sort columns from the
+#     PostgreSQL source and seeds an `upsert` on_conflict on the inferred PK — exactly what
+#     `refresh_mode: changes` needs to apply UPDATE/DELETE events. So PK / on_conflict / indexes
+#     are intentionally NOT declared below; inference fills them (it is gap-filling only and never
+#     overrides a user-set value, so declaring them would just suppress the very thing we test).
+#   - It supplies the inferred row_count/table_bytes the adaptive loop's data-aware warm-start
+#     gates on; without extended inference adaptive silently falls back to `auto` (static).
+# Background compaction stays at the auto-derived (non-zero) default — the controller rides its
+# tick. No per-ACTUATOR knob value is set anywhere: an explicit knob would *pin* it under adaptive
+# (collapsing its tuning bounds to a point), so the un-pinned baseline gives the loop full freedom.
+# The `cayenne_goal_*` SLOs below are NOT actuator knobs — they are the high-level targets the
+# closed loop converges toward (it still moves the un-pinned actuators freely to hit them).
+#
+# sql_results / task_history stay off to match the baseline and the -cdc-tuned configs, so a
+# comparison isolates the effect of adaptive tuning, not caching/history overhead.
+
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: 5432
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
+runtime:
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
+datasets:
+  # ---- TPC-C core tables (mutated by OLTP workload) ----
+  # No primary_key / on_conflict / indexes: `schema_inference: extended` detects them from the
+  # PostgreSQL source and seeds the upsert on_conflict the CDC (changes) path requires.
+
+  - from: postgres:warehouse
+    name: warehouse
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+    acceleration: &cayenne_accel
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      params: &cayenne_params
+        cayenne_tuning: adaptive
+        # The only line that differs from the sqlite-default adaptive twin: select the Turso
+        # metastore backend. This is a structural backend choice, not a tunable actuator, so it
+        # does not pin any knob under adaptive tuning.
+        cayenne_metastore: turso
+        # Goal-driven SLOs the closed loop converges toward. Replication-lag and
+        # freshness apply to the CDC (changes) tables; they are inert on the
+        # full-refresh reference tables that share this anchor (no CDC ingest).
+        # Query-latency (p99) and QPH apply to all tables.
+        cayenne_goal_replication_lag: '5s'
+        cayenne_goal_freshness: '30s'
+        cayenne_goal_query_latency: '10s'
+        cayenne_goal_qph: '5000'
+
+  - from: postgres:district
+    name: district
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+    acceleration: *cayenne_accel
+
+  - from: postgres:customer
+    name: customer
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+    acceleration: *cayenne_accel
+
+  - from: postgres:new_order
+    name: new_order
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+    acceleration: *cayenne_accel
+
+  - from: postgres:oorder
+    name: oorder
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+    acceleration: *cayenne_accel
+
+  - from: postgres:order_line
+    name: order_line
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+    acceleration: *cayenne_accel
+
+  - from: postgres:stock
+    name: stock
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+    acceleration: *cayenne_accel
+
+  # ---- Static reference tables (no OLTP mutations, full refresh) ----
+  # Same: PK / on_conflict / indexes come from extended inference.
+
+  - from: postgres:item
+    name: item
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+    acceleration: &cayenne_accel_full
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      params: *cayenne_params
+
+  - from: postgres:region
+    name: region
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+    acceleration: *cayenne_accel_full
+
+  - from: postgres:nation
+    name: nation
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+    acceleration: *cayenne_accel_full
+
+  - from: postgres:supplier
+    name: supplier
+    schema_inference: extended
+    params:
+      <<: *postgres_params
+    acceleration: *cayenne_accel_full

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
@@ -1,0 +1,316 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]-cdc-tuned-turso-sf100
+
+# Turso-metastore variant of postgres-cayenne[file]-cdc-tuned-sf100: identical CDC tuning;
+# only the Cayenne metastore backend differs — cayenne_metastore: turso (libsql MVCC /
+# BEGIN CONCURRENT) instead of sqlite. Exercises the Turso metastore at SF-100 on the
+# scheduled CH-benCHmark so its write-conflict / commit behavior is tracked vs the sqlite twin.
+#
+# Target: 64 vCPU / 256 GiB RAM, EBS gp3 (m7a.16xlarge-class). Goal: every CDC table under
+# 5s replication lag at SF-100 @ 10K txn/s, with >=5K QPH on the OLAP queries.
+#
+# Tuning (values validated on the 16-core local SF-100 run — all 7 tables <5s, ~97% of 5K
+# QPH — then scaled to 64c/256GB; the write-path values are core/RAM-invariant because the
+# wall is the single-writer-per-table metastore txn, not CPU or batch size):
+#   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
+#     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
+#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
+#     WAL drain ahead of bursty OLTP without enlarging the per-apply batch.
+#   - target_partitions 64: read-path parallelism matched to vCPU count (drives the QPH goal).
+#   - cayenne_pk_keyset_cache_mb 256 pinned on ALL tables: defeats the backwards memory-aware
+#     auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) and keeps the heavy-update tables
+#     (stock, order_line) on the cheap bloom path (256 = SF-100 sweep optimum).
+#   - per-table cayenne_write_concurrency / segment_cache_mb / compaction_* for the high-volume
+#     upsert tables; reference tables lighter. write_concurrency stays moderate (4/2): lower
+#     fan-out relieves CPU contention for OLAP (validated on the 128-core write-concurrency run).
+#   - metastore/footer caches (1024/1024 MiB, 4096 MiB mmap) are sized to the SF-100 working set,
+#     bounded by catalog/footer size — so 256 GiB adds headroom, not bigger caches.
+#
+# NOTE: validated on 16-core local + the 128-core write-concurrency study; the 64c/256GB
+# end-to-end run is the remaining validation (m7a.16xlarge + gp3).
+runtime:
+  params:
+    cdc_prefetch_buffer: '16384'
+    cdc_max_coalesced_envelopes: '16384'
+    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesce_age_ms: '250'
+    cdc_commit_timeout_ms: '60000'
+    cayenne_sort_merge_min_rows: '50000000'
+    cayenne_footer_cache_mb: '1024'
+    cayenne_metastore_cache_mb: '1024'
+    cayenne_metastore_mmap_mb: '4096'
+  query:
+    target_partitions: 64
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: '5432'
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
+datasets:
+  # ------------------------------------------------------------------
+  # High-volume PK upsert tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:district
+    name: district
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+      params: &accel_high_volume
+        cayenne_metastore: turso
+        cayenne_file_path: .spice/cayenne/district
+        # Explicit: the engine default flipped to `memory`. This pod IS the
+        # file-durability variant (per-batch durable persist before the slot
+        # ack) — its identity must not depend on the build's default. The
+        # memory-durability twin is postgres-cayenne[file]-cdc-memory.yaml.
+        cayenne_cdc_durability: file
+        # KEY deletes even in file mode: deletion_mode auto resolves to
+        # position, which serializes compaction with writers (try_lock
+        # starvation under continuous CDC — measured unbounded file/read-amp
+        # growth on the delete-receiving table). Key-delete compaction runs
+        # concurrently with writers.
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '4'
+        cayenne_segment_cache_mb: '1024'
+        cayenne_compaction_trigger_protected_snapshots: '3'
+        # Pinned to 256 MiB (SF-100 sweep optimum). The keyset pin is scale-dependent: it
+        # must sit just UNDER the heavy-update tables' (stock, order_line) PK keysets so
+        # they stay on the cheap bloom path — at SF-100 that is 256 (1024 would fit them
+        # on the expensive exact path; the SF-1000 venue pins 1024). The memory-aware
+        # auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) is BACKWARDS — pin it.
+        cayenne_pk_keyset_cache_mb: '256'
+        cayenne_compaction_trigger_snapshot_age_ms: '15000'
+        cayenne_compaction_max_files_per_pick: '64'
+        cayenne_compaction_background_interval_ms: '3000'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
+
+  - from: postgres:customer
+    name: customer
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/customer
+        cayenne_target_file_size_mb: '256'
+
+  - from: postgres:new_order
+    name: new_order
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/new_order
+
+  - from: postgres:oorder
+    name: oorder
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/oorder
+
+  - from: postgres:order_line
+    name: order_line
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/order_line
+        cayenne_write_concurrency: '4'
+        cayenne_target_file_size_mb: '256'
+        cayenne_compaction_trigger_files: '8'
+        cayenne_compaction_trigger_snapshot_age_ms: '30000'
+        cayenne_compaction_max_files_per_pick: '128'
+        cayenne_segment_cache_mb: '2048'
+
+  - from: postgres:stock
+    name: stock
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/stock
+        cayenne_target_file_size_mb: '256'
+
+  # ------------------------------------------------------------------
+  # Low-volume reference tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:warehouse
+    name: warehouse
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: w_id
+      on_conflict:
+        w_id: upsert
+      params: &accel_medium
+        cayenne_metastore: turso
+        cayenne_file_path: .spice/cayenne/warehouse
+        # See &accel_high_volume: explicit file durability + key deletes.
+        cayenne_cdc_durability: file
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '4'
+        cayenne_segment_cache_mb: '64'
+        # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
+        cayenne_pk_keyset_cache_mb: '256'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
+
+  # ------------------------------------------------------------------
+  # Static reference tables (no OLTP mutations, full refresh).
+  # ------------------------------------------------------------------
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+      params:
+        <<: *accel_medium
+        cayenne_file_path: .spice/cayenne/item
+
+  - from: postgres:region
+    name: region
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      params: &accel_small
+        cayenne_metastore: turso
+        cayenne_file_path: .spice/cayenne/region
+        # See &accel_high_volume: explicit file durability + key deletes.
+        cayenne_cdc_durability: file
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '2'
+        cayenne_segment_cache_mb: '16'
+        # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
+        cayenne_pk_keyset_cache_mb: '256'
+
+  - from: postgres:nation
+    name: nation
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/nation
+
+  - from: postgres:supplier
+    name: supplier
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: su_suppkey
+      on_conflict:
+        su_suppkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/supplier

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
@@ -1,0 +1,287 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]-cdc-tuned-turso-sf1000
+
+# Turso-metastore variant of postgres-cayenne[file]-cdc-tuned-sf1000: identical CDC tuning;
+# only the Cayenne metastore backend differs — cayenne_metastore: turso (libsql MVCC /
+# BEGIN CONCURRENT) instead of sqlite. Exercises the Turso metastore at SF-1000 on the
+# scheduled CH-benCHmark so its write-conflict / commit behavior is tracked vs the sqlite twin.
+
+runtime:
+  params:
+    cdc_prefetch_buffer: '16384'
+    cdc_max_coalesced_envelopes: '16384'
+    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesce_age_ms: '250'
+    cdc_commit_timeout_ms: '60000'
+    cayenne_sort_merge_min_rows: '50000000'
+    cayenne_footer_cache_mb: '1024'
+    cayenne_metastore_cache_mb: '1024'
+    cayenne_metastore_mmap_mb: '4096'
+  query:
+    target_partitions: 64
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
+postgres_connection_params: &postgres_params
+  pg_host: 127.0.0.1
+  pg_port: '5432'
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
+datasets:
+  # ------------------------------------------------------------------
+  # High-volume PK upsert tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:district
+    name: district
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+      params: &accel_high_volume
+        cayenne_metastore: turso
+        cayenne_file_path: .spice/cayenne/district
+        # Explicit: the engine default flipped to `memory`. This pod IS the
+        # file-durability variant (per-batch durable persist before the slot
+        # ack) — its identity must not depend on the build's default. The
+        # memory-durability twin is postgres-cayenne[file]-cdc-memory.yaml.
+        cayenne_cdc_durability: file
+        # KEY deletes even in file mode: deletion_mode auto resolves to
+        # position, which serializes compaction with writers (try_lock
+        # starvation under continuous CDC — measured unbounded file/read-amp
+        # growth on the delete-receiving table). Key-delete compaction runs
+        # concurrently with writers.
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '4'
+        cayenne_segment_cache_mb: '1024'
+        cayenne_compaction_trigger_protected_snapshots: '3'
+        cayenne_pk_keyset_cache_mb: '256'
+        cayenne_compaction_trigger_snapshot_age_ms: '15000'
+        cayenne_compaction_max_files_per_pick: '64'
+        cayenne_compaction_background_interval_ms: '3000'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
+
+  - from: postgres:customer
+    name: customer
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/customer
+        cayenne_target_file_size_mb: '256'
+
+  - from: postgres:new_order
+    name: new_order
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/new_order
+
+  - from: postgres:oorder
+    name: oorder
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/oorder
+
+  - from: postgres:order_line
+    name: order_line
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/order_line
+        cayenne_write_concurrency: '4'
+        cayenne_target_file_size_mb: '256'
+        cayenne_compaction_trigger_files: '8'
+        cayenne_compaction_trigger_snapshot_age_ms: '30000'
+        cayenne_compaction_max_files_per_pick: '128'
+        cayenne_segment_cache_mb: '2048'
+
+  - from: postgres:stock
+    name: stock
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/stock
+        cayenne_target_file_size_mb: '256'
+
+  # ------------------------------------------------------------------
+  # Low-volume reference tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:warehouse
+    name: warehouse
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: w_id
+      on_conflict:
+        w_id: upsert
+      params: &accel_medium
+        cayenne_metastore: turso
+        cayenne_file_path: .spice/cayenne/warehouse
+        # See &accel_high_volume: explicit file durability + key deletes.
+        cayenne_cdc_durability: file
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '4'
+        cayenne_segment_cache_mb: '64'
+        cayenne_pk_keyset_cache_mb: '256'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
+
+  # ------------------------------------------------------------------
+  # Static reference tables (no OLTP mutations, full refresh).
+  # ------------------------------------------------------------------
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+      params:
+        <<: *accel_medium
+        cayenne_file_path: .spice/cayenne/item
+
+  - from: postgres:region
+    name: region
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      params: &accel_small
+        cayenne_metastore: turso
+        cayenne_file_path: .spice/cayenne/region
+        # See &accel_high_volume: explicit file durability + key deletes.
+        cayenne_cdc_durability: file
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '2'
+        cayenne_segment_cache_mb: '16'
+        cayenne_pk_keyset_cache_mb: '256'
+
+  - from: postgres:nation
+    name: nation
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/nation
+
+  - from: postgres:supplier
+    name: supplier
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: su_suppkey
+      on_conflict:
+        su_suppkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/supplier

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned-turso.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned-turso.yaml
@@ -1,0 +1,9 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 100
+    terminals: 100
+    duration: 600
+    ready_wait: 600
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-adaptive-turso.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-adaptive-turso.yaml
@@ -1,0 +1,9 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-adaptive-turso.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 1000
+    terminals: 100
+    duration: 600
+    ready_wait: 900
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned-turso.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned-turso.yaml
@@ -1,0 +1,9 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 1000
+    terminals: 100
+    duration: 600
+    ready_wait: 900
+    rate: 10000

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -47,6 +47,13 @@ pub struct DispatchArgs {
     #[arg(long)]
     pub(crate) max_concurrent: Option<usize>,
 
+    /// When `--max-concurrent` is set, how many minutes to wait for a free slot
+    /// before dispatching anyway. Raise this above a single run's wall-clock for
+    /// long workloads (e.g. SF-1000 HTAP) so the slot wait actually serializes them
+    /// instead of giving up early. Ignored unless `--max-concurrent` is set.
+    #[arg(long, default_value = "30")]
+    pub(crate) max_concurrent_wait_timeout_mins: u64,
+
     /// Dry run mode - print the workflow dispatch request without sending it
     #[arg(long, default_value = "false")]
     pub(crate) dry_run: bool,

--- a/tools/testoperator/src/commands/dispatch/mod.rs
+++ b/tools/testoperator/src/commands/dispatch/mod.rs
@@ -35,6 +35,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
         spiced_commit,
         update_snapshots,
         max_concurrent,
+        max_concurrent_wait_timeout_mins,
         ..
     } = args;
     if !path.is_dir() && !path.is_file() {
@@ -226,6 +227,7 @@ pub async fn dispatch(args: DispatchArgs) -> Result<()> {
                     &octo_client,
                     Some(payload),
                     max_concurrent,
+                    Duration::from_mins(max_concurrent_wait_timeout_mins),
                 )
                 .await
             }
@@ -266,18 +268,13 @@ async fn dispatch_workflow_with_concurrency(
     octo: &Octocrab,
     input: Option<serde_json::Value>,
     max_concurrent: usize,
+    slot_wait_timeout: Duration,
 ) -> Result<()> {
     println!(
-        "Checking for available slot to run workflow (limit: {max_concurrent} concurrent runs)..."
+        "Checking for available slot to run workflow (limit: {max_concurrent} concurrent runs, waiting up to {} min)...",
+        slot_wait_timeout.as_secs() / 60
     );
-    if let Err(err) = wait_for_slot(
-        &workflow,
-        octo,
-        max_concurrent,
-        Duration::from_mins(30), // 30 mins
-    )
-    .await
-    {
+    if let Err(err) = wait_for_slot(&workflow, octo, max_concurrent, slot_wait_timeout).await {
         eprintln!("Error waiting for slot: {err}");
     }
 


### PR DESCRIPTION
## What

Adds **Turso-metastore** (`cayenne_metastore: turso` — libsql MVCC / `BEGIN CONCURRENT`) counterparts to the scheduled CH-benCHmark, and **serializes all scheduled SF100/SF1000 runs** so heavy CDC benchmarks don't contend on the shared xlarge runner pool. Builds on #11363 (twice-daily SF1000 dir dispatch); the new configs ride the existing dir dispatches, so no new dispatch steps were needed for them.

### New Turso spicepods (identical tuning to their sqlite twins — only the metastore backend differs)
- `postgres-cayenne[file]-cdc-tuned-turso-sf100` / `-sf1000` — clones of the `-cdc-tuned-sf100/-sf1000` configs
- `postgres-cayenne[file]-adaptive-turso` — adaptive twin; only `cayenne_metastore: turso` added (structural backend choice, not a pinned actuator)

### New dispatch configs
- `sf100/…-cdc-tuned-turso` — rides the every-3h SF100 dir dispatch
- `sf1000/…-cdc-tuned-turso` + `sf1000/…-adaptive-turso` — ride the twice-daily SF1000 dir dispatch (#11363)

### Adaptive SF1000 for both metastores
- **sqlite**: `sf1000/…-adaptive.yaml` (from #11363)
- **turso**: `sf1000/…-adaptive-turso.yaml` (this PR)

## Serialization — ALL SF100/SF1000 runs, every variant (one at a time)

Per the requirement, **all** scheduled SF100 and SF1000 CH-benCHmark runs across **every** variant (sqlite/turso cdc-tuned, adaptive, cdc-memory, duckdb) run strictly **one at a time** — not just one-per-variant. Four layers:

1. **Dispatch pacing** — `--max-concurrent 1` on the SF100 + SF1000 htap dispatch steps. `testoperator dispatch` gates on the whole `htap` workflow's active runs (`queued + in_progress + waiting`), so it waits for each run to **fully complete** before dispatching the next → true FIFO, **no supersession**. This intentionally spans all variants (the gate is workflow-wide).
2. **Slot-wait timeout** — new `--max-concurrent-wait-timeout-mins` flag (default 30, preserved for other callers) set to **180** for chbench, so the dispatcher outlasts a single SF1000 run (htap job cap 120 min) instead of giving up early.
3. **Job timeout** — `dispatch-scheduled` `timeout-minutes: 720`, so the serial SF1000 batch (6 variants × up to 120 min) fully dispatches without the job being killed at GitHub's 6 h default.
4. **Concurrency group** — `testoperator_run_htap.yml` shares one group `chbench-htap-sf100-sf1000` (keyed by scale factor) across all SF100/SF1000 runs, `cancel-in-progress: false`, as a backstop against cross-cron / manual overlap. Other scale factors get a unique `github.run_id` group and stay parallel.

> Note: an earlier revision scoped serialization to Turso-only; it was widened to all variants per review/owner direction. The description above reflects the current behavior.

## Notes
- **Cadence**: SF1000-turso follows #11363's twice-daily SF1000 schedule (rides that dir dispatch); SF100-turso rides the every-3h SF100 dispatch.
- Turso metastore is built into Linux spiced (`runtime` builds `cayenne` with `features=["turso"]`), so trunk-built scheduled runs support `cayenne_metastore: turso`.

## Validation
- All new/edited YAML parses; every dataset in the 3 Turso spicepods resolves `cayenne_metastore: turso`; dispatch configs map to the right spicepod + scale_factor.
- `cargo check -p testoperator` and `cargo clippy -p testoperator` (CI deny-flags) are green for the new `--max-concurrent-wait-timeout-mins` flag. Spicepod-validator + actionlint run in CI.