### PR TITLE
fix(status): probe metrics endpoint over https when TLS is enabled

### DIFF
--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -152,6 +152,7 @@ where
         vsearch,
         auth_layer,
         &cors_config,
+        tls_config.is_some(),
         #[cfg(feature = "mcp")]
         mcp_config.as_ref(),
     );

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -318,6 +318,7 @@ pub(crate) fn routes(
     search: Arc<search_engine::SearchEngine>,
     auth_layer: Option<AuthLayer>,
     cors_config: &CorsConfig,
+    metrics_tls: bool,
     #[cfg(feature = "mcp")] mcp_config: Option<&McpConfig>,
 ) -> Router {
     let mut authenticated_router = Router::new()
@@ -481,6 +482,7 @@ pub(crate) fn routes(
     authenticated_router = authenticated_router
         .layer(Extension(Arc::clone(rt)))
         .layer(Extension(rt.metrics_endpoint))
+        .layer(Extension(v1::status::MetricsTlsEnabled(metrics_tls)))
         .layer(Extension(config));
 
     // Apply request body size limit to prevent DoS attacks via unbounded request payloads

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -38,6 +38,14 @@ pub struct QueryParams {
     pub format: Format,
 }
 
+/// Marker extension indicating whether the metrics endpoint terminates TLS.
+///
+/// When spiced is configured with TLS the metrics server is served over HTTPS,
+/// so the status probe must use the `https` scheme (and tolerate a loopback
+/// certificate mismatch) rather than hardcoding `http`.
+#[derive(Debug, Clone, Copy)]
+pub struct MetricsTlsEnabled(pub bool);
+
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ConnectionDetails {
@@ -98,6 +106,7 @@ pub struct ConnectionDetails {
 pub(crate) async fn get(
     Extension(cfg): Extension<Arc<config::Config>>,
     Extension(with_metrics): Extension<Option<SocketAddr>>,
+    Extension(metrics_tls): Extension<MetricsTlsEnabled>,
     Query(params): Query<QueryParams>,
 ) -> Response {
     let cfg = cfg.as_ref();
@@ -119,13 +128,15 @@ pub(crate) async fn get(
             name: "metrics",
             endpoint: with_metrics.map_or("N/A".to_string(), |addr| addr.to_string()),
             status: match with_metrics {
-                Some(metrics_url) => match get_metrics_status(&metrics_url.to_string()).await {
-                    Ok(status) => status,
-                    Err(e) => {
-                        tracing::error!("Error getting metrics status from {metrics_url}: {e}");
-                        ComponentStatus::error_with_message(e.to_string())
+                Some(metrics_url) => {
+                    match get_metrics_status(&metrics_url.to_string(), metrics_tls.0).await {
+                        Ok(status) => status,
+                        Err(e) => {
+                            tracing::error!("Error getting metrics status from {metrics_url}: {e}");
+                            ComponentStatus::error_with_message(e.to_string())
+                        }
                     }
-                },
+                }
                 None => ComponentStatus::Disabled,
             },
         },
@@ -180,9 +191,11 @@ async fn get_flight_status(flight_addr: &str) -> ComponentStatus {
 
 async fn get_metrics_status(
     metrics_addr: &str,
+    tls_enabled: bool,
 ) -> Result<ComponentStatus, Box<dyn std::error::Error>> {
     use std::sync::LazyLock;
 
+    // Plain HTTP client for non-TLS metrics endpoints.
     static METRICS_CLIENT: LazyLock<Result<reqwest::Client, reqwest::Error>> =
         LazyLock::new(|| {
             reqwest::Client::builder()
@@ -191,14 +204,32 @@ async fn get_metrics_status(
                 .build()
         });
 
-    let client = METRICS_CLIENT.as_ref().map_err(|e| {
+    // HTTPS client for TLS-terminating metrics endpoints. This probe is an
+    // in-process loopback request, so the certificate's SAN almost certainly
+    // won't match 127.0.0.1/0.0.0.0 — accept invalid certs for the health check.
+    static METRICS_TLS_CLIENT: LazyLock<Result<reqwest::Client, reqwest::Error>> =
+        LazyLock::new(|| {
+            reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(2))
+                .timeout(Duration::from_secs(5))
+                .danger_accept_invalid_certs(true)
+                .build()
+        });
+
+    let client = if tls_enabled {
+        &METRICS_TLS_CLIENT
+    } else {
+        &METRICS_CLIENT
+    };
+    let client = client.as_ref().map_err(|e| {
         Box::new(std::io::Error::other(format!(
             "Failed to build metrics HTTP client: {e}"
         ))) as Box<dyn std::error::Error>
     })?;
 
+    let scheme = if tls_enabled { "https" } else { "http" };
     let resp = client
-        .get(format!("http://{metrics_addr}/health"))
+        .get(format!("{scheme}://{metrics_addr}/health"))
         .send()
         .await?;
     if resp.status().is_success() && resp.text().await? == "OK" {


### PR DESCRIPTION
## Problem

`spice status` (and `GET /v1/status`) reports the metrics connection as `error` whenever spiced is terminating TLS.

When `runtime.tls` is configured, the metrics server is served over **HTTPS** (it receives the same `tls_config` as the HTTP server in `Runtime::start`). But the status probe in `status.rs` hardcoded the `http://` scheme, so the request failed the TLS handshake and the metrics endpoint was reported as an error.

Fixes #11176.

## Fix

The minimal 3-spot change suggested in the issue:

1. **`crates/runtime/src/http/v1/status.rs`** — add a `MetricsTlsEnabled(bool)` marker extension, take it as a second `Extension` on the `get` handler, and pass it to `get_metrics_status`. The probe now picks `https` vs `http` from the flag. The HTTPS path uses a separate `LazyLock<reqwest::Client>` built with `danger_accept_invalid_certs(true)` — the probe is an in-process loopback request and the certificate's SAN won't match `127.0.0.1`/`0.0.0.0`.
2. **`crates/runtime/src/http/routes.rs`** — plumb a `metrics_tls: bool` parameter through `routes::routes(...)` and add `.layer(Extension(MetricsTlsEnabled(...)))` alongside the existing `rt.metrics_endpoint` extension.
3. **`crates/runtime/src/http/mod.rs`** — pass `tls_config.is_some()` at the `routes::routes(...)` call site (`tls_config` is already in scope).

## Testing

- `cargo check -p runtime` — clean.
- `make lint-rust` — clean (workspace pedantic clippy + rustfmt).