### PR TITLE
tune(chbench): write_concurrency 4->8 + target_file_size 512 for cdc-tuned sf100+sf1000 spicepods

### DIFF
--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
@@ -181,7 +181,6 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        cayenne_write_concurrency: '8'
         cayenne_target_file_size_mb: '512'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'
@@ -259,6 +258,8 @@ datasets:
       params:
         <<: *accel_medium
         cayenne_file_path: .spice/cayenne/item
+        # static full-refresh: pin write_concurrency low so the &accel_medium bump (for the warehouse changes table) does not apply here.
+        cayenne_write_concurrency: '2'
 
   - from: postgres:region
     name: region

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
@@ -85,7 +85,7 @@ datasets:
         # growth on the delete-receiving table). Key-delete compaction runs
         # concurrently with writers.
         cayenne_deletion_mode: key
-        cayenne_write_concurrency: '4'
+        cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '1024'
         cayenne_compaction_trigger_protected_snapshots: '3'
         # Pinned to 256 MiB (SF-100 sweep optimum). The keyset pin is scale-dependent: it
@@ -118,7 +118,10 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/customer
-        cayenne_target_file_size_mb: '256'
+        # 512 (was 256): fewer/larger files speed scans on the many-core CI runner. NOTE: this
+        # regresses on ~16-core hosts (compaction rewrites contend for scarce cores); it is a
+        # many-core value. write_concurrency 8 (anchors) is the paired apply-side bump — see PR.
+        cayenne_target_file_size_mb: '512'
 
   - from: postgres:new_order
     name: new_order
@@ -176,8 +179,8 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        cayenne_write_concurrency: '4'
-        cayenne_target_file_size_mb: '256'
+        cayenne_write_concurrency: '8'
+        cayenne_target_file_size_mb: '512'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'
         cayenne_compaction_max_files_per_pick: '128'
@@ -201,7 +204,7 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/stock
-        cayenne_target_file_size_mb: '256'
+        cayenne_target_file_size_mb: '512'
 
   # ------------------------------------------------------------------
   # Low-volume reference tables.
@@ -228,7 +231,7 @@ datasets:
         # See &accel_high_volume: explicit file durability + key deletes.
         cayenne_cdc_durability: file
         cayenne_deletion_mode: key
-        cayenne_write_concurrency: '4'
+        cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '64'
         # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
         cayenne_pk_keyset_cache_mb: '256'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
@@ -5,9 +5,10 @@ name: postgres-cayenne[file]-cdc-tuned-sf100
 # Target: 64 vCPU / 256 GiB RAM, EBS gp3 (m7a.16xlarge-class). Goal: every CDC table under
 # 5s replication lag at SF-100 @ 10K txn/s, with >=5K QPH on the OLAP queries.
 #
-# Tuning (values validated on the 16-core local SF-100 run — all 7 tables <5s, ~97% of 5K
-# QPH — then scaled to 64c/256GB; the write-path values are core/RAM-invariant because the
-# wall is the single-writer-per-table metastore txn, not CPU or batch size):
+# Tuning (the write-path knobs below are MANY-CORE values, raised for the 64c runner's
+# headroom — they are NOT core-invariant: on a 16-core host the box saturates at 10K and the
+# CDC apply is core-bound, so the larger tables lag. The many-core CI runner clears >=5K QPH
+# and holds 6/7 tables <5s under load; order_line is the remaining apply bottleneck):
 #   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
 #     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
 #   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
@@ -17,8 +18,9 @@ name: postgres-cayenne[file]-cdc-tuned-sf100
 #     auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) and keeps the heavy-update tables
 #     (stock, order_line) on the cheap bloom path (256 = SF-100 sweep optimum).
 #   - per-table cayenne_write_concurrency / segment_cache_mb / compaction_* for the high-volume
