### PR TITLE
feat(cluster): support distributed (Ballista) scans of Iceberg tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ef85534eca57620fe2a61e3e202ecbbca2471868#ef85534eca57620fe2a61e3e202ecbbca2471868"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9515,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ef85534eca57620fe2a61e3e202ecbbca2471868#ef85534eca57620fe2a61e3e202ecbbca2471868"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9530,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ef85534eca57620fe2a61e3e202ecbbca2471868#ef85534eca57620fe2a61e3e202ecbbca2471868"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ef85534eca57620fe2a61e3e202ecbbca2471868#ef85534eca57620fe2a61e3e202ecbbca2471868"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ef85534eca57620fe2a61e3e202ecbbca2471868#ef85534eca57620fe2a61e3e202ecbbca2471868"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9589,7 +9589,7 @@ dependencies = [
 [[package]]
 name = "iceberg_test_utils"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=ef85534eca57620fe2a61e3e202ecbbca2471868#ef85534eca57620fe2a61e3e202ecbbca2471868"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
 dependencies = [
  "iceberg",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c#5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9515,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c#5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9530,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c#5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c#5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c#5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9589,7 +9589,7 @@ dependencies = [
 [[package]]
 name = "iceberg_test_utils"
 version = "0.9.1"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=17183547f127cccf7b47ee25dab99b5dcc8dc340#17183547f127cccf7b47ee25dab99b5dcc8dc340"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c#5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c"
 dependencies = [
  "iceberg",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -458,12 +458,12 @@ tokio-rusqlite = { git = "https://github.com/spiceai/tokio-rusqlite.git", rev = 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ef85534eca57620fe2a61e3e202ecbbca2471868" } # branch: spiceai-0.9.1-df-54
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ef85534eca57620fe2a61e3e202ecbbca2471868" } # branch: spiceai-0.9.1-df-54
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ef85534eca57620fe2a61e3e202ecbbca2471868" } # branch: spiceai-0.9.1-df-54
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ef85534eca57620fe2a61e3e202ecbbca2471868" } # branch: spiceai-0.9.1-df-54
-iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ef85534eca57620fe2a61e3e202ecbbca2471868" } # branch: spiceai-0.9.1-df-54
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "ef85534eca57620fe2a61e3e202ecbbca2471868" } # branch: spiceai-0.9.1-df-54
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
+iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
 
 # candle-* crates are already redirected to the spiceai/candle fork via the
 # [patch.crates-io] block higher up in this file. Keeping those here would be

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -458,12 +458,12 @@ tokio-rusqlite = { git = "https://github.com/spiceai/tokio-rusqlite.git", rev = 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
-iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "17183547f127cccf7b47ee25dab99b5dcc8dc340" } # branch: phillip/df-54-snapshot-pinning (snapshot pinning; merge into spiceai-0.9.1-df-54)
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c" } # branch: spiceai-0.9.1-df-54
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c" } # branch: spiceai-0.9.1-df-54
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c" } # branch: spiceai-0.9.1-df-54
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c" } # branch: spiceai-0.9.1-df-54
+iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c" } # branch: spiceai-0.9.1-df-54
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "5c5557c3bce7eb53b16573aa82d90c37c2fa3c8c" } # branch: spiceai-0.9.1-df-54
 
 # candle-* crates are already redirected to the spiceai/candle fork via the
 # [patch.crates-io] block higher up in this file. Keeping those here would be

--- a/crates/data_components/src/iceberg/delete.rs
+++ b/crates/data_components/src/iceberg/delete.rs
@@ -362,6 +362,14 @@ impl IcebergDeletionProvider {
             inner,
         }
     }
+
+    /// The wrapped provider (the underlying `IcebergTableProvider`). Exposed so
+    /// wrapper-peeling helpers can see through this layer to the concrete
+    /// Iceberg provider.
+    #[must_use]
+    pub fn inner(&self) -> &Arc<dyn datafusion::datasource::TableProvider> {
+        &self.inner
+    }
 }
 
 impl Debug for IcebergDeletionProvider {

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -306,11 +306,12 @@ message CayenneAccelerationExecNode {}
 // `FileIO`), and its planned `FileScanTask`s carry fields the iceberg crate
 // intentionally refuses to serialize (partition / partition_spec). So instead of
 // shipping the plan, we serialize a minimal recipe — the DataFusion table
-// reference plus the scan's projection, filters, and limit — and on the executor
-// re-derive an equivalent scan by calling the already-registered provider's
-// `scan()`. Reusing the registered provider means no catalog is rebuilt and no
-// secrets cross the wire; re-planning with the same projection/filters yields the
-// same per-partition bucketing the scheduler produced.
+// reference plus the scan's projection, filters, limit, and output partitioning —
+// and on the executor re-derive an equivalent scan by calling the
+// already-registered provider's `scan()` lazily at execution time. Reusing the
+// registered provider means no catalog is rebuilt and no secrets cross the wire;
+// re-planning with the same projection/filters yields the same per-partition
+// bucketing the scheduler produced.
 message IcebergTableScanExecNode {
     // DataFusion table reference (e.g. `dataset`, or `catalog.schema.table`) used
     // to resolve the registered Iceberg provider on the executor.
@@ -324,6 +325,23 @@ message IcebergTableScanExecNode {
     repeated bytes filters = 4;
     // Optional row limit pushed into the scan.
     optional uint64 limit = 5;
+    // Output partitioning, so the deferred node reports the same partition count
+    // the scheduler planned before the (lazy) scan actually runs.
+    IcebergPartitioning partitioning = 6;
+}
+
+// Serializable form of the scan's output `Partitioning`.
+message IcebergPartitioning {
+    // 0 = UnknownPartitioning, 1 = Hash, 2 = RoundRobinBatch.
+    uint32 kind = 1;
+    uint64 partition_count = 2;
+    // Hash partitioning columns (only populated when kind == 1).
+    repeated IcebergHashColumn hash_columns = 3;
+}
+
+message IcebergHashColumn {
+    string name = 1;
+    uint64 index = 2;
 }
 
 // Execution plan node for UDTFs.

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -288,6 +288,7 @@ message SpicePhysicalPlanNode {
         BytesProcessedExecNode bytes_processed = 2;
         CayenneAccelerationExecNode cayenne_acceleration = 3;
         UdtfExecNode udtf = 4;
+        IcebergTableScanExecNode iceberg_table_scan = 5;
     }
 }
 
@@ -298,6 +299,32 @@ message SchemaCastScanExecNode {
 message BytesProcessedExecNode {}
 
 message CayenneAccelerationExecNode {}
+
+// Execution plan node for distributed Iceberg table scans.
+//
+// An `IcebergTableScan` holds a live, non-serializable `Table` (with an open
+// `FileIO`), and its planned `FileScanTask`s carry fields the iceberg crate
+// intentionally refuses to serialize (partition / partition_spec). So instead of
+// shipping the plan, we serialize a minimal recipe — the DataFusion table
+// reference plus the scan's projection, filters, and limit — and on the executor
+// re-derive an equivalent scan by calling the already-registered provider's
+// `scan()`. Reusing the registered provider means no catalog is rebuilt and no
+// secrets cross the wire; re-planning with the same projection/filters yields the
+// same per-partition bucketing the scheduler produced.
+message IcebergTableScanExecNode {
+    // DataFusion table reference (e.g. `dataset`, or `catalog.schema.table`) used
+    // to resolve the registered Iceberg provider on the executor.
+    string table_ref = 1;
+    // Projected column indices. Empty + `has_projection=false` means "all columns".
+    repeated uint32 projection = 2;
+    bool has_projection = 3;
+    // Pushed-down filters, each a datafusion-proto-serialized logical `Expr`.
+    // Re-applied on re-plan so the executor reproduces the same file pruning
+    // (hence the same partition count) as the scheduler.
+    repeated bytes filters = 4;
+    // Optional row limit pushed into the scan.
+    optional uint64 limit = 5;
+}
 
 // Execution plan node for UDTFs.
 // This allows UDTF results to be distributed across a cluster by serializing

--- a/crates/runtime-proto/proto/spice.proto
+++ b/crates/runtime-proto/proto/spice.proto
@@ -328,6 +328,11 @@ message IcebergTableScanExecNode {
     // Output partitioning, so the deferred node reports the same partition count
     // the scheduler planned before the (lazy) scan actually runs.
     IcebergPartitioning partitioning = 6;
+    // Snapshot pinned at planning time on the scheduler. Every executor task
+    // plans against this snapshot, so all partitions of one query read a single
+    // consistent snapshot even if the table is committed to mid-query. Absent =
+    // read the current snapshot (e.g. table had no snapshot at plan time).
+    optional int64 snapshot_id = 7;
 }
 
 // Serializable form of the scan's output `Partitioning`.

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -15,16 +15,20 @@ limitations under the License.
 */
 
 use crate::Runtime;
-use crate::execution_plan::UdtfExec;
+use crate::dataconnector::iceberg_cluster::IcebergClusterTableProvider;
+use crate::datafusion::planner::peel_table_provider_wrappers;
+use crate::execution_plan::{IcebergScanExec, UdtfExec};
 use crate::metrics::telemetry::track_bytes_processed;
 use arrow_schema::Schema;
 use ballista_core::serde::BallistaPhysicalExtensionCodec;
 #[cfg(not(windows))]
 use cayenne::provider::CayenneAccelerationExec;
-use datafusion::common::{DataFusionError, Result, exec_err};
+use datafusion::common::{DataFusionError, Result, TableReference, exec_err};
 use datafusion::execution::{FunctionRegistry, TaskContext};
+use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_expr::ScalarUDF;
+use datafusion_proto::bytes::Serializeable;
 use datafusion_proto::generated::datafusion_common;
 #[cfg(not(windows))]
 use datafusion_proto::physical_plan::AsExecutionPlan;
@@ -35,8 +39,8 @@ use prost::Message;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion::extension::bytes_processed::BytesProcessedExec;
 use runtime_proto::{
-    BytesProcessedExecNode, CayenneAccelerationExecNode, SchemaCastScanExecNode,
-    SpicePhysicalPlanNode, UdtfExecNode, spice_physical_plan_node,
+    BytesProcessedExecNode, CayenneAccelerationExecNode, IcebergTableScanExecNode,
+    SchemaCastScanExecNode, SpicePhysicalPlanNode, UdtfExecNode, spice_physical_plan_node,
 };
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -140,6 +144,40 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
 
                 Ok(Arc::new(UdtfExec::new(args, inner_plan)))
             }
+            Some(spice_physical_plan_node::Node::IcebergTableScan(node)) => {
+                let runtime = self.runtime()?;
+                let table_ref = TableReference::from(node.table_ref.as_str());
+
+                let projection: Option<Vec<usize>> = if node.has_projection {
+                    Some(
+                        node.projection
+                            .iter()
+                            .map(|c| usize::try_from(*c).unwrap_or(usize::MAX))
+                            .collect(),
+                    )
+                } else {
+                    None
+                };
+                let filters = node
+                    .filters
+                    .iter()
+                    .map(|bytes| Expr::from_bytes_with_ctx(bytes, ctx))
+                    .collect::<Result<Vec<Expr>>>()?;
+                let limit = node.limit.map(|l| usize::try_from(l).unwrap_or(usize::MAX));
+
+                // Re-derive the scan by replaying TableProvider::scan on the
+                // already-registered Iceberg provider, reusing its catalog. No
+                // secrets cross the wire and no catalog is rebuilt — the executor
+                // loaded the same app definition, so re-planning with the same
+                // projection/filters reproduces the scheduler's bucketing.
+                replan_registered_iceberg_scan(
+                    &runtime,
+                    &table_ref,
+                    projection.as_ref(),
+                    &filters,
+                    limit,
+                )
+            }
             None => {
                 #[cfg(not(windows))]
                 if let Ok(plan) = Self::try_decode_nested_physical_plan(buf, ctx) {
@@ -182,6 +220,40 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                     schema: schema_buf,
                 })),
             }
