### PR TITLE
fix(catalog): restore DDL after DataFusion 54 broke transparent catalog-provider downcasts

### DIFF
--- a/crates/cayenne/src/ddl/handler.rs
+++ b/crates/cayenne/src/ddl/handler.rs
@@ -30,7 +30,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use datafusion_ddl::{CatalogDdlHandler, CreateSchemaParams, CreateTableParams, DropTableParams};
 
-use crate::catalog_provider::CayenneCatalogProvider;
+use crate::ddl::get_cayenne_provider;
 use crate::ddl::operations;
 use crate::ddl::physical_plans::{
     CayenneCreateSchemaExec, CayenneCreateTableExec, CayenneDropTableExec,
@@ -52,7 +52,7 @@ impl CatalogDdlHandler for CayenneDdlHandler {
     ) -> bool {
         catalog_list
             .catalog(catalog_name)
-            .is_some_and(|c| c.downcast_ref::<CayenneCatalogProvider>().is_some())
+            .is_some_and(|c| get_cayenne_provider(c.as_ref()).is_some())
     }
 
     fn create_table_exec(

--- a/crates/cayenne/src/ddl/mod.rs
+++ b/crates/cayenne/src/ddl/mod.rs
@@ -30,23 +30,38 @@ pub use handler::CayenneDdlHandler;
 pub use merge_planner::{CayenneDmlHandler, LocalMergePlanInput, build_local_merge_plan_input};
 pub use physical_plans::CayenneMergeExec;
 
+use data_components::RefreshingCatalogProvider;
 use datafusion::catalog::CatalogProvider;
+use runtime_datafusion::composed_catalog::ComposedCatalogProvider;
 
 use crate::catalog_provider::CayenneCatalogProvider;
 
-/// Returns `true` if `provider` is a direct [`CayenneCatalogProvider`].
-///
-/// The runtime extends this check to also cover `ComposedCatalogProvider`.
+/// Returns `true` if `provider` is Cayenne-backed, peeling the transparent
+/// [`RefreshingCatalogProvider`] and [`ComposedCatalogProvider`] wrappers.
 #[must_use]
 pub fn is_cayenne_catalog(provider: &dyn CatalogProvider) -> bool {
-    provider.downcast_ref::<CayenneCatalogProvider>().is_some()
+    get_cayenne_provider(provider).is_some()
 }
 
-/// Try to extract a [`CayenneCatalogProvider`] reference via direct downcast.
+/// Extract the [`CayenneCatalogProvider`] reference, peeling the transparent
+/// [`RefreshingCatalogProvider`] and [`ComposedCatalogProvider`] wrappers in any
+/// nesting order.
 ///
-/// Returns `None` for wrapped providers — use the runtime's `get_cayenne_provider`
-/// to also handle `ComposedCatalogProvider`.
+/// `DataFusion` 54 removed `CatalogProvider::as_any`, which those wrappers used to
+/// delegate to their inner provider so that `downcast_ref::<CayenneCatalogProvider>()`
+/// transparently saw through them. The `Any`-based `downcast_ref` that replaced it
+/// only resolves to the wrapper's own type, so the wrappers must be peeled
+/// explicitly.
 #[must_use]
 pub fn get_cayenne_provider(provider: &dyn CatalogProvider) -> Option<&CayenneCatalogProvider> {
-    provider.downcast_ref::<CayenneCatalogProvider>()
+    if let Some(cayenne) = provider.downcast_ref::<CayenneCatalogProvider>() {
+        return Some(cayenne);
+    }
+    if let Some(refreshing) = provider.downcast_ref::<RefreshingCatalogProvider>() {
+        return get_cayenne_provider(refreshing.inner_catalog());
+    }
+    if let Some(composed) = provider.downcast_ref::<ComposedCatalogProvider>() {
+        return get_cayenne_provider(composed.external().as_ref());
+    }
+    None
 }

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -443,6 +443,96 @@ pub trait RefreshableCatalogProvider: CatalogProvider {
     async fn refresh(&self) -> Result<(), Box<dyn Error + Send + Sync>>;
 }
 
+/// A [`CatalogProvider`] that periodically refreshes its contents from a remote
+/// catalog by polling the wrapped [`RefreshableCatalogProvider`].
+///
+/// This is a *transparent* wrapper: every catalog registered through a
+/// `RefreshableCatalogProvider` is wrapped in one of these. Concrete-type
+/// detection (e.g. "is this catalog Cayenne-backed?") must therefore peel the
+/// wrapper via [`RefreshingCatalogProvider::inner_catalog`] before downcasting.
+///
+/// `DataFusion` 54 removed `CatalogProvider::as_any`, which this wrapper used to
+/// delegate to its inner provider so that `downcast_ref::<ConcreteProvider>()`
+/// transparently saw through it. The `Any`-based `downcast_ref` that replaced it
+/// can only ever resolve to the wrapper's own type, so callers must peel
+/// explicitly — see [`RefreshingCatalogProvider::inner_catalog`].
+#[derive(Debug)]
+pub struct RefreshingCatalogProvider {
+    inner: Arc<dyn RefreshableCatalogProvider>,
+    refresh_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl RefreshingCatalogProvider {
+    #[must_use]
+    pub fn new(inner: Arc<dyn RefreshableCatalogProvider>) -> Self {
+        Self {
+            inner,
+            refresh_task: None,
+        }
+    }
+
+    /// Returns the wrapped catalog provider.
+    ///
+    /// Catalog-type detection must peel this wrapper via this accessor to reach
+    /// the underlying provider (e.g. a `CayenneCatalogProvider`); see the
+    /// type-level documentation for why.
+    #[must_use]
+    pub fn inner_catalog(&self) -> &dyn CatalogProvider {
+        self.inner.as_ref()
+    }
+
+    /// Spawns the background refresh loop and returns the started provider.
+    #[must_use]
+    pub fn start_refresh(mut self, interval: Option<std::time::Duration>) -> Self {
+        let interval = interval.unwrap_or(std::time::Duration::from_mins(1));
+        let inner = Arc::clone(&self.inner);
+        self.refresh_task = Some(tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                if let Err(e) = inner.refresh().await {
+                    tracing::error!("Failed to refresh catalog: {e}");
+                }
+            }
+        }));
+        self
+    }
+}
+
+#[deny(clippy::missing_trait_methods)]
+impl CatalogProvider for RefreshingCatalogProvider {
+    fn schema_names(&self) -> Vec<String> {
+        self.inner.schema_names()
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn datafusion::catalog::SchemaProvider>> {
+        self.inner.schema(name)
+    }
+
+    fn register_schema(
+        &self,
+        name: &str,
+        schema: Arc<dyn datafusion::catalog::SchemaProvider>,
+    ) -> datafusion::error::Result<Option<Arc<dyn datafusion::catalog::SchemaProvider>>> {
+        self.inner.register_schema(name, schema)
+    }
+
+    fn deregister_schema(
+        &self,
+        name: &str,
+        cascade: bool,
+    ) -> datafusion::error::Result<Option<Arc<dyn datafusion::catalog::SchemaProvider>>> {
+        self.inner.deregister_schema(name, cascade)
+    }
+}
+
+impl Drop for RefreshingCatalogProvider {
+    fn drop(&mut self) {
+        if let Some(task) = self.refresh_task.take() {
+            task.abort();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -29,10 +29,11 @@ use crate::{
 };
 use async_trait::async_trait;
 use data_components::RefreshableCatalogProvider;
+pub use data_components::RefreshingCatalogProvider;
 use datafusion::catalog::CatalogProvider;
 use deferred::DeferredCatalogProvider;
 use snafu::prelude::*;
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::sync::Mutex;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -78,9 +79,6 @@ pub enum Error {
 
     #[snafu(transparent)]
     IcebergSnafu { source: iceberg::Error },
-
-    #[snafu(display("Failed to start a catalog refresh task. The task is already running."))]
-    RefreshTaskAlreadyStarted {},
 
     #[snafu(display(
         "Failed to read partition metadata for table {schema_name}.{table_name}: {source}"
@@ -390,80 +388,8 @@ pub async fn get_catalog_provider(
             .refreshable_catalog_provider(runtime, catalog)
             .await?,
     )
-    .start_refresh(refresh_interval)?;
+    .start_refresh(refresh_interval);
     Ok(Arc::new(provider))
-}
-
-/// A `CatalogProvider` that periodically refreshes its contents from a remote catalog.
-#[derive(Debug)]
-pub struct RefreshingCatalogProvider {
-    inner: Arc<dyn RefreshableCatalogProvider>,
-    refresh_task: Option<JoinHandle<Result<()>>>,
-}
-
-impl RefreshingCatalogProvider {
-    fn new(inner: Arc<dyn RefreshableCatalogProvider>) -> Self {
-        Self {
-            inner,
-            refresh_task: None,
-        }
-    }
-
-    fn start_refresh(mut self, interval: Option<Duration>) -> Result<Self> {
-        if self.refresh_task.is_some() {
-            return Err(Error::RefreshTaskAlreadyStarted {});
-        }
-
-        let interval = interval.unwrap_or(Duration::from_mins(1));
-        let inner = Arc::clone(&self.inner);
-        self.refresh_task = Some(tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(interval).await;
-                match inner.refresh().await {
-                    Ok(()) => (),
-                    Err(e) => {
-                        tracing::error!("Failed to refresh catalog: {}", e);
-                    }
-                }
-            }
-        }));
-        Ok(self)
-    }
-}
-
-#[deny(clippy::missing_trait_methods)]
-impl CatalogProvider for RefreshingCatalogProvider {
-    fn schema_names(&self) -> Vec<String> {
-        self.inner.schema_names()
-    }
-
-    fn schema(&self, name: &str) -> Option<Arc<dyn datafusion::catalog::SchemaProvider>> {
-        self.inner.schema(name)
-    }
-
-    fn register_schema(
-        &self,
-        name: &str,
-        schema: Arc<dyn datafusion::catalog::SchemaProvider>,
-    ) -> datafusion::error::Result<Option<Arc<dyn datafusion::catalog::SchemaProvider>>> {
-        self.inner.register_schema(name, schema)
-    }
-
-    fn deregister_schema(
-        &self,
-        name: &str,
-        cascade: bool,
-    ) -> datafusion::error::Result<Option<Arc<dyn datafusion::catalog::SchemaProvider>>> {
-        self.inner.deregister_schema(name, cascade)
-    }
-}
-
-impl Drop for RefreshingCatalogProvider {
-    fn drop(&mut self) {
-        if let Some(task) = self.refresh_task.take() {
-            task.abort();
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/cayenne_ddl/mod.rs
@@ -38,25 +38,19 @@ use datafusion::catalog::CatalogProvider;
 
 use cayenne::catalog_provider::CayenneCatalogProvider;
 
-use super::composed_catalog::ComposedCatalogProvider;
 use crate::catalogconnector::PartitionAwareCatalog;
 
-/// Returns `true` if `provider` is Cayenne-backed — handles both a direct
-/// [`CayenneCatalogProvider`] and the runtime's [`ComposedCatalogProvider`] wrapper.
+/// Returns `true` if `provider` is Cayenne-backed, peeling the transparent
+/// `RefreshingCatalogProvider` and `ComposedCatalogProvider` wrappers.
 pub fn is_cayenne_catalog(provider: &dyn CatalogProvider) -> bool {
     get_cayenne_provider(provider).is_some()
 }
 
-/// Extract the [`CayenneCatalogProvider`] reference, handling both direct and
-/// `ComposedCatalogProvider`-wrapped cases.
+/// Extract the [`CayenneCatalogProvider`] reference, peeling the transparent
+/// catalog wrappers. Delegates to the wrapper-aware helper in the `cayenne`
+/// crate so the peeling logic lives in one place.
 pub fn get_cayenne_provider(provider: &dyn CatalogProvider) -> Option<&CayenneCatalogProvider> {
-    if let Some(cayenne) = provider.downcast_ref::<CayenneCatalogProvider>() {
-        return Some(cayenne);
-    }
-    if let Some(composed) = provider.downcast_ref::<ComposedCatalogProvider>() {
-        return composed.external().downcast_ref::<CayenneCatalogProvider>();
-    }
-    None
+    cayenne::ddl::get_cayenne_provider(provider)
 }
 
 /// Return a [`PartitionAwareCatalog`] reference if the provider is Cayenne-backed.

--- a/crates/runtime/src/datafusion/iceberg_ddl/mod.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/mod.rs
@@ -45,6 +45,7 @@ use datafusion::catalog::CatalogProvider;
 
 use super::DataFusion;
 use super::composed_catalog::ComposedCatalogProvider;
+use crate::catalogconnector::RefreshingCatalogProvider;
 
 /// Coerce Arrow data types that are not natively supported by iceberg-rust's
 /// `arrow_schema_to_schema` into their closest Iceberg-compatible equivalents.
@@ -94,21 +95,30 @@ pub fn new_shared_datafusion_ref() -> SharedDataFusionRef {
     Arc::new(OnceLock::new())
 }
 
-/// Try to extract the Iceberg catalog from a `CatalogProvider`.
-/// Handles both direct `IcebergCatalogProvider` and `ComposedCatalogProvider`
-/// wrapping an `IcebergCatalogProvider`.
+/// Extract a concrete [`IcebergCatalogProvider`] reference, peeling the runtime's
+/// transparent catalog wrappers ([`RefreshingCatalogProvider`] and
+/// [`ComposedCatalogProvider`]) in any nesting order.
+///
+/// `DataFusion` 54 removed `CatalogProvider::as_any`, which these wrappers used to
+/// delegate to their inner provider so that `downcast_ref::<IcebergCatalogProvider>()`
+/// transparently saw through them. The wrappers must now be peeled explicitly.
+pub fn iceberg_provider_ref(provider: &dyn CatalogProvider) -> Option<&IcebergCatalogProvider> {
+    if let Some(iceberg) = provider.downcast_ref::<IcebergCatalogProvider>() {
+        return Some(iceberg);
+    }
+    if let Some(refreshing) = provider.downcast_ref::<RefreshingCatalogProvider>() {
+        return iceberg_provider_ref(refreshing.inner_catalog());
+    }
+    if let Some(composed) = provider.downcast_ref::<ComposedCatalogProvider>() {
+        return iceberg_provider_ref(composed.external().as_ref());
+    }
+    None
+}
+
+/// Try to extract the Iceberg catalog from a `CatalogProvider`, peeling the
+/// runtime's transparent catalog wrappers (see [`iceberg_provider_ref`]).
 pub fn composed_catalog_to_iceberg(
     provider: &dyn CatalogProvider,
 ) -> Option<Arc<dyn iceberg::Catalog>> {
-    // Try direct downcast
-    if let Some(iceberg) = provider.downcast_ref::<IcebergCatalogProvider>() {
-        return Some(Arc::clone(iceberg.catalog()));
-    }
-    // Try via ComposedCatalogProvider
-    if let Some(composed) = provider.downcast_ref::<ComposedCatalogProvider>()
-        && let Some(iceberg) = composed.external().downcast_ref::<IcebergCatalogProvider>()
-    {
-        return Some(Arc::clone(iceberg.catalog()));
-    }
-    None
+    iceberg_provider_ref(provider).map(|p| Arc::clone(p.catalog()))
 }

--- a/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
+++ b/crates/runtime/src/datafusion/iceberg_ddl/physical_plans.rs
@@ -39,9 +39,7 @@ use super::acceleration_options::DatasetOptions;
 use crate::accelerated_table::AcceleratedTable;
 use crate::cluster::ExecutorRegistry;
 use crate::datafusion::DataFusion;
-use crate::datafusion::composed_catalog::ComposedCatalogProvider;
 use data_components::RefreshableCatalogProvider;
-use data_components::iceberg::provider::IcebergCatalogProvider;
 use datafusion::catalog::CatalogProviderList;
 
 use crate::component::dataset::acceleration::{Acceleration as RuntimeAcceleration, Mode};
@@ -1117,29 +1115,18 @@ async fn refresh_iceberg_catalog_provider(
         )));
     };
 
-    if let Some(iceberg_provider) = df_catalog.downcast_ref::<IcebergCatalogProvider>() {
-        iceberg_provider.refresh().await.map_err(|e| {
-            DataFusionError::Execution(format!(
-                "Failed to refresh Iceberg catalog '{df_catalog_name}': {e}"
-            ))
-        })?;
-        return Ok(());
-    }
+    let Some(iceberg_provider) = super::iceberg_provider_ref(df_catalog.as_ref()) else {
+        return Err(DataFusionError::Execution(format!(
+            "Catalog '{df_catalog_name}' is not an Iceberg catalog"
+        )));
+    };
 
-    if let Some(composed) = df_catalog.downcast_ref::<ComposedCatalogProvider>()
-        && let Some(iceberg_provider) = composed.external().downcast_ref::<IcebergCatalogProvider>()
-    {
-        iceberg_provider.refresh().await.map_err(|e| {
-            DataFusionError::Execution(format!(
-                "Failed to refresh Iceberg catalog '{df_catalog_name}': {e}"
-            ))
-        })?;
-        return Ok(());
-    }
-
-    Err(DataFusionError::Execution(format!(
-        "Catalog '{df_catalog_name}' is not an Iceberg catalog"
-    )))
+    iceberg_provider.refresh().await.map_err(|e| {
+        DataFusionError::Execution(format!(
+            "Failed to refresh Iceberg catalog '{df_catalog_name}': {e}"
+        ))
+    })?;
+    Ok(())
 }
 
 async fn rollback_created_iceberg_table(

--- a/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
+++ b/crates/runtime/tests/cayenne_catalog_ddl/mod.rs
@@ -2452,3 +2452,84 @@ async fn cayenne_catalog_rejected_without_distributed_mode() -> Result<(), Strin
         })
         .await
 }
