### PR TITLE
fix(cluster): distributed (Ballista) query-execution config + scheduled SF10 bench

### DIFF
--- a/.github/workflows/testoperator_dispatch_cluster.yml
+++ b/.github/workflows/testoperator_dispatch_cluster.yml
@@ -9,10 +9,10 @@ name: testoperator cluster bench dispatch
 # Spice Cloud resource usage bounded.
 
 on:
-  # No automatic schedule for now — the distributed cluster benchmark is run
-  # manually via workflow_dispatch until the outstanding cluster issues are
-  # resolved (executor ephemeral-storage eviction, see #11433, plus the
-  # related ballista fixes). Re-add a `schedule:` cron once it runs clean.
+  schedule:
+    # Daily SF10 distributed TPC-H baseline (08:00 UTC). Scheduled runs build
+    # from trunk and fan out the tpch/sf10/distributed dispatch matrix.
+    - cron: '0 8 * * *'
   workflow_dispatch:
     inputs:
       spiced_ref:
@@ -130,12 +130,14 @@ jobs:
       needs.resolve-image.result == 'success' &&
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     runs-on: spiceai-dev-runners
+    env:
+      # Scheduled runs target the SF10 distributed matrix; manual dispatch
+      # overrides via the dispatch_dir input.
+      DISPATCH_DIR: ${{ github.event.inputs.dispatch_dir || (github.event_name == 'schedule' && 'tpch/sf10/distributed') || '.' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Verify dispatch directory
-        env:
-          DISPATCH_DIR: ${{ github.event.inputs.dispatch_dir || '.' }}
         run: |
           set -euo pipefail
           dir="tools/testoperator/dispatch_cluster/${DISPATCH_DIR}"
@@ -159,7 +161,6 @@ jobs:
       - name: Dispatch each spicepod
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISPATCH_DIR: ${{ github.event.inputs.dispatch_dir || '.' }}
           IMAGE_TAG: ${{ needs.resolve-image.outputs.image_tag }}
           SPICED_SHA: ${{ needs.resolve-image.outputs.spiced_sha }}
           # Each dispatch yaml entry today is a single `tests.bench` block. We

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=cdd3c00f649e8304c9cccd9544b8aea9517ec56f#cdd3c00f649e8304c9cccd9544b8aea9517ec56f"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d64ad577c76d46de2ee1d1675368d3ce5d058dc4#d64ad577c76d46de2ee1d1675368d3ce5d058dc4"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=cdd3c00f649e8304c9cccd9544b8aea9517ec56f#cdd3c00f649e8304c9cccd9544b8aea9517ec56f"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d64ad577c76d46de2ee1d1675368d3ce5d058dc4#d64ad577c76d46de2ee1d1675368d3ce5d058dc4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=cdd3c00f649e8304c9cccd9544b8aea9517ec56f#cdd3c00f649e8304c9cccd9544b8aea9517ec56f"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d64ad577c76d46de2ee1d1675368d3ce5d058dc4#d64ad577c76d46de2ee1d1675368d3ce5d058dc4"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=942ebe2c87a4b8087fd11010fc3511f193d2a842#942ebe2c87a4b8087fd11010fc3511f193d2a842"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e81a77947b1c0a7d31e790de6a4fbc9ffcd14671#e81a77947b1c0a7d31e790de6a4fbc9ffcd14671"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=942ebe2c87a4b8087fd11010fc3511f193d2a842#942ebe2c87a4b8087fd11010fc3511f193d2a842"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e81a77947b1c0a7d31e790de6a4fbc9ffcd14671#e81a77947b1c0a7d31e790de6a4fbc9ffcd14671"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=942ebe2c87a4b8087fd11010fc3511f193d2a842#942ebe2c87a4b8087fd11010fc3511f193d2a842"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e81a77947b1c0a7d31e790de6a4fbc9ffcd14671#e81a77947b1c0a7d31e790de6a4fbc9ffcd14671"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e81a77947b1c0a7d31e790de6a4fbc9ffcd14671#e81a77947b1c0a7d31e790de6a4fbc9ffcd14671"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0b33b4473e1afba3923e754f9d37b868a9c4880b#0b33b4473e1afba3923e754f9d37b868a9c4880b"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e81a77947b1c0a7d31e790de6a4fbc9ffcd14671#e81a77947b1c0a7d31e790de6a4fbc9ffcd14671"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0b33b4473e1afba3923e754f9d37b868a9c4880b#0b33b4473e1afba3923e754f9d37b868a9c4880b"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=e81a77947b1c0a7d31e790de6a4fbc9ffcd14671#e81a77947b1c0a7d31e790de6a4fbc9ffcd14671"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0b33b4473e1afba3923e754f9d37b868a9c4880b#0b33b4473e1afba3923e754f9d37b868a9c4880b"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=689624681688a92b61fe2cf677ca159e0560448a#689624681688a92b61fe2cf677ca159e0560448a"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=942ebe2c87a4b8087fd11010fc3511f193d2a842#942ebe2c87a4b8087fd11010fc3511f193d2a842"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=689624681688a92b61fe2cf677ca159e0560448a#689624681688a92b61fe2cf677ca159e0560448a"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=942ebe2c87a4b8087fd11010fc3511f193d2a842#942ebe2c87a4b8087fd11010fc3511f193d2a842"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=689624681688a92b61fe2cf677ca159e0560448a#689624681688a92b61fe2cf677ca159e0560448a"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=942ebe2c87a4b8087fd11010fc3511f193d2a842#942ebe2c87a4b8087fd11010fc3511f193d2a842"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4#fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=68962468#689624681688a92b61fe2cf677ca159e0560448a"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4#fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=68962468#689624681688a92b61fe2cf677ca159e0560448a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4#fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=68962468#689624681688a92b61fe2cf677ca159e0560448a"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5592,7 +5592,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5616,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5665,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "futures",
  "log",
@@ -5675,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5712,7 +5712,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5735,7 +5735,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5757,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5828,12 +5828,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5959,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5979,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6027,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6042,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6058,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6067,7 +6067,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "chrono",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6149,7 +6149,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "chrono",
@@ -6179,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6197,7 +6197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6229,7 +6229,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "chrono",
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6270,7 +6270,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6285,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6326,7 +6326,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d64ad577c76d46de2ee1d1675368d3ce5d058dc4#d64ad577c76d46de2ee1d1675368d3ce5d058dc4"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3#7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d64ad577c76d46de2ee1d1675368d3ce5d058dc4#d64ad577c76d46de2ee1d1675368d3ce5d058dc4"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3#7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=d64ad577c76d46de2ee1d1675368d3ce5d058dc4#d64ad577c76d46de2ee1d1675368d3ce5d058dc4"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3#7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0b33b4473e1afba3923e754f9d37b868a9c4880b#0b33b4473e1afba3923e754f9d37b868a9c4880b"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=77f5fbce42b00ba91236564cfc60054f91fbcc6a#77f5fbce42b00ba91236564cfc60054f91fbcc6a"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0b33b4473e1afba3923e754f9d37b868a9c4880b#0b33b4473e1afba3923e754f9d37b868a9c4880b"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=77f5fbce42b00ba91236564cfc60054f91fbcc6a#77f5fbce42b00ba91236564cfc60054f91fbcc6a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0b33b4473e1afba3923e754f9d37b868a9c4880b#0b33b4473e1afba3923e754f9d37b868a9c4880b"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=77f5fbce42b00ba91236564cfc60054f91fbcc6a#77f5fbce42b00ba91236564cfc60054f91fbcc6a"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=77f5fbce42b00ba91236564cfc60054f91fbcc6a#77f5fbce42b00ba91236564cfc60054f91fbcc6a"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=414a36f98551b625da853bc594df85989411e306#414a36f98551b625da853bc594df85989411e306"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=77f5fbce42b00ba91236564cfc60054f91fbcc6a#77f5fbce42b00ba91236564cfc60054f91fbcc6a"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=414a36f98551b625da853bc594df85989411e306#414a36f98551b625da853bc594df85989411e306"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=77f5fbce42b00ba91236564cfc60054f91fbcc6a#77f5fbce42b00ba91236564cfc60054f91fbcc6a"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=414a36f98551b625da853bc594df85989411e306#414a36f98551b625da853bc594df85989411e306"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=989c9b79f2a091a3c16141529a6aa9fb4a51bb4e#989c9b79f2a091a3c16141529a6aa9fb4a51bb4e"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0f6d5d9980b9a4ed84bdecf877e5c1346435f3da#0f6d5d9980b9a4ed84bdecf877e5c1346435f3da"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=989c9b79f2a091a3c16141529a6aa9fb4a51bb4e#989c9b79f2a091a3c16141529a6aa9fb4a51bb4e"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0f6d5d9980b9a4ed84bdecf877e5c1346435f3da#0f6d5d9980b9a4ed84bdecf877e5c1346435f3da"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=989c9b79f2a091a3c16141529a6aa9fb4a51bb4e#989c9b79f2a091a3c16141529a6aa9fb4a51bb4e"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0f6d5d9980b9a4ed84bdecf877e5c1346435f3da#0f6d5d9980b9a4ed84bdecf877e5c1346435f3da"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=414a36f98551b625da853bc594df85989411e306#414a36f98551b625da853bc594df85989411e306"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=cdd3c00f649e8304c9cccd9544b8aea9517ec56f#cdd3c00f649e8304c9cccd9544b8aea9517ec56f"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=414a36f98551b625da853bc594df85989411e306#414a36f98551b625da853bc594df85989411e306"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=cdd3c00f649e8304c9cccd9544b8aea9517ec56f#cdd3c00f649e8304c9cccd9544b8aea9517ec56f"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=414a36f98551b625da853bc594df85989411e306#414a36f98551b625da853bc594df85989411e306"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=cdd3c00f649e8304c9cccd9544b8aea9517ec56f#cdd3c00f649e8304c9cccd9544b8aea9517ec56f"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3#7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=989c9b79f2a091a3c16141529a6aa9fb4a51bb4e#989c9b79f2a091a3c16141529a6aa9fb4a51bb4e"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3#7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=989c9b79f2a091a3c16141529a6aa9fb4a51bb4e#989c9b79f2a091a3c16141529a6aa9fb4a51bb4e"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3#7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=989c9b79f2a091a3c16141529a6aa9fb4a51bb4e#989c9b79f2a091a3c16141529a6aa9fb4a51bb4e"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5622,7 +5622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5646,7 +5646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5671,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "futures",
  "log",
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5718,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5763,7 +5763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5785,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5834,12 +5834,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5882,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5934,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5965,7 +5965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6009,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6033,7 +6033,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6048,7 +6048,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6064,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6073,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "chrono",
@@ -6134,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6169,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "chrono",
@@ -6185,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "chrono",
@@ -6264,7 +6264,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6276,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6291,7 +6291,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6332,7 +6332,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8#1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "fc500ce94d6cd5b1bc8da744b2ca1e8c7bddeca4" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "68962468" } # spiceai-54 + shuffle pooling + reconcile sweep (datafusion-ballista PR #57)
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "68962468" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "68962468" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "989c9b79f2a091a3c16141529a6aa9fb4a51bb4e" } # branch: phillip/cluster-shuffle-scheduler-fixes
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "989c9b79f2a091a3c16141529a6aa9fb4a51bb4e" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "989c9b79f2a091a3c16141529a6aa9fb4a51bb4e" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0f6d5d9980b9a4ed84bdecf877e5c1346435f3da" } # branch: spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0f6d5d9980b9a4ed84bdecf877e5c1346435f3da" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0f6d5d9980b9a4ed84bdecf877e5c1346435f3da" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "77f5fbce42b00ba91236564cfc60054f91fbcc6a" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "77f5fbce42b00ba91236564cfc60054f91fbcc6a" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "77f5fbce42b00ba91236564cfc60054f91fbcc6a" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "414a36f98551b625da853bc594df85989411e306" } # spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "414a36f98551b625da853bc594df85989411e306" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "414a36f98551b625da853bc594df85989411e306" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d64ad577c76d46de2ee1d1675368d3ce5d058dc4" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d64ad577c76d46de2ee1d1675368d3ce5d058dc4" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d64ad577c76d46de2ee1d1675368d3ce5d058dc4" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3" } # spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0b33b4473e1afba3923e754f9d37b868a9c4880b" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0b33b4473e1afba3923e754f9d37b868a9c4880b" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0b33b4473e1afba3923e754f9d37b868a9c4880b" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "77f5fbce42b00ba91236564cfc60054f91fbcc6a" } # spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "77f5fbce42b00ba91236564cfc60054f91fbcc6a" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "77f5fbce42b00ba91236564cfc60054f91fbcc6a" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "414a36f98551b625da853bc594df85989411e306" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "414a36f98551b625da853bc594df85989411e306" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "414a36f98551b625da853bc594df85989411e306" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "cdd3c00f649e8304c9cccd9544b8aea9517ec56f" } # spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "cdd3c00f649e8304c9cccd9544b8aea9517ec56f" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "cdd3c00f649e8304c9cccd9544b8aea9517ec56f" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "689624681688a92b61fe2cf677ca159e0560448a" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "689624681688a92b61fe2cf677ca159e0560448a" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "689624681688a92b61fe2cf677ca159e0560448a" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "942ebe2c87a4b8087fd11010fc3511f193d2a842" } # spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "942ebe2c87a4b8087fd11010fc3511f193d2a842" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "942ebe2c87a4b8087fd11010fc3511f193d2a842" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,41 +394,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e81a77947b1c0a7d31e790de6a4fbc9ffcd14671" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e81a77947b1c0a7d31e790de6a4fbc9ffcd14671" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e81a77947b1c0a7d31e790de6a4fbc9ffcd14671" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0b33b4473e1afba3923e754f9d37b868a9c4880b" } # spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0b33b4473e1afba3923e754f9d37b868a9c4880b" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0b33b4473e1afba3923e754f9d37b868a9c4880b" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "cdd3c00f649e8304c9cccd9544b8aea9517ec56f" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "cdd3c00f649e8304c9cccd9544b8aea9517ec56f" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "cdd3c00f649e8304c9cccd9544b8aea9517ec56f" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d64ad577c76d46de2ee1d1675368d3ce5d058dc4" } # spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d64ad577c76d46de2ee1d1675368d3ce5d058dc4" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "d64ad577c76d46de2ee1d1675368d3ce5d058dc4" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "7b1b1458dfa04bab7fb8d9bf4d7ae665603caae3" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "989c9b79f2a091a3c16141529a6aa9fb4a51bb4e" } # branch: phillip/cluster-shuffle-scheduler-fixes
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "989c9b79f2a091a3c16141529a6aa9fb4a51bb4e" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "989c9b79f2a091a3c16141529a6aa9fb4a51bb4e" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"
@@ -394,41 +394,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "1151bb4f2ef5271c9241e94a9a13e27a59dfa7a8" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "942ebe2c87a4b8087fd11010fc3511f193d2a842" } # spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "942ebe2c87a4b8087fd11010fc3511f193d2a842" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "942ebe2c87a4b8087fd11010fc3511f193d2a842" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e81a77947b1c0a7d31e790de6a4fbc9ffcd14671" } # spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e81a77947b1c0a7d31e790de6a4fbc9ffcd14671" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "e81a77947b1c0a7d31e790de6a4fbc9ffcd14671" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -34,6 +34,7 @@ use ::datafusion::sql::ResolvedTableReference;
 use app::App;
 use ballista_core::config::ShuffleFormat as BallistaShuffleFormat;
 use ballista_core::extension::SessionConfigExt;
