### PR TITLE
feat(views): support params.file_format for embedding chunking

### DIFF
--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -42,6 +42,7 @@ pub struct View {
     pub ready_state: ReadyState,
     pub runtime: Arc<Runtime>,
     pub vectors: Option<VectorStore>,
+    pub params: HashMap<String, String>,
     pub app: Arc<App>,
 }
 
@@ -53,6 +54,7 @@ impl PartialEq for View {
             && self.columns == other.columns
             && self.acceleration == other.acceleration
             && self.vectors == other.vectors
+            && self.params == other.params
             && self.ready_state == other.ready_state
     }
 }
@@ -67,6 +69,7 @@ impl std::fmt::Debug for View {
             .field("acceleration", &self.acceleration)
             .field("ready_state", &self.ready_state)
             .field("vectors", &self.vectors)
+            .field("params", &self.params)
             .finish_non_exhaustive()
     }
 }
@@ -165,6 +168,7 @@ pub struct ViewBuilder {
     pub acceleration: Option<acceleration::Acceleration>,
     pub ready_state: ReadyState,
     pub vectors: Option<VectorStore>,
+    pub params: HashMap<String, String>,
 }
 
 impl TryFrom<spicepod_view::View> for ViewBuilder {
@@ -219,6 +223,11 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
             acceleration,
             ready_state: ReadyState::from(view.ready_state),
             vectors: view.vectors,
+            params: view
+                .params
+                .as_ref()
+                .map(spicepod::param::Params::as_string_map)
+                .unwrap_or_default(),
         })
     }
 }
@@ -278,6 +287,7 @@ impl ViewBuilder {
             acceleration: None,
             ready_state: ReadyState::default(),
             vectors: None,
+            params: HashMap::default(),
         }
     }
 
@@ -291,6 +301,7 @@ impl ViewBuilder {
             acceleration: self.acceleration,
             ready_state: self.ready_state,
             vectors: self.vectors,
+            params: self.params,
             runtime,
             app,
         }

--- a/crates/runtime/src/view.rs
+++ b/crates/runtime/src/view.rs
@@ -112,6 +112,7 @@ pub(crate) async fn prepare_view(
 
     // Add any embedding columns (and vector engine, if applicable)
     if view.has_embeddings() {
+        let file_format = view.params.get("file_format").map(String::as_str);
         if let Some(ref vectors) = view.vectors
             && vectors.enabled
         {
@@ -121,7 +122,7 @@ pub(crate) async fn prepare_view(
                 &view.runtime.secrets(),
                 &view.name,
                 &view.columns,
-                None,
+                file_format,
                 tbl_provider,
                 vectors,
             )
@@ -144,7 +145,7 @@ pub(crate) async fn prepare_view(
                     })
                     .collect(),
                 &view.runtime.embeds(),
-                None, // TODO handle file formats: `view.params.get("file_format").map(String::as_str)`.
+                file_format,
             )
             .await
             .boxed()

--- a/crates/spicepod/src/component/view.rs
+++ b/crates/spicepod/src/component/view.rs
@@ -23,8 +23,8 @@ use serde_json::Value;
 
 use super::{Nameable, WithDependsOn, dataset::ReadyState, is_default};
 use crate::{
-    acceleration::Acceleration, metadata::metadata_value_to_string, semantic::Column,
-    vector::VectorStore,
+    acceleration::Acceleration, metadata::metadata_value_to_string, param::Params,
+    semantic::Column, vector::VectorStore,
 };
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
@@ -58,6 +58,9 @@ pub struct View {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vectors: Option<VectorStore>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Params>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "dependsOn", default)]
     pub depends_on: Vec<String>,
@@ -83,6 +86,7 @@ impl View {
             ready_state: ReadyState::default(),
             depends_on: Vec::default(),
             vectors: None,
+            params: None,
         }
     }
 
@@ -137,7 +141,42 @@ impl WithDependsOn<View> for View {
             acceleration: self.acceleration.clone(),
             ready_state: self.ready_state,
             vectors: self.vectors.clone(),
+            params: self.params.clone(),
             depends_on: depends_on.to_vec(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_params_with_file_format() {
+        let yaml = r"
+name: my_view
+sql: SELECT body FROM docs
+params:
+  file_format: md
+";
+        let view: View = yaml::from_str(yaml).expect("view should deserialize");
+        let params = view.params.expect("params should be present");
+        assert_eq!(
+            params
+                .as_string_map()
+                .get("file_format")
+                .map(String::as_str),
+            Some("md")
+        );
+    }
+
+    #[test]
+    fn params_defaults_to_none_when_absent() {
+        let yaml = r"
+name: my_view
+sql: SELECT body FROM docs
+";
+        let view: View = yaml::from_str(yaml).expect("view should deserialize");
+        assert!(view.params.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Resolves the TODO at `crates/runtime/src/view.rs` — views had no general `params` field, so `file_format` could not be passed into embedding chunking. This adds a `params` bag to views (mirroring datasets) and wires `params.file_format` through to the chunking config.

Closes #8268

## Changes

- **`crates/spicepod/src/component/view.rs`**: add `params: Option<Params>` to the spicepod `View` (mirrors `Dataset`), threaded through `new()` and `WithDependsOn`.
- **`crates/runtime/src/component/view.rs`**: add `params: HashMap<String, String>` to the runtime `View`/`ViewBuilder`; resolve from the spicepod `Params` via `as_string_map()` in `TryFrom`, exactly like the dataset builder. Included in `PartialEq`/`Debug`.
- **`crates/runtime/src/view.rs`**: in `prepare_view`, derive `file_format` from `view.params.get("file_format")` and pass it into both the `wrap_table_as_index` (vector-engine) and `EmbeddingTable::from_spicepod_columns` (plain embedding) paths.

## Notes

- This is a generic `params` bag, so future view-level params beyond `file_format` are supported for free.
- No secret interpolation at view-build time — consistent with datasets; `file_format` is a literal string.
- The generated `.schema/spicepod.schema.json` is regenerated automatically by the `Generate Spicepod JSON schema` workflow on merge to `trunk`.

## Testing

- Added unit tests in the spicepod view module covering `params.file_format` deserialization and the absent-params default.