### PR TITLE
fix: Support reading column types longer than 128 chars in Redshift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6369,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=6b64a83d3bbd243003750c8b2e59eac50e094d65#6b64a83d3bbd243003750c8b2e59eac50e094d65"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=465bbba54e5e09ece6649fa78b690b5315c5dece#465bbba54e5e09ece6649fa78b690b5315c5dece"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ datafusion-proto-common = "54.0.0"
 datafusion-pruning = "54.0.0"
 datafusion-spark = "54.0.0"
 datafusion-substrait = "54.0.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "6b64a83d3bbd243003750c8b2e59eac50e094d65" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "465bbba54e5e09ece6649fa78b690b5315c5dece" } # spiceai-54
 
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates `datafusion-table-providers`: https://github.com/spiceai/datafusion-table-providers/pull/24