### PR TITLE
fix: /v1/queries chunk row_offset uses cumulative offset, not chunk_index * chunk_size (fixes #11271)

### DIFF
--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -1181,7 +1181,8 @@ mod tests {
         use arrow::datatypes::{DataType, Field, Schema};
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let values: Vec<i32> = (0..num_rows as i32).collect();
+        let row_count = i32::try_from(num_rows).expect("row count should fit in i32");
+        let values: Vec<i32> = (0..row_count).collect();
         arrow::array::RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(values))])
             .expect("to create batch")
     }

--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -897,8 +897,15 @@ fn build_chunk_response(
         .map(arrow::array::RecordBatch::num_rows)
         .sum();
 
-    // Calculate row offset based on chunk index using the configured chunk size
-    let row_offset = chunk_index.saturating_mul(DEFAULT_CHUNK_SIZE);
+    // Use the chunk's recorded cumulative starting offset. Chunks are not fixed-size
+    // (they hold whole batches and flush once the row threshold is reached), so the
+    // offset cannot be derived from `chunk_index * DEFAULT_CHUNK_SIZE`. Fall back to that
+    // estimate only for results persisted before per-chunk offsets were recorded.
+    let row_offset = job_result
+        .chunk_row_offsets
+        .get(chunk_index)
+        .copied()
+        .unwrap_or_else(|| chunk_index.saturating_mul(DEFAULT_CHUNK_SIZE));
 
     // Determine next chunk info
     let (next_chunk_index, next_chunk_url) =
@@ -1147,5 +1154,68 @@ mod tests {
         assert_eq!(preview.chars().count(), 100);
         assert!(preview.ends_with("..."));
         assert!(long_sql.starts_with(preview.trim_end_matches("...")));
+    }
+
+    fn job_result_with_offsets(
+        total_chunk_count: usize,
+        chunk_row_offsets: Vec<usize>,
+    ) -> crate::jobs::JobResult {
+        crate::jobs::JobResult {
+            manifest: crate::jobs::JobResultManifest {
+                format: "ARROW_IPC".to_string(),
+                schema: crate::jobs::JobSchema {
+                    column_count: 1,
+                    columns: vec![],
+                },
+                total_row_count: chunk_row_offsets.iter().sum(),
+                total_chunk_count,
+                total_byte_count: 0,
+            },
+            chunk_indices: (0..total_chunk_count).collect(),
+            chunk_row_offsets,
+        }
+    }
+
+    fn batch_with_rows(num_rows: usize) -> arrow::array::RecordBatch {
+        use arrow::array::Int32Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let values: Vec<i32> = (0..num_rows as i32).collect();
+        arrow::array::RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(values))])
+            .expect("to create batch")
+    }
+
+    #[test]
+    fn build_chunk_response_uses_recorded_offset() {
+        // Regression test for #11271: chunks are not fixed-size, so the reported
+        // row_offset must come from the recorded cumulative offsets, not from
+        // chunk_index * DEFAULT_CHUNK_SIZE.
+        let job_result = job_result_with_offsets(3, vec![0, 12000, 24000]);
+        let batches = vec![batch_with_rows(3000)];
+
+        let response = build_chunk_response("q1", 1, &batches, &job_result)
+            .expect("chunk response should build");
+
+        assert_eq!(response.chunk_index, 1);
+        assert_eq!(response.row_offset, 12000);
+        assert_eq!(response.row_count, 3000);
+        assert_eq!(response.next_chunk_index, Some(2));
+    }
+
+    #[test]
+    fn build_chunk_response_falls_back_to_estimate_when_offset_absent() {
+        use crate::jobs::DEFAULT_CHUNK_SIZE;
+
+        // Results persisted before per-chunk offsets existed deserialize with an empty
+        // chunk_row_offsets; the handler must fall back to the legacy estimate rather
+        // than panic.
+        let job_result = job_result_with_offsets(3, vec![]);
+        let batches = vec![batch_with_rows(10)];
+
+        let response = build_chunk_response("q1", 2, &batches, &job_result)
+            .expect("chunk response should build");
+
+        assert_eq!(response.row_offset, 2 * DEFAULT_CHUNK_SIZE);
     }
 }

--- a/crates/runtime/src/jobs/state.rs
+++ b/crates/runtime/src/jobs/state.rs
@@ -136,6 +136,17 @@ pub struct JobResult {
     pub manifest: JobResultManifest,
     /// List of chunk indices available
     pub chunk_indices: Vec<usize>,
+    /// Cumulative starting row offset of each chunk, aligned with `chunk_indices`.
+    ///
+    /// Chunks are flushed once a row threshold is reached but are built by appending
+    /// whole record batches, so a chunk routinely holds more than `chunk_size` rows.
+    /// The starting offset therefore cannot be derived as `chunk_index * chunk_size`;
+    /// it is recorded here as the cumulative row count of all preceding chunks.
+    ///
+    /// Defaults to empty for results persisted before this field existed; readers must
+    /// fall back gracefully when an offset is absent.
+    #[serde(default)]
+    pub chunk_row_offsets: Vec<usize>,
 }
 
 /// Complete state of a job.

