### PR TITLE
feat(secrets): check and report secret references at startup

### DIFF
--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -480,6 +480,22 @@ impl RuntimeBuilder {
         let resource_monitor = crate::resource_monitor::ResourceMonitor::new();
         let secrets = Arc::new(RwLock::new(Self::load_secrets(self.app.as_ref()).await));
 
+        // Diagnostics-only: resolve every `${ store:key }` reference in the
+        // app up front so secret problems surface as one consolidated report
+        // instead of scattered per-component errors. Skipped on cluster
+        // executors, where secrets resolve via scheduler RPC and the
+        // scheduler has already validated them. Never changes component
+        // loading; never logs secret values.
+        let is_cluster_executor = matches!(
+            self.resolved_cluster_config
+                .as_ref()
+                .and_then(ResolvedClusterConfig::effective_role),
+            Some(ClusterRole::Executor)
+        );
+        if !is_cluster_executor && let Some(app) = self.app.as_ref() {
+            crate::secrets_preflight::run(app, &*secrets.read().await).await;
+        }
+
         // Create the shared app reference early so DataFusion, Runtime, and PartitionService share it.
         let shared_app: Arc<RwLock<Option<Arc<App>>>> = Arc::new(RwLock::new(self.app));
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -486,6 +486,11 @@ impl RuntimeBuilder {
         // executors, where secrets resolve via scheduler RPC and the
         // scheduler has already validated them. Never changes component
         // loading; never logs secret values.
+        //
+        // Wrapped in `in_tracing_context_async` for the same reason as
+        // `load_secrets`: this runs before `spiced::init_tracing` installs the
+        // global subscriber, so without a temporary subscriber the summary
+        // would be dropped on the floor.
         let is_cluster_executor = matches!(
             self.resolved_cluster_config
                 .as_ref()
@@ -493,7 +498,8 @@ impl RuntimeBuilder {
             Some(ClusterRole::Executor)
         );
         if !is_cluster_executor && let Some(app) = self.app.as_ref() {
-            crate::secrets_preflight::run(app, &*secrets.read().await).await;
+            let secrets_guard = secrets.read().await;
+            in_tracing_context_async(crate::secrets_preflight::run(app, &secrets_guard)).await;
         }
 
         // Create the shared app reference early so DataFusion, Runtime, and PartitionService share it.

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -478,7 +478,7 @@ impl RuntimeBuilder {
 
         // Create resource monitor early so it can be passed to DataFusion
         let resource_monitor = crate::resource_monitor::ResourceMonitor::new();
-        let secrets = Arc::new(RwLock::new(Self::load_secrets(self.app.as_ref()).await));
+        let loaded_secrets = Self::load_secrets(self.app.as_ref()).await;
 
         // Diagnostics-only: resolve every `${ store:key }` reference in the
         // app up front so secret problems surface as one consolidated report
@@ -487,6 +487,8 @@ impl RuntimeBuilder {
         // scheduler has already validated them. Never changes component
         // loading; never logs secret values.
         //
+        // Runs on the owned `Secrets` before it is wrapped in the shared
+        // `RwLock` below, so no lock guard is held across the lookups' awaits.
         // Wrapped in `in_tracing_context_async` for the same reason as
         // `load_secrets`: this runs before `spiced::init_tracing` installs the
         // global subscriber, so without a temporary subscriber the summary
@@ -498,9 +500,10 @@ impl RuntimeBuilder {
             Some(ClusterRole::Executor)
         );
         if !is_cluster_executor && let Some(app) = self.app.as_ref() {
-            let secrets_guard = secrets.read().await;
-            in_tracing_context_async(crate::secrets_preflight::run(app, &secrets_guard)).await;
+            in_tracing_context_async(crate::secrets_preflight::run(app, &loaded_secrets)).await;
         }
+
+        let secrets = Arc::new(RwLock::new(loaded_secrets));
 
         // Create the shared app reference early so DataFusion, Runtime, and PartitionService share it.
         let shared_app: Arc<RwLock<Option<Arc<App>>>> = Arc::new(RwLock::new(self.app));

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -131,6 +131,7 @@ pub mod search;
 pub mod secrets {
     pub use runtime_secrets::*;
 }
+mod secrets_preflight;
 pub mod cluster;
 pub mod spice_metrics;
 pub mod status;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -131,8 +131,8 @@ pub mod search;
 pub mod secrets {
     pub use runtime_secrets::*;
 }
-mod secrets_preflight;
 pub mod cluster;
+mod secrets_preflight;
 pub mod spice_metrics;
 pub mod status;
 pub mod task_history;

--- a/crates/runtime/src/secrets_preflight.rs
+++ b/crates/runtime/src/secrets_preflight.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -142,33 +142,33 @@ fn collect_references(app: &App) -> Vec<LocatedRef> {
 
     for dataset in &app.datasets {
         if let Some(params) = &dataset.params {
-            scan_map("dataset", &dataset.name, params.as_string_map(), &mut refs);
+            scan_map("dataset", &dataset.name, &params.as_string_map(), &mut refs);
         }
     }
     for catalog in &app.catalogs {
         if let Some(params) = &catalog.params {
-            scan_map("catalog", &catalog.name, params.as_string_map(), &mut refs);
+            scan_map("catalog", &catalog.name, &params.as_string_map(), &mut refs);
         }
     }
     for view in &app.views {
         if let Some(params) = &view.params {
-            scan_map("view", &view.name, params.as_string_map(), &mut refs);
+            scan_map("view", &view.name, &params.as_string_map(), &mut refs);
         }
     }
     for model in &app.models {
-        scan_map("model", &model.name, value_map(&model.params), &mut refs);
+        scan_map("model", &model.name, &value_map(&model.params), &mut refs);
     }
     for embedding in &app.embeddings {
         scan_map(
             "embedding",
             &embedding.name,
-            value_map(&embedding.params),
+            &value_map(&embedding.params),
             &mut refs,
         );
     }
     for tool in &app.tools {
-        scan_map("tool", &tool.name, tool.params.clone(), &mut refs);
-        scan_map("tool", &tool.name, tool.env.clone(), &mut refs);
+        scan_map("tool", &tool.name, &tool.params, &mut refs);
+        scan_map("tool", &tool.name, &tool.env, &mut refs);
     }
 
     refs
@@ -192,14 +192,16 @@ fn value_map(params: &HashMap<String, serde_json::Value>) -> HashMap<String, Str
 }
 
 /// Scans one component's `param -> value` map and appends every reference found.
+/// Borrows the map so call sites (notably `tool.params` / `tool.env`) don't
+/// clone during startup.
 fn scan_map(
     kind: &'static str,
     component: &str,
-    params: HashMap<String, String>,
+    params: &HashMap<String, String>,
     refs: &mut Vec<LocatedRef>,
 ) {
     for (param, value) in params {
-        for reference in iter_secret_references(&value) {
+        for reference in iter_secret_references(value) {
             refs.push(LocatedRef {
                 kind,
                 component: component.to_string(),

--- a/crates/runtime/src/secrets_preflight.rs
+++ b/crates/runtime/src/secrets_preflight.rs
@@ -115,8 +115,10 @@ pub(crate) async fn run(app: &App, secrets: &Secrets) {
     tracing::warn!("{report}");
 }
 
-/// Human-readable explanation of a non-`Found` status. Carries only store/key
-/// names and store error text — never secret values.
+/// Human-readable explanation of a [`RefStatus`]. Carries only store/key
+/// names and store error text — never secret values. Callers only pass the
+/// non-`Found` statuses (the unresolved references); the `Found` arm is
+/// handled for exhaustiveness.
 fn describe(status: &RefStatus) -> String {
     match status {
         RefStatus::Found { .. } => "resolved".to_string(),

--- a/crates/runtime/src/secrets_preflight.rs
+++ b/crates/runtime/src/secrets_preflight.rs
@@ -1,0 +1,352 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Startup secret preflight.
+//!
+//! Walks every `${ store:key }` reference in the loaded app's component
+//! configuration and resolves each against the configured secret stores
+//! *before* components start loading, so a missing secret or a misconfigured
+//! store surfaces as one consolidated, root-caused report up front instead of
+//! as scattered per-component "missing required parameter" errors later.
+//!
+//! This is diagnostics only: it never changes whether or how components load,
+//! and it never logs secret values (it consumes [`RefStatus`], which carries
+//! store/key names and error text only).
+
+use std::collections::HashMap;
+
+use app::App;
+use runtime_secrets::{RefStatus, Secrets, iter_secret_references};
+
+const DOCS_URL: &str = "https://spiceai.org/docs/components/secret-stores";
+
+/// A single secret reference together with where it was found.
+struct LocatedRef {
+    /// Component kind, e.g. `dataset`, `model`.
+    kind: &'static str,
+    /// Component name (the `name:` field).
+    component: String,
+    /// Parameter name the reference appeared in.
+    param: String,
+    /// Store segment of `${ store:key }`.
+    store: String,
+    /// Key segment of `${ store:key }`.
+    key: String,
+}
+
+impl LocatedRef {
+    /// `${ store:key }` as written, for the report.
+    fn reference(&self) -> String {
+        format!("${{ {}:{} }}", self.store, self.key)
+    }
+
+    /// `kind 'name' (param)` provenance, for the report.
+    fn provenance(&self) -> String {
+        format!("{} '{}' ({})", self.kind, self.component, self.param)
+    }
+}
+
+/// Runs the preflight against the app's components and logs a single summary.
+///
+/// On success: one `INFO` line (or nothing when there are no references). On
+/// problems: one `WARN` block listing each unresolved reference with its
+/// provenance and root cause. Never aborts; never logs secret values.
+pub(crate) async fn run(app: &App, secrets: &Secrets) {
+    let refs = collect_references(app);
+    if refs.is_empty() {
+        return;
+    }
+
+    // Resolve each distinct (store, key) once — components loading right after
+    // re-hit the same lookups, which the store-level TTL caches absorb, but
+    // within the preflight itself we dedupe so a key reused across components
+    // costs a single check.
+    let mut cache: HashMap<(String, String), RefStatus> = HashMap::new();
+    let mut problems: Vec<(&LocatedRef, RefStatus)> = Vec::new();
+    for located in &refs {
+        let cache_key = (located.store.clone(), located.key.clone());
+        let status = match cache.get(&cache_key) {
+            Some(status) => status.clone(),
+            None => {
+                let status = secrets.check_reference(&located.store, &located.key).await;
+                cache.insert(cache_key, status.clone());
+                status
+            }
+        };
+        if !matches!(status, RefStatus::Found { .. }) {
+            problems.push((located, status));
+        }
+    }
+
+    if problems.is_empty() {
+        tracing::info!(
+            "Secret preflight: {} secret reference(s) resolved.",
+            refs.len()
+        );
+        return;
+    }
+
+    let mut report = format!(
+        "Secret preflight: {} of {} secret reference(s) have problems:",
+        problems.len(),
+        refs.len()
+    );
+    for (located, status) in &problems {
+        report.push_str(&format!(
+            "\n  ✗ {}  {} — {}",
+            located.reference(),
+            located.provenance(),
+            describe(status)
+        ));
+    }
+    report.push_str(&format!("\nDocs: {DOCS_URL}"));
+    tracing::warn!("{report}");
+}
+
+/// Human-readable explanation of a non-`Found` status. Carries only store/key
+/// names and store error text — never secret values.
+fn describe(status: &RefStatus) -> String {
+    match status {
+        RefStatus::Found { .. } => "resolved".to_string(),
+        RefStatus::NotFound { searched } => {
+            format!("not found in [{}]", searched.join(", "))
+        }
+        RefStatus::StoreError { store, error } => {
+            format!("store '{store}' error: {error}")
+        }
+        RefStatus::UnknownStore { configured } => {
+            format!(
+                "references undefined store; configured stores: [{}]",
+                configured.join(", ")
+            )
+        }
+    }
+}
+
+/// Collects every `${ store:key }` reference across the app's component
+/// parameter maps, tagged with provenance.
+fn collect_references(app: &App) -> Vec<LocatedRef> {
+    let mut refs = Vec::new();
+
+    for dataset in &app.datasets {
+        if let Some(params) = &dataset.params {
+            scan_map("dataset", &dataset.name, params.as_string_map(), &mut refs);
+        }
+    }
+    for catalog in &app.catalogs {
+        if let Some(params) = &catalog.params {
+            scan_map("catalog", &catalog.name, params.as_string_map(), &mut refs);
+        }
+    }
+    for view in &app.views {
+        if let Some(params) = &view.params {
+            scan_map("view", &view.name, params.as_string_map(), &mut refs);
+        }
+    }
+    for model in &app.models {
+        scan_map("model", &model.name, value_map(&model.params), &mut refs);
+    }
+    for embedding in &app.embeddings {
+        scan_map(
+            "embedding",
+            &embedding.name,
+            value_map(&embedding.params),
+            &mut refs,
+        );
+    }
+    for tool in &app.tools {
+        scan_map("tool", &tool.name, tool.params.clone(), &mut refs);
+        scan_map("tool", &tool.name, tool.env.clone(), &mut refs);
+    }
+
+    refs
+}
+
+/// Converts a `HashMap<String, serde_json::Value>` (model/embedding params)
+/// into scannable strings. String scalars are scanned as-is; other shapes are
+/// serialized so a reference nested in an array/object is still surfaced,
+/// attributed to the top-level parameter name.
+fn value_map(params: &HashMap<String, serde_json::Value>) -> HashMap<String, String> {
+    params
+        .iter()
+        .map(|(k, v)| {
+            let s = match v {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            (k.clone(), s)
+        })
+        .collect()
+}
+
+/// Scans one component's `param -> value` map and appends every reference found.
+fn scan_map(
+    kind: &'static str,
+    component: &str,
+    params: HashMap<String, String>,
+    refs: &mut Vec<LocatedRef>,
+) {
+    for (param, value) in params {
+        for reference in iter_secret_references(&value) {
+            refs.push(LocatedRef {
+                kind,
+                component: component.to_string(),
+                param: param.clone(),
+                store: reference.store,
+                key: reference.key,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app::AppBuilder;
+    use spicepod::component::dataset::Dataset;
+    use spicepod::component::embeddings::Embeddings;
+    use spicepod::component::model::Model;
+    use spicepod::component::tool::Tool;
+    use spicepod::param::Params;
+    use std::collections::HashMap;
+
+    fn dataset_with_params(name: &str, params: &[(&str, &str)]) -> Dataset {
+        let mut ds = Dataset::new("memory:data", name);
+        let map: HashMap<String, String> = params
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        ds.params = Some(Params::from_string_map(map));
+        ds
+    }
+
+    fn find<'a>(refs: &'a [LocatedRef], param: &str) -> Option<&'a LocatedRef> {
+        refs.iter().find(|r| r.param == param)
+    }
+
+    #[test]
+    fn collects_dataset_param_references_with_provenance() {
+        let app = AppBuilder::new("test")
+            .with_dataset(dataset_with_params(
+                "reports",
+                &[
+                    ("pg_pass", "${ secrets:PG_PASS }"),
+                    ("pg_host", "localhost"), // no reference
+                ],
+            ))
+            .build();
+
+        let refs = collect_references(&app);
+        assert_eq!(refs.len(), 1);
+        let r = &refs[0];
+        assert_eq!(r.kind, "dataset");
+        assert_eq!(r.component, "reports");
+        assert_eq!(r.param, "pg_pass");
+        assert_eq!(r.store, "secrets");
+        assert_eq!(r.key, "PG_PASS");
+        assert_eq!(r.reference(), "${ secrets:PG_PASS }");
+        assert_eq!(r.provenance(), "dataset 'reports' (pg_pass)");
+    }
+
+    #[test]
+    fn collects_references_across_component_kinds_including_tool_env() {
+        let mut model_params = HashMap::new();
+        model_params.insert(
+            "openai_api_key".to_string(),
+            serde_json::Value::String("${ secrets:OPENAI_KEY }".to_string()),
+        );
+        let model = Model {
+            params: model_params,
+            ..Model::new("openai:gpt-4o", "gpt")
+        };
+
+        let mut embed_params = HashMap::new();
+        embed_params.insert(
+            "hf_token".to_string(),
+            serde_json::Value::String("${ env:HF_TOKEN }".to_string()),
+        );
+        let embedding = Embeddings {
+            params: embed_params,
+            ..Embeddings::new("huggingface:foo", "embedder")
+        };
+
+        // Tool has no constructor and several optional fields; build it from
+        // JSON so the test stays robust to field additions.
+        let tool: Tool = serde_json::from_value(serde_json::json!({
+            "from": "mcp:thing",
+            "name": "mytool",
+            "params": { "api_key": "${ secrets:TOOL_KEY }" },
+            "env": { "TOKEN": "${ env:TOOL_ENV }" },
+        }))
+        .expect("valid tool");
+
+        let app = AppBuilder::new("test")
+            .with_model(model)
+            .with_embedding(embedding)
+            .with_tool(tool)
+            .build();
+
+        let refs = collect_references(&app);
+        // model + embedding + tool.params + tool.env
+        assert_eq!(refs.len(), 4);
+
+        let model_ref = find(&refs, "openai_api_key").expect("model ref");
+        assert_eq!(model_ref.kind, "model");
+        assert_eq!((model_ref.store.as_str(), model_ref.key.as_str()), ("secrets", "OPENAI_KEY"));
+
+        let embed_ref = find(&refs, "hf_token").expect("embedding ref");
+        assert_eq!(embed_ref.kind, "embedding");
+
+        let tool_param = find(&refs, "api_key").expect("tool param ref");
+        assert_eq!(tool_param.kind, "tool");
+        assert_eq!(tool_param.key, "TOOL_KEY");
+
+        let tool_env = find(&refs, "TOKEN").expect("tool env ref");
+        assert_eq!(tool_env.kind, "tool");
+        assert_eq!((tool_env.store.as_str(), tool_env.key.as_str()), ("env", "TOOL_ENV"));
+    }
+
+    #[test]
+    fn no_references_yields_empty() {
+        let app = AppBuilder::new("test")
+            .with_dataset(dataset_with_params("plain", &[("host", "localhost")]))
+            .build();
+        assert!(collect_references(&app).is_empty());
+    }
+
+    #[test]
+    fn describe_renders_each_status_without_values() {
+        assert_eq!(
+            describe(&RefStatus::NotFound {
+                searched: vec!["aws".to_string(), "env".to_string()],
+            }),
+            "not found in [aws, env]"
+        );
+        assert_eq!(
+            describe(&RefStatus::StoreError {
+                store: "aws".to_string(),
+                error: "bad creds".to_string(),
+            }),
+            "store 'aws' error: bad creds"
+        );
+        assert_eq!(
+            describe(&RefStatus::UnknownStore {
+                configured: vec!["env".to_string()],
+            }),
+            "references undefined store; configured stores: [env]"
+        );
+    }
+}

--- a/crates/runtime/src/secrets_preflight.rs
+++ b/crates/runtime/src/secrets_preflight.rs
@@ -27,6 +27,7 @@ limitations under the License.
 //! store/key names and error text only).
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 
 use app::App;
 use runtime_secrets::{RefStatus, Secrets, iter_secret_references};
@@ -78,13 +79,12 @@ pub(crate) async fn run(app: &App, secrets: &Secrets) {
     let mut problems: Vec<(&LocatedRef, RefStatus)> = Vec::new();
     for located in &refs {
         let cache_key = (located.store.clone(), located.key.clone());
-        let status = match cache.get(&cache_key) {
-            Some(status) => status.clone(),
-            None => {
-                let status = secrets.check_reference(&located.store, &located.key).await;
-                cache.insert(cache_key, status.clone());
-                status
-            }
+        let status = if let Some(status) = cache.get(&cache_key) {
+            status.clone()
+        } else {
+            let status = secrets.check_reference(&located.store, &located.key).await;
+            cache.insert(cache_key, status.clone());
+            status
         };
         if !matches!(status, RefStatus::Found { .. }) {
             problems.push((located, status));
@@ -92,27 +92,26 @@ pub(crate) async fn run(app: &App, secrets: &Secrets) {
     }
 
     if problems.is_empty() {
-        tracing::info!(
-            "Secret preflight: {} secret reference(s) resolved.",
-            refs.len()
-        );
+        tracing::info!("Secrets: all {} secret reference(s) resolved.", refs.len());
         return;
     }
 
     let mut report = format!(
-        "Secret preflight: {} of {} secret reference(s) have problems:",
+        "Secrets: {} of {} secret reference(s) could not be resolved:",
         problems.len(),
         refs.len()
     );
     for (located, status) in &problems {
-        report.push_str(&format!(
+        // Infallible: writing to a String never errors.
+        let _ = write!(
+            report,
             "\n  ✗ {}  {} — {}",
             located.reference(),
             located.provenance(),
             describe(status)
-        ));
+        );
     }
-    report.push_str(&format!("\nDocs: {DOCS_URL}"));
+    let _ = write!(report, "\nDocs: {DOCS_URL}");
     tracing::warn!("{report}");
 }
 
@@ -305,7 +304,10 @@ mod tests {
 
         let model_ref = find(&refs, "openai_api_key").expect("model ref");
         assert_eq!(model_ref.kind, "model");
-        assert_eq!((model_ref.store.as_str(), model_ref.key.as_str()), ("secrets", "OPENAI_KEY"));
+        assert_eq!(
+            (model_ref.store.as_str(), model_ref.key.as_str()),
+            ("secrets", "OPENAI_KEY")
+        );
 
         let embed_ref = find(&refs, "hf_token").expect("embedding ref");
         assert_eq!(embed_ref.kind, "embedding");
@@ -316,7 +318,10 @@ mod tests {
 
         let tool_env = find(&refs, "TOKEN").expect("tool env ref");
         assert_eq!(tool_env.kind, "tool");
-        assert_eq!((tool_env.store.as_str(), tool_env.key.as_str()), ("env", "TOOL_ENV"));
+        assert_eq!(
+            (tool_env.store.as_str(), tool_env.key.as_str()),
+            ("env", "TOOL_ENV")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Missing-secret and misconfigured-store problems previously surfaced piecemeal — one error per `${ store:key }` substitution, scattered through component-load logs, *after* each component had already begun loading. There was no single place that said what was wrong with a deployment's secrets.

This adds a startup check that runs right after the secret stores load: it walks every component's parameter/env maps (datasets, catalogs, views, models, embeddings, tools), extracts each `${ store:key }` reference via `iter_secret_references`, and resolves each distinct `(store, key)` once via `Secrets::check_reference` (#11195). It emits a single consolidated log:

- **success** — one INFO line (`Secrets: all N secret reference(s) resolved.`), or nothing when the app has no references;
- **problems** — one WARN block, each line carrying the reference, its `kind 'name' (param)` provenance, and the root cause:

```
Secrets: 2 of 14 secret reference(s) could not be resolved:
  ✗ ${ secrets:SNOWFLAKE_PASSWORD }  dataset 'reports' (snowflake_password) — not found in [aws, env]
  ✗ ${ aws:API_KEY }                 model 'gpt' (openai_api_key) — store 'aws' error: <root cause>
Docs: https://spiceai.org/docs/components/secret-stores
```

## Constraints

- **Diagnostics only** — never changes whether or how components load. (A fail-fast variant is a separate, optional follow-up.)
- **Never logs secret values** — consumes `RefStatus` (store/key names and error text only).
- **Cluster executors skipped** — there secrets resolve via scheduler RPC and the scheduler has already validated them.
- Cheap: each distinct `(store, key)` is checked once, and the stores' existing TTL caches absorb the lookups components repeat moments later.

## Testing

4 unit tests: provenance extraction for dataset params, cross-kind collection including tool `env`, the empty-app case, and `describe()` rendering for each `RefStatus` variant. `make lint-rust` clean.

## Series

Fifth PR in the secret-store UX series (#11175 → #11181 → #11188 → #11195 → this). Groundwork for `spice secrets check` / `GET /v1/secrets`, which will reuse this walk on demand.