### PR TITLE
fix(cluster): restore shuffle_location/temp_directory injection lost from #11454

### DIFF
--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -1237,14 +1237,19 @@ pub async fn initialize_cluster_executor(
                 .unwrap_or_else(|| env::temp_dir().to_string_lossy().to_string())
         }
         Some(loc) => {
-            // Local disk mode with explicit path
-            // Validate the path exists or can be created
+            // Local disk mode with explicit path — ensure the work dir exists.
+            // Cluster-bench points this at a per-run subdir of the /data PVC,
+            // which won't exist until created; create it so the executor doesn't
+            // fall back to (and fill) the default temp dir.
             let path = std::path::Path::new(loc);
             if !path.exists() {
-                tracing::warn!(
-                    "shuffle_location '{}' does not exist. Ensure the directory exists and is writable by the executor process.",
-                    loc
-                );
+                if let Err(e) = std::fs::create_dir_all(path) {
+                    tracing::warn!(
+                        "failed to create shuffle_location '{}': {}. Shuffle writes may fail or fall back to the default temp dir.",
+                        loc,
+                        e
+                    );
+                }
             }
             loc.to_string()
         }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -2064,6 +2064,31 @@ async fn generate_initial_spicepod(
         }
     }
 
+    // Route Ballista shuffle output and query temp/spill files to the
+    // configured (PVC-backed) locations instead of the executor's default temp
+    // dir. Without this, cluster-bench executors write shuffle to the small
+    // `tmp` EmptyDir, exceed its limit, and get evicted mid-query (livelocking
+    // the run). Executors take this config from the scheduler, so inject it into
+    // the scheduler spicepod here (mirrors SCHEDULER_STATE_LOCATION above). The
+    // env vars are exported by the cluster-bench workflow from the test config.
+    if let Some(loc) = std::env::var("SPIDAPTER_SHUFFLE_LOCATION")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+    {
+        spicepod
+            .runtime
+            .params
+            .insert("shuffle_location".to_string(), loc.trim().to_string());
+    }
+    if let Some(dir) = std::env::var("SPIDAPTER_QUERY_TEMP_DIRECTORY")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+    {
+        let mut query = spicepod.runtime.query.take().unwrap_or_default();
+        query.temp_directory = Some(dir.trim().to_string());
+        spicepod.runtime.query = Some(query);
+    }
+
     Ok(spicepod)
 }
 


### PR DESCRIPTION
## Problem

Cluster-bench executors are evicted mid-query with `Usage of EmptyDir volume "tmp" exceeds the limit "1Gi"`. They write Ballista shuffle output to the default temp dir (the 1Gi `tmp` EmptyDir) instead of the `/data` PVC, exceed it, and get evicted — which surfaces as inter-executor shuffle-fetch DNS (`Name or service not known`) and `Connection reset` failures as the pods are recreated, livelocking the run.

## Root cause

The spidapter + runtime parts of #11454 were lost in a later merge. The cluster-bench workflow exports `SPIDAPTER_SHUFFLE_LOCATION`/`SPIDAPTER_QUERY_TEMP_DIRECTORY` from the test config, but `tools/spidapter/stdio_server.rs` no longer consumes them (only `SCHEDULER_STATE_LOCATION` survives), so the generated **scheduler** spicepod has no `runtime.params.shuffle_location`. Executors take their config from the scheduler, so they fall back to the default temp dir.

## Fix

- **spidapter (`stdio_server.rs`)**: inject `SPIDAPTER_SHUFFLE_LOCATION` → `runtime.params.shuffle_location` and `SPIDAPTER_QUERY_TEMP_DIRECTORY` → `runtime.query.temp_directory` into the generated scheduler spicepod (mirrors the existing `SCHEDULER_STATE_LOCATION` handling).
- **runtime (`cluster/mod.rs`)**: `create_dir_all` the configured shuffle work_dir instead of only warning, so a per-run `/data` PVC subdir is usable.

Diagnosed against a live SF10 cluster-bench run (executors evicted; scheduler spicepod missing `shuffle_location`).

https://claude.ai/code/session_01G8drJk8Fx5ynRQZ4WkuVju