### PR TITLE
chore(deps): bump datafusion-ballista to spiceai-54 HEAD (scheduler panic + shuffle empty-partition fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=04466b42332e5255e35b87350db3e741c17af033#04466b42332e5255e35b87350db3e741c17af033"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1774c0c08587fb149f2b4ff2cc6e238f138f3b8#e1774c0c08587fb149f2b4ff2cc6e238f138f3b8"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=04466b42332e5255e35b87350db3e741c17af033#04466b42332e5255e35b87350db3e741c17af033"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1774c0c08587fb149f2b4ff2cc6e238f138f3b8#e1774c0c08587fb149f2b4ff2cc6e238f138f3b8"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=04466b42332e5255e35b87350db3e741c17af033#04466b42332e5255e35b87350db3e741c17af033"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1774c0c08587fb149f2b4ff2cc6e238f138f3b8#e1774c0c08587fb149f2b4ff2cc6e238f138f3b8"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -8289,8 +8289,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -9444,7 +9444,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -13988,8 +13988,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
- "parking_lot 0.12.5",
+ "hashbrown 0.5.0",
+ "parking_lot 0.11.2",
  "rand 0.8.6",
 ]
 
@@ -14459,8 +14459,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -14494,7 +14494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -17486,7 +17486,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -18027,7 +18027,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -22659,7 +22659,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1774c0c08587fb149f2b4ff2cc6e238f138f3b8#e1774c0c08587fb149f2b4ff2cc6e238f138f3b8"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4#fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1774c0c08587fb149f2b4ff2cc6e238f138f3b8#e1774c0c08587fb149f2b4ff2cc6e238f138f3b8"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4#fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e1774c0c08587fb149f2b4ff2cc6e238f138f3b8#e1774c0c08587fb149f2b4ff2cc6e238f138f3b8"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4#fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=29f95792bf5658b98586ef26a1129aea02ac8140#29f95792bf5658b98586ef26a1129aea02ac8140"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=04466b42332e5255e35b87350db3e741c17af033#04466b42332e5255e35b87350db3e741c17af033"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=29f95792bf5658b98586ef26a1129aea02ac8140#29f95792bf5658b98586ef26a1129aea02ac8140"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=04466b42332e5255e35b87350db3e741c17af033#04466b42332e5255e35b87350db3e741c17af033"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=29f95792bf5658b98586ef26a1129aea02ac8140#29f95792bf5658b98586ef26a1129aea02ac8140"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=04466b42332e5255e35b87350db3e741c17af033#04466b42332e5255e35b87350db3e741c17af033"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,9 +140,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "04466b42332e5255e35b87350db3e741c17af033" } # spiceai-54-patches
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "04466b42332e5255e35b87350db3e741c17af033" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "04466b42332e5255e35b87350db3e741c17af033" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1774c0c08587fb149f2b4ff2cc6e238f138f3b8" } # spiceai-54-patches + executor heartbeat fix
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1774c0c08587fb149f2b4ff2cc6e238f138f3b8" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1774c0c08587fb149f2b4ff2cc6e238f138f3b8" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,9 +140,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1774c0c08587fb149f2b4ff2cc6e238f138f3b8" } # spiceai-54-patches + executor heartbeat fix
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1774c0c08587fb149f2b4ff2cc6e238f138f3b8" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e1774c0c08587fb149f2b4ff2cc6e238f138f3b8" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" } # spiceai-54 HEAD (incl. #53 scheduler panic fix + #54 shuffle empty-partition fix)
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" } # spiceai-54 HEAD (incl. #53 scheduler panic fix + #54 shuffle empty-partition fix)
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" } # spiceai-54
 ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" }
 ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" }
 base64 = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,9 +140,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "29f95792bf5658b98586ef26a1129aea02ac8140" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "29f95792bf5658b98586ef26a1129aea02ac8140" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "29f95792bf5658b98586ef26a1129aea02ac8140" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "04466b42332e5255e35b87350db3e741c17af033" } # spiceai-54-patches
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "04466b42332e5255e35b87350db3e741c17af033" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "04466b42332e5255e35b87350db3e741c17af033" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"


### PR DESCRIPTION
Bumps the `datafusion-ballista` fork pin (`ballista-core`/`-executor`/`-scheduler`) from `29f9579` to `04466b42`.

The new commit is the current pin **plus a single surgical fix** to the Ballista scheduler — nothing else changes (it is `29f9579` + the patch, not the `spiceai-54` tip, so no unrelated `shuffle_writer.rs` drift is pulled in).

## The fix

`ExecutionStage::update_task_info` unwrapped `self.task_infos[partition_id]`, which is `None` when a task was reset after its executor was lost / heartbeat-timed-out. A late, in-flight `TaskStatus` update from that executor then panicked the scheduler **event-loop worker thread**, closing the event channel — after which every job submission and executor heartbeat failed with `Fail to send event due to channel closed`, permanently wedging the scheduler. The fix ignores the stale update instead of unwrapping.

Fork PR: spiceai/datafusion-ballista#53

## How it was found

A distributed TPC-H **SF10** cluster benchmark (Spice Cloud, 3 executors): the first heavy query timed out executor heartbeats, the scheduler reset the stage's tasks, and a trailing status update triggered the panic. Every query then failed to submit. This bump unblocks that benchmark.

No spiced code changes; deps only.