-#     upsert tables; reference tables lighter. write_concurrency stays moderate (4/2): lower
-#     fan-out relieves CPU contention for OLAP (validated on the 128-core write-concurrency run).
+#     upsert tables; reference tables lighter. write_concurrency = 8 (was 4) on the changes
+#     tables: the CDC apply is encode-parallelism-bound, so more shards consume the runner's
+#     encode budget; reference tables stay at 2. target_file_size 512 (was 256) on high-volume.
 #   - metastore/footer caches (1024/1024 MiB, 4096 MiB mmap) are sized to the SF-100 working set,
 #     bounded by catalog/footer size — so 256 GiB adds headroom, not bigger caches.
 #

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
@@ -64,7 +64,7 @@ datasets:
         # growth on the delete-receiving table). Key-delete compaction runs
         # concurrently with writers.
         cayenne_deletion_mode: key
-        cayenne_write_concurrency: '4'
+        cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '1024'
         cayenne_compaction_trigger_protected_snapshots: '3'
         cayenne_pk_keyset_cache_mb: '256'
@@ -92,7 +92,10 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/customer
-        cayenne_target_file_size_mb: '256'
+        # 512 (was 256): fewer/larger files speed scans on the many-core CI runner (SF-1000 has
+        # 10x the data, so this matters more). NOTE: regresses on ~16-core hosts (compaction
+        # contention); many-core value. write_concurrency 8 (anchors) is the paired apply bump.
+        cayenne_target_file_size_mb: '512'
 
   - from: postgres:new_order
     name: new_order
@@ -150,8 +153,8 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        cayenne_write_concurrency: '4'
-        cayenne_target_file_size_mb: '256'
+        cayenne_write_concurrency: '8'
+        cayenne_target_file_size_mb: '512'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'
         cayenne_compaction_max_files_per_pick: '128'
@@ -175,7 +178,7 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/stock
-        cayenne_target_file_size_mb: '256'
+        cayenne_target_file_size_mb: '512'
 
   # ------------------------------------------------------------------
   # Low-volume reference tables.
@@ -202,7 +205,7 @@ datasets:
         # See &accel_high_volume: explicit file durability + key deletes.
         cayenne_cdc_durability: file
         cayenne_deletion_mode: key
-        cayenne_write_concurrency: '4'
+        cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '64'
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
@@ -153,7 +153,6 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        cayenne_write_concurrency: '8'
         cayenne_target_file_size_mb: '512'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'
@@ -230,6 +229,8 @@ datasets:
       params:
         <<: *accel_medium
         cayenne_file_path: .spice/cayenne/item
+        # static full-refresh: pin write_concurrency low so the &accel_medium bump (for the warehouse changes table) does not apply here.
+        cayenne_write_concurrency: '2'
 
   - from: postgres:region
     name: region

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
@@ -10,9 +10,10 @@ name: postgres-cayenne[file]-cdc-tuned-turso-sf100
 # Target: 64 vCPU / 256 GiB RAM, EBS gp3 (m7a.16xlarge-class). Goal: every CDC table under
 # 5s replication lag at SF-100 @ 10K txn/s, with >=5K QPH on the OLAP queries.
 #
-# Tuning (values validated on the 16-core local SF-100 run — all 7 tables <5s, ~97% of 5K
-# QPH — then scaled to 64c/256GB; the write-path values are core/RAM-invariant because the
-# wall is the single-writer-per-table metastore txn, not CPU or batch size):
+# Tuning (the write-path knobs below are MANY-CORE values, raised for the 64c runner's
+# headroom — they are NOT core-invariant: on a 16-core host the box saturates at 10K and the
+# CDC apply is core-bound, so the larger tables lag. The many-core CI runner clears >=5K QPH
+# and holds 6/7 tables <5s under load; order_line is the remaining apply bottleneck):
 #   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
 #     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
 #   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
@@ -22,8 +23,9 @@ name: postgres-cayenne[file]-cdc-tuned-turso-sf100
 #     auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) and keeps the heavy-update tables
 #     (stock, order_line) on the cheap bloom path (256 = SF-100 sweep optimum).
 #   - per-table cayenne_write_concurrency / segment_cache_mb / compaction_* for the high-volume
