### PR TITLE
Default cayenne_force_view_types to false

### DIFF
--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -949,12 +949,8 @@ pub struct VortexConfig {
     /// offset overflow in hash-join build-side `concat_batches` (e.g. `CH-benCH`
     /// q21 at SF1000, where `su_name` fans out across a ~100M-row join).
     ///
-    /// Runtime-configurable: the accelerator factory sets it (default on; opt out
-    /// with the `cayenne_force_view_types` acceleration param). It is `#[serde(skip)]`
-    /// because it is a read-only scan behavior re-derived on every open, NOT
-    /// serialized into Cayenne metadata — so toggling it never affects stored data
-    /// and it is intentionally excluded from `configuration_matches`. Off by default
-    /// for direct construction (unit tests keep `Utf8`). See `viewify_read_schema`.
+    /// Runtime-configurable: the accelerator factory sets it (default off; opt in
+    /// with `cayenne_force_view_types: true`).
     #[serde(skip)]
     pub force_view_read_schema: bool,
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -644,17 +644,14 @@ impl CayenneAccelerator {
     ) -> cayenne::metadata::VortexConfig {
         let mut config = cayenne::metadata::VortexConfig {
             footer_cache_mb,
-            // Default the query/scan path to Arrow view types (Utf8View/BinaryView)
-            // so DataFusion plans joins/aggregates on view arrays and the
-            // hash-join build-side `concat_batches` cannot hit the i32 2 GiB offset
-            // overflow (CH-benCH q21 @SF1000). The stored schema stays Utf8/Binary.
-            // Operators can opt out with `cayenne_force_view_types: false`.
-            force_view_read_schema: true,
+            // Default the query/scan path to native Arrow types (Utf8/Binary).
+            force_view_read_schema: false,
             ..Default::default()
         };
         if let Some(acceleration) = source.acceleration()
             && let Some(v) = acceleration.params.get("cayenne_force_view_types")
         {
+            // Any value other than `false` enables view types
             config.force_view_read_schema = !v.trim().eq_ignore_ascii_case("false");
         }
 

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -2367,23 +2367,17 @@ mod accelerator_compat_tests {
                 // For Vortex, check if unsupported types are converted to Utf8
                 if matches!(engine, Engine::Cayenne) {
                     // Cayenne converts these unsupported types and Map to a string
-                    // (Utf8) column. Then, with force_view_read_schema (default on
-                    // in the accelerator factory), it advertises Utf8 columns as
-                    // Utf8View on the read schema. So the expected stored type is
-                    // Utf8 for unsupported/Map and the original type otherwise; any
-                    // stored Utf8 surfaces as Utf8View. (Binary / LargeUtf8 /
-                    // LargeBinary are NOT viewified — see `viewify_read_schema`.)
-                    let expected_stored = if vortex_unsupported_types.contains(original_type)
+                    // (Utf8) column. The accelerator factory now defaults
+                    // force_view_read_schema to OFF, so the read schema keeps native
+                    // Utf8 (no Utf8View viewification unless the table opts in with
+                    // `cayenne_force_view_types: true`). So the expected type is Utf8
+                    // for unsupported/Map and the original type otherwise.
+                    let expected_table = if vortex_unsupported_types.contains(original_type)
                         || matches!(original_type, DataType::Map(_, _))
                     {
                         DataType::Utf8
                     } else {
                         original_type.clone()
-                    };
-                    let expected_table = if expected_stored == DataType::Utf8 {
-                        DataType::Utf8View
-                    } else {
-                        expected_stored
                     };
                     assert_eq!(
                         table_type, &expected_table,


### PR DESCRIPTION
## 📝 Summary

Cayenne scans now default to native Arrow `Utf8`/`Binary` instead of view types.

`Utf8View`/`BinaryView` are not compacted across `RepartitionExec`, so wide strings fanned out through a partitioned join inflate query-pool reservations (CH-benCH q10 SF500: ~7×  pool peak reservation ~2.35 GB -> 15.33 GB), driving spills / `ResourceExhausted` under a memory limit.

Opt-in preserved: set `cayenne_force_view_types: true` to re-enable view types per table.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