--- a/crates/runtime/src/jobs/store.rs
+++ b/crates/runtime/src/jobs/store.rs
@@ -253,11 +253,15 @@ impl JobStore {
         let mut total_rows = 0usize;
         let mut total_bytes = 0usize;
         let mut chunk_indices = Vec::new();
+        // Cumulative starting row offset of each flushed chunk (rows in all prior chunks).
+        let mut chunk_row_offsets = Vec::new();
 
         // Buffer for accumulating batches until we reach chunk_size
         let mut current_chunk_batches: Vec<RecordBatch> = Vec::new();
         let mut current_chunk_rows = 0usize;
         let mut chunk_index = 0usize;
+        // Rows already committed to prior chunks; the starting offset of the next chunk.
+        let mut committed_rows = 0usize;
 
         while let Some(batch_result) = stream.next().await {
             let batch = batch_result.map_err(|e| super::error::Error::StreamRead {
@@ -302,6 +306,14 @@ impl JobStore {
                 }
 
                 chunk_indices.push(chunk_index);
+                chunk_row_offsets.push(committed_rows);
+                committed_rows = committed_rows.checked_add(current_chunk_rows).ok_or_else(
+                    || super::error::Error::IntegerOverflow {
+                        field: "chunk_row_offset".to_string(),
+                        left_value: committed_rows,
+                        right_value: current_chunk_rows,
+                    },
+                )?;
                 chunk_index = chunk_index.checked_add(1).ok_or_else(|| {
                     super::error::Error::IntegerOverflow {
                         field: "chunk_index".to_string(),
@@ -334,6 +346,7 @@ impl JobStore {
             }
 
             chunk_indices.push(chunk_index);
+            chunk_row_offsets.push(committed_rows);
         }
 
         Ok(Self::build_job_result(
@@ -342,6 +355,7 @@ impl JobStore {
             total_bytes,
             chunk_indices.len(),
             chunk_indices,
+            chunk_row_offsets,
         ))
     }
 
@@ -352,6 +366,7 @@ impl JobStore {
         total_bytes: usize,
         total_chunks: usize,
         chunk_indices: Vec<usize>,
+        chunk_row_offsets: Vec<usize>,
     ) -> JobResult {
         // Build schema info - use Display instead of Debug for stable type names
         let columns: Vec<ColumnSchema> = schema
@@ -390,6 +405,7 @@ impl JobStore {
                 total_byte_count: total_bytes,
             },
             chunk_indices,
+            chunk_row_offsets,
         }
     }
 
@@ -794,6 +810,7 @@ mod tests {
                 total_byte_count: 0,
             },
             chunk_indices: vec![],
+            chunk_row_offsets: vec![],
         };
 
         let completed = job_store
@@ -877,6 +894,7 @@ mod tests {
             assert_eq!(result.manifest.total_row_count, 0);
             assert_eq!(result.manifest.total_chunk_count, 0);
             assert!(result.chunk_indices.is_empty());
+            assert!(result.chunk_row_offsets.is_empty());
 
             // Schema should be preserved even with empty stream
             assert_eq!(result.manifest.schema.column_count, 2);
@@ -912,6 +930,7 @@ mod tests {
             assert_eq!(result.manifest.total_row_count, 3);
             assert_eq!(result.manifest.total_chunk_count, 1);
             assert_eq!(result.chunk_indices, vec![0]);
+            assert_eq!(result.chunk_row_offsets, vec![0]);
 
             // Verify chunk can be read back
             let chunks = job_store
@@ -957,6 +976,7 @@ mod tests {
             // All batches fit in one chunk since chunk_size is 100
             assert_eq!(result.manifest.total_chunk_count, 1);
             assert_eq!(result.chunk_indices, vec![0]);
+            assert_eq!(result.chunk_row_offsets, vec![0]);
         }
 
         #[tokio::test]
@@ -1004,6 +1024,8 @@ mod tests {
             // - chunk 2: batch3 (1 row) -> flushed at end
             assert_eq!(result.manifest.total_chunk_count, 3);
             assert_eq!(result.chunk_indices, vec![0, 1, 2]);
+            // Each batch is exactly chunk_size rows, so offsets are 0, 2, 4.
+            assert_eq!(result.chunk_row_offsets, vec![0, 2, 4]);
 
             // Verify all chunks can be read
             for i in 0..3 {
@@ -1013,6 +1035,50 @@ mod tests {
                     .expect("to read chunk");
                 assert!(!chunks.is_empty());
             }
+        }
+
+        #[tokio::test]
+        async fn test_chunk_row_offsets_with_oversized_batches() {
+            // Regression test for #11271: chunks are flushed once the row threshold is
+            // reached but contain whole batches, so a chunk routinely holds MORE than
+            // chunk_size rows. The recorded offset must be the cumulative row count of
+            // prior chunks, not `chunk_index * chunk_size`.
+            let store = Arc::new(InMemory::new());
+            // chunk_size=2 but each batch is 3 rows, so every chunk overshoots.
+            let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(2);
+
+            let state = job_store
+                .create_job(make_request("SELECT * FROM test"), false)
+                .await
+                .expect("to create job");
+
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+            let make_batch = |vals: Vec<i32>| {
+                RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vals))])
+                    .expect("to create batch")
+            };
+
+            // Three 3-row batches: each one alone trips the threshold and flushes.
+            let batches = vec![
+                make_batch(vec![1, 2, 3]),
+                make_batch(vec![4, 5, 6]),
+                make_batch(vec![7, 8, 9]),
+            ];
+
+            let stream = create_test_stream(Arc::clone(&schema), batches);
+
+            let result = job_store
+                .write_result_chunks_from_stream(&state.job_id, stream)
+                .await
+                .expect("to write stream");
+
+            assert_eq!(result.manifest.total_row_count, 9);
+            assert_eq!(result.manifest.total_chunk_count, 3);
+            assert_eq!(result.chunk_indices, vec![0, 1, 2]);
+            // True cumulative offsets are 0, 3, 6 — NOT the 0, 2, 4 that the old
+            // `chunk_index * chunk_size` formula would have produced.
+            assert_eq!(result.chunk_row_offsets, vec![0, 3, 6]);
         }
 
         #[tokio::test]

--- a/crates/runtime/src/jobs/store.rs
+++ b/crates/runtime/src/jobs/store.rs
@@ -307,13 +307,14 @@ impl JobStore {
 
                 chunk_indices.push(chunk_index);
                 chunk_row_offsets.push(committed_rows);
-                committed_rows = committed_rows.checked_add(current_chunk_rows).ok_or_else(
-                    || super::error::Error::IntegerOverflow {
-                        field: "chunk_row_offset".to_string(),
-                        left_value: committed_rows,
-                        right_value: current_chunk_rows,
-                    },
-                )?;
+                committed_rows =
+                    committed_rows
+                        .checked_add(current_chunk_rows)
+                        .ok_or_else(|| super::error::Error::IntegerOverflow {
+                            field: "chunk_row_offset".to_string(),
+                            left_value: committed_rows,
+                            right_value: current_chunk_rows,
+                        })?;
                 chunk_index = chunk_index.checked_add(1).ok_or_else(|| {
                     super::error::Error::IntegerOverflow {
                         field: "chunk_index".to_string(),


### PR DESCRIPTION
## Summary

**Root cause:** `build_chunk_response` in `crates/runtime/src/http/v1/queries.rs` computed `row_offset = chunk_index * DEFAULT_CHUNK_SIZE`. But chunks are not fixed-size: `write_result_chunks_from_stream` appends whole record batches and flushes once `current_chunk_rows >= chunk_size`, so a chunk routinely holds more than `DEFAULT_CHUNK_SIZE` rows (e.g. 3000-row batches → chunk 0 has 12000 rows). A client paginating `GET /v1/queries/{id}/results/chunks/{n}` therefore saw chunk 1 labeled `row_offset: 10000` when its true offset was 12000 — clients reconstructing global row positions or resuming overlapped/mis-attributed rows at every chunk boundary. The row data was complete; only the positioning metadata was wrong.

**Fix:** Record each chunk's actual cumulative starting offset (the row count of all preceding chunks) in `JobResult` while streaming, and return that from `build_chunk_response`.

## Changes

- `jobs/state.rs`: add `chunk_row_offsets: Vec<usize>` to `JobResult`, aligned with `chunk_indices`. Marked `#[serde(default)]` so results persisted before this field existed still deserialize.
- `jobs/store.rs`: track `committed_rows` while flushing chunks and push the cumulative starting offset for each chunk (overflow-checked like the sibling counters); thread it through `build_job_result`.
- `http/v1/queries.rs`: read `job_result.chunk_row_offsets[chunk_index]`; fall back to the legacy `chunk_index * DEFAULT_CHUNK_SIZE` estimate only when the offset is absent (old persisted results), so the handler never panics.

## Test plan

- `make lint`
- `make test`

New/updated tests:
- `jobs::store` `test_chunk_row_offsets_with_oversized_batches` — regression test: 3-row batches with `chunk_size=2` produce true offsets `[0, 3, 6]`, not the `[0, 2, 4]` the old formula gave. Fails on old code, passes on new.
- `jobs::store` existing chunk tests assert `chunk_row_offsets` (`[]`, `[0]`, `[0, 2, 4]`).
- `http::v1::queries` `build_chunk_response_uses_recorded_offset` (offset read from manifest) and `build_chunk_response_falls_back_to_estimate_when_offset_absent` (legacy fallback).

Locally verified the touched `runtime` crate compiles and `cargo test -p runtime` for the affected modules passes (13 tests); `cargo clippy -p runtime` is clean for the changed files (the two remaining warnings are pre-existing in unrelated files). Full `make lint`/`make test` left to CI.

## Checklist

- [x] Root cause identified and fixed at the source
- [x] Regression test fails on old code, passes on new
- [x] Backward-compatible deserialization for persisted results
- [x] No change to row data — only corrected positioning metadata

Fixes #11271