### PR TITLE
fix: resolve table-reference qualification in results-cache invalidation (fixes #11266)

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -147,7 +147,10 @@ pub const SPICE_DEFAULT_SCHEMA: &str = "public";
 /// until TTL expiry. Resolving both sides first makes the comparison robust to
 /// qualification differences.
 #[must_use]
-pub fn resolved_table_match(stored: &HashSet<TableReference>, target: &TableReference) -> bool {
+pub fn resolved_table_match<S: std::hash::BuildHasher>(
+    stored: &HashSet<TableReference, S>,
+    target: &TableReference,
+) -> bool {
     let resolved_target = target
         .clone()
         .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -124,6 +124,41 @@ impl AsTableRefs for LogicalPlan {
     }
 }
 
+/// Default catalog and schema used to resolve table references before comparing
+/// them during cache invalidation.
+///
+/// These mirror `runtime_datafusion::SPICE_DEFAULT_CATALOG` /
+/// `SPICE_DEFAULT_SCHEMA`. They are duplicated here because the `cache` crate
+/// cannot depend on `runtime-datafusion` without forming a dependency cycle
+/// (`runtime-datafusion -> search -> datafusion-optimizer-rules -> cache`).
+pub const SPICE_DEFAULT_CATALOG: &str = "spice";
+pub const SPICE_DEFAULT_SCHEMA: &str = "public";
+
+/// Returns `true` if `target` refers to the same physical table as any reference
+/// in `stored`, after resolving both sides to fully-qualified
+/// (`catalog.schema.table`) form.
+///
+/// Cache entries record table references exactly as written in the originating
+/// SQL (e.g. bare `customer` or fully-qualified `spice.public.customer`), while
+/// invalidators — accelerated-refresh completion, `INSERT INTO`, and other DML —
+/// may pass a differently-qualified reference for the same table. Plain
+/// `TableReference` equality therefore misses entries that name the same table
+/// with a different qualification, leaving stale rows served as fresh cache hits
+/// until TTL expiry. Resolving both sides first makes the comparison robust to
+/// qualification differences.
+#[must_use]
+pub fn resolved_table_match(stored: &HashSet<TableReference>, target: &TableReference) -> bool {
+    let resolved_target = target
+        .clone()
+        .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA);
+    stored.iter().any(|stored_ref| {
+        stored_ref
+            .clone()
+            .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
+            == resolved_target
+    })
+}
+
 #[async_trait]
 pub trait CacheProvider<V: Clone + Send + Sync + 'static>:
     HashProvider + std::fmt::Debug + std::fmt::Display

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -495,7 +495,7 @@ impl<
         if let Some(ref moka_cache) = self.moka_cache {
             moka_cache
                 .invalidate_entries_if(move |_key, value| {
-                    value.as_table_refs().contains(&table_ref)
+                    crate::resolved_table_match(value.as_table_refs().as_ref(), &table_ref)
                 })
                 .context(FailedToInvalidateCacheSnafu {
                     table_name: table_name_arc,
@@ -515,7 +515,7 @@ impl<
                 let mut keys_to_remove = Vec::new();
                 for key in backend.iter_keys().await {
                     if let Some(value) = backend.get(&key).await
-                        && value.as_table_refs().contains(&table_ref)
+                        && crate::resolved_table_match(value.as_table_refs().as_ref(), &table_ref)
                     {
                         keys_to_remove.push(key);
                     }
@@ -555,11 +555,12 @@ mod tests {
     }
 
     async fn create_test_cached_result() -> CachedQueryResult {
+        create_test_cached_result_with_table(TableReference::bare("test_table")).await
+    }
+
+    async fn create_test_cached_result_with_table(table: TableReference) -> CachedQueryResult {
         let record_batch = create_test_record_batch();
-        let mut input_tables = HashSet::new();
-        input_tables.insert(TableReference::Bare {
-            table: Arc::from("test_table"),
-        });
+        let input_tables = HashSet::from([table]);
 
         let encoder = crate::encoding::get_encoder(spicepod::component::caching::Encoding::None);
 
@@ -711,6 +712,77 @@ mod tests {
             .is_none()
             .then_some(())
             .expect("cache should not contain key after invalidation");
+    }
+
+    /// Regression test for #11266: cache invalidation must resolve both the
+    /// stored and the invalidating table reference to fully-qualified form, so a
+    /// differently-qualified entry (e.g. `spice.public.foo`) is still
+    /// invalidated by a bare/partial reference (e.g. `foo`) for the same table,
+    /// and vice versa. Exact `TableReference` equality misses these, leaving
+    /// stale rows served as fresh cache hits until TTL.
+    #[rstest]
+    // Stored fully-qualified, invalidated bare.
+    #[case::full_invalidated_by_bare(
+        TableReference::full("spice", "public", "foo"),
+        TableReference::bare("foo"),
+        true
+    )]
+    // Stored bare, invalidated fully-qualified.
+    #[case::bare_invalidated_by_full(
+        TableReference::bare("foo"),
+        TableReference::full("spice", "public", "foo"),
+        true
+    )]
+    // Stored partial, invalidated bare (same default catalog).
+    #[case::partial_invalidated_by_bare(
+        TableReference::partial("public", "foo"),
+        TableReference::bare("foo"),
+        true
+    )]
+    // Different physical table — must NOT be invalidated.
+    #[case::different_table_preserved(
+        TableReference::full("spice", "public", "foo"),
+        TableReference::bare("bar"),
+        false
+    )]
+    // Different (non-default) schema — must NOT be invalidated.
+    #[case::different_schema_preserved(
+        TableReference::full("spice", "other", "foo"),
+        TableReference::bare("foo"),
+        false
+    )]
+    #[tokio::test]
+    async fn test_cache_invalidate_resolves_qualification(
+        #[case] stored: TableReference,
+        #[case] invalidate_with: TableReference,
+        #[case] expect_invalidated: bool,
+    ) {
+        let cache: LruCache<CachedQueryResult, _, _> = LruCache::new(
+            10,
+            Duration::from_mins(1),
+            RandomState::default(),
+            CachingPolicy::Lru,
+            CacheEngine::Moka,
+        );
+        let result = create_test_cached_result_with_table(stored).await;
+
+        let key = CacheKey::Query("test_query", None).as_raw_key(cache.hasher());
+        cache.put_raw_key(&key.as_u64(), result).await;
+
+        assert!(
+            cache.get_raw_key(&key.as_u64()).await.is_some(),
+            "cache should contain the key before invalidation"
+        );
+
+        cache
+            .invalidate_for_table(invalidate_with)
+            .expect("should invalidate cache");
+
+        assert_eq!(
+            cache.get_raw_key(&key.as_u64()).await.is_none(),
+            expect_invalidated,
+            "invalidation outcome mismatch"
+        );
     }
 
     #[rstest]

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -169,7 +169,9 @@ impl<
         };
         let table_name = Arc::clone(table_name);
         self.cache
