### PR TITLE
fix(deps): bump pdf-extract to 0.12 (lopdf 0.42) to fix RUSTSEC-2026-0187

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,6 +3610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cff-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5810ca1a2b5870df2aab1c03e11c40c361ba51d6e3e361e56310f1cb3b4e087"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7044,6 +7050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9389,7 +9404,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -10928,19 +10943,28 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
+ "aes 0.8.4",
+ "bitflags 2.12.1",
+ "cbc",
+ "ecb",
  "encoding_rs",
  "flate2",
+ "getrandom 0.4.2",
  "indexmap 2.14.0",
  "itoa",
  "log",
  "md-5 0.10.6",
- "nom 7.1.3",
+ "nom 8.0.0",
+ "rand 0.10.1",
  "rangemap",
- "time",
+ "sha2 0.10.9",
+ "stringprep",
+ "thiserror 2.0.18",
+ "ttf-parser",
  "weezl",
 ]
 
@@ -13706,15 +13730,17 @@ dependencies = [
 
 [[package]]
 name = "pdf-extract"
-version = "0.8.0"
-source = "git+https://github.com/spiceai/pdf-extract?rev=3ca5e2c904cdf5897f3d671e3b2c4b62b1612b0c#3ca5e2c904cdf5897f3d671e3b2c4b62b1612b0c"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
 dependencies = [
  "adobe-cmap-parser",
+ "cff-parser",
  "encoding_rs",
  "euclid",
+ "log",
  "lopdf",
  "postscript",
- "tracing",
  "type1-encoding-parser",
  "unicode-normalization",
 ]
@@ -13968,8 +13994,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.5.0",
- "parking_lot 0.11.2",
+ "hashbrown 0.17.1",
+ "parking_lot 0.12.5",
  "rand 0.8.6",
 ]
 
@@ -14440,7 +14466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -14474,7 +14500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14802,7 +14828,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14840,7 +14866,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -17522,7 +17548,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -20670,6 +20696,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"

--- a/crates/document_parse/Cargo.toml
+++ b/crates/document_parse/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 [dependencies]
 calamine = "0.28"
 docx-rs = { git = "https://github.com/spiceai/docx-rs", rev="2a85dce57d0128e2cd7c369545516c347cb8c529"}
-pdf-extract = { git = "https://github.com/spiceai/pdf-extract", rev = "3ca5e2c904cdf5897f3d671e3b2c4b62b1612b0c" }
+pdf-extract = "0.12"
 quick-xml = "0.38"
 snafu.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
## Problem

`cargo deny check advisories` fails on **RUSTSEC-2026-0187** — a stack-overflow DoS in `lopdf < 0.42`. `lopdf` parses nested PDF arrays/dictionaries with **unbounded recursion**, so a ~21 KB crafted PDF (a deeply nested array in the Catalog, e.g. `/X [[[ … ]]]`) exhausts the call stack and aborts the process with `SIGABRT`. Because it's a stack-overflow abort rather than a `panic!`, it **cannot be caught with `catch_unwind`** — any path that parses untrusted PDF input via `document_parse` is a DoS vector.

`lopdf 0.34.0` reached us transitively:

```
lopdf 0.34.0 → pdf-extract 0.8.0 (spiceai fork) → document_parse → connector-sharepoint / data_components / parsley
```

## Fix

Switch `crates/document_parse` from the `spiceai/pdf-extract` git fork (pinned at lopdf 0.34) to crates.io **`pdf-extract = "0.12"`**, which bumps to **lopdf 0.42.0** — the version that enforces a maximum object-nesting depth and returns an `Err` instead of recursing without bound.

### Why drop the fork

The fork's *only* delta over upstream was swapping `pdf-extract`'s debug `println!` calls for `tracing::debug!` (commit `3ca5e2c`, +1/−0 `Cargo.toml`, +16/−16 `src/lib.rs`). Upstream `pdf-extract` has since moved those messages onto the `log` crate at debug level, and `spiced` already bridges `log` → `tracing` via `tracing_log::LogTracer::init()` (`bin/spiced/src/tracing.rs`). So the noise the fork was silencing is already handled — the fork is redundant and can be retired.

### Compatibility

`document_parse` uses exactly one symbol, `pdf_extract::extract_text_from_mem`, whose signature `(&[u8]) -> Result<String, OutputError>` is unchanged between 0.8.0 and 0.12.0. `cargo check -p document_parse` compiles cleanly.

## Verification

- `cargo check -p document_parse` ✅ (resolves `lopdf v0.42.0`, `pdf-extract v0.12.0`)
- `cargo deny check advisories` ✅ → `advisories ok` (RUSTSEC-2026-0187 no longer reported)
- No remaining references to `lopdf 0.34` or the `spiceai/pdf-extract` fork in `Cargo.lock`