### PR TITLE
fix(ci): keep dev/nightly Cargo version valid SemVer when short SHA is all-numeric

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -79,7 +79,11 @@ jobs:
           commit_hash=$(git rev-parse --short HEAD)
           date="$(date +%Y%m%d)"
           version="${date}-${commit_hash}"
-          nightly_label="nightly.${date}.${commit_hash}"
+          # `g`-prefix the commit hash (git-describe convention) so it is always a
+          # valid SemVer pre-release identifier in the Cargo.toml version below.
+          # An all-numeric short SHA with a leading zero (e.g. 0882134) is an
+          # invalid numeric SemVer identifier and fails `cargo build`.
+          nightly_label="nightly.${date}.g${commit_hash}"
           echo "rel_version=${version}" >> $GITHUB_OUTPUT
           echo "nightly_label=${nightly_label}" >> $GITHUB_OUTPUT
           echo "Preparing to publish nightly build with version: \"${version}\""

--- a/.github/workflows/spiced_docker_dev.yml
+++ b/.github/workflows/spiced_docker_dev.yml
@@ -46,7 +46,11 @@ jobs:
           safe_branch=$(echo "$branch_name" | sed 's/[^a-zA-Z0-9]/-/g' | head -c 20)
           date="$(date +%Y%m%d)"
           version="${date}-${safe_branch}-${commit_hash}"
-          dev_label="dev.${date}.${commit_hash}"
+          # `g`-prefix the commit hash (git-describe convention) so it is always a
+          # valid SemVer pre-release identifier in the Cargo.toml version below.
+          # An all-numeric short SHA with a leading zero (e.g. 0882134) is an
+          # invalid numeric SemVer identifier and fails `cargo build`.
+          dev_label="dev.${date}.g${commit_hash}"
           echo "rel_version=${version}" >> $GITHUB_OUTPUT
           echo "dev_label=${dev_label}" >> $GITHUB_OUTPUT
           echo "Building dev image with version: \"${version}\""


### PR DESCRIPTION
## Problem

The dev (`spiced_docker_dev`) and nightly (`build_nightly`) image builds embed the commit short SHA into the `Cargo.toml` version as a SemVer pre-release identifier, e.g.:

```
2.1.0-unstable.dev.20260620.0882134
```

When a short SHA is **all decimal digits with a leading zero** (e.g. `0882134`), it is an invalid *numeric* SemVer identifier and `cargo build` fails:

```
error: invalid leading zero in pre-release identifier
  --> Cargo.toml:96:11
96 | version = "2.1.0-unstable.dev.20260620.0882134"
```

Most short SHAs contain `a`–`f` hex letters (making the segment alphanumeric, where leading zeros *are* allowed), so this only fails on the unlucky commits whose short SHA is all digits and starts with `0` — an intermittent, timing-dependent failure.

Example failure: https://github.com/spiceai/spiceai/actions/runs/27856210723/job/82444116146

## Fix

Prefix the hash with `g` (the `git describe` convention) in the dev/nightly labels, so the pre-release identifier is always alphanumeric and valid regardless of the SHA's digits:

```
2.1.0-unstable.dev.20260620.g0882134
```

Only the SemVer-parsed `Cargo.toml` version is affected; the free-form image tag (`rel_version`) is left unchanged.
