### PR TITLE
fix(queries): run async /v1/queries jobs under the submitting request context

### DIFF
--- a/crates/runtime-request-context/src/context.rs
+++ b/crates/runtime-request-context/src/context.rs
@@ -173,6 +173,21 @@ impl RequestContext {
         REQUEST_CONTEXT.scope(self, f).await
     }
 
+    /// Spawns `future` onto the Tokio runtime bound to the current request
+    /// context, so work that outlives the calling task — e.g. a background job
+    /// — still runs as the originating principal. Outside a request this binds
+    /// the internal context.
+    pub fn spawn_current<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let context = REQUEST_CONTEXT
+            .try_with(Arc::clone)
+            .unwrap_or_else(|_| Arc::clone(&INTERNAL_REQUEST_CONTEXT));
+        tokio::spawn(context.scope(future))
+    }
+
     /// Wraps provided stream with the current request context.
     pub fn scope_stream<S>(self: Arc<Self>, stream: S) -> impl Stream<Item = S::Item>
     where
@@ -675,6 +690,33 @@ mod tests {
     use http::{HeaderMap, HeaderValue};
 
     use crate::{CacheControl, CacheKeyType, Protocol, RequestContextBuilder};
+
+    /// A task spawned via `spawn_current` observes the spawning request's
+    /// context rather than the internal context. Results-cache namespacing and
+    /// principal-scoped authz/masking depend on it.
+    #[tokio::test]
+    async fn spawn_current_carries_request_context() {
+        use crate::{AsyncMarker, CacheNamespace, RequestContext};
+        use std::sync::Arc;
+        use tokio::sync::oneshot;
+
+        let context = Arc::new(RequestContext::builder(Protocol::Http).build());
+        let (tx, rx) = oneshot::channel();
+        context
+            .scope(async move {
+                RequestContext::spawn_current(async move {
+                    let namespace =
+                        RequestContext::current(AsyncMarker::new().await).cache_namespace();
+                    tx.send(namespace).expect("receiver alive");
+                });
+            })
+            .await;
+
+        assert_eq!(
+            rx.await.expect("spawned task reported its context"),
+            CacheNamespace::Public
+        );
+    }
 
     #[test]
     fn test_bind_client_supplied_cache_key() {

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -24,6 +24,8 @@ use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
+use runtime_request_context::{AsyncMarker, RequestContext};
+
 use crate::datafusion::DataFusion;
 use crate::datafusion::query::{QueryBuilder, QueryHandle, QueryHandleError};
 use crate::http::v1::queries::SubmitQueryRequest;
@@ -73,6 +75,17 @@ impl JobExecutor {
         }
     }
 
+    /// Spawns `fut` bound to the current request context so the background job
+    /// runs as the submitting principal — results-cache namespacing and
+    /// principal-scoped authz/masking key off it.
+    async fn spawn_in_request_context<F>(fut: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let request_context = RequestContext::current(AsyncMarker::new().await);
+        tokio::spawn(request_context.scope(fut));
+    }
+
     /// Submits a new query job for async execution.
     ///
     /// Returns the job state immediately. The query will be executed in the background.
@@ -99,7 +112,7 @@ impl JobExecutor {
         let active_jobs = Arc::clone(&self.active_jobs);
         let job_id_clone = job_id.clone();
 
-        tokio::spawn(
+        Self::spawn_in_request_context(
             async move {
                 let result = Self::execute_job(
                     &job_store,
@@ -122,7 +135,8 @@ impl JobExecutor {
                 }
             }
             .instrument(tracing::info_span!("job_execution", job_id = %job_id)),
-        );
+        )
+        .await;
 
         Ok(state)
     }
@@ -389,5 +403,35 @@ impl JobExecutor {
             }
             QueryHandleError::JobNotFound { .. } => (JobErrorCode::NotFound, e.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runtime_request_context::{CacheNamespace, Protocol};
+    use tokio::sync::oneshot;
+
+    /// A spawned job observes the submitting request's context rather than the
+    /// internal context. Results-cache namespacing and principal-scoped
+    /// authz/masking depend on it.
+    #[tokio::test]
+    async fn spawned_job_inherits_request_context() {
+        let (tx, rx) = oneshot::channel();
+
+        let request_context = Arc::new(RequestContext::builder(Protocol::Http).build());
+        request_context
+            .scope(async move {
+                JobExecutor::spawn_in_request_context(async move {
+                    let namespace =
+                        RequestContext::current(AsyncMarker::new().await).cache_namespace();
+                    tx.send(namespace).expect("receiver alive");
+                })
+                .await;
+            })
+            .await;
+
+        let observed = rx.await.expect("spawned job did not report its context");
+        assert_eq!(observed, CacheNamespace::Public);
     }
 }

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -24,7 +24,7 @@ use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
-use runtime_request_context::{AsyncMarker, RequestContext};
+use runtime_request_context::RequestContext;
 
 use crate::datafusion::DataFusion;
 use crate::datafusion::query::{QueryBuilder, QueryHandle, QueryHandleError};
@@ -75,17 +75,6 @@ impl JobExecutor {
         }
     }
 
-    /// Spawns `fut` bound to the current request context so the background job
-    /// runs as the submitting principal — results-cache namespacing and
-    /// principal-scoped authz/masking key off it.
-    async fn spawn_in_request_context<F>(fut: F)
-    where
-        F: Future<Output = ()> + Send + 'static,
-    {
-        let request_context = RequestContext::current(AsyncMarker::new().await);
-        tokio::spawn(request_context.scope(fut));
-    }
-
     /// Submits a new query job for async execution.
     ///
     /// Returns the job state immediately. The query will be executed in the background.
@@ -112,7 +101,10 @@ impl JobExecutor {
         let active_jobs = Arc::clone(&self.active_jobs);
         let job_id_clone = job_id.clone();
 
-        Self::spawn_in_request_context(
+        // Bind the job to the submitting request's context so it runs as the
+        // caller's principal — results-cache namespacing and principal-scoped
+        // authz/masking key off it.
+        RequestContext::spawn_current(
             async move {
                 let result = Self::execute_job(
                     &job_store,
@@ -135,8 +127,7 @@ impl JobExecutor {
                 }
             }
             .instrument(tracing::info_span!("job_execution", job_id = %job_id)),
-        )
-        .await;
+        );
 
         Ok(state)
     }
@@ -403,35 +394,5 @@ impl JobExecutor {
             }
             QueryHandleError::JobNotFound { .. } => (JobErrorCode::NotFound, e.to_string()),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use runtime_request_context::{CacheNamespace, Protocol};
-    use tokio::sync::oneshot;
-
-    /// A spawned job observes the submitting request's context rather than the
-    /// internal context. Results-cache namespacing and principal-scoped
-    /// authz/masking depend on it.
-    #[tokio::test]
-    async fn spawned_job_inherits_request_context() {
-        let (tx, rx) = oneshot::channel();
-
-        let request_context = Arc::new(RequestContext::builder(Protocol::Http).build());
-        request_context
-            .scope(async move {
-                JobExecutor::spawn_in_request_context(async move {
-                    let namespace =
-                        RequestContext::current(AsyncMarker::new().await).cache_namespace();
-                    tx.send(namespace).expect("receiver alive");
-                })
-                .await;
-            })
-            .await;
-
-        let observed = rx.await.expect("spawned job did not report its context");
-        assert_eq!(observed, CacheNamespace::Public);
     }
 }


### PR DESCRIPTION
## Problem

`JobExecutor::submit` spawned the background query job with a bare `tokio::spawn`. The request context is a task-local, so the spawn dropped it and the job planned and executed under the internal context (`Protocol::Internal`). For async queries submitted to `/v1/queries`, this meant:

- Results were cached in the shared `System` namespace instead of the caller's principal namespace — async results were not isolated per principal, and were never shared with the equivalent `/v1/sql` query.
- The request's `Cache-Control` header (and any client-supplied cache key) had no effect.
- Principal-scoped authorization and row/column masking were bypassed during planning, because the enforcer saw no principal.

## Fix

Capture the submitting request's context in `submit` and re-establish it across the spawn with `RequestContext::scope`, so the background job runs as the submitting principal.

## Test

Adds a regression test asserting that a job spawned by the executor observes the submitter's cache namespace rather than the internal (`System`) one.