+        } else if let Some(scan_exec) = node.downcast_ref::<IcebergScanExec>() {
+            // Serialize the scan recipe (table ref + projection/filters/limit).
+            // The executor replays `TableProvider::scan` with these to re-derive
+            // an equivalent scan — the iceberg `FileScanTask`s themselves are not
+            // serializable (partition / partition_spec fields), so the plan is
+            // rebuilt remotely rather than shipped.
+            let (has_projection, projection) = match scan_exec.projection() {
+                Some(cols) => (
+                    true,
+                    cols.iter()
+                        .map(|c| u32::try_from(*c).unwrap_or(u32::MAX))
+                        .collect(),
+                ),
+                None => (false, Vec::new()),
+            };
+            let filters = scan_exec
+                .filters()
+                .iter()
+                .map(|expr| expr.to_bytes().map(|b| b.to_vec()))
+                .collect::<Result<Vec<Vec<u8>>>>()?;
+
+            SpicePhysicalPlanNode {
+                node: Some(spice_physical_plan_node::Node::IcebergTableScan(
+                    IcebergTableScanExecNode {
+                        table_ref: scan_exec.table_ref().to_string(),
+                        projection,
+                        has_projection,
+                        filters,
+                        limit: scan_exec
+                            .limit()
+                            .map(|l| u64::try_from(l).unwrap_or(u64::MAX)),
+                    },
+                )),
+            }
         } else {
             #[cfg(not(windows))]
             if node.downcast_ref::<CayenneAccelerationExec>().is_some() {
@@ -209,6 +281,61 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
     fn try_decode_udf(&self, name: &str, _buf: &[u8]) -> Result<Arc<ScalarUDF>> {
         self.runtime()?.df.ctx.udf(name)
     }
+}
+
+/// Re-derives an Iceberg scan on this executor by replaying
+/// [`TableProvider::scan`] on the already-registered provider for `table_ref`.
+///
+/// The executor loaded the same app definition as the scheduler, so the Iceberg
+/// provider (an [`IcebergClusterTableProvider`], possibly behind registration
+/// wrappers) is already registered. Resolving it and re-calling `scan` with the
+/// same projection/filters/limit rebuilds an equivalent, identically bucketed
+/// scan — reusing the provider's catalog (no secrets cross the wire, no catalog
+/// rebuilt) and producing a fresh [`IcebergScanExec`].
+fn replan_registered_iceberg_scan(
+    runtime: &Arc<Runtime>,
+    table_ref: &TableReference,
+    projection: Option<&Vec<usize>>,
+    filters: &[Expr],
+    limit: Option<usize>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    // The codec API is synchronous but resolution/scan are async; this path runs
+    // only at plan-decode time on an executor, so blocking is acceptable.
+    let provider = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(runtime.df.get_table(table_ref))
+    })
+    .ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "Iceberg table {table_ref} is not registered on this executor; \
+             cannot reconstruct the distributed scan"
+        ))
+    })?;
+
+    // Peel the registration wrappers (FederatedTableProviderAdaptor,
+    // MetadataEnrichedTableProvider) down to the IcebergClusterTableProvider that
+    // dataset registration leaves in the catalog. The Spice `FederatedTable`
+    // holder is already resolved to its inner provider at registration time, so
+    // it is never the registered provider here.
+    let peeled = peel_table_provider_wrappers(&provider);
+    if peeled
+        .downcast_ref::<IcebergClusterTableProvider>()
+        .is_none()
+    {
+        return exec_err!(
+            "registered provider for {table_ref} is not an IcebergClusterTableProvider; \
+             distributed Iceberg scans require the Iceberg data connector"
+        );
+    }
+
+    let session_state = runtime.df.ctx.state();
+    tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(peeled.scan(
+            &session_state,
+            projection,
+            filters,
+            limit,
+        ))
+    })
 }
 
 #[cfg(not(windows))]

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -148,12 +148,23 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                 let runtime = self.runtime()?;
                 let table_ref = TableReference::from(node.table_ref.as_str());
 
+                // Surface conversion failures as structured errors rather than
+                // saturating: a corrupt recipe or scheduler/executor version skew
+                // should fail clearly here, not as a later out-of-bounds column or
+                // an effectively unbounded limit.
                 let projection: Option<Vec<usize>> = if node.has_projection {
                     Some(
                         node.projection
                             .iter()
-                            .map(|c| usize::try_from(*c).unwrap_or(usize::MAX))
-                            .collect(),
+                            .map(|c| {
+                                usize::try_from(*c).map_err(|_| {
+                                    DataFusionError::Internal(format!(
+                                        "iceberg scan recipe for {table_ref} has projection index \
+                                         {c} that does not fit in usize"
+                                    ))
+                                })
+                            })
+                            .collect::<Result<Vec<usize>>>()?,
                     )
                 } else {
                     None
@@ -163,7 +174,17 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                     .iter()
                     .map(|bytes| Expr::from_bytes_with_ctx(bytes, ctx))
                     .collect::<Result<Vec<Expr>>>()?;
-                let limit = node.limit.map(|l| usize::try_from(l).unwrap_or(usize::MAX));
+                let limit = node
+                    .limit
+                    .map(|l| {
+                        usize::try_from(l).map_err(|_| {
+                            DataFusionError::Internal(format!(
+                                "iceberg scan recipe for {table_ref} has limit {l} that does not \
+                                 fit in usize"
+                            ))
+                        })
+                    })
+                    .transpose()?;
 
                 // Re-derive the scan by replaying TableProvider::scan on the
                 // already-registered Iceberg provider, reusing its catalog. No
@@ -172,6 +193,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                 // projection/filters reproduces the scheduler's bucketing.
                 replan_registered_iceberg_scan(
                     &runtime,
+                    ctx,
                     &table_ref,
                     projection.as_ref(),
                     &filters,
@@ -225,13 +247,22 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             // The executor replays `TableProvider::scan` with these to re-derive
             // an equivalent scan — the iceberg `FileScanTask`s themselves are not
             // serializable (partition / partition_spec fields), so the plan is
-            // rebuilt remotely rather than shipped.
+            // rebuilt remotely rather than shipped. Conversions that don't fit the
+            // wire types fail serialization explicitly rather than silently
+            // saturating into a malformed recipe.
             let (has_projection, projection) = match scan_exec.projection() {
                 Some(cols) => (
                     true,
                     cols.iter()
-                        .map(|c| u32::try_from(*c).unwrap_or(u32::MAX))
-                        .collect(),
+                        .map(|c| {
+                            u32::try_from(*c).map_err(|_| {
+                                DataFusionError::Internal(format!(
+                                    "IcebergScanExec projection index {c} does not fit in u32; \
+                                     cannot serialize the scan for distributed execution"
+                                ))
+                            })
+                        })
+                        .collect::<Result<Vec<u32>>>()?,
                 ),
                 None => (false, Vec::new()),
             };
@@ -240,6 +271,17 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                 .iter()
                 .map(|expr| expr.to_bytes().map(|b| b.to_vec()))
                 .collect::<Result<Vec<Vec<u8>>>>()?;
+            let limit = scan_exec
+                .limit()
+                .map(|l| {
+                    u64::try_from(l).map_err(|_| {
+                        DataFusionError::Internal(format!(
+                            "IcebergScanExec limit {l} does not fit in u64; cannot serialize the \
+                             scan for distributed execution"
+                        ))
+                    })
+                })
+                .transpose()?;
 
             SpicePhysicalPlanNode {
                 node: Some(spice_physical_plan_node::Node::IcebergTableScan(
@@ -248,9 +290,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                         projection,
                         has_projection,
                         filters,
-                        limit: scan_exec
-                            .limit()
-                            .map(|l| u64::try_from(l).unwrap_or(u64::MAX)),
+                        limit,
                     },
                 )),
             }
@@ -292,8 +332,15 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
 /// same projection/filters/limit rebuilds an equivalent, identically bucketed
 /// scan — reusing the provider's catalog (no secrets cross the wire, no catalog
 /// rebuilt) and producing a fresh [`IcebergScanExec`].
+///
+/// The replan uses the runtime's session state but overrides `target_partitions`
+/// with the value from the per-job [`TaskContext`]. Iceberg's partition (bucket)
+/// count is `target_partitions.min(num_tasks)`, so the replan must use the same
+/// `target_partitions` the scheduler planned with — otherwise the executor could
+/// rebuild a scan with a different partition count than the stage expects.
 fn replan_registered_iceberg_scan(
     runtime: &Arc<Runtime>,
+    ctx: &TaskContext,
     table_ref: &TableReference,
     projection: Option<&Vec<usize>>,
     filters: &[Expr],
@@ -327,7 +374,15 @@ fn replan_registered_iceberg_scan(
         );
     }
 
-    let session_state = runtime.df.ctx.state();
+    // Align target_partitions with the scheduler's per-job config so the rebuilt
+    // scan buckets into the same number of partitions as the planned stage.
+    let mut session_state = runtime.df.ctx.state();
+    session_state
+        .config_mut()
+        .options_mut()
+        .execution
+        .target_partitions = ctx.session_config().options().execution.target_partitions;
+
     tokio::task::block_in_place(|| {
         tokio::runtime::Handle::current().block_on(peeled.scan(
             &session_state,
@@ -420,5 +475,53 @@ mod tests {
             plan.contains("CayenneAccelerationExec"),
             "Cayenne scan marker should survive distributed codec roundtrip: {plan}"
         );
+    }
+
+    #[test]
+    fn iceberg_scan_exec_encodes_recipe() {
+        use datafusion::logical_expr::{col as logical_col, lit};
+        use datafusion::physical_plan::empty::EmptyExec;
+
+        // The encode arm reads only IcebergScanExec's own recipe fields, not the
+        // inner plan's type, so an EmptyExec inner is sufficient to exercise it.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::Float64, true),
+        ]));
+        let inner: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let scan = IcebergScanExec::new(
+            TableReference::bare("trips"),
+            inner,
+            Some(vec![0, 2]),
+            vec![logical_col("a").gt(lit(5_i64))],
+            Some(10),
+        );
+
+        let codec = SpicePhysicalCodec {
+            inner: Arc::new(BallistaPhysicalExtensionCodec::default()),
+            runtime: None,
+        };
+        let mut buf = Vec::new();
+        codec
+            .try_encode(Arc::new(scan), &mut buf)
+            .expect("IcebergScanExec should serialize through the Spice codec");
+
+        let wrapper =
+            SpicePhysicalPlanNode::decode(buf.as_slice()).expect("encoded blob should decode");
+        match wrapper.node {
+            Some(spice_physical_plan_node::Node::IcebergTableScan(node)) => {
+                assert_eq!(node.table_ref, "trips");
+                assert!(node.has_projection);
+                assert_eq!(node.projection, vec![0_u32, 2_u32]);
+                assert_eq!(node.limit, Some(10_u64));
+                assert_eq!(
+                    node.filters.len(),
+                    1,
+                    "the pushed-down filter should be serialized into the recipe"
+                );
+            }
+            other => panic!("expected an IcebergTableScan recipe node, got {other:?}"),
+        }
     }
 }

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -16,9 +16,9 @@ limitations under the License.
 
 use crate::Runtime;
 use crate::dataconnector::iceberg_cluster::IcebergClusterTableProvider;
