### PR TITLE
chore(ci): remove HTAP SF100 from scheduled runs

### DIFF
--- a/.github/workflows/testoperator_dispatch_htap.yml
+++ b/.github/workflows/testoperator_dispatch_htap.yml
@@ -2,8 +2,6 @@ name: testoperator dispatch htap
 
 on:
   schedule:
-    # htap-sf100, every 3h (0200, 0500, 0800, 1100, 1400, 1700, 2000, 2300) — HTAP CH-benCHmark SF100 (spiceai-dev-xlarge-runners)
-    - cron: '0 2,5,8,11,14,17,20,23 * * *'
     # htap-sf1000, twice daily (0000, 1200) — HTAP CH-benCHmark SF1000 (spiceai-dev-xlarge-runners)
     - cron: '0 0,12 * * *'
     # htap-sf1, twice daily (0600, 1800) — HTAP CH-benCHmark SF1 (spiceai-dev-large-runners)
@@ -98,7 +96,6 @@ jobs:
           FLAGS=""
           if [ -z "$SF" ]; then
             case "${{ github.event.schedule }}" in
-              '0 2,5,8,11,14,17,20,23 * * *') SF=sf100 ;;
               '0 0,12 * * *')                 SF=sf1000 ;;
               '0 6,18 * * *')                 SF=sf1 ;;
               *)                              SF= ;;   # unrecognized cron — dispatch nothing


### PR DESCRIPTION
## 📝 Summary

Removes the HTAP CH-benCHmark SF100 cron (every 3h) from the testoperator HTAP dispatch workflow.

- SF1000 (twice daily) and SF1 (twice daily) scheduled runs are unchanged.
- `sf100` remains available via manual `workflow_dispatch`.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
