### PR TITLE
fix(datafusion): accurate projected scan byte size so hash joins build the smaller side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5622,7 +5622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5646,7 +5646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5671,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "futures",
  "log",
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5718,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5763,7 +5763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5785,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5834,12 +5834,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5882,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5934,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5965,7 +5965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6009,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6033,7 +6033,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6048,7 +6048,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6064,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6073,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "chrono",
@@ -6134,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6169,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "chrono",
@@ -6185,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6204,7 +6204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6236,7 +6236,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "chrono",
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6277,7 +6277,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6292,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6305,7 +6305,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6351,7 +6351,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=9349f7f80422b8088fc5b2dc23990d7fd498b5b3#9349f7f80422b8088fc5b2dc23990d7fd498b5b3"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "regex",
  "toml 1.1.2+spec-1.1.0",
  "windows-registry",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5622,7 +5622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5646,7 +5646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5671,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "futures",
  "log",
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5718,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5763,7 +5763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5785,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5834,12 +5834,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5882,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5934,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5965,7 +5965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6009,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6033,7 +6033,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6048,7 +6048,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6064,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6073,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "chrono",
@@ -6134,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6169,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "chrono",
@@ -6185,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6197,13 +6197,14 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-pruning",
  "itertools 0.14.0",
+ "log",
  "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6235,7 +6236,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "chrono",
@@ -6264,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6276,7 +6277,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6291,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6304,7 +6305,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6332,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6350,7 +6351,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ec52d75bb6c796a047f052a5e00a227145b872f1#ec52d75bb6c796a047f052a5e00a227145b872f1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=077f2394ef3e4238770c669d08242ac0970446a3#077f2394ef3e4238770c669d08242ac0970446a3"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6807,7 +6808,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7318,7 +7319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8299,8 +8300,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -9404,7 +9405,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -10049,7 +10050,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12248,7 +12249,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13994,8 +13995,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.5.0",
- "parking_lot 0.11.2",
+ "hashbrown 0.17.1",
+ "parking_lot 0.12.5",
  "rand 0.8.6",
 ]
 
@@ -14465,7 +14466,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14828,7 +14829,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14866,7 +14867,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -16897,7 +16898,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16974,7 +16975,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17548,7 +17549,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -18089,7 +18090,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -18180,7 +18181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18644,7 +18645,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19371,7 +19372,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19433,7 +19434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19641,7 +19642,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",
@@ -22716,7 +22717,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,43 +430,6 @@ datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "0
 datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
 