+
+// =============================================================================
+// Test: partitioned CREATE TABLE using `PARTITION BY (bucket(N, col))` (the
+// spicebench form) — regression for the DataFusion 54 upgrade (#11360) where
+// this exact statement failed with
+//   "Unsupported Query. Unsupported logical plan: CreateMemoryTable"
+// =============================================================================
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "spicebench"),
+    ignore = "requires the spicebench feature"
+)]
+async fn cayenne_catalog_ddl_create_table_bucket_partition() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let temp_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            let catalog = make_cayenne_catalog(
+                "spicebench",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let app = AppBuilder::new("cayenne_ddl_bucket_partition")
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_resolved_cluster_config(test_cluster_config())
+                .with_runtime_config(Config::default().with_caching_disabled())
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err("Timeout waiting for components to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+            runtime_ready_check_with_timeout(&rt, Duration::from_secs(30)).await;
+
+            exec(&rt, "CREATE SCHEMA spicebench.bench").await?;
+
+            // Exact spicebench setup statement: composite PRIMARY KEY,
+            // quoted identifiers, and `PARTITION BY (bucket(N, col))`.
+            exec(
+                &rt,
+                r#"CREATE TABLE IF NOT EXISTS spicebench.bench."customer" (
+                    "c_custkey" BIGINT, "c_name" TEXT, "c_address" TEXT, "c_nationkey" BIGINT,
+                    "c_phone" TEXT, "c_acctbal" DECIMAL(15, 2), "c_mktsegment" TEXT,
+                    "c_comment" TEXT, "__created_at" TIMESTAMP,
+                    PRIMARY KEY ("c_custkey", "c_nationkey")
+                ) PARTITION BY (bucket(5, c_nationkey))"#,
+            )
+            .await?;
+
+            // The table must appear in information_schema (i.e. it was actually
+            // created as a partitioned cayenne table, not silently dropped).
+            let batches = run_query(
+                &rt,
+                "SELECT table_name FROM information_schema.tables
+                 WHERE table_catalog = 'spicebench' AND table_name = 'customer'",
+            )
+            .await?;
+            assert!(
+                !batches.is_empty() && batches[0].num_rows() == 1,
+                "Expected customer table in information_schema, got {batches:?}"
+            );
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/cluster/distributed_cayenne_catalog.rs
+++ b/crates/runtime/tests/cluster/distributed_cayenne_catalog.rs
@@ -2229,3 +2229,88 @@ async fn test_distributed_cayenne_late_join_ddl_replay() -> Result<(), anyhow::E
         })
         .await
 }
