### PR TITLE
feat(chbenchmark): dedicated in-cluster Postgres + CPU pinning on xlarge runner

### DIFF
--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -121,41 +121,24 @@ jobs:
         if: github.event.inputs.runner_type != 'spiceai-dev-xlarge-runners'
         uses: ./.github/actions/setup-chbench-postgres
 
-      - name: Start resource monitor
-        run: |
-          echo -e "timestamp\tpg_cpu_pct\tpg_mem\tpg_block_io\tspiced_cpu_pct\tspiced_rss_kb\ttestop_cpu_pct\ttestop_rss_kb" > /tmp/resource-monitor.tsv
-          (while true; do
-            ts=$(date -u +%H:%M:%S)
-            pg=$(docker stats chbench-pg --no-stream --format "{{.CPUPerc}}\t{{.MemUsage}}\t{{.BlockIO}}" 2>/dev/null || echo "0%\t0\t0")
-            spiced_line=$(ps -eo pcpu,rss,comm | grep '[s]piced' | head -1 || true)
-            testop_line=$(ps -eo pcpu,rss,comm | grep '[t]estoperator' | head -1 || true)
-            spiced_cpu=$(echo "$spiced_line" | awk '{print $1+0}')
-            spiced_rss=$(echo "$spiced_line" | awk '{print $2+0}')
-            testop_cpu=$(echo "$testop_line" | awk '{print $1+0}')
-            testop_rss=$(echo "$testop_line" | awk '{print $2+0}')
-            echo -e "${ts}\t${pg}\t${spiced_cpu}\t${spiced_rss}\t${testop_cpu}\t${testop_rss}" >> /tmp/resource-monitor.tsv
-            sleep 10
-          done) &
-          echo $! > /tmp/monitor-pid.txt
-          echo "Resource monitor started (PID: $(cat /tmp/monitor-pid.txt))"
-
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |
-          # On the xlarge runner, pin spiced and testoperator to disjoint CPU sets
-          # so they don't contend for cores during the benchmark:
-          #   spiced       -> cores 0-63  (64)
-          #   testoperator -> cores 64-79 (16)
+          # On the xlarge runner (64-core EPYC, 2 threads/core, SMT siblings are
+          # cpu N and cpu 64+N), pin spiced and testoperator to whole physical
+          # cores so they don't contend — not even via hyperthread siblings:
+          #   spiced       -> cores 0-31  (logical CPUs 0-31,64-95   = 64 threads)
+          #   testoperator -> cores 32-39 (logical CPUs 32-39,96-103 = 16 threads)
           SPICED_BIN=/usr/local/bin/spiced
           TESTOP_PREFIX=""
           if [ "${{ github.event.inputs.runner_type }}" = "spiceai-dev-xlarge-runners" ] && command -v taskset >/dev/null 2>&1; then
             cat > /tmp/spiced-pinned.sh <<'EOF'
           #!/usr/bin/env bash
-          exec taskset -c 0-63 /usr/local/bin/spiced "$@"
+          exec taskset -c 0-31,64-95 /usr/local/bin/spiced "$@"
           EOF
             chmod +x /tmp/spiced-pinned.sh
             SPICED_BIN=/tmp/spiced-pinned.sh
-            TESTOP_PREFIX="taskset -c 64-79"
-            echo "CPU pinning: spiced -> 0-63, testoperator -> 64-79"
+            TESTOP_PREFIX="taskset -c 32-39,96-103"
+            echo "CPU pinning: spiced -> 64 logical CPUs, testoperator -> 16 logical CPUs"
           fi
           $TESTOP_PREFIX testoperator run htap \
             -s "${SPICED_BIN}" \