-use crate::datafusion::planner::peel_table_provider_wrappers;
 use crate::execution_plan::{IcebergScanExec, UdtfExec};
 use crate::metrics::telemetry::track_bytes_processed;
+use crate::search::util::find_concrete_table_provider;
 use arrow_schema::Schema;
 use ballista_core::serde::BallistaPhysicalExtensionCodec;
 #[cfg(not(windows))]
@@ -204,8 +204,14 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                          cannot reconstruct the distributed scan"
                     ))
                 })?;
-                let peeled = peel_table_provider_wrappers(&provider);
-                let Some(cluster) = peeled.downcast_ref::<IcebergClusterTableProvider>() else {
+                // Locate the cluster provider through ALL known runtime wrappers
+                // (FederatedTableProviderAdaptor, MetadataEnrichedTableProvider,
+                // EmbeddingTable, IndexedTableProvider, AcceleratedTable, …), not
+                // just the federation/metadata pair — an Iceberg dataset with
+                // embeddings or a search index is wrapped further.
+                let Some(cluster) =
+                    find_concrete_table_provider::<IcebergClusterTableProvider>(&provider)
+                else {
                     return exec_err!(
                         "registered provider for {table_ref} is not an IcebergClusterTableProvider; \
                          distributed Iceberg scans require the Iceberg data connector"

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -23,6 +23,8 @@ use arrow_schema::Schema;
 use ballista_core::serde::BallistaPhysicalExtensionCodec;
 #[cfg(not(windows))]
 use cayenne::provider::CayenneAccelerationExec;
+use data_components::iceberg::delete::IcebergDeletionProvider;
+use datafusion::catalog::TableProvider;
 use datafusion::common::{DataFusionError, Result, TableReference, exec_err};
 use datafusion::execution::{FunctionRegistry, TaskContext};
 use datafusion::logical_expr::Expr;
@@ -37,6 +39,7 @@ use datafusion_proto::physical_plan::AsExecutionPlan;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 #[cfg(not(windows))]
 use datafusion_proto::protobuf::PhysicalPlanNode;
+use iceberg_datafusion::IcebergTableProvider;
 use prost::Message;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion::extension::bytes_processed::BytesProcessedExec;
@@ -208,13 +211,23 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                          distributed Iceberg scans require the Iceberg data connector"
                     );
                 };
-                // The concrete Iceberg provider (not the cluster wrapper), so
-                // replaying its scan() yields the bare scan without re-wrapping.
-                let inner_provider = Arc::clone(cluster.inner());
+                // Resolve the concrete IcebergTableProvider (the cluster wrapper's
+                // inner, peeling the deletion wrapper on the read-write path) and
+                // pin it to the snapshot the scheduler chose, so every executor task
+                // of this query reads the same snapshot. Scanning this provider
+                // directly also yields the bare scan without re-wrapping.
+                let Some(iceberg_provider) = concrete_iceberg_provider(cluster.inner()) else {
+                    return exec_err!(
+                        "IcebergClusterTableProvider for {table_ref} does not wrap an \
+                         IcebergTableProvider; cannot reconstruct the distributed scan"
+                    );
+                };
+                let pinned: Arc<dyn TableProvider> =
+                    Arc::new(iceberg_provider.clone().with_snapshot_id(node.snapshot_id));
 
                 // Output schema = table schema projected by the recipe, taken
                 // synchronously from the registered provider.
-                let table_schema = inner_provider.schema();
+                let table_schema = pinned.schema();
                 let output_schema = match &projection {
                     Some(p) => Arc::new(table_schema.project(p)?),
                     None => table_schema,
@@ -222,7 +235,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
 
                 Ok(Arc::new(IcebergScanExec::new_deferred(
                     table_ref,
-                    inner_provider,
+                    pinned,
                     projection,
                     filters,
                     limit,
@@ -323,6 +336,8 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                         filters,
                         limit,
                         partitioning: Some(partitioning),
+                        // Pin the plan-time snapshot so every executor task reads it.
+                        snapshot_id: scan_exec.snapshot_id(),
                     },
                 )),
             }
@@ -353,6 +368,19 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
     fn try_decode_udf(&self, name: &str, _buf: &[u8]) -> Result<Arc<ScalarUDF>> {
         self.runtime()?.df.ctx.udf(name)
     }
+}
+
+/// Returns the concrete [`IcebergTableProvider`] behind a cluster wrapper's inner
+/// provider — directly (read path) or through the [`IcebergDeletionProvider`] the
+/// read-write path inserts. The returned provider is used (cloned + snapshot
+/// pinned) to replay the scan on the executor.
+fn concrete_iceberg_provider(inner: &Arc<dyn TableProvider>) -> Option<&IcebergTableProvider> {
+    if let Some(p) = inner.downcast_ref::<IcebergTableProvider>() {
+        return Some(p);
+    }
+    inner
+        .downcast_ref::<IcebergDeletionProvider>()
+        .and_then(|d| d.inner().downcast_ref::<IcebergTableProvider>())
 }
 
 /// Serializes a scan's output [`Partitioning`] into its wire form, so the

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -188,7 +188,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                         })
                     })
                     .transpose()?;
-                let partitioning = decode_partitioning(node.partitioning.as_ref());
+                let partitioning = decode_partitioning(node.partitioning.as_ref())?;
 
                 // Resolve the registered provider synchronously — no catalog I/O,
                 // no blocking bridge. The executor loaded the same app definition,
@@ -312,7 +312,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                     })
                 })
                 .transpose()?;
-            let partitioning = encode_partitioning(scan_exec.properties().output_partitioning());
+            let partitioning = encode_partitioning(scan_exec.properties().output_partitioning())?;
 
             SpicePhysicalPlanNode {
                 node: Some(spice_physical_plan_node::Node::IcebergTableScan(
@@ -362,69 +362,90 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
 /// Hash partitioning is reproduced only when every expression is a plain
 /// [`Column`]; otherwise the count is preserved as
 /// [`Partitioning::UnknownPartitioning`].
-fn encode_partitioning(partitioning: &Partitioning) -> IcebergPartitioning {
-    let to_u64 = |n: usize| u64::try_from(n).unwrap_or(u64::MAX);
-    match partitioning {
+fn encode_partitioning(partitioning: &Partitioning) -> Result<IcebergPartitioning> {
+    // Counts/indices fail serialization explicitly rather than saturating into a
+    // malformed recipe (consistent with how projection/limit are encoded).
+    fn to_u64(n: usize) -> Result<u64> {
+        u64::try_from(n).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "IcebergScanExec partitioning value {n} does not fit in u64; cannot serialize \
+                 the scan for distributed execution"
+            ))
+        })
+    }
+    Ok(match partitioning {
         Partitioning::UnknownPartitioning(n) => IcebergPartitioning {
             kind: 0,
-            partition_count: to_u64(*n),
+            partition_count: to_u64(*n)?,
             hash_columns: Vec::new(),
         },
         Partitioning::RoundRobinBatch(n) => IcebergPartitioning {
             kind: 2,
-            partition_count: to_u64(*n),
+            partition_count: to_u64(*n)?,
             hash_columns: Vec::new(),
         },
         Partitioning::Hash(exprs, n) => {
-            let hash_columns: Vec<IcebergHashColumn> = exprs
-                .iter()
-                .filter_map(|expr| {
-                    expr.downcast_ref::<Column>().map(|c| IcebergHashColumn {
+            // Reproduce Hash partitioning only when every expr is a plain Column;
+            // otherwise preserve just the count as UnknownPartitioning.
+            let mut hash_columns = Vec::with_capacity(exprs.len());
+            let mut all_columns = true;
+            for expr in exprs {
+                if let Some(c) = expr.downcast_ref::<Column>() {
+                    hash_columns.push(IcebergHashColumn {
                         name: c.name().to_string(),
-                        index: to_u64(c.index()),
-                    })
-                })
-                .collect();
-            if hash_columns.len() == exprs.len() {
+                        index: to_u64(c.index())?,
+                    });
+                } else {
+                    all_columns = false;
+                    break;
+                }
+            }
+            if all_columns {
                 IcebergPartitioning {
                     kind: 1,
-                    partition_count: to_u64(*n),
+                    partition_count: to_u64(*n)?,
                     hash_columns,
                 }
             } else {
                 IcebergPartitioning {
                     kind: 0,
-                    partition_count: to_u64(*n),
+                    partition_count: to_u64(*n)?,
                     hash_columns: Vec::new(),
                 }
             }
         }
-    }
+    })
 }
 
-/// Reconstructs a [`Partitioning`] from its wire form.
-fn decode_partitioning(partitioning: Option<&IcebergPartitioning>) -> Partitioning {
+/// Reconstructs a [`Partitioning`] from its wire form. Values that don't fit
+/// `usize` (corrupt recipe / platform skew) fail rather than saturating.
+fn decode_partitioning(partitioning: Option<&IcebergPartitioning>) -> Result<Partitioning> {
+    fn to_usize(v: u64) -> Result<usize> {
+        usize::try_from(v).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "iceberg scan recipe partitioning value {v} does not fit in usize"
+            ))
+        })
+    }
     let Some(p) = partitioning else {
-        return Partitioning::UnknownPartitioning(1);
+        return Ok(Partitioning::UnknownPartitioning(1));
     };
