### PR TITLE
feat(llms): native GLM support — opt-in flash-attn + surface reasoning_content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "async-openai"
 version = "0.32.0"
-source = "git+https://github.com/spiceai/async-openai?rev=98e0c53be444e2427177cc77554d70813913d775#98e0c53be444e2427177cc77554d70813913d775"
+source = "git+https://github.com/spiceai/async-openai?rev=8bf53e63b4704f81b025213dfd9cde4d1ac5c7e0#8bf53e63b4704f81b025213dfd9cde4d1ac5c7e0"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "async-openai-macros"
 version = "0.1.1"
-source = "git+https://github.com/spiceai/async-openai?rev=98e0c53be444e2427177cc77554d70813913d775#98e0c53be444e2427177cc77554d70813913d775"
+source = "git+https://github.com/spiceai/async-openai?rev=8bf53e63b4704f81b025213dfd9cde4d1ac5c7e0#8bf53e63b4704f81b025213dfd9cde4d1ac5c7e0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,8 @@ arrow-json = "58.0.0"
 arrow-odbc = "22" # crates.io 22+ accepts arrow ">=29, <59" so it resolves to the workspace Arrow 58 (the prior git pin v21 was capped at arrow <58, which forced a separate Arrow-57 subtree + an IPC bridge)
 arrow-row = "58.0.0"
 arrow-schema = "58.0.0"
