### PR TITLE
feat(cluster): support distributed (Ballista) scans of Iceberg catalog tables

### DIFF
--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -280,10 +280,15 @@ impl IcebergSchemaProvider {
     /// distributed-plan deserialization, where no async context is available.
     #[must_use]
     pub fn table_sync(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        // Recover a poisoned lock (as `refresh` does) rather than returning
+        // `None`: an unrelated panic must not make a table appear to vanish,
+        // which would surface as a confusing "table not registered" error during
+        // distributed scan reconstruction on an executor.
         self.tables
             .read()
-            .ok()
-            .and_then(|tables| tables.get(name).cloned())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(name)
+            .cloned()
     }
 
     /// Returns a reference to the underlying Iceberg catalog client.

--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -33,12 +33,21 @@ use crate::iceberg::catalog::Error;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// A hook that wraps each Iceberg table provider as it is loaded from the
+/// catalog, given its `(schema_name, table_name)`. The runtime injects this so
+/// catalog-sourced Iceberg scans can be serialized for distributed (Ballista)
+/// execution — `data_components` cannot name the runtime's
+/// `IcebergClusterTableProvider` directly, so the runtime supplies a closure
+/// that applies it. When `None`, table providers are returned unwrapped (the
+/// single-node behavior).
+pub type CatalogTableWrapper =
+    Arc<dyn Fn(&str, &str, Arc<dyn TableProvider>) -> Arc<dyn TableProvider> + Send + Sync>;
+
 /// Provides an interface to manage and access multiple schemas
 /// within an Iceberg [`Catalog`].
 ///
 /// Acts as a centralized catalog provider that aggregates
 /// multiple [`SchemaProvider`], each associated with distinct namespaces.
-#[derive(Debug)]
 pub struct IcebergCatalogProvider {
     /// The underlying Iceberg catalog client.
     catalog: Arc<dyn Catalog>,
@@ -46,10 +55,22 @@ pub struct IcebergCatalogProvider {
     root_namespace: Option<NamespaceIdent>,
     /// Optional glob patterns for filtering tables.
     include: Option<GlobSet>,
+    /// Optional hook to wrap each loaded table provider (see
+    /// [`CatalogTableWrapper`]). Reapplied on every refresh.
+    table_wrapper: Option<CatalogTableWrapper>,
     /// A `RwLock`-protected `HashMap` where keys are namespace names
     /// and values are dynamic references to objects implementing the
     /// [`SchemaProvider`] trait.
     schemas: RwLock<HashMap<String, Arc<dyn SchemaProvider>>>,
+}
+
+impl std::fmt::Debug for IcebergCatalogProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IcebergCatalogProvider")
+            .field("root_namespace", &self.root_namespace)
+            .field("has_table_wrapper", &self.table_wrapper.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl IcebergCatalogProvider {
@@ -69,14 +90,21 @@ impl IcebergCatalogProvider {
         client: Arc<dyn Catalog>,
         root_namespace: Option<NamespaceIdent>,
         includes: Option<&GlobSet>,
+        table_wrapper: Option<CatalogTableWrapper>,
     ) -> Result<Self> {
-        let schemas =
-            Self::load_schemas(Arc::clone(&client), root_namespace.as_ref(), includes).await?;
+        let schemas = Self::load_schemas(
+            Arc::clone(&client),
+            root_namespace.as_ref(),
+            includes,
+            table_wrapper.as_ref(),
+        )
+        .await?;
 
         Ok(IcebergCatalogProvider {
             catalog: client,
             root_namespace,
             include: includes.cloned(),
+            table_wrapper,
             schemas: RwLock::new(schemas),
         })
     }
@@ -98,6 +126,7 @@ impl IcebergCatalogProvider {
         client: Arc<dyn Catalog>,
         root_namespace: Option<&NamespaceIdent>,
         includes: Option<&GlobSet>,
+        table_wrapper: Option<&CatalogTableWrapper>,
     ) -> Result<HashMap<String, Arc<dyn SchemaProvider>>> {
         // Create the semaphore first, so we can use it in the closures below
         let load_semaphore = Arc::new(Semaphore::new(10));
@@ -134,6 +163,7 @@ impl IcebergCatalogProvider {
                 NamespaceIdent::new(name.clone()),
                 semaphore_clone,
                 includes,
+                table_wrapper.cloned(),
             )
         }))
         .await?;
@@ -174,6 +204,7 @@ impl RefreshableCatalogProvider for IcebergCatalogProvider {
             Arc::clone(&self.catalog),
             self.root_namespace.as_ref(),
             self.include.as_ref(),
+            self.table_wrapper.as_ref(),
         )
         .await?;
 
@@ -223,15 +254,36 @@ impl IcebergSchemaProvider {
         namespace: NamespaceIdent,
         load_semaphore: Arc<Semaphore>,
         include: Option<&GlobSet>,
+        table_wrapper: Option<CatalogTableWrapper>,
     ) -> Result<Self> {
-        let tables =
-            Self::load_tables(Arc::clone(&client), &namespace, load_semaphore, include).await?;
+        let tables = Self::load_tables(
+            Arc::clone(&client),
+            &namespace,
+            load_semaphore,
+            include,
+            table_wrapper.as_ref(),
+        )
+        .await?;
 
         Ok(IcebergSchemaProvider {
             catalog: client,
             namespace,
             tables: RwLock::new(tables),
         })
+    }
+
+    /// Synchronously look up a cached table provider by name.
+    ///
+    /// Tables are loaded eagerly at construction (and on catalog refresh), so
+    /// this is a lock-and-clone with no catalog I/O. The runtime relies on this
+    /// to resolve catalog-sourced Iceberg providers on remote executors during
+    /// distributed-plan deserialization, where no async context is available.
+    #[must_use]
+    pub fn table_sync(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        self.tables
+            .read()
+            .ok()
+            .and_then(|tables| tables.get(name).cloned())
     }
 
     /// Returns a reference to the underlying Iceberg catalog client.
@@ -252,6 +304,7 @@ impl IcebergSchemaProvider {
         namespace: &NamespaceIdent,
         load_semaphore: Arc<Semaphore>,
         include: Option<&GlobSet>,
+        table_wrapper: Option<&CatalogTableWrapper>,
     ) -> Result<HashMap<String, Arc<dyn TableProvider>>> {
         let table_names: Vec<_> = client
             .list_tables(namespace)
@@ -276,11 +329,17 @@ impl IcebergSchemaProvider {
                 let client_clone = Arc::clone(&client);
                 let name_clone = Arc::new(name.clone());
                 let semaphore_clone = Arc::clone(&load_semaphore);
+                let wrapper_clone = table_wrapper.cloned();
                 async move {
                     // Map the inner Result to include the table name
-                    Self::load_table(client_clone, Arc::clone(&name_clone), semaphore_clone)
-                        .await
-                        .map(|opt_provider| (name_clone, opt_provider))
+                    Self::load_table(
+                        client_clone,
+                        Arc::clone(&name_clone),
+                        semaphore_clone,
+                        wrapper_clone,
+                    )
+                    .await
+                    .map(|opt_provider| (name_clone, opt_provider))
                 }
             })
             .collect();
@@ -303,6 +362,7 @@ impl IcebergSchemaProvider {
         catalog: Arc<dyn Catalog>,
         table_name: Arc<TableIdent>,
         semaphore: Arc<Semaphore>,
+        table_wrapper: Option<CatalogTableWrapper>,
     ) -> Result<Option<Arc<dyn TableProvider>>> {
         // Acquire a permit from the semaphore to limit concurrent table loads
         let _permit = semaphore
@@ -329,6 +389,20 @@ impl IcebergSchemaProvider {
                         Arc::new(provider),
                     );
                     let adapted: Arc<dyn TableProvider> = Arc::new(deletion_provider);
+
+                    // Wrap so catalog-sourced Iceberg scans can cross Ballista
+                    // node boundaries. The schema name is the (single-level)
+                    // namespace under which this table is registered, so the
+                    // recipe's `catalog.schema.table` reference resolves back to
+                    // this provider on a remote executor. In a single-node
+                    // session the wrapper is a transparent pass-through.
+                    let adapted = match &table_wrapper {
+                        Some(wrap) => {
+                            let schema_name = table_name.namespace().as_ref().join(".");
+                            wrap(&schema_name, table_name.name(), adapted)
+                        }
+                        None => adapted,
+                    };
                     Ok(Some(adapted))
                 }
                 Err(e) => Err(handle_iceberg_error(e)),

--- a/crates/data_components/tests/hadoop_catalog_test.rs
+++ b/crates/data_components/tests/hadoop_catalog_test.rs
@@ -521,7 +521,7 @@ mod tests {
             let catalog = Arc::new(catalog) as Arc<dyn Catalog>;
 
             let provider =
-                IcebergCatalogProvider::try_new(Arc::clone(&catalog), None, Some(&glob_set))
+                IcebergCatalogProvider::try_new(Arc::clone(&catalog), None, Some(&glob_set), None)
                     .await
                     .expect("Should create provider");
 
@@ -568,7 +568,7 @@ mod tests {
             );
 
             // recreate provider with no includes
-            let provider = IcebergCatalogProvider::try_new(catalog, None, None)
+            let provider = IcebergCatalogProvider::try_new(catalog, None, None, None)
                 .await
                 .expect("Should create provider without includes");
 

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -30,9 +30,32 @@ use data_components::{
             hadoop::{HadoopCatalogBuilder, MetadataMode},
             rest::RestCatalog,
         },
-        provider::IcebergCatalogProvider,
+        provider::{CatalogTableWrapper, IcebergCatalogProvider},
     },
 };
+use datafusion::catalog::TableProvider;
+use datafusion::sql::TableReference;
+
+use crate::dataconnector::iceberg_cluster::IcebergClusterTableProvider;
+
+/// Builds the hook that makes catalog-sourced Iceberg scans serializable for
+/// distributed (Ballista) execution.
+///
+/// Each loaded table provider is wrapped in an [`IcebergClusterTableProvider`]
+/// keyed by its fully-qualified `catalog.schema.table` reference — mirroring the
+/// single-dataset Iceberg data connector, which wraps every dataset the same
+/// way. All three parts are qualified because a remote executor resolves the
+/// recipe's reference through `get_table_sync`, which needs the catalog and
+/// schema to locate this provider. In a single-node session the wrapper is a
+/// transparent pass-through, so non-distributed catalogs are unaffected.
+fn cluster_table_wrapper(catalog_name: &str) -> CatalogTableWrapper {
+    let catalog_name = catalog_name.to_string();
+    Arc::new(move |schema: &str, table: &str, provider| {
+        let table_ref =
+            TableReference::full(catalog_name.clone(), schema.to_string(), table.to_string());
+        Arc::new(IcebergClusterTableProvider::new(table_ref, provider)) as Arc<dyn TableProvider>
+    })
+}
 use iceberg::{CatalogBuilder, Namespace, NamespaceIdent, io::StorageFactory};
 use iceberg_catalog_rest::{
     REST_CATALOG_PROP_URI, RestCatalog as IcebergRestCatalog, RestCatalogBuilder,
@@ -115,6 +138,7 @@ impl IcebergCatalog {
         s3_credential_loader: Option<CustomAwsCredentialLoader>,
         catalog: &Catalog,
         catalog_id: &str,
+        table_wrapper: Option<CatalogTableWrapper>,
     ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
         let operator = build_opendal_operator(catalog_id, &props).map_err(|e| {
             super::Error::InvalidConfiguration {
@@ -163,6 +187,7 @@ impl IcebergCatalog {
             Arc::new(hadoop_catalog),
             None,
             catalog.include.as_ref(),
+            table_wrapper,
         )
         .await
         .map_err(|e| super::Error::UnableToGetCatalogProvider {
@@ -321,6 +346,10 @@ impl CatalogConnector for IcebergCatalog {
             );
         };
 
+        // Wrap every catalog table so its scans serialize for distributed
+        // execution, mirroring the single-dataset Iceberg connector.
+        let table_wrapper = Some(cluster_table_wrapper(&catalog.name));
+
         let mut props = HashMap::new();
         for (key, value) in &self.params {
             if let Some(prop_vec) = map_param_name_to_iceberg_prop(key.as_str()) {
@@ -385,6 +414,7 @@ impl CatalogConnector for IcebergCatalog {
                 s3_credential_loader,
                 catalog,
                 &catalog_id,
+                table_wrapper,
             )
             .await;
         }
@@ -418,6 +448,7 @@ impl CatalogConnector for IcebergCatalog {
             Arc::new(catalog_client),
             namespace.map(|n| n.name().clone()),
             catalog.include.as_ref(),
+            table_wrapper,
         )
         .await
         .map_err(|e| super::Error::UnableToGetCatalogProvider {

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -113,9 +113,7 @@ use runtime_acceleration::snapshot::AccelerationLayout;
 ))]
 use runtime_acceleration::snapshot::SnapshotManager;
 use runtime_async::ManagedTokioRuntime;
-use runtime_datafusion::{
-    query_engine::Error as QueryEngineError, schema_provider::SpiceSchemaProvider,
-};
+use runtime_datafusion::query_engine::Error as QueryEngineError;
 use runtime_datafusion_index::IndexedTableProvider;
 use runtime_table_partition::provider::PartitionTableProvider;
 use schema::ensure_schema_exists;
@@ -157,6 +155,7 @@ pub mod secrets_context_extension;
 pub mod table;
 pub use runtime_datafusion::sort_columns;
 pub(crate) mod sql_validator;
+pub(crate) mod sync_table;
 pub mod tool_udf;
 pub mod udf;
 pub mod udtf;
@@ -944,9 +943,11 @@ impl DataFusion {
 
         let schema_provider = Self::resolve_schema_provider(&catalog_provider, table_reference)?;
 
-        let spice_schema_provider = schema_provider.downcast_ref::<SpiceSchemaProvider>()?;
-
-        spice_schema_provider.table_sync(table_reference.table())
+        // Centralized synchronous resolution: handles every schema-provider type
+        // that caches its tables (`SpiceSchemaProvider`, the Iceberg catalog's
+        // `IcebergSchemaProvider`, …). See `sync_table` for how to extend it to
+        // another catalog.
+        sync_table::resolve_table_sync(schema_provider.as_ref(), table_reference.table())
     }
 
     /// Register a table with its [`SchemaProvider`] if it exists and marks it as writable.

--- a/crates/runtime/src/datafusion/sync_table.rs
+++ b/crates/runtime/src/datafusion/sync_table.rs
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Synchronous table resolution for cache-backed schema providers.
+//!
+//! `DataFusion`'s [`SchemaProvider::table`] is async, but some paths need a table
+//! provider with no async context and without blocking on catalog I/O — most
+//! importantly distributed-plan deserialization on a remote executor, which
+//! rebuilds a registered Iceberg scan during (synchronous) decode.
+//!
+//! A schema provider may opt into synchronous resolution by implementing
+//! [`SyncTableProvider`] — only sound when its tables are cached in memory.
+//! [`resolve_table_sync`] is the single place that views a `dyn SchemaProvider`
+//! as that capability, so callers never repeat the downcast chain.
+//!
+//! # Adding another catalog
+//!
+//! To make another catalog's tables resolvable synchronously, implement
+//! [`SyncTableProvider`] for its schema provider and add one entry to
+//! [`SYNC_CASTS`]. Note this is only possible for providers that cache their
+//! tables; providers that fetch table metadata lazily (over the network) cannot
+//! offer synchronous access without first caching.
+
+use std::sync::Arc;
+
+use data_components::iceberg::provider::IcebergSchemaProvider;
+use datafusion::catalog::{SchemaProvider, TableProvider};
+use runtime_datafusion::schema_provider::SpiceSchemaProvider;
+
+/// A [`SchemaProvider`] whose tables are cached and can therefore be resolved
+/// synchronously (no async, no catalog I/O).
+pub(crate) trait SyncTableProvider {
+    /// Look up a table by name from the provider's in-memory cache.
+    fn sync_table(&self, name: &str) -> Option<Arc<dyn TableProvider>>;
+}
+
+impl SyncTableProvider for SpiceSchemaProvider {
+    fn sync_table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        self.table_sync(name)
+    }
+}
+
+impl SyncTableProvider for IcebergSchemaProvider {
+    fn sync_table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        self.table_sync(name)
+    }
+}
+
+/// Views a `dyn SchemaProvider` as a [`SyncTableProvider`] when its concrete
+/// type supports synchronous resolution. One entry per supporting type — this
+/// list is the single extension point for adding a catalog's synchronous tables.
+///
+/// `downcast_ref` is called directly on the trait object: in `DataFusion` 54
+/// `Any` is a supertrait of `SchemaProvider` (and `as_any` was removed).
+type SyncCast = fn(&dyn SchemaProvider) -> Option<&dyn SyncTableProvider>;
+const SYNC_CASTS: &[SyncCast] = &[
+    |s| {
+        s.downcast_ref::<SpiceSchemaProvider>()
+            .map(|p| p as &dyn SyncTableProvider)
+    },
+    |s| {
+        s.downcast_ref::<IcebergSchemaProvider>()
+            .map(|p| p as &dyn SyncTableProvider)
+    },
+];
+
+/// Resolve table `name` synchronously from `schema_provider`, or `None` if the
+/// provider does not support synchronous access (see [`SyncTableProvider`]).
+///
+/// This is the centralized entry point: anything that needs a table without an
+/// async context calls here rather than matching on schema-provider types.
+pub(crate) fn resolve_table_sync(
+    schema_provider: &dyn SchemaProvider,
+    name: &str,
+) -> Option<Arc<dyn TableProvider>> {
+    SYNC_CASTS
+        .iter()
+        .find_map(|cast| cast(schema_provider))
+        .and_then(|sync| sync.sync_table(name))
+}

--- a/crates/runtime/tests/cluster/distributed_iceberg.rs
+++ b/crates/runtime/tests/cluster/distributed_iceberg.rs
@@ -1,0 +1,268 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Distributed (Ballista) integration tests for Iceberg scans, covering **both**
+//! the Iceberg *data connector* (a single `datasets` entry) and the Iceberg
+//! *catalog connector* (a `catalogs` entry).
+//!
+//! # What this guards against
+//!
+//! Iceberg's `IcebergTableScan` holds a live, non-serializable `Table`, so it
+//! cannot cross a Ballista node boundary. PR #11378 fixed this for the **data
+//! connector** by wrapping every Iceberg provider in an
+//! `IcebergClusterTableProvider`, whose scan emits a serializable
+//! `IcebergScanExec` in a distributed session. Catalog-sourced tables, however,
+//! are built on a different path (`IcebergCatalogProvider` →
+//! `IcebergSchemaProvider`) that never applied the wrapper, so a distributed
+//! query over a catalog table failed during plan serialization with:
+//!
+//! ```text
+//! DataFusion error: Internal error: Unsupported plan and extension codec failed
+//! with [Internal error: unsupported plan type: IcebergTableScan { table: Table {
+//! file_io: FileIO ... }]
+//! ```
+//!
+//! The catalog connector now installs the same wrapper, and `get_table_sync`
+//! resolves the catalog's `IcebergSchemaProvider` so a remote executor can
+//! reconstruct the scan. The catalog test below is the direct regression for
+//! that gap; the dataset test guards that the (already-working) data-connector
+//! path keeps working through the cluster.
+//!
+//! # Credentials
+//!
+//! Like the rest of the Iceberg suite, these tests read a Glue/S3 fixture and
+//! require `AWS_ICEBERG_ACCOUNT_ID`, `AWS_ICEBERG_REGION`,
+//! `AWS_ICEBERG_ACCESS_KEY_ID`, and `AWS_ICEBERG_SECRET_ACCESS_KEY`. They skip
+//! (and pass) when `AWS_ICEBERG_ACCOUNT_ID` is unset, so a local `cargo test`
+//! without credentials is not a spurious failure; CI provides the credentials.
+
+use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
+use std::time::Duration;
+
+use app::AppBuilder;
+use arrow::array::RecordBatch;
+use futures::FutureExt;
+use spicepod::component::catalog::Catalog;
+use spicepod::component::dataset::Dataset;
+use spicepod::param::Params;
+
+use crate::{configure_test_datafusion, init_tracing, utils::test_request_context};
+
+use super::harness::ClusterHarness;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// The Glue account id for the shared Iceberg test fixture, or `None` when the
+/// credentials are not configured (so the test skips instead of failing).
+fn iceberg_account_id() -> Option<String> {
+    std::env::var("AWS_ICEBERG_ACCOUNT_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// S3 storage params resolved from the environment, shared by the dataset and
+/// catalog components.
+fn iceberg_s3_params() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            "iceberg_s3_region".to_string(),
+            "${ env:AWS_ICEBERG_REGION }".to_string(),
+        ),
+        (
+            "iceberg_s3_access_key_id".to_string(),
+            "${ env:AWS_ICEBERG_ACCESS_KEY_ID }".to_string(),
+        ),
+        (
+            "iceberg_s3_secret_access_key".to_string(),
+            "${ env:AWS_ICEBERG_SECRET_ACCESS_KEY }".to_string(),
+        ),
+    ])
+}
+
+/// A Glue-backed Iceberg `Catalog` component scoped to the test namespaces.
+fn make_iceberg_catalog(account_id: &str, catalog_name: &str) -> Catalog {
+    let mut catalog = Catalog::new(
+        format!(
+            "iceberg:https://glue.ap-northeast-2.amazonaws.com/iceberg/v1/catalogs/{account_id}/namespaces"
+        ),
+        catalog_name.to_string(),
+    );
+    catalog.include = vec!["testdb_001.*".to_string(), "testdb_002.*".to_string()];
+    catalog.params = Some(Params::from_string_map(iceberg_s3_params()));
+    catalog
+}
+
+/// A single-table Iceberg `Dataset` component (the data-connector path).
+fn make_iceberg_dataset(account_id: &str, namespace: &str, table: &str, name: &str) -> Dataset {
+    let from = format!(
+        "iceberg:https://glue.ap-northeast-2.amazonaws.com/iceberg/v1/catalogs/{account_id}/namespaces/{namespace}/tables/{table}"
+    );
+    let mut dataset = Dataset::new(from, name.to_string());
+    dataset.params = Some(Params::from_string_map(iceberg_s3_params()));
+    dataset
+}
+
+/// Total number of rows across all batches.
+fn total_rows(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(RecordBatch::num_rows).sum()
+}
+
+/// Run a test body against a [`ClusterHarness`], ensuring shutdown even on an
+/// early `Err` or panic (mirrors the cayenne catalog cluster tests).
+async fn run_with_harness<F>(harness: ClusterHarness, f: F) -> Result<(), anyhow::Error>
+where
+    F: for<'a> FnOnce(
+        &'a ClusterHarness,
+    )
+        -> Pin<Box<dyn std::future::Future<Output = Result<(), anyhow::Error>> + 'a>>,
+{
+    let result = AssertUnwindSafe(f(&harness)).catch_unwind().await;
+    harness.shutdown().await;
+    match result {
+        Ok(inner) => inner,
+        Err(panic_payload) => std::panic::resume_unwind(panic_payload),
+    }
+}
+
+// =============================================================================
+// Test: distributed scan of an Iceberg *catalog* table
+// =============================================================================
+//
+// Direct regression for the catalog-path wrapper gap. Without the fix the
+// scheduler fails to serialize the catalog table's `IcebergTableScan` for the
+// executor and the query errors with "unsupported plan type: IcebergTableScan".
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
+async fn test_distributed_iceberg_catalog_scan() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    let Some(account_id) = iceberg_account_id() else {
+        tracing::warn!(
+            "skipping test_distributed_iceberg_catalog_scan: AWS_ICEBERG_ACCOUNT_ID not set"
+        );
+        return Ok(());
+    };
+
+    test_request_context()
+        .scope(async move {
+            configure_test_datafusion();
+
+            let catalog = make_iceberg_catalog(&account_id, "ice_glue");
+
+            let harness = ClusterHarness::builder()
+                .scheduler(
+                    AppBuilder::new("distributed_iceberg_catalog")
+                        .with_catalog(catalog.clone())
+                        .build(),
+                )
+                .executor_with_app(
+                    AppBuilder::new("executor_iceberg_catalog")
+                        .with_catalog(catalog)
+                        .build(),
+                )
+                .start()
+                .await?;
+
+            run_with_harness(harness, |harness| {
+                Box::pin(async move {
+                    harness.wait_for_executors(Duration::from_secs(30)).await?;
+
+                    let sql = "SELECT * FROM ice_glue.testdb_001.iceberg_table_001 LIMIT 10";
+
+                    // EXPLAIN must plan cleanly through the scheduler's
+                    // distributed context (this is where the unserializable
+                    // scan previously surfaced).
+                    let _ = harness.explain(sql).await?;
+
+                    // The scan is shipped to the executor and re-planned there;
+                    // a successful, non-empty result proves the catalog table's
+                    // scan now serializes and round-trips across the cluster.
+                    let batches = harness.query(sql).await?;
+                    assert!(
+                        total_rows(&batches) > 0,
+                        "distributed catalog scan returned no rows"
+                    );
+
+                    Ok(())
+                })
+            })
+            .await
+        })
+        .await
+}
+
+// =============================================================================
+// Test: distributed scan of an Iceberg *dataset* (data connector)
+// =============================================================================
+//
+// Guards that the data-connector path (the original PR #11378 fix) keeps
+// working through the cluster, alongside the new catalog path.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
+async fn test_distributed_iceberg_dataset_scan() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    let Some(account_id) = iceberg_account_id() else {
+        tracing::warn!(
+            "skipping test_distributed_iceberg_dataset_scan: AWS_ICEBERG_ACCOUNT_ID not set"
+        );
+        return Ok(());
+    };
+
+    test_request_context()
+        .scope(async move {
+            configure_test_datafusion();
+
+            let dataset = make_iceberg_dataset(&account_id, "tpch_sf1", "customer", "customer");
+
+            let harness = ClusterHarness::builder()
+                .scheduler(
+                    AppBuilder::new("distributed_iceberg_dataset")
+                        .with_dataset(dataset.clone())
+                        .build(),
+                )
+                .executor_with_app(
+                    AppBuilder::new("executor_iceberg_dataset")
+                        .with_dataset(dataset)
+                        .build(),
+                )
+                .start()
+                .await?;
+
+            run_with_harness(harness, |harness| {
+                Box::pin(async move {
+                    harness.wait_for_executors(Duration::from_secs(30)).await?;
+
+                    let sql = "SELECT * FROM customer LIMIT 10";
+                    let _ = harness.explain(sql).await?;
+
+                    let batches = harness.query(sql).await?;
+                    assert!(
+                        total_rows(&batches) > 0,
+                        "distributed dataset scan returned no rows"
+                    );
+
+                    Ok(())
+                })
+            })
+            .await
+        })
+        .await
+}