-    let n = usize::try_from(p.partition_count).unwrap_or(usize::MAX);
-    match p.kind {
+    let n = to_usize(p.partition_count)?;
+    Ok(match p.kind {
         1 => {
-            let exprs: Vec<Arc<dyn PhysicalExpr>> = p
-                .hash_columns
-                .iter()
-                .map(|c| {
-                    Arc::new(Column::new(
-                        &c.name,
-                        usize::try_from(c.index).unwrap_or(usize::MAX),
-                    )) as Arc<dyn PhysicalExpr>
-                })
-                .collect();
+            let exprs: Vec<Arc<dyn PhysicalExpr>> =
+                p.hash_columns
+                    .iter()
+                    .map(|c| {
+                        Ok::<_, DataFusionError>(Arc::new(Column::new(&c.name, to_usize(c.index)?))
+                            as Arc<dyn PhysicalExpr>)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
             Partitioning::Hash(exprs, n)
         }
         2 => Partitioning::RoundRobinBatch(n),
         _ => Partitioning::UnknownPartitioning(n),
-    }
+    })
 }
 
 #[cfg(not(windows))]

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -26,7 +26,9 @@ use cayenne::provider::CayenneAccelerationExec;
 use datafusion::common::{DataFusionError, Result, TableReference, exec_err};
 use datafusion::execution::{FunctionRegistry, TaskContext};
 use datafusion::logical_expr::Expr;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_expr::Partitioning;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
 use datafusion_expr::ScalarUDF;
 use datafusion_proto::bytes::Serializeable;
 use datafusion_proto::generated::datafusion_common;
@@ -39,8 +41,9 @@ use prost::Message;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion::extension::bytes_processed::BytesProcessedExec;
 use runtime_proto::{
-    BytesProcessedExecNode, CayenneAccelerationExecNode, IcebergTableScanExecNode,
-    SchemaCastScanExecNode, SpicePhysicalPlanNode, UdtfExecNode, spice_physical_plan_node,
+    BytesProcessedExecNode, CayenneAccelerationExecNode, IcebergHashColumn, IcebergPartitioning,
+    IcebergTableScanExecNode, SchemaCastScanExecNode, SpicePhysicalPlanNode, UdtfExecNode,
+    spice_physical_plan_node,
 };
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -185,20 +188,47 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                         })
                     })
                     .transpose()?;
+                let partitioning = decode_partitioning(node.partitioning.as_ref());
 
-                // Re-derive the scan by replaying TableProvider::scan on the
-                // already-registered Iceberg provider, reusing its catalog. No
-                // secrets cross the wire and no catalog is rebuilt — the executor
-                // loaded the same app definition, so re-planning with the same
-                // projection/filters reproduces the scheduler's bucketing.
-                replan_registered_iceberg_scan(
-                    &runtime,
-                    ctx,
-                    &table_ref,
-                    projection.as_ref(),
-                    &filters,
+                // Resolve the registered provider synchronously — no catalog I/O,
+                // no blocking bridge. The executor loaded the same app definition,
+                // so the Iceberg dataset is already registered (in the default
+                // catalog, which is sync-accessible). The actual scan is replayed
+                // lazily at execute() time; see IcebergScanExec::new_deferred.
+                let provider = runtime.df.get_table_sync(&table_ref).ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "Iceberg table {table_ref} is not registered on this executor; \
+                         cannot reconstruct the distributed scan"
+                    ))
+                })?;
+                let peeled = peel_table_provider_wrappers(&provider);
+                let Some(cluster) = peeled.downcast_ref::<IcebergClusterTableProvider>() else {
+                    return exec_err!(
+                        "registered provider for {table_ref} is not an IcebergClusterTableProvider; \
+                         distributed Iceberg scans require the Iceberg data connector"
+                    );
+                };
+                // The concrete Iceberg provider (not the cluster wrapper), so
+                // replaying its scan() yields the bare scan without re-wrapping.
+                let inner_provider = Arc::clone(cluster.inner());
+
+                // Output schema = table schema projected by the recipe, taken
+                // synchronously from the registered provider.
+                let table_schema = inner_provider.schema();
+                let output_schema = match &projection {
+                    Some(p) => Arc::new(table_schema.project(p)?),
+                    None => table_schema,
+                };
+
+                Ok(Arc::new(IcebergScanExec::new_deferred(
+                    table_ref,
+                    inner_provider,
+                    projection,
+                    filters,
                     limit,
-                )
+                    output_schema,
+                    partitioning,
+                )))
             }
             None => {
                 #[cfg(not(windows))]
@@ -282,6 +312,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                     })
                 })
                 .transpose()?;
+            let partitioning = encode_partitioning(scan_exec.properties().output_partitioning());
 
             SpicePhysicalPlanNode {
                 node: Some(spice_physical_plan_node::Node::IcebergTableScan(
@@ -291,6 +322,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                         has_projection,
                         filters,
                         limit,
+                        partitioning: Some(partitioning),
                     },
                 )),
             }
@@ -323,74 +355,76 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
     }
 }
 
-/// Re-derives an Iceberg scan on this executor by replaying
-/// [`TableProvider::scan`] on the already-registered provider for `table_ref`.
+/// Serializes a scan's output [`Partitioning`] into its wire form, so the
+/// deferred node on the executor reports the same partition count the scheduler
+/// planned (before the lazy scan runs).
 ///
-/// The executor loaded the same app definition as the scheduler, so the Iceberg
-/// provider (an [`IcebergClusterTableProvider`], possibly behind registration
-/// wrappers) is already registered. Resolving it and re-calling `scan` with the
-/// same projection/filters/limit rebuilds an equivalent, identically bucketed
-/// scan — reusing the provider's catalog (no secrets cross the wire, no catalog
-/// rebuilt) and producing a fresh [`IcebergScanExec`].
-///
-/// The replan uses the runtime's session state but overrides `target_partitions`
-/// with the value from the per-job [`TaskContext`]. Iceberg's partition (bucket)
-/// count is `target_partitions.min(num_tasks)`, so the replan must use the same
-/// `target_partitions` the scheduler planned with — otherwise the executor could
-/// rebuild a scan with a different partition count than the stage expects.
-fn replan_registered_iceberg_scan(
-    runtime: &Arc<Runtime>,
-    ctx: &TaskContext,
-    table_ref: &TableReference,
-    projection: Option<&Vec<usize>>,
-    filters: &[Expr],
-    limit: Option<usize>,
-) -> Result<Arc<dyn ExecutionPlan>> {
-    // The codec API is synchronous but resolution/scan are async; this path runs
-    // only at plan-decode time on an executor, so blocking is acceptable.
-    let provider = tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current().block_on(runtime.df.get_table(table_ref))
-    })
-    .ok_or_else(|| {
-        DataFusionError::Execution(format!(
-            "Iceberg table {table_ref} is not registered on this executor; \
-             cannot reconstruct the distributed scan"
-        ))
-    })?;
-
-    // Peel the registration wrappers (FederatedTableProviderAdaptor,
-    // MetadataEnrichedTableProvider) down to the IcebergClusterTableProvider that
-    // dataset registration leaves in the catalog. The Spice `FederatedTable`
-    // holder is already resolved to its inner provider at registration time, so
-    // it is never the registered provider here.
-    let peeled = peel_table_provider_wrappers(&provider);
-    if peeled
-        .downcast_ref::<IcebergClusterTableProvider>()
-        .is_none()
-    {
-        return exec_err!(
-            "registered provider for {table_ref} is not an IcebergClusterTableProvider; \
-             distributed Iceberg scans require the Iceberg data connector"
-        );
+/// Hash partitioning is reproduced only when every expression is a plain
+/// [`Column`]; otherwise the count is preserved as
+/// [`Partitioning::UnknownPartitioning`].
+fn encode_partitioning(partitioning: &Partitioning) -> IcebergPartitioning {
+    let to_u64 = |n: usize| u64::try_from(n).unwrap_or(u64::MAX);
+    match partitioning {
+        Partitioning::UnknownPartitioning(n) => IcebergPartitioning {
+            kind: 0,
+            partition_count: to_u64(*n),
+            hash_columns: Vec::new(),
+        },
+        Partitioning::RoundRobinBatch(n) => IcebergPartitioning {
+            kind: 2,
+            partition_count: to_u64(*n),
+            hash_columns: Vec::new(),
+        },
+        Partitioning::Hash(exprs, n) => {
+            let hash_columns: Vec<IcebergHashColumn> = exprs
+                .iter()
+                .filter_map(|expr| {
+                    expr.downcast_ref::<Column>().map(|c| IcebergHashColumn {
+                        name: c.name().to_string(),
+                        index: to_u64(c.index()),
+                    })
+                })
+                .collect();
+            if hash_columns.len() == exprs.len() {
+                IcebergPartitioning {
+                    kind: 1,
+                    partition_count: to_u64(*n),
+                    hash_columns,
+                }
+            } else {
+                IcebergPartitioning {
+                    kind: 0,
+                    partition_count: to_u64(*n),
+                    hash_columns: Vec::new(),
+                }
+            }
+        }
     }
+}
 
-    // Align target_partitions with the scheduler's per-job config so the rebuilt
-    // scan buckets into the same number of partitions as the planned stage.
-    let mut session_state = runtime.df.ctx.state();
-    session_state
-        .config_mut()
-        .options_mut()
-        .execution
-        .target_partitions = ctx.session_config().options().execution.target_partitions;
-
-    tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current().block_on(peeled.scan(
-            &session_state,
-            projection,
-            filters,
-            limit,
-        ))
-    })
+/// Reconstructs a [`Partitioning`] from its wire form.
+fn decode_partitioning(partitioning: Option<&IcebergPartitioning>) -> Partitioning {
+    let Some(p) = partitioning else {
+        return Partitioning::UnknownPartitioning(1);
+    };
+    let n = usize::try_from(p.partition_count).unwrap_or(usize::MAX);
+    match p.kind {
+        1 => {
+            let exprs: Vec<Arc<dyn PhysicalExpr>> = p
+                .hash_columns
+                .iter()
+                .map(|c| {
+                    Arc::new(Column::new(
+                        &c.name,
+                        usize::try_from(c.index).unwrap_or(usize::MAX),
+                    )) as Arc<dyn PhysicalExpr>
+                })
+                .collect();
+            Partitioning::Hash(exprs, n)
+        }
+        2 => Partitioning::RoundRobinBatch(n),
+        _ => Partitioning::UnknownPartitioning(n),
+    }
 }
 
 #[cfg(not(windows))]

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -29,10 +29,8 @@ use iceberg_storage_opendal::OpenDalStorageFactory;
 use secrecy::ExposeSecret;
 use util::concat_arrays;
 
-#[cfg(feature = "iceberg-write")]
-use iceberg::NamespaceIdent;
-
 use super::DataConnectorFactory;
+use super::iceberg_cluster::IcebergClusterTableProvider;
 use crate::{
     catalogconnector::iceberg::{
         ICEBERG_PARAM_LEN, get_rest_catalog, map_param_name_to_iceberg_prop,
@@ -104,15 +102,13 @@ impl DataConnectorFactory for IcebergDataConnectorFactory {
     }
 }
 
-/// Holds the components needed for both read and read-write Iceberg providers.
+/// Holds the components needed for read, read-write, and distributed Iceberg
+/// providers: the base provider plus the catalog and identity used to reload the
+/// table on remote executors during distributed (Ballista) execution.
 struct IcebergTableParts {
     provider: Arc<dyn TableProvider>,
-    #[cfg(feature = "iceberg-write")]
     catalog: Arc<dyn Catalog>,
-    #[cfg(feature = "iceberg-write")]
-    namespace: NamespaceIdent,
-    #[cfg(feature = "iceberg-write")]
-    table_name: String,
+    table_identifier: TableIdent,
 }
 
 #[derive(Clone, Debug)]
@@ -128,16 +124,8 @@ impl IcebergDataConnector {
         })
     }
 
