### PR TITLE
fix(udfs): rebind dot_product alias to Spice's inner_product on DataFusion 54

### DIFF
--- a/crates/runtime-datafusion-udfs/src/inner_product.rs
+++ b/crates/runtime-datafusion-udfs/src/inner_product.rs
@@ -34,9 +34,21 @@ use crate::vector_simd::{
 
 pub static INNER_PRODUCT_UDF_NAME: &str = "inner_product";
 
+/// Alias so `dot_product(a, b)` resolves to this UDF.
+///
+/// `DataFusion` 54's built-in `inner_product` declares the same `dot_product`
+/// alias. Spice registers this UDF *after* `DataFusion`'s defaults
+/// (`register_core_scalar_udfs` runs after `with_default_features`), and
+/// `SessionState::register_udf` stores each alias under its own key — so
+/// declaring the alias here makes both `inner_product` and `dot_product`
+/// resolve to this SIMD (`simsimd`) impl rather than `DataFusion`'s scalar
+/// `Float64` fallback.
+pub static DOT_PRODUCT_UDF_ALIAS: &str = "dot_product";
+
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct InnerProduct {
     signature: Signature,
+    aliases: Vec<String>,
 }
 
 impl Default for InnerProduct {
@@ -50,6 +62,7 @@ impl InnerProduct {
     pub fn new() -> Self {
         Self {
             signature: Signature::user_defined(Volatility::Immutable),
+            aliases: vec![DOT_PRODUCT_UDF_ALIAS.to_string()],
         }
     }
 }
@@ -61,6 +74,10 @@ impl ScalarUDFImpl for InnerProduct {
 
     fn signature(&self) -> &Signature {
         &self.signature
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
@@ -86,6 +103,16 @@ mod tests {
     use crate::vector_simd::testing::fsl_f32;
     use arrow::array::AsArray;
     use arrow::datatypes::Float64Type;
+
+    #[test]
+    fn declares_dot_product_alias() {
+        // `dot_product` must resolve to this UDF. DataFusion 54's built-in
+        // `inner_product` also claims this alias, so Spice must declare it to
+        // win the `dot_product` registry key when it overrides the built-in.
+        let udf = InnerProduct::new();
+        assert_eq!(udf.aliases().len(), 1);
+        assert_eq!(udf.aliases()[0], DOT_PRODUCT_UDF_ALIAS);
+    }
 
     #[test]
     fn basic_dot() {

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -833,7 +833,9 @@ fn json_functions() -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use datafusion::arrow::datatypes::DataType;
+    use datafusion::arrow::array::AsArray;
+    use datafusion::arrow::datatypes::{DataType, Float64Type};
+    use datafusion::execution::SessionStateBuilder;
     use datafusion::logical_expr::expr::ScalarFunction;
     use datafusion::logical_expr::{ColumnarValue, Volatility as DataFusionVolatility, create_udf};
     use datafusion::prelude::{Expr, lit};
@@ -842,6 +844,7 @@ mod tests {
         json_as_text_udf, json_contains_udf, json_get_bool_udf, json_get_float_udf,
         json_get_int_udf, json_get_json_udf, json_get_str_udf, json_get_udf, json_length_udf,
     };
+    use runtime_datafusion_udfs::inner_product::DOT_PRODUCT_UDF_ALIAS;
 
     use super::*;
 
@@ -1175,5 +1178,81 @@ mod tests {
             BTreeSet::from([COSINE_DISTANCE_UDF_NAME, INNER_PRODUCT_UDF_NAME, "rand"]),
             "unexpected change to the set of Spice functions pushable to DuckDB"
         );
+    }
+
+    /// Build a `SessionContext` the way `builder.rs` does: `DataFusion` defaults
+    /// first (which, with `nested_expressions`, register `DataFusion` 54's
+    /// `cosine_distance` / `inner_product` / `dot_product`), then Spice's core
+    /// scalar UDFs, which override them by name.
+    fn ctx_like_runtime() -> SessionContext {
+        let state = SessionStateBuilder::new().with_default_features().build();
+        let ctx = SessionContext::new_with_state(state);
+        register_core_scalar_udfs(&ctx);
+        ctx
+    }
+
+    async fn eval_f64(ctx: &SessionContext, sql: &str) -> datafusion::common::Result<f64> {
+        let batches = ctx.sql(sql).await?.collect().await?;
+        Ok(batches[0].column(0).as_primitive::<Float64Type>().value(0))
+    }
+
+    /// Locks in that Spice's `cosine_distance` — not `DataFusion` 54's same-named
+    /// built-in — is the impl bound after registration, and that it keeps the
+    /// `(1 - similarity) / 2` remap to `[0, 1]`. `DataFusion`'s built-in returns
+    /// `1 - similarity` over `[0, 2]`; if it ever shadowed Spice's UDF the
+    /// orthogonal case below would be `1.0` instead of `0.5`, silently changing
+    /// every `vector_search` relevance score (`score = 1 - cosine_distance`).
+    #[tokio::test]
+    async fn cosine_distance_keeps_spice_zero_to_one_semantics() {
+        let ctx = ctx_like_runtime();
+
+        let identical = eval_f64(&ctx, "SELECT cosine_distance([1.0, 0.0], [1.0, 0.0])")
+            .await
+            .expect("cosine_distance over List literals should evaluate");
+        assert!(
+            (identical - 0.0).abs() < 1e-9,
+            "identical vectors must be 0.0, got {identical}"
+        );
+
+        let orthogonal = eval_f64(&ctx, "SELECT cosine_distance([1.0, 0.0], [0.0, 1.0])")
+            .await
+            .expect("cosine_distance over List literals should evaluate");
+        assert!(
+            (orthogonal - 0.5).abs() < 1e-9,
+            "orthogonal vectors must be 0.5 (Spice's [0,1] remap); 1.0 would mean \
+             DataFusion 54's built-in shadowed Spice's cosine_distance, got {orthogonal}"
+        );
+
+        let opposite = eval_f64(&ctx, "SELECT cosine_distance([1.0, 0.0], [-1.0, 0.0])")
+            .await
+            .expect("cosine_distance over List literals should evaluate");
+        assert!(
+            (opposite - 1.0).abs() < 1e-9,
+            "opposite vectors must be 1.0 (top of Spice's [0,1] range), got {opposite}"
+        );
+    }
+
+    /// Locks in that both `inner_product` and its `dot_product` alias resolve to
+    /// Spice's SIMD UDF rather than `DataFusion` 54's built-in. Spice's impl
+    /// accepts only `FixedSizeList<Float32, N>`; `DataFusion`'s accepts
+    /// `List`/`LargeList` of any numeric and would return `11.0` for the call
+    /// below. A `FixedSizeList` coercion error is therefore the discriminator
+    /// that Spice's impl — including for the `dot_product` alias key — is bound.
+    #[tokio::test]
+    async fn inner_product_and_dot_product_bind_to_spice_impl() {
+        let ctx = ctx_like_runtime();
+
+        for name in [INNER_PRODUCT_UDF_NAME, DOT_PRODUCT_UDF_ALIAS] {
+            let err = eval_f64(&ctx, &format!("SELECT {name}([1.0, 2.0], [3.0, 4.0])"))
+                .await
+                .expect_err(&format!(
+                    "{name} over List<Float64> must error — Spice's FixedSizeList<Float32>-only \
+                     impl should be bound, not DataFusion 54's List-accepting built-in"
+                ));
+            assert!(
+                err.to_string().contains("FixedSizeList"),
+                "{name}: expected a FixedSizeList coercion error from Spice's impl, got: {err}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

DataFusion 54 added built-in `cosine_distance` and `inner_product` scalar
functions to its default nested-function set, the latter carrying a
`dot_product` alias. These collide by name with Spice's own vector UDFs.

The runtime builds its `SessionState` with `with_default_features()`
(registering DataFusion's variants) and then calls `register_core_scalar_udfs`,
which overrides `cosine_distance` and `inner_product` by name with Spice's SIMD
(`simsimd`) `FixedSizeList<Float32>` implementations — so those two win.

But `SessionState::register_udf` stores each alias under its **own** key, and
Spice's `InnerProduct` declared no aliases. So DataFusion's `dot_product` alias
survived registration, and `dot_product(...)` silently resolved to DataFusion's
scalar `Float64` implementation instead of Spice's SIMD one.

## Changes

- **Declare the `dot_product` alias on Spice's `InnerProduct`** so both
  `inner_product` and `dot_product` resolve to the SIMD impl (overwriting
  DataFusion's `dot_product` registry key).
- **Add regression tests** that reproduce the runtime's registration order
  (`with_default_features()` then `register_core_scalar_udfs`) and lock in that
  Spice's variants win over DataFusion 54's same-named built-ins:
  - `cosine_distance` keeps its `(1 - similarity) / 2` remap to `[0, 1]`.
    DataFusion's built-in returns `1 - similarity` over `[0, 2]`, which would
    change every `vector_search` relevance score (`score = 1 - cosine_distance`).
  - `inner_product` and `dot_product` bind to the `FixedSizeList<Float32>`-only
    SIMD impl, not DataFusion's `List`-accepting scalar one.

No behavior change for `cosine_distance`/`inner_product` (Spice already won those
by registration order); the only runtime change is `dot_product` now mapping to
Spice's SIMD impl.

## Testing

- `cargo test -p runtime-datafusion-udfs --lib inner_product` — green (4/4,
  including the new `declares_dot_product_alias`).
- `cargo check -p runtime --tests` — green (the two new `udf.rs` regression
  tests compile); full runtime test execution via CI.
- Scoped pedantic clippy on the `runtime-datafusion-udfs` lib — clean.
