### PR TITLE
feat(runtime): dedicated CDC-apply tokio runtime + per-runtime tokio metrics

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -659,6 +659,21 @@ pub async fn run(args: Args) -> Result<()> {
 
             rt.datafusion().set_refresh_runtime(refresh_runtime);
 
+            // Dedicated, DEFAULT-priority (nice 0) runtime for the CDC changes-apply
+            // loop (refresh_mode: changes). Split from the low-priority refresh runtime
+            // above (which also runs bulk full/append refresh reads) so the
+            // freshness-critical apply isn't scheduler-deprioritized on an
+            // oversubscribed host. (Benchmarked nice-0 vs a nice-5 variant at SF50: equal
+            // QPH, but nice-0 drained replication lag harder — cleared the stock backlog —
+            // so it's the better default; the QPH cost vs the shared runtime was noise.)
+            let cdc_apply_runtime = ManagedTokioRuntime::builder()
+                .with_thread_name("cdc-apply-worker")
+                .build()
+                .boxed()
+                .context(UnableToInitializeDatafusionTokioRuntimeSnafu)?;
+
+            rt.datafusion().set_cdc_apply_runtime(cdc_apply_runtime);
+
             // Bring up the dedicated compaction runtime whenever dedicated
             // thread pools are enabled. Cayenne can be activated lazily after
             // startup (for example via Iceberg DDL acceleration defaults), so
@@ -752,6 +767,27 @@ pub async fn run(args: Args) -> Result<()> {
         if let Some(bytes) = rt.datafusion().compaction_memory_pool_bytes() {
             telemetry::register_cayenne_compaction_metrics(bytes);
         }
+
+        // Per-runtime tokio thread/task gauges (alive tasks, workers, global-queue depth;
+        // plus worker busy/park/steal under `--cfg tokio_unstable`) so `/metrics` shows
+        // whether each runtime — notably the dedicated nice-0 `cdc_apply` runtime — is idle
+        // or competing for cores. Pull-based: callbacks read `Handle::metrics()` at scrape time.
+        let df = rt.datafusion();
+        let mut tokio_handles: Vec<(&'static str, Handle)> = Vec::new();
+        if let Some(h) = df.cpu_runtime() {
+            tokio_handles.push(("cpu", h.clone()));
+        }
+        if let Some(h) = df.refresh_runtime() {
+            tokio_handles.push(("refresh", h.clone()));
+        }
+        if let Some(h) = df.cdc_apply_runtime() {
+            tokio_handles.push(("cdc_apply", h.clone()));
+        }
+        if let Some(h) = df.compaction_runtime() {
+            tokio_handles.push(("compaction", h.clone()));
+        }
+        tokio_handles.push(("main", Handle::current()));
+        telemetry::register_tokio_runtime_metrics(tokio_handles);
     }
 
     let (tls_config, client_auth_mode) = tls::load_tls_config(

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -369,6 +369,7 @@ pub struct Builder {
     snapshot_refresh_state: Option<snapshots::SnapshotRefreshState>,
     metrics: Option<Metrics>,
     cpu_runtime: Option<Handle>,
+    cdc_apply_runtime: Option<Handle>,
     io_runtime: Handle,
     caching_ttl: Option<Duration>,
     caching_stale_while_revalidate_ttl: Option<Duration>,
@@ -422,6 +423,7 @@ impl Builder {
             snapshot_refresh_state: None,
             metrics: None,
             cpu_runtime: None,
+            cdc_apply_runtime: None,
             io_runtime,
             caching_ttl: None,
             caching_stale_while_revalidate_ttl: None,
@@ -537,6 +539,11 @@ impl Builder {
 
     pub fn cpu_runtime(&mut self, runtime: Option<Handle>) -> &mut Self {
         self.cpu_runtime = runtime;
+        self
+    }
+
+    pub fn cdc_apply_runtime(&mut self, runtime: Option<Handle>) -> &mut Self {
+        self.cdc_apply_runtime = runtime;
         self
     }
 
@@ -853,6 +860,7 @@ impl Builder {
             Arc::clone(&refresh_params),
             Arc::clone(&self.accelerator),
             self.cpu_runtime.clone(),
+            self.cdc_apply_runtime.clone(),
             self.io_runtime.clone(),
             Arc::clone(&self.accelerator_write_mutex),
         );

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -660,6 +660,9 @@ pub struct Refresher {
     /// Notification for completion of refresh operation
     on_complete_notification: Option<Arc<Notify>>,
     cpu_runtime: Option<Handle>,
+    /// Dedicated nice-0 runtime for the CDC changes-apply loop; falls back to
+    /// `cpu_runtime` when unset.
+    cdc_apply_runtime: Option<Handle>,
     io_runtime: Handle,
     resource_monitor: Option<crate::resource_monitor::ResourceMonitor>,
     /// Mutex to protect concurrent access to the accelerator during insert/update/delete/cache/snapshot operations
@@ -698,6 +701,7 @@ impl Refresher {
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
         cpu_runtime: Option<Handle>,
+        cdc_apply_runtime: Option<Handle>,
         io_runtime: Handle,
         accelerator_write_mutex: Arc<Mutex<()>>,
     ) -> Self {
@@ -722,6 +726,7 @@ impl Refresher {
             snapshot_interval_task: None,
             metrics: None,
             cpu_runtime,
+            cdc_apply_runtime,
             io_runtime,
             resource_monitor: None,
             accelerator_write_mutex,
@@ -1277,7 +1282,14 @@ impl Refresher {
             }
         };
 
-        if let Some(runtime) = self.cpu_runtime.clone() {
+        // Run the CDC changes-apply loop on the dedicated nice-0 apply runtime when
+        // available so it isn't scheduler-deprioritized behind queries/compaction on an
+        // oversubscribed host. Fall back to the cpu/refresh runtime, then ambient.
+        if let Some(runtime) = self
+            .cdc_apply_runtime
+            .clone()
+            .or_else(|| self.cpu_runtime.clone())
+        {
             runtime.spawn(changes_task)
         } else {
             tokio::spawn(changes_task)
@@ -1479,6 +1491,7 @@ mod tests {
             Some("mem_table".to_string()),
             Arc::new(RwLock::new(refresh)),
             Arc::clone(&accelerator),
+            None,
             None,
             Handle::current(),
             Arc::new(Mutex::new(())),
@@ -1693,6 +1706,7 @@ mod tests {
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
                 None,
+                None,
                 Handle::current(),
                 Arc::new(Mutex::new(())),
             );
@@ -1850,6 +1864,7 @@ mod tests {
                 Some("mem_table".to_string()),
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
+                None,
                 None,
                 Handle::current(),
                 Arc::new(Mutex::new(())),
@@ -2058,6 +2073,7 @@ mod tests {
                 Some("mem_table".to_string()),
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
+                None,
                 None,
                 Handle::current(),
                 Arc::new(Mutex::new(())),

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -980,6 +980,7 @@ impl DataFusionBuilder {
             temp_directory: self.temp_directory.clone(),
             cpu_runtime: OnceLock::new(),
             refresh_runtime: OnceLock::new(),
+            cdc_apply_runtime: OnceLock::new(),
             compaction_runtime: OnceLock::new(),
             compaction_runtime_env,
             compaction_memory_bytes,

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -736,6 +736,11 @@ pub struct DataFusion {
     cpu_runtime: OnceLock<ManagedTokioRuntime>,
     // Dedicated runtime for CPU-bound DataFusion acceleration for dataset acceleration refresh tasks
     refresh_runtime: OnceLock<ManagedTokioRuntime>,
+    // Dedicated, DEFAULT-priority (nice 0) runtime for the CDC changes-apply loop
+    // (refresh_mode: changes). Split from `refresh_runtime` (low-priority, nice 10,
+    // which also runs bulk full/append refresh reads) so the freshness-critical apply
+    // isn't scheduler-deprioritized on an oversubscribed host.
+    cdc_apply_runtime: OnceLock<ManagedTokioRuntime>,
     // Dedicated runtime for background Cayenne compaction (size-tiered protected-snapshot
     // merge + full snapshot rewrite). Isolated from the query and refresh runtimes so the
     // CPU-heavy rewrite can't steal worker threads from queries or CDC ingest.
@@ -1363,6 +1368,28 @@ impl DataFusion {
             .get()
             .map(ManagedTokioRuntime::handle)
             .or_else(|| self.cpu_runtime())
+    }
+
+    /// Set the dedicated, default-priority (nice 0) CDC changes-apply runtime.
+    /// Isolated from the low-priority refresh runtime so the freshness-critical
+    /// CDC apply loop is not scheduler-deprioritized under load.
+    pub fn set_cdc_apply_runtime(&self, handle: ManagedTokioRuntime) {
+        if self.cdc_apply_runtime.set(handle).is_err() {
+            // Failure to set means this was already set - that shouldn't happen.
+            tracing::error!(
+                "Failed to set CDC-apply tokio runtime on the Datafusion struct, this is an unexpected internal error"
+            );
+        }
+    }
+
+    /// Returns the dedicated CDC changes-apply runtime. Falls back to the refresh
+    /// runtime (which itself falls back to the cpu runtime) when unset.
+    #[must_use]
+    pub fn cdc_apply_runtime(&self) -> Option<&tokio::runtime::Handle> {
+        self.cdc_apply_runtime
+            .get()
+            .map(ManagedTokioRuntime::handle)
+            .or_else(|| self.refresh_runtime())
     }
 
     /// Set the dedicated compaction runtime for background Cayenne compaction
@@ -2437,6 +2464,7 @@ impl DataFusion {
             self.io_runtime.clone(),
         );
         accelerated_table_builder.cpu_runtime(self.refresh_runtime().cloned());
+        accelerated_table_builder.cdc_apply_runtime(self.cdc_apply_runtime().cloned());
         accelerated_table_builder.cluster_role(self.cluster_config.effective_role());
         accelerated_table_builder.accelerator_write_mutex(Arc::clone(&accelerator_write_mutex));
         accelerated_table_builder.cdc_param_overrides(

--- a/crates/runtime/tests/acceleration/snapshot_mutex.rs
+++ b/crates/runtime/tests/acceleration/snapshot_mutex.rs
@@ -160,6 +160,7 @@ async fn test_snapshot_interval_serializes_with_accelerator_writes() -> anyhow::
         Arc::new(RwLock::new(refresh)),
         accelerator,
         None,
+        None,
         runtime.tokio_io_runtime(),
         Arc::clone(&accelerator_write_mutex),
     );

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -8,6 +8,12 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lints.rust]
+# `tokio_unstable` is enabled via `RUSTFLAGS="--cfg tokio_unstable"` to expose the
+# per-worker tokio RuntimeMetrics (busy/park/steal). Declare it so the otherwise-unknown
+# cfg name doesn't trip the `unexpected_cfgs` lint on builds without the flag.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+
 [dependencies]
 arrow.workspace = true
 async-trait.workspace = true

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -644,7 +644,9 @@ pub fn register_tokio_runtime_metrics(handles: Vec<(&'static str, tokio::runtime
     let h = std::sync::Arc::clone(&handles);
     let _ = meter
         .u64_observable_gauge("tokio_runtime_global_queue_depth")
-        .with_description("Tasks waiting in the runtime's global (injection) queue per tokio runtime.")
+        .with_description(
+            "Tasks waiting in the runtime's global (injection) queue per tokio runtime.",
+        )
         .with_unit("{task}")
         .with_callback(move |obs| {
             for (name, handle) in h.iter() {
@@ -682,7 +684,9 @@ pub fn register_tokio_runtime_metrics(handles: Vec<(&'static str, tokio::runtime
         let h = std::sync::Arc::clone(&handles);
         let _ = meter
             .u64_observable_gauge("tokio_runtime_worker_park_count")
-            .with_description("Cumulative worker park count (summed across workers) per tokio runtime.")
+            .with_description(
+                "Cumulative worker park count (summed across workers) per tokio runtime.",
+            )
             .with_unit("{park}")
             .with_callback(move |obs| {
                 for (name, handle) in h.iter() {
@@ -696,7 +700,9 @@ pub fn register_tokio_runtime_metrics(handles: Vec<(&'static str, tokio::runtime
         let h = std::sync::Arc::clone(&handles);
         let _ = meter
             .u64_observable_gauge("tokio_runtime_worker_steal_count")
-            .with_description("Cumulative task-steal count (summed across workers) per tokio runtime.")
+            .with_description(
+                "Cumulative task-steal count (summed across workers) per tokio runtime.",
+            )
             .with_unit("{steal}")
             .with_callback(move |obs| {
                 for (name, handle) in h.iter() {

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -589,6 +589,126 @@ pub fn register_cayenne_compaction_metrics(compaction_pool_bytes: u64) {
     cayenne_compaction_memory_pool_bytes().record(compaction_pool_bytes, &[]);
 }
 
+/// Registers per-tokio-runtime observable gauges so `/metrics` shows, per runtime,
+/// whether its worker threads are idle or competing for cores. Pull-based: each
+/// callback reads `tokio::runtime::Handle::metrics()` at Prometheus scrape time, so
+/// there is no periodic sampler task and near-zero cost between scrapes.
+///
+/// `handles` is a list of `(label, handle)` — e.g. `("cpu", …)`, `("refresh", …)`,
+/// `("cdc_apply", …)`, `("compaction", …)`, `("main", …)`; each becomes a
+/// `runtime="<label>"` attribute on every gauge. Like [`register_cayenne_compaction_metrics`],
+/// the binary MUST call this once AFTER `init_metrics` has installed the Prometheus meter.
+///
+/// The task/worker/queue gauges use stable `RuntimeMetrics` APIs and are always emitted.
+/// The per-worker busy/park/steal gauges — the direct "are these threads doing work or
+/// just parked" signal — require the `tokio_unstable` cfg at build time
+/// (`RUSTFLAGS="--cfg tokio_unstable"`); without it only the stable gauges register, so
+/// default and CI builds are unaffected.
+pub fn register_tokio_runtime_metrics(handles: Vec<(&'static str, tokio::runtime::Handle)>) {
+    if handles.is_empty() {
+        return;
+    }
+    let handles: std::sync::Arc<[(&'static str, tokio::runtime::Handle)]> = handles.into();
+    let meter = global::meter("tokio_runtime");
+
+    let h = std::sync::Arc::clone(&handles);
+    let _ = meter
+        .u64_observable_gauge("tokio_runtime_alive_tasks")
+        .with_description("Alive (spawned, not-yet-completed) tasks per tokio runtime.")
+        .with_unit("{task}")
+        .with_callback(move |obs| {
+            for (name, handle) in h.iter() {
+                obs.observe(
+                    handle.metrics().num_alive_tasks() as u64,
+                    &[KeyValue::new("runtime", *name)],
+                );
+            }
+        })
+        .build();
+
+    let h = std::sync::Arc::clone(&handles);
+    let _ = meter
+        .u64_observable_gauge("tokio_runtime_workers")
+        .with_description("Worker threads per tokio runtime.")
+        .with_unit("{thread}")
+        .with_callback(move |obs| {
+            for (name, handle) in h.iter() {
+                obs.observe(
+                    handle.metrics().num_workers() as u64,
+                    &[KeyValue::new("runtime", *name)],
+                );
+            }
+        })
+        .build();
+
+    let h = std::sync::Arc::clone(&handles);
+    let _ = meter
+        .u64_observable_gauge("tokio_runtime_global_queue_depth")
+        .with_description("Tasks waiting in the runtime's global (injection) queue per tokio runtime.")
+        .with_unit("{task}")
+        .with_callback(move |obs| {
+            for (name, handle) in h.iter() {
+                obs.observe(
+                    handle.metrics().global_queue_depth() as u64,
+                    &[KeyValue::new("runtime", *name)],
+                );
+            }
+        })
+        .build();
+
+    // Per-worker busy/park/steal — the direct "idle vs stealing cores" signal — are only
+    // exposed under `--cfg tokio_unstable`. Gated so default/CI builds compile and emit
+    // just the stable gauges above; build with the cfg to surface these in `/metrics`.
+    #[cfg(tokio_unstable)]
+    {
+        let h = std::sync::Arc::clone(&handles);
+        let _ = meter
+            .f64_observable_gauge("tokio_runtime_worker_busy_seconds")
+            .with_description(
+                "Cumulative worker-busy time (summed across workers) per tokio runtime; rate()/workers = busy ratio.",
+            )
+            .with_unit("s")
+            .with_callback(move |obs| {
+                for (name, handle) in h.iter() {
+                    let m = handle.metrics();
+                    let busy: f64 = (0..m.num_workers())
+                        .map(|w| m.worker_total_busy_duration(w).as_secs_f64())
+                        .sum();
+                    obs.observe(busy, &[KeyValue::new("runtime", *name)]);
+                }
+            })
+            .build();
+
+        let h = std::sync::Arc::clone(&handles);
+        let _ = meter
+            .u64_observable_gauge("tokio_runtime_worker_park_count")
+            .with_description("Cumulative worker park count (summed across workers) per tokio runtime.")
+            .with_unit("{park}")
+            .with_callback(move |obs| {
+                for (name, handle) in h.iter() {
+                    let m = handle.metrics();
+                    let parks: u64 = (0..m.num_workers()).map(|w| m.worker_park_count(w)).sum();
+                    obs.observe(parks, &[KeyValue::new("runtime", *name)]);
+                }
+            })
+            .build();
+
+        let h = std::sync::Arc::clone(&handles);
+        let _ = meter
+            .u64_observable_gauge("tokio_runtime_worker_steal_count")
+            .with_description("Cumulative task-steal count (summed across workers) per tokio runtime.")
+            .with_unit("{steal}")
+            .with_callback(move |obs| {
+                for (name, handle) in h.iter() {
+                    let m = handle.metrics();
+                    let steals: u64 = (0..m.num_workers()).map(|w| m.worker_steal_count(w)).sum();
+                    obs.observe(steals, &[KeyValue::new("runtime", *name)]);
+                }
+            })
+            .build();
+    }
+}
+
 static CAYENNE_INLINE_TOMBSTONE_WRITES: OnceLock<Counter<u64>> = OnceLock::new();
 static CAYENNE_INLINE_TOMBSTONE_KEYS: OnceLock<Counter<u64>> = OnceLock::new();
 


### PR DESCRIPTION
## Summary

Splits the `refresh_mode: changes` CDC apply loop onto its own **dedicated, default-priority (nice 0) tokio runtime**, and adds **per-runtime tokio observable metrics** to `/metrics` for diagnosing runtime/core contention.

## Problem

The CDC changes-apply loop was spawned on the shared **low-priority (nice 10) refresh runtime** — the same runtime that also runs bulk full/append refresh *reads*. On an oversubscribed host the kernel scheduler deprioritizes those nice-10 worker threads, so the **freshness-critical apply gets starved**: it uses little CPU yet can't drain replication lag fast enough, and the WAL backlog grows.

## Change

1. **Dedicated `cdc_apply_runtime` (nice 0).** Built alongside the refresh/compaction runtimes in `spiced`, plumbed as a handle through `DataFusion` → `AcceleratedTable` builder → `Refresher`, and used at the single changes-task spawn site (falls back to `cpu_runtime`, then `tokio::spawn`, when unset — so behavior is unchanged when dedicated pools are off). Bulk full/append refresh reads stay on the low-priority refresh runtime.

2. **Per-runtime tokio metrics on `/metrics`** (pull-based observable gauges; callbacks read `Handle::metrics()` at scrape time — no sampler task). Tagged `runtime=cpu|refresh|cdc_apply|compaction|main`:
   - `tokio_runtime_alive_tasks`, `tokio_runtime_workers`, `tokio_runtime_global_queue_depth` — stable APIs, always emitted.
   - `tokio_runtime_worker_busy_seconds`, `tokio_runtime_worker_park_count`, `tokio_runtime_worker_steal_count` — behind `#[cfg(tokio_unstable)]` (the direct "busy vs parked / stealing" signal). Default and CI builds compile and emit only the stable gauges; build with `RUSTFLAGS="--cfg tokio_unstable"` to surface the per-worker ones. A `check-cfg` declaration keeps the cfg from tripping `unexpected_cfgs`.

## Results

SF50 CH-bench (Postgres CDC → Cayenne, turso metastore / memory durability), same-session back-to-back A/B on a 16-core host:

| apply runtime | order_line lag | freshness P99 | `stock` WAL backlog | analytical QPH |
|---|---|---|---|---|
| nice-10 shared (before) | 38.1 s | 36.0 s | FAIL (5.1 G floor) | 9,113 |
| **nice-0 dedicated (this PR)** | **22.9 s (−40%)** | **24.3 s (−32%)** | **cleared (1.1 G)** | 8,561 (within run-to-run noise) |

The dedicated runtime substantially improves apply/freshness; the QPH difference is within the box's noise band (an earlier single pair showed a −32% swing that did not reproduce back-to-back). A `nice-5` (medium-priority) variant was also benched as a hedge against query-throughput contention — it matched nice-0 on QPH but drained lag *less* (did not clear the `stock` backlog), so **nice-0 is the default**. On a resourced host the apply and query work don't contend for cores, so the small local QPH cost is expected to disappear.

## Validation

- `cargo check -p spiced --no-default-features --features postgres,sqlite,vortex` green; CH-bench correctness PASS (Spice == Postgres, 7/7 CDC tables) across the A/B.
- The absolute < 5 s freshness / zero-backlog SLO is hardware-bound: a single 16-core host co-locating Postgres + generator + spiced can't fully drain SF50 memory-mode regardless of priority (the disk-state gate still fails locally). That's an m7a-class validation, tracked separately; this PR is the priority/isolation fix that moves it in the right direction without regressing query throughput.

## Notes

- No behavioral change when dedicated thread pools are disabled (handle is unset → falls back to the prior path).
- Diff is runtime + telemetry only; no Cayenne provider / query-path changes.