-    async fn create_iceberg_table_provider(
-        &self,
-        dataset: &Dataset,
-    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        let parts = self.create_iceberg_table_parts(dataset).await?;
-        Ok(parts.provider)
-    }
-
-    /// Creates the Iceberg table provider along with the catalog, namespace, and table name.
-    /// This is used by `read_write_provider` to create a deletion-capable wrapper.
+    /// Creates the Iceberg table provider along with the catalog and table
+    /// identity, used to build read, read-write, and distributed providers.
     async fn create_iceberg_table_parts(
         &self,
         dataset: &Dataset,
@@ -272,12 +260,8 @@ impl IcebergDataConnector {
 
         Ok(IcebergTableParts {
             provider: Arc::new(table_provider),
-            #[cfg(feature = "iceberg-write")]
             catalog: catalog_client,
-            #[cfg(feature = "iceberg-write")]
-            namespace: table_identifier.namespace().clone(),
-            #[cfg(feature = "iceberg-write")]
-            table_name,
+            table_identifier,
         })
     }
 
@@ -298,8 +282,6 @@ impl IcebergDataConnector {
             })?;
 
         // Load the specific table
-        #[cfg(feature = "iceberg-write")]
-        let table_name_str = table_name.clone();
         let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
 
         // Determine storage factory from scheme if not explicitly provided
@@ -353,12 +335,8 @@ impl IcebergDataConnector {
 
         Ok(IcebergTableParts {
             provider: Arc::new(table_provider),
-            #[cfg(feature = "iceberg-write")]
             catalog: catalog_client,
-            #[cfg(feature = "iceberg-write")]
-            namespace: table_identifier.namespace().clone(),
-            #[cfg(feature = "iceberg-write")]
-            table_name: table_name_str,
+            table_identifier,
         })
     }
 }
@@ -373,7 +351,14 @@ impl DataConnector for IcebergDataConnector {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        self.create_iceberg_table_provider(dataset).await
+        let parts = self.create_iceberg_table_parts(dataset).await?;
+
+        // Wrap so the scan can be serialized for distributed (Ballista) execution.
+        // In a single-node session this is a transparent pass-through.
+        Ok(Arc::new(IcebergClusterTableProvider::new(
+            dataset.name.clone(),
+            parts.provider,
+        )))
     }
 
     #[cfg(feature = "iceberg-write")]
@@ -390,11 +375,16 @@ impl DataConnector for IcebergDataConnector {
         // Wrap in IcebergDeletionProvider for DELETE FROM support.
         let deletion_provider = data_components::iceberg::delete::IcebergDeletionProvider::new(
             parts.catalog,
-            parts.namespace,
-            parts.table_name,
+            parts.table_identifier.namespace().clone(),
+            parts.table_identifier.name().to_string(),
             parts.provider,
         );
-        Some(Ok(Arc::new(deletion_provider)))
+
+        // Then wrap so the scan can be serialized for distributed execution.
+        Some(Ok(Arc::new(IcebergClusterTableProvider::new(
+            dataset.name.clone(),
+            Arc::new(deletion_provider),
+        ))))
     }
 }
 

--- a/crates/runtime/src/dataconnector/iceberg_cluster.rs
+++ b/crates/runtime/src/dataconnector/iceberg_cluster.rs
@@ -69,6 +69,14 @@ impl IcebergClusterTableProvider {
     pub fn new(table_ref: TableReference, inner: Arc<dyn TableProvider>) -> Self {
         Self { table_ref, inner }
     }
+
+    /// The wrapped provider (an `IcebergTableProvider`, or an
+    /// `IcebergDeletionProvider` around one). Exposed so wrapper-peeling helpers
+    /// can see through this layer to the concrete Iceberg provider.
+    #[must_use]
+    pub fn inner(&self) -> &Arc<dyn TableProvider> {
+        &self.inner
+    }
 }
 
 #[async_trait]

--- a/crates/runtime/src/dataconnector/iceberg_cluster.rs
+++ b/crates/runtime/src/dataconnector/iceberg_cluster.rs
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A `TableProvider` wrapper that makes Iceberg table scans serializable for
+//! distributed (Ballista) execution.
+//!
+//! Iceberg's `IcebergTableScan` holds a live, non-serializable `Table`, and its
+//! planned `FileScanTask`s carry fields the iceberg crate intentionally refuses
+//! to serialize. So this wrapper sits in front of the Iceberg provider and, **only
+//! when the query is planned in a distributed session**, wraps the produced
+//! `IcebergTableScan` in an [`IcebergScanExec`] that carries the table's
+//! [`TableReference`] plus the scan's projection/filters/limit. The physical
+//! codec serializes that recipe, and the executor re-derives an equivalent scan
+//! by resolving this same provider and replaying `scan()` — reusing its catalog,
+//! so no secrets cross the wire.
+//!
+//! In a single-node session the wrapper is a transparent pass-through: it returns
+//! the inner scan unchanged, so non-distributed plans are unaffected.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use arrow_schema::SchemaRef as ArrowSchemaRef;
+use async_trait::async_trait;
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::{Constraints, Result as DFResult, Statistics};
+use datafusion::datasource::TableType;
+use datafusion::logical_expr::dml::InsertOp;
+use datafusion::logical_expr::{Expr, LogicalPlan, TableProviderFilterPushDown};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::sql::TableReference;
+use iceberg_datafusion::physical_plan::IcebergTableScan;
+
+use crate::execution_plan::{IcebergScanExec, session_is_distributed};
+
+/// Wraps an Iceberg `TableProvider` so its scans can cross Ballista node
+/// boundaries. Carries the `DataFusion` [`TableReference`] used to resolve this
+/// provider on a remote executor and replay the scan there.
+pub struct IcebergClusterTableProvider {
+    table_ref: TableReference,
+    inner: Arc<dyn TableProvider>,
+}
+
+impl std::fmt::Debug for IcebergClusterTableProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IcebergClusterTableProvider")
+            .field("table_ref", &self.table_ref.to_string())
+            .finish_non_exhaustive()
+    }
+}
+
+impl IcebergClusterTableProvider {
+    /// Wraps `inner` with the reference used to resolve it for distributed
+    /// execution.
+    #[must_use]
+    pub fn new(table_ref: TableReference, inner: Arc<dyn TableProvider>) -> Self {
+        Self { table_ref, inner }
+    }
+}
+
+#[async_trait]
+impl TableProvider for IcebergClusterTableProvider {
+    fn schema(&self) -> ArrowSchemaRef {
+        self.inner.schema()
+    }
+
+    fn constraints(&self) -> Option<&Constraints> {
+        self.inner.constraints()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.inner.table_type()
+    }
+
+    fn get_table_definition(&self) -> Option<&str> {
+        self.inner.get_table_definition()
+    }
+
+    fn get_logical_plan(&'_ self) -> Option<Cow<'_, LogicalPlan>> {
+        self.inner.get_logical_plan()
+    }
+
+    fn get_column_default(&self, column: &str) -> Option<&Expr> {
+        self.inner.get_column_default(column)
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DFResult<Vec<TableProviderFilterPushDown>> {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    fn statistics(&self) -> Option<Statistics> {
+        self.inner.statistics()
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let plan = self.inner.scan(state, projection, filters, limit).await?;
+
+        // Only wrap for distributed planning. In a single-node session the scan
+        // is returned unchanged, so non-distributed plans are untouched. The
+        // downcast guards against the inner provider returning a non-Iceberg
+        // plan (it never should), in which case we also leave it untouched.
+        // The scan arguments are captured so the executor can replay this exact
+        // `scan()` call to re-derive an equivalent (identically bucketed) scan.
+        if session_is_distributed(state.config())
+            && plan.downcast_ref::<IcebergTableScan>().is_some()
+        {
+            return Ok(Arc::new(IcebergScanExec::new(
+                self.table_ref.clone(),
+                plan,
+                projection.cloned(),
+                filters.to_vec(),
+                limit,
+            )));
+        }
+
+        Ok(plan)
+    }
+
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        overwrite: InsertOp,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.inner.insert_into(state, input, overwrite).await
+    }
+
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.inner.delete_from(state, filters).await
+    }
+}

--- a/crates/runtime/src/dataconnector/iceberg_cluster.rs
+++ b/crates/runtime/src/dataconnector/iceberg_cluster.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 
 use arrow_schema::SchemaRef as ArrowSchemaRef;
 use async_trait::async_trait;
-use datafusion::catalog::{Session, TableProvider};
+use datafusion::catalog::{ScanArgs, ScanResult, Session, TableProvider};
 use datafusion::common::{Constraints, Result as DFResult, Statistics};
 use datafusion::datasource::TableType;
 use datafusion::logical_expr::dml::InsertOp;
@@ -79,6 +79,10 @@ impl IcebergClusterTableProvider {
     }
 }
 