+# Pinned to spiceai/async-openai#36 (adds `reasoning_content` to ChatCompletionResponseMessage).
+# Refresh to the merged commit on the `spiceai` branch once that PR lands.
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "8bf53e63b4704f81b025213dfd9cde4d1ac5c7e0", features = [
     "byot",
     "embedding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ arrow-json = "58.0.0"
 arrow-odbc = "22" # crates.io 22+ accepts arrow ">=29, <59" so it resolves to the workspace Arrow 58 (the prior git pin v21 was capped at arrow <58, which forced a separate Arrow-57 subtree + an IPC bridge)
 arrow-row = "58.0.0"
 arrow-schema = "58.0.0"
-async-openai = { git = "https://github.com/spiceai/async-openai", rev = "98e0c53be444e2427177cc77554d70813913d775", features = [
+async-openai = { git = "https://github.com/spiceai/async-openai", rev = "8bf53e63b4704f81b025213dfd9cde4d1ac5c7e0", features = [
     "byot",
     "embedding",
     "chat-completion",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -82,10 +82,15 @@ cuda = [
     "tei_backend/cuda",
     "tei_candle/cuda",
     "mistralrs-core/cuda",
-    "mistralrs-core/flash-attn",
     "mistralrs/cuda",
-    "mistralrs/flash-attn",
     "cudarc/cuda-version-from-build-system",
+]
+# Flash-Attention is opt-in (compose with `cuda`). It MUST stay off for
+# MLA-attention models (GLM-4.5/5.x, DeepSeek-V3/R1) whose kernels abort it;
+# enable only for standard-attention models that benefit.
+flash-attn = [
+    "mistralrs-core/flash-attn",
+    "mistralrs/flash-attn",
 ]
 local_embed = [
     "dep:tei_backend",

--- a/crates/llms/src/accumulate.rs
+++ b/crates/llms/src/accumulate.rs
@@ -78,6 +78,7 @@ pub fn fold_completion_stream(
                 finish_reason: None,
                 logprobs: None,
                 message: ChatCompletionResponseMessage {
+                    reasoning_content: None,
                     content: None,
                     refusal: None,
                     tool_calls: None,

--- a/crates/llms/src/anthropic/chat.rs
+++ b/crates/llms/src/anthropic/chat.rs
@@ -179,6 +179,7 @@ fn create_completion_message(
         .collect::<Result<Vec<_>, Box<dyn std::error::Error + Send + Sync>>>()?;
 
     Ok(ChatCompletionResponseMessage {
+        reasoning_content: None,
         tool_calls: Some(tool_calls),
         refusal: None,
         annotations: None,

--- a/crates/llms/src/bedrock/chat/mod.rs
+++ b/crates/llms/src/bedrock/chat/mod.rs
@@ -590,6 +590,7 @@ impl BedrockConverse {
                 Ok::<_, OpenAIError>(ChatChoice {
                     index: 0,
                     message: ChatCompletionResponseMessage {
+                        reasoning_content: None,
                         content: Some(content.into_iter().flatten().join("\n")),
                         refusal: Some(refusals.into_iter().flatten().join("\n")),
                         tool_calls: if tool_calls_enum.is_empty() {

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -686,6 +686,7 @@ pub trait Chat: Sync + Send {
         })? {
             Some(resp) => vec![ChatChoice {
                 message: ChatCompletionResponseMessage {
+                    reasoning_content: None,
                     content: Some(resp),
                     tool_calls: None,
                     role: Role::System,

--- a/crates/llms/src/google/chat.rs
+++ b/crates/llms/src/google/chat.rs
@@ -316,6 +316,7 @@ fn convert_google_response_to_openai(
             ChatChoice {
                 index: idx as u32,
                 message: ChatCompletionResponseMessage {
+                    reasoning_content: None,
                     role: Role::Assistant,
                     content,
                     tool_calls: tool_calls_opt,

--- a/crates/llms/src/openai/responses_adapter.rs
+++ b/crates/llms/src/openai/responses_adapter.rs
@@ -548,6 +548,7 @@ fn chat_message_from_response_output(output: Vec<OutputItem>) -> ChatCompletionR
     }
 
     ChatCompletionResponseMessage {
+        reasoning_content: None,
         content: (!text_parts.is_empty()).then(|| text_parts.join("\n")),
         refusal: (!refusal_parts.is_empty()).then(|| refusal_parts.join("\n")),
         tool_calls: (!tool_calls.is_empty()).then_some(tool_calls),

--- a/crates/runtime-datafusion-udfs/src/ai.rs
+++ b/crates/runtime-datafusion-udfs/src/ai.rs
@@ -645,6 +645,7 @@ mod tests {
                 choices: vec![ChatChoice {
                     index: 0,
                     message: ChatCompletionResponseMessage {
+                        reasoning_content: None,
                         content: Some(response_text),
                         role: Role::Assistant,
                         #[expect(deprecated)]
@@ -948,6 +949,7 @@ mod tests {
                 choices: vec![ChatChoice {
                     index: 0,
                     message: ChatCompletionResponseMessage {
+                        reasoning_content: None,
                         content: None, // This represents a null/empty response
                         role: Role::Assistant,
                         #[expect(deprecated)]


### PR DESCRIPTION
## What

Adds in-process (mistral.rs) support for **GLM reasoning models** and the plumbing to surface their chain-of-thought through Spice's OpenAI-compatible API. First step toward serving GLM natively in Spice.

Two changes:

### 1. Flash-Attention is now opt-in (`flash-attn` feature)

Previously `cuda` force-enabled `mistralrs/flash-attn`. GLM-4.5/5.x and DeepSeek-V3/R1 use **MLA attention**, whose kernels abort when Flash-Attention is enabled. Splitting FA into its own opt-in feature lets the base CUDA build serve these models, while standard-attention models can still build `--features cuda,flash-attn`.

### 2. Surface `reasoning_content`

Reasoning models (GLM, DeepSeek-R1, QwQ) emit chain-of-thought *separately* from the answer. mistral.rs extracts the `<think>` block into `ResponseMessage.reasoning_content`, but Spice's `to_openai_response` round-trips the response through async-openai's `ChatCompletionResponseMessage` via serde — which had no such field, so the reasoning was **silently dropped**.

- async-openai now carries `reasoning_content` (**depends on spiceai/async-openai#36**, pinned here at `8bf53e6`).
- The struct-literal sites that build `ChatCompletionResponseMessage` (anthropic, bedrock, google, openai-responses adapter, chat trait, stream accumulator, + 2 udf tests) default it to `None`; only the mistral.rs serde path populates it.

## Validation

On a GB10 / Grace-Blackwell (sm_121), CUDA 13.0:

```yaml
models:
  - from: huggingface:THUDM/GLM-Z1-9B-0414
    name: glm-z1
    params:
      model_type: glm4
```

- Model loads (~18 GB GPU) and serves `/v1/chat/completions`.
- `reasoning_content` is populated — e.g. a bat-and-ball prompt returns 4153 chars of reasoning in `reasoning_content` and the final answer ($0.05) in `content`, with `<think>` no longer leaking into `content`.

## Dependency / merge order

**Merge spiceai/async-openai#36 first.** This PR pins async-openai to that branch commit (`8bf53e6`) so CI builds now; the pin will be refreshed to the merged SHA before this merges.

## Follow-ups

- **Streaming:** add `reasoning_content` to `ChatCompletionStreamResponseDelta` + map it in `chunk_choices_to_openai`.
- **Distributed:** enable mistral.rs `ring` backend to pool GLM across nodes.

## Test plan

- [x] Builds `--features cuda` on sm_121 (validated locally; async-openai source is byte-identical to the pinned commit)
- [x] GLM-Z1-9B-0414 loads and answers correctly
- [x] `reasoning_content` populated on reasoning prompts; `content` holds the final answer
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