--- a/crates/runtime/tests/cluster/mod.rs
+++ b/crates/runtime/tests/cluster/mod.rs
@@ -17,6 +17,8 @@ limitations under the License.
 mod cancel_tasks;
 mod distributed_acceleration;
 mod distributed_cayenne_catalog;
+#[cfg(not(target_os = "windows"))]
+mod distributed_iceberg;
 mod distributed_task_history;
 pub mod harness;
 mod in_memory_shuffle;


### PR DESCRIPTION
## Summary

Follow-up to #11378, which enabled distributed (Ballista) scans of Iceberg **datasets** but not Iceberg tables exposed through a **catalog** (`catalogs:`). A distributed query over a catalog-sourced Iceberg table fails during plan serialization on the scheduler:

```
DataFusion error: Internal error: Unsupported plan and extension codec failed
with [Internal error: unsupported plan type: IcebergTableScan { table: Table {
file_io: FileIO ... }]
```

Root cause: `IcebergTableScan` holds a live, non-serializable `Table`. #11378 fixed this for the data connector by wrapping the provider in `IcebergClusterTableProvider` (whose `scan()` emits a serializable `IcebergScanExec` in a distributed session). Catalog tables take a separate path (`IcebergCatalogProvider` → `IcebergSchemaProvider`) that never applied the wrapper, so the raw scan reached the codec.

