### PR TITLE
fix: Support external Redshift table schema inference and Hive external type parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6369,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=2189ca20b6fc78386f6fab753b3ee6e50573018e#2189ca20b6fc78386f6fab753b3ee6e50573018e"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=3d8eca098dc5aefe361625b834ad834d2b846137#3d8eca098dc5aefe361625b834ad834d2b846137"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ datafusion-proto-common = "54.0.0"
 datafusion-pruning = "54.0.0"
 datafusion-spark = "54.0.0"
 datafusion-substrait = "54.0.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "2189ca20b6fc78386f6fab753b3ee6e50573018e" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "3d8eca098dc5aefe361625b834ad834d2b846137" } # spiceai-54
 
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates datafusion-table-providers to include a schema inference fix for Redshift external tables: https://github.com/spiceai/datafusion-table-providers/pull/20
