### PR TITLE
feat(s3_vectors): paginate QueryVectors for topK up to 10,000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16980,6 +16980,7 @@ dependencies = [
  "aws-sdk-s3vectors",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -50,8 +50,11 @@ use tracing::{Instrument, info_span};
 /// The JSON key within a `QueryVector` response that contains the distance to the query vector.
 pub static S3_VECTOR_DISTANCE_NAME: &str = "distance";
 
-/// Maximum topK results retrievable by a `QueryVector` operation. <https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-limitations.html>
-pub static S3_VECTOR_MAX_TOPK: i32 = 100;
+/// Maximum topK results retrievable by a `QueryVector` operation.
+pub use s3_vectors::QUERY_VECTORS_MAX_TOPK as S3_VECTOR_MAX_TOPK;
+
+/// Maximum number of results returned per page in a `QueryVectors` API call.
+pub use s3_vectors::QUERY_VECTORS_PAGE_SIZE as S3_VECTOR_PAGE_SIZE;
 
 /// Maximum number of keys per `GetVectors` API call. <https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-limitations.html>
 pub static GET_VECTORS_MAX_KEYS: usize = 100;
@@ -121,8 +124,10 @@ impl TableProvider for S3VectorsQueryTable {
                 S3_VECTOR_MAX_TOPK
             }
             Some(Ok(l)) => l,
-            // No limit, or failed conversion
-            None | Some(Err(_)) => S3_VECTOR_MAX_TOPK,
+            // Conversion failed (limit > i32::MAX) — clamp to max
+            Some(Err(_)) => S3_VECTOR_MAX_TOPK,
+            // No limit specified — default to one page of results
+            None => S3_VECTOR_PAGE_SIZE,
         };
         return Ok(Arc::new(S3VectorsQueryExec::new(
             &self.table,
@@ -807,8 +812,12 @@ mod tests {
 
     #[test]
     fn test_s3_vector_max_topk_value() {
-        // Verify the constant is set to 100 as per updated S3 Vectors API limits
-        assert_eq!(S3_VECTOR_MAX_TOPK, 100);
+        assert_eq!(S3_VECTOR_MAX_TOPK, 10_000);
+    }
+
+    #[test]
+    fn test_s3_vector_page_size_value() {
+        assert_eq!(S3_VECTOR_PAGE_SIZE, 100);
     }
 
     #[test]
@@ -872,10 +881,10 @@ mod tests {
 
         let session_state = SessionContext::new().state();
 
-        // Test with limit exceeding S3_VECTOR_MAX_TOPK (100)
+        // Test with limit exceeding S3_VECTOR_MAX_TOPK (10_000)
         // The scan should clamp the limit to S3_VECTOR_MAX_TOPK
         let plan = query_table
-            .scan(&session_state, None, &[], Some(200))
+            .scan(&session_state, None, &[], Some(20_000))
             .await
             .expect("scan should succeed");
 
@@ -884,7 +893,7 @@ mod tests {
             .downcast_ref::<S3VectorsQueryExec>()
             .expect("should be S3VectorsQueryExec");
 
-        // The limit should be clamped to S3_VECTOR_MAX_TOPK (100)
+        // The limit should be clamped to S3_VECTOR_MAX_TOPK (10_000)
         assert_eq!(exec.limit, S3_VECTOR_MAX_TOPK);
     }
 
@@ -1013,7 +1022,7 @@ mod tests {
 
         let session_state = SessionContext::new().state();
 
-        // Test with no limit - should use S3_VECTOR_MAX_TOPK as default
+        // Test with no limit - should default to one page (S3_VECTOR_PAGE_SIZE)
         let plan = query_table
             .scan(&session_state, None, &[], None)
             .await
@@ -1024,8 +1033,8 @@ mod tests {
             .downcast_ref::<S3VectorsQueryExec>()
             .expect("should be S3VectorsQueryExec");
 
-        // The limit should be S3_VECTOR_MAX_TOPK (100)
-        assert_eq!(exec.limit, S3_VECTOR_MAX_TOPK);
+        // The limit should be S3_VECTOR_PAGE_SIZE (100)
+        assert_eq!(exec.limit, S3_VECTOR_PAGE_SIZE);
     }
 
     #[test]
@@ -1133,5 +1142,387 @@ mod tests {
             obj.get("field2").and_then(serde_json::Value::as_f64),
             Some(42.0)
         );
+    }
+
+    /// Helper to create a standard test `S3VectorsQueryTable` for limit tests.
+    fn make_query_table(mock_client: Arc<MockClient>) -> S3VectorsQueryTable {
+        let bucket_name = "test-bucket";
+        let index_name = "test-index";
+
+        mock_client.data.lock().expect("lock").indexes.insert(
+            bucket_name.to_string(),
+            vec![
+                IndexSummary::builder()
+                    .vector_bucket_name(bucket_name)
+                    .set_index_arn(Some("arn".to_string()))
+                    .creation_time(DateTime::from_secs(1))
+                    .index_name(index_name.to_string())
+                    .build()
+                    .expect("build"),
+            ],
+        );
+
+        mock_client
+            .data
+            .lock()
+            .expect("lock")
+            .vectors
+            .insert(index_name.to_string(), vec![]);
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(S3_VECTOR_PRIMARY_KEY_NAME, DataType::Utf8, false),
+            Field::new(
+                S3_VECTOR_EMBEDDING_NAME,
+                DataType::new_list(DataType::Float32, true),
+                false,
+            ),
+            Field::new(S3_VECTOR_DISTANCE_NAME, DataType::Float64, false),
+        ]));
+
+        let s3_table = S3VectorsTable {
+            client: mock_client,
+            schema,
+            constraints: Constraints::default(),
+            idx: Arc::new(S3VectorIdentifier::Index {
+                bucket_name: bucket_name.to_string(),
+                index_name: index_name.to_string(),
+            }),
+            dimension: 3,
+            columns: MetadataColumns::none(),
+            distance_metric: DistanceMetric::Cosine,
+        };
+
+        let compute_vector = Arc::new(MockComputeVector::new(vec![1.0, 2.0, 3.0]));
+        S3VectorsQueryTable::new(s3_table, compute_vector, "test query".to_string())
+    }
+
+    /// Scans the table and returns the resulting `S3VectorsQueryExec` limit.
+    async fn scan_limit(query_table: &S3VectorsQueryTable, limit: Option<usize>) -> i32 {
+        let session_state = SessionContext::new().state();
+        let plan = query_table
+            .scan(&session_state, None, &[], limit)
+            .await
+            .expect("scan should succeed");
+        plan.downcast_ref::<S3VectorsQueryExec>()
+            .expect("should be S3VectorsQueryExec")
+            .limit
+    }
+
+    #[test]
+    fn test_page_size_less_than_max_topk() {
+        assert!(
+            S3_VECTOR_PAGE_SIZE < S3_VECTOR_MAX_TOPK,
+            "S3_VECTOR_PAGE_SIZE ({S3_VECTOR_PAGE_SIZE}) must be less than S3_VECTOR_MAX_TOPK ({S3_VECTOR_MAX_TOPK})",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_limit_exactly_at_page_size() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        assert_eq!(scan_limit(&query_table, Some(100)).await, 100);
+    }
+
+    #[tokio::test]
+    async fn test_limit_one_above_page_size() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        assert_eq!(scan_limit(&query_table, Some(101)).await, 101);
+    }
+
+    #[tokio::test]
+    async fn test_limit_exactly_at_max_topk() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        assert_eq!(scan_limit(&query_table, Some(10_000)).await, 10_000);
+    }
+
+    #[tokio::test]
+    async fn test_limit_one_above_max_topk() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        assert_eq!(
+            scan_limit(&query_table, Some(10_001)).await,
+            S3_VECTOR_MAX_TOPK
+        );
+    }
+
+    #[tokio::test]
+    async fn test_limit_of_one() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        assert_eq!(scan_limit(&query_table, Some(1)).await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_limit_usize_max_clamps_to_max_topk() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        // usize::MAX fails i32::try_from, so clamps to S3_VECTOR_MAX_TOPK
+        assert_eq!(
+            scan_limit(&query_table, Some(usize::MAX)).await,
+            S3_VECTOR_MAX_TOPK
+        );
+    }
+
+    #[tokio::test]
+    async fn test_limit_i32_max_as_usize_clamps_to_max_topk() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        // i32::MAX as usize is larger than S3_VECTOR_MAX_TOPK, should clamp
+        assert_eq!(
+            scan_limit(&query_table, Some(i32::MAX as usize)).await,
+            S3_VECTOR_MAX_TOPK
+        );
+    }
+
+    #[tokio::test]
+    async fn test_limit_just_below_page_size() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        assert_eq!(scan_limit(&query_table, Some(99)).await, 99);
+    }
+
+    #[tokio::test]
+    async fn test_limit_multi_page_boundary() {
+        let query_table = make_query_table(Arc::new(MockClient::new()));
+        // Exact multiple of page size (e.g. 500 = 5 pages)
+        assert_eq!(scan_limit(&query_table, Some(500)).await, 500);
+    }
+
+    #[test]
+    fn test_to_flat_value_no_distance() {
+        let query_output = QueryOutputVector::builder()
+            .key("key-no-dist".to_string())
+            .build()
+            .expect("build");
+
+        let result = super::to_flat_value(query_output, None);
+        let obj = result.as_object().expect("should be object");
+
+        assert_eq!(
+            obj.get(S3_VECTOR_PRIMARY_KEY_NAME),
+            Some(&serde_json::Value::String("key-no-dist".to_string()))
+        );
+        assert!(
+            obj.get(S3_VECTOR_DISTANCE_NAME).is_none(),
+            "distance should not be present when not set"
+        );
+    }
+
+    #[test]
+    fn test_to_flat_value_empty_metadata() {
+        use aws_smithy_types::Document;
+
+        let metadata = Document::Object(std::collections::HashMap::new());
+        let query_output = QueryOutputVector::builder()
+            .key("key-empty-meta".to_string())
+            .metadata(metadata)
+            .build()
+            .expect("build");
+
+        let result = super::to_flat_value(query_output, None);
+        let obj = result.as_object().expect("should be object");
+
+        // Only the primary key should be present
+        assert_eq!(obj.len(), 1);
+        assert!(obj.contains_key(S3_VECTOR_PRIMARY_KEY_NAME));
+    }
+
+    #[test]
+    fn test_to_flat_value_metadata_key_does_not_override_primary_key() {
+        use aws_smithy_types::Document;
+
+        // If metadata contains a field matching the primary key column name,
+        // the actual key should still win (it is inserted after metadata).
+        let metadata = Document::Object(
+            vec![(
+                S3_VECTOR_PRIMARY_KEY_NAME.to_string(),
+                Document::String("metadata-value".to_string()),
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        let query_output = QueryOutputVector::builder()
+            .key("actual-key".to_string())
+            .metadata(metadata)
+            .build()
+            .expect("build");
+
+        let result = super::to_flat_value(query_output, None);
+        let obj = result.as_object().expect("should be object");
+
+        assert_eq!(
+            obj.get(S3_VECTOR_PRIMARY_KEY_NAME),
+            Some(&serde_json::Value::String("actual-key".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_to_flat_value_distance_zero() {
+        let query_output = QueryOutputVector::builder()
+            .key("exact-match".to_string())
+            .distance(0.0_f32)
+            .build()
+            .expect("build");
+
+        let result = super::to_flat_value(query_output, None);
+        let obj = result.as_object().expect("should be object");
+
+        let distance = obj
+            .get(S3_VECTOR_DISTANCE_NAME)
+            .expect("distance should be present");
+        assert_eq!(distance.as_f64(), Some(0.0));
+    }
+
+    #[test]
+    fn test_to_flat_value_empty_vector_data() {
+        let query_output = QueryOutputVector::builder()
+            .key("empty-vec".to_string())
+            .build()
+            .expect("build");
+
+        let vector_data = VectorData::Float32(vec![]);
+        let result = super::to_flat_value(query_output, Some(vector_data));
+        let obj = result.as_object().expect("should be object");
+
+        let embedding = obj
+            .get(S3_VECTOR_EMBEDDING_NAME)
+            .expect("embedding should be present");
+        let arr = embedding.as_array().expect("should be array");
+        assert!(
+            arr.is_empty(),
+            "embedding array should be empty for 0-dim vector"
+        );
+    }
+
+    #[test]
+    fn test_to_flat_value_metadata_with_nested_objects() {
+        use aws_smithy_types::Document;
+
+        let nested = Document::Object(
+            vec![("inner".to_string(), Document::String("value".to_string()))]
+                .into_iter()
+                .collect(),
+        );
+        let metadata = Document::Object(
+            vec![("nested_field".to_string(), nested)]
+                .into_iter()
+                .collect(),
+        );
+
+        let query_output = QueryOutputVector::builder()
+            .key("nested-key".to_string())
+            .metadata(metadata)
+            .build()
+            .expect("build");
+
+        let result = super::to_flat_value(query_output, None);
+        let obj = result.as_object().expect("should be object");
+
+        let nested_field = obj.get("nested_field").expect("nested_field should exist");
+        assert!(nested_field.is_object(), "nested field should be an object");
+        assert_eq!(
+            nested_field.get("inner"),
+            Some(&serde_json::Value::String("value".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_to_flat_value_metadata_with_boolean_and_null() {
+        use aws_smithy_types::Document;
+
+        let metadata = Document::Object(
+            vec![
+                ("bool_field".to_string(), Document::Bool(true)),
+                ("null_field".to_string(), Document::Null),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let query_output = QueryOutputVector::builder()
+            .key("bool-null-key".to_string())
+            .metadata(metadata)
+            .build()
+            .expect("build");
+
+        let result = super::to_flat_value(query_output, None);
+        let obj = result.as_object().expect("should be object");
+
+        assert_eq!(obj.get("bool_field"), Some(&serde_json::Value::Bool(true)));
+        assert_eq!(obj.get("null_field"), Some(&serde_json::Value::Null));
+    }
+
+    #[test]
+    fn test_to_flat_value_metadata_with_array() {
+        use aws_smithy_types::Document;
+
+        let metadata = Document::Object(
+            vec![(
+                "tags".to_string(),
+                Document::Array(vec![
+                    Document::String("a".to_string()),
+                    Document::String("b".to_string()),
+                ]),
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        let query_output = QueryOutputVector::builder()
+            .key("array-key".to_string())
+            .metadata(metadata)
+            .build()
+            .expect("build");
+
+        let result = super::to_flat_value(query_output, None);
+        let obj = result.as_object().expect("should be object");
+
+        let tags = obj.get("tags").expect("tags should exist");
+        let arr = tags.as_array().expect("should be array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0], serde_json::Value::String("a".to_string()));
+        assert_eq!(arr[1], serde_json::Value::String("b".to_string()));
+    }
+
+    #[test]
+    fn test_to_flat_value_all_fields_populated() {
+        use aws_smithy_types::{Document, Number};
+
+        let metadata = Document::Object(
+            vec![
+                ("genre".to_string(), Document::String("sci-fi".to_string())),
+                ("year".to_string(), Document::Number(Number::PosInt(2024))),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let query_output = QueryOutputVector::builder()
+            .key("full-key".to_string())
+            .distance(0.25_f32)
+            .metadata(metadata)
+            .build()
+            .expect("build");
+
+        let vector_data = VectorData::Float32(vec![0.1, 0.2]);
+        let result = super::to_flat_value(query_output, Some(vector_data));
+        let obj = result.as_object().expect("should be object");
+
+        assert_eq!(
+            obj.get(S3_VECTOR_PRIMARY_KEY_NAME),
+            Some(&serde_json::Value::String("full-key".to_string()))
+        );
+        assert_eq!(
+            obj.get(S3_VECTOR_DISTANCE_NAME)
+                .and_then(serde_json::Value::as_f64),
+            Some(0.25)
+        );
+        assert_eq!(
+            obj.get("genre"),
+            Some(&serde_json::Value::String("sci-fi".to_string()))
+        );
+        assert_eq!(
+            obj.get("year").and_then(serde_json::Value::as_u64),
+            Some(2024)
+        );
+
+        let embedding = obj.get(S3_VECTOR_EMBEDDING_NAME).expect("embedding");
+        let arr = embedding.as_array().expect("array");
+        assert_eq!(arr.len(), 2);
     }
 }

--- a/crates/s3_vectors/Cargo.toml
+++ b/crates/s3_vectors/Cargo.toml
@@ -14,6 +14,7 @@ aws-config.workspace = true
 aws-sdk-s3vectors.workspace = true
 aws-smithy-runtime-api.workspace = true
 aws-smithy-types.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/s3_vectors/src/lib.rs
+++ b/crates/s3_vectors/src/lib.rs
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::sync::{Arc, Mutex};
+
 use async_trait::async_trait;
 use aws_config::SdkConfig;
 
 pub use aws_sdk_s3vectors::{
-    config::http::HttpResponse,
+    config::http::{HttpRequest, HttpResponse},
     error::SdkError,
     operation::{
         create_index::{CreateIndexError, CreateIndexInput, CreateIndexOutput},
@@ -60,6 +62,132 @@ pub use aws_smithy_types::{DateTime, Document, Number, error::operation::BuildEr
 
 pub static LIST_VECTORS_MAX_RESULTS: usize = 500;
 pub static PUT_VECTORS_MAX_ITEMS: usize = 500;
+
+/// Maximum number of results returned per page in a `QueryVectors` API call.
+pub static QUERY_VECTORS_PAGE_SIZE: i32 = 100;
+
+/// Maximum topK value for a paginated `QueryVectors` request.
+pub static QUERY_VECTORS_MAX_TOPK: i32 = 10_000;
+
+/// Interceptor that captures the `nextToken` from the `QueryVectors` response body.
+#[derive(Debug)]
+struct CaptureNextToken {
+    captured: Arc<Mutex<Option<CapturedNextToken>>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CapturedNextToken {
+    Token(String),
+    Missing,
+    Failed(&'static str),
+}
+
+impl aws_smithy_runtime_api::client::interceptors::Intercept for CaptureNextToken {
+    fn name(&self) -> &'static str {
+        "CaptureNextToken"
+    }
+
+    fn modify_before_deserialization(
+        &self,
+        context: &mut aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut<'_>,
+        _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
+        _cfg: &mut aws_smithy_types::config_bag::ConfigBag,
+    ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
+        let body = context.response().body();
+        let captured = match body.bytes() {
+            Some(bytes) => match serde_json::from_slice::<serde_json::Value>(bytes) {
+                Ok(json) => json
+                    .get("nextToken")
+                    .and_then(|v| v.as_str())
+                    .map_or(CapturedNextToken::Missing, |token| {
+                        CapturedNextToken::Token(token.to_string())
+                    }),
+                Err(_) => CapturedNextToken::Failed(
+                    "S3 Vectors response body is not valid JSON while reading nextToken",
+                ),
+            },
+            None => CapturedNextToken::Failed(
+                "S3 Vectors response body is unavailable while reading nextToken",
+            ),
+        };
+
+        if let Ok(mut guard) = self.captured.lock() {
+            *guard = Some(captured);
+        }
+        Ok(())
+    }
+}
+
+fn inject_query_vectors_next_token(
+    mut request: HttpRequest,
+    token: &str,
+) -> std::result::Result<HttpRequest, std::io::Error> {
+    let body_bytes = request.body().bytes().ok_or_else(|| {
+        std::io::Error::other("Failed to paginate S3 QueryVectors: request body is unavailable")
+    })?;
+    let mut json = serde_json::from_slice::<serde_json::Value>(body_bytes).map_err(|source| {
+        std::io::Error::other(format!(
+            "Failed to paginate S3 QueryVectors: request body is not valid JSON: {source}"
+        ))
+    })?;
+    json["nextToken"] = serde_json::Value::String(token.to_string());
+
+    let new_body = serde_json::to_vec(&json).map_err(|source| {
+        std::io::Error::other(format!(
+            "Failed to paginate S3 QueryVectors: request body could not be serialized: {source}"
+        ))
+    })?;
+    let content_length = new_body.len();
+    *request.body_mut() = aws_smithy_types::body::SdkBody::from(new_body);
+    request
+        .headers_mut()
+        .insert("content-length", content_length.to_string());
+
+    Ok(request)
+}
+
+fn query_vectors_page_size_usize() -> usize {
+    usize::try_from(QUERY_VECTORS_PAGE_SIZE).unwrap_or(usize::MAX)
+}
+
+fn next_query_vectors_request_token(
+    retrieved_vectors: usize,
+    page_vectors: usize,
+    requested_top_k: usize,
+    response_token: CapturedNextToken,
+    previous_token: Option<&str>,
+) -> std::result::Result<Option<String>, &'static str> {
+    if retrieved_vectors >= requested_top_k {
+        return Ok(None);
+    }
+
+    match response_token {
+        CapturedNextToken::Token(token) if token.is_empty() => {
+            if page_vectors < query_vectors_page_size_usize() {
+                Ok(None)
+            } else {
+                Err("S3 Vectors returned a full page with an empty nextToken")
+            }
+        }
+        CapturedNextToken::Token(token) if Some(token.as_str()) == previous_token => {
+            Err("S3 Vectors returned a duplicate nextToken")
+        }
+        CapturedNextToken::Token(token) => Ok(Some(token)),
+        CapturedNextToken::Missing => Ok(None),
+        CapturedNextToken::Failed(_) if page_vectors < query_vectors_page_size_usize() => Ok(None),
+        CapturedNextToken::Failed(reason) => Err(reason),
+    }
+}
+
+fn query_vectors_pagination_error(
+    top_k: i32,
+    retrieved_vectors: usize,
+    reason: &str,
+) -> SdkError<QueryVectorsError> {
+    SdkError::construction_failure(format!(
+        "Failed to paginate S3 QueryVectors for topK {top_k}: {reason}; retrieved {retrieved_vectors} results"
+    ))
+}
 
 /// Wrapper for `aws_sdk_s3vectors::Client` that implements the `S3Vectors` trait
 #[derive(Debug)]
@@ -289,18 +417,111 @@ impl S3Vectors for Client {
         &self,
         input: &QueryVectorsInput,
     ) -> Result<QueryVectorsOutput, SdkError<QueryVectorsError>> {
-        self.client
-            .query_vectors()
-            .set_vector_bucket_name(input.vector_bucket_name.clone())
-            .set_index_name(input.index_name.clone())
-            .set_index_arn(input.index_arn.clone())
-            .set_query_vector(input.query_vector.clone())
-            .set_top_k(input.top_k)
-            .set_return_distance(input.return_distance)
-            .set_return_metadata(input.return_metadata)
-            .set_filter(input.filter.clone())
-            .send()
-            .await
+        // An explicit `top_k == 0` means the caller asked for zero results
+        // (e.g., SQL `LIMIT 0`). Short-circuit to an empty response instead of
+        // clamping to 1, which would break result correctness.
+        if input.top_k == Some(0) {
+            return QueryVectorsOutput::builder()
+                .set_vectors(Some(Vec::new()))
+                .build()
+                .map_err(SdkError::construction_failure);
+        }
+
+        let top_k = input
+            .top_k
+            .unwrap_or(QUERY_VECTORS_PAGE_SIZE)
+            .clamp(1, QUERY_VECTORS_MAX_TOPK);
+
+        if top_k <= QUERY_VECTORS_PAGE_SIZE {
+            return self
+                .client
+                .query_vectors()
+                .set_vector_bucket_name(input.vector_bucket_name.clone())
+                .set_index_name(input.index_name.clone())
+                .set_index_arn(input.index_arn.clone())
+                .set_query_vector(input.query_vector.clone())
+                .top_k(top_k)
+                .set_return_distance(input.return_distance)
+                .set_return_metadata(input.return_metadata)
+                .set_filter(input.filter.clone())
+                .send()
+                .await;
+        }
+
+        // Paginated query: collect results across multiple pages
+        let mut all_vectors = Vec::new();
+        let mut next_token: Option<String> = None;
+        let mut distance_metric = None;
+
+        loop {
+            let captured = Arc::new(Mutex::new(None::<CapturedNextToken>));
+            let interceptor = CaptureNextToken {
+                captured: Arc::clone(&captured),
+            };
+
+            let mut operation = self
+                .client
+                .query_vectors()
+                .set_vector_bucket_name(input.vector_bucket_name.clone())
+                .set_index_name(input.index_name.clone())
+                .set_index_arn(input.index_arn.clone())
+                .set_query_vector(input.query_vector.clone())
+                .top_k(top_k)
+                .set_return_distance(input.return_distance)
+                .set_return_metadata(input.return_metadata)
+                .set_filter(input.filter.clone())
+                .customize()
+                .interceptor(interceptor);
+
+            if let Some(token) = next_token.clone() {
+                operation = operation
+                    .map_request(move |request| inject_query_vectors_next_token(request, &token));
+            }
+
+            let result = operation.send().await;
+
+            let output = result?;
+
+            distance_metric = distance_metric.or(output.distance_metric);
+            let page_vectors = output.vectors.len();
+            all_vectors.extend(output.vectors);
+
+            let response_token = captured
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+                .unwrap_or(CapturedNextToken::Failed(
+                    "S3 Vectors response was not inspected for nextToken",
+                ));
+
+            let top_k_usize = usize::try_from(top_k).unwrap_or(usize::MAX);
+            match next_query_vectors_request_token(
+                all_vectors.len(),
+                page_vectors,
+                top_k_usize,
+                response_token,
+                next_token.as_deref(),
+            ) {
+                Ok(Some(token)) => next_token = Some(token),
+                Ok(None) => break,
+                Err(reason) => {
+                    return Err(query_vectors_pagination_error(
+                        top_k,
+                        all_vectors.len(),
+                        reason,
+                    ));
+                }
+            }
+        }
+
+        let top_k_usize = usize::try_from(top_k).unwrap_or(usize::MAX);
+        all_vectors.truncate(top_k_usize);
+
+        QueryVectorsOutput::builder()
+            .set_vectors(Some(all_vectors))
+            .set_distance_metric(distance_metric)
+            .build()
+            .map_err(SdkError::construction_failure)
     }
 }
 
@@ -397,6 +618,426 @@ pub mod tests {
         error::SdkError,
         types::{PutInputVector, VectorData},
     };
+
+    use super::*;
+
+    #[test]
+    fn test_query_vectors_page_size_constant() {
+        assert_eq!(QUERY_VECTORS_PAGE_SIZE, 100);
+    }
+
+    #[test]
+    fn test_query_vectors_max_topk_constant() {
+        assert_eq!(QUERY_VECTORS_MAX_TOPK, 10_000);
+    }
+
+    #[test]
+    fn test_page_size_divides_max_topk() {
+        // Max topK should be a multiple of page size for clean pagination
+        assert_eq!(
+            QUERY_VECTORS_MAX_TOPK % QUERY_VECTORS_PAGE_SIZE,
+            0,
+            "QUERY_VECTORS_MAX_TOPK should be a multiple of QUERY_VECTORS_PAGE_SIZE"
+        );
+    }
+
+    #[test]
+    fn test_page_size_less_than_max_topk() {
+        assert!(
+            QUERY_VECTORS_PAGE_SIZE < QUERY_VECTORS_MAX_TOPK,
+            "QUERY_VECTORS_PAGE_SIZE must be less than QUERY_VECTORS_MAX_TOPK"
+        );
+    }
+
+    #[test]
+    fn test_capture_next_token_with_token() {
+        use aws_smithy_runtime_api::client::interceptors::Intercept;
+        use aws_smithy_runtime_api::http::StatusCode;
+
+        let captured = Arc::new(Mutex::new(None::<CapturedNextToken>));
+        let interceptor = CaptureNextToken {
+            captured: Arc::clone(&captured),
+        };
+
+        // Simulate a response body with nextToken
+        let body_json = serde_json::json!({
+            "vectors": [],
+            "nextToken": "abc123"
+        });
+        let body_bytes = serde_json::to_vec(&body_json).expect("serialize");
+        let response = aws_smithy_runtime_api::client::orchestrator::HttpResponse::new(
+            StatusCode::try_from(200).expect("200"),
+            aws_smithy_types::body::SdkBody::from(body_bytes),
+        );
+
+        // Build an interceptor context to test
+        let mut context =
+            aws_smithy_runtime_api::client::interceptors::context::InterceptorContext::new(
+                aws_smithy_runtime_api::client::interceptors::context::Input::doesnt_matter(),
+            );
+        context.set_request(aws_smithy_runtime_api::client::orchestrator::HttpRequest::empty());
+        context.set_response(response);
+
+        let mut cfg = aws_smithy_types::config_bag::ConfigBag::base();
+        let rc = aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder::for_tests()
+            .build()
+            .expect("build runtime components");
+
+        let mut ctx_mut = aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut::from(&mut context);
+        interceptor
+            .modify_before_deserialization(&mut ctx_mut, &rc, &mut cfg)
+            .expect("interceptor should succeed for valid nextToken");
+
+        let token = captured.lock().expect("lock").clone();
+        assert_eq!(token, Some(CapturedNextToken::Token("abc123".to_string())));
+    }
+
+    #[test]
+    fn test_capture_next_token_without_token() {
+        use aws_smithy_runtime_api::client::interceptors::Intercept;
+        use aws_smithy_runtime_api::http::StatusCode;
+
+        let captured = Arc::new(Mutex::new(None::<CapturedNextToken>));
+        let interceptor = CaptureNextToken {
+            captured: Arc::clone(&captured),
+        };
+
+        // Response body without nextToken (last page)
+        let body_json = serde_json::json!({
+            "vectors": [{"key": "v1"}]
+        });
+        let body_bytes = serde_json::to_vec(&body_json).expect("serialize");
+        let response = aws_smithy_runtime_api::client::orchestrator::HttpResponse::new(
+            StatusCode::try_from(200).expect("200"),
+            aws_smithy_types::body::SdkBody::from(body_bytes),
+        );
+
+        let mut context =
+            aws_smithy_runtime_api::client::interceptors::context::InterceptorContext::new(
+                aws_smithy_runtime_api::client::interceptors::context::Input::doesnt_matter(),
+            );
+        context.set_request(aws_smithy_runtime_api::client::orchestrator::HttpRequest::empty());
+        context.set_response(response);
+
+        let mut cfg = aws_smithy_types::config_bag::ConfigBag::base();
+        let rc = aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder::for_tests()
+            .build()
+            .expect("build runtime components");
+
+        let mut ctx_mut = aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut::from(&mut context);
+        interceptor
+            .modify_before_deserialization(&mut ctx_mut, &rc, &mut cfg)
+            .expect("interceptor should succeed without nextToken");
+
+        let token = captured.lock().expect("lock").clone();
+        assert_eq!(token, Some(CapturedNextToken::Missing));
+    }
+
+    #[test]
+    fn test_capture_next_token_with_null_token() {
+        use aws_smithy_runtime_api::client::interceptors::Intercept;
+        use aws_smithy_runtime_api::http::StatusCode;
+
+        let captured = Arc::new(Mutex::new(None::<CapturedNextToken>));
+        let interceptor = CaptureNextToken {
+            captured: Arc::clone(&captured),
+        };
+
+        // nextToken is present but null
+        let body_json = serde_json::json!({
+            "vectors": [],
+            "nextToken": null
+        });
+        let body_bytes = serde_json::to_vec(&body_json).expect("serialize");
+        let response = aws_smithy_runtime_api::client::orchestrator::HttpResponse::new(
+            StatusCode::try_from(200).expect("200"),
+            aws_smithy_types::body::SdkBody::from(body_bytes),
+        );
+
+        let mut context =
+            aws_smithy_runtime_api::client::interceptors::context::InterceptorContext::new(
+                aws_smithy_runtime_api::client::interceptors::context::Input::doesnt_matter(),
+            );
+        context.set_request(aws_smithy_runtime_api::client::orchestrator::HttpRequest::empty());
+        context.set_response(response);
+
+        let mut cfg = aws_smithy_types::config_bag::ConfigBag::base();
+        let rc = aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder::for_tests()
+            .build()
+            .expect("build runtime components");
+
+        let mut ctx_mut = aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut::from(&mut context);
+        interceptor
+            .modify_before_deserialization(&mut ctx_mut, &rc, &mut cfg)
+            .expect("interceptor should succeed with null nextToken");
+
+        // null is not a string, so as_str() returns None
+        let token = captured.lock().expect("lock").clone();
+        assert_eq!(token, Some(CapturedNextToken::Missing));
+    }
+
+    #[test]
+    fn test_capture_next_token_with_empty_body() {
+        use aws_smithy_runtime_api::client::interceptors::Intercept;
+        use aws_smithy_runtime_api::http::StatusCode;
+
+        let captured = Arc::new(Mutex::new(None::<CapturedNextToken>));
+        let interceptor = CaptureNextToken {
+            captured: Arc::clone(&captured),
+        };
+
+        // Empty body — should not panic
+        let response = aws_smithy_runtime_api::client::orchestrator::HttpResponse::new(
+            StatusCode::try_from(200).expect("200"),
+            aws_smithy_types::body::SdkBody::empty(),
+        );
+
+        let mut context =
+            aws_smithy_runtime_api::client::interceptors::context::InterceptorContext::new(
+                aws_smithy_runtime_api::client::interceptors::context::Input::doesnt_matter(),
+            );
+        context.set_request(aws_smithy_runtime_api::client::orchestrator::HttpRequest::empty());
+        context.set_response(response);
+
+        let mut cfg = aws_smithy_types::config_bag::ConfigBag::base();
+        let rc = aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder::for_tests()
+            .build()
+            .expect("build runtime components");
+
+        let mut ctx_mut = aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut::from(&mut context);
+        interceptor
+            .modify_before_deserialization(&mut ctx_mut, &rc, &mut cfg)
+            .expect("interceptor should succeed with empty body");
+
+        let token = captured.lock().expect("lock").clone();
+        assert_eq!(
+            token,
+            Some(CapturedNextToken::Failed(
+                "S3 Vectors response body is not valid JSON while reading nextToken"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_capture_next_token_with_invalid_json() {
+        use aws_smithy_runtime_api::client::interceptors::Intercept;
+        use aws_smithy_runtime_api::http::StatusCode;
+
+        let captured = Arc::new(Mutex::new(None::<CapturedNextToken>));
+        let interceptor = CaptureNextToken {
+            captured: Arc::clone(&captured),
+        };
+
+        // Invalid JSON body — should not panic, should leave captured as None
+        let response = aws_smithy_runtime_api::client::orchestrator::HttpResponse::new(
+            StatusCode::try_from(200).expect("200"),
+            aws_smithy_types::body::SdkBody::from("not valid json"),
+        );
+
+        let mut context =
+            aws_smithy_runtime_api::client::interceptors::context::InterceptorContext::new(
+                aws_smithy_runtime_api::client::interceptors::context::Input::doesnt_matter(),
+            );
+        context.set_request(aws_smithy_runtime_api::client::orchestrator::HttpRequest::empty());
+        context.set_response(response);
+
+        let mut cfg = aws_smithy_types::config_bag::ConfigBag::base();
+        let rc = aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder::for_tests()
+            .build()
+            .expect("build runtime components");
+
+        let mut ctx_mut = aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut::from(&mut context);
+        interceptor
+            .modify_before_deserialization(&mut ctx_mut, &rc, &mut cfg)
+            .expect("interceptor should succeed with invalid JSON");
+
+        let token = captured.lock().expect("lock").clone();
+        assert_eq!(
+            token,
+            Some(CapturedNextToken::Failed(
+                "S3 Vectors response body is not valid JSON while reading nextToken"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_capture_next_token_with_empty_string_token() {
+        use aws_smithy_runtime_api::client::interceptors::Intercept;
+        use aws_smithy_runtime_api::http::StatusCode;
+
+        let captured = Arc::new(Mutex::new(None::<CapturedNextToken>));
+        let interceptor = CaptureNextToken {
+            captured: Arc::clone(&captured),
+        };
+
+        // nextToken is an empty string
+        let body_json = serde_json::json!({
+            "vectors": [],
+            "nextToken": ""
+        });
+        let body_bytes = serde_json::to_vec(&body_json).expect("serialize");
+        let response = aws_smithy_runtime_api::client::orchestrator::HttpResponse::new(
+            StatusCode::try_from(200).expect("200"),
+            aws_smithy_types::body::SdkBody::from(body_bytes),
+        );
+
+        let mut context =
+            aws_smithy_runtime_api::client::interceptors::context::InterceptorContext::new(
+                aws_smithy_runtime_api::client::interceptors::context::Input::doesnt_matter(),
+            );
+        context.set_request(aws_smithy_runtime_api::client::orchestrator::HttpRequest::empty());
+        context.set_response(response);
+
+        let mut cfg = aws_smithy_types::config_bag::ConfigBag::base();
+        let rc = aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder::for_tests()
+            .build()
+            .expect("build runtime components");
+
+        let mut ctx_mut = aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut::from(&mut context);
+        interceptor
+            .modify_before_deserialization(&mut ctx_mut, &rc, &mut cfg)
+            .expect("interceptor should succeed with empty string nextToken");
+
+        // Empty string is still a valid string — should be captured as Some("")
+        let token = captured.lock().expect("lock").clone();
+        assert_eq!(token, Some(CapturedNextToken::Token(String::new())));
+    }
+
+    #[test]
+    fn test_inject_query_vectors_next_token() {
+        let body_json = serde_json::json!({
+            "indexName": "test-index",
+            "queryVector": { "float32": [1.0, 2.0] },
+            "topK": 200,
+            "vectorBucketName": "test-bucket"
+        });
+        let body_bytes = serde_json::to_vec(&body_json).expect("serialize");
+        let request = HttpRequest::new(aws_smithy_types::body::SdkBody::from(body_bytes));
+
+        let request = inject_query_vectors_next_token(request, "token-1")
+            .expect("nextToken injection succeeds");
+        let body = request.body().bytes().expect("body bytes");
+        let json = serde_json::from_slice::<serde_json::Value>(body).expect("valid JSON body");
+        let content_length = request
+            .headers()
+            .get("content-length")
+            .expect("content-length header");
+        let expected_content_length = body.len().to_string();
+
+        assert_eq!(
+            json.get("nextToken").and_then(serde_json::Value::as_str),
+            Some("token-1")
+        );
+        assert_eq!(content_length, expected_content_length.as_str());
+    }
+
+    #[test]
+    fn test_inject_query_vectors_next_token_rejects_invalid_json() {
+        let request = HttpRequest::new(aws_smithy_types::body::SdkBody::from("not JSON"));
+        let error = inject_query_vectors_next_token(request, "token-1")
+            .expect_err("invalid JSON should fail token injection");
+
+        assert!(
+            error.to_string().contains("request body is not valid JSON"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_next_query_vectors_request_token_complete_at_requested_top_k() {
+        let next =
+            next_query_vectors_request_token(200, 100, 200, CapturedNextToken::Missing, None)
+                .expect("complete pagination should succeed");
+
+        assert_eq!(next, None);
+    }
+
+    #[test]
+    fn test_next_query_vectors_request_token_continues_with_token() {
+        let next = next_query_vectors_request_token(
+            100,
+            query_vectors_page_size_usize(),
+            200,
+            CapturedNextToken::Token("token-1".to_string()),
+            None,
+        )
+        .expect("pagination should continue with token");
+
+        assert_eq!(next, Some("token-1".to_string()));
+    }
+
+    #[test]
+    fn test_next_query_vectors_request_token_allows_short_final_page_without_token() {
+        let next = next_query_vectors_request_token(
+            150,
+            50,
+            200,
+            CapturedNextToken::Missing,
+            Some("token-1"),
+        )
+        .expect("short final page without token should complete");
+
+        assert_eq!(next, None);
+    }
+
+    #[test]
+    fn test_next_query_vectors_request_token_allows_full_final_page_without_token() {
+        let next = next_query_vectors_request_token(
+            100,
+            query_vectors_page_size_usize(),
+            200,
+            CapturedNextToken::Missing,
+            None,
+        )
+        .expect("full final page without token should complete");
+
+        assert_eq!(next, None);
+    }
+
+    #[test]
+    fn test_next_query_vectors_request_token_errors_on_full_page_capture_failure() {
+        let error = next_query_vectors_request_token(
+            100,
+            query_vectors_page_size_usize(),
+            200,
+            CapturedNextToken::Failed("capture failed"),
+            None,
+        )
+        .expect_err("full page with failed token capture should fail safely");
+
+        assert_eq!(error, "capture failed");
+    }
+
+    #[test]
+    fn test_next_query_vectors_request_token_errors_on_empty_token_after_full_page() {
+        let error = next_query_vectors_request_token(
+            100,
+            query_vectors_page_size_usize(),
+            200,
+            CapturedNextToken::Token(String::new()),
+            None,
+        )
+        .expect_err("empty token after full page should fail safely");
+
+        assert_eq!(
+            error,
+            "S3 Vectors returned a full page with an empty nextToken"
+        );
+    }
+
+    #[test]
+    fn test_next_query_vectors_request_token_errors_on_duplicate_token() {
+        let error = next_query_vectors_request_token(
+            200,
+            query_vectors_page_size_usize(),
+            300,
+            CapturedNextToken::Token("token-1".to_string()),
+            Some("token-1"),
+        )
+        .expect_err("duplicate token should fail safely");
+
+        assert_eq!(error, "S3 Vectors returned a duplicate nextToken");
+    }
 
     #[tokio::test]
     #[ignore = "reason unknown"]


### PR DESCRIPTION
## 📝 Summary

S3 Vectors QueryVectors now supports topK up to 10,000 via paginated responses (100 results per page). Previously topK was capped at 100 and issued a single request, silently truncating vector searches at 100 rows.

- Raise the cap to QUERY_VECTORS_MAX_TOPK (10,000) and add QUERY_VECTORS_PAGE_SIZE (100) as the per-page limit
- Transparent pagination in Client::query_vectors for topK > 100 via a CaptureNextToken interceptor that captures nextToken from each response and injects it into the next request body
- Default scan limit (no SQL LIMIT) is one page; oversized limits clamp to the max; LIMIT 0 short-circuits to an empty result
- Unit tests for the interceptor, token injection, termination logic, and limit boundaries

## 🔗 Related

## 🚨 Breaking Changes

None. The single-page fast path is unchanged for `topK <= 100`.

## 📚 Docs

The S3 Vectors search docs should be updated to reflect the new 10,000 `topK`
limit (previously documented as 100).

## 👀 Notes for Reviewers

- The pagination loop has safety guards against malformed responses: it errors
  on a duplicate `nextToken`, a full page returned with an empty token, or a
  token-capture failure on a full page — preventing infinite loops and silent
  truncation.
- Tested with `cargo test -p s3_vectors --lib` (19 tests) and
  `cargo test -p data_components --lib --features s3_vectors` (51 tests);
  `cargo clippy` clean for both crates.