### PR TITLE
feat(cayenne): extend HLL NDV sketching to string and date columns

### DIFF
--- a/crates/cayenne/src/hll.rs
+++ b/crates/cayenne/src/hll.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 //! A small, mergeable [`HyperLogLog`] cardinality sketch maintained incrementally
 //! on the Cayenne write path, plus a [`NdvSketches`] container that holds one
-//! sketch per NDV-tracked column (integer, string, or date) and (de)serializes
+//! sketch per NDV-tracked column (integer, string, or temporal) and (de)serializes
 //! them for the metastore.
 //!
 //! Why a purpose-built sketch: `DataFusion`'s `approx_distinct` `HyperLogLog` is

--- a/crates/cayenne/src/hll.rs
+++ b/crates/cayenne/src/hll.rs
@@ -16,14 +16,16 @@ limitations under the License.
 
 //! A small, mergeable [`HyperLogLog`] cardinality sketch maintained incrementally
 //! on the Cayenne write path, plus a [`NdvSketches`] container that holds one
-//! sketch per (integer) column and (de)serializes them for the metastore.
+//! sketch per NDV-tracked column (integer, string, or date) and (de)serializes
+//! them for the metastore.
 //!
 //! Why a purpose-built sketch: `DataFusion`'s `approx_distinct` `HyperLogLog` is
 //! private to its aggregate executor and not importable, and no other HLL crate
 //! is in the dependency graph. The estimate only needs to be accurate enough to
-//! *size distributed joins* on sparse integer keys (e.g. CDC `o_custkey` spanning
-//! ~1e9 with ~1M distinct), so a standard register-array HLL at precision
-//! [`PRECISION`] (≈1.6% standard error) is more than sufficient.
+//! *size distributed joins and group-bys* on keys whose distinct count diverges
+//! sharply from their min/max range (e.g. CDC `o_custkey` spanning ~1e9 with ~1M
+//! distinct, or string group keys like `n_name`), so a standard register-array
+//! HLL at precision [`PRECISION`] (≈1.6% standard error) is more than sufficient.
 //!
 //! Mergeability is the reason this is incremental rather than recomputed: HLL is
 //! a register-wise max, so a write's sketch folds into the metastore aggregate
@@ -188,7 +190,7 @@ impl Default for HyperLogLog {
 }
 
 /// Per-column NDV sketches, keyed by column index in the table schema. Only
-/// NDV-tracked columns (integers, strings, dates) get a sketch.
+/// NDV-tracked columns (integers, strings, temporal) get a sketch.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct NdvSketches {
     columns: BTreeMap<u32, HyperLogLog>,

--- a/crates/cayenne/src/hll.rs
+++ b/crates/cayenne/src/hll.rs
@@ -105,6 +105,14 @@ impl HyperLogLog {
         self.add_hash(hash);
     }
 