-# datafusion = { path = "/Users/sg/spice/other/datafusion/datafusion/core" }
-# datafusion-catalog = { path = "/Users/sg/spice/other/datafusion/datafusion/catalog" }
-# datafusion-catalog-listing = { path = "/Users/sg/spice/other/datafusion/datafusion/catalog-listing" }
-# datafusion-common = { path = "/Users/sg/spice/other/datafusion/datafusion/common" }
-# datafusion-common-runtime = { path = "/Users/sg/spice/other/datafusion/datafusion/common-runtime" }
-# datafusion-datasource = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource" }
-# datafusion-datasource-arrow = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource-arrow" }
-# datafusion-datasource-csv = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource-csv" }
-# datafusion-datasource-json = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource-json" }
-# datafusion-datasource-parquet = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource-parquet" }
-# datafusion-doc = { path = "/Users/sg/spice/other/datafusion/datafusion/doc" }
-# datafusion-execution = { path = "/Users/sg/spice/other/datafusion/datafusion/execution" }
-# datafusion-expr = { path = "/Users/sg/spice/other/datafusion/datafusion/expr" }
-# datafusion-expr-common = { path = "/Users/sg/spice/other/datafusion/datafusion/expr-common" }
-# datafusion-functions = { path = "/Users/sg/spice/other/datafusion/datafusion/functions" }
-# datafusion-functions-aggregate = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-aggregate" }
-# datafusion-functions-aggregate-common = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-aggregate-common" }
-# datafusion-functions-nested = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-nested" }
-# datafusion-functions-table = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-table" }
-# datafusion-functions-window = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-window" }
-# datafusion-functions-window-common = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-window-common" }
-# datafusion-macros = { path = "/Users/sg/spice/other/datafusion/datafusion/macros" }
-# datafusion-optimizer = { path = "/Users/sg/spice/other/datafusion/datafusion/optimizer" }
-# datafusion-physical-expr = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-expr" }
-# datafusion-physical-expr-adapter = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-expr-adapter" }
-# datafusion-physical-expr-common = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-expr-common" }
-# datafusion-physical-optimizer = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-optimizer" }
-# datafusion-physical-plan = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-plan" }
-# datafusion-proto = { path = "/Users/sg/spice/other/datafusion/datafusion/proto" }
-# datafusion-proto-common = { path = "/Users/sg/spice/other/datafusion/datafusion/proto-common" }
-# datafusion-pruning = { path = "/Users/sg/spice/other/datafusion/datafusion/pruning" }
-# datafusion-session = { path = "/Users/sg/spice/other/datafusion/datafusion/session" }
-# datafusion-spark = { path = "/Users/sg/spice/other/datafusion/datafusion/spark" }
-# datafusion-sql = { path = "/Users/sg/spice/other/datafusion/datafusion/sql" }
-# datafusion-substrait = { path = "/Users/sg/spice/other/datafusion/datafusion/substrait" }
-
-
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).
 # Pulled in transitively via `mysql_async` (the MySQL connector); it was the sole

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,41 +394,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "9349f7f80422b8088fc5b2dc23990d7fd498b5b3" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,41 +394,78 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "ec52d75bb6c796a047f052a5e00a227145b872f1" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "077f2394ef3e4238770c669d08242ac0970446a3" }
+
+# datafusion = { path = "/Users/sg/spice/other/datafusion/datafusion/core" }
+# datafusion-catalog = { path = "/Users/sg/spice/other/datafusion/datafusion/catalog" }
+# datafusion-catalog-listing = { path = "/Users/sg/spice/other/datafusion/datafusion/catalog-listing" }
+# datafusion-common = { path = "/Users/sg/spice/other/datafusion/datafusion/common" }
+# datafusion-common-runtime = { path = "/Users/sg/spice/other/datafusion/datafusion/common-runtime" }
+# datafusion-datasource = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource" }
+# datafusion-datasource-arrow = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource-arrow" }
+# datafusion-datasource-csv = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource-csv" }
+# datafusion-datasource-json = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource-json" }
+# datafusion-datasource-parquet = { path = "/Users/sg/spice/other/datafusion/datafusion/datasource-parquet" }
+# datafusion-doc = { path = "/Users/sg/spice/other/datafusion/datafusion/doc" }
+# datafusion-execution = { path = "/Users/sg/spice/other/datafusion/datafusion/execution" }
+# datafusion-expr = { path = "/Users/sg/spice/other/datafusion/datafusion/expr" }
+# datafusion-expr-common = { path = "/Users/sg/spice/other/datafusion/datafusion/expr-common" }
+# datafusion-functions = { path = "/Users/sg/spice/other/datafusion/datafusion/functions" }
+# datafusion-functions-aggregate = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-aggregate" }
+# datafusion-functions-aggregate-common = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-aggregate-common" }
+# datafusion-functions-nested = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-nested" }
+# datafusion-functions-table = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-table" }
+# datafusion-functions-window = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-window" }
+# datafusion-functions-window-common = { path = "/Users/sg/spice/other/datafusion/datafusion/functions-window-common" }
+# datafusion-macros = { path = "/Users/sg/spice/other/datafusion/datafusion/macros" }
+# datafusion-optimizer = { path = "/Users/sg/spice/other/datafusion/datafusion/optimizer" }
+# datafusion-physical-expr = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-expr" }
+# datafusion-physical-expr-adapter = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-expr-adapter" }
+# datafusion-physical-expr-common = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-expr-common" }
+# datafusion-physical-optimizer = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-optimizer" }
+# datafusion-physical-plan = { path = "/Users/sg/spice/other/datafusion/datafusion/physical-plan" }
+# datafusion-proto = { path = "/Users/sg/spice/other/datafusion/datafusion/proto" }
+# datafusion-proto-common = { path = "/Users/sg/spice/other/datafusion/datafusion/proto-common" }
+# datafusion-pruning = { path = "/Users/sg/spice/other/datafusion/datafusion/pruning" }
+# datafusion-session = { path = "/Users/sg/spice/other/datafusion/datafusion/session" }
+# datafusion-spark = { path = "/Users/sg/spice/other/datafusion/datafusion/spark" }
+# datafusion-sql = { path = "/Users/sg/spice/other/datafusion/datafusion/sql" }
+# datafusion-substrait = { path = "/Users/sg/spice/other/datafusion/datafusion/substrait" }
+
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/crates/vortex/src/persistent/format.rs
+++ b/crates/vortex/src/persistent/format.rs
@@ -1010,7 +1010,7 @@ mod tests {
     /// projected columns' bytes rather than the full unprojected row width.
     #[tokio::test]
     async fn propagates_per_column_byte_size() -> anyhow::Result<()> {
-        let ctx = TestSessionContext::default();
+        let ctx = TestSessionContext::new(true);
 
         // Wide schema: fixed-width Int, a narrow Utf8, and a FAT Utf8 (`data`)
         // standing in for a `VARCHAR(500)`-style column.

--- a/crates/vortex/src/persistent/format.rs
+++ b/crates/vortex/src/persistent/format.rs
@@ -1003,74 +1003,114 @@ mod tests {
         Ok(())
     }
 
-    /// Verifies the Vortex -> DataFusion statistics boundary: a written Vortex
-    /// file surfaces per-column byte sizes (from the footer's
-    /// `UncompressedSizeInBytes`) into `ColumnStatistics.byte_size` — including
-    /// for variable-width (`Utf8`) columns — and `total_byte_size` is their sum.
+    /// Verifies the Vortex -> DataFusion statistics boundary: a written
+    /// Vortex file surfaces per-column byte sizes (from the footer's
+    /// `UncompressedSizeInBytes`) into `ColumnStatistics.byte_size` — including for
+    /// variable-width (`Utf8`) columns — and a projected scan reports only the
+    /// projected columns' bytes rather than the full unprojected row width.
     #[tokio::test]
     async fn propagates_per_column_byte_size() -> anyhow::Result<()> {
-        use datafusion_catalog::TableProvider;
-
         let ctx = TestSessionContext::default();
 
-        // Mixed schema: a fixed-width Int and a variable-width Utf8 column.
+        // Wide schema: fixed-width Int, a narrow Utf8, and a FAT Utf8 (`data`)
+        // standing in for a `VARCHAR(500)`-style column.
         ctx.session
             .sql(
-                "CREATE EXTERNAL TABLE t (id INT NOT NULL, s VARCHAR NOT NULL) \
+                "CREATE EXTERNAL TABLE t \
+                 (id INT NOT NULL, s VARCHAR NOT NULL, data VARCHAR NOT NULL) \
                  STORED AS vortex LOCATION 'table/'",
             )
             .await?
             .collect()
             .await?;
 
-        // Write a known number of rows through the real Vortex writer.
+        // Write a known number of rows; `data` holds a long value so dropping it
+        // via projection produces a large, unmistakable drop in total_byte_size.
         let n = 8usize;
+        let wide = "x".repeat(200);
+        let values = (1..=n)
+            .map(|i| format!("({i}, 's{i}', '{wide}')"))
+            .collect::<Vec<_>>()
+            .join(", ");
         ctx.session
-            .sql(
-                "INSERT INTO t VALUES \
-                 (1,'aa'),(2,'bb'),(3,'cc'),(4,'dd'),(5,'ee'),(6,'ff'),(7,'gg'),(8,'hh')",
-            )
+            .sql(&format!("INSERT INTO t VALUES {values}"))
             .await?
             .collect()
             .await?;
 
-        // Read the scan statistics the way the optimizer does (all columns).
         let provider = ctx.session.table_provider("t").await?;
         let state = ctx.session.state();
-        let scan = provider.scan(&state, None, &[], None).await?;
-        let stats = scan.partition_statistics(None)?;
 
-        assert_eq!(stats.num_rows.get_value(), Some(&n), "row count");
+        // --- All columns: per-column byte_size present, total == sum ---------
+        let all = provider
+            .scan(&state, None, &[], None)
+            .await?
+            .partition_statistics(None)?;
+        assert_eq!(all.num_rows.get_value(), Some(&n), "row count");
 
-        let id_bytes = stats.column_statistics[0].byte_size;
-        let s_bytes = stats.column_statistics[1].byte_size;
+        let id_bytes = *all.column_statistics[0]
+            .byte_size
+            .get_value()
+            .expect("Int column byte_size must be populated");
+        let s_bytes = *all.column_statistics[1]
+            .byte_size
+            .get_value()
+            .expect("narrow Utf8 byte_size must be populated");
+        let data_bytes = *all.column_statistics[2]
+            .byte_size
+            .get_value()
+            .expect("wide Utf8 byte_size must be populated");
 
-        // Both columns — including the Utf8 one — must carry a per-column size.
         assert!(
-            id_bytes.get_value().is_some(),
-            "Int column byte_size must be populated, got {id_bytes:?}"
+            id_bytes >= 4 * n,
+            "Int32 byte_size should be >= 4*rows, got {id_bytes}"
         );
         assert!(
-            s_bytes.get_value().is_some(),
-            "Utf8 column byte_size must be populated, got {s_bytes:?}"
+            data_bytes > s_bytes,
+            "wide column must report more bytes than the narrow one ({data_bytes} vs {s_bytes})"
         );
 
-        // The fixed-width column's uncompressed size is at least 4 bytes/value.
-        assert!(
-            *id_bytes.get_value().unwrap() >= 4 * n,
-            "Int32 byte_size should be >= 4*rows, got {id_bytes:?}"
-        );
-
-        // total_byte_size is the sum of the per-column byte sizes.
-        let sum: usize = stats
-            .column_statistics
-            .iter()
-            .map(|c| *c.byte_size.get_value().expect("every column has byte_size"))
-            .sum();
+        let all_total = *all
+            .total_byte_size
+            .get_value()
+            .expect("all-columns total present");
         assert_eq!(
-            stats.total_byte_size.get_value(),
-            Some(&sum),
-            "total_byte_size must equal the sum of per-column byte_size"
+            all_total,
+            id_bytes + s_bytes + data_bytes,
+            "all-columns total_byte_size must equal the sum of per-column byte_size"
+        );
+
+        // --- Projected scans: total reflects ONLY the projected columns ------
+        // Project [id] (fixed-width): total is just the int column.
+        let proj_id_cols = vec![0usize];
+        let proj_id = provider
+            .scan(&state, Some(&proj_id_cols), &[], None)
+            .await?
+            .partition_statistics(None)?;
+        assert_eq!(
+            proj_id.total_byte_size.get_value(),
+            Some(&id_bytes),
+            "projecting [id] must report only the id column's bytes"
+        );
+
+        // Project [s] (variable-width survives, fat `data` dropped).
+        let proj_s_cols = vec![1usize];
+        let proj_s = provider
+            .scan(&state, Some(&proj_s_cols), &[], None)
+            .await?
+            .partition_statistics(None)?;
+        assert_eq!(
+            proj_s.total_byte_size.get_value(),
+            Some(&s_bytes),
+            "projecting [s] must report only the s column's bytes, not the full row"
+        );
+        assert!(
+            *proj_s
+                .total_byte_size
+                .get_value()
+                .expect("projected total present")
+                < all_total,
+            "projected total must drop the unprojected wide `data` column"
         );
 
         Ok(())

--- a/crates/vortex/src/persistent/format.rs
+++ b/crates/vortex/src/persistent/format.rs
@@ -1003,6 +1003,79 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies the Vortex -> DataFusion statistics boundary: a written Vortex
+    /// file surfaces per-column byte sizes (from the footer's
+    /// `UncompressedSizeInBytes`) into `ColumnStatistics.byte_size` — including
+    /// for variable-width (`Utf8`) columns — and `total_byte_size` is their sum.
+    #[tokio::test]
+    async fn propagates_per_column_byte_size() -> anyhow::Result<()> {
+        use datafusion_catalog::TableProvider;
+
+        let ctx = TestSessionContext::default();
+
+        // Mixed schema: a fixed-width Int and a variable-width Utf8 column.
+        ctx.session
+            .sql(
+                "CREATE EXTERNAL TABLE t (id INT NOT NULL, s VARCHAR NOT NULL) \
+                 STORED AS vortex LOCATION 'table/'",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        // Write a known number of rows through the real Vortex writer.
+        let n = 8usize;
+        ctx.session
+            .sql(
+                "INSERT INTO t VALUES \
+                 (1,'aa'),(2,'bb'),(3,'cc'),(4,'dd'),(5,'ee'),(6,'ff'),(7,'gg'),(8,'hh')",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        // Read the scan statistics the way the optimizer does (all columns).
+        let provider = ctx.session.table_provider("t").await?;
+        let state = ctx.session.state();
+        let scan = provider.scan(&state, None, &[], None).await?;
+        let stats = scan.partition_statistics(None)?;
+
+        assert_eq!(stats.num_rows.get_value(), Some(&n), "row count");
+
+        let id_bytes = stats.column_statistics[0].byte_size;
+        let s_bytes = stats.column_statistics[1].byte_size;
+
+        // Both columns — including the Utf8 one — must carry a per-column size.
+        assert!(
+            id_bytes.get_value().is_some(),
+            "Int column byte_size must be populated, got {id_bytes:?}"
+        );
+        assert!(
+            s_bytes.get_value().is_some(),
+            "Utf8 column byte_size must be populated, got {s_bytes:?}"
+        );
+
+        // The fixed-width column's uncompressed size is at least 4 bytes/value.
+        assert!(
+            *id_bytes.get_value().unwrap() >= 4 * n,
+            "Int32 byte_size should be >= 4*rows, got {id_bytes:?}"
+        );
+
+        // total_byte_size is the sum of the per-column byte sizes.
+        let sum: usize = stats
+            .column_statistics
+            .iter()
+            .map(|c| *c.byte_size.get_value().expect("every column has byte_size"))
+            .sum();
+        assert_eq!(
+            stats.total_byte_size.get_value(),
+            Some(&sum),
+            "total_byte_size must equal the sum of per-column byte_size"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn format_plumbs_footer_initial_read_size() {
         let mut opts = VortexTableOptions::default();


### PR DESCRIPTION
## 📝 Summary

Include the following Datafusion improvement
- https://github.com/spiceai/datafusion/pull/174

Hash joins over Vortex-backed (cayenne) accelerated tables could build the larger side when a query projects a wide table down to a few narrow columns. `JoinSelection` compares `total_byte_size` before row counts, and a projected Vortex scan reported the full unprojected row width whenever a variable-width (e.g. `Utf8`) column survived the projection - so a row-light but byte-fat scan looked "large", was pushed to the probe side, and the optimizer built the genuinely larger input.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
