### PR TITLE
fix(cluster): drive Flight TLS handshakes concurrently (fix shuffle-fetch connection resets)

### DIFF
--- a/crates/runtime/src/tls/flight_incoming.rs
+++ b/crates/runtime/src/tls/flight_incoming.rs
@@ -33,6 +33,13 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{TlsAcceptor, server::TlsStream};
 use tokio_stream::wrappers::TcpListenerStream;
 
+/// Maximum number of TLS handshakes to drive concurrently off the listener.
+/// Generous because handshakes are I/O-bound and cheap to hold; the goal is to
+/// keep the TCP accept queue drained under a connection burst (e.g. a
+/// distributed shuffle where many peers each open dozens of fetch connections
+/// at once).
+const MAX_CONCURRENT_TLS_HANDSHAKES: usize = 1024;
+
 /// Build a stream of accepted+handshaked TLS connections suitable for
 /// `tonic::transport::Server::serve_with_incoming`.
 pub fn tls_incoming(
@@ -42,33 +49,37 @@ pub fn tls_incoming(
     let acceptor = TlsAcceptor::from(server_config);
     let tcp = TcpListenerStream::new(listener);
 
-    // Per-connection TLS handshake. We spawn one task per accept so a slow
-    // handshake from one client does not block accepting the next.
+    // Drive many TLS handshakes concurrently. A burst of incoming connections —
+    // e.g. a distributed shuffle where each reducer opens up to 64 fetch
+    // connections per peer with no client-side pooling — must not back up behind
+    // a single in-flight handshake. The previous implementation spawned a task
+    // per accept but then `join.await`ed each one inline in the stream, which
+    // serialized acceptance: the next TCP connection was not accepted until the
+    // current handshake finished, overflowing the listener accept queue under
+    // load so peers saw `connection reset by peer`. `buffer_unordered` keeps
+    // accepting (draining the backlog) while up to `MAX_CONCURRENT_TLS_HANDSHAKES`
+    // handshakes proceed at once. A failed handshake is logged and dropped —
+    // yielding `Err` would terminate the tonic server.
     let handshakes = tcp
-        .filter_map(move |conn| {
-            let acceptor = acceptor.clone();
-            async move {
-                let stream = match conn {
-                    Ok(s) => s,
-                    Err(e) => {
-                        tracing::debug!("Flight: TCP accept error: {e}");
-                        return None;
-                    }
-                };
-                Some(tokio::spawn(async move { acceptor.accept(stream).await }))
-            }
-        })
-        .filter_map(|join| async move {
-            match join.await {
-                Ok(Ok(tls)) => Some(Ok(tls)),
-                Ok(Err(e)) => {
-                    tracing::debug!("Flight: TLS handshake error: {e}");
-                    // Yielding an `Err` here would terminate the tonic server.
-                    // Drop the bad connection silently instead.
+        .filter_map(|conn| async move {
+            match conn {
+                Ok(stream) => Some(stream),
+                Err(e) => {
+                    tracing::debug!("Flight: TCP accept error: {e}");
                     None
                 }
-                Err(join_err) => {
-                    tracing::debug!("Flight: TLS handshake task panicked: {join_err}");
+            }
+        })
+        .map(move |stream| {
+            let acceptor = acceptor.clone();
+            async move { acceptor.accept(stream).await }
+        })
+        .buffer_unordered(MAX_CONCURRENT_TLS_HANDSHAKES)
+        .filter_map(|res| async move {
+            match res {
+                Ok(tls) => Some(Ok(tls)),
+                Err(e) => {
+                    tracing::debug!("Flight: TLS handshake error: {e}");
                     None
                 }
             }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -2054,16 +2054,20 @@ async fn generate_initial_spicepod(
     if let Ok(shuffle_location) = std::env::var("SPIDAPTER_SHUFFLE_LOCATION") {
         let shuffle_location = shuffle_location.trim();
         if !shuffle_location.is_empty() {
-            spicepod.runtime.params.insert(
-                "shuffle_location".to_string(),
-                shuffle_location.to_string(),
-            );
+            spicepod
+                .runtime
+                .params
+                .insert("shuffle_location".to_string(), shuffle_location.to_string());
         }
     }
     if let Ok(temp_directory) = std::env::var("SPIDAPTER_QUERY_TEMP_DIRECTORY") {
         let temp_directory = temp_directory.trim();
         if !temp_directory.is_empty() {
-            let mut query = spicepod.runtime.query.clone().unwrap_or_else(Query::default);
+            let mut query = spicepod
+                .runtime
+                .query
+                .clone()
+                .unwrap_or_else(Query::default);
             query.temp_directory = Some(temp_directory.to_string());
             spicepod.runtime.query = Some(query);
         }


### PR DESCRIPTION
## Problem

In the distributed cluster benchmark, **every multi-stage join query failed** with executor-to-executor `FetchFailed(... Connection reset by peer)` on the mTLS Flight shuffle fetch, while single-stage queries (no shuffle) passed.

Root cause: the Flight server's `tls_incoming` accepted one TCP connection, **awaited its TLS handshake inline, then accepted the next** — serializing acceptance despite a comment to the contrary. A distributed-join shuffle opens a burst of fetch connections (up to 64 per reducer per peer, no client-side pooling); the listener accept queue overflowed while handshakes drained one-at-a-time, and the kernel reset the excess.

## Fix

Drive up to `MAX_CONCURRENT_TLS_HANDSHAKES` (1024) handshakes concurrently via `buffer_unordered`, so acceptance keeps draining the backlog instead of blocking on each handshake.

## Validation

Live SF10 cluster run: **zero** `Connection reset` / `FetchFailed` errors across the whole run (previously every join query failed at the reset); 31+ shuffle stages completed cleanly.

Stacked on #11454. (A separate, pre-existing scan-amplification issue still affects query latency — tracked separately.)