### PR TITLE
fix: Flight DoPut silently dropped client batches on early sink completion (fixes #11270)

### DIFF
--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -286,6 +286,39 @@ fn allow_scheduler_trusted_executor_write(datafusion: &DataFusion) -> bool {
         && datafusion.cluster_config.tls_config().is_some()
 }
 
+/// Drains the messages remaining on the inbound flight stream after the write
+/// sink has already completed, returning the number of discarded messages that
+/// carried record-batch data — i.e. client rows that were streamed but never
+/// written. Keepalive heartbeats and empty trailer messages do not carry data
+/// and are not counted, so a sink that completes exactly as the stream ends
+/// reports zero discarded batches and the write is still acked as a success.
+async fn drain_discarded_data_batches<S>(stream: &mut S) -> usize
+where
+    S: futures::Stream<Item = Result<FlightData, Status>> + Unpin,
+{
+    let mut discarded = 0usize;
+    while let Some(msg) = stream.next().await {
+        match msg {
+            Ok(data) => {
+                // A message carries record-batch (or dictionary) data when its
+                // body is non-empty; keepalive heartbeats are tagged and never
+                // count as lost client data.
+                if data.app_metadata.as_ref() != crate::flight::KEEPALIVE_APP_METADATA
+                    && !data.data_body.is_empty()
+                {
+                    discarded += 1;
+                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Error reading remaining message after early write completion: {e}"
+                );
+            }
+        }
+    }
+    discarded
+}
+
 fn create_response_stream(
     path: TableReference,
     schema: SchemaRef,
@@ -344,13 +377,23 @@ fn create_response_stream(
                             // The write operation completed before the flight stream
                             // ended. This can happen when the data sink does not
                             // consume the input stream or finishes early. Drain
-                            // remaining messages and report success.
-                            tracing::warn!("Write operation completed before stream ended for dataset: {path}");
-                            while let Some(msg) = streaming_flight.next().await {
-                                if let Err(e) = msg {
-                                    tracing::error!("Error reading remaining message after early write completion: {e}");
-                                }
+                            // the remaining messages, but if any of them carried
+                            // record-batch data those client rows were never
+                            // written — fail loudly instead of acking a silent
+                            // partial ingest.
+                            let discarded = drain_discarded_data_batches(&mut streaming_flight).await;
+                            if discarded > 0 {
+                                tracing::error!(
+                                    dataset = %path,
+                                    discarded_batches = discarded,
+                                    "Write sink completed before the client finished streaming; {discarded} data batch(es) were not written",
+                                );
+                                yield Err(Status::data_loss(format!(
+                                    "Write sink for dataset `{path}` finished before the client stream ended; {discarded} data batch(es) streamed by the client were not written",
+                                )));
+                                break;
                             }
+                            tracing::warn!("Write operation completed before stream ended for dataset: {path}");
                             yield Ok(PutResult::default());
                             break;
                         }
@@ -421,15 +464,19 @@ fn create_response_stream(
                                 write_result = &mut write_future => {
                                     match write_result {
                                         Ok(()) => {
-                                            // Sink finished while a batch was still pending —
-                                            // mirror the early-completion arm: drain and succeed.
-                                            tracing::warn!("Write operation completed before stream ended for dataset: {path}");
-                                            while let Some(msg) = streaming_flight.next().await {
-                                                if let Err(e) = msg {
-                                                    tracing::error!("Error reading remaining message after early write completion: {e}");
-                                                }
-                                            }
-                                            yield Ok(PutResult::default());
+                                            // Sink finished while a batch was still pending. That
+                                            // pending batch was not accepted by the sink, so it
+                                            // counts as discarded along with anything left on the
+                                            // wire; fail loudly rather than ack a partial ingest.
+                                            let discarded = 1 + drain_discarded_data_batches(&mut streaming_flight).await;
+                                            tracing::error!(
+                                                dataset = %path,
+                                                discarded_batches = discarded,
+                                                "Write sink completed while a client batch was still pending; {discarded} data batch(es) were not written",
+                                            );
+                                            yield Err(Status::data_loss(format!(
+                                                "Write sink for dataset `{path}` finished before the client stream ended; {discarded} data batch(es) streamed by the client were not written",
+                                            )));
                                             break;
                                         }
                                         Err(e) => {
@@ -471,9 +518,10 @@ fn create_response_stream(
                             if let Err(e) = write_result {
                                 tracing::error!("Write operation failed. Details included in the response.");
                                 yield Err(Status::internal(format!("Write operation failed: {e}")));
+                                break;
                             }
                             tracing::debug!("Write operation completed successfully for dataset: {path}");
-                            yield Ok(PutResult::default())
+                            yield Ok(PutResult::default());
                             break;
                         }
                         Some(Err(e)) => {
@@ -508,4 +556,61 @@ async fn handle_record_batch(
         )));
     }
     Ok(PutResult::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn data_message(body: &'static [u8]) -> FlightData {
+        FlightData {
+            data_body: body.into(),
+            ..Default::default()
+        }
+    }
+
+    fn keepalive_message() -> FlightData {
+        FlightData {
+            app_metadata: crate::flight::KEEPALIVE_APP_METADATA.into(),
+            // Even if a keepalive carried a body, it must never be counted as
+            // discarded client data.
+            data_body: (&b"heartbeat"[..]).into(),
+            ..Default::default()
+        }
+    }
+
+    /// Only data-bearing messages count as discarded; keepalives, empty
+    /// trailers, and transient read errors are ignored.
+    #[tokio::test]
+    async fn drain_counts_only_data_bearing_messages() {
+        let messages = vec![
+            Ok(data_message(b"batch-1")),
+            Ok(keepalive_message()),
+            Ok(data_message(b"batch-2")),
+            Ok(FlightData::default()), // empty trailer message
+            Err(Status::internal("transient read error")),
+            Ok(data_message(b"batch-3")),
+        ];
+        let mut stream = futures::stream::iter(messages);
+        assert_eq!(drain_discarded_data_batches(&mut stream).await, 3);
+    }
+
+    /// A sink that completes exactly as the stream ends discards nothing, so
+    /// the write is still acked as a success.
+    #[tokio::test]
+    async fn drain_empty_stream_reports_zero() {
+        let mut stream = futures::stream::iter(Vec::<Result<FlightData, Status>>::new());
+        assert_eq!(drain_discarded_data_batches(&mut stream).await, 0);
+    }
+
+    #[tokio::test]
+    async fn drain_keepalive_and_trailers_only_reports_zero() {
+        let messages = vec![
+            Ok(keepalive_message()),
+            Ok(FlightData::default()),
+            Ok(keepalive_message()),
+        ];
+        let mut stream = futures::stream::iter(messages);
+        assert_eq!(drain_discarded_data_batches(&mut stream).await, 0);
+    }
 }


### PR DESCRIPTION
## Summary

`DoPut` (`crates/runtime/src/flight/do_put.rs`) silently lost client rows on early sink completion. When the write future resolved `Ok(())` before the inbound flight stream ended, the handler **drained and discarded** all remaining incoming `FlightData` and unconditionally yielded `Ok(PutResult::default())` — so any batches the client streamed after the sink stopped consuming were never written, yet the client received success. This is silent partial ingest / data loss.

Root cause: the two early-completion arms treated "sink finished before the stream ended" as a normal success and threw away whatever was still on the wire, regardless of whether those messages carried data.

## Changes

- Add `drain_discarded_data_batches`, which drains the remaining stream and **counts** the messages that carry record-batch data (non-empty `data_body`, excluding keepalive heartbeats and empty trailers).
- Both early-completion arms now return `Status::data_loss` when any client data batch was discarded, instead of acking success. A sink that completes exactly as the stream ends discards nothing, so legitimate early completion still succeeds.
- The nested arm (sink finished while a batch was still pending) counts that in-flight, never-accepted batch as discarded too.
- Fix the secondary bug at the finalization-failure path: the `yield Err(...)` was missing a `break`, so the generator fell through and also logged success / yielded a spurious `Ok` after the error.

## Test plan

- `make lint`
- `make test`
- New unit tests for `drain_discarded_data_batches`: counts only data-bearing messages (keepalives, empty trailers, and transient read errors ignored); empty stream reports zero; keepalive/trailer-only stream reports zero.

## Checklist

- [x] New unit tests cover the data-loss detection and the no-false-positive cases
- [x] No change to the success path when the stream ends cleanly
- [x] Scoped clippy clean on the changed file (pre-existing unrelated warnings only)

Fixes #11270