### PR TITLE
fix(deps): evict rustls 0.21 / rustls-webpki 0.101.7 (GHSA-82j2-j2ch-gfr8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,23 +1935,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
  "h2 0.4.14",
- "http 0.2.12",
  "http 1.4.1",
- "http-body 0.4.6",
- "hyper 0.14.32",
  "hyper 1.10.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tracing",
 ]
@@ -7683,7 +7677,7 @@ dependencies = [
  "futures",
  "http 1.4.1",
  "parking_lot 0.12.5",
- "rustls-native-certs 0.8.4",
+ "rustls-native-certs",
  "secrecy",
  "snafu",
  "tokio",
@@ -9319,21 +9313,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -9342,10 +9321,10 @@ dependencies = [
  "hyper 1.10.1",
  "hyper-util",
  "log",
- "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.7",
 ]
@@ -11786,7 +11765,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.4",
  "rustc_version_runtime",
- "rustls 0.23.40",
+ "rustls",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -11799,7 +11778,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-openssl",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "typed-builder 0.22.0",
  "uuid 1.23.2",
@@ -12794,7 +12773,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonwebtoken 10.4.0",
@@ -13830,11 +13809,11 @@ dependencies = [
  "bytes",
  "hmac 0.12.1",
  "rand 0.9.4",
- "rustls 0.23.40",
+ "rustls",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "webpki-roots 0.26.11",
@@ -14821,7 +14800,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls 0.23.40",
+ "rustls",
  "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
@@ -14842,7 +14821,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -15661,7 +15640,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
@@ -15672,8 +15651,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -15681,7 +15660,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -15711,7 +15690,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -15719,14 +15698,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -16178,7 +16157,7 @@ dependencies = [
  "runtime-secrets",
  "runtime-table-partition",
  "rusqlite",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pemfile 2.2.0",
  "s3_vectors",
  "scheduler",
@@ -16207,7 +16186,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-rusqlite",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -16798,18 +16777,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -16819,21 +16786,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -16887,10 +16842,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -16902,16 +16857,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -17220,16 +17165,6 @@ dependencies = [
  "pbkdf2 0.12.2",
  "salsa20",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -18278,8 +18213,8 @@ dependencies = [
  "prost-types",
  "rand 0.9.4",
  "reqwest 0.12.24",
- "rustls 0.23.40",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -18335,7 +18270,7 @@ dependencies = [
  "runtime-async",
  "runtime-auth",
  "runtime-datafusion",
- "rustls 0.23.40",
+ "rustls",
  "snafu",
  "snmalloc-rs",
  "spice-cloud",
@@ -18445,7 +18380,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.24",
  "runtime-secrets",
- "rustls 0.23.40",
+ "rustls",
  "serde",
  "serde_json",
  "spice-cloud-client",
@@ -19420,7 +19355,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.24",
  "rstest 0.26.1",
- "rustls 0.23.40",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -19584,7 +19519,7 @@ dependencies = [
  "once_cell",
  "pulldown-cmark 0.12.2",
  "regex",
- "rustls 0.23.40",
+ "rustls",
  "strum 0.26.3",
  "thiserror 2.0.18",
  "tiktoken-rs 0.6.0",
@@ -19655,8 +19590,7 @@ dependencies = [
 [[package]]
 name = "tiberius"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
+source = "git+https://github.com/spiceai/tiberius?rev=9ae93c65222b51b0579945ffce5cba053cb23cca#9ae93c65222b51b0579945ffce5cba053cb23cca"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -19671,10 +19605,9 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pretty-hex",
- "rustls-native-certs 0.6.3",
- "rustls-pemfile 1.0.4",
+ "rustls-native-certs",
  "thiserror 1.0.69",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "uuid 1.23.2",
@@ -20012,21 +19945,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls",
  "tokio",
 ]
 
@@ -20201,11 +20124,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs 0.8.4",
+ "rustls-native-certs",
  "socket2 0.6.4",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.5.3",
  "tower-layer",
@@ -21255,7 +21178,7 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,17 +126,20 @@ async-trait = "0.1.89"
 aws-config = "1.8.17"
 aws-credential-types = "1.2.13"
 aws-runtime = "1.7.1"
-aws-sdk-bedrockruntime = "1.132.0"
-aws-sdk-cognitoidentity = "1.101.0"
-aws-sdk-cognitoidentityprovider = "1.118.0"
-aws-sdk-dynamodb = "1.115.0"
-aws-sdk-ec2 = "1.113.0"
-aws-sdk-dynamodbstreams = "1.101.0"
-aws-sdk-glue = "1.149.0"
-aws-sdk-s3 = "1.134.0"
-aws-sdk-s3vectors = "1.26.0"
-aws-sdk-secretsmanager = "1.106.0"
-aws-sdk-sts = "1.105.0"
+# aws-sdk-* default features include both `rustls` (legacy aws-smithy-runtime/tls-rustls
+# connector → rustls 0.21) and `default-https-client` (modern rustls-aws-lc → rustls 0.23).
+# Drop `rustls` (keep `default-https-client`) so only the modern rustls 0.23 connector is built.
+aws-sdk-bedrockruntime = { version = "1.132.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-cognitoidentity = { version = "1.101.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-cognitoidentityprovider = { version = "1.118.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-dynamodb = { version = "1.115.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-ec2 = { version = "1.113.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-dynamodbstreams = { version = "1.101.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-glue = { version = "1.149.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-s3 = { version = "1.134.0", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
+aws-sdk-s3vectors = { version = "1.26.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-secretsmanager = { version = "1.106.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-sts = { version = "1.105.0", default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
 aws-smithy-async = "1.2.14"
 aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
@@ -306,11 +309,11 @@ sysinfo = "0.38.4"
 system-adapter-protocol = { git = "https://github.com/spiceai/spicebench.git", rev = "6c00cb7e811a51d8b22191bac798f49b76e779ad", features = ["client", "server"] }
 tantivy = "0.26.0"
 tempfile = "3"
-tiberius = { version = "0.12.3", default-features = false, features = [
+tiberius = { git = "https://github.com/spiceai/tiberius", rev = "9ae93c65222b51b0579945ffce5cba053cb23cca", default-features = false, features = [
     "tds73",
     "rustls",
     "chrono",
-] }
+] } # spiceai branch
 tokenizers = "0.21.2"
 tokio = { version = "1", features = [
     "io-std",


### PR DESCRIPTION
## Evict rustls 0.21 / rustls-webpki 0.101.7

`rustls-webpki 0.101.7` (GHSA-82j2-j2ch-gfr8 / RUSTSEC-2026-0104, plus the name-constraint advisories GHSA-965h / GHSA-xgp8) stayed in `Cargo.lock` alongside the patched `0.103.13` because `rustls 0.21.12` was still pulled in. A Dependabot alert clears only when **no** copy is in range, so both copies had to go. `rustls 0.21` had **two independent roots**, both addressed here:

### 1. AWS SDK
Every `aws-sdk-*` crate's `default` feature set includes **both** connectors:
- `rustls` → `aws-smithy-runtime/tls-rustls` → `legacy-rustls-ring` → hyper-rustls 0.24 → **rustls 0.21**
- `default-https-client` → `aws-smithy-http-client/rustls-aws-lc` → hyper-rustls 0.27 → **rustls 0.23**

`aws-config`'s own default already uses only the modern connector; the legacy copy came from the individual SDK clients. Each `aws-sdk-*` is now `default-features = false` with its defaults re-listed **minus `rustls`** (keeping `default-https-client`, `rt-tokio`; `s3` also keeps `sigv4a`+`http-1x`, `sts` keeps `sigv4a`). The modern HTTPS connector is still bundled, so client construction (including `Config::builder()` paths) is unchanged at runtime.

### 2. MSSQL (tiberius)
`tiberius 0.12.3` pins `tokio-rustls 0.24` → `rustls 0.21` and has no upstream rustls-0.23 release. Repointed to the **`spiceai/tiberius`** fork's `spiceai` branch, which carries the rustls-0.23 stack (port of [prisma/tiberius#419](https://github.com/prisma/tiberius/pull/419): tokio-rustls 0.26, rustls 0.23, rustls-native-certs 0.8, aws-lc-rs provider).

### Result
`Cargo.lock` rustls family is now single-version: **rustls 0.23.40**, **rustls-webpki 0.103.13**, **tokio-rustls 0.26.4**, **hyper-rustls 0.27.9** — no `rustls 0.21` / `rustls-webpki 0.101.7`. Lockfile-only + dependency-feature changes; `cargo check` passes for `aws-sdk-credential-bridge`, `s3_vectors`, `dynamodb-streams`, `runtime-secrets`, and `connector-mssql`. CI/integration tests validate live S3/Glue/DynamoDB/Bedrock/MSSQL connectivity.
