### PR TITLE
fix(cli): spice query honors --http-endpoint instead of failing on a Flight connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18198,7 +18198,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "3.2.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=ae23f851d1f9a253019a50eb43f3905fbb338a1a#ae23f851d1f9a253019a50eb43f3905fbb338a1a"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=1b0852221fdee5814ecf92f8203b18b980d4c291#1b0852221fdee5814ecf92f8203b18b980d4c291"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18198,7 +18198,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "3.2.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=1b0852221fdee5814ecf92f8203b18b980d4c291#1b0852221fdee5814ecf92f8203b18b980d4c291"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=93b75c3c7d1a812b23d00b45adf537d7a2415496#93b75c3c7d1a812b23d00b45adf537d7a2415496"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18198,7 +18198,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "3.2.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=7bc9e455d47aa8899acc5c6c91f7448bea5637b2#7bc9e455d47aa8899acc5c6c91f7448bea5637b2"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=ae23f851d1f9a253019a50eb43f3905fbb338a1a#ae23f851d1f9a253019a50eb43f3905fbb338a1a"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,7 +367,7 @@ vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "729249d
 vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
 
 x509-certificate = "0.25.0"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "7bc9e455d47aa8899acc5c6c91f7448bea5637b2" } # branch: spiceai-58
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "ae23f851d1f9a253019a50eb43f3905fbb338a1a" } # phillip/client-optional-flight
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,7 +367,7 @@ vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "729249d
 vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
 
 x509-certificate = "0.25.0"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "1b0852221fdee5814ecf92f8203b18b980d4c291" } # phillip/client-lazy-flight
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "93b75c3c7d1a812b23d00b45adf537d7a2415496" } # spiceai/spice-rs#77
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,7 +367,7 @@ vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "729249d
 vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
 
 x509-certificate = "0.25.0"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "ae23f851d1f9a253019a50eb43f3905fbb338a1a" } # phillip/client-optional-flight
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "1b0852221fdee5814ecf92f8203b18b980d4c291" } # phillip/client-lazy-flight
 
 [profile.release-lto]
 inherits = "release"


### PR DESCRIPTION
## Problem

`spice query --http-endpoint <url>` failed with `Invalid HTTP response: transport error` and never used the configured HTTP endpoint. The command targets the async `/v1/queries` REST API, but the spiceai SDK (`spice-rs`) eagerly opened a Flight connection (defaulting to `localhost:50051`) when building the client — so building an HTTP-only client failed before any HTTP call when nothing was listening on the default Flight port.

## Change

Bumps the `spiceai` SDK rev to the merged build (spiceai/spice-rs#77) that connects Flight **lazily**. Building a client no longer opens a Flight connection; HTTP-only callers like `spice query` never trigger one, while Flight callers connect on first query exactly as before. Non-breaking — no existing behavior changes.

## Validation

Built `spice` against the pinned SDK rev and ran against a local cluster:

```
spice query --http-endpoint http://127.0.0.1:<port> "SELECT 1 AS answer"
✓ SUCCEEDED — renders the result table
```

Previously this errored with `Invalid HTTP response: transport error`. Submitting to either scheduler endpoint is honored.