-            .invalidate_entries_if(move |_key, value| value.as_table_refs().contains(&table_ref))
+            .invalidate_entries_if(move |_key, value| {
+                crate::resolved_table_match(value.as_table_refs().as_ref(), &table_ref)
+            })
             .context(FailedToInvalidateCacheSnafu { table_name })?;
 
         Ok(())


### PR DESCRIPTION
## Summary

Results-cache invalidation used **exact `TableReference` equality**
(`value.as_table_refs().contains(&table_ref)`), so a cached entry whose stored
ref differs in qualification from the invalidator's ref — for the same physical
table — was never invalidated.

Cache entries record table refs exactly as written in the originating SQL
(`crates/cache/src/utils.rs` `get_logical_plan_input_tables`): `SELECT * FROM spice.public.foo`
stores `Full{spice,public,foo}`, while `SELECT * FROM foo` stores `Bare{foo}`.
Invalidators pass a *different* qualification for the same table:

- accelerated-refresh completion invalidates with the bare dataset name (`accelerated_table/refresh.rs`)
- `INSERT INTO foo` invalidates `Bare{foo}` (`datafusion/query.rs`, `flightsql/statement_update.rs`)

So a cached `SELECT * FROM spice.public.foo` survived refresh and DML invalidation and
kept returning pre-mutation rows as a fresh `CacheHit` until TTL expiry. Impact scales
with the configured TTL (default 1s limits the window; operator-configured 10m+ does not).

## Root cause

The invalidation predicate used raw `HashSet::contains`. The runtime already knows raw
equality is unreliable — `datafusion/mod.rs` defines `resolved_equality` (resolve both
sides to `spice.public`) — but the cache predicate didn't use that semantics.

## Changes

- Add `resolved_table_match(stored, target)` to `crates/cache/src/lib.rs`, which resolves
  both the stored refs and the invalidating ref to fully-qualified `catalog.schema.table`
  form (via `TableReference::resolve`) before comparing — mirroring the runtime's
  `resolved_equality`. Defaults are `spice`/`public`, duplicated locally because `cache`
  cannot depend on `runtime-datafusion` without a dependency cycle.
- Use it in all three invalidation paths: the Moka and Pingora LRU backends
  (`lru_cache.rs`) and `SimpleCache` (`simple_cache.rs`).
- Regression test (`test_cache_invalidate_resolves_qualification`) covering both
  directions (full<->bare, partial<->bare) plus negative cases (different table, different
  non-default schema must NOT be invalidated). The positive cases fail on the old
  `contains`-based predicate.

Scoped to the equality semantics — the core reported bug, spanning all three backends.

## Out of scope (follow-up)

The issue also notes a smaller *timing* concern: on the generic HTTP DML path,
`invalidate_for_table` runs at **planning** time (`query.rs`), before the mutation
executes, so a concurrent SELECT can repopulate the cache with pre-mutation rows. That's
a separate, more invasive change (move invalidation to post-execution like the Flight
paths) and is left for a dedicated PR.

## Test plan

- `make lint`
- `make test`

## Checklist

- [x] Root cause identified and fixed at the shared predicate (all backends)
- [x] Regression test added (fails on old code, passes on new)
- [x] `cargo clippy -p cache --all-targets` clean
- [x] `cargo test -p cache --lib` green (77 passed)
- [x] `cargo fmt` applied

Fixes #11266