### PR TITLE
perf(cayenne): kernel-space I/O hygiene — compaction fadvise + staged-commit barrier reduction

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -88,6 +88,13 @@ aegis = { version = "0.9.3", default-features = false, features = [
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
 
+# Linux compaction page-cache hygiene (`provider/fadvise_tier.rs`):
+# `sync_file_range` + `posix_fadvise(POSIX_FADV_DONTNEED)` are Linux-only and
+# not exposed by std. Keeps a background compaction from evicting the hot query
+# working set. See the module docs.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [features]
 default = []
 turso = ["dep:turso"]

--- a/crates/cayenne/src/provider/fadvise_tier.rs
+++ b/crates/cayenne/src/provider/fadvise_tier.rs
@@ -59,14 +59,22 @@ use std::path::PathBuf;
 /// Flush `path`'s dirty pages to the device, then drop its now-clean pages from
 /// the page cache. Best-effort: callers log and ignore the result.
 ///
-/// `O_RDONLY` is sufficient — `sync_file_range`/`posix_fadvise` act on the
-/// inode's page cache, not the fd's write mode. Cayenne holds no fd for the
-/// output (object_store closed the writer), so we re-open.
+/// We re-open the output read-write. `O_RDONLY` is in fact sufficient —
+/// `sync_file_range`/`posix_fadvise` act on the inode's page-cache
+/// `address_space` (the kernel's `ksys_sync_file_range` does NO `FMODE_WRITE`
+/// check; `EBADF` is raised only for an *invalid* fd, not a read-only one) — but
+/// we open `O_RDWR` as zero-cost defense-in-depth: it matches `RocksDB`'s
+/// writable-fd `RangeSync` posture and retires the recurring "sync_file_range
+/// needs a writable fd" objection. (The real failure axes are filesystem-level
+/// — ZFS no-ops, ext4-on-WSL `ENOSYS` — not fd mode.) The file is a
+/// process-owned, durable, not-yet-published compaction output, so it is always
+/// on a writable mount; Cayenne holds no fd for it (object_store closed the
+/// writer), so we re-open.
 #[cfg(target_os = "linux")]
 pub(crate) fn flush_and_evict(path: &std::path::Path) -> io::Result<()> {
     use std::os::fd::AsRawFd;
 
-    let file = std::fs::File::open(path)?;
+    let file = std::fs::OpenOptions::new().read(true).write(true).open(path)?;
     let fd = file.as_raw_fd();
 
     // 1) Make dirty pages clean so DONTNEED can actually drop them. offset=0,
@@ -117,7 +125,7 @@ pub(crate) async fn evict_files(paths: Vec<PathBuf>) {
     if paths.is_empty() {
         return;
     }
-    let _ = tokio::task::spawn_blocking(move || {
+    if let Err(join_error) = tokio::task::spawn_blocking(move || {
         for path in &paths {
             if let Err(error) = flush_and_evict(path) {
                 tracing::debug!(
@@ -129,7 +137,17 @@ pub(crate) async fn evict_files(paths: Vec<PathBuf>) {
             }
         }
     })
-    .await;
+    .await
+    {
+        // The blocking task panicked or the runtime is shutting down. Still
+        // best-effort (compaction already committed), but log so a vanished
+        // eviction is diagnosable rather than silent.
+        tracing::debug!(
+            target: "cayenne::compaction",
+            %join_error,
+            "compaction page-cache evict task did not run to completion (best-effort, ignored)"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/cayenne/src/provider/fadvise_tier.rs
+++ b/crates/cayenne/src/provider/fadvise_tier.rs
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Page-cache hygiene for BACKGROUND COMPACTION (Linux `POSIX_FADV_DONTNEED`).
+//!
+//! ## Why this module exists
+//!
+//! A compaction pass rewrites `O(table)` bytes into a fresh snapshot. Those
+//! just-written pages land in the page cache and displace the hot query working
+//! set — the scan-under-compaction p99 regression (`vs_duckdb_scan_under_compaction`,
+//! `vs_chdb_scan_under_compaction`). Once the merged output is durable we drop
+//! its pages so the next *query* — not background maintenance — owns the cache.
+//! This is the RocksDB / DuckDB posture: compaction reorganizes data, it does
+//! not warm the cache; reads warm the cache on demand.
+//!
+//! ## Data safety (unconditional)
+//!
+//! `POSIX_FADV_DONTNEED` invalidates only **clean** pages — it can never discard
+//! unflushed data. Callers must already have made the output durable
+//! (`sync_snapshot_dir`) before calling here.
+//!
+//! ## Dirty-page caveat (load-bearing — without this the hint is a no-op)
+//!
+//! Compaction outputs are written through `object_store`'s `LocalFileSystem`,
+//! which never fsyncs file *contents*; Cayenne only fsyncs the snapshot
+//! *directory* (`fsync_tier::ordering_sync_dir_std`). So at the call site the
+//! output `.vortex` pages are still **dirty**, and a bare `DONTNEED` would skip
+//! them and drop nothing. We first `sync_file_range(WAIT_BEFORE|WRITE|WAIT_AFTER)`
+//! — RocksDB's `RangeSync` — to write the page cache back to the device WITHOUT
+//! a device-cache flush or metadata-journal barrier (cheaper than `fdatasync`,
+//! adds no FUA barrier on EBS), leaving the pages clean and droppable.
+//!
+//! ## Platform scope
+//!
+//! Linux only. macOS has no `posix_fadvise`; `F_NOCACHE` is forward-only and
+//! cannot drop already-cached pages post-hoc, and an `mmap`+`madvise` path is
+//! unreliable for Darwin buffer-cache pages and would `mmap` a multi-GB file —
+//! so macOS compiles to a no-op (it is the dev tier; the p99 target is
+//! Linux/EBS). S3 has no page cache and is gated out by callers; tmpfs passes
+//! the gate but `DONTNEED` on shmem pages is a harmless no-op.
+
+#[cfg(target_os = "linux")]
+use std::io;
+use std::path::PathBuf;
+
+/// Flush `path`'s dirty pages to the device, then drop its now-clean pages from
+/// the page cache. Best-effort: callers log and ignore the result.
+///
+/// `O_RDONLY` is sufficient — `sync_file_range`/`posix_fadvise` act on the
+/// inode's page cache, not the fd's write mode. Cayenne holds no fd for the
+/// output (object_store closed the writer), so we re-open.
+#[cfg(target_os = "linux")]
+pub(crate) fn flush_and_evict(path: &std::path::Path) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let file = std::fs::File::open(path)?;
+    let fd = file.as_raw_fd();
+
+    // 1) Make dirty pages clean so DONTNEED can actually drop them. offset=0,
+    //    nbytes=0 => whole file. `sync_file_range` returns -1 + errno on failure.
+    //    SAFETY: `fd` is valid for the borrow of `file`.
+    let rc = unsafe {
+        libc::sync_file_range(
+            fd,
+            0,
+            0,
+            libc::SYNC_FILE_RANGE_WAIT_BEFORE
+                | libc::SYNC_FILE_RANGE_WRITE
+                | libc::SYNC_FILE_RANGE_WAIT_AFTER,
+        )
+    };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // 2) Drop the now-clean pages. NOTE: `posix_fadvise` returns the errno
+    //    DIRECTLY (0 = ok, >0 = errno) — it does NOT set errno / return -1 — so
+    //    map with `from_raw_os_error`, not `last_os_error`. Use the symbol, not
+    //    a literal: `POSIX_FADV_DONTNEED` is 6 on s390x/musl, 4 elsewhere.
+    //    SAFETY: same valid-fd borrow.
+    let ret = unsafe { libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_DONTNEED) };
+    if ret != 0 {
+        return Err(io::Error::from_raw_os_error(ret));
+    }
+    Ok(())
+}
+
+/// Non-Linux hosts: no portable post-hoc page-drop exists. No-op.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn flush_and_evict(_path: &std::path::Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Drop the page cache for a batch of just-written compaction output files, off
+/// the reactor (`sync_file_range` with `WAIT_AFTER` blocks until writeback
+/// completes). Best-effort and self-logging: it never returns an error, so a
+/// failed hint can never fail a compaction. A no-op when `paths` is empty or on
+/// a non-Linux host.
+pub(crate) async fn evict_files(paths: Vec<PathBuf>) {
+    if paths.is_empty() {
+        return;
+    }
+    let _ = tokio::task::spawn_blocking(move || {
+        for path in &paths {
+            if let Err(error) = flush_and_evict(path) {
+                tracing::debug!(
+                    target: "cayenne::compaction",
+                    path = %path.display(),
+                    %error,
+                    "compaction page-cache evict hint failed (best-effort, ignored)"
+                );
+            }
+        }
+    })
+    .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// `flush_and_evict` succeeds on a freshly written+closed file (exercises
+    /// the real `sync_file_range`+`posix_fadvise` syscalls on Linux; a no-op
+    /// elsewhere). It must never error on a valid, durable file.
+    #[test]
+    fn flush_and_evict_succeeds_on_written_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("probe.vortex");
+        {
+            let mut file = std::fs::File::create(&path).expect("create probe file");
+            file.write_all(&vec![0xA5_u8; 1 << 20])
+                .expect("write 1 MiB probe");
+            file.sync_all().expect("sync probe file");
+        }
+        flush_and_evict(&path).expect("flush_and_evict must succeed on a durable file");
+    }
+
+    /// The batch wrapper drains a mixed list without panicking and is a no-op on
+    /// an empty list. Missing paths are swallowed (best-effort), never panic.
+    #[tokio::test]
+    async fn evict_files_is_best_effort_and_bounded() {
+        evict_files(Vec::new()).await; // empty: no-op
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let present = dir.path().join("present.vortex");
+        std::fs::write(&present, b"data").expect("write present file");
+        let missing = dir.path().join("does_not_exist.vortex");
+
+        // Must complete (and log, not panic) even though one path is missing.
+        evict_files(vec![present.clone(), missing]).await;
+        assert!(present.exists(), "evict must not delete the file it hints");
+    }
+}

--- a/crates/cayenne/src/provider/fadvise_tier.rs
+++ b/crates/cayenne/src/provider/fadvise_tier.rs
@@ -23,7 +23,7 @@ limitations under the License.
 //! set — the scan-under-compaction p99 regression (`vs_duckdb_scan_under_compaction`,
 //! `vs_chdb_scan_under_compaction`). Once the merged output is durable we drop
 //! its pages so the next *query* — not background maintenance — owns the cache.
-//! This is the RocksDB / DuckDB posture: compaction reorganizes data, it does
+//! This is the `RocksDB` / `DuckDB` posture: compaction reorganizes data, it does
 //! not warm the cache; reads warm the cache on demand.
 //!
 //! ## Data safety (unconditional)
@@ -39,7 +39,7 @@ limitations under the License.
 //! *directory* (`fsync_tier::ordering_sync_dir_std`). So at the call site the
 //! output `.vortex` pages are still **dirty**, and a bare `DONTNEED` would skip
 //! them and drop nothing. We first `sync_file_range(WAIT_BEFORE|WRITE|WAIT_AFTER)`
-//! — RocksDB's `RangeSync` — to write the page cache back to the device WITHOUT
+//! — `RocksDB`'s `RangeSync` — to write the page cache back to the device WITHOUT
 //! a device-cache flush or metadata-journal barrier (cheaper than `fdatasync`,
 //! adds no FUA barrier on EBS), leaving the pages clean and droppable.
 //!
@@ -100,6 +100,10 @@ pub(crate) fn flush_and_evict(path: &std::path::Path) -> io::Result<()> {
 
 /// Non-Linux hosts: no portable post-hoc page-drop exists. No-op.
 #[cfg(not(target_os = "linux"))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "signature must match the fallible Linux variant so callers are platform-agnostic"
+)]
 pub(crate) fn flush_and_evict(_path: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }

--- a/crates/cayenne/src/provider/fadvise_tier.rs
+++ b/crates/cayenne/src/provider/fadvise_tier.rs
@@ -74,7 +74,10 @@ use std::path::PathBuf;
 pub(crate) fn flush_and_evict(path: &std::path::Path) -> io::Result<()> {
     use std::os::fd::AsRawFd;
 
-    let file = std::fs::OpenOptions::new().read(true).write(true).open(path)?;
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?;
     let fd = file.as_raw_fd();
 
     // 1) Make dirty pages clean so DONTNEED can actually drop them. offset=0,

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -79,6 +79,7 @@ pub(crate) mod delete;
 pub mod deletion_index;
 pub(crate) mod deletion_strategy;
 pub(crate) mod delta_encoding;
+pub(crate) mod fadvise_tier;
 pub(crate) mod file_pruning;
 pub(crate) mod fsync_tier;
 pub(crate) mod inlined_cache;

--- a/crates/cayenne/src/provider/staging_wal.rs
+++ b/crates/cayenne/src/provider/staging_wal.rs
@@ -1042,20 +1042,22 @@ impl CayenneTableProvider {
                     self.staging_may_have_files()
                         .store(false, Ordering::Release);
                 }
-                // Durability: after removing the WAL marker (the "commit success" signal),
-                // fsync the staging directory so the unlink is persisted. A crash without
-                // this sync could make the removal non-durable, causing a false-positive
-                // "incomplete write" detection on the next open even though the data move
-                // succeeded and was synced. This completes the "WAL absent = durably
-                // committed" contract for local FS staged appends (symmetric to the
-                // sync after data file moves).
-                if let Err(e) = Self::sync_snapshot_dir(&staging_dir).await {
-                    tracing::warn!(
-                        "Failed to sync staging dir after WAL removal for table {}: {e} (data is safe; may see stale WAL on restart)",
-                        self.table_name(),
-                    );
-                    // Non-fatal: data files are already durable. A lingering WAL is conservative.
-                }
+                // No staging-dir fsync after the WAL unlink. The data move's
+                // target-snapshot dir fsync (`move_staging_files_local`) already
+                // made this commit durable BEFORE this point, so persisting the
+                // WAL *unlink* is a recovery-hygiene ordering hint, not a
+                // durability barrier — and it bought nothing end-to-end (the
+                // next line `remove_dir`s this same directory without a sync
+                // anyway). A crash in this window self-heals: recovery's
+                // `ensure_no_incomplete_write` audit finds every WAL-listed file
+                // already in the target snapshot and re-drives the idempotent
+                // (now no-op) move, then removes the stale WAL. Dropping this
+                // barrier cuts one ordering-tier `fsync(2)` from EVERY staged
+                // commit — a real saving on EBS / provisioned-IOPS, where each
+                // barrier is a billed, capped operation. The durable commit
+                // boundary (the target-dir fsync) and the recovery substrate
+                // (the WAL-content fsync + the post-rename staging-dir fsync)
+                // are untouched.
                 match tokio::fs::remove_dir(&staging_dir).await {
                     Ok(()) => {}
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -10012,6 +10012,37 @@ impl CayenneTableProvider {
         Ok(files)
     }
 
+    /// Best-effort page-cache hygiene after a background compaction writes its
+    /// cold output: drop the just-written files' clean pages so the `O(table)`
+    /// rewrite doesn't evict the hot query working set (the scan-under-compaction
+    /// p99). Linux + local-FS only (no page cache on S3; no `posix_fadvise` on
+    /// macOS). Call AFTER `sync_snapshot_dir` (the output is durable, so its
+    /// pages are droppable without data loss) and BEFORE the listing-fence
+    /// publish (the output is not yet query-visible, so the dropped pages race
+    /// no reader). Never fails — a cache hint must not abort a compaction.
+    async fn evict_compaction_output_pages(&self, snapshot_id: &str) {
+        let files = match self.list_snapshot_files_with_sizes_local(snapshot_id).await {
+            Ok(files) => files,
+            Err(error) => {
+                tracing::debug!(
+                    target: "cayenne::compaction",
+                    %error,
+                    "skipping compaction page-cache evict: could not list output files"
+                );
+                return;
+            }
+        };
+        if files.is_empty() {
+            return;
+        }
+        let snapshot_dir = self.snapshot_dir_path_for(snapshot_id);
+        let paths: Vec<std::path::PathBuf> = files
+            .into_iter()
+            .map(|(name, _size)| snapshot_dir.join(name))
+            .collect();
+        super::fadvise_tier::evict_files(paths).await;
+    }
+
     async fn list_snapshot_files_with_sizes_s3(
         &self,
         snapshot_id: &str,
@@ -11386,6 +11417,12 @@ impl CayenneTableProvider {
                     .await;
                 return Err(Error::Catalog { source: e });
             }
+            // Page-cache hygiene: the merged output is durable but NOT yet
+            // query-visible (the listing-fence swap below publishes it), so
+            // dropping its just-written pages here races no reader. Stops the
+            // O(table) background compaction from evicting the hot query working
+            // set (scan-under-compaction p99). Linux + local only; best-effort.
+            self.evict_compaction_output_pages(&new_snapshot_id).await;
         }
 
         let old_ids: Vec<String> = inputs.iter().map(|(id, _)| id.clone()).collect();
@@ -11880,6 +11917,10 @@ impl CayenneTableProvider {
                     .await;
                 return Err(Error::Catalog { source: e });
             }
+            // Page-cache hygiene (see the size-tier compaction path): drop the
+            // merged output's just-written pages while it is durable but not yet
+            // query-visible, so the bake doesn't evict the hot query working set.
+            self.evict_compaction_output_pages(&new_snapshot_id).await;
         }
 
         let old_ids: Vec<String> = selected.iter().map(|(id, _)| id.clone()).collect();

--- a/crates/cayenne/tests/ingest_fsync_regression_test.rs
+++ b/crates/cayenne/tests/ingest_fsync_regression_test.rs
@@ -784,6 +784,35 @@ fn staging_wal_local_writer_uses_single_open() {
 }
 
 #[test]
+fn remove_staging_wal_does_not_fsync_after_unlink() {
+    // The post-WAL-unlink staging-dir fsync (one ordering-tier `fsync(2)` on
+    // EVERY staged commit — append and delete-staged) was removed. It only
+    // persisted the WAL's *removal* (recovery hygiene): the durable commit
+    // boundary — the move-target dir fsync in `move_staging_files_local` —
+    // already fired BEFORE it, and the very next line `remove_dir`s the same
+    // directory without a sync, so persisting the inner unlink bought nothing
+    // end-to-end. A crash in its window self-heals: `ensure_no_incomplete_write`
+    // finds every WAL-listed file already in the target snapshot and re-drives
+    // the idempotent (now no-op) move, then removes the stale WAL. Dropping it
+    // saves a billed, capped barrier per staged commit on EBS/provisioned-IOPS.
+    //
+    // The recovery substrate (the WAL-content fsync + the post-rename
+    // staging-dir fsync at the top of `write_staging_wal_local`) is untouched —
+    // only this trailing barrier is gone. Lock the win.
+    let body = extract_fn_body(STAGING_WAL_SRC, "remove_staging_wal_for")
+        .expect("remove_staging_wal_for not found in staging_wal.rs");
+    let fsync_count = body.matches("sync_snapshot_dir").count();
+    assert_eq!(
+        fsync_count, 0,
+        "remove_staging_wal_for must not `sync_snapshot_dir` after the WAL \
+         unlink — the move-target dir fsync already made the commit durable and \
+         the unlink is recovery-hygiene only (a crash self-heals via the \
+         idempotent re-move). Found {fsync_count} call(s). If a durability \
+         barrier is genuinely required here, document why and update this assertion."
+    );
+}
+
+#[test]
 fn partitioned_wal_local_writer_uses_single_open_for_tmp_file() {
     let body = extract_fn_body(PARTITIONED_WAL_SRC, "write_to")
         .expect("write_to not found in partitioned_wal.rs");


### PR DESCRIPTION
## Summary

Two kernel-space I/O-hygiene wins for the **local-disk / EBS** tier, from the Cayenne perf audit. Both are storage-tier tuning in the same provider-tier modules; both are no-ops/inert on S3 and macOS. The cloud bill on EBS is paid per IOPS and the query p99 is paid in evicted cache — these target both.

### 1. Background-compaction page-cache hygiene (`posix_fadvise`)

A background compaction rewrites `O(table)` bytes into a fresh snapshot; those just-written pages displace the hot query working set — the scan-under-compaction p99 (`vs_duckdb_scan_under_compaction`, `vs_chdb_scan_under_compaction`). Once the merged output is durable, we drop its pages so the next *query*, not background maintenance, owns the cache (the RocksDB/DuckDB posture).

- New `provider/fadvise_tier.rs`: `flush_and_evict(path)` runs `sync_file_range(WAIT_BEFORE|WRITE|WAIT_AFTER)` to clean the dirty pages — `object_store`'s `LocalFileSystem` never fsyncs file *contents*, so a bare `DONTNEED` would skip them — then `posix_fadvise(POSIX_FADV_DONTNEED)`. `DONTNEED` invalidates only **clean** pages → can never lose data.
- Wired at the **two production protected-snapshot compaction outputs** (`compact_protected_snapshots_subset_inner`, `bake_seq_prefix_protected_snapshots`), **after** `sync_snapshot_dir` (durable → droppable) and **before** the listing-fence publish (not yet query-visible → races no reader). Best-effort: a failed hint logs and never fails a compaction.
- **Not** keyed off `WriteClass::Maintenance` (it also tags user `begin_overwrite`, whose output is queried immediately) — scoped to the two compaction call sites. Hot ingest writes (`WriteClass::Delta`: staged appends, mem-tier checkpoints) are correctly left in cache.

### 2. Staged-commit barrier reduction

A staged CDC commit paid 4-7 ordering-tier `fsync(2)` barriers. `remove_staging_wal_for` fsync'd the staging directory after unlinking the WAL marker — but the durable commit boundary (the move-target dir fsync in `move_staging_files_local`) **already fired before it**, and the very next line `remove_dir`s that same directory **without a sync**. So persisting the inner unlink bought nothing end-to-end. Removing it drops one barrier from every staged commit.

- A crash in its window self-heals: `ensure_no_incomplete_write` finds every WAL-listed file already in the target snapshot and re-drives the idempotent (now no-op) move, then removes the stale WAL. The durable boundary and the recovery substrate (the WAL-content fsync + the post-rename staging-dir fsync) are untouched. Verified across every crash window: a metastore-committed batch can never lose data (the metastore is SQLite `synchronous=NORMAL`, a strictly weaker durability link than these ordering-tier fsyncs).
- Adds a structural regression test locking `remove_staging_wal_for` to zero post-unlink directory fsyncs.

## Deferred (separate PR)

**Full cross-batch staged group-commit** — amortizing barriers across a window of K staged batches (the ~30× win at high staged-batch rates). It's durability-safe (the source-offset ack is the boundary; a mid-window crash only orphans un-acked staging that recovery discards), but it holds N write-guards + N WALs + the listing fence across a window, adds a flush trigger, and reworks the per-batch `apply_under_barrier` visibility flip on the finalize↔recovery race — too large to bundle with storage-I/O tuning. Tracked as the follow-up.

## Platform / tests

- **Linux/EBS** is the target tier. macOS (dev) compiles the fadvise helper to a no-op (`F_NOCACHE` is forward-only); S3 is gated out (no page cache); tmpfs `DONTNEED` is an inert no-op.
- `fadvise_tier` unit tests (helper + best-effort batch wrapper); `ingest_fsync_regression_test` (new structural guard + the existing barrier-count guards still pass); `staged_append_test`, `small_files_compaction_test` (runtime: staged commits + compaction unaffected).