+// Deny missing trait methods so that a newly added `TableProvider` method (even
+// one with a default) forces an explicit decision here, rather than silently
+// bypassing this wrapper's distributed-scan handling.
+#[deny(clippy::missing_trait_methods)]
 #[async_trait]
 impl TableProvider for IcebergClusterTableProvider {
     fn schema(&self) -> ArrowSchemaRef {
@@ -146,6 +150,26 @@ impl TableProvider for IcebergClusterTableProvider {
         Ok(plan)
     }
 
+    async fn scan_with_args<'a>(
+        &self,
+        state: &dyn Session,
+        args: ScanArgs<'a>,
+    ) -> DFResult<ScanResult> {
+        // Route through our own `scan` (mirroring the trait's default) so the
+        // distributed `IcebergScanExec` wrapping is applied. Forwarding straight
+        // to `self.inner` would bypass it and make Iceberg scans unserializable.
+        let projection = args.projection().map(<[usize]>::to_vec);
+        let plan = self
+            .scan(
+                state,
+                projection.as_ref(),
+                args.filters().unwrap_or(&[]),
+                args.limit(),
+            )
+            .await?;
+        Ok(plan.into())
+    }
+
     async fn insert_into(
         &self,
         state: &dyn Session,
@@ -161,5 +185,18 @@ impl TableProvider for IcebergClusterTableProvider {
         filters: Vec<Expr>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         self.inner.delete_from(state, filters).await
+    }
+
+    async fn update(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.inner.update(state, assignments, filters).await
+    }
+
+    async fn truncate(&self, state: &dyn Session) -> DFResult<Arc<dyn ExecutionPlan>> {
+        self.inner.truncate(state).await
     }
 }

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -175,6 +175,7 @@ pub mod ducklake;
 pub mod gcs;
 pub mod glue;
 pub mod iceberg;
+pub mod iceberg_cluster;
 pub mod parameters;
 pub mod s3;
 pub mod sink;

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -298,7 +298,9 @@ fn is_dual_write_table_provider(table_provider: &Arc<dyn TableProvider>) -> bool
 /// `FederatedTableProviderAdaptor`, and datasets that declare table- or
 /// column-level metadata are wrapped in a `MetadataEnrichedTableProvider` by
 /// `register_accelerated_table`.
-fn peel_table_provider_wrappers(table_provider: &Arc<dyn TableProvider>) -> Arc<dyn TableProvider> {
+pub(crate) fn peel_table_provider_wrappers(
+    table_provider: &Arc<dyn TableProvider>,
+) -> Arc<dyn TableProvider> {
     let mut current = Arc::clone(table_provider);
     loop {
         if let Some(adaptor) = current.downcast_ref::<FederatedTableProviderAdaptor>() {

--- a/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
+++ b/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
@@ -16,43 +16,51 @@ limitations under the License.
 
 //! A serializable leaf execution plan for distributed Iceberg scans.
 //!
-//! An [`IcebergTableScan`] holds a live, non-serializable `Table`, and its
-//! planned `FileScanTask`s carry fields the iceberg crate intentionally refuses
-//! to serialize. So instead of shipping the plan, this leaf wraps it and carries
-//! the `DataFusion` [`TableReference`] of the registered Iceberg provider plus
-//! the scan's projection, filters, and limit. The physical codec serializes that
-//! recipe; on the executor it resolves the same registered provider and replays
-//! `TableProvider::scan` to re-derive an equivalent, identically-bucketed scan,
-//! reusing the provider's catalog (so no secrets cross the wire).
+//! An `IcebergTableScan` holds a live, non-serializable `Table`, and its planned
+//! `FileScanTask`s carry fields the iceberg crate intentionally refuses to
+//! serialize. So instead of shipping the plan, this leaf carries a *recipe* — the
+//! `DataFusion` [`TableReference`] of the registered Iceberg provider plus the
+//! scan's projection, filters, and limit — which the physical codec serializes.
+//!
+//! It has two modes ([`ScanSource`]):
+//! - **Planned** (scheduler / single-node): wraps the concrete scan the provider
+//!   produced, so physical planning sees real schema and partitioning.
+//! - **Deferred** (remote executor, after decode): holds the registered provider
+//!   resolved synchronously from the recipe; the actual `TableProvider::scan` is
+//!   replayed lazily inside [`execute`](IcebergScanExec::execute) — in proper
+//!   async context — so no catalog I/O happens during synchronous plan
+//!   deserialization and no blocking bridge is needed.
 //!
 //! It is a *leaf* node: [`children`](IcebergScanExec::children) returns an empty
-//! list so the non-serializable inner scan is never handed to Ballista's codec.
-//! All execution is delegated to the inner [`IcebergTableScan`].
+//! list so the non-serializable scan is never handed to Ballista's codec.
 
 use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
 use arrow_schema::SchemaRef;
+use datafusion::catalog::TableProvider;
 use datafusion::common::{Result, Statistics, TableReference};
 use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::logical_expr::Expr;
-use datafusion::physical_expr::OrderingRequirements;
+use datafusion::physical_expr::{EquivalenceProperties, OrderingRequirements, Partitioning};
 use datafusion::physical_plan::execution_plan::{
-    CardinalityEffect, InvariantLevel, check_default_invariants,
+    Boundedness, CardinalityEffect, EmissionType, InvariantLevel, check_default_invariants,
 };
 use datafusion::physical_plan::filter_pushdown::{
     ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
 };
 use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PhysicalExpr, PlanProperties,
     SortOrderPushdownResult, expressions::PhysicalSortExpr,
 };
-use datafusion::prelude::SessionConfig;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use futures::TryStreamExt;
 use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
 
 /// Returns `true` when `config` belongs to a distributed (Ballista) session.
@@ -70,24 +78,27 @@ pub fn session_is_distributed(config: &SessionConfig) -> bool {
         .is_some()
 }
 
-/// A leaf execution plan that wraps an [`IcebergTableScan`] for distributed
-/// execution.
-///
-/// It carries the [`TableReference`] of the registered Iceberg provider plus the
-/// scan's projection, filters, and limit. The physical codec serializes this
-/// recipe; the executor resolves the registered provider and calls its `scan()`
-/// with the same arguments to re-derive an equivalent (identically bucketed)
-/// scan — sidestepping the iceberg `FileScanTask` fields that are intentionally
-/// non-serializable, while reusing the provider's catalog (no secrets on the
-/// wire). Execution is delegated to `inner`.
+/// How an [`IcebergScanExec`] produces its rows.
+#[derive(Debug)]
+enum ScanSource {
+    /// Planning-time: the concrete scan the provider produced (scheduler side and
+    /// single-node execution). Execution delegates straight to it.
+    Planned(Arc<dyn ExecutionPlan>),
+    /// Decode-time on a remote executor: the registered Iceberg provider, resolved
+    /// synchronously from the recipe. The scan is re-derived lazily at `execute()`
+    /// time so no catalog I/O runs during synchronous plan deserialization.
+    Deferred(Arc<dyn TableProvider>),
+}
+
+/// A leaf execution plan that represents a distributed Iceberg scan. See the
+/// module docs for the planning-vs-deferred modes.
 #[derive(Debug)]
 pub struct IcebergScanExec {
     /// `DataFusion` reference of the registered Iceberg table, used by the codec
     /// to resolve the provider (and reuse its catalog) on the executor.
     table_ref: TableReference,
-    /// The wrapped Iceberg scan (an `IcebergTableScan`). Held privately and never
-    /// exposed as a child, so Ballista never tries to serialize it directly.
-    inner: Arc<dyn ExecutionPlan>,
+    /// Output schema (projected). Cached so `schema()` is sync in both modes.
+    schema: SchemaRef,
     /// Column projection passed to `TableProvider::scan`, replayed on the executor.
     projection: Option<Vec<usize>>,
     /// Pushed-down filters passed to `TableProvider::scan`, replayed on the
@@ -95,11 +106,16 @@ pub struct IcebergScanExec {
     filters: Vec<Expr>,
     /// Row limit passed to `TableProvider::scan`.
     limit: Option<usize>,
+    /// Cached plan properties (schema + partitioning).
+    properties: Arc<PlanProperties>,
+    /// Where rows come from — see [`ScanSource`].
+    source: ScanSource,
 }
 
 impl IcebergScanExec {
-    /// Wraps `inner` (an `IcebergTableScan`) with the table reference and the
-    /// scan arguments needed to reconstruct an equivalent scan remotely.
+    /// Planning-time constructor: wraps the concrete `inner` scan (an
+    /// `IcebergTableScan`) the provider produced, carrying the scan arguments the
+    /// codec needs to serialize a recipe.
     #[must_use]
     pub fn new(
         table_ref: TableReference,
@@ -108,12 +124,48 @@ impl IcebergScanExec {
         filters: Vec<Expr>,
         limit: Option<usize>,
     ) -> Self {
+        let schema = inner.schema();
+        let properties = Arc::clone(inner.properties());
         Self {
             table_ref,
-            inner,
+            schema,
             projection,
             filters,
             limit,
+            properties,
+            source: ScanSource::Planned(inner),
+        }
+    }
+
+    /// Decode-time constructor: builds a deferred scan over the registered
+    /// `provider`. `schema` and `partitioning` are reconstructed from the recipe
+    /// so `properties()` is correct before the (lazy) scan runs. The provider must
+    /// be the concrete Iceberg provider (e.g. `cluster.inner()`), not the cluster
+    /// wrapper, so replaying its `scan()` yields the bare scan without re-wrapping.
+    #[must_use]
+    pub fn new_deferred(
+        table_ref: TableReference,
+        provider: Arc<dyn TableProvider>,
+        projection: Option<Vec<usize>>,
+        filters: Vec<Expr>,
+        limit: Option<usize>,
+        schema: SchemaRef,
+        partitioning: Partitioning,
+    ) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            partitioning,
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        Self {
+            table_ref,
+            schema,
+            projection,
+            filters,
+            limit,
+            properties,
+            source: ScanSource::Deferred(provider),
         }
     }
 
@@ -121,12 +173,6 @@ impl IcebergScanExec {
     #[must_use]
     pub fn table_ref(&self) -> &TableReference {
         &self.table_ref
-    }
-
-    /// The wrapped Iceberg scan (an `IcebergTableScan`).
-    #[must_use]
-    pub fn inner(&self) -> &Arc<dyn ExecutionPlan> {
-        &self.inner
     }
 
     /// The scan's column projection.
@@ -150,8 +196,20 @@ impl IcebergScanExec {
 
 impl DisplayAs for IcebergScanExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "IcebergScanExec table_ref=[{}] ", self.table_ref)?;
-        self.inner.fmt_as(t, f)
+        write!(f, "IcebergScanExec table_ref=[{}]", self.table_ref)?;
+        match &self.source {
+            ScanSource::Planned(inner) => {
+                write!(f, " ")?;
+                inner.fmt_as(t, f)
+            }
+            ScanSource::Deferred(_) => {
+                let projection = self
+                    .projection
+                    .as_ref()
+                    .map_or_else(String::new, |p| format!("{p:?}"));
+                write!(f, " deferred projection:[{projection}]")
+            }
+        }
     }
 }
 
@@ -177,11 +235,11 @@ impl ExecutionPlan for IcebergScanExec {
     }
 
     fn properties(&self) -> &Arc<PlanProperties> {
-        self.inner.properties()
+        &self.properties
     }
 
     fn schema(&self) -> SchemaRef {
-        self.inner.schema()
+        Arc::clone(&self.schema)
     }
 
     fn check_invariants(&self, check: InvariantLevel) -> Result<()> {
@@ -240,15 +298,44 @@ impl ExecutionPlan for IcebergScanExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        self.inner.execute(partition, context)
+        match &self.source {
+            ScanSource::Planned(inner) => inner.execute(partition, context),
+            ScanSource::Deferred(provider) => {
+                let provider = Arc::clone(provider);
+                let projection = self.projection.clone();
+                let filters = self.filters.clone();
+                let limit = self.limit;
+                let schema = self.schema();
+
+                // Re-derive the scan lazily, in async context. A SessionState
+                // carrying the per-job config (notably `target_partitions`) makes
+                // the rebuilt scan bucket the same way the scheduler planned.
+                let fut = async move {
+                    let session =
+                        SessionContext::new_with_config(context.session_config().clone()).state();
+                    let plan = provider
+                        .scan(&session, projection.as_ref(), &filters, limit)
+                        .await?;
+                    plan.execute(partition, context)
+                };
+                let stream = futures::stream::once(fut).try_flatten();
+                Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+            }
+        }
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
-        self.inner.metrics()
+        match &self.source {
+            ScanSource::Planned(inner) => inner.metrics(),
+            ScanSource::Deferred(_) => None,
+        }
     }
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
-        self.inner.partition_statistics(partition)
+        match &self.source {
+            ScanSource::Planned(inner) => inner.partition_statistics(partition),
+            ScanSource::Deferred(_) => Ok(Arc::new(Statistics::new_unknown(&self.schema))),
+        }
     }
 
     fn supports_limit_pushdown(&self) -> bool {

--- a/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
+++ b/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
@@ -62,6 +62,7 @@ use datafusion::physical_plan::{
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::TryStreamExt;
 use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
+use tokio::sync::OnceCell;
 
 /// Returns `true` when `config` belongs to a distributed (Ballista) session.
 ///
@@ -85,9 +86,15 @@ enum ScanSource {
     /// single-node execution). Execution delegates straight to it.
     Planned(Arc<dyn ExecutionPlan>),
     /// Decode-time on a remote executor: the registered Iceberg provider, resolved
-    /// synchronously from the recipe. The scan is re-derived lazily at `execute()`
-    /// time so no catalog I/O runs during synchronous plan deserialization.
-    Deferred(Arc<dyn TableProvider>),
+    /// synchronously from the recipe. The scan is re-derived lazily on the first
+    /// `execute()` and memoized in `scan`, so it is planned exactly once per
+    /// instance (not once per partition) — avoiding redundant `plan_files()` work
+    /// and keeping every partition of this instance on a single snapshot/fileset.
+    /// No catalog I/O runs during synchronous plan deserialization.
+    Deferred {
+        provider: Arc<dyn TableProvider>,
+        scan: Arc<OnceCell<Arc<dyn ExecutionPlan>>>,
+    },
 }
 
 /// A leaf execution plan that represents a distributed Iceberg scan. See the
@@ -165,7 +172,10 @@ impl IcebergScanExec {
             filters,
             limit,
             properties,
-            source: ScanSource::Deferred(provider),
+            source: ScanSource::Deferred {
+                provider,
+                scan: Arc::new(OnceCell::new()),
+            },
         }
     }
 
@@ -202,11 +212,10 @@ impl DisplayAs for IcebergScanExec {
                 write!(f, " ")?;
                 inner.fmt_as(t, f)
             }
-            ScanSource::Deferred(_) => {
-                let projection = self
-                    .projection
-                    .as_ref()
-                    .map_or_else(String::new, |p| format!("{p:?}"));
+            ScanSource::Deferred { .. } => {
+                let projection = self.projection.as_ref().map_or_else(String::new, |p| {
+                    p.iter().map(usize::to_string).collect::<Vec<_>>().join(",")
+                });
                 write!(f, " deferred projection:[{projection}]")
             }
         }
@@ -300,21 +309,31 @@ impl ExecutionPlan for IcebergScanExec {
     ) -> Result<SendableRecordBatchStream> {
         match &self.source {
             ScanSource::Planned(inner) => inner.execute(partition, context),
-            ScanSource::Deferred(provider) => {
+            ScanSource::Deferred { provider, scan } => {
                 let provider = Arc::clone(provider);
+                let scan = Arc::clone(scan);
                 let projection = self.projection.clone();
                 let filters = self.filters.clone();
                 let limit = self.limit;
                 let schema = self.schema();
 
-                // Re-derive the scan lazily, in async context. A SessionState
-                // carrying the per-job config (notably `target_partitions`) makes
-                // the rebuilt scan bucket the same way the scheduler planned.
+                // Re-derive the scan lazily, in async context, and memoize it: the
+                // first partition to execute plans it (via plan_files); every other
+                // partition of this instance reuses the same plan, so they all read
+                // one consistent snapshot/fileset and re-planning happens once. A
+                // SessionState carrying the per-job config (notably
+                // `target_partitions`) makes the rebuilt scan bucket the way the
+                // scheduler planned.
                 let fut = async move {
-                    let session =
-                        SessionContext::new_with_config(context.session_config().clone()).state();
-                    let plan = provider
-                        .scan(&session, projection.as_ref(), &filters, limit)
+                    let plan = scan
+                        .get_or_try_init(|| async {
+                            let session =
+                                SessionContext::new_with_config(context.session_config().clone())
+                                    .state();
+                            provider
+                                .scan(&session, projection.as_ref(), &filters, limit)
+                                .await
+                        })
                         .await?;
                     plan.execute(partition, context)
                 };
@@ -327,14 +346,14 @@ impl ExecutionPlan for IcebergScanExec {
     fn metrics(&self) -> Option<MetricsSet> {
         match &self.source {
             ScanSource::Planned(inner) => inner.metrics(),
-            ScanSource::Deferred(_) => None,
+            ScanSource::Deferred { .. } => None,
         }
     }
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
         match &self.source {
             ScanSource::Planned(inner) => inner.partition_statistics(partition),
-            ScanSource::Deferred(_) => Ok(Arc::new(Statistics::new_unknown(&self.schema))),
+            ScanSource::Deferred { .. } => Ok(Arc::new(Statistics::new_unknown(&self.schema))),
         }
     }
 

--- a/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
+++ b/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
@@ -339,16 +339,19 @@ impl ExecutionPlan for IcebergScanExec {
                 // Re-derive the scan lazily, in async context, and memoize it: the
                 // first partition to execute plans it (via plan_files); every other
                 // partition of this instance reuses the same plan, so they all read
-                // one consistent snapshot/fileset and re-planning happens once. A
-                // SessionState carrying the per-job config (notably
-                // `target_partitions`) makes the rebuilt scan bucket the way the
-                // scheduler planned.
+                // one consistent snapshot/fileset and re-planning happens once. The
+                // session carries the per-job config (notably `target_partitions`,
+                // so the rebuilt scan buckets the way the scheduler planned) and the
+                // executing task's own `RuntimeEnv` (object stores, memory pool,
+                // disk manager), so the replay matches the task's environment.
                 let fut = async move {
                     let plan = scan
                         .get_or_try_init(|| async {
-                            let session =
-                                SessionContext::new_with_config(context.session_config().clone())
-                                    .state();
+                            let session = SessionContext::new_with_config_rt(
+                                context.session_config().clone(),
+                                context.runtime_env(),
+                            )
+                            .state();
                             provider
                                 .scan(&session, projection.as_ref(), &filters, limit)
                                 .await

--- a/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
+++ b/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
@@ -1,0 +1,308 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A serializable leaf execution plan for distributed Iceberg scans.
+//!
+//! An [`IcebergTableScan`] holds a live, non-serializable `Table`, and its
+//! planned `FileScanTask`s carry fields the iceberg crate intentionally refuses
+//! to serialize. So instead of shipping the plan, this leaf wraps it and carries
+//! the `DataFusion` [`TableReference`] of the registered Iceberg provider plus
+//! the scan's projection, filters, and limit. The physical codec serializes that
+//! recipe; on the executor it resolves the same registered provider and replays
+//! `TableProvider::scan` to re-derive an equivalent, identically-bucketed scan,
+//! reusing the provider's catalog (so no secrets cross the wire).
+//!
+//! It is a *leaf* node: [`children`](IcebergScanExec::children) returns an empty
+//! list so the non-serializable inner scan is never handed to Ballista's codec.
+//! All execution is delegated to the inner [`IcebergTableScan`].
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow_schema::SchemaRef;
+use datafusion::common::{Result, Statistics, TableReference};
+use datafusion::config::ConfigOptions;
+use datafusion::error::DataFusionError;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::Expr;
+use datafusion::physical_expr::OrderingRequirements;
+use datafusion::physical_plan::execution_plan::{
+    CardinalityEffect, InvariantLevel, check_default_invariants,
+};
+use datafusion::physical_plan::filter_pushdown::{
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
+};
+use datafusion::physical_plan::metrics::MetricsSet;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PhysicalExpr, PlanProperties,
+    SortOrderPushdownResult, expressions::PhysicalSortExpr,
+};
+use datafusion::prelude::SessionConfig;
+use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
+
+/// Returns `true` when `config` belongs to a distributed (Ballista) session.
+///
+/// [`SpiceClusterConfig`] is installed on the session config only when the
+/// runtime is acting as a cluster scheduler/executor, so its presence is a
+/// reliable signal that a query will be planned and shipped across nodes. In a
+/// single-node session it is absent, so Iceberg scans are left untouched.
+#[must_use]
+pub fn session_is_distributed(config: &SessionConfig) -> bool {
+    config
+        .options()
+        .extensions
+        .get::<SpiceClusterConfig>()
+        .is_some()
+}
+
+/// A leaf execution plan that wraps an [`IcebergTableScan`] for distributed
+/// execution.
+///
+/// It carries the [`TableReference`] of the registered Iceberg provider plus the
+/// scan's projection, filters, and limit. The physical codec serializes this
+/// recipe; the executor resolves the registered provider and calls its `scan()`
+/// with the same arguments to re-derive an equivalent (identically bucketed)
+/// scan — sidestepping the iceberg `FileScanTask` fields that are intentionally
+/// non-serializable, while reusing the provider's catalog (no secrets on the
+/// wire). Execution is delegated to `inner`.
+#[derive(Debug)]
+pub struct IcebergScanExec {
+    /// `DataFusion` reference of the registered Iceberg table, used by the codec
+    /// to resolve the provider (and reuse its catalog) on the executor.
+    table_ref: TableReference,
+    /// The wrapped Iceberg scan (an `IcebergTableScan`). Held privately and never
+    /// exposed as a child, so Ballista never tries to serialize it directly.
+    inner: Arc<dyn ExecutionPlan>,
+    /// Column projection passed to `TableProvider::scan`, replayed on the executor.
+    projection: Option<Vec<usize>>,
+    /// Pushed-down filters passed to `TableProvider::scan`, replayed on the
+    /// executor so it reproduces the same file pruning / partition count.
+    filters: Vec<Expr>,
+    /// Row limit passed to `TableProvider::scan`.
+    limit: Option<usize>,
+}
+
+impl IcebergScanExec {
+    /// Wraps `inner` (an `IcebergTableScan`) with the table reference and the
+    /// scan arguments needed to reconstruct an equivalent scan remotely.
+    #[must_use]
+    pub fn new(
+        table_ref: TableReference,
+        inner: Arc<dyn ExecutionPlan>,
+        projection: Option<Vec<usize>>,
+        filters: Vec<Expr>,
+        limit: Option<usize>,
+    ) -> Self {
+        Self {
+            table_ref,
+            inner,
+            projection,
+            filters,
+            limit,
+        }
+    }
+
+    /// The `DataFusion` reference of the registered Iceberg table.
+    #[must_use]
+    pub fn table_ref(&self) -> &TableReference {
+        &self.table_ref
+    }
+
+    /// The wrapped Iceberg scan (an `IcebergTableScan`).
+    #[must_use]
+    pub fn inner(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.inner
+    }
+
+    /// The scan's column projection.
+    #[must_use]
+    pub fn projection(&self) -> Option<&Vec<usize>> {
+        self.projection.as_ref()
+    }
+
+    /// The scan's pushed-down filters.
+    #[must_use]
+    pub fn filters(&self) -> &[Expr] {
+        &self.filters
+    }
+
+    /// The scan's row limit.
+    #[must_use]
+    pub fn limit(&self) -> Option<usize> {
+        self.limit
+    }
+}
+
+impl DisplayAs for IcebergScanExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "IcebergScanExec table_ref=[{}] ", self.table_ref)?;
+        self.inner.fmt_as(t, f)
+    }
+}
+
+#[deny(clippy::missing_trait_methods)]
+impl ExecutionPlan for IcebergScanExec {
+    fn downcast_delegate(&self) -> Option<&dyn ExecutionPlan> {
+        None
+    }
+
+    fn with_preserve_order(&self, _preserve_order: bool) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+
+    fn name(&self) -> &'static str {
+        "IcebergScanExec"
+    }
+
+    fn static_name() -> &'static str
+    where
+        Self: Sized,
+    {
+        "IcebergScanExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        self.inner.properties()
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+
+    fn check_invariants(&self, check: InvariantLevel) -> Result<()> {
+        check_default_invariants(self, check)
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![]
+    }
+
+    fn required_input_ordering(&self) -> Vec<Option<OrderingRequirements>> {
+        vec![]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![]
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        // Leaf node: the inner Iceberg scan is reconstructed from the serialized
+        // recipe, never traversed or serialized as a child.
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Execution(
+                "IcebergScanExec expects no children".to_string(),
+            ))
+        }
+    }
+
+    fn reset_state(self: Arc<Self>) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn repartitioned(
+        &self,
+        _target_partitions: usize,
+        _config: &ConfigOptions,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        self.inner.execute(partition, context)
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        self.inner.metrics()
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
+        self.inner.partition_statistics(partition)
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
+
+    fn with_fetch(&self, _limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        None
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+
+    fn try_swapping_with_projection(
+        &self,
+        _projection: &ProjectionExec,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(None)
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        Ok(FilterDescription::all_unsupported(
+            &parent_filters,
+            &self.children(),
+        ))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+    }
+
+    fn with_new_state(&self, _state: Arc<dyn Any + Send + Sync>) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        _order: &[PhysicalSortExpr],
+    ) -> Result<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        Ok(SortOrderPushdownResult::Unsupported)
+    }
+}

--- a/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
+++ b/crates/runtime/src/execution_plan/iceberg_scan_exec.rs
@@ -61,6 +61,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::TryStreamExt;
+use iceberg_datafusion::physical_plan::IcebergTableScan;
 use runtime_datafusion::config::cluster_config::SpiceClusterConfig;
 use tokio::sync::OnceCell;
 
@@ -201,6 +202,24 @@ impl IcebergScanExec {
     #[must_use]
     pub fn limit(&self) -> Option<usize> {
         self.limit
+    }
+
+    /// The snapshot to pin for this scan, derived from the wrapped scan at plan
+    /// time: the scan's explicit snapshot if any, else the table's current
+    /// snapshot. The codec serializes this so every executor task plans against
+    /// the same snapshot — giving one consistent snapshot across all partitions
+    /// of a distributed query even under concurrent commits. Returns `None` for a
+    /// deferred node (its provider already carries the pin) or if the wrapped plan
+    /// isn't an `IcebergTableScan`.
+    #[must_use]
+    pub fn snapshot_id(&self) -> Option<i64> {
+        match &self.source {
+            ScanSource::Planned(inner) => inner.downcast_ref::<IcebergTableScan>().and_then(|s| {
+                s.snapshot_id()
+                    .or_else(|| s.table().metadata().current_snapshot_id())
+            }),
+            ScanSource::Deferred { .. } => None,
+        }
     }
 }
 

--- a/crates/runtime/src/execution_plan/mod.rs
+++ b/crates/runtime/src/execution_plan/mod.rs
@@ -16,6 +16,8 @@ limitations under the License.
 
 //! Custom execution plans for the Spice runtime.
 
+pub mod iceberg_scan_exec;
 pub mod udtf_exec;
 
+pub use iceberg_scan_exec::{IcebergScanExec, session_is_distributed};
 pub use udtf_exec::UdtfExec;

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -20,6 +20,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use app::App;
 use data_components::MetadataEnrichedTableProvider;
+use data_components::iceberg::delete::IcebergDeletionProvider;
 use datafusion::common::Column;
 use datafusion::error::DataFusionError;
 use datafusion::{datasource::TableProvider, sql::TableReference};
@@ -34,6 +35,7 @@ use snafu::ResultExt;
 use tokio::sync::RwLock;
 
 use crate::accelerated_table::AcceleratedTable;
+use crate::dataconnector::iceberg_cluster::IcebergClusterTableProvider;
 use crate::datafusion::{DataFusion, SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
 
 use crate::embeddings::table::EmbeddingTable;
@@ -73,6 +75,19 @@ pub(crate) fn find_concrete_table_provider<T: TableProvider + 'static>(
 
         if let Some(metadata_table) = current_tbl.downcast_ref::<MetadataEnrichedTableProvider>() {
             current_tbl = metadata_table.get_inner_ref();
+            continue;
+        }
+
+        // The Iceberg data connector wraps its providers so distributed (Ballista)
+        // scans can be serialized; peel both layers so callers (e.g. the health
+        // monitor's Iceberg skip) still see the underlying `IcebergTableProvider`.
+        if let Some(cluster_table) = current_tbl.downcast_ref::<IcebergClusterTableProvider>() {
+            current_tbl = cluster_table.inner();
+            continue;
+        }
+
+        if let Some(deletion_table) = current_tbl.downcast_ref::<IcebergDeletionProvider>() {
+            current_tbl = deletion_table.inner();
             continue;
         }
 
@@ -416,5 +431,28 @@ mod tests {
         assert!(find_concrete_table_provider::<IndexedTableProvider>(&wrapped_table).is_some());
 
         assert!(find_concrete_table_provider::<EmbeddingTable>(&wrapped_table).is_none());
+    }
+
+    #[test]
+    fn test_find_concrete_table_provider_peels_iceberg_cluster_wrapper() {
+        use datafusion::sql::TableReference;
+
+        let base: Arc<dyn TableProvider> = Arc::new(
+            MemTable::try_new(Arc::new(Schema::empty()), vec![]).expect("failed to make table"),
+        );
+
+        let wrapped: Arc<dyn TableProvider> = Arc::new(IcebergClusterTableProvider::new(
+            TableReference::bare("trips"),
+            Arc::clone(&base),
+        ));
+
+        // The Iceberg cluster wrapper must be peeled so concrete-provider lookups
+        // (e.g. the health monitor's Iceberg skip, #6994) still reach the inner
+        // provider. Using MemTable as the inner exercises the peel arm without a
+        // live Iceberg catalog.
+        assert!(
+            find_concrete_table_provider::<MemTable>(&wrapped).is_some(),
+            "find_concrete_table_provider must peel IcebergClusterTableProvider"
+        );
     }
 }


### PR DESCRIPTION
## What

Enables querying **Iceberg tables in distributed (Ballista cluster) query mode**.
Previously a distributed query over an Iceberg dataset failed during scheduler
plan serialization:

```
Internal error: Unsupported plan and extension codec failed with
[External error: Serialization not implemented for this field].
Plan: IcebergScanExec { inner: IcebergTableScan { ... } }
```

`IcebergTableScan` is a bespoke `ExecutionPlan` that Ballista's codec can't
serialize, so it never crossed the scheduler→executor boundary.

## Approach

The runtime work lives in Spice; cross-task snapshot consistency additionally
needs **one small, backward-compatible iceberg-rust fork change** (see
**Fork dependency** below).

- **`IcebergScanExec`** (`execution_plan/iceberg_scan_exec.rs`): a leaf
  `ExecutionPlan` with two modes. *Planned* (scheduler) wraps the native
  `IcebergTableScan` so physical planning sees real schema/partitioning. *Deferred*
  (executor, after decode) holds the registered provider and re-derives the scan
  **lazily inside `execute()`** — memoized in a `OnceCell` so it is planned once
  per instance, not once per partition. As a leaf it never hands the
  non-serializable inner scan to Ballista's codec.
- **`IcebergClusterTableProvider`** (`dataconnector/iceberg_cluster.rs`): wraps
  the Iceberg provider and, **only in a distributed session** (detected via the
  `SpiceClusterConfig` session extension), wraps the produced scan in
  `IcebergScanExec`. Single-node sessions are a transparent pass-through, so
  non-distributed plans are unchanged. `#[deny(clippy::missing_trait_methods)]`
  keeps every `TableProvider` method explicitly forwarded.
- **`SpicePhysicalCodec`** encode/decode: serializes a minimal recipe
  (`IcebergTableScanExecNode` = table ref + projection + serialized filter `Expr`s
  + limit + output partitioning + **pinned snapshot id**). Decode is fully
  synchronous (`get_table_sync`, no blocking bridge): it resolves the
  already-registered provider through all runtime wrappers
  (`find_concrete_table_provider`), pins it to the recipe's snapshot, and the
  lazy `execute()` replays `TableProvider::scan(...)`. **No catalog is rebuilt and
  no credentials cross the wire** — the executor reuses the catalog it already
  built from the app definition (secrets resolved via the normal cluster
  `ExpandSecret` RPC).

### Why re-plan instead of shipping the planned tasks?

Iceberg's `FileScanTask` has `partition` / `partition_spec` fields the iceberg
crate intentionally marks non-serializable (`serialize_not_implemented`). So the
executor re-derives the scan from the recipe (regenerating valid `FileScanTask`s,
including partition data) rather than shipping the planned buckets. Serializing
the projection/filters/`target_partitions` reproduces the same file pruning and
bucket count as the scheduler.

### Cross-task snapshot consistency

The scheduler pins the **plan-time snapshot** (the scan's own, else the table's
current) and serializes it in the recipe; every executor task pins its provider
clone to that snapshot via `with_snapshot_id`. So all partitions of one query
read a single consistent snapshot, even if the table is committed to mid-query.

## Fork dependency

Cross-task snapshot pinning needs the catalog-backed `IcebergTableProvider` to
accept a pinned snapshot (its `scan()` previously hardcoded the current
snapshot). That is added in **spiceai/iceberg-rust#45**
(`IcebergTableProvider::with_snapshot_id`, default `None` = current snapshot —
fully backward-compatible), now **merged into `spiceai-0.9.1-df-54`**. This PR
pins the `iceberg-*` git deps to the merged branch rev (`Cargo.toml` /
`Cargo.lock`, iceberg-rev-only diff) — no dependency on an unmerged branch.

## Scope

- Read/query path via the **Iceberg data connector** (`from: iceberg:...`
  datasets). REST and Hadoop catalogs both work (the executor reuses whatever
  catalog the registered provider was built from).
- Follow-ups (not in this PR): the Iceberg **catalog connector** path, and
  distributed Iceberg **writes** (`IcebergWriteExec` / `IcebergCommitExec`).

## Testing

- **Manual distributed cluster runs** (separate scheduler + executor processes,
  mTLS, REST catalog + MinIO via docker), querying through the async distributed
  API (`POST /v1/queries`) — the path that ships the plan to executors:
  - aggregates / group-by / filters / limit all returned correct results, with
    the executor running the scan stage across multiple partitions;
  - snapshot pinning: `query (12 rows)` → append 3 rows (new snapshot) →
    `query (15 rows)` — each query correctly reads its plan-time snapshot.
- Fork: `cargo test -p iceberg-datafusion --lib` (86 passed).
- `make lint-rust` clean; physical-codec + wrapper-peel unit tests added.