-#     upsert tables; reference tables lighter. write_concurrency stays moderate (4/2): lower
-#     fan-out relieves CPU contention for OLAP (validated on the 128-core write-concurrency run).
+#     upsert tables; reference tables lighter. write_concurrency = 8 (was 4) on the changes
+#     tables: the CDC apply is encode-parallelism-bound, so more shards consume the runner's
+#     encode budget; reference tables stay at 2. target_file_size 512 (was 256) on high-volume.
 #   - metastore/footer caches (1024/1024 MiB, 4096 MiB mmap) are sized to the SF-100 working set,
 #     bounded by catalog/footer size — so 256 GiB adds headroom, not bigger caches.
 #

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
@@ -90,7 +90,7 @@ datasets:
         # growth on the delete-receiving table). Key-delete compaction runs
         # concurrently with writers.
         cayenne_deletion_mode: key
-        cayenne_write_concurrency: '4'
+        cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '1024'
         cayenne_compaction_trigger_protected_snapshots: '3'
         # Pinned to 256 MiB (SF-100 sweep optimum). The keyset pin is scale-dependent: it
@@ -123,7 +123,10 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/customer
-        cayenne_target_file_size_mb: '256'
+        # 512 (was 256): fewer/larger files speed scans on the many-core CI runner. NOTE: this
+        # regresses on ~16-core hosts (compaction rewrites contend for scarce cores); it is a
+        # many-core value. write_concurrency 8 (anchors) is the paired apply-side bump — see PR.
+        cayenne_target_file_size_mb: '512'
 
   - from: postgres:new_order
     name: new_order
@@ -181,8 +184,8 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        cayenne_write_concurrency: '4'
-        cayenne_target_file_size_mb: '256'
+        cayenne_write_concurrency: '8'
+        cayenne_target_file_size_mb: '512'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'
         cayenne_compaction_max_files_per_pick: '128'
@@ -206,7 +209,7 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/stock
-        cayenne_target_file_size_mb: '256'
+        cayenne_target_file_size_mb: '512'
 
   # ------------------------------------------------------------------
   # Low-volume reference tables.
@@ -233,7 +236,7 @@ datasets:
         # See &accel_high_volume: explicit file durability + key deletes.
         cayenne_cdc_durability: file
         cayenne_deletion_mode: key
-        cayenne_write_concurrency: '4'
+        cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '64'
         # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
         cayenne_pk_keyset_cache_mb: '256'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
@@ -186,7 +186,6 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        cayenne_write_concurrency: '8'
         cayenne_target_file_size_mb: '512'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'
@@ -264,6 +263,8 @@ datasets:
       params:
         <<: *accel_medium
         cayenne_file_path: .spice/cayenne/item
+        # static full-refresh: pin write_concurrency low so the &accel_medium bump (for the warehouse changes table) does not apply here.
+        cayenne_write_concurrency: '2'
 
   - from: postgres:region
     name: region

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
@@ -68,7 +68,7 @@ datasets:
         # growth on the delete-receiving table). Key-delete compaction runs
         # concurrently with writers.
         cayenne_deletion_mode: key
-        cayenne_write_concurrency: '4'
+        cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '1024'
         cayenne_compaction_trigger_protected_snapshots: '3'
         cayenne_pk_keyset_cache_mb: '256'
@@ -96,7 +96,10 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/customer
-        cayenne_target_file_size_mb: '256'
+        # 512 (was 256): fewer/larger files speed scans on the many-core CI runner (SF-1000 has
+        # 10x the data, so this matters more). NOTE: regresses on ~16-core hosts (compaction
+        # contention); many-core value. write_concurrency 8 (anchors) is the paired apply bump.
+        cayenne_target_file_size_mb: '512'
 
   - from: postgres:new_order
     name: new_order