@@ -175,21 +158,6 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           # Dedicated in-cluster PG pod on xlarge; per-run docker container (loopback) elsewhere.
           CHBENCH_PG_HOST: ${{ github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners' && 'chbench-postgres.dataplatform.svc.cluster.local' || '127.0.0.1' }}
-
-      - name: Stop resource monitor
-        if: always()
-        run: |
-          if [ -f /tmp/monitor-pid.txt ]; then
-            kill "$(cat /tmp/monitor-pid.txt)" 2>/dev/null || true
-          fi
-
-      - name: Upload resource monitor
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: resource-monitor
-          path: /tmp/resource-monitor.tsv
-          retention-days: 7
 
       # The dedicated PG pod is long-lived and shared across runs, so a crashed
       # or cancelled run can leave inactive replication slots (which retain WAL

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -115,7 +115,10 @@ jobs:
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
 
+      # On spiceai-dev-xlarge-runners a dedicated in-cluster PostgreSQL pod is used,
+      # so skip the local docker Postgres there.
       - name: Setup CH-benCH PostgreSQL
+        if: github.event.inputs.runner_type != 'spiceai-dev-xlarge-runners'
         uses: ./.github/actions/setup-chbench-postgres
 
       - name: Start resource monitor
@@ -138,8 +141,24 @@ jobs:
 
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |
-          testoperator run htap \
-            -s /usr/local/bin/spiced \
+          # On the xlarge runner, pin spiced and testoperator to disjoint CPU sets
+          # so they don't contend for cores during the benchmark:
+          #   spiced       -> cores 0-63  (64)
+          #   testoperator -> cores 64-79 (16)
+          SPICED_BIN=/usr/local/bin/spiced
+          TESTOP_PREFIX=""
+          if [ "${{ github.event.inputs.runner_type }}" = "spiceai-dev-xlarge-runners" ] && command -v taskset >/dev/null 2>&1; then
+            cat > /tmp/spiced-pinned.sh <<'EOF'
+          #!/usr/bin/env bash
+          exec taskset -c 0-63 /usr/local/bin/spiced "$@"
+          EOF
+            chmod +x /tmp/spiced-pinned.sh
+            SPICED_BIN=/tmp/spiced-pinned.sh
+            TESTOP_PREFIX="taskset -c 64-79"
+            echo "CPU pinning: spiced -> 0-63, testoperator -> 64-79"
+          fi
+          $TESTOP_PREFIX testoperator run htap \
+            -s "${SPICED_BIN}" \
             -p '${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}' \
             --query-set chbench \
             --scale-factor ${{ github.event.inputs.scale_factor }} \
@@ -154,7 +173,8 @@ jobs:
         env:
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          CHBENCH_PG_HOST: 127.0.0.1
+          # Dedicated in-cluster PG pod on xlarge; per-run docker container (loopback) elsewhere.
+          CHBENCH_PG_HOST: ${{ github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners' && 'chbench-postgres.dataplatform.svc.cluster.local' || '127.0.0.1' }}
 
       - name: Stop resource monitor
         if: always()
@@ -170,3 +190,49 @@ jobs:
           name: resource-monitor
           path: /tmp/resource-monitor.tsv
           retention-days: 7
+
+      # The dedicated PG pod is long-lived and shared across runs, so a crashed
+      # or cancelled run can leave inactive replication slots (which retain WAL
+      # and eventually fill the disk) and orphaned publications. Drop any left
+      # behind. testoperator already drops its tables/publication at the start of
+      # the next run, but inactive slots are not covered by that.
+      - name: Clean up PG replication slots
+        if: always() && github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners'
+        env:
+          CHBENCH_PG_HOST: chbench-postgres.dataplatform.svc.cluster.local
+          CHBENCH_PG_PORT: '5432'
+          CHBENCH_PG_USER: bench
+          CHBENCH_PG_PASS: bench
+          CHBENCH_PG_DB: chbench
+        run: |
+          cat > /tmp/chbench-slot-cleanup.sql <<'SQL'
+          DO $$
+          DECLARE r RECORD;
+          BEGIN
+            FOR r IN
+              SELECT slot_name FROM pg_replication_slots
+              WHERE slot_name LIKE 'spice_%' AND NOT active
+            LOOP
+              RAISE NOTICE 'dropping replication slot %', r.slot_name;
+              PERFORM pg_drop_replication_slot(r.slot_name);
+            END LOOP;
+            FOR r IN
+              SELECT pubname FROM pg_publication WHERE pubname LIKE 'spice_%'
+            LOOP
+              RAISE NOTICE 'dropping publication %', r.pubname;
+              EXECUTE format('DROP PUBLICATION IF EXISTS %I', r.pubname);
+            END LOOP;
+          END $$;
+          SQL
+          if ! command -v psql >/dev/null 2>&1; then
+            echo "psql not found; installing postgresql-client..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client || true
+          fi
+          if command -v psql >/dev/null 2>&1; then
+            PGPASSWORD="${CHBENCH_PG_PASS}" psql \
+              -h "${CHBENCH_PG_HOST}" -p "${CHBENCH_PG_PORT}" \
+              -U "${CHBENCH_PG_USER}" -d "${CHBENCH_PG_DB}" \
+              -v ON_ERROR_STOP=0 -f /tmp/chbench-slot-cleanup.sql || true
+          else
+            echo "No psql client available; skipping replication slot cleanup."
+          fi

--- a/crates/test-framework/src/execution/mod.rs
+++ b/crates/test-framework/src/execution/mod.rs
@@ -60,7 +60,7 @@ limitations under the License.
 //!
 //! #[async_trait]
 //! impl QueryExecutor for PostgresExecutor {
-//!     async fn execute(&self, query: &Query) -> Result<ExecutionResult> {
+//!     async fn execute(&self, query: &Query, collect_batches: bool) -> Result<ExecutionResult> {
 //!         let start = std::time::Instant::now();
 //!         let rows = self.client.query(&query.sql, &[]).await?;
 //!
@@ -107,8 +107,14 @@ pub struct ExecutionResult {
 /// Trait for executing queries against different backends
 #[async_trait]
 pub trait QueryExecutor: Send + Sync {
-    /// Execute a query and return the result
-    async fn execute(&self, query: &Query) -> Result<ExecutionResult>;
+    /// Execute a query and return the result.
+    ///
+    /// When `collect_batches` is `false`, executors that stream results (e.g.
+    /// Flight) MUST count rows without retaining the `RecordBatch`es — they
+    /// return `batches: None`. Throughput runs pass `false` so a worker does not
+    /// materialize a large result set in memory just to drop it; pass `true`
+    /// only when the batches are actually consumed (validation or snapshots).
+    async fn execute(&self, query: &Query, collect_batches: bool) -> Result<ExecutionResult>;
 
     /// Name of this executor for logging/metrics
     fn name(&self) -> &'static str;
@@ -161,7 +167,7 @@ impl Clone for FlightExecutor {
 
 #[async_trait]
 impl QueryExecutor for FlightExecutor {
-    async fn execute(&self, query: &Query) -> Result<ExecutionResult> {
+    async fn execute(&self, query: &Query, collect_batches: bool) -> Result<ExecutionResult> {
         let start = std::time::Instant::now();
 
         let mut result_stream = self
@@ -169,19 +175,24 @@ impl QueryExecutor for FlightExecutor {
             .sql_with_params(&query.sql, query.get_parameters_batch().transpose()?)
             .await?;
 
-        let mut batches = Vec::new();
+        // When the caller does not need the batches (the throughput path: no
+        // validation, no snapshot), stream-and-discard — count rows and drop
+        // each batch — so a worker never materializes a full result set in
+        // memory just to drop it. Only retain batches when asked.
+        let mut batches = collect_batches.then(Vec::new);
         let mut row_count = 0;
 
         while let Some(batch) = result_stream.try_next().await? {
-            let batch_rows = batch.num_rows();
-            row_count += batch_rows;
-            batches.push(batch);
+            row_count += batch.num_rows();
+            if let Some(batches) = &mut batches {
+                batches.push(batch);
+            }
         }
 
         Ok(ExecutionResult {
             duration: start.elapsed(),
             row_count,
-            batches: Some(batches),
+            batches,
         })
     }
 
@@ -230,7 +241,9 @@ impl Clone for HttpExecutor {
 
 #[async_trait]
 impl QueryExecutor for HttpExecutor {
-    async fn execute(&self, query: &Query) -> Result<ExecutionResult> {
+    // The HTTP `/v1/sql` endpoint returns only a `row_count`, never the rows, so
+    // `collect_batches` is irrelevant here — `batches` is always `None`.
+    async fn execute(&self, query: &Query, _collect_batches: bool) -> Result<ExecutionResult> {
         let start = std::time::Instant::now();
         let sql_text = query.to_sql_with_inlined_params();
         let sql_url = format!("{}/v1/sql", self.base_url);
@@ -314,7 +327,9 @@ impl Clone for DistributedExecutor {
 
 #[async_trait]
 impl QueryExecutor for DistributedExecutor {
-    async fn execute(&self, query: &Query) -> Result<ExecutionResult> {
+    // The async `/v1/queries` endpoint reports a `row_count` in its status, not
+    // the rows, so `collect_batches` is irrelevant here — `batches` is `None`.
+    async fn execute(&self, query: &Query, _collect_batches: bool) -> Result<ExecutionResult> {
         let start = std::time::Instant::now();
         let sql_text = query.to_sql_with_inlined_params();
         let queries_url = format!("{}/v1/queries", self.base_url);

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -569,8 +569,7 @@ impl SpiceTestQueryWorker {
         // validation (executor must support it) or a results snapshot. The
         // throughput path needs neither, so the executor streams-and-discards
         // instead of materializing the full result set in memory.
-        let collect_batches =
-            results_snapshot || (validate && self.executor.supports_validation());
+        let collect_batches = results_snapshot || (validate && self.executor.supports_validation());
 
         // Execute query using the configured executor
         let result = self.executor.execute(query, collect_batches).await?;

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -565,8 +565,15 @@ impl SpiceTestQueryWorker {
         results_snapshot: bool,
         validate: bool,
     ) -> Result<()> {
+        // Only retain result batches when something actually consumes them:
+        // validation (executor must support it) or a results snapshot. The
+        // throughput path needs neither, so the executor streams-and-discards
+        // instead of materializing the full result set in memory.
+        let collect_batches =
+            results_snapshot || (validate && self.executor.supports_validation());
+
         // Execute query using the configured executor
-        let result = self.executor.execute(query).await?;
+        let result = self.executor.execute(query, collect_batches).await?;
 
         // Handle validation if supported and requested
         if validate

--- a/test/spicepods/chbench/accelerated/postgres-arrow.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-arrow.yaml
@@ -3,7 +3,7 @@ kind: Spicepod
 name: postgres-arrow
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: 5432
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-turso.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-turso.yaml
@@ -31,7 +31,7 @@ name: postgres-cayenne[file]-adaptive-turso
 # comparison isolates the effect of adaptive tuning, not caching/history overhead.
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: 5432
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
@@ -26,7 +26,7 @@ name: postgres-cayenne[file]-adaptive
 # comparison isolates the effect of adaptive tuning, not caching/history overhead.
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: 5432
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-memory.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-memory.yaml
@@ -29,7 +29,7 @@ name: postgres-cayenne[file]-cdc-memory
 # comparison isolates the effect of in-memory CDC durability, not caching/history overhead.
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: 5432
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-keymode.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-keymode.yaml
@@ -21,7 +21,7 @@ runtime:
     enabled: false
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: '5432'
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1.yaml
@@ -33,7 +33,7 @@ runtime:
     enabled: false
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: '5432'
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf10.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf10.yaml
@@ -33,7 +33,7 @@ runtime:
     enabled: false
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: '5432'
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
@@ -46,7 +46,7 @@ runtime:
     enabled: false
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: '5432'
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
@@ -23,7 +23,7 @@ runtime:
     enabled: false
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: '5432'
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
@@ -51,7 +51,7 @@ runtime:
     enabled: false
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: '5432'
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
@@ -27,7 +27,7 @@ runtime:
     enabled: false
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: '5432'
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-full-refresh.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-full-refresh.yaml
@@ -6,7 +6,7 @@ name: postgres-cayenne[file]-full-refresh
 # (no OLTP load) for robust explain-plan snapshots for analytical queries.
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: 5432
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file].yaml
@@ -10,7 +10,7 @@ name: postgres-cayenne[file]
 # effect of tuning, not caching/history overhead.
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: 5432
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
+++ b/test/spicepods/chbench/accelerated/postgres-duckdb[file].yaml
@@ -3,7 +3,7 @@ kind: Spicepod
 name: postgres-duckdb[file]
 
 postgres_connection_params: &postgres_params
-  pg_host: 127.0.0.1
+  pg_host: ${env:CHBENCH_PG_HOST}
   pg_port: 5432
   pg_db: chbench
   pg_user: bench

--- a/test/spicepods/chbench/federated/postgres.yaml
+++ b/test/spicepods/chbench/federated/postgres.yaml
@@ -6,7 +6,7 @@ datasets:
   - from: postgres:warehouse
     name: warehouse
     params: &postgres_params
-      pg_host: 127.0.0.1
+      pg_host: ${env:CHBENCH_PG_HOST}
       pg_port: 5432
       pg_db: chbench
       pg_user: bench


### PR DESCRIPTION
## 📝 Summary

On `spiceai-dev-xlarge-runners`, the HTAP/CH-benCH benchmark now runs against a dedicated in-cluster Postgres instead of a per-run docker container, with the benchmark processes pinned to disjoint physical cores to remove CPU contention and make OLTP generation more consistent/stable.

- Dedicated Postgres on xlarge — skip the per-run `setup-chbench-postgres` docker step and point at the in-cluster PG service.
- Configurable spicepod host — chbench spicepods resolve `pg_host` from `${env:CHBENCH_PG_HOST}` (was hardcoded `127.0.0.1`), so spiced and testoperator target the same Postgres.
- CPU pinning (64-core EPYC) — spiced - 64 logical CPUs (physical cores 0-31), testoperator - 16 logical CPUs (cores 32-39), each on whole physical cores so they don't contend (including SMT siblings). Postgres takes other cores from remaining (pinned in its own deployment).
- Remove resource-monitor steps — the `docker stats`-based monitor doesn't apply to the dedicated PG pod and is redundant with `--metrics`.

Other:
- Query workers previously collected every `RecordBatch` of a result into a `Vec` regardless of whether anything consumed it. For HTAP/throughput runs — and any worker run without results validation or snapshots — those batches were materialized and then dropped unused, inflating the harness's own memory footprint and contaminating memory measurements of the system under test. This change makes workers count rows and discard batches in that case, only retaining results when they're actually needed.


Example run: https://github.com/spiceai/spiceai/actions/runs/27971699400/job/82779685616

>OLTP Report (608.5s)
  tpmC (NewOrder/min): 269821.0
  transactions: 6087211 committed, 33 aborted (0.00% abort rate)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