+
+// =============================================================================
+// Test: partitioned CREATE TABLE using `PARTITION BY (bucket(N, col))` — the
+// spicebench setup form. Regression for the DataFusion 54 upgrade (#11360),
+// which broke this exact statement with
+//   "Unsupported Query. Unsupported logical plan: CreateMemoryTable"
+// while bare `PARTITION BY <col>` (covered by the other tests) kept working.
+// =============================================================================
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
+#[cfg_attr(
+    not(feature = "spicebench"),
+    ignore = "requires the spicebench feature"
+)]
+async fn test_distributed_cayenne_ddl_bucket_partition() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    let temp_dir = tempfile::tempdir()?;
+    let data_dir = temp_dir.path().join("data");
+    let metadata_dir = temp_dir.path().join("metadata");
+
+    test_request_context()
+        .scope(async {
+            configure_test_datafusion();
+
+            let catalog = make_cayenne_catalog(
+                "spicebench",
+                &data_dir.to_string_lossy(),
+                &metadata_dir.to_string_lossy(),
+            );
+
+            let harness = ClusterHarness::builder()
+                .scheduler(
+                    AppBuilder::new("distributed_cayenne_bucket_partition")
+                        .with_catalog(catalog.clone())
+                        .build(),
+                )
+                .executor_with_app(
+                    AppBuilder::new("executor_bucket_partition")
+                        .with_catalog(catalog)
+                        .build(),
+                )
+                .start()
+                .await?;
+
+            run_with_harness(harness, |harness| {
+                Box::pin(async move {
+                    harness.wait_for_executors(Duration::from_secs(15)).await?;
+
+                    harness.query("CREATE SCHEMA spicebench.bench").await?;
+
+                    // Exact spicebench setup statement: composite PRIMARY KEY,
+                    // quoted identifiers, and `PARTITION BY (bucket(N, col))`.
+                    harness
+                        .query(
+                            r#"CREATE TABLE IF NOT EXISTS spicebench.bench."customer" (
+                                "c_custkey" BIGINT, "c_name" TEXT, "c_address" TEXT,
+                                "c_nationkey" BIGINT, "c_phone" TEXT,
+                                "c_acctbal" DECIMAL(15, 2), "c_mktsegment" TEXT,
+                                "c_comment" TEXT, "__created_at" TIMESTAMP,
+                                PRIMARY KEY ("c_custkey", "c_nationkey")
+                            ) PARTITION BY (bucket(5, c_nationkey))"#,
+                        )
+                        .await?;
+
+                    let info_batches = harness
+                        .query(
+                            "SELECT table_name FROM information_schema.tables
+                             WHERE table_catalog = 'spicebench' AND table_name = 'customer'",
+                        )
+                        .await?;
+                    assert_eq!(
+                        total_rows(&info_batches),
+                        1,
+                        "customer table should appear in information_schema after \
+                         partitioned CREATE TABLE"
+                    );
+
+                    Ok(())
+                })
+            })
+            .await
+        })
+        .await
+}