## What changed

**A. Wrap catalog leaf tables.** `data_components` can't reference the runtime's `IcebergClusterTableProvider`, so `IcebergCatalogProvider` gains an optional `CatalogTableWrapper` hook, threaded through schema/table loading and reapplied on refresh. The Iceberg **catalog connector** injects a closure that wraps each loaded table in `IcebergClusterTableProvider`, keyed by its fully-qualified `catalog.schema.table` reference (the executor resolves the recipe by that reference). It's a transparent pass-through in single-node sessions, exactly like the data-connector path.

**B. Resolve catalog tables on the executor.** Distributed decode reconstructs the scan via `DataFusion::get_table_sync`, which previously only handled `SpiceSchemaProvider`. Catalog schemas are `IcebergSchemaProvider`. Instead of adding another inline downcast, synchronous resolution is centralized in a new `datafusion::sync_table` module:

- a `SyncTableProvider` capability trait (implemented for `SpiceSchemaProvider` and `IcebergSchemaProvider`, both backed by an in-memory table cache), and
- `resolve_table_sync(&dyn SchemaProvider, name)`, which dispatches through a single extension list.

`get_table_sync` becomes a one-line delegation. Adding another **cache-backed** catalog is one trait impl + one list entry. (Lazy/network catalogs — Glue, Unity, Postgres, Snowflake — fetch metadata on demand and can't serve tables synchronously without first caching; they simply don't opt in.)

The codec decode path is unchanged: `concrete_iceberg_provider` already peels the `IcebergDeletionProvider` that catalog tables are wrapped in.

## Testing

- `crates/runtime/tests/cluster/distributed_iceberg.rs`: cluster-harness integration tests covering **both** the catalog and dataset connector paths (distributed `SELECT` through scheduler → executor). Consistent with the rest of the Iceberg suite, they read a Glue/S3 fixture and require `AWS_ICEBERG_*` credentials; they skip cleanly when unset so a local `cargo test` without credentials is not a spurious failure.
- `cargo check` clean for `data_components`, `runtime`, and all test targets.
- `make lint-rust` validation in progress.
