### PR TITLE
Bump datafusion: better hash-join build-side selection for multi-column / computed keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5592,7 +5592,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5616,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5665,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "futures",
  "log",
@@ -5675,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5712,7 +5712,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5735,7 +5735,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5757,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5828,12 +5828,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5959,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5979,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6027,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6042,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6058,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6067,7 +6067,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "chrono",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6149,7 +6149,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "chrono",
@@ -6179,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6197,7 +6197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6229,7 +6229,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "chrono",
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6270,7 +6270,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6285,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6326,7 +6326,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=15498b4c9cd2807b6df8bc4309229a4fd46793c4#15498b4c9cd2807b6df8bc4309229a4fd46793c4"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5592,7 +5592,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5616,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5665,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "futures",
  "log",
@@ -5675,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5712,7 +5712,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5735,7 +5735,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5757,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5828,12 +5828,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5959,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5979,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6027,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6042,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6058,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6067,7 +6067,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6149,7 +6149,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6179,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6197,7 +6197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6229,7 +6229,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6270,7 +6270,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6285,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6326,7 +6326,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9#33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a6f5bdd8574df970c8ba5dd6d4220aa87a68671a#a6f5bdd8574df970c8ba5dd6d4220aa87a68671a"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,41 +389,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "15498b4c9cd2807b6df8bc4309229a4fd46793c4" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,41 +389,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "33c9881a8ed6b4c6a2691c61d490aafc3cf0bfe9" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "a6f5bdd8574df970c8ba5dd6d4220aa87a68671a" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).


### PR DESCRIPTION
## 📝 Summary

Updates the patched `datafusion` rev to pick up two join-cardinality estimation fixes. Both correct intermediate-join row estimates that were steering `JoinSelection` to the wrong hash-join build side / partition mode, producing slow, memory-heavy plans on analytical queries with composite or expression join keys (observed on CH-benCHmark Q10 and Q18).

- https://github.com/spiceai/datafusion/pull/171/

## Impact 

### Q10 SF100

With corrected estimates, the `customer⋈nation ⋈ oorder` join flips from a single-partition broadcast build of the larger side to a partitioned build of the smaller side — same result rows, far less memory:

| metric (middle join) | before | after |
|---|---|---|
| mode | `CollectLeft` | `Partitioned` |
| build side | customer⋈nation, 3.00M | oorder, 1.02M |
| build memory | **562.9 MB** | **60.8 MB** |
| intermediate output | 11.2 GB | 416.8 MB |
| output rows | 1.02M | 1.02M |

Note: the final `order_line` join and the aggregate/sort above are structurally unchanged and remain the dominant cost, so total wall time is similar — the win here is plan shape and memory headroom, not a guaranteed speedup.

### Q18 SF100

| metric (final join) | before | after |
|---|---|---|
| build side | order_line, 30.16M | oorder⋈customer, 1.02M |
| probe side | oorder⋈customer, 1.02M | order_line, 30.16M |
| **build memory** | **~1.75 GB** | **148.8 MB** (~12×) |
| build time | 6.61s | 28ms |
| join compute | 7.49s | 493ms (~15×) |
| output rows | 10.20M | 10.20M |
| **wall time** | **1.269s** | **0.482s** (~62% faster) |

Building from the 1.02M side instead of the 30.16M fact eliminates the multi-second hash-build; same result, ~15× less join compute and less build memory 

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