### PR DESCRIPTION
## Problem

DataFusion 54 (#11360) removed `CatalogProvider::as_any` from the trait, replacing it with an `Any`-supertrait `downcast_ref` that always resolves to the wrapper's own concrete type. `RefreshingCatalogProvider` — the periodic-refresh wrapper that **every** registered catalog is wrapped in — used `as_any` to delegate to its inner provider, making concrete-type downcasts transparent. The DF54 upgrade mechanically deleted that override.

As a result, `get_cayenne_provider` / `DdlAnalyzerRule::is_target_catalog` could no longer see the `CayenneCatalogProvider` (or `IcebergCatalogProvider`) inside the wrapper, so the DDL analyzer left `CREATE SCHEMA` / `CREATE TABLE` plans un-rewritten and physical planning rejected them:

```
Unsupported Query. Unsupported logical plan: CreateCatalogSchema
Unsupported Query. Unsupported logical plan: CreateMemoryTable
```

This broke **all** cayenne and iceberg catalog DDL — not just partitioned/bucketed tables.

Executors compound the failure: only schedulers get an `executor_registry`, so executors re-plan scheduler-forwarded DDL with the single-node `cayenne::CayenneDdlHandler` and fail with `Failed to forward DDL to any executor`.

## Root cause

#11360 deleted:

```rust
impl CatalogProvider for RefreshingCatalogProvider {
-    fn as_any(&self) -> &dyn Any { self.inner.as_any() } // delegated to the wrapped provider
     ...
}
```

DF54's replacement inherent `downcast_ref` (`(self as &dyn Any).downcast_ref()`) can only ever resolve to `RefreshingCatalogProvider` itself — there is no hook to delegate through. (Parsing is identical in sqlparser 0.61 ↔ 0.62; this is purely a catalog-detection regression, not a parser/`bucket()` change.)

## Fix

Explicitly peel the transparent catalog wrappers before concrete-type downcasts:

- Move `RefreshingCatalogProvider` to `data_components` (next to `RefreshableCatalogProvider`) so the lower `cayenne` crate can downcast/peel it; add an `inner_catalog()` accessor. No new dependency edges or cycles.
- `cayenne::ddl::get_cayenne_provider` becomes the single wrapper-aware helper, peeling `RefreshingCatalogProvider` + `ComposedCatalogProvider` recursively. The runtime helper, `is_cayenne_catalog`, and `is_target_catalog` delegate to it.
- Iceberg: add an `iceberg_provider_ref` peel chokepoint; `composed_catalog_to_iceberg` and the post-DDL catalog refresh route through it.

`PARTITION BY (bucket(N, col))` + composite `PRIMARY KEY` semantics are preserved — the extension-extraction path was always correct; only catalog *detection* was broken.

## Testing

- New regression tests for `CREATE SCHEMA` + partitioned `CREATE TABLE ... PARTITION BY (bucket(N, col))` (composite PK, quoted identifiers) in **both** single-node (`cayenne_catalog_ddl`) and distributed scheduler+executor (`distributed_cayenne_catalog`) cayenne catalogs — both pass.
- `make lint-rust` clean.

## Note

DF54 added a `downcast_delegate` hook, but only on `ExecutionPlan`, not `CatalogProvider`. Mirroring it onto `CatalogProvider` in the fork would be a more transparent fix (no call-site changes), but is intentionally out of scope here.
