### PR TITLE
fix(cayenne): preserve partition count when rewriting oversized semi/anti joins to SortMergeJoin

### DIFF
--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -688,10 +688,16 @@ fn try_rewrite_oversized_join(
         return Ok(None);
     };
 
-    let left: Arc<dyn ExecutionPlan> =
-        Arc::new(SortExec::new(left_ordering, Arc::clone(hash_join.left())));
-    let right: Arc<dyn ExecutionPlan> =
-        Arc::new(SortExec::new(right_ordering, Arc::clone(hash_join.right())));
+    // Preserve the input partitioning. This rule runs AFTER `EnforceDistribution`,
+    // so a `mode=Partitioned` `HashJoinExec` already has both inputs hash-
+    // partitioned on the join keys into N partitions;
+    let left: Arc<dyn ExecutionPlan> = Arc::new(
+        SortExec::new(left_ordering, Arc::clone(hash_join.left())).with_preserve_partitioning(true),
+    );
+    let right: Arc<dyn ExecutionPlan> = Arc::new(
+        SortExec::new(right_ordering, Arc::clone(hash_join.right()))
+            .with_preserve_partitioning(true),
+    );
 
     let join = SortMergeJoinExec::try_new(
         left,
@@ -1405,14 +1411,17 @@ mod tests {
     use datafusion::common::{JoinType, NullEquality};
     use datafusion::config::ConfigOptions;
     use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::execution::TaskContext;
     use datafusion::execution::object_store::ObjectStoreUrl;
     use datafusion::physical_expr::aggregate::AggregateExprBuilder;
     use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    use datafusion::physical_plan::Partitioning;
     use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
     use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode, SortMergeJoinExec};
+    use datafusion::physical_plan::repartition::RepartitionExec;
     use datafusion::physical_plan::sorts::sort::SortExec;
     use datafusion::physical_plan::union::UnionExec;
-    use datafusion::physical_plan::{ExecutionPlan, displayable};
+    use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties, displayable};
     use datafusion_common::stats::Precision;
     use datafusion_common::{DataFusionError, Result as DFResult, Statistics};
     use datafusion_datasource::file::FileSource;
