### PR TITLE
fix(search): persist character chunk offsets so search snippets aren't shifted/garbled (fixes #11269)

### DIFF
--- a/crates/chunking/src/lib.rs
+++ b/crates/chunking/src/lib.rs
@@ -45,7 +45,7 @@ type ChunkIter<'a> = Box<dyn Iterator<Item = &'a str> + 'a>;
 pub trait Chunker: Sync + Send {
     fn chunk_indices<'a>(&self, text: &'a str) -> ChunkIndicesIter<'a>;
 
-    /// Chunks a given `text`, and for each returning the starting (inclusive) and ending (exclusive) indexes into the input `text`.
+    /// Chunks a given `text`, and for each returning the starting (inclusive) and ending (exclusive) **byte** indexes into the input `text`.
     fn chunk_with_offsets<'a>(
         &self,
         text: &'a str,
@@ -54,6 +54,39 @@ pub trait Chunker: Sync + Send {
             self.chunk_indices(text)
                 .map(|(idx, chunk)| ((idx, idx + chunk.len()), chunk)),
         )
+    }
+
+    /// Like [`Chunker::chunk_with_offsets`] but returns **character** offsets
+    /// (0-based start inclusive, end exclusive) rather than byte offsets.
+    ///
+    /// The search read path recovers the matched snippet with DataFusion
+    /// `substring`, which is 1-based and character-counted (PostgreSQL
+    /// semantics). Persisting character offsets — rather than the byte offsets
+    /// `chunk_with_offsets` yields — lets the reader extract the exact chunk for
+    /// non-ASCII text, where a byte index and a character index diverge. See
+    /// issue #11269.
+    fn chunk_with_char_offsets<'a>(
+        &self,
+        text: &'a str,
+    ) -> Box<dyn Iterator<Item = ((usize, usize), &'a str)> + 'a> {
+        // `chunk_indices` yields byte starts in non-decreasing document order, so
+        // walk the char cursor forward between successive starts in O(n) total
+        // rather than re-scanning the prefix for every chunk.
+        let mut prev_byte = 0usize;
+        let mut prev_char = 0usize;
+        Box::new(self.chunk_indices(text).map(move |(byte_idx, chunk)| {
+            let char_start = if byte_idx >= prev_byte {
+                prev_char + text[prev_byte..byte_idx].chars().count()
+            } else {
+                // Defensive: a chunker that emits out-of-order starts (none do
+                // today) still gets a correct, if non-incremental, answer.
+                text[..byte_idx].chars().count()
+            };
+            prev_byte = byte_idx;
+            prev_char = char_start;
+            let char_end = char_start + chunk.chars().count();
+            ((char_start, char_end), chunk)
+        }))
     }
 
     fn chunks<'a>(&self, text: &'a str) -> ChunkIter<'a> {
@@ -391,6 +424,89 @@ mod tests {
                 "Offset range should extract the correct chunk"
             );
         }
+    }
+
+    /// Recover a chunk from `text` using 0-based, end-exclusive character
+    /// offsets — mirrors how the search read path applies the stored offsets via
+    /// DataFusion `substring`.
+    fn chars_in_range(text: &str, start: usize, end: usize) -> String {
+        text.chars().skip(start).take(end - start).collect()
+    }
+
+    #[test]
+    fn test_chunk_with_char_offsets_ascii() {
+        let cfg = ChunkingConfig {
+            target_chunk_size: 5,
+            overlap_size: 0,
+            trim_whitespace: false,
+            file_format: None,
+        };
+        let chunker = RecursiveSplittingChunker::with_character_sizer(&cfg)
+            .expect("failed to create chunker");
+
+        let text = "Hello world";
+        // With trimming disabled and pure-ASCII text, character offsets equal
+        // byte offsets, so they must match `chunk_with_offsets` exactly.
+        let byte_chunks: Vec<_> = chunker.chunk_with_offsets(text).collect();
+        let char_chunks: Vec<_> = chunker.chunk_with_char_offsets(text).collect();
+        assert_eq!(
+            byte_chunks, char_chunks,
+            "ASCII char offsets == byte offsets"
+        );
+
+        for ((start, end), chunk) in &char_chunks {
+            assert_eq!(
+                chars_in_range(text, *start, *end),
+                *chunk,
+                "char offset range should recover the chunk"
+            );
+        }
+    }
+
+    #[test]
+    fn test_chunk_with_char_offsets_non_ascii() {
+        let cfg = ChunkingConfig {
+            target_chunk_size: 4,
+            overlap_size: 0,
+            trim_whitespace: false,
+            file_format: None,
+        };
+        let chunker = RecursiveSplittingChunker::with_character_sizer(&cfg)
+            .expect("failed to create chunker");
+
+        // Multi-byte characters: each of these is 1 char but 2-4 bytes in UTF-8.
+        let text = "café über señor ☕ data";
+        let byte_chunks: Vec<_> = chunker.chunk_with_offsets(text).collect();
+        let char_chunks: Vec<_> = chunker.chunk_with_char_offsets(text).collect();
+
+        assert!(!char_chunks.is_empty(), "expected at least one chunk");
+        assert_eq!(
+            byte_chunks.len(),
+            char_chunks.len(),
+            "byte and char chunking should yield the same chunks"
+        );
+
+        // Every chunk must be recoverable from the text via its character range.
+        for ((start, end), chunk) in &char_chunks {
+            assert_eq!(
+                chars_in_range(text, *start, *end),
+                *chunk,
+                "char offset range should recover the chunk for non-ASCII text"
+            );
+        }
+
+        // The bug being fixed (#11269): byte offsets and character offsets
+        // diverge once a multi-byte character precedes a chunk. Confirm the two
+        // forms actually differ here, so this test would fail if the helper
+        // silently fell back to byte offsets.
+        let any_offset_differs = byte_chunks
+            .iter()
+            .zip(&char_chunks)
+            .any(|((b_off, _), (c_off, _))| b_off != c_off);
+        assert!(
+            any_offset_differs,
+            "char offsets must diverge from byte offsets for multi-byte text"
+        );
     }
 
     #[test]

