### PR TITLE
chore(testoperator): read cluster-bench TPC-H data from us-west-2 (avoid cross-region egress)

### DIFF
--- a/test/spicepods/tpch/sf10/federated/s3-public[parquet].yaml
+++ b/test/spicepods/tpch/sf10/federated/s3-public[parquet].yaml
@@ -3,29 +3,30 @@ kind: Spicepod
 name: s3-public[parquet]-federated
 
 datasets:
-  - from: s3://spiceai-public-datasets/tpch_sf10/customer.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf10/customer.parquet
     name: customer
     params: &s3_params
       file_format: parquet
       s3_auth: public
-  - from: s3://spiceai-public-datasets/tpch_sf10/lineitem.parquet
+      s3_region: us-west-2
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf10/lineitem.parquet
     name: lineitem
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf10/nation.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf10/nation.parquet
     name: nation
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf10/orders.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf10/orders.parquet
     name: orders
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf10/part.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf10/part.parquet
     name: part
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf10/partsupp.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf10/partsupp.parquet
     name: partsupp
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf10/region.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf10/region.parquet
     name: region
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf10/supplier.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf10/supplier.parquet
     name: supplier
     params: *s3_params

--- a/test/spicepods/tpch/sf100/federated/s3-public[parquet].yaml
+++ b/test/spicepods/tpch/sf100/federated/s3-public[parquet].yaml
@@ -3,29 +3,30 @@ kind: Spicepod
 name: s3-public[parquet]-federated
 
 datasets:
-  - from: s3://spiceai-public-datasets/tpch_sf100/customer.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf100/customer.parquet
     name: customer
     params: &s3_params
       file_format: parquet
       s3_auth: public
-  - from: s3://spiceai-public-datasets/tpch_sf100/lineitem.parquet
+      s3_region: us-west-2
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf100/lineitem.parquet
     name: lineitem
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf100/nation.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf100/nation.parquet
     name: nation
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf100/orders.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf100/orders.parquet
     name: orders
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf100/part.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf100/part.parquet
     name: part
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf100/partsupp.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf100/partsupp.parquet
     name: partsupp
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf100/region.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf100/region.parquet
     name: region
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf100/supplier.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf100/supplier.parquet
     name: supplier
     params: *s3_params

--- a/test/spicepods/tpch/sf50/federated/s3-public[parquet].yaml
+++ b/test/spicepods/tpch/sf50/federated/s3-public[parquet].yaml
@@ -3,29 +3,30 @@ kind: Spicepod
 name: s3-public[parquet]-federated
 
 datasets:
-  - from: s3://spiceai-public-datasets/tpch_sf50/customer.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf50/customer.parquet
     name: customer
     params: &s3_params
       file_format: parquet
       s3_auth: public
-  - from: s3://spiceai-public-datasets/tpch_sf50/lineitem.parquet
+      s3_region: us-west-2
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf50/lineitem.parquet
     name: lineitem
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf50/nation.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf50/nation.parquet
     name: nation
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf50/orders.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf50/orders.parquet
     name: orders
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf50/part.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf50/part.parquet
     name: part
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf50/partsupp.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf50/partsupp.parquet
     name: partsupp
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf50/region.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf50/region.parquet
     name: region
     params: *s3_params
-  - from: s3://spiceai-public-datasets/tpch_sf50/supplier.parquet
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpch_sf50/supplier.parquet
     name: supplier
     params: *s3_params


### PR DESCRIPTION
## Problem

The distributed TPC-H **cluster** benchmark provisions its Spice Cloud app in **us-west-2**, but the federated spicepods read the parquet data from a **us-east-1** bucket (`spiceai-public-datasets`). Every scan therefore crosses regions — paid S3 egress on each of the 22 queries × iterations × scale factors, run after run.

## Change

Point the `sf10`/`sf50`/`sf100` `federated/s3-public[parquet].yaml` spicepods at a us-west-2 mirror of the same data — `s3://spiceai-sandbox-tpch-us-west-2/tpch_sf{10,50,100}/` (public-read, server-side copied from the us-east-1 source) — and set `s3_region: us-west-2`.

These spicepods are referenced **only** by `tools/testoperator/dispatch_cluster/tpch/sf*/distributed/`, so the change is scoped to the cluster benchmark; no other bench is affected. Data and source bucket are both in the sandbox account, same as before.

## Effect

Cluster-bench data reads stay in-region → no cross-region S3 transfer charges.

https://claude.ai/code/session_01G8drJk8Fx5ynRQZ4WkuVju