### PR TITLE
ci(chbench): move HTAP schedule to dedicated dispatch workflow, add SF1 cron + in-memory tuned configs

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # daily-main, 0900 UTC / 0200 PDT  — full bench suite
     - cron: '0 9 * * *'
-    # htap-sf100, every 3h (0200, 0500, 0800, 1100, 1400, 1700, 2000, 2300) — HTAP CH-benCHmark SF100
-    - cron: '0 2,5,8,11,14,17,20,23 * * *'
-    # htap-sf1000, twice daily (0000, 1200) — HTAP CH-benCHmark SF1000
-    - cron: '0 0,12 * * *'
 
   workflow_dispatch:
     inputs:
@@ -45,10 +41,7 @@ jobs:
   dispatch-scheduled:
     name: Dispatch tests - Scheduled
     runs-on: spiceai-dev-runners
-    # Serial chbench htap dispatch (--max-concurrent 1) blocks this job for the sum of the batch's
-    # run durations; the SF1000 batch (6 variants x up to the 120-min htap cap) can run several
-    # hours, so raise the cap well above GitHub's 6h default. Shorter crons (daily-main, htap-sf100)
-    # finish early — this is only an upper bound.
+    # daily-main dispatches the bench suite (including the chbench bench run) and returns once all child workflows are dispatched
     timeout-minutes: 720
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.scheduled == 'true') }}
     strategy:
@@ -107,8 +100,6 @@ jobs:
         run: |
           case "${{ github.event.schedule }}" in
             '0 9 * * *')               NAME=daily-main ;;
-            '0 2,5,8,11,14,17,20,23 * * *') NAME=htap-sf100 ;;
-            '0 0,12 * * *')            NAME=htap-sf1000 ;;
             *)                         NAME=           ;;   # manual / unrecognized cron — match nothing
           esac
           echo "Resolved schedule name: $NAME"
@@ -239,35 +230,12 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ matrix.branch }}
 
-      # HTAP CH-benCHmark — SF100 fires on its own every-3h cron. --max-concurrent 1 makes the
-      # dispatcher wait for each run to finish before dispatching the next (true serial, no
-      # supersession); --max-concurrent-wait-timeout-mins 180 covers a full run's wall-clock so
-      # the slot wait doesn't give up early. The htap concurrency group is the backstop.
-      - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF100
-        if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'htap-sf100' }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf100 --workflow htap --max-concurrent 1 --max-concurrent-wait-timeout-mins 180
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ matrix.branch }}
-
+      # CH-benCHmark explain-plan bench (no OLTP load) runs with the daily bench suite. The scheduled
+      # HTAP runs (SF1/SF100/SF1000) are part of testoperator_dispatch_htap.yml.
       - name: Dispatch Testoperator - Scheduled CH-BenCHmark Bench - SF100
         if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/sf100 --workflow bench
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ matrix.branch }}
-
-      # SF1000 fires twice daily. --max-concurrent 1 + the long slot-wait timeout serialize the
-      # whole SF1000 variant batch run-by-run (no supersession), and serialize against any still-
-      # draining SF100 run via the shared htap active-run count.
-      - name: Dispatch Testoperator - Scheduled CH-BenCHmark - SF1000
-        if: ${{ matrix.branch == 'trunk' && steps.sched.outputs.name == 'htap-sf1000' }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/chbench/sf1000 --workflow htap --max-concurrent 1 --max-concurrent-wait-timeout-mins 180
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_dispatch_htap.yml
+++ b/.github/workflows/testoperator_dispatch_htap.yml
@@ -1,6 +1,14 @@
 name: testoperator dispatch htap
 
 on:
+  schedule:
+    # htap-sf100, every 3h (0200, 0500, 0800, 1100, 1400, 1700, 2000, 2300) — HTAP CH-benCHmark SF100 (spiceai-dev-xlarge-runners)
+    - cron: '0 2,5,8,11,14,17,20,23 * * *'
+    # htap-sf1000, twice daily (0000, 1200) — HTAP CH-benCHmark SF1000 (spiceai-dev-xlarge-runners)
+    - cron: '0 0,12 * * *'
+    # htap-sf1, twice daily (0600, 1800) — HTAP CH-benCHmark SF1 (spiceai-dev-large-runners)
+    - cron: '0 6,18 * * *'
+
   workflow_dispatch:
     inputs:
       spiced_commit:
@@ -19,10 +27,15 @@ on:
 
 jobs:
   dispatch-htap:
-    name: Dispatch HTAP - ${{ github.event.inputs.scale_factor }}
+    name: Dispatch HTAP - ${{ github.event.inputs.scale_factor || github.event.schedule }}
     runs-on: spiceai-dev-runners
+    # On schedule the dispatcher serializes the batch (--max-concurrent 1) and blocks for the sum of
+    # its run durations; an SF1000 batch can run several hours, so raise the cap above GitHub's 6h.
+    timeout-minutes: 720
+    # Per-cron group on schedule (so the SF1/SF100/SF1000 dispatchers don't block each other),
+    # per-ref on manual dispatch.
     concurrency:
-      group: testoperator-dispatch-htap-${{ github.event.ref }}
+      group: testoperator-dispatch-htap-${{ github.event.schedule || github.event.ref }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -41,7 +54,8 @@ jobs:
         id: setup-spiced
         with:
           spiced_commit: ${{ github.event.inputs.spiced_commit }}
-          ref: ${{ github.event.ref }}
+          # github.event.ref is empty on schedule (cron only runs on the default branch).
+          ref: ${{ github.event.ref || 'refs/heads/trunk' }}
 
       - name: Display spiced commit
         run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
@@ -72,11 +86,35 @@ jobs:
             "$SPICEPOD_VALIDATOR" "$file"
           done
 
-      - name: Dispatch Testoperator - HTAP - CH-BenCHmark - ${{ github.event.inputs.scale_factor }}
+      # On manual dispatch the scale factor comes from the input. On schedule, derive it from the
+      # cron that fired. Scheduled batches also serialize (--max-concurrent 1) so each run finishes
+      # before the next is dispatched; --max-concurrent-wait-timeout-mins covers a full run's
+      # wall-clock so the slot wait doesn't give up early. Manual dispatch keeps the original
+      # fire-and-forget behaviour (no serialization flags).
+      - name: Resolve scale factor
+        id: resolve
         run: |
-          testoperator dispatch ./tools/testoperator/dispatch/chbench/${{ github.event.inputs.scale_factor }} \
-            --workflow htap
+          SF="${{ github.event.inputs.scale_factor }}"
+          FLAGS=""
+          if [ -z "$SF" ]; then
+            case "${{ github.event.schedule }}" in
+              '0 2,5,8,11,14,17,20,23 * * *') SF=sf100 ;;
+              '0 0,12 * * *')                 SF=sf1000 ;;
+              '0 6,18 * * *')                 SF=sf1 ;;
+              *)                              SF= ;;   # unrecognized cron — dispatch nothing
+            esac
+            FLAGS="--max-concurrent 1 --max-concurrent-wait-timeout-mins 180"
+          fi
+          echo "Resolved scale factor: '$SF' (flags: '$FLAGS')"
+          echo "scale_factor=$SF" >> "$GITHUB_OUTPUT"
+          echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch Testoperator - HTAP - CH-BenCHmark - ${{ steps.resolve.outputs.scale_factor }}
+        if: ${{ steps.resolve.outputs.scale_factor != '' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/chbench/${{ steps.resolve.outputs.scale_factor }} \
+            --workflow htap ${{ steps.resolve.outputs.flags }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ github.event.ref }}
+          WORKFLOW_COMMIT: ${{ github.event.ref || 'trunk' }}

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -407,6 +407,7 @@ jobs:
           SCYLLADB_HOST: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && '127.0.0.1' || '' }}
           SCYLLADB_PORT: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && '9042' || '' }}
           SCYLLADB_KEYSPACE: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && 'tpch_sf1' || '' }}
+          CHBENCH_PG_HOST: 127.0.0.1
 
       - name: Run the benchmark test (with overrides) - ${{ github.event.inputs.spicepod_path }}
         if: ${{ github.event.inputs.query_overrides != '' }}
@@ -485,6 +486,7 @@ jobs:
           SCYLLADB_HOST: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && '127.0.0.1' || '' }}
           SCYLLADB_PORT: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && '9042' || '' }}
           SCYLLADB_KEYSPACE: ${{ contains(github.event.inputs.spicepod_path, 'scylladb') && 'tpch_sf1' || '' }}
+          CHBENCH_PG_HOST: 127.0.0.1
 
       - name: Install GH CLI
         if: steps.determine_update_snapshots.outputs.update_snapshots == 'always'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf100.yaml
@@ -1,0 +1,326 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]-cdc-tuned-memory-sf100
+
+# Target: 64 vCPU / 256 GiB RAM, EBS gp3 (m7a.16xlarge-class). Goal: every CDC table under
+# 5s replication lag at SF-100 @ 10K txn/s, with >=5K QPH on the OLAP queries.
+#
+# Tuning (the write-path knobs below are MANY-CORE values, raised for the 64c runner's
+# headroom — they are NOT core-invariant: on a 16-core host the box saturates at 10K and the
+# CDC apply is core-bound, so the larger tables lag. The many-core CI runner clears >=5K QPH
+# and holds 6/7 tables <5s under load; order_line is the remaining apply bottleneck):
+#   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
+#     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
+#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
+#     WAL drain ahead of bursty OLTP without enlarging the per-apply batch.
+#   - target_partitions 48: read-path parallelism tuned for the QPH goal on the 64c runner.
+#   - cayenne_pk_keyset_cache_mb 256 pinned on ALL tables: defeats the backwards memory-aware
+#     auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) and keeps the heavy-update tables
+#     (stock, order_line) on the cheap bloom path (256 = SF-100 sweep optimum).
+#   - per-table cayenne_write_concurrency / segment_cache_mb / compaction_* for the high-volume
+#     upsert tables; reference tables lighter. write_concurrency = 8 (was 4) on the changes
+#     tables: the CDC apply is encode-parallelism-bound, so more shards consume the runner's
+#     encode budget; reference tables stay at 2. target_file_size 512 (was 256) on high-volume.
+#   - metastore/footer caches (1024/1024 MiB, 4096 MiB mmap) are sized to the SF-100 working set,
+#     bounded by catalog/footer size — so 256 GiB adds headroom, not bigger caches.
+#
+# NOTE: validated on 16-core local + the 128-core write-concurrency study; the 64c/256GB
+# end-to-end run is the remaining validation (m7a.16xlarge + gp3).
+runtime:
+  params:
+    cdc_prefetch_buffer: '16384'
+    cdc_max_coalesced_envelopes: '16384'
+    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesce_age_ms: '250'
+    cdc_commit_timeout_ms: '60000'
+    cayenne_sort_merge_min_rows: '50000000'
+    cayenne_footer_cache_mb: '1024'
+    cayenne_metastore_cache_mb: '1024'
+    cayenne_metastore_mmap_mb: '4096'
+  query:
+    target_partitions: 48
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
+postgres_connection_params: &postgres_params
+  pg_host: ${env:CHBENCH_PG_HOST}
+  pg_port: '5432'
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
+datasets:
+  # ------------------------------------------------------------------
+  # High-volume PK upsert tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:district
+    name: district
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+      params: &accel_high_volume
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/district
+        # In-memory CDC durability variant: the memtable tier absorbs writes and
+        # flushes by size/age (the `mem_tier_*` knobs below), trading per-batch
+        # durable persist for ingest throughput. This is the counterpart to the
+        # file-durability `…-cdc-tuned-sf100` pod.
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_bytes: '1073741824' # 1 GiB
+        cayenne_cdc_mem_tier_min_flush_bytes: '134217728' # 128 MiB
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        # KEY deletes even in file mode: deletion_mode auto resolves to
+        # position, which serializes compaction with writers (try_lock
+        # starvation under continuous CDC — measured unbounded file/read-amp
+        # growth on the delete-receiving table). Key-delete compaction runs
+        # concurrently with writers.
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '8'
+        cayenne_segment_cache_mb: '1024'
+        cayenne_compaction_trigger_protected_snapshots: '3'
+        # Pinned to 256 MiB (SF-100 sweep optimum). The keyset pin is scale-dependent: it
+        # must sit just UNDER the heavy-update tables' (stock, order_line) PK keysets so
+        # they stay on the cheap bloom path — at SF-100 that is 256 (1024 would fit them
+        # on the expensive exact path; the SF-1000 venue pins 1024). The memory-aware
+        # auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) is BACKWARDS — pin it.
+        cayenne_pk_keyset_cache_mb: '256'
+        cayenne_compaction_trigger_snapshot_age_ms: '15000'
+        cayenne_compaction_max_files_per_pick: '64'
+        cayenne_compaction_background_interval_ms: '3000'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
+
+  - from: postgres:customer
+    name: customer
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/customer
+        # 512 (was 256): fewer/larger files speed scans on the many-core CI runner. NOTE: this
+        # regresses on ~16-core hosts (compaction rewrites contend for scarce cores); it is a
+        # many-core value. write_concurrency 8 (anchors) is the paired apply-side bump — see PR.
+        cayenne_target_file_size_mb: '512'
+
+  - from: postgres:new_order
+    name: new_order
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/new_order
+
+  - from: postgres:oorder
+    name: oorder
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/oorder
+
+  - from: postgres:order_line
+    name: order_line
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/order_line
+        cayenne_target_file_size_mb: '512'
+        cayenne_compaction_trigger_files: '8'
+        cayenne_compaction_trigger_snapshot_age_ms: '30000'
+        cayenne_compaction_max_files_per_pick: '128'
+        cayenne_segment_cache_mb: '2048'
+
+  - from: postgres:stock
+    name: stock
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/stock
+        cayenne_target_file_size_mb: '512'
+
+  # ------------------------------------------------------------------
+  # Low-volume reference tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:warehouse
+    name: warehouse
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: w_id
+      on_conflict:
+        w_id: upsert
+      params: &accel_medium
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/warehouse
+        # See &accel_high_volume: in-memory CDC durability + key deletes.
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
+        cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '8'
+        cayenne_segment_cache_mb: '64'
+        # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
+        cayenne_pk_keyset_cache_mb: '256'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
+
+  # ------------------------------------------------------------------
+  # Static reference tables (no OLTP mutations, full refresh).
+  # ------------------------------------------------------------------
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+      params:
+        <<: *accel_medium
+        cayenne_file_path: .spice/cayenne/item
+        # static full-refresh: pin write_concurrency low so the &accel_medium bump (for the warehouse changes table) does not apply here.
+        cayenne_write_concurrency: '2'
+
+  - from: postgres:region
+    name: region
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      params: &accel_small
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/region
+        # See &accel_high_volume: in-memory CDC durability + key deletes.
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
+        cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '2'
+        cayenne_segment_cache_mb: '16'
+        # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
+        cayenne_pk_keyset_cache_mb: '256'
+
+  - from: postgres:nation
+    name: nation
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/nation
+
+  - from: postgres:supplier
+    name: supplier
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: su_suppkey
+      on_conflict:
+        su_suppkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/supplier

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf100.yaml
@@ -27,6 +27,8 @@ name: postgres-cayenne[file]-cdc-tuned-memory-sf100
 # NOTE: validated on 16-core local + the 128-core write-concurrency study; the 64c/256GB
 # end-to-end run is the remaining validation (m7a.16xlarge + gp3).
 runtime:
+  flight:
+    ipc_compression: lz4_frame
   params:
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
@@ -1,0 +1,307 @@
+version: v1
+kind: Spicepod
+name: postgres-cayenne[file]-cdc-tuned-memory-sf1000
+
+# In-memory CDC durability variant of `…-cdc-tuned-sf1000`. The memtable tier absorbs writes and
+# flushes by size/age (the `mem_tier_*` knobs below), trading per-batch durable persist for ingest
+# throughput. Sized for a 64 vCPU / 256 GiB host (m7a.16xlarge-class) with EBS gp3 — the CDC write
+# path issues few fsyncs, so gp3 base IOPS is sufficient. Everything except the durability knobs is
+# inherited verbatim from the file-durability pod.
+runtime:
+  flight:
+    ipc_compression: lz4_frame
+  params:
+    cdc_prefetch_buffer: '16384'
+    cdc_max_coalesced_envelopes: '16384'
+    cdc_max_coalesced_bytes: '134217728' # 128 MB
+    cdc_max_coalesce_age_ms: '250'
+    cdc_commit_timeout_ms: '60000'
+    cayenne_sort_merge_min_rows: '50000000'
+    cayenne_footer_cache_mb: '1024'
+    cayenne_metastore_cache_mb: '1024'
+    cayenne_metastore_mmap_mb: '4096'
+  query:
+    target_partitions: 48
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+
+postgres_connection_params: &postgres_params
+  pg_host: ${env:CHBENCH_PG_HOST}
+  pg_port: '5432'
+  pg_db: chbench
+  pg_user: bench
+  pg_pass: bench
+  pg_sslmode: disable
+
+datasets:
+  # ------------------------------------------------------------------
+  # High-volume PK upsert tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:district
+    name: district
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_district
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (d_w_id, d_id)
+      on_conflict:
+        (d_w_id, d_id): upsert
+      params: &accel_high_volume
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/district
+        # In-memory CDC durability: each batch lands in a bounded RAM tier and the slot ack is
+        # deferred to a periodic/cap-triggered checkpoint, removing the per-batch durable-commit
+        # cost from the write path. On crash the un-checkpointed tail replays from the slot and the
+        # PK-idempotent apply converges exactly-once. This is the counterpart to `…-cdc-tuned-sf1000`.
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_bytes: '1073741824' # 1 GiB resident cap (synchronous backstop)
+        cayenne_cdc_mem_tier_min_flush_bytes: '134217728' # 128 MiB min-flush gate (fewer, larger checkpoints)
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        # KEY deletes even in file mode: deletion_mode auto resolves to
+        # position, which serializes compaction with writers (try_lock
+        # starvation under continuous CDC — measured unbounded file/read-amp
+        # growth on the delete-receiving table). Key-delete compaction runs
+        # concurrently with writers.
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '8'
+        cayenne_segment_cache_mb: '1024'
+        cayenne_compaction_trigger_protected_snapshots: '3'
+        # Pinned to 1024 MiB at SF-1000: the keyset pin must sit just UNDER the heavy-update tables'
+        # (stock, order_line) PK keysets so they stay on the cheap bloom path. Their keysets are ~10x
+        # the SF-100 size, so the SF-1000 optimum is 1024 (SF-100 pins 256). The memory-aware
+        # auto-default (total_mem/32 -> ~8 GiB on a 256 GiB host) is BACKWARDS — pin it.
+        cayenne_pk_keyset_cache_mb: '1024'
+        cayenne_compaction_trigger_snapshot_age_ms: '15000'
+        cayenne_compaction_max_files_per_pick: '64'
+        cayenne_compaction_background_interval_ms: '3000'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
+
+  - from: postgres:customer
+    name: customer
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_customer
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (c_w_id, c_d_id, c_id)
+      on_conflict:
+        (c_w_id, c_d_id, c_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/customer
+        # 512 (was 256): fewer/larger files speed scans on the many-core CI runner (SF-1000 has
+        # 10x the data, so this matters more). NOTE: regresses on ~16-core hosts (compaction
+        # contention); many-core value. write_concurrency 8 (anchors) is the paired apply bump.
+        cayenne_target_file_size_mb: '512'
+
+  - from: postgres:new_order
+    name: new_order
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_new_order
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (no_w_id, no_d_id, no_o_id)
+      on_conflict:
+        (no_w_id, no_d_id, no_o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/new_order
+
+  - from: postgres:oorder
+    name: oorder
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_oorder
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (o_w_id, o_d_id, o_id)
+      on_conflict:
+        (o_w_id, o_d_id, o_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/oorder
+
+  - from: postgres:order_line
+    name: order_line
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_order_line
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (ol_w_id, ol_d_id, ol_o_id, ol_number)
+      on_conflict:
+        (ol_w_id, ol_d_id, ol_o_id, ol_number): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/order_line
+        cayenne_target_file_size_mb: '512'
+        cayenne_compaction_trigger_files: '8'
+        cayenne_compaction_trigger_snapshot_age_ms: '30000'
+        cayenne_compaction_max_files_per_pick: '128'
+        cayenne_segment_cache_mb: '2048'
+
+  - from: postgres:stock
+    name: stock
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_stock
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: (s_w_id, s_i_id)
+      on_conflict:
+        (s_w_id, s_i_id): upsert
+      params:
+        <<: *accel_high_volume
+        cayenne_file_path: .spice/cayenne/stock
+        cayenne_target_file_size_mb: '512'
+
+  # ------------------------------------------------------------------
+  # Low-volume reference tables.
+  # ------------------------------------------------------------------
+
+  - from: postgres:warehouse
+    name: warehouse
+    params:
+      <<: *postgres_params
+      pg_replication_slot: spice_warehouse
+      pg_replication_initial_snapshot: 'true'
+      pg_replication_bootstrap_batch_size: '1048576'
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      primary_key: w_id
+      on_conflict:
+        w_id: upsert
+      params: &accel_medium
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/warehouse
+        # See &accel_high_volume: in-memory CDC durability + key deletes. Smaller tier (age-flushed
+        # by the background checkpoint tick).
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
+        cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '8'
+        cayenne_segment_cache_mb: '64'
+        cayenne_pk_keyset_cache_mb: '256'
+        cdc_max_coalesce_age_ms: '3000'
+        cdc_max_coalesced_bytes: '536870912' # 512 MB
+
+  # ------------------------------------------------------------------
+  # Static reference tables (no OLTP mutations, full refresh).
+  # ------------------------------------------------------------------
+
+  - from: postgres:item
+    name: item
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: i_id
+      on_conflict:
+        i_id: upsert
+      params:
+        <<: *accel_medium
+        cayenne_file_path: .spice/cayenne/item
+        # static full-refresh: pin write_concurrency low so the &accel_medium bump (for the warehouse changes table) does not apply here.
+        cayenne_write_concurrency: '2'
+
+  - from: postgres:region
+    name: region
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: r_regionkey
+      on_conflict:
+        r_regionkey: upsert
+      params: &accel_small
+        cayenne_metastore: sqlite
+        cayenne_file_path: .spice/cayenne/region
+        # See &accel_high_volume: in-memory CDC durability + key deletes.
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
+        cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_deletion_mode: key
+        cayenne_write_concurrency: '2'
+        cayenne_segment_cache_mb: '16'
+        cayenne_pk_keyset_cache_mb: '256'
+
+  - from: postgres:nation
+    name: nation
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: n_nationkey
+      on_conflict:
+        n_nationkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/nation
+
+  - from: postgres:supplier
+    name: supplier
+    params:
+      <<: *postgres_params
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: full
+      primary_key: su_suppkey
+      on_conflict:
+        su_suppkey: upsert
+      params:
+        <<: *accel_small
+        cayenne_file_path: .spice/cayenne/supplier

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned-memory.yaml
@@ -1,0 +1,9 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf100.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 100
+    terminals: 100
+    duration: 600
+    ready_wait: 600
+    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned-memory.yaml
@@ -1,0 +1,9 @@
+tests:
+  htap:
+    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 1000
+    terminals: 100
+    duration: 600
+    ready_wait: 900
+    rate: 10000


### PR DESCRIPTION
## 📝 Summary


Changes to CH-benCHmark (HTAP) benchmark setup:

1. Move scheduled HTAP dispatch to its own workflow
- Moved the scheduled HTAP CH-benCHmark crons + dispatch steps out of `testoperator_dispatch.yml` into the dedicated `testoperator_dispatch_htap.yml`.
- Added cron schedules for SF1 (new, twice daily on `0 6,18`, `spiceai-dev-large-runners`)
- Fixed `testoperator_run_bench.yml`: added `CHBENCH_PG_HOST: 127.0.0.1` to bench run steps (the local docker Postgres host), which was missing and left the secret empty.

2. Add in-memory CDC durability tuned configs (SF100 + SF1000)
- New spicepods `postgres-cayenne[file]-cdc-tuned-memory-sf100.yaml` and `…-sf1000.yaml`: in-memory CDC durability counterparts of the file-durability `-cdc-tuned`
- Wired both into the SF100 and SF1000 HTAP dispatch dirs so the scheduled batches pick them up automatically.


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
