### PR TITLE
fix(cayenne): live/tier-accurate join build-side stats (merge-on-read deletes + never-shrink NDV)

### DIFF
--- a/crates/cayenne/src/provider/delete/filter_exec.rs
+++ b/crates/cayenne/src/provider/delete/filter_exec.rs
@@ -265,16 +265,28 @@ fn deletion_filtered_statistics(
     let Precision::Inexact(rows) = stats.num_rows else {
         return stats;
     };
-    if net_deletions == 0 || rows == 0 {
+    // Keep the pre-deletion upper bound when the subtraction would over-apply
+    // (`net_deletions >= rows`). `net_deletions` is derived from whole-table
+    // tombstone key counts and can meet or exceed this scan's `num_rows` (e.g. a
+    // count mismatch between the union row estimate and the deletion index);
+    // collapsing to `num_rows = 0` is the dangerous direction — it can make a
+    // non-empty relation look empty and get it wrongly broadcast. Over-estimating
+    // (keeping the upper bound) only declines a broadcast, the safe direction.
+    if net_deletions == 0 || rows == 0 || net_deletions >= rows {
         return stats;
     }
-    let live = rows.saturating_sub(net_deletions);
+    let live = rows - net_deletions;
     // Scale total_byte_size by the surviving row fraction so build-side byte
-    // thresholds see the live footprint, not the pre-deletion one.
+    // thresholds see the live footprint, not the pre-deletion one. Use saturating
+    // multiplication and round the division UP: systematically under-estimating
+    // bytes would bias build-side selection toward broadcasting (the riskier
+    // direction), so bias the estimate high instead.
     if let Precision::Inexact(bytes) = stats.total_byte_size {
-        let scaled = u128::try_from(bytes).unwrap_or(0) * u128::try_from(live).unwrap_or(0)
-            / u128::try_from(rows).unwrap_or(1);
-        stats.total_byte_size = Precision::Inexact(usize::try_from(scaled).unwrap_or(bytes));
+        let bytes_u128 = u128::try_from(bytes).unwrap_or(u128::MAX);
+        let live_u128 = u128::try_from(live).unwrap_or(u128::MAX);
+        let rows_u128 = u128::try_from(rows).unwrap_or(u128::MAX);
+        let scaled = bytes_u128.saturating_mul(live_u128).div_ceil(rows_u128);
+        stats.total_byte_size = Precision::Inexact(usize::try_from(scaled).unwrap_or(usize::MAX));
     }
     stats.num_rows = Precision::Inexact(live);
     stats
@@ -1428,10 +1440,12 @@ mod tests {
         assert_eq!(agg.num_rows, Precision::Inexact(2));
     }
 
-    /// Over-subtraction guard: more pending deletes than input rows clamps
-    /// `num_rows` at 0 (no underflow), staying `Inexact`.
+    /// Over-apply guard: when the (whole-table) deletion count meets or exceeds
+    /// the scan's row count, keep the pre-deletion upper bound rather than
+    /// collapsing `num_rows` toward 0 — collapsing is the dangerous direction (it
+    /// can make a non-empty relation look empty and get it wrongly broadcast).
     #[test]
-    fn deletion_filter_clamps_num_rows_at_zero() {
+    fn deletion_filter_keeps_upper_bound_when_deletes_exceed_rows() {
         let tombstones = Arc::new(DeletionIndex::from_map(HashMap::from([
             (1_i64, 5_i64),
             (2, 5),
@@ -1446,10 +1460,11 @@ mod tests {
             0,
             None,
         );
+        // 5 deletes >= 3 scanned rows -> keep the upper bound (3), not 0.
         let agg = exec
             .partition_statistics(None)
             .expect("aggregate statistics");
-        assert_eq!(agg.num_rows, Precision::Inexact(0));
+        assert_eq!(agg.num_rows, Precision::Inexact(3));
     }
 
     /// `net_table_deletions` keeps the pre-deletion upper bound (returns 0) when

--- a/crates/cayenne/src/provider/delete/filter_exec.rs
+++ b/crates/cayenne/src/provider/delete/filter_exec.rs
@@ -220,8 +220,10 @@ pub(crate) fn is_pk_visible_row_key(
 }
 
 /// Demote child scan statistics to `Inexact` because a deletion filter removes
-/// (and, under `InsertRecordHandling::Apply`, may also re-add) an unknown subset
-/// of input rows.
+/// (and, under `InsertRecordHandling::Apply`, may also re-add) a subset of input
+/// rows, and — for the table-wide aggregate — subtract the pending merge-on-read
+/// deletion count from `num_rows`/`total_byte_size` so consumers size the *live*
+/// relation rather than the pre-deletion on-disk count.
 ///
 /// The child here is a Cayenne Vortex scan whose per-partition statistics — row
 /// counts and column min/max — are derived exactly from file-level metadata
@@ -236,10 +238,80 @@ pub(crate) fn is_pk_visible_row_key(
 /// - **Absent** statistics (e.g. the scan ran with `collect_stat = false`, so no
 ///   file metadata was materialized) stay `Absent` through `to_inexact()` — i.e.
 ///   the unknown-input case degrades to unknown output, not a fabricated value.
+///
+/// `net_deletions` is the count of rows the filter is expected to remove for the
+/// statistics being produced — the recorded deletions net of upsert re-insertions
+/// that keep their row (see [`net_table_deletions`]). It is subtracted from
+/// `num_rows` (clamped at 0), and `total_byte_size` is scaled by the surviving
+/// fraction. Without this subtraction a table with N pending merge-on-read
+/// deletes reports its full `live + N` on-disk row count, mis-sizing
+/// `JoinSelection`'s build-side / broadcast choice (which reads `num_rows` /
+/// `total_byte_size` directly) until the next compaction resets the count.
+/// Under-counting the removals is the safe direction — an over-sized `num_rows`
+/// only declines a broadcast — whereas over-subtracting could broadcast an
+/// actually-large table, so `net_deletions` is a deliberately conservative lower
+/// bound on rows removed and callers pass `0` where the applicable subset is
+/// unknown (per-partition stats; protected-snapshot scans).
 fn deletion_filtered_statistics(
     input_statistics: datafusion_common::Statistics,
+    net_deletions: usize,
 ) -> datafusion_common::Statistics {
-    input_statistics.to_inexact()
+    use datafusion_common::stats::Precision;
+
+    let mut stats = input_statistics.to_inexact();
+    // `to_inexact()` maps Exact -> Inexact and leaves Absent as Absent, so only an
+    // Inexact (known) row count can — and should — be reduced here. Nothing to do
+    // when there are no deletions to apply or the relation is already empty.
+    let Precision::Inexact(rows) = stats.num_rows else {
+        return stats;
+    };
+    if net_deletions == 0 || rows == 0 {
+        return stats;
+    }
+    let live = rows.saturating_sub(net_deletions);
+    // Scale total_byte_size by the surviving row fraction so build-side byte
+    // thresholds see the live footprint, not the pre-deletion one.
+    if let Precision::Inexact(bytes) = stats.total_byte_size {
+        let scaled = u128::try_from(bytes).unwrap_or(0) * u128::try_from(live).unwrap_or(0)
+            / u128::try_from(rows).unwrap_or(1);
+        stats.total_byte_size = Precision::Inexact(usize::try_from(scaled).unwrap_or(bytes));
+    }
+    stats.num_rows = Precision::Inexact(live);
+    stats
+}
+
+/// Estimate how many rows a deletion filter removes from the *table-wide*
+/// statistics, given the recorded deletion/insert counts.
+///
+/// The caller invokes this only for the whole-table aggregate (`partition ==
+/// None`) and only when there is no protected-snapshot cutoff — per-partition
+/// stats can't attribute the table's deletes to one partition, and under a cutoff
+/// only deletions newer than it apply (an unknown subset); both keep the
+/// pre-deletion upper bound by passing no subtraction.
+///
+/// Returns `0` (keep the upper bound) when the input scan has a pushed filter:
+/// the file-metadata `num_rows` then describes the *filtered subset*, while
+/// `delete_len` is whole-table, so subtracting it could drive `num_rows` far
+/// below the live count — the dangerous over-subtraction direction, where a
+/// too-small build side gets wrongly broadcast. Otherwise the net removal is the
+/// recorded deletion count, less — under [`InsertRecordHandling::Apply`] — the
+/// upsert re-insertions that keep their row (a conservative lower bound on rows
+/// removed).
+fn net_table_deletions(
+    insert_record_handling: InsertRecordHandling,
+    input_has_pushed_filter: bool,
+    delete_len: usize,
+    insert_len: usize,
+) -> usize {
+    if input_has_pushed_filter {
+        return 0;
+    }
+    match insert_record_handling {
+        // A deleted-then-reinserted PK keeps a live row, so it is not removed.
+        InsertRecordHandling::Apply => delete_len.saturating_sub(insert_len),
+        // Re-inserts never override the delete; every recorded delete removes a row.
+        InsertRecordHandling::Ignore => delete_len,
+    }
 }
 
 // ============================================================================
@@ -375,8 +447,23 @@ impl ExecutionPlan for KeyBasedDeletionFilterExec {
         &self,
         partition: Option<usize>,
     ) -> datafusion_common::Result<Arc<datafusion_common::Statistics>> {
+        // Only the whole-table aggregate (`partition == None`) is delete-aware, and
+        // only outside a protected-snapshot cutoff — see `net_table_deletions`. Both
+        // gates short-circuit here so the per-partition path skips the scan-subtree
+        // filter walk entirely.
+        let net_deletions = if partition.is_none() && self.min_delete_seq_to_apply.is_none() {
+            net_table_deletions(
+                self.insert_record_handling,
+                crate::provider::scan::plan_has_pushed_filter(&self.input),
+                self.tombstones.delete_len(),
+                self.tombstones.insert_len(),
+            )
+        } else {
+            0
+        };
         Ok(Arc::new(deletion_filtered_statistics(
             self.input.partition_statistics(partition)?.as_ref().clone(),
+            net_deletions,
         )))
     }
 
@@ -741,8 +828,23 @@ impl ExecutionPlan for Int64PkDeletionFilterExec {
         &self,
         partition: Option<usize>,
     ) -> datafusion_common::Result<Arc<datafusion_common::Statistics>> {
+        // Only the whole-table aggregate (`partition == None`) is delete-aware, and
+        // only outside a protected-snapshot cutoff — see `net_table_deletions`. Both
+        // gates short-circuit here so the per-partition path skips the scan-subtree
+        // filter walk entirely.
+        let net_deletions = if partition.is_none() && self.min_delete_seq_to_apply.is_none() {
+            net_table_deletions(
+                self.insert_record_handling,
+                crate::provider::scan::plan_has_pushed_filter(&self.input),
+                self.tombstones.delete_len(),
+                self.tombstones.insert_len(),
+            )
+        } else {
+            0
+        };
         Ok(Arc::new(deletion_filtered_statistics(
             self.input.partition_statistics(partition)?.as_ref().clone(),
+            net_deletions,
         )))
     }
 
@@ -1226,12 +1328,15 @@ mod tests {
         let stats = exec
             .partition_statistics(Some(0))
             .expect("partition statistics");
+        // Per-partition: the upper bound (3), precision relaxed — the per-partition
+        // delete distribution is unknown, so no subtraction here.
         assert_eq!(stats.num_rows, Precision::Inexact(3));
-        // Aggregate (partition = None) must also be inexact, not unknown.
+        // Aggregate (partition = None) is delete-aware: 3 rows - 1 deleted key
+        // (Ignore -> the delete is not overridden) = 2 live rows.
         let agg = exec
             .partition_statistics(None)
             .expect("aggregate statistics");
-        assert_eq!(agg.num_rows, Precision::Inexact(3));
+        assert_eq!(agg.num_rows, Precision::Inexact(2));
     }
 
     /// Same downgrade for the byte-keyed (composite/non-integer PK) filter.
@@ -1254,6 +1359,146 @@ mod tests {
         assert_eq!(stats.num_rows, Precision::Inexact(3));
     }
 
+    /// The table-wide aggregate (`partition == None`) is delete-aware: it
+    /// subtracts the pending merge-on-read deletion count from `num_rows` so
+    /// `JoinSelection` (which reads `num_rows`/`total_byte_size` directly) sizes
+    /// the LIVE relation, not the pre-deletion on-disk count. Per-partition stats
+    /// keep the upper bound, since the per-partition delete distribution is unknown.
+    #[test]
+    fn deletion_filter_aggregate_num_rows_is_delete_aware() {
+        // 3-row scan, 1 deleted key (Ignore: the delete is never overridden).
+        let exec = Int64PkDeletionFilterExec::new(
+            exact_int64_scan(),
+            int64_tombstones(),
+            InsertRecordHandling::Ignore,
+            0,
+            None,
+        );
+        let agg = exec
+            .partition_statistics(None)
+            .expect("aggregate statistics");
+        assert_eq!(agg.num_rows, Precision::Inexact(2));
+        let per = exec
+            .partition_statistics(Some(0))
+            .expect("partition statistics");
+        assert_eq!(per.num_rows, Precision::Inexact(3));
+    }
+
+    /// Protected-snapshot scans (`min_delete_seq_to_apply` set) keep the upper
+    /// bound: only deletions newer than the cutoff apply and we don't cheaply
+    /// know how many that is, so no subtraction.
+    #[test]
+    fn deletion_filter_protected_snapshot_keeps_upper_bound() {
+        let exec = Int64PkDeletionFilterExec::new(
+            exact_int64_scan(),
+            int64_tombstones(),
+            InsertRecordHandling::Ignore,
+            0,
+            Some(0),
+        );
+        let agg = exec
+            .partition_statistics(None)
+            .expect("aggregate statistics");
+        assert_eq!(agg.num_rows, Precision::Inexact(3));
+    }
+
+    /// Upsert-churn safety: a key that was deleted AND re-inserted keeps its row
+    /// under `InsertRecordHandling::Apply`, so it must NOT be subtracted. With
+    /// `delete_len == insert_len` the net removal is 0 — guarding against
+    /// catastrophically under-sizing a heavily-upserted CDC table (the dangerous
+    /// over-subtraction direction that would wrongly broadcast a large relation).
+    #[test]
+    fn deletion_filter_does_not_subtract_reinserted_upserts() {
+        // 2 deleted keys, 1 of them re-inserted (upsert, insert_seq > delete_seq)
+        // -> net removed = delete_len(2) - insert_len(1) = 1.
+        let tombstones = Arc::new(DeletionIndex::from_maps(
+            HashMap::from([(2_i64, 5_i64), (3_i64, 5_i64)]),
+            HashMap::from([(2_i64, 10_i64)]),
+        ));
+        let exec = Int64PkDeletionFilterExec::new(
+            exact_int64_scan(),
+            tombstones,
+            InsertRecordHandling::Apply,
+            0,
+            None,
+        );
+        let agg = exec
+            .partition_statistics(None)
+            .expect("aggregate statistics");
+        assert_eq!(agg.num_rows, Precision::Inexact(2));
+    }
+
+    /// Over-subtraction guard: more pending deletes than input rows clamps
+    /// `num_rows` at 0 (no underflow), staying `Inexact`.
+    #[test]
+    fn deletion_filter_clamps_num_rows_at_zero() {
+        let tombstones = Arc::new(DeletionIndex::from_map(HashMap::from([
+            (1_i64, 5_i64),
+            (2, 5),
+            (3, 5),
+            (4, 5),
+            (5, 5),
+        ])));
+        let exec = Int64PkDeletionFilterExec::new(
+            exact_int64_scan(),
+            tombstones,
+            InsertRecordHandling::Ignore,
+            0,
+            None,
+        );
+        let agg = exec
+            .partition_statistics(None)
+            .expect("aggregate statistics");
+        assert_eq!(agg.num_rows, Precision::Inexact(0));
+    }
+
+    /// `net_table_deletions` keeps the pre-deletion upper bound (returns 0) when
+    /// the input scan has a pushed filter — its `num_rows` is the filtered subset,
+    /// so subtracting the whole-table `delete_len` would over-subtract (the
+    /// dangerous direction). Otherwise it subtracts `delete_len` (`Ignore`) or
+    /// `delete_len - insert_len` (`Apply`), clamped at 0.
+    #[test]
+    fn net_table_deletions_keeps_upper_bound_under_pushed_filter() {
+        // No pushed filter: subtract.
+        assert_eq!(
+            net_table_deletions(InsertRecordHandling::Ignore, false, 10, 0),
+            10
+        );
+        assert_eq!(
+            net_table_deletions(InsertRecordHandling::Apply, false, 10, 3),
+            7
+        );
+        // Pushed filter: keep the upper bound (num_rows is the filtered subset).
+        assert_eq!(
+            net_table_deletions(InsertRecordHandling::Ignore, true, 10, 0),
+            0
+        );
+        assert_eq!(
+            net_table_deletions(InsertRecordHandling::Apply, true, 10, 3),
+            0
+        );
+        // Apply with more re-inserts than deletes clamps at 0 (no underflow).
+        assert_eq!(
+            net_table_deletions(InsertRecordHandling::Apply, false, 3, 5),
+            0
+        );
+    }
+
+    /// `total_byte_size` is scaled by the surviving row fraction so build-side
+    /// byte thresholds see the live footprint.
+    #[test]
+    fn deletion_filtered_statistics_scales_byte_size_by_survivors() {
+        let input = Statistics {
+            num_rows: Precision::Exact(10),
+            total_byte_size: Precision::Exact(100),
+            column_statistics: vec![],
+        };
+        // Remove 4 of 10 -> 6 live; bytes 100 * 6/10 = 60.
+        let out = deletion_filtered_statistics(input, 4);
+        assert_eq!(out.num_rows, Precision::Inexact(6));
+        assert_eq!(out.total_byte_size, Precision::Inexact(60));
+    }
+
     /// Column min/max bounds survive the downgrade (still useful for range
     /// pruning) — deleting rows can only shrink a range, so the bounds stay
     /// conservative; only their precision relaxes to `Inexact`.
@@ -1271,7 +1516,7 @@ mod tests {
                 byte_size: Precision::Absent,
             }],
         };
-        let out = deletion_filtered_statistics(input_stats);
+        let out = deletion_filtered_statistics(input_stats, 0);
         let col = &out.column_statistics[0];
         assert_eq!(
             col.min_value,
@@ -1292,7 +1537,8 @@ mod tests {
     fn deletion_filter_keeps_unknown_when_metadata_absent() {
         let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
         let unknown = Statistics::new_unknown(&schema);
-        let out = deletion_filtered_statistics(unknown);
+        // Absent stays Absent regardless of the deletion count (nothing to reduce).
+        let out = deletion_filtered_statistics(unknown, 5);
         assert_eq!(out.num_rows, Precision::Absent);
         assert_eq!(out.total_byte_size, Precision::Absent);
     }

--- a/crates/cayenne/src/provider/scan.rs
+++ b/crates/cayenne/src/provider/scan.rs
@@ -445,13 +445,18 @@ fn file_scan_configs(plan: &Arc<dyn ExecutionPlan>) -> Vec<&FileScanConfig> {
     configs
 }
 
-/// Whether any file source in `plan`'s subtree carries a pushed-down filter (a
-/// static predicate or a dynamic join filter). The file-metadata `num_rows`
-/// describes the *unfiltered* file, so a consumer reasoning about a scan's live
-/// row count — e.g. the deletion filter's delete-aware `num_rows`, which
-/// subtracts a whole-table deletion count — must not treat a filtered scan's
-/// (subset) count as the whole-table count. Reused by
-/// [`CayenneAccelerationExec::has_pushed_filter`] and the deletion-filter execs.
+/// Whether any file source reachable from `plan` carries a pushed-down filter (a
+/// static predicate or a dynamic join filter). Reachability is exactly what
+/// [`file_scan_configs`] walks — it descends only identity-preserving wrappers
+/// and `UnionExec` (the Cayenne base+delta shape), not arbitrary intermediate
+/// operators — so a filter buried under a non-passthrough node is not detected.
+/// That matches the intended callers, whose `FileScanConfig`s sit directly under
+/// such wrappers: the file-metadata `num_rows` describes the *unfiltered* file,
+/// so a consumer reasoning about a scan's live row count — e.g. the deletion
+/// filter's delete-aware `num_rows`, which subtracts a whole-table deletion count
+/// — must not treat a filtered scan's (subset) count as the whole-table count.
+/// Reused by [`CayenneAccelerationExec::has_pushed_filter`] and the
+/// deletion-filter execs.
 pub(crate) fn plan_has_pushed_filter(plan: &Arc<dyn ExecutionPlan>) -> bool {
     file_scan_configs(plan)
         .iter()

--- a/crates/cayenne/src/provider/scan.rs
+++ b/crates/cayenne/src/provider/scan.rs
@@ -283,9 +283,7 @@ impl CayenneAccelerationExec {
     /// the metadata cannot answer an aggregate restricted to a row subset.
     #[must_use]
     pub(crate) fn has_pushed_filter(&self) -> bool {
-        file_scan_configs(&self.inner)
-            .iter()
-            .any(|config| config.file_source().filter().is_some())
+        plan_has_pushed_filter(&self.inner)
     }
 
     /// Push additional dynamic filters into the underlying file source.
@@ -333,20 +331,43 @@ impl CayenneAccelerationExec {
 /// reads only `total_byte_size`/`num_rows`, and join-cardinality estimation
 /// prefers NDV when present, so the restored NDV is what carries the estimate —
 /// min/max are not needed here and only re-introduce the assertion hazard.
+///
+/// The refilled NDV is capped at the child's `num_rows`: a column cannot have
+/// more distinct values than it has rows. The overlay NDV is the whole-table HLL
+/// aggregate, which only ever GROWS — it is never shrunk on a delete, an
+/// upsert-supersede, or a retention drop, and is not filter-aware — so on a
+/// churned or selectively-filtered scan it can exceed the child's live row count.
+/// Without the cap that never-shrink over-count would inflate the per-key NDV and
+/// mis-drive `estimate_inner_join_cardinality`.
 fn restore_absent_column_statistics(mut child: Statistics, overlay: &Statistics) -> Statistics {
     if child.column_statistics.len() != overlay.column_statistics.len() {
         return child;
     }
+    let child_num_rows = child.num_rows;
     for (col, src) in child
         .column_statistics
         .iter_mut()
         .zip(overlay.column_statistics.iter())
     {
         if matches!(col.distinct_count, Precision::Absent) {
-            col.distinct_count = src.distinct_count;
+            col.distinct_count = cap_distinct_count_at_rows(src.distinct_count, child_num_rows);
         }
     }
     child
+}
+
+/// Clamp an NDV (`distinct_count`) to a row count — a column cannot have more
+/// distinct values than it has rows. Returns the NDV unchanged when either side
+/// is unknown or it is already within bounds; a clamped value is `Inexact`
+/// (it is a derived bound, not a measured count).
+fn cap_distinct_count_at_rows(
+    distinct_count: Precision<usize>,
+    num_rows: Precision<usize>,
+) -> Precision<usize> {
+    match (distinct_count.get_value(), num_rows.get_value()) {
+        (Some(&ndv), Some(&rows)) if ndv > rows => Precision::Inexact(rows),
+        _ => distinct_count,
+    }
 }
 
 fn compute_scan_identity(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<ScanIdentity>> {
@@ -422,6 +443,19 @@ fn file_scan_configs(plan: &Arc<dyn ExecutionPlan>) -> Vec<&FileScanConfig> {
     let mut configs = Vec::new();
     collect_file_scan_configs(plan, &mut configs);
     configs
+}
+
+/// Whether any file source in `plan`'s subtree carries a pushed-down filter (a
+/// static predicate or a dynamic join filter). The file-metadata `num_rows`
+/// describes the *unfiltered* file, so a consumer reasoning about a scan's live
+/// row count — e.g. the deletion filter's delete-aware `num_rows`, which
+/// subtracts a whole-table deletion count — must not treat a filtered scan's
+/// (subset) count as the whole-table count. Reused by
+/// [`CayenneAccelerationExec::has_pushed_filter`] and the deletion-filter execs.
+pub(crate) fn plan_has_pushed_filter(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    file_scan_configs(plan)
+        .iter()
+        .any(|config| config.file_source().filter().is_some())
 }
 
 /// Counts file-backed scan sources (snapshot generations) and the total files
@@ -1117,7 +1151,9 @@ mod tests {
                 max_value: Precision::Inexact(ScalarValue::Int64(Some(9999))),
                 min_value: Precision::Inexact(ScalarValue::Int64(Some(1))),
                 sum_value: Precision::Absent,
-                distinct_count: Precision::Inexact(42),
+                // <= the 3-row union count, so the row-count cap is a no-op here;
+                // the cap has its own tests (`overlay_refilled_ndv_*`).
+                distinct_count: Precision::Inexact(2),
                 byte_size: Precision::Absent,
             }],
         });
@@ -1147,7 +1183,7 @@ mod tests {
         let col = &restored.column_statistics[0];
         assert!(matches!(col.min_value, Precision::Absent));
         assert!(matches!(col.max_value, Precision::Absent));
-        assert_eq!(col.distinct_count, Precision::Inexact(42));
+        assert_eq!(col.distinct_count, Precision::Inexact(2));
         assert_eq!(
             restored.num_rows, poisoned.num_rows,
             "overlay must not override the child's filter-aware num_rows"
@@ -1219,5 +1255,78 @@ mod tests {
         // Absent distinct_count is filled from the overlay.
         assert_eq!(col.distinct_count, Precision::Inexact(50));
         assert_eq!(restored.num_rows, Precision::Exact(100));
+    }
+
+    /// The refilled NDV is capped at the child's `num_rows`: a column cannot have
+    /// more distinct values than it has rows. The whole-table overlay NDV is an
+    /// HLL union that only grows (never shrinks on delete/upsert-supersede), so it
+    /// can exceed the live row count; the cap keeps it from inflating the join
+    /// cardinality estimate.
+    #[test]
+    fn overlay_refilled_ndv_is_capped_at_num_rows() {
+        use datafusion_common::ColumnStatistics;
+
+        let child = Statistics {
+            num_rows: Precision::Exact(3),
+            total_byte_size: Precision::Absent,
+            column_statistics: vec![ColumnStatistics {
+                null_count: Precision::Absent,
+                max_value: Precision::Absent,
+                min_value: Precision::Absent,
+                sum_value: Precision::Absent,
+                distinct_count: Precision::Absent,
+                byte_size: Precision::Absent,
+            }],
+        };
+        let overlay = Statistics {
+            num_rows: Precision::Absent,
+            total_byte_size: Precision::Absent,
+            column_statistics: vec![ColumnStatistics {
+                null_count: Precision::Absent,
+                max_value: Precision::Absent,
+                min_value: Precision::Absent,
+                sum_value: Precision::Absent,
+                // Over-counts the live 3 rows (HLL never-shrink drift).
+                distinct_count: Precision::Inexact(42),
+                byte_size: Precision::Absent,
+            }],
+        };
+
+        let restored = restore_absent_column_statistics(child, &overlay);
+        // Capped at num_rows (3), not the inflated overlay NDV (42).
+        assert_eq!(
+            restored.column_statistics[0].distinct_count,
+            Precision::Inexact(3)
+        );
+    }
+
+    /// The NDV cap clamps only when the NDV strictly exceeds the row count, and is
+    /// a no-op when either side is unknown.
+    #[test]
+    fn cap_distinct_count_at_rows_clamps_only_when_exceeding() {
+        // Exceeds rows -> clamped to rows (Inexact).
+        assert_eq!(
+            cap_distinct_count_at_rows(Precision::Inexact(42), Precision::Exact(3)),
+            Precision::Inexact(3)
+        );
+        // Within bounds -> unchanged.
+        assert_eq!(
+            cap_distinct_count_at_rows(Precision::Inexact(2), Precision::Exact(3)),
+            Precision::Inexact(2)
+        );
+        // Equal -> unchanged.
+        assert_eq!(
+            cap_distinct_count_at_rows(Precision::Exact(3), Precision::Exact(3)),
+            Precision::Exact(3)
+        );
+        // Unknown NDV or unknown rows -> unchanged.
+        assert_eq!(
+            cap_distinct_count_at_rows(Precision::Absent, Precision::Exact(3)),
+            Precision::Absent
+        );
+        assert_eq!(
+            cap_distinct_count_at_rows(Precision::Inexact(5), Precision::Absent),
+            Precision::Inexact(5)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes two **pre-existing** cross-tier statistics defects that mis-size Cayenne hash-join build-side / broadcast selection on delete-heavy and heavily-upserted CDC tables. Both are **independent of #11440** (the DataFusion join-cardinality bump): `JoinSelection` reads `num_rows`/`total_byte_size` directly, bypassing the cardinality estimator #11440 changed.

- **`num_rows` over-count (merge-on-read deletes).** The deletion filter reported its child's *pre-deletion* row count — `deletion_filtered_statistics` only downgraded precision to `Inexact` and never subtracted the deleted rows. So a table with `N` pending deletes was sized at `live + N` (and pre-deletion bytes) until the next compaction, mis-sizing joins against it. Now subtracts the table-wide pending-deletion count (`delete_len`, less upsert re-insertions under `Apply`) from `num_rows` and scales `total_byte_size` by the surviving fraction.
- **NDV over-count (never-shrink HLL).** The refilled whole-table join-key NDV comes from an HLL union that only ever *grows* (never shrunk on delete / upsert-supersede / retention) and isn't filter-aware, so it could exceed the live or filtered row count and inflate `estimate_inner_join_cardinality`. Now capped at the child's `num_rows` in `restore_absent_column_statistics` (a column can't have more distinct values than rows).

Statistics-only change — it affects plan choice (build side, broadcast vs. shuffle), never query results.

## Pre-Landing Review

Adversarial self-review surfaced **one critical hazard, fixed before commit**:

- **Over-subtraction on filtered scans** (the dangerous direction — a too-small build side gets wrongly broadcast → OOM). These execs are pushdown-transparent, so a selectively-filtered scan's `num_rows` is the *filtered subset* while `delete_len` is whole-table. Guarded: the deletion subtraction is skipped whenever the input scan has a pushed filter (new `plan_has_pushed_filter`), and is gated to `partition == None` with no protected-snapshot cutoff. Upsert churn is handled via `delete_len - insert_len` (re-inserted rows aren't counted as removed). The NDV cap is independently safe (`NDV ≤ row count` is universally true).

No other issues found.

## Test plan

- [x] 35 cayenne unit tests pass (`cargo test -p cayenne --lib -- provider::scan provider::delete::filter_exec`), including new regression tests: delete-aware aggregate `num_rows`, per-partition upper-bound preserved, protected-snapshot upper-bound, upsert-churn safety, zero-clamp, `total_byte_size` scaling, pushed-filter guard, and the NDV row-count cap.
- [x] Both CI clippy gates green (`--lib` + `--tests`, `--no-deps`, exact `make lint` flags); no warnings in changed files.
- [x] `cargo fmt` clean.
- [ ] Full workspace test suite — runs in CI.

> Context: surfaced while investigating a suspected #11440 join performance regression on CH-benCH / TPC-DS. #11440 itself was found non-regressive (its new divisor cap actually *defends* against the NDV over-count) and needs no change; these are the orthogonal, pre-existing defects.