@@ -154,8 +157,8 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        cayenne_write_concurrency: '4'
-        cayenne_target_file_size_mb: '256'
+        cayenne_write_concurrency: '8'
+        cayenne_target_file_size_mb: '512'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'
         cayenne_compaction_max_files_per_pick: '128'
@@ -179,7 +182,7 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/stock
-        cayenne_target_file_size_mb: '256'
+        cayenne_target_file_size_mb: '512'
 
   # ------------------------------------------------------------------
   # Low-volume reference tables.
@@ -206,7 +209,7 @@ datasets:
         # See &accel_high_volume: explicit file durability + key deletes.
         cayenne_cdc_durability: file
         cayenne_deletion_mode: key
-        cayenne_write_concurrency: '4'
+        cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '64'
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
@@ -157,7 +157,6 @@ datasets:
       params:
         <<: *accel_high_volume
         cayenne_file_path: .spice/cayenne/order_line
-        cayenne_write_concurrency: '8'
         cayenne_target_file_size_mb: '512'
         cayenne_compaction_trigger_files: '8'
         cayenne_compaction_trigger_snapshot_age_ms: '30000'
@@ -234,6 +233,8 @@ datasets:
       params:
         <<: *accel_medium
         cayenne_file_path: .spice/cayenne/item
+        # static full-refresh: pin write_concurrency low so the &accel_medium bump (for the warehouse changes table) does not apply here.
+        cayenne_write_concurrency: '2'
 
   - from: postgres:region
     name: region


### PR DESCRIPTION
## Summary

Applies the HTAP tuning findings to the `cdc-tuned` spicepods that the **scheduled benchmark runs dispatch** (`.github/workflows/testoperator_dispatch.yml`): htap-sf100 (cron `0 2,5,8,...`, 3-hourly) and htap-sf1000 (cron `0 0,12`), both at `rate: 10000` on `spiceai-dev-xlarge-runners`.

Files (4): `accelerated/postgres-cayenne[file]-cdc-tuned-{sf100,sf1000}.yaml` and their `-turso-` variants.

### `write_concurrency` 4 → 8 (all 7 `changes` tables, via the `&accel_high_volume` / `&accel_medium` anchors)

Per-process profiling of the SF-100 HTAP workload showed the CDC apply path is **encode-parallelism-bound**: `write_concurrency=4` caps each table's Vortex encode to 4 shards while the process-global encode budget allows ~12 (`cores − query_reserve`). Raising to 8 lets the apply consume the headroom. Static full-refresh tables (`&accel_small`: region/nation/supplier) stay at 2.

### `target_file_size_mb` 256 → 512 (high-volume tables: customer, order_line, stock)

Fewer, larger files → faster scans on a many-core runner. **Caveat (also inline):** this *regresses* on ~16-core hosts — bigger files mean heavier compaction rewrites that contend for scarce cores (measured −22% QPH on a 16-core box). It is a **many-core value**; the scheduled runner also runs SF-1000 HTAP so it should be many-core. If `spiceai-dev-xlarge-runners` is ~16 cores, revert `tfs` — the next scheduled run shows it.

### Measured CI context (latest scheduled htap-sf100, pre-merge / old config)

QPH **5350** (clears >5K), and 6 of 7 tables already hold replication lag <5s under load; **only `order_line` lags** (39s, the highest-churn table). So on the CI runner the goal is one-table-away — this PR's `wc=8` targets order_line's apply directly (it likely needs more to fully close <5s; see the order_line per-table apply-parallelism follow-up). The adaptive variant auto-determines both knobs at runtime — verified.

### SF-1000

Same `wc 4→8` + `tfs 256→512` mirrored onto the SF-1000 cdc-tuned spicepods. `pk_keyset_cache_mb` left **untouched** (scale-specific). **Note:** the sf1000 keyset is `256`, but the sf100 config's own comment says the sf1000 venue should pin `1024` — likely an oversight, flagged for a separate fix (not in this PR).

Companion: `spicehq/cayenne-bench-runs#2` (local bench pod); spiceai #11332 (OLAP scan/admission levers) merged.