+    /// Add a raw byte value (e.g. a UTF-8 string or binary key). Uses the same
+    /// stable, explicit byte hashing as [`add_i128`](Self::add_i128) so the
+    /// mapping is consistent across runs and builds for the persisted sketch.
+    pub fn add_bytes(&mut self, value: &[u8]) {
+        let hash = hash_index::hash_key_bytes(&[value]);
+        self.add_hash(hash);
+    }
+
     /// Merge another sketch into this one (register-wise max). No-op on a
     /// precision mismatch (treated as incompatible rather than panicking).
     pub fn merge(&mut self, other: &Self) {
@@ -180,7 +188,7 @@ impl Default for HyperLogLog {
 }
 
 /// Per-column NDV sketches, keyed by column index in the table schema. Only
-/// integer columns (join-key candidates) get a sketch.
+/// NDV-tracked columns (integers, strings, dates) get a sketch.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct NdvSketches {
     columns: BTreeMap<u32, HyperLogLog>,
@@ -360,6 +368,23 @@ mod tests {
         assert!(
             est <= 3,
             "duplicate-only sketch estimated {est}, expected ~1"
+        );
+    }
+
+    #[test]
+    fn add_bytes_counts_distinct_strings() {
+        let mut hll = HyperLogLog::new();
+        for v in 0..10_000u64 {
+            // Distinct strings; repeat each a few times to confirm dedup.
+            let s = format!("name-{v}");
+            for _ in 0..3 {
+                hll.add_bytes(s.as_bytes());
+            }
+        }
+        let est = hll.estimate();
+        assert!(
+            within_error(est, 10_000, 0.05),
+            "string est={est} outside 5% of 10,000"
         );
     }
 

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -1536,7 +1536,8 @@ pub struct TableStatistics {
     /// Serialized per-column NDV (distinct-count) `HyperLogLog` sketches
     /// ([`crate::hll::NdvSketches`]), `None` when no NDV-tracked column has a
     /// sketch. Merged across writes register-wise; used to size distributed
-    /// joins and group-bys on integer, string, and date keys. See [`crate::hll`].
+    /// joins and group-bys on integer, string, and temporal (date/time/timestamp)
+    /// keys. See [`crate::hll`].
     pub ndv_sketches: Option<Vec<u8>>,
 }
 

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -1534,9 +1534,9 @@ pub struct TableStatistics {
     /// the authoritative rewritten count.
     pub num_rows: i64,
     /// Serialized per-column NDV (distinct-count) `HyperLogLog` sketches
-    /// ([`crate::hll::NdvSketches`]), `None` when no integer column has a sketch.
-    /// Merged across writes register-wise; used to size distributed joins on
-    /// sparse integer keys. See [`crate::hll`].
+    /// ([`crate::hll::NdvSketches`]), `None` when no NDV-tracked column has a
+    /// sketch. Merged across writes register-wise; used to size distributed
+    /// joins and group-bys on integer, string, and date keys. See [`crate::hll`].
     pub ndv_sketches: Option<Vec<u8>>,
 }
 

--- a/crates/cayenne/src/provider/column_stats.rs
+++ b/crates/cayenne/src/provider/column_stats.rs
@@ -50,7 +50,7 @@ struct ColumnStatsState {
     columns: Vec<vortex::array::stats::StatsSet>,
     seeded: Vec<bool>,
     /// Per-column NDV (distinct-count) `HyperLogLog` sketch, `Some` for the
-    /// NDV-tracked columns (integers, strings, dates — see
+    /// NDV-tracked columns (integers, strings, temporal — see
     /// [`ColumnStatsAccumulator::supports_ndv`]). Parallel to `columns` for O(1)
     /// access on the write hot path. See [`crate::hll`].
     ndv: Vec<Option<crate::hll::HyperLogLog>>,
@@ -111,7 +111,7 @@ impl ColumnStatsAccumulator {
                 ))
             })
             .collect();
-        // NDV sketches only for NDV-tracked columns (integers, strings, dates);
+        // NDV sketches only for NDV-tracked columns (integers, strings, temporal);
         // other columns get `None` so the write path skips them.
         let ndv: Vec<Option<crate::hll::HyperLogLog>> = schema
             .fields()
@@ -137,7 +137,14 @@ impl ColumnStatsAccumulator {
     ///   sparse CDC keys;
     /// - strings — group-by / join keys (e.g. `n_name`, `c_state`) where min/max
     ///   carries no cardinality signal;
-    /// - dates — low-cardinality temporal group keys (e.g. `o_entry_d`).
+    /// - temporal (dates, times, timestamps) — low-cardinality group keys (e.g.
+    ///   `o_entry_d`, `ol_delivery_d`) whose distinct count is far smaller than
+    ///   their min/max range.
+    ///
+    /// Deliberately excluded: floats, decimals, and booleans — these are
+    /// measures, not keys, so an NDV signal would not feed join/group-by sizing.
+    /// The set mirrors the integer/string/temporal arms folded in
+    /// [`add_column_to_hll`](Self::add_column_to_hll); keep the two in sync.
     ///
     /// The sketch hashes all of these uniformly (`add_hash`), yielding `Inexact`
     /// NDV — exactly what the optimizer's cardinality gate accepts.
@@ -157,6 +164,9 @@ impl ColumnStatsAccumulator {
                 | DataType::Utf8View
                 | DataType::Date32
                 | DataType::Date64
+                | DataType::Time32(_)
+                | DataType::Time64(_)
+                | DataType::Timestamp(_, _)
         )
     }
 
