### PR TITLE
chore(deps): bump vortex to spiceai-54 HEAD (flat reader subrange decode fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21393,7 +21393,7 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -21427,7 +21427,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21445,7 +21445,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "arc-swap",
  "arcref",
@@ -21496,7 +21496,7 @@ dependencies = [
 [[package]]
 name = "vortex-array-macros"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -21506,7 +21506,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21533,7 +21533,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -21546,7 +21546,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -21559,7 +21559,7 @@ dependencies = [
 [[package]]
 name = "vortex-compressor"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21615,7 +21615,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -21629,7 +21629,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -21643,7 +21643,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -21656,7 +21656,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "fastlanes",
  "itertools 0.14.0",
@@ -21673,7 +21673,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -21717,7 +21717,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -21727,7 +21727,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "fsst-rs",
  "prost 0.14.3",
@@ -21741,7 +21741,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "async-fs",
  "async-stream",
@@ -21771,7 +21771,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -21788,7 +21788,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "arcref",
  "arrow-array",
@@ -21830,7 +21830,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -21840,7 +21840,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "parking_lot 0.12.5",
  "sketches-ddsketch",
@@ -21849,7 +21849,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "pco",
  "prost 0.14.3",
@@ -21863,7 +21863,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "prost 0.14.3",
  "prost-types",
@@ -21872,7 +21872,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "arrow-array",
  "itertools 0.14.0",
@@ -21888,7 +21888,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "async-trait",
  "futures",
@@ -21904,7 +21904,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -21920,7 +21920,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "dashmap",
  "lasso",
@@ -21932,7 +21932,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21947,7 +21947,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "dashmap",
  "hashbrown 0.17.1",
@@ -21957,7 +21957,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "vortex-array",
  "vortex-buffer",
@@ -21970,7 +21970,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=729249dd35e9af37ffbcd606ea51ebb60f9ac71b#729249dd35e9af37ffbcd606ea51ebb60f9ac71b"
+source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,13 +358,13 @@ flatbuffers = "25.2.10"
 # Vortex tagged releases publish version 0.1.0 in their Cargo.toml, not the actual release version,
 # so we specify git deps here directly. The [patch.crates-io] entries below exist to override
 # transitive vortex dependencies pulled in by other patched crates.
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
-vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
 vortex-datafusion = { path = "crates/vortex" }
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
 
 x509-certificate = "0.25.0"
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "93b75c3c7d1a812b23d00b45adf537d7a2415496" } # spiceai/spice-rs#77
@@ -488,9 +488,9 @@ arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a4037
 arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" } # branch: lukim/spiceai-58.3.0
 parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" }      # branch: lukim/spiceai-58.3.0
 
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
 vortex-datafusion = { path = "crates/vortex" }
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "729249dd35e9af37ffbcd606ea51ebb60f9ac71b" } # spiceai-54
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54


### PR DESCRIPTION
## Summary

Bumps the `vortex` / `vortex-*` git pins from `729249dd` to `ab4f0b17` — the
current `spiceai-54` HEAD.

## What this brings in

- **Fix flat reader subrange decode reuse** (the headline change), plus the
  rebase of the `spiceai-54` perf work (intra-file decode parallelism and the
  per-`ExecutionCtx` `ArrayKernels` snapshot) onto the Vortex 0.75.0 base.

The net source delta versus the previously pinned commit is internal-only
(`vortex-layout/.../flat/reader.rs`, `vortex-array/.../arc_swap_map.rs`,
`vortex-array/.../optimizer/kernels.rs`) — **no public API change**, so no
Spice-side code changes are required.

## Upstream branch note

The `spiceai-54` tip was briefly broken: the rebase that produced `e09ec32c`
dropped `ArcSwapMap::load_full` and a `HashMap` import still used by the kernel
snapshot, so `vortex-array` failed to compile (`E0599` / `E0425`). That was
fixed upstream in [spiceai/vortex#70](https://github.com/spiceai/vortex/pull/70),
now folded into the `spiceai-54` HEAD this PR pins to. The restored files are
byte-identical to the last good commit, so the fix is a pure un-break.

## Verification

- `cargo check -p cayenne -p vortex-datafusion` — clean.
- `Cargo.lock` regenerated by cargo (git rev only; dependency tree unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
