### PR TITLE
fix(cayenne): shard CDC upserts with pending deletions so the N>1 slot-ack advances

### DIFF
--- a/crates/cayenne/src/provider/mutation_writer.rs
+++ b/crates/cayenne/src/provider/mutation_writer.rs
@@ -314,15 +314,29 @@ impl<'a> AppendMutationWriter<'a> {
             && self.table.has_pending_deletions();
 
         // N>1 in-memory CDC: validate + append per PK-hash shard within one apply
-        // (§5 Phase 3). Engaged ONLY when the table is on the in-memory merge-on-read
-        // shape with deferral armed, has no pending PK deletions (those force the
-        // durable path), AND is configured for >1 shard. Every other case — and
+        // (§5 Phase 3). Engaged for EVERY in-memory upsert apply on a non-partitioned,
+        // deferral-armed, >1-shard table.
+        //
+        // CRITICAL — this path must NOT be gated on `!pending_pk_deletions`. A real CDC
+        // table almost always carries a tombstone in its durable deletion index (every
+        // upsert supersedes, every delete tombstones), so gating on it diverted ~98% of
+        // applies to the SERIAL shard-0 path — which stamps `source_position = None`, so
+        // the checkpoint's `durable_epoch = MAX(source_position)` never covered them and
+        // the source slot froze (the SF-100 N=4 WAL→38 GB stall; ~2239 serial vs ~82
+        // sharded applies on order_line). Sharding a pending-deletion upsert is SOUND: the
+        // per-shard validation handles on-conflict supersession (it builds per-shard
+        // `OnConflictDeletions`), and a new row is immune to any pre-existing tombstone
+        // because its `data_sequence` is reserved strictly above every prior
+        // `delete_sequence` — the same seq-ordering the serial staged path relies on — so a
+        // stale-PRESENT existence-index hit costs at most a harmless redundant tombstone
+        // under upsert semantics. CDC DELETE bursts take the separately-sharded
+        // `append_delete_intents_sharded`, so EVERY apply at N>1 stays on the one
+        // `apply_epoch` slot-ack axis the checkpoint reconciles. Every other case — and
         // ALWAYS at N=1 — falls through to the byte-identical serial path below.
         let mem_tier_shards = self.table.mem_tier_shard_count();
         if mem_tier_shards > 1
             && self.table.is_cdc_memory_mode()
             && self.table.has_slot_advancer()
-            && !pending_pk_deletions
             && self.table.metadata().partition_column.is_none()
         {
             if let Some(prepared) = self

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2218,12 +2218,6 @@ pub struct CayenneTableProvider {
     /// (the single shard keeps `MemTier::epoch` as the slot-ack currency, so the
     /// N=1 path is byte-identical). Shared across writer clones.
     mem_tier_apply_epoch: Arc<std::sync::atomic::AtomicU64>,
-    /// The highest epoch the most recent mem-tier checkpoint reported durable (the
-    /// last value handed to `fire_slot_advancer`). Observability ONLY — it feeds the
-    /// `cayenne_mem_tier_durable_epoch` gauge so the gap against `mem_tier_apply_epoch`
-    /// exposes a stuck slot-ack watermark (the N>1 WAL-drain stall) directly. Not read
-    /// by any control path. Shared across writer clones.
-    last_durable_epoch: Arc<std::sync::atomic::AtomicU64>,
     /// Cross-layer handle the runtime installs in memory mode so
     /// `checkpoint_mem_tier` can advance the source slot AFTER the durable fence
     /// (the slot-deferral correctness seam). `None` in file mode (and for
@@ -6408,7 +6402,6 @@ impl CayenneTableProvider {
                 .collect::<Vec<_>>()
                 .into(),
             mem_tier_apply_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            last_durable_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             slot_advancer: Arc::new(ParkingMutex::new(None)),
             mem_tier_max_age_ms,
             // Local providers can use `ensure_no_incomplete_write`'s
@@ -7158,7 +7151,6 @@ impl CayenneTableProvider {
             // lock (the seq-ordering invariant requires a single lock per table).
             mem_tier_publish_locks: Arc::clone(&self.mem_tier_publish_locks),
             mem_tier_apply_epoch: Arc::clone(&self.mem_tier_apply_epoch),
-            last_durable_epoch: Arc::clone(&self.last_durable_epoch),
             slot_advancer: Arc::clone(&self.slot_advancer),
             mem_tier_max_age_ms: self.mem_tier_max_age_ms,
             staging_wal_present: Arc::clone(&self.staging_wal_present),
@@ -16812,9 +16804,28 @@ impl CayenneTableProvider {
                     .mem_tier_apply_epoch
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst));
             };
-            return self
-                .append_to_mem_tier(Vec::new(), &deletions, total_incoming_bytes, 0)
-                .await;
+            // Stamp the shared per-apply slot-ack epoch even on this shard-0 fallback:
+            // a `source_position = None` append on a sharded tier (N>1) would make the
+            // checkpoint's MAX(source_position) watermark skip it → the deferred source
+            // slot stalls (the mixed-axis N>1 bug). Route through `append_to_shard` with
+            // the epoch so this stays on the single `apply_epoch` axis like every other
+            // N>1 apply, and return that epoch as the deferral receipt.
+            let apply_epoch = self
+                .mem_tier_apply_epoch
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let no_keys: HashSet<OwnedRow> = HashSet::new();
+            self.append_to_shard(
+                0,
+                Vec::new(),
+                &deletions,
+                total_incoming_bytes,
+                0,
+                Some(apply_epoch),
+                &no_keys,
+                None,
+            )
+            .await?;
+            return Ok(apply_epoch);
         };
 
         // Build each shard's tombstone-only `OnConflictDeletions` from its
@@ -17160,6 +17171,19 @@ impl CayenneTableProvider {
         // sharded path (a known limit of the opt-in N>1 path).
         maintained_aggregate_delete_rows: Option<&RecordBatch>,
     ) -> Result<u64> {
+        // INVARIANT: at N>1 every mem-tier append MUST carry a `source_position` (the
+        // per-apply `apply_epoch` slot-ack axis). A `None`-stamped append on a sharded
+        // tier is invisible to the checkpoint's MAX(source_position) watermark, which
+        // stalls the deferred source slot (the N>1 WAL-drain bug). `None` is valid ONLY
+        // at N==1, where the single shard keeps `MemTier::epoch` as the slot-ack
+        // currency. This guards against a future serial-at-N>1 caller silently
+        // re-opening that hole.
+        debug_assert!(
+            source_position.is_some() || self.mem_tier.shard_count() == 1,
+            "append_to_shard at N>1 (shard_count={}) requires source_position (apply_epoch); \
+             a None-stamped append stalls the source slot",
+            self.mem_tier.shard_count()
+        );
         let incoming_rows: u64 = batches
             .iter()
             .map(|b| b.num_rows() as u64)
@@ -17561,10 +17585,13 @@ impl CayenneTableProvider {
                 seq,
             )
         };
-        // The all-shards-atomic capture window — at N>1 this is the ONLY span that
-        // holds `write_lock`, so its duration is the per-checkpoint apply-stall. A
-        // spike here (vs the off-fence `mem_tier_checkpoint` total below) means the
-        // capture, not the encode, is contending the write path.
+        // The all-shards-atomic capture window: the per-shard snapshot load +
+        // sequence reservation under the publish locks. At N>1 `write_lock` is held
+        // from before this span through the WHOLE checkpoint (capture + encode +
+        // commit — see the LOAD-BEARING note above; the encode is NOT off-write_lock
+        // here), so this metric isolates the CAPTURE portion of that hold. The encode
+        // portion is `mem_tier_checkpoint` (total) minus this; comparing the two
+        // localizes a per-checkpoint apply-stall to the capture vs the encode.
         record_cayenne_write_phase(
             &self.table_metadata.table_name,
             "mem_tier_checkpoint_capture",
@@ -17985,12 +18012,10 @@ impl CayenneTableProvider {
     /// up (memory mode). A no-op in file mode / when the runtime did not install
     /// a handle.
     async fn fire_slot_advancer(&self, durable_epoch: u64) {
-        // Observability: record the durable watermark and the live apply-epoch
+        // Observability: emit the durable watermark alongside the live apply-epoch
         // counter so `cayenne_mem_tier_{durable,apply}_epoch` expose the slot-ack
         // gap. A gap that GROWS while checkpoints keep firing is a stuck watermark
         // (the N>1 WAL-drain stall) — vs the trigger never firing (the tick counter).
-        self.last_durable_epoch
-            .store(durable_epoch, std::sync::atomic::Ordering::Relaxed);
         telemetry::track_cayenne_mem_tier_epoch(
             self.mem_tier_apply_epoch
                 .load(std::sync::atomic::Ordering::Relaxed),
@@ -25591,24 +25616,33 @@ mod tests {
         let n = 4_usize;
         let ctx = SessionContext::new();
         let runtime_env = ctx.runtime_env();
-        let (provider, _catalog, _tmp) = create_sharded_cdc_upsert_table(
-            "shard_with_pending_del",
-            Arc::clone(&runtime_env),
-            n,
-        )
-        .await;
+        let (provider, _catalog, _tmp) =
+            create_sharded_cdc_upsert_table("shard_with_pending_del", Arc::clone(&runtime_env), n)
+                .await;
         let schema = Arc::clone(&provider.table_metadata.schema);
 
         // Make the DURABLE deletion index hold a tombstone: seed keys + checkpoint
         // (durable), then delete one + checkpoint. The tombstone hides a now-durable
         // row, so it must persist durably ⇒ `has_pending_deletions()` is true after.
-        apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), &[(1, 10), (2, 20), (3, 30)]).await;
-        provider.checkpoint_mem_tier().await.expect("seed checkpoint");
+        apply_upsert_burst(
+            &ctx,
+            &provider,
+            Arc::clone(&schema),
+            &[(1, 10), (2, 20), (3, 30)],
+        )
+        .await;
+        provider
+            .checkpoint_mem_tier()
+            .await
+            .expect("seed checkpoint");
         provider
             .write_cdc_delete_keys_in_memory(&int64_id_batch(&[2]))
             .await
             .expect("delete absorb");
-        provider.checkpoint_mem_tier().await.expect("delete checkpoint");
+        provider
+            .checkpoint_mem_tier()
+            .await
+            .expect("delete checkpoint");
         assert!(
             provider.has_pending_deletions(),
             "precondition: the durable deletion index must hold a tombstone so the \

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -2218,6 +2218,12 @@ pub struct CayenneTableProvider {
     /// (the single shard keeps `MemTier::epoch` as the slot-ack currency, so the
     /// N=1 path is byte-identical). Shared across writer clones.
     mem_tier_apply_epoch: Arc<std::sync::atomic::AtomicU64>,
+    /// The highest epoch the most recent mem-tier checkpoint reported durable (the
+    /// last value handed to `fire_slot_advancer`). Observability ONLY — it feeds the
+    /// `cayenne_mem_tier_durable_epoch` gauge so the gap against `mem_tier_apply_epoch`
+    /// exposes a stuck slot-ack watermark (the N>1 WAL-drain stall) directly. Not read
+    /// by any control path. Shared across writer clones.
+    last_durable_epoch: Arc<std::sync::atomic::AtomicU64>,
     /// Cross-layer handle the runtime installs in memory mode so
     /// `checkpoint_mem_tier` can advance the source slot AFTER the durable fence
     /// (the slot-deferral correctness seam). `None` in file mode (and for
@@ -6402,6 +6408,7 @@ impl CayenneTableProvider {
                 .collect::<Vec<_>>()
                 .into(),
             mem_tier_apply_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            last_durable_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             slot_advancer: Arc::new(ParkingMutex::new(None)),
             mem_tier_max_age_ms,
             // Local providers can use `ensure_no_incomplete_write`'s
@@ -7151,6 +7158,7 @@ impl CayenneTableProvider {
             // lock (the seq-ordering invariant requires a single lock per table).
             mem_tier_publish_locks: Arc::clone(&self.mem_tier_publish_locks),
             mem_tier_apply_epoch: Arc::clone(&self.mem_tier_apply_epoch),
+            last_durable_epoch: Arc::clone(&self.last_durable_epoch),
             slot_advancer: Arc::clone(&self.slot_advancer),
             mem_tier_max_age_ms: self.mem_tier_max_age_ms,
             staging_wal_present: Arc::clone(&self.staging_wal_present),
@@ -17428,6 +17436,7 @@ impl CayenneTableProvider {
     }
 
     async fn checkpoint_mem_tier_inner(&self, acquire_write_lock_for_capture: bool) -> Result<u64> {
+        let checkpoint_start = Instant::now();
         // Capture the corpus to flush AND reserve this checkpoint's
         // snapshot_sequence ATOMICALLY under ALL shard `mem_tier_publish_locks`
         // (index order, deadlock-free), so the capture+reservation is mutually
@@ -17454,6 +17463,16 @@ impl CayenneTableProvider {
         // apply and shard B WITHOUT it — a torn cut whose acked source position
         // covers rows never captured.
         let n = self.mem_tier.shard_count();
+        let capture_start = Instant::now();
+        // LOAD-BEARING: at N>1 `write_lock` is held across the WHOLE checkpoint
+        // (capture + off-fence encode + commit + clear), NOT just the capture.
+        // Scoping it to the capture alone (releasing before the encode) DEADLOCKED
+        // under sustained N>1 load — a concurrent apply racing the checkpoint's clear
+        // hung spiced after ~57 checkpoints in the SF-100 N=4 run (20-min log silence,
+        // health endpoint dead). So this serialization is required for deadlock-safety.
+        // It does NOT cause the WAL-drain stall: with this hold in place, checkpoints
+        // still fire ~57× yet the source slot does not advance — the real stall is
+        // downstream in the slot-ack watermark (under investigation), not here.
         let _capture_write_guard = if acquire_write_lock_for_capture && n > 1 {
             Some(self.write_lock.lock().await)
         } else {
@@ -17542,6 +17561,15 @@ impl CayenneTableProvider {
                 seq,
             )
         };
+        // The all-shards-atomic capture window — at N>1 this is the ONLY span that
+        // holds `write_lock`, so its duration is the per-checkpoint apply-stall. A
+        // spike here (vs the off-fence `mem_tier_checkpoint` total below) means the
+        // capture, not the encode, is contending the write path.
+        record_cayenne_write_phase(
+            &self.table_metadata.table_name,
+            "mem_tier_checkpoint_capture",
+            capture_start,
+        );
         // Emptiness must be judged on the REAL captured shard snapshots, not the
         // synthetic union view: `union_snapshot_view` carries the cross-shard
         // tombstone union + the summed byte/row counts but ALWAYS has empty
@@ -17648,6 +17676,11 @@ impl CayenneTableProvider {
                 )
                 .await?;
             }
+            record_cayenne_write_phase(
+                &self.table_metadata.table_name,
+                "mem_tier_checkpoint",
+                checkpoint_start,
+            );
             self.fire_slot_advancer(flushed_epoch).await;
             return Ok(0);
         }
@@ -17842,6 +17875,11 @@ impl CayenneTableProvider {
         self.persist_table_stats(&stats, RowCountUpdate::Unchanged)
             .await;
 
+        record_cayenne_write_phase(
+            &self.table_metadata.table_name,
+            "mem_tier_checkpoint",
+            checkpoint_start,
+        );
         // ONLY NOW — after the Vortex file + metastore pointer are durable — tell
         // the runtime it may advance the source slot to cover this epoch.
         self.fire_slot_advancer(flushed_epoch).await;
@@ -17947,6 +17985,21 @@ impl CayenneTableProvider {
     /// up (memory mode). A no-op in file mode / when the runtime did not install
     /// a handle.
     async fn fire_slot_advancer(&self, durable_epoch: u64) {
+        // Observability: record the durable watermark and the live apply-epoch
+        // counter so `cayenne_mem_tier_{durable,apply}_epoch` expose the slot-ack
+        // gap. A gap that GROWS while checkpoints keep firing is a stuck watermark
+        // (the N>1 WAL-drain stall) — vs the trigger never firing (the tick counter).
+        self.last_durable_epoch
+            .store(durable_epoch, std::sync::atomic::Ordering::Relaxed);
+        telemetry::track_cayenne_mem_tier_epoch(
+            self.mem_tier_apply_epoch
+                .load(std::sync::atomic::Ordering::Relaxed),
+            durable_epoch,
+            &[telemetry::KeyValue::new(
+                "table",
+                self.table_metadata.table_name.clone(),
+            )],
+        );
         let advancer = self.slot_advancer.lock().clone();
         if let Some(advancer) = advancer {
             advancer.on_checkpoint_durable(durable_epoch).await;
@@ -21863,9 +21916,25 @@ impl CayenneTableProvider {
 #[async_trait::async_trait]
 impl super::compaction::MemTierCheckpointRunner for CayenneTableProvider {
     async fn run_mem_tier_checkpoint_tick(&self) {
+        // Background tick OUTCOME telemetry (`cayenne_mem_tier_checkpoint_tick_total`):
+        // attributes a stalled deferred slot ack to the trigger path vs the checkpoint
+        // body. A flat-zero `fired` under a growing WAL backlog is the smoking gun the
+        // N>1 sharded tier diagnosis lacked (no checkpoint-fire metric existed).
+        let tick_table = self.table_metadata.table_name.clone();
+        let emit_tick = |outcome: &'static str| {
+            telemetry::track_cayenne_mem_tier_checkpoint_tick(&[
+                telemetry::KeyValue::new("table", tick_table.clone()),
+                telemetry::KeyValue::new("outcome", outcome),
+            ]);
+        };
         // Only memory-mode tables that the runtime has armed have a deferred
         // slot ack to advance; everything else has nothing to flush here.
-        if !self.is_cdc_memory_mode() || !self.has_slot_advancer() {
+        if !self.is_cdc_memory_mode() {
+            emit_tick("not_memory_mode");
+            return;
+        }
+        if !self.has_slot_advancer() {
+            emit_tick("no_advancer");
             return;
         }
         // Cheap lock-free early-out: skip taking the checkpoint lock on an idle
@@ -21877,6 +21946,7 @@ impl super::compaction::MemTierCheckpointRunner for CayenneTableProvider {
             // checkpoint is always all-shards-atomic (§3.4 Fix 2), so the trigger
             // is the aggregate. At N==1 these are exactly shard 0's bytes/age.
             if self.mem_tier.is_empty() {
+                emit_tick("skipped_empty");
                 return;
             }
             // Churn gate: each durable checkpoint costs a new snapshot dir,
@@ -21897,6 +21967,7 @@ impl super::compaction::MemTierCheckpointRunner for CayenneTableProvider {
                 let size_ready =
                     i64::try_from(self.mem_tier.total_bytes()).unwrap_or(i64::MAX) >= min_flush;
                 if !size_ready && !self.mem_tier_age_cap_reached_whole_tier() {
+                    emit_tick("skipped_gate");
                     return;
                 }
             }
@@ -21913,11 +21984,14 @@ impl super::compaction::MemTierCheckpointRunner for CayenneTableProvider {
             // deferred committers stay queued and the next tick retries; surface
             // it as a warning rather than flipping refresh status from a
             // background task.
+            emit_tick("failed");
             tracing::warn!(
                 target: "cayenne::mem_tier",
                 table = %self.table_metadata.table_name,
                 "Periodic mem-tier checkpoint failed (deferred slot ack not advanced; will retry next tick): {e}"
             );
+        } else {
+            emit_tick("fired");
         }
     }
 
@@ -25433,6 +25507,136 @@ mod tests {
             collect_id_value_pairs(&ctx, &over, "whole_tier_over").await,
             burst,
             "the whole-tier flush preserved every row"
+        );
+    }
+
+    /// REGRESSION (SF-100 N=4 WAL-drain stall). The PRIMARY production drain at
+    /// N>1 is the periodic BACKGROUND tick (`run_mem_tier_checkpoint_tick`), NOT a
+    /// direct `checkpoint_mem_tier()` call (the byte-cap spill is documented as a
+    /// rare backstop). Every existing checkpoint test calls `checkpoint_mem_tier()`
+    /// directly, so the TRIGGER path was never covered at N>1. In the SF-100 N=4
+    /// run the tick fired 0 checkpoints: the tier never drained, the source slot
+    /// was never acked, and the WAL backlog grew unbounded (38 GB) even though the
+    /// data stayed correct + query-visible. The tick MUST fire the all-shards
+    /// checkpoint and advance the slot to the latest apply epoch at N>1, exactly as
+    /// it does at N=1.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sharded_cdc_background_tick_drains_and_advances_slot_at_n_gt_1() {
+        let n = 4_usize;
+        let ctx = SessionContext::new();
+        let runtime_env = ctx.runtime_env();
+        // min_flush_bytes = 0 (helper default) ⇒ the tick's churn gate is always
+        // "ready", so this isolates the tick's drain behavior, not a size threshold.
+        let (provider, _catalog, _tmp) =
+            create_sharded_cdc_upsert_table("bg_tick_n4", Arc::clone(&runtime_env), n).await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        let durable = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        provider.install_slot_advancer(std::sync::Arc::new(EpochRecorder(std::sync::Arc::clone(
+            &durable,
+        ))));
+
+        let bursts: Vec<Vec<(i64, i64)>> = vec![
+            vec![(1, 10), (2, 20), (3, 30)],
+            vec![(10, 100), (11, 110)],
+            vec![(30, 300), (31, 310), (32, 320)],
+        ];
+        let mut max_epoch = 0_u64;
+        for b in &bursts {
+            if let Some(e) = apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), b).await {
+                max_epoch = max_epoch.max(e);
+            }
+        }
+        assert!(
+            !provider.mem_tier.is_empty(),
+            "rows resident in the tier before the background tick"
+        );
+        assert_eq!(
+            durable.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "no checkpoint has fired yet, so the slot has not advanced"
+        );
+
+        // Drive the PRODUCTION drain trigger — the periodic background tick — NOT a
+        // direct `checkpoint_mem_tier()` call.
+        provider.run_mem_tier_checkpoint_tick().await;
+
+        assert_eq!(
+            durable.load(std::sync::atomic::Ordering::SeqCst),
+            max_epoch,
+            "the background tick must advance the slot to the latest apply epoch at N>1 \
+             (SF-100 N=4 stall: the tick never drained, so the slot froze and WAL grew to 38 GB)"
+        );
+        for s in 0..n {
+            assert!(
+                provider.mem_tier.shard(s).load().is_empty(),
+                "shard {s} drained by the background tick at N>1"
+            );
+        }
+    }
+
+    /// REGRESSION (SF-100 N=4 WAL-drain stall, ROOT CAUSE). The `!pending_pk_deletions`
+    /// gate in `write_cdc_pipelined` diverted an upsert apply onto the SERIAL shard-0
+    /// path (which stamps `source_position = None`) whenever the table's durable
+    /// deletion index held ANY tombstone — which is ~always for a real CDC table (every
+    /// supersession and every delete leaves one). At SF-100 N=4 that diverted ~98% of
+    /// applies off the sharded path, so the checkpoint's `durable_epoch = MAX(source_position)`
+    /// never reflected them and the source slot froze (WAL → 38 GB). An upsert at N>1
+    /// MUST take the SHARDED path — stamping the per-apply `apply_epoch` axis — even when
+    /// durable deletions are pending. We detect the path via `mem_tier_apply_epoch`: the
+    /// sharded path allocates a fresh per-apply epoch (bumps it); the serial shard-0 path
+    /// does not. Pre-fix this asserts-false (serial path, no bump); post-fix it passes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sharded_cdc_upsert_shards_despite_pending_durable_deletions() {
+        let n = 4_usize;
+        let ctx = SessionContext::new();
+        let runtime_env = ctx.runtime_env();
+        let (provider, _catalog, _tmp) = create_sharded_cdc_upsert_table(
+            "shard_with_pending_del",
+            Arc::clone(&runtime_env),
+            n,
+        )
+        .await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        // Make the DURABLE deletion index hold a tombstone: seed keys + checkpoint
+        // (durable), then delete one + checkpoint. The tombstone hides a now-durable
+        // row, so it must persist durably ⇒ `has_pending_deletions()` is true after.
+        apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), &[(1, 10), (2, 20), (3, 30)]).await;
+        provider.checkpoint_mem_tier().await.expect("seed checkpoint");
+        provider
+            .write_cdc_delete_keys_in_memory(&int64_id_batch(&[2]))
+            .await
+            .expect("delete absorb");
+        provider.checkpoint_mem_tier().await.expect("delete checkpoint");
+        assert!(
+            provider.has_pending_deletions(),
+            "precondition: the durable deletion index must hold a tombstone so the \
+             pre-fix `!pending_pk_deletions` gate would divert the next upsert to serial"
+        );
+
+        // A fresh upsert WITH pending durable deletions present. The sharded path bumps
+        // `mem_tier_apply_epoch`; the serial shard-0 path (pre-fix) does not.
+        let epoch_before = provider
+            .mem_tier_apply_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
+        apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), &[(4, 40)]).await;
+        let epoch_after = provider
+            .mem_tier_apply_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            epoch_after > epoch_before,
+            "an upsert at N>1 must take the SHARDED path (stamping the apply_epoch axis) \
+             even with pending durable deletions — otherwise its source_position is None \
+             and the checkpoint watermark never covers it (the WAL-drain stall). \
+             apply_epoch before={epoch_before} after={epoch_after}"
+        );
+
+        // And merge-on-read stays correct: key 2 deleted, 1/3 retained, 4 inserted.
+        assert_eq!(
+            collect_id_value_pairs(&ctx, &provider, "shard_with_pending_del").await,
+            vec![(1, 10), (3, 30), (4, 40)],
+            "sharded upsert with pending deletions preserves the correct merge-on-read result"
         );
     }
 

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -501,6 +501,66 @@ pub fn track_cayenne_cdc_absorbed_delete_keys(keys: u64, dimensions: &[KeyValue]
         .add(keys, dimensions);
 }
 
+static CAYENNE_MEM_TIER_CHECKPOINT_TICK: OnceLock<Counter<u64>> = OnceLock::new();
+
+/// Counts background mem-tier checkpoint TICK outcomes (`cdc_durability: memory`),
+/// so a stalled deferred source-slot ack is attributable to the trigger vs the
+/// checkpoint body. Outcomes (carried as the `outcome` dimension): `fired` (the
+/// tick ran a checkpoint), `skipped_empty` (whole tier empty), `skipped_gate`
+/// (size/age churn gate held it off), `no_advancer` / `not_memory_mode` (early
+/// return before the gate), `failed` (the checkpoint errored). A flat-zero `fired`
+/// under a growing WAL backlog localizes a slot-ack stall to the trigger path —
+/// the exact signal missing when the sharded (N>1) tier stopped draining.
+/// `dimensions` carries `table` + `outcome`.
+pub fn track_cayenne_mem_tier_checkpoint_tick(dimensions: &[KeyValue]) {
+    CAYENNE_MEM_TIER_CHECKPOINT_TICK
+        .get_or_init(|| {
+            cayenne_operational_meter()
+                .u64_counter("cayenne_mem_tier_checkpoint_tick_total")
+                .with_description(
+                    "Background mem-tier checkpoint tick outcomes (fired / skipped_empty / skipped_gate / no_advancer / not_memory_mode / failed), labeled by table and outcome.",
+                )
+                .with_unit("ticks")
+                .build()
+        })
+        .add(1, dimensions);
+}
+
+static CAYENNE_MEM_TIER_APPLY_EPOCH: OnceLock<Gauge<u64>> = OnceLock::new();
+static CAYENNE_MEM_TIER_DURABLE_EPOCH: OnceLock<Gauge<u64>> = OnceLock::new();
+
+/// The per-apply slot-ack epoch axis (`cdc_durability: memory`): `apply_epoch` is the
+/// latest allocated per-apply epoch counter; `durable_epoch` is the highest epoch the
+/// most recent mem-tier checkpoint reported durable (what `fire_slot_advancer` handed
+/// the runtime to advance the source slot). The GAP (`apply_epoch − durable_epoch`) is
+/// the un-acked source-slot backlog measured in apply epochs: a small/steady gap means
+/// the slot keeps pace; a gap that GROWS while checkpoints keep firing means the
+/// watermark is stuck — the exact signature of the N>1 WAL-drain stall, and the signal
+/// that pins it to the watermark computation vs the trigger. `dimensions` carries
+/// `table`. Emitted on each `fire_slot_advancer` (i.e. each completed checkpoint).
+pub fn track_cayenne_mem_tier_epoch(apply_epoch: u64, durable_epoch: u64, dimensions: &[KeyValue]) {
+    CAYENNE_MEM_TIER_APPLY_EPOCH
+        .get_or_init(|| {
+            cayenne_operational_meter()
+                .u64_gauge("cayenne_mem_tier_apply_epoch")
+                .with_description(
+                    "Latest allocated per-apply slot-ack epoch counter (cdc_durability: memory).",
+                )
+                .build()
+        })
+        .record(apply_epoch, dimensions);
+    CAYENNE_MEM_TIER_DURABLE_EPOCH
+        .get_or_init(|| {
+            cayenne_operational_meter()
+                .u64_gauge("cayenne_mem_tier_durable_epoch")
+                .with_description(
+                    "Highest per-apply epoch the last mem-tier checkpoint reported durable (handed to fire_slot_advancer to advance the source slot).",
+                )
+                .build()
+        })
+        .record(durable_epoch, dimensions);
+}
+
 static CAYENNE_COMPACTION_DURATION_MS: OnceLock<Histogram<f64>> = OnceLock::new();
 
 /// Build-once accessor for the compaction-duration histogram. The first call

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-turso.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-turso.yaml
@@ -66,6 +66,10 @@ datasets:
       refresh_mode: changes
       params: &cayenne_params
         cayenne_tuning: adaptive
+        # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
+        # parallel within one apply on the memory-tier (changes) tables. Inert on the
+        # full-refresh reference tables that share this anchor (not CDC memory mode).
+        cayenne_cdc_mem_tier_shards: '4'
         # The only line that differs from the sqlite-default adaptive twin: select the Turso
         # metastore backend. This is a structural backend choice, not a tunable actuator, so it
         # does not pin any knob under adaptive tuning.

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
@@ -61,6 +61,10 @@ datasets:
       refresh_mode: changes
       params: &cayenne_params
         cayenne_tuning: adaptive
+        # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
+        # parallel within one apply on the memory-tier (changes) tables. Inert on the
+        # full-refresh reference tables that share this anchor (not CDC memory mode).
+        cayenne_cdc_mem_tier_shards: '4'
         # Goal-driven SLOs the closed loop converges toward. Replication-lag and
         # freshness apply to the CDC (changes) tables; they are inert on the
         # full-refresh reference tables that share this anchor (no CDC ingest).


### PR DESCRIPTION
Follow-up to #11421 (in-memory CDC intra-apply sharding).

## Problem
At `cayenne_cdc_mem_tier_shards > 1`, the in-memory CDC sharded apply path is gated on `!pending_pk_deletions`. But `has_pending_deletions()` is true whenever the durable deletion index holds **any** tombstone — i.e. ~always for a real CDC table (every upsert supersedes a prior version, every delete leaves a tombstone). So the gate diverts the **vast majority** of applies to the serial shard‑0 path.

The serial path appends to shard 0 with `source_position = None`. The all-shards-atomic checkpoint computes `durable_epoch = MAX(source_position)`; with the sharded path bypassed it sees only `None`, so at N>1 `flushed_epoch` collapses to `0` (via `union_snapshot_view(.., durable_epoch.unwrap_or(0))`) and `fire_slot_advancer(0)` advances nothing. **The source replication slot never advances and WAL grows unbounded**, even though applied data is correct and query-visible. N=1 is immune because it falls back to the single shard's `MemTier::epoch`.

Measured at SF‑100, 3‑node, N=4: ~2239 serial vs ~82 sharded applies on `order_line`; WAL backlog froze at 38 GB.

## Fix
Remove `!pending_pk_deletions` from the sharded gate so every N>1 upsert shards onto the single `apply_epoch` slot-ack axis (CDC delete bursts already shard via `append_delete_intents_sharded`). This is sound:
- per-shard validation already builds per-shard `OnConflictDeletions`, so it handles on-conflict supersession;
- a newly-appended row is immune to any pre-existing tombstone because its `data_sequence` is reserved strictly above every prior `delete_sequence` (the same seq-ordering the serial staged path relies on);
- a stale-PRESENT existence-index hit costs at most a harmless redundant tombstone under upsert semantics.

## Observability (new metrics)
- `cayenne_write_phase_duration_ms{phase="mem_tier_checkpoint"|"mem_tier_checkpoint_capture"}` — total checkpoint duration / the capture (write-lock-held) window.
- `cayenne_mem_tier_checkpoint_tick_total{outcome="fired"|"skipped_empty"|"skipped_gate"|"no_advancer"|"failed"}` — background-tick outcomes.
- `cayenne_mem_tier_apply_epoch` / `cayenne_mem_tier_durable_epoch` gauges — their gap is the un-acked slot-ack backlog (a growing gap with checkpoints firing = a stuck watermark).

## Validation
Unit: full cayenne lib suite green (686/0), incl. a new regression test `sharded_cdc_upsert_shards_despite_pending_durable_deletions` and the existing `sharded_cdc_delete_then_reinsert_equals_serial` (gate-removal correctness guard).

End-to-end SF‑100 N=4 (3-node, Postgres CDC → Cayenne):
| | before | after |
|---|---|---|
| WAL drain | 38 GB, frozen | 56 B, all slots |
| Correctness | stalled | 7/7 Δ0.0000%, converged 17.9 s |
| sharded vs serial applies (order_line) | 82 / 2239 | 1880 / 0 |
| `durable_epoch` vs `apply_epoch` | stuck ~0 | tracks (gap = 1) |
| peak WAL | 38 GB | 3.4 GB |

Default remains `cayenne_cdc_mem_tier_shards: 1`; this fixes the opt-in N>1 path. (Separate, untouched here: the SF‑1000 N>1 peak-memory concern.)