@@ -2167,6 +2176,100 @@ mod tests {
         assert!(
             sort_merge.right().downcast_ref::<SortExec>().is_some(),
             "right anti-join input should be explicitly sorted"
+        );
+    }
+
+    fn hash_repartition(
+        input: Arc<dyn ExecutionPlan>,
+        column: &str,
+        partitions: usize,
+    ) -> Arc<dyn ExecutionPlan> {
+        let expr = col(column, input.schema().as_ref()).expect("repartition column should exist");
+        Arc::new(
+            RepartitionExec::try_new(input, Partitioning::Hash(vec![expr], partitions))
+                .expect("repartition should be valid"),
+        )
+    }
+
+    /// When the rewriter replaces an inner semi/anti join that sits
+    /// under a `mode=Partitioned` `HashJoinExec`, the replacement must keep the
+    /// same output partition count — otherwise the `SortExec`-coalesced
+    /// `SortMergeJoinExec` (1 partition) feeds a parent that still expects N,
+    /// and the join's runtime sanity check fails at `execute()`.
+    #[test]
+    fn rewrite_under_partitioned_parent_preserves_partition_count() {
+        let schema = order_line_schema();
+        let partitions = 4usize;
+
+        // Inner `EXISTS` (LeftSemi) join over same-source large scans, hash-
+        // partitioned to N — a valid `mode=Partitioned` join emitting N
+        // partitions, mirroring the EnforceDistribution'd TPC-H q21 plan.
+        let semi: Arc<dyn ExecutionPlan> = Arc::new(hash_join_with_join_type(
+            hash_repartition(
+                large_exact_cayenne_file_exec(&schema, "order_line.vortex"),
+                "order_id",
+                partitions,
+            ),
+            hash_repartition(
+                large_exact_cayenne_file_exec(&schema, "order_line.vortex"),
+                "order_id",
+                partitions,
+            ),
+            "order_id",
+            "order_id",
+            JoinType::LeftSemi,
+            NullEquality::NullEqualsNothing,
+        ));
+
+        // Parent `NOT EXISTS` (LeftAnti) join consuming the semi join on its
+        // build side. Its build side is a join (no exact row stats), so the
+        // rewriter leaves it a `HashJoinExec(mode=Partitioned)`.
+        let probe = hash_repartition(
+            large_exact_cayenne_file_exec(&schema, "order_line.vortex"),
+            "order_id",
+            partitions,
+        );
+        let parent: Arc<dyn ExecutionPlan> = Arc::new(hash_join_with_join_type(
+            semi,
+            probe,
+            "order_id",
+            "order_id",
+            JoinType::LeftAnti,
+            NullEquality::NullEqualsNothing,
+        ));
+
+        // Precondition: before the rewrite both parent inputs emit N partitions.
+        let parent_hj = parent
+            .downcast_ref::<HashJoinExec>()
+            .expect("parent should be a hash join");
+        assert_eq!(
+            parent_hj.left().output_partitioning().partition_count(),
+            partitions,
+        );
+        assert_eq!(
+            parent_hj.right().output_partitioning().partition_count(),
+            partitions,
+        );
+
+        let optimized = optimize_anti_join_sort_merge(parent);
+
+        let parent_hj = optimized
+            .downcast_ref::<HashJoinExec>()
+            .expect("parent NOT-EXISTS join must remain a HashJoinExec");
+        assert!(
+            parent_hj
+                .left()
+                .downcast_ref::<SortMergeJoinExec>()
+                .is_some(),
+            "inner EXISTS join should have been rewritten to a SortMergeJoinExec",
+        );
+
+        let left_partitions = parent_hj.left().output_partitioning().partition_count();
+        let right_partitions = parent_hj.right().output_partitioning().partition_count();
+        assert_eq!(
+            left_partitions, right_partitions,
+            "rewrite must preserve the build-side partition count under a mode=Partitioned parent \
+             (got {left_partitions} != {right_partitions})",
         );
     }
 

--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -1411,7 +1411,6 @@ mod tests {
     use datafusion::common::{JoinType, NullEquality};
     use datafusion::config::ConfigOptions;
     use datafusion::datasource::memory::MemorySourceConfig;
-    use datafusion::execution::TaskContext;
     use datafusion::execution::object_store::ObjectStoreUrl;
     use datafusion::physical_expr::aggregate::AggregateExprBuilder;
     use datafusion::physical_optimizer::PhysicalOptimizerRule;


### PR DESCRIPTION
## 📝 Summary

`CayenneAntiJoinSortMergeRewriter` rewrites an oversized semi/anti `HashJoinExec` into a spillable `SortMergeJoinExec`, wrapping each input in a `SortExec`. Those `SortExec`s used the default `preserve_partitioning = false`, which **coalesces each input to a single partition**, so the replacement `SortMergeJoinExec` emitted 1 partition instead of the original N.

The rule runs **after** `EnforceDistribution`, so when the rewritten join sits under a parent `HashJoinExec(mode=Partitioned)` (e.g. TPC-H q21's `NOT EXISTS` anti-join over its `EXISTS` semi-join), the parent still expects N partitions on that side. The mismatch trips DataFusion's runtime sanity check at `HashJoinExec::execute`:

>Internal error: Invalid HashJoinExec, partition count mismatch 1!=16, consider using RepartitionExec.

## Fix

Set `.with_preserve_partitioning(true)` on both `SortExec` inputs. A valid `mode=Partitioned` join already has its inputs hash-partitioned on the join keys into N partitions; sorting each partition independently keeps that partitioning, so the `SortMergeJoinExec` runs partitioned and preserves the original output partition count. For single-partition inputs it's a no-op.

This mirrors the "preserve the partition count" fix in #11025 (which addressed the same `partition count mismatch` assertion for the `EmptyHashJoinExec` rewrite); 

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/11395

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