@@ -197,10 +207,20 @@ impl ColumnStatsAccumulator {
         fold_int!(UInt16Array);
         fold_int!(UInt32Array);
         fold_int!(UInt64Array);
-        // Dates are integer-backed (Date32 = days, Date64 = ms since epoch);
-        // hash them through the same i128 path as integers.
+        // Temporal types are integer-backed (Date32 = days; Date64/Timestamp =
+        // ms/us/ns since epoch; Time32/Time64 = since midnight) — hash them
+        // through the same i128 path as integers. The array type is independent
+        // of any timezone, so a single downcast per unit covers tz-aware columns.
         fold_int!(Date32Array);
         fold_int!(Date64Array);
+        fold_int!(TimestampSecondArray);
+        fold_int!(TimestampMillisecondArray);
+        fold_int!(TimestampMicrosecondArray);
+        fold_int!(TimestampNanosecondArray);
+        fold_int!(Time32SecondArray);
+        fold_int!(Time32MillisecondArray);
+        fold_int!(Time64MicrosecondArray);
+        fold_int!(Time64NanosecondArray);
         fold_bytes!(StringArray);
         fold_bytes!(LargeStringArray);
         fold_bytes!(StringViewArray);
@@ -665,31 +685,40 @@ impl ColumnStatsAccumulator {
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{Date32Array, Float64Array, Int64Array, StringArray};
+    use arrow::array::{
+        Date32Array, Float64Array, Int64Array, StringArray, TimestampMicrosecondArray,
+    };
     use arrow::record_batch::RecordBatch;
-    use arrow_schema::{DataType, Field};
+    use arrow_schema::{DataType, Field, TimeUnit};
 
     use super::*;
 
     #[test]
-    fn ndv_sketches_cover_integer_string_and_date_columns() {
-        // Schema mixes NDV-tracked types (int, string, date) with an excluded
-        // type (float) to confirm the gate and the per-column fold.
+    fn ndv_sketches_cover_integer_string_and_temporal_columns() {
+        // Schema mixes NDV-tracked types (int, string, date, timestamp) with an
+        // excluded type (float) to confirm the gate and the per-column fold.
+        // Timestamp is the column class behind TPC `o_entry_d` / `ol_delivery_d`.
         let schema = arrow_schema::Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("name", DataType::Utf8, true),
             Field::new("d", DataType::Date32, true),
+            Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                true,
+            ),
             Field::new("amount", DataType::Float64, true),
         ]);
         let acc = ColumnStatsAccumulator::new(&schema);
 
         // 100 distinct ids, 4 distinct names (each repeated 25x), 10 distinct
-        // dates, and floats (which must not get a sketch).
+        // dates, 7 distinct timestamps, and floats (which must not get a sketch).
         let ids: Int64Array = (0..100i64).map(Some).collect();
         let names: StringArray = (0..100)
             .map(|i| Some(format!("name-{}", i % 4)))
             .collect();
         let dates: Date32Array = (0..100).map(|i| Some(i % 10)).collect();
+        let timestamps: TimestampMicrosecondArray = (0..100).map(|i| Some(i % 7)).collect();
         let amounts: Float64Array = (0..100).map(|i| Some(f64::from(i))).collect();
 
         let batch = RecordBatch::try_new(
@@ -698,6 +727,7 @@ mod tests {
                 Arc::new(ids),
                 Arc::new(names),
                 Arc::new(dates),
+                Arc::new(timestamps),
                 Arc::new(amounts),
             ],
         )
@@ -714,9 +744,12 @@ mod tests {
         // date: 10 distinct.
         let date_ndv = sketches.estimate(2).expect("date sketch present");
         assert!((9..=11).contains(&date_ndv), "date NDV {date_ndv} not ~10");
+        // timestamp: 7 distinct.
+        let ts_ndv = sketches.estimate(3).expect("timestamp sketch present");
+        assert!((6..=8).contains(&ts_ndv), "timestamp NDV {ts_ndv} not ~7");
         // float (amount): excluded — no sketch.
         assert_eq!(
-            sketches.estimate(3),
+            sketches.estimate(4),
             None,
             "float column must not get an NDV sketch"
         );

--- a/crates/cayenne/src/provider/column_stats.rs
+++ b/crates/cayenne/src/provider/column_stats.rs
@@ -702,11 +702,7 @@ mod tests {
             Field::new("id", DataType::Int64, false),
             Field::new("name", DataType::Utf8, true),
             Field::new("d", DataType::Date32, true),
-            Field::new(
-                "ts",
-                DataType::Timestamp(TimeUnit::Microsecond, None),
-                true,
-            ),
+            Field::new("ts", DataType::Timestamp(TimeUnit::Microsecond, None), true),
             Field::new("amount", DataType::Float64, true),
         ]);
         let acc = ColumnStatsAccumulator::new(&schema);
@@ -714,9 +710,7 @@ mod tests {
         // 100 distinct ids, 4 distinct names (each repeated 25x), 10 distinct
         // dates, 7 distinct timestamps, and floats (which must not get a sketch).
         let ids: Int64Array = (0..100i64).map(Some).collect();
-        let names: StringArray = (0..100)
-            .map(|i| Some(format!("name-{}", i % 4)))
-            .collect();
+        let names: StringArray = (0..100).map(|i| Some(format!("name-{}", i % 4))).collect();
         let dates: Date32Array = (0..100).map(|i| Some(i % 10)).collect();
         let timestamps: TimestampMicrosecondArray = (0..100).map(|i| Some(i % 7)).collect();
         let amounts: Float64Array = (0..100).map(|i| Some(f64::from(i))).collect();

--- a/crates/cayenne/src/provider/column_stats.rs
+++ b/crates/cayenne/src/provider/column_stats.rs
@@ -268,7 +268,7 @@ impl ColumnStatsAccumulator {
             }
 
             // Maintain the per-column NDV sketch for NDV-tracked columns
-            // (integers, strings, dates).
+            // (integers, strings, temporal).
             if let Some(Some(hll)) = state.ndv.get_mut(i) {
                 Self::add_column_to_hll(col.as_ref(), hll);
             }

--- a/crates/cayenne/src/provider/column_stats.rs
+++ b/crates/cayenne/src/provider/column_stats.rs
@@ -49,8 +49,9 @@ use vortex::dtype::arrow::FromArrowType;
 struct ColumnStatsState {
     columns: Vec<vortex::array::stats::StatsSet>,
     seeded: Vec<bool>,
-    /// Per-column NDV (distinct-count) `HyperLogLog` sketch, `Some` only for
-    /// integer columns (join-key candidates). Parallel to `columns` for O(1)
+    /// Per-column NDV (distinct-count) `HyperLogLog` sketch, `Some` for the
+    /// NDV-tracked columns (integers, strings, dates — see
+    /// [`ColumnStatsAccumulator::supports_ndv`]). Parallel to `columns` for O(1)
     /// access on the write hot path. See [`crate::hll`].
     ndv: Vec<Option<crate::hll::HyperLogLog>>,
 }
@@ -110,8 +111,8 @@ impl ColumnStatsAccumulator {
                 ))
             })
             .collect();