+use ballista_core::extension::SessionConfigHelperExt;
 use ballista_core::registry::BallistaFunctionRegistry;
 use ballista_core::serde::BallistaCodec;
 use ballista_core::serde::protobuf::executor_resource::Resource;
@@ -1875,7 +1876,53 @@ async fn create_scheduler_server(
                 .with_option_extension(SpiceClusterConfig::default())
                 .with_option_extension(incoming_request_context)
                 .with_ballista_shuffle_format(ballista_shuffle_format)
-                .with_ballista_shuffle_memory_mode(shuffle_memory_mode);
+                .with_ballista_shuffle_memory_mode(shuffle_memory_mode)
+                // Enforce the DataFusion settings distributed (Ballista) execution
+                // requires for correctness — the same set the executor applies via
+                // `new_with_ballista`. The session builder otherwise rebuilds from
+                // `current_context.copied_config()` (the local single-node config),
+                // and this config is serialized into the task props sent to
+                // executors, so it governs both the distributed plan and its
+                // execution. Among other things this disables CollectLeft broadcast
+                // joins (whose left child must be a single partition — invalid once
+                // the input is a multi-partition shuffle) and round-robin
+                // repartition.
+                .ballista_restricted_configuration();
+
+            // The following optimizations all rely on shared mutable state within a
+            // single process and are incorrect (or fatal) once a plan is split into
+            // stages that run in separate executor processes. They are not disabled
+            // by `ballista_restricted_configuration`, so disable them explicitly on
+            // the session/planning config (which is serialized into executor task
+            // props):
+            {
+                let opts = cfg.options_mut();
+
+                // File-scan work-stealing shares one queue of unopened files across
+                // all of a scan's partition streams. In-process that means each file
+                // is read once; under Ballista every executor process rebuilds the
+                // full queue and reads the whole input — N-fold scan amplification
+                // and N-fold inflated aggregate results.
+                opts.execution.enable_file_scan_work_stealing = false;
+
+                // The hash-join dynamic filter builds a min/max filter from the
+                // build side at runtime and pushes it into the probe-side scan via
+                // shared plan state; across a stage boundary it can never be
+                // populated, and its serialized form carries probe-side column
+                // indices that don't resolve against the receiving stage's schema.
+                // (TopK/aggregate dynamic filters are left enabled — they merely
+                // stay empty across stages rather than erroring.)
+                opts.optimizer.enable_join_dynamic_filter_pushdown = false;
+
+                // Uncorrelated scalar subqueries are otherwise executed by a
+                // `ScalarSubqueryExec` that evaluates them eagerly on one node into a
+                // shared results container; a shuffle boundary between the exec and
+                // its dependent `ScalarSubqueryExpr`s leaves a child stage unable to
+                // decode the expr. Disabling this rewrites them to left joins via
+                // `ScalarSubqueryToJoin` (DataFusion's documented escape hatch for
+                // distributed execution frameworks), which distribute correctly.
+                opts.optimizer.enable_physical_uncorrelated_scalar_subquery = false;
+            }
 
             // Apply object store shuffle configuration if specified
             if let Some(ref storage_type) = shuffle_storage_type {

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -2283,12 +2283,6 @@ fn apply_distributed_execution_config(cfg: SessionConfig) -> SessionConfig {
     {
         let opts = cfg.options_mut();
 
-        // File-scan work-stealing shares one queue of unopened files across all of a
-        // scan's partition streams. In-process each file is read once; under Ballista
-        // every executor process rebuilds the full queue and reads the whole input —
-        // N-fold scan amplification and N-fold inflated aggregates.
-        opts.execution.enable_file_scan_work_stealing = false;
-
         // The hash-join dynamic filter builds a min/max filter from the build side at
         // runtime and pushes it into the probe-side scan via shared plan state; across
         // a stage boundary it can never be populated, and its serialized form carries
@@ -2331,7 +2325,6 @@ mod tests {
             super::apply_distributed_execution_config(::datafusion::prelude::SessionConfig::new());
         let opts = cfg.options();
         // Single-process-only optimizations must be disabled for distributed execution.
-        assert!(!opts.execution.enable_file_scan_work_stealing);
         assert!(!opts.optimizer.enable_join_dynamic_filter_pushdown);
         assert!(!opts.optimizer.enable_physical_uncorrelated_scalar_subquery);
         // Ballista restricted configuration disables round-robin repartition.

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -2003,8 +2003,14 @@ async fn create_scheduler_server(
         on_work_available: Some(on_work_available),
         on_cancel_tasks: Some(on_cancel_tasks),
 
-        // Faster failure detection: 30s timeout with 10s heartbeat interval
-        executor_timeout_seconds: 30,
+        // 120s timeout with a 10s heartbeat interval (12 missed beats). Raised from
+        // 30s: under heavy distributed queries the executor->scheduler heartbeat can
+        // lapse for tens of seconds while an executor is busy, and a 30s timeout
+        // falsely marks a live, busy executor dead -> the scheduler removes it ->
+        // its in-flight stage tasks fail -> the query flaps/hangs. A larger tolerance
+        // rides over transient lapses without meaningfully delaying real dead-executor
+        // detection for a cluster doing minutes-long distributed queries.
+        executor_timeout_seconds: 120,
 
         // The Spice executor uses pull-based polling (execution_loop::poll_loop),
         // so the scheduler must use PullStaged to register executors via PollWork RPCs.

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -2039,12 +2039,8 @@ async fn create_scheduler_server(
         on_work_available: Some(on_work_available),
         on_cancel_tasks: Some(on_cancel_tasks),
 
-        // Mark an executor dead after 120s without a heartbeat (heartbeats are sent
-        // every 10s, i.e. 12 missed beats). A heavy distributed query can keep an
-        // executor busy enough that its heartbeats lapse for tens of seconds, so the
-        // tolerance keeps a live, busy executor registered while still detecting a
-        // genuinely dead one promptly relative to minutes-long distributed queries.
-        executor_timeout_seconds: 120,
+        // Mark an executor dead after 30s without a heartbeat (heartbeats every 10s).
+        executor_timeout_seconds: 30,
 
         // The Spice executor uses pull-based polling (execution_loop::poll_loop),
         // so the scheduler must use PullStaged to register executors via PollWork RPCs.

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -2265,7 +2265,7 @@ async fn executor_bind_object_stores(rt: Arc<Runtime>) -> crate::Result<()> {
     Ok(())
 }
 
-/// Apply the DataFusion configuration that distributed (Ballista) execution requires
+/// Apply the `DataFusion` configuration that distributed (Ballista) execution requires
 /// for correctness, returning the adjusted [`SessionConfig`].
 ///
 /// This is the same set the executor applies via `new_with_ballista`, applied here so

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -2327,9 +2327,8 @@ mod tests {
 
     #[test]
     fn distributed_execution_config_disables_single_process_optimizations() {
-        let cfg = super::apply_distributed_execution_config(
-            ::datafusion::prelude::SessionConfig::new(),
-        );
+        let cfg =
+            super::apply_distributed_execution_config(::datafusion::prelude::SessionConfig::new());
         let opts = cfg.options();
         // Single-process-only optimizations must be disabled for distributed execution.
         assert!(!opts.execution.enable_file_scan_work_stealing);

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -179,6 +179,11 @@ pub async fn start_internal_cluster_server(
     Ok(())
 }
 
+/// Upper bound on h2 pending-accept resets the executor Flight server tolerates
+/// before tripping Rapid-Reset flood protection. Set well above any realistic
+/// shuffle cancellation burst; see `start_executor_flight_server` for rationale.
+const EXECUTOR_MAX_PENDING_ACCEPT_RESET_STREAMS: usize = 100_000;
+
 /// Starts the executor Flight server for both Ballista shuffle data and Spice SQL queries.
 ///
 /// This server uses a composite Flight service that routes:
@@ -213,7 +218,6 @@ pub async fn start_executor_flight_server(
     // in production that path is secured by cluster mTLS. Running without mTLS requires
     // the dev-only `--allow-insecure-connections` flag, which is not used in deployments
     // exposed to untrusted clients, so relaxing the Rapid-Reset threshold is safe.
-    const EXECUTOR_MAX_PENDING_ACCEPT_RESET_STREAMS: usize = 100_000;
     let server = configure_flight_server_transport(Server::builder())
         .http2_max_pending_accept_reset_streams(Some(EXECUTOR_MAX_PENDING_ACCEPT_RESET_STREAMS));
 

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -207,15 +207,15 @@ pub async fn start_executor_flight_server(
     // fetch concurrently over a pooled, multiplexed HTTP/2 connection per peer, and a
     // stage cancellation resets the in-flight fetch streams in bursts. Those legitimate
     // RST_STREAMs would otherwise trip h2's Rapid-Reset flood protection
-    // (`GOAWAY ENHANCE_YOUR_CALM` after 20 pending-accept resets, hyperium/hyper#2877).
-    // This endpoint is internal — reachable only by the scheduler and peer executors
-    // over cluster mTLS — so the threshold is set well above any realistic shuffle
-    // cancellation burst.
+    // (`GOAWAY ENHANCE_YOUR_CALM` after 20 pending-accept resets, hyperium/hyper#2877),
+    // so the threshold is set well above any realistic shuffle cancellation burst. This
+    // is an internal cluster endpoint reached only by the scheduler and peer executors;
+    // in production that path is secured by cluster mTLS. Running without mTLS requires
+    // the dev-only `--allow-insecure-connections` flag, which is not used in deployments
+    // exposed to untrusted clients, so relaxing the Rapid-Reset threshold is safe.
     const EXECUTOR_MAX_PENDING_ACCEPT_RESET_STREAMS: usize = 100_000;
     let server = configure_flight_server_transport(Server::builder())
-        .http2_max_pending_accept_reset_streams(Some(
-            EXECUTOR_MAX_PENDING_ACCEPT_RESET_STREAMS,
-        ));
+        .http2_max_pending_accept_reset_streams(Some(EXECUTOR_MAX_PENDING_ACCEPT_RESET_STREAMS));
 
     if cluster_server_config.is_some() {
         tracing::info!("Cluster mTLS enabled for executor flight server");

--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -203,7 +203,22 @@ pub async fn start_executor_flight_server(
         });
     }
 
-    let server = configure_flight_server_transport(Server::builder());
+    // The executor Flight server is the cluster shuffle endpoint: many reducer
+    // partitions fetch concurrently, and a stage cancellation (e.g. a failed sibling
+    // task, or a query that errors mid-flight) resets the in-flight fetch streams in
+    // bursts. Shuffle clients now pool a single multiplexed HTTP/2 connection per
+    // peer (datafusion-ballista `shuffle_reader::fetch_partition_remote`), so those
+    // legitimate RST_STREAMs concentrate on one connection and trip h2's default
+    // Rapid-Reset flood protection (`GOAWAY ENHANCE_YOUR_CALM` after only 20
+    // pending-accept resets, hyperium/hyper#2877). This endpoint is internal —
+    // reachable only by the scheduler and peer executors over cluster mTLS — so the
+    // flood heuristic is a false positive here; raise the threshold well above any
+    // realistic shuffle cancellation burst.
+    const EXECUTOR_MAX_PENDING_ACCEPT_RESET_STREAMS: usize = 100_000;
+    let server = configure_flight_server_transport(Server::builder())
+        .http2_max_pending_accept_reset_streams(Some(
+            EXECUTOR_MAX_PENDING_ACCEPT_RESET_STREAMS,
+        ));
 
     if cluster_server_config.is_some() {
         tracing::info!("Cluster mTLS enabled for executor flight server");


### PR DESCRIPTION
Configures Spice's distributed (Ballista, PullStaged) query execution and pins the fork dependencies that carry the supporting fixes.

## Query planning (`cluster/mod.rs`)
Distributed sessions disable the DataFusion optimizations that assume a single process and break once a query is split across executor stages:
- **Hash-join dynamic-filter pushdown** — builds a runtime min/max filter pushed into the probe-side scan via shared plan state; it can never be populated across a stage boundary, and its serialized form carries probe-side column indices that don't resolve against the receiving stage.
- **Physical uncorrelated scalar subqueries** — plan as a `ScalarSubqueryExec` whose expression only decodes inside that exec, so a shuffle boundary leaves the dependent stage unable to decode it. Disabling rewrites them to joins, which distribute correctly.

These sit alongside `ballista_restricted_configuration` (CollectLeft broadcast joins, round-robin repartition). `apply_distributed_execution_config` centralizes them and is unit-tested. Scan over-read is handled in the Ballista fork — the executor restricts each task's `DataSourceExec` to its partition's file group — so it is not a session-config concern here.

## Executor Flight server (`cluster/servers.rs`)
Raises `http2_max_pending_accept_reset_streams` to absorb the RST_STREAM bursts when concurrent shuffle-fetch streams are cancelled on the pooled HTTP/2 connections. The endpoint is internal (reachable only by the scheduler and peer executors over cluster mTLS).

## Scheduled SF10 benchmark (`testoperator_dispatch_cluster.yml`)
Adds a daily (08:00 UTC) scheduled run of the SF10 distributed TPC-H cluster bench off trunk as a continuous baseline; manual `workflow_dispatch` still overrides the dispatch matrix.

## Dependencies (`Cargo.toml`)
- **ballista** → the spiceai fork carrying shuffle-fetch connection pooling + HTTP/2 keepalive, pull-based scheduler reconciliation, reliable task-status delivery, graph-persistence robustness, the per-partition scan restriction, and the uncorrelated-scalar-subquery disable.
- **datafusion** → the spiceai-54 fork base.
