### PR TITLE
fix(mcp): record task_history spans for tool calls proxied through /v1/mcp

### DIFF
--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -118,6 +118,21 @@ impl ServerHandler for RuntimeServer {
                 // model-driven tool calls (see `McpToolWrapper::call`). Without
                 // this, gateway tool calls bypass the task_history span entirely.
                 let input = serde_json::to_string(&arguments).unwrap_or_default();
+
+                // Security: Validate serialized argument size to prevent DoS,
+                // matching the non-proxy path below. `/v1/mcp` is externally
+                // accessible, so reject oversized payloads before logging them
+                // to task history or forwarding them upstream.
+                if input.len() > MAX_ARGS_SIZE {
+                    return Err(McpError::invalid_params(
+                        format!(
+                            "Arguments too large ({} bytes). Maximum: {MAX_ARGS_SIZE} bytes",
+                            input.len()
+                        ),
+                        None,
+                    ));
+                }
+
                 let task_name = format!("tool_use::{tool_name}");
                 let mcp_server = tool_name
                     .split_once('/')

--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -27,6 +27,7 @@ use rmcp::{
 };
 use serde_json::{Map, Value, json};
 use std::{borrow::Cow, future::Future, ops::Deref, sync::Arc};
+use tracing_futures::Instrument;
 use util::security::{MAX_SAFE_JSON_DEPTH, get_json_depth};
 
 #[derive(Clone)]
@@ -112,10 +113,34 @@ impl ServerHandler for RuntimeServer {
                     }
                 }
 
-                return mcp_proxy
+                // Record the proxied call in task history so tool calls made
+                // through the `/v1/mcp` gateway are audited identically to
+                // model-driven tool calls (see `McpToolWrapper::call`). Without
+                // this, gateway tool calls bypass the task_history span entirely.
+                let input = serde_json::to_string(&arguments).unwrap_or_default();
+                let task_name = format!("tool_use::{tool_name}");
+                let mcp_server = tool_name
+                    .split_once('/')
+                    .map_or_else(|| tool_name.to_string(), |(server, _)| server.to_string());
+                let span = tracing::span!(target: "task_history", tracing::Level::INFO, "tool_use::mcp", tool = %tool_name, input = %input);
+                tracing::info!(target: "task_history", parent: &span, task_override = %task_name, mcp_server = %mcp_server, "labels");
+
+                return match mcp_proxy
                     .call_tool(arguments)
+                    .instrument(span.clone())
                     .await
-                    .map_err(|e| McpError::internal_error(e.to_string(), None));
+                {
+                    Ok(result) => {
+                        if let Ok(captured_output) = serde_json::to_string(&result.content) {
+                            tracing::info!(target: "task_history", parent: &span, captured_output = %captured_output);
+                        }
+                        Ok(result)
+                    }
+                    Err(e) => {
+                        tracing::error!(target: "task_history", parent: &span, "{e}");
+                        Err(McpError::internal_error(e.to_string(), None))
+                    }
+                };
             }
 
             let args = serde_json::to_string(&arguments)


### PR DESCRIPTION
## Problem

Tool calls that arrive through the `/v1/mcp` gateway for a tool backed by an
upstream MCP server take the `McpProxy::call_tool` passthrough in
`RuntimeServer::call_tool` (the "If possible, we pass the call through to the
MCP server" branch). That passthrough bypassed the `task_history` span that the
model-driven path (`McpToolWrapper::call`) emits.

As a result, tool calls made by **external MCP clients** through the gateway
were never recorded in `runtime.task_history` — only tool calls driven by
Spice's own model tool-loop produced `tool_use::<server>/<tool>` rows. Anything
consuming Spice's tools over MCP (an agent, or agent-to-agent invocation through
a broker tool) was invisible to the audit trail.

## Fix

Instrument the gateway proxy branch with the same `task_history` span the
model-driven path already uses:

- task name `tool_use::<server>/<tool>`
- `tool` and `input` fields, `mcp_server` label
- captured output on success, error capture on failure

Now any tool call routed through `/v1/mcp` is audited identically, whether it
was triggered by Spice's own model loop or an external MCP client. The
non-proxy branch already goes through `tool.call()` (which carries the span);
only the proxy passthrough was missing it.

## Verification

Built `spiced` with this change, registered an MCP server as a tool, and called
a proxied tool through `/v1/mcp` from an external MCP client. Before: no row.
After, `runtime.task_history` contains:

| task | tool | mcp_server | input | captured_output |
|---|---|---|---|---|
| `tool_use::agent_mesh/request_room_cleaning` | `agent_mesh/request_room_cleaning` | `agent_mesh` | `{"room":"909",…}` | `[{"type":"text",…}]` |

(Standalone gateway tool calls become root tasks with their own `trace_id`, the
same way `sql_query` rows do.)