-        // NDV sketches only for integer columns (join-key candidates); other
-        // columns get `None` so the write path skips them.
+        // NDV sketches only for NDV-tracked columns (integers, strings, dates);
+        // other columns get `None` so the write path skips them.
         let ndv: Vec<Option<crate::hll::HyperLogLog>> = schema
             .fields()
             .iter()
@@ -129,10 +130,17 @@ impl ColumnStatsAccumulator {
         }
     }
 
-    /// Whether to maintain an NDV sketch for `dt`. Restricted to integer types:
-    /// these are the join-key candidates (e.g. `*_custkey`, `*_orderkey`) whose
-    /// distinct count can diverge sharply from their min/max range under sparse
-    /// CDC keys. Mirrors the consumer-side `supports_ndv` in the cluster reporter.
+    /// Whether to maintain an NDV sketch for `dt`. Covers the types whose
+    /// distinct count is useful for join/group-by sizing and can diverge sharply
+    /// from a min/max range:
+    /// - integers — join-key candidates (e.g. `*_custkey`, `*_orderkey`) under
+    ///   sparse CDC keys;
+    /// - strings — group-by / join keys (e.g. `n_name`, `c_state`) where min/max
+    ///   carries no cardinality signal;
+    /// - dates — low-cardinality temporal group keys (e.g. `o_entry_d`).
+    ///
+    /// The sketch hashes all of these uniformly (`add_hash`), yielding `Inexact`
+    /// NDV — exactly what the optimizer's cardinality gate accepts.
     fn supports_ndv(dt: &DataType) -> bool {
         matches!(
             dt,
@@ -144,14 +152,24 @@ impl ColumnStatsAccumulator {
                 | DataType::UInt16
                 | DataType::UInt32
                 | DataType::UInt64
+                | DataType::Utf8
+                | DataType::LargeUtf8
+                | DataType::Utf8View
+                | DataType::Date32
+                | DataType::Date64
         )
     }
 
-    /// Fold every non-null value of an integer Arrow column into `hll`. Iterates
-    /// the typed array directly (no `ScalarValue` boxing) to keep the write hot
-    /// path cheap, sign-extending to `i128` so all widths share one hash path.
-    fn add_int_column_to_hll(col: &dyn arrow::array::Array, hll: &mut crate::hll::HyperLogLog) {
-        macro_rules! fold {
+    /// Fold every non-null value of an NDV-tracked Arrow column into `hll`.
+    /// Iterates the typed array directly (no `ScalarValue` boxing) to keep the
+    /// write hot path cheap. Integer and date values sign-extend to `i128` so all
+    /// widths share one hash path; strings hash their raw UTF-8 bytes. Types not
+    /// listed here (i.e. those for which [`supports_ndv`] returns `false`) are
+    /// silently ignored.
+    ///
+    /// [`supports_ndv`]: Self::supports_ndv
+    fn add_column_to_hll(col: &dyn arrow::array::Array, hll: &mut crate::hll::HyperLogLog) {
+        macro_rules! fold_int {
             ($array_ty:ty) => {{
                 if let Some(a) = col.as_any().downcast_ref::<$array_ty>() {
                     for v in a.iter().flatten() {
@@ -161,14 +179,31 @@ impl ColumnStatsAccumulator {
                 }
             }};
         }
-        fold!(Int8Array);
-        fold!(Int16Array);
-        fold!(Int32Array);
-        fold!(Int64Array);
-        fold!(UInt8Array);
-        fold!(UInt16Array);
-        fold!(UInt32Array);
-        fold!(UInt64Array);
+        macro_rules! fold_bytes {
+            ($array_ty:ty) => {{
+                if let Some(a) = col.as_any().downcast_ref::<$array_ty>() {
+                    for v in a.iter().flatten() {
+                        hll.add_bytes(v.as_bytes());
+                    }
+                    return;
+                }
+            }};
+        }
+        fold_int!(Int8Array);
+        fold_int!(Int16Array);
+        fold_int!(Int32Array);
+        fold_int!(Int64Array);
+        fold_int!(UInt8Array);
+        fold_int!(UInt16Array);
+        fold_int!(UInt32Array);
+        fold_int!(UInt64Array);
+        // Dates are integer-backed (Date32 = days, Date64 = ms since epoch);
+        // hash them through the same i128 path as integers.
+        fold_int!(Date32Array);
+        fold_int!(Date64Array);
+        fold_bytes!(StringArray);
+        fold_bytes!(LargeStringArray);
+        fold_bytes!(StringViewArray);
     }
 
     /// Update accumulated stats from a `RecordBatch`.
@@ -212,9 +247,10 @@ impl ColumnStatsAccumulator {
                 state.seeded[i] = true;
             }
 
-            // Maintain the per-column NDV sketch for integer columns.
+            // Maintain the per-column NDV sketch for NDV-tracked columns
+            // (integers, strings, dates).
             if let Some(Some(hll)) = state.ndv.get_mut(i) {
-                Self::add_int_column_to_hll(col.as_ref(), hll);
+                Self::add_column_to_hll(col.as_ref(), hll);
             }
         }
     }
@@ -622,5 +658,67 @@ impl ColumnStatsAccumulator {
             &self.dtypes,
             &self.schema,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{Date32Array, Float64Array, Int64Array, StringArray};
+    use arrow::record_batch::RecordBatch;
+    use arrow_schema::{DataType, Field};
+
+    use super::*;
+
+    #[test]
+    fn ndv_sketches_cover_integer_string_and_date_columns() {
+        // Schema mixes NDV-tracked types (int, string, date) with an excluded
+        // type (float) to confirm the gate and the per-column fold.
+        let schema = arrow_schema::Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("d", DataType::Date32, true),
+            Field::new("amount", DataType::Float64, true),
+        ]);
+        let acc = ColumnStatsAccumulator::new(&schema);
+
+        // 100 distinct ids, 4 distinct names (each repeated 25x), 10 distinct
+        // dates, and floats (which must not get a sketch).
+        let ids: Int64Array = (0..100i64).map(Some).collect();
+        let names: StringArray = (0..100)
+            .map(|i| Some(format!("name-{}", i % 4)))
+            .collect();
+        let dates: Date32Array = (0..100).map(|i| Some(i % 10)).collect();
+        let amounts: Float64Array = (0..100).map(|i| Some(f64::from(i))).collect();
+
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(ids),
+                Arc::new(names),
+                Arc::new(dates),
+                Arc::new(amounts),
+            ],
+        )
+        .expect("batch");
+        acc.update(&batch);
+
+        let sketches = acc.to_ndv_sketches();
+        // id: ~100 distinct.
+        let id_ndv = sketches.estimate(0).expect("id sketch present");
+        assert!((90..=110).contains(&id_ndv), "id NDV {id_ndv} not ~100");
+        // name: 4 distinct, despite 100 rows.
+        let name_ndv = sketches.estimate(1).expect("name sketch present");
+        assert!((3..=5).contains(&name_ndv), "name NDV {name_ndv} not ~4");
+        // date: 10 distinct.
+        let date_ndv = sketches.estimate(2).expect("date sketch present");
+        assert!((9..=11).contains(&date_ndv), "date NDV {date_ndv} not ~10");
+        // float (amount): excluded — no sketch.
+        assert_eq!(
+            sketches.estimate(3),
+            None,
+            "float column must not get an NDV sketch"
+        );
     }
 }


