### PR TITLE
fix(ci): point table-providers validation at the spiceai-54 branch

### DIFF
--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Validate datafusion-table-providers commit
         run: bash .github/scripts/validate_table_providers_commit.sh
         env:
-          BRANCH: spiceai-54 # temporary
+          BRANCH: spiceai-54
 
       - name: Show sccache stats
         if: runner.os == 'macOS' && steps.setup-spiceio.outputs.endpoint != ''

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Validate datafusion-table-providers commit
         run: bash .github/scripts/validate_table_providers_commit.sh
         env:
-          BRANCH: sgrebnov/spiceai-54 # temporary
+          BRANCH: spiceai-54 # temporary
 
       - name: Show sccache stats
         if: runner.os == 'macOS' && steps.setup-spiceio.outputs.endpoint != ''

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Validate datafusion-table-providers commit
         run: bash .github/scripts/validate_table_providers_commit.sh
         env:
-          BRANCH: spiceai-54 # temporary
+          BRANCH: spiceai-54
 
   # Run Rust linting
   lint-rust:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Validate datafusion-table-providers commit
         run: bash .github/scripts/validate_table_providers_commit.sh
         env:
-          BRANCH: sgrebnov/spiceai-54 # temporary
+          BRANCH: spiceai-54 # temporary
 
   # Run Rust linting
   lint-rust:


### PR DESCRIPTION
## What

The `Validate datafusion-table-providers commit` step (in `check_changes`) hardcodes
`BRANCH: sgrebnov/spiceai-54`, but that branch no longer exists in
[spiceai/datafusion-table-providers](https://github.com/spiceai/datafusion-table-providers).
The pinned `Cargo.toml` rev (`2189ca20…`) now lives on the **`spiceai-54`** branch
(matching the existing `# spiceai-54` annotation on the dependency pin).

As a result the step fails on every Rust PR off trunk:

```
Error: Could not find 'sgrebnov/spiceai-54' branch in
https://github.com/spiceai/datafusion-table-providers.git
```

`check_changes` is a dependency of `Rust Lint` and `Build and Test`, so those are
skipped and PRs can't go green.

## Change

Point the validation `BRANCH` env at `spiceai-54` (the branch that actually holds
the pinned commit) in both `pr.yml` and `pr-develop.yml`. One line each.

## Verification

`git ls-remote https://github.com/spiceai/datafusion-table-providers.git refs/heads/spiceai-54`
returns `2189ca20b6fc78386f6fab753b3ee6e50573018e`, which is exactly the rev pinned
in `Cargo.toml` — so the validation script (`--is-ancestor`) will pass.