--- a/crates/chunking/src/lib.rs
+++ b/crates/chunking/src/lib.rs
@@ -59,8 +59,8 @@ pub trait Chunker: Sync + Send {
     /// Like [`Chunker::chunk_with_offsets`] but returns **character** offsets
     /// (0-based start inclusive, end exclusive) rather than byte offsets.
     ///
-    /// The search read path recovers the matched snippet with DataFusion
-    /// `substring`, which is 1-based and character-counted (PostgreSQL
+    /// The search read path recovers the matched snippet with `DataFusion`
+    /// `substring`, which is 1-based and character-counted (`PostgreSQL`
     /// semantics). Persisting character offsets — rather than the byte offsets
     /// `chunk_with_offsets` yields — lets the reader extract the exact chunk for
     /// non-ASCII text, where a byte index and a character index diverge. See
@@ -428,7 +428,7 @@ mod tests {
 
     /// Recover a chunk from `text` using 0-based, end-exclusive character
     /// offsets — mirrors how the search read path applies the stored offsets via
-    /// DataFusion `substring`.
+    /// `DataFusion` `substring`.
     fn chars_in_range(text: &str, start: usize, end: usize) -> String {
         text.chars().skip(start).take(end - start).collect()
     }

--- a/crates/runtime-search/src/candidate/vector.rs
+++ b/crates/runtime-search/src/candidate/vector.rs
@@ -489,9 +489,16 @@ impl ChunkedNonIndexVectorGeneration {
                         .map(|pk| Column::new(Some("rank"), pk).into())
                         .collect::<Vec<LogicalExpr>>(),
                     vec![
+                        // Stored offsets are 0-based character offsets; DataFusion
+                        // `substring` is 1-based and character-counted, so the start
+                        // position is `offset[1] + 1`. See issue #11269.
                         substring(
                             ident(self.embedding_column.clone()),
-                            array_element(col("rank.offset"), lit(1)),
+                            binary_expr(
+                                array_element(col("rank.offset"), lit(1)),
+                                Operator::Plus,
+                                lit(1),
+                            ),
                             binary_expr(
                                 array_element(col("rank.offset"), lit(2)),
                                 Operator::Minus,

--- a/crates/runtime-search/src/embeddings/execution_plan.rs
+++ b/crates/runtime-search/src/embeddings/execution_plan.rs
@@ -829,9 +829,12 @@ async fn get_vectors_with_chunker(
         // TODO: filter_map doesn't handle nulls
         .map(|s| match s {
             Some(s) if !s.is_empty() => {
+                // Persist character offsets (start, end), not byte offsets: the
+                // read path recovers the snippet with DataFusion `substring`,
+                // which is 1-based and character-counted. See issue #11269.
                 let chunks = chunker
-                    .chunk_indices(s)
-                    .map(|(idx, s)| (idx, s.to_string()))
+                    .chunk_with_char_offsets(s)
+                    .map(|(offsets, s)| (offsets, s.to_string()))
                     .collect_vec();
                 (chunks.len(), chunks)
             }
@@ -895,16 +898,10 @@ async fn get_vectors_with_chunker(
             }
         }
 
-        // Explicitly find `end` to handle when chunks have overlap.
+        // `chunk_with_char_offsets` already supplies the exact (start, end)
+        // character span per chunk, including when chunks overlap.
         for i in 0..chunkz_in_row {
-            let start = chunk_offsets[curr + i];
-            let end = start
-                + chunks
-                    .as_slice()
-                    .get(curr + i)
-                    .map(String::len)
-                    .unwrap_or_default();
-
+            let (start, end) = chunk_offsets[curr + i];
             chunks_builder.values().append_value(start as i32);
             chunks_builder.values().append_value(end as i32);
             chunks_builder.append(true);

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -885,13 +885,13 @@ mod tests {
             trim_whitespace: false,
             file_format: None,
         };
-        let chunker =
+        let text_chunker =
             RecursiveSplittingChunker::with_character_sizer(&cfg).expect("create chunker");
 
         // Multi-byte characters so byte and character offsets diverge — the heart
         // of the bug. The first chunk also exercises the 0-based→1-based fix.
         let text = "café über señor data points";
-        let chunked: Vec<((usize, usize), String)> = chunker
+        let chunked: Vec<((usize, usize), String)> = text_chunker
             .chunk_with_char_offsets(text)
             .map(|(off, c)| (off, c.to_string()))
             .collect();

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -442,8 +442,11 @@ impl SearchIndex for ChunkedSearchIndex {
         let (offsets, chunks): (Vec<Vec<(usize, usize)>>, Vec<Vec<_>>) = arr_str
             .map(|s_opt| {
                 if let Some(s) = s_opt {
+                    // Character offsets, not byte offsets: the read path extracts
+                    // the snippet with DataFusion `substring` (1-based, char-counted).
+                    // See issue #11269.
                     self.chunker
-                        .chunk_with_offsets(s)
+                        .chunk_with_char_offsets(s)
                         .collect::<Vec<_>>()
                         .into_iter()
                         .unzip::<_, _, Vec<(usize, usize)>, Vec<&str>>()
@@ -856,6 +859,109 @@ mod tests {
         // [2, 1, 3, 4, 1] with budget=5: 2+1=3, +3=6>5 → flush; 3, +4=7>5 → flush; 4, +1=5 → ok.
         let groups = group_rows_by_chunk_budget(&[2, 1, 3, 4, 1], 5);
         assert_eq!(groups, vec![(0, 2), (2, 1), (3, 2)]);
+    }
+
+    /// Regression for issue #11269: the chunk offsets persisted by the write
+    /// path (`to_offset_array` of `chunk_with_char_offsets`) must round-trip
+    /// through the read path's `substring` extraction and recover each chunk
+    /// exactly — including for non-ASCII text, where byte offsets (the old
+    /// behavior) produced shifted/garbled snippets.
+    #[tokio::test]
+    async fn substring_read_path_recovers_chunks_including_unicode() {
+        use arrow::array::ArrayRef;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+        use chunking::{ChunkingConfig, RecursiveSplittingChunker};
+        use datafusion::datasource::MemTable;
+        use datafusion::logical_expr::Operator;
+        use datafusion::prelude::{
+            SessionContext, array_element, binary_expr, cast, col, lit, substring,
+        };
+        use std::sync::Arc;
+
+        let cfg = ChunkingConfig {
+            target_chunk_size: 4,
+            overlap_size: 0,
+            trim_whitespace: false,
+            file_format: None,
+        };
+        let chunker =
+            RecursiveSplittingChunker::with_character_sizer(&cfg).expect("create chunker");
+
+        // Multi-byte characters so byte and character offsets diverge — the heart
+        // of the bug. The first chunk also exercises the 0-based→1-based fix.
+        let text = "café über señor data points";
+        let chunked: Vec<((usize, usize), String)> = chunker
+            .chunk_with_char_offsets(text)
+            .map(|(off, c)| (off, c.to_string()))
+            .collect();
+        assert!(
+            chunked.len() >= 2,
+            "need multiple chunks to exercise offsets, got {}",
+            chunked.len()
+        );
+
+        let offsets: Vec<Vec<(usize, usize)>> = vec![chunked.iter().map(|(off, _)| *off).collect()];
+        let offset_arr = to_offset_array(&offsets, false);
+        let n = chunked.len();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("q", DataType::Utf8, false),
+            Field::new("q_offset", offset_arr.data_type().clone(), false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![text; n])) as ArrayRef,
+                Arc::new(offset_arr) as ArrayRef,
+            ],
+        )
+        .expect("build record batch");
+
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).expect("create memtable");
+        let df = ctx.read_table(Arc::new(table)).expect("read table");
+
+        // Mirrors the extraction in `SearchTableProvider::add_match_column`
+        // (crates/search/src/provider.rs) and the candidate vector read path
+        // (crates/runtime-search/src/candidate/vector.rs): 0-based character
+        // offsets, 1-based char-counted `substring`, so start = offset[1] + 1
+        // and length = offset[2] - offset[1].
+        let start = array_element(col("q_offset"), lit(1));
+        let extracted = df
+            .select(vec![
+                cast(
+                    substring(
+                        col("q"),
+                        binary_expr(start.clone(), Operator::Plus, lit(1)),
+                        binary_expr(
+                            array_element(col("q_offset"), lit(2)),
+                            Operator::Minus,
+                            start,
+                        ),
+                    ),
+                    DataType::Utf8,
+                )
+                .alias("match"),
+            ])
+            .expect("select substring");
+
+        let results = extracted.collect().await.expect("collect results");
+        let total: usize = results.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total, n, "one extracted snippet per chunk");
+
+        let col0 = results[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("utf8 match column");
+        for (i, (_, chunk)) in chunked.iter().enumerate() {
+            assert_eq!(
+                col0.value(i),
+                chunk.as_str(),
+                "extracted snippet must equal the original chunk (row {i})"
+            );
+        }
     }
 
     #[test]

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -396,15 +396,19 @@ impl SearchQueryProvider {
                 .map(Expr::Column)
                 .collect(),
             vec![
+                // Stored offsets are 0-based character offsets; DataFusion
+                // `substring` is 1-based and character-counted, so the start
+                // position is `chunk_offset[1] + 1` and the length is
+                // `chunk_offset[2] - chunk_offset[1]`. See issue #11269.
                 // cast(
                 //   substring(
-                //      search_column, chunk_offset[1], chunk_offset[2] - chunk_offset[1]),
+                //      search_column, chunk_offset[1] + 1, chunk_offset[2] - chunk_offset[1]),
                 //   ),
                 //  'Utf8') as '_match'
                 cast(
                     substring(
                         col(search_col),
-                        array_element(col(search_offset), lit(1)),
+                        binary_expr(first.clone(), Operator::Plus, lit(1)),
                         binary_expr(second, Operator::Minus, first),
                     ),
                     DataType::Utf8,


### PR DESCRIPTION
## Summary (root cause)

Chunked search stored **0-based byte** offsets per chunk on the write side (`(start, start + chunk.len())`), but the read side extracts the matched snippet with DataFusion `substring`, which is **1-based and character-counted** (PostgreSQL semantics). Two bugs resulted:

1. **Off-by-one for all text** — a 0-based byte start used as a 1-based position shifts every snippet one character left; the first chunk loses its last character (`substr(s, 0, 7)` returns 6 chars).
2. **Byte/character divergence for non-ASCII** — once a multi-byte character precedes a chunk, the stored byte offset no longer matches the character position `substring` counts, garbling the snippet arbitrarily.

Scores and ranking were unaffected — only the returned `_match` / `_value` text was wrong.

## Changes

- `crates/chunking/src/lib.rs`: add `Chunker::chunk_with_char_offsets`, returning 0-based, end-exclusive **character** offsets. Computed in O(n) via a forward char cursor over `chunk_indices` (handles overlapping chunks; degrades gracefully if a chunker ever emits out-of-order starts).
- Write sites switched to character offsets: `crates/search/src/index/chunking.rs` (feeds `to_offset_array`) and `crates/runtime-search/src/embeddings/execution_plan.rs` (drops the now-redundant byte-length end recomputation).
- Read sites compute the substring start as `offset[1] + 1` (length `offset[2] - offset[1]` is already the character count): `SearchTableProvider::add_match_column` (`crates/search/src/provider.rs`) and the candidate vector value extraction (`crates/runtime-search/src/candidate/vector.rs`).

Write and read change together by necessity; acceleration data is rebuilt on refresh, so persisted byte-offset data is replaced with character offsets.

## Performance impact

`chunk_with_char_offsets` adds one forward character scan over the source string per document (O(n) total, not O(n times chunks)), on the indexing/embedding write path only. Read-path cost is unchanged (one extra integer add in the projection expression).

## Test plan
- [x] Added regression test for non-ASCII chunk recovery through the production write + read path (`substring_read_path_recovers_chunks_including_unicode` in `crates/search/src/index/chunking.rs`): builds offsets via the production helpers, runs the exact read-side `substring` extraction over a `MemTable`, and asserts each extracted snippet equals the original chunk.
- [x] Added edge case tests for ASCII (char offsets equal byte offsets) and multi-byte text (char offsets must diverge from byte offsets) in `crates/chunking/src/lib.rs`.
- [x] `make lint` passes (workspace-wide fmt check plus full clippy)
- [x] `make test` passes

## Checklist
- [x] Root cause documented in the commit message and PR body
- [x] Fix scoped to the search chunk-offset read/write path
- [x] No snapshot/workflow drift staged

Fixes #11269