### PR DESCRIPTION
## What

Extends the per-column HyperLogLog NDV (distinct-count) sketches from integer-only to also cover **string** (`Utf8`/`LargeUtf8`/`Utf8View`) and **date** (`Date32`/`Date64`) columns on the Cayenne write path.

Integer NDV sketching already landed on `trunk` (via the metadata aggregate-pushdown work). Previously, non-integer group/join keys had `Absent` `distinct_count`, so the optimizer had no cardinality signal for them. After this change those columns report `Inexact` NDV — exactly what the optimizer's cardinality gate accepts.

## Why

This feeds two downstream optimizations:

- **Eager aggregation** — string/date group-by keys (e.g. `n_name`, `c_state`, `o_entry_d`) now have a cardinality estimate, so the planner can size partial-aggregate state and decide when to push aggregation below joins.
- **Join optimization** — string/date join keys get an NDV estimate that can diverge sharply from a min/max range, improving distributed-join sizing on sparse keys.

## Changes

- **`hll`**: add `HyperLogLog::add_bytes` for stable byte-key hashing (same explicit byte-hashing path as `add_i128`, so the persisted sketch is stable across runs/builds).
- **`column_stats`**: widen `supports_ndv` to strings/dates; rename `add_int_column_to_hll` → `add_column_to_hll`, folding dates through the `i128` path and strings through `add_bytes` (typed-array iteration, no `ScalarValue` boxing on the hot path).
- Refresh stale "integer-only" doc comments across `hll`, `column_stats`, and `metadata`.

The read-back and merge paths were already generic over column index, so this is a pure write-path change.

## Tests

- `hll::add_bytes_counts_distinct_strings` — `add_bytes` distinct-count estimate within 5%.
- `column_stats::ndv_sketches_cover_integer_string_and_date_columns` — confirms int/string/date columns get sketches and floats don't.

Both pass (`cargo test -p cayenne --lib`).
