### PR TITLE
perf(cayenne): orphaned deletion-vector cleanup off the write path, behind a knob

### DIFF
--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -290,6 +290,25 @@ pub trait MetadataCatalog: Send + Sync {
     /// Get all active delete files for a table (across all virtual files).
     async fn get_table_delete_files(&self, table_id: &str) -> CatalogResult<Vec<DeleteFile>>;
 
+    /// Get orphan-eligible key-based delete files for a table, bounded by `limit`.
+    ///
+    /// Returns rows that are both key-based (`source_data_file_path IS NULL` — the
+    /// reliable discriminator, since the catalog does not persist `deletion_type`)
+    /// and at or below `max_sequence` (`sequence_number <= max_sequence`). The
+    /// caller passes the surviving-sequence floor as `max_sequence`: a key DV with
+    /// delete sequence `D` only shadows data with sequence `< D`, so once the floor
+    /// is `>= D` it shadows nothing and is safe to remove.
+    ///
+    /// This is the bounded query the orphaned-DV cleanup sweep uses instead of
+    /// fetching every delete-file row and filtering in memory; `limit` caps the
+    /// per-sweep working set (the sweep requeues if more remain).
+    async fn get_orphan_eligible_delete_files(
+        &self,
+        table_id: &str,
+        max_sequence: i64,
+        limit: usize,
+    ) -> CatalogResult<Vec<DeleteFile>>;
+
     /// Remove delete files (deletion vectors) by ID for a table.
     async fn remove_delete_files(
         &self,

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -1596,18 +1596,6 @@ impl MetadataCatalog for CayenneCatalog {
             })
     }
 
-    // INVARIANT (orphaned-DV cleanup): this is a low-level pointer flip on the
-    // live catalog. Today it is only used as part of a wholesale, self-contained
-    // Acceleration Snapshot restore, which re-extracts the snapshot's OWN data and
-    // deletion-vector (`.arrow`) files and metastore before/around this flip and
-    // reloads the provider from scratch — so it never reuses the live table's files.
-    // The orphaned-DV cleanup (`CayenneTableProvider::sweep_orphaned_deletion_vectors`)
-    // relies on that: it deletes DV files once they are below the surviving-sequence
-    // floor. If this primitive is ever used to flip `current_snapshot_id` to an
-    // OLDER snapshot on a LIVE table WITHOUT re-extracting its files, that older
-    // state could reference DV files the sweep already deleted. Before doing so,
-    // either keep orphaned DVs alive longer or reject restoring below the cleanup
-    // point. See the matching note on `sweep_orphaned_deletion_vectors`.
     async fn set_current_snapshot(&self, table_id: &str, snapshot_id: &str) -> CatalogResult<()> {
         self.metastore
             .execute_helper(ExecuteParams {
@@ -1731,6 +1719,18 @@ impl MetadataCatalog for CayenneCatalog {
             })
     }
 
+    // INVARIANT (orphaned-DV cleanup): this is a low-level pointer flip on the
+    // live catalog. Today it is only used as part of a wholesale, self-contained
+    // Acceleration Snapshot restore, which re-extracts the snapshot's OWN data and
+    // deletion-vector (`.arrow`) files and metastore before/around this flip and
+    // reloads the provider from scratch — so it never reuses the live table's files.
+    // The orphaned-DV cleanup (`CayenneTableProvider::sweep_orphaned_deletion_vectors`)
+    // relies on that: it deletes DV files once they are below the surviving-sequence
+    // floor. If this primitive is ever used to flip `current_snapshot_id` to an
+    // OLDER snapshot on a LIVE table WITHOUT re-extracting its files, that older
+    // state could reference DV files the sweep already deleted. Before doing so,
+    // either keep orphaned DVs alive longer or reject restoring below the cleanup
+    // point. See the matching note on `sweep_orphaned_deletion_vectors`.
     async fn get_orphan_eligible_delete_files(
         &self,
         table_id: &str,

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -1596,6 +1596,18 @@ impl MetadataCatalog for CayenneCatalog {
             })
     }
 
+    // INVARIANT (orphaned-DV cleanup): this is a low-level pointer flip on the
+    // live catalog. Today it is only used as part of a wholesale, self-contained
+    // Acceleration Snapshot restore, which re-extracts the snapshot's OWN data and
+    // deletion-vector (`.arrow`) files and metastore before/around this flip and
+    // reloads the provider from scratch — so it never reuses the live table's files.
+    // The orphaned-DV cleanup (`CayenneTableProvider::sweep_orphaned_deletion_vectors`)
+    // relies on that: it deletes DV files once they are below the surviving-sequence
+    // floor. If this primitive is ever used to flip `current_snapshot_id` to an
+    // OLDER snapshot on a LIVE table WITHOUT re-extracting its files, that older
+    // state could reference DV files the sweep already deleted. Before doing so,
+    // either keep orphaned DVs alive longer or reject restoring below the cleanup
+    // point. See the matching note on `sweep_orphaned_deletion_vectors`.
     async fn set_current_snapshot(&self, table_id: &str, snapshot_id: &str) -> CatalogResult<()> {
         self.metastore
             .execute_helper(ExecuteParams {
@@ -1709,6 +1721,50 @@ impl MetadataCatalog for CayenneCatalog {
                         sequence_number: row.get_optional_i64(8)?.unwrap_or(0),
                         // Metadata-only publish: NULL on legacy rows / pure deletes →
                         // the merge-on-read load falls back to cayenne_insert_record.
+                        reinsert_sequence: row.get_optional_i64(9)?,
+                    })
+                },
+            )
+            .await
+            .map_err(|e| CatalogError::FailedToGetTableDeleteFiles {
+                source: Box::new(e),
+            })
+    }
+
+    async fn get_orphan_eligible_delete_files(
+        &self,
+        table_id: &str,
+        max_sequence: i64,
+        limit: usize,
+    ) -> CatalogResult<Vec<DeleteFile>> {
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        self.metastore
+            .query_helper(
+                QueryParams {
+                    sql: "SELECT delete_file_id, table_id, path, path_is_relative,
+                        format, delete_count, file_size_bytes, source_data_file_path, sequence_number,
+                        reinsert_sequence
+                 FROM cayenne_delete_file
+                 WHERE table_id = ?1 AND source_data_file_path IS NULL AND sequence_number <= ?2
+                 LIMIT ?3",
+                    params: vec![
+                        MetastoreValue::Text(table_id.to_string()),
+                        MetastoreValue::Integer(max_sequence),
+                        MetastoreValue::Integer(limit),
+                    ],
+                },
+                |row| {
+                    Ok(DeleteFile {
+                        delete_file_id: row.get_string(0)?,
+                        table_id: row.get_string(1)?,
+                        source_data_file_path: row.get_optional_string(7)?,
+                        path: row.get_string(2)?,
+                        path_is_relative: row.get_bool(3)?,
+                        format: row.get_string(4)?,
+                        delete_count: row.get_i64(5)?,
+                        file_size_bytes: row.get_i64(6)?,
+                        deletion_type: crate::metadata::DeletionType::default(),
+                        sequence_number: row.get_optional_i64(8)?.unwrap_or(0),
                         reinsert_sequence: row.get_optional_i64(9)?,
                     })
                 },

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -292,7 +292,7 @@ pub enum CompressionStrategy {
 ///
 /// The exact level → scheme-set mapping lives in
 /// `provider::delta_encoding::strategy_builder_for_level`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum DeltaEncoding {
     /// Size-gated: light for small deltas, full for large writes.
@@ -1222,12 +1222,28 @@ impl VortexConfig {
 impl Default for VortexConfig {
     fn default() -> Self {
         Self {
+            footer_cache_mb: None,
             segment_cache_mb: 256,
             // Balanced file size for scan throughput and write amplification
             target_vortex_file_size_mb: 256,
+            // No sort columns by default
+            sort_columns: Vec::new(),
+            // Shard key derives from the primary key unless overridden
+            shard_key_columns: Vec::new(),
+            compression_strategy: CompressionStrategy::default(),
+            // `auto`: size-gated light encoding for small deltas (re-encoded
+            // by compaction). Local micro A/B (2026-06-06) was neutral on the
+            // upsert/bulk lanes; the aggregate CPU-per-delta benefit targets
+            // production-scale CDC and is to be validated there. Set the
+            // param to `7` to opt out (pre-feature behavior).
+            delta_encoding: DeltaEncoding::default(),
             upload_concurrency: default_upload_concurrency(),
+            write_concurrency: None,
             compaction_trigger_files: default_compaction_trigger_files(),
             bake_deletion_index_trigger: default_bake_deletion_index_trigger(),
+            // Orphaned-DV cleanup disabled by default (pre-feature behavior, and
+            // the A/B baseline); opt in with `cayenne_orphaned_dv_cleanup_min_files`.
+            orphaned_dv_cleanup_min_files: None,
             compaction_trigger_protected_snapshots: default_compaction_trigger_protected_snapshots(
             ),
             compaction_trigger_snapshot_age_ms: default_compaction_trigger_snapshot_age_ms(),
@@ -1240,15 +1256,31 @@ impl Default for VortexConfig {
             inline_flush_max_rows: default_inline_flush_max_rows(),
             inline_flush_max_segments: default_inline_flush_max_segments(),
             inline_flush_max_bytes: default_inline_flush_max_bytes(),
+            pk_conflict_detection: PkConflictDetection::default(),
+            pk_keyset_cache_mb: None,
+            deletion_mode: DeletionMode::default(),
+            cdc_durability: CdcDurability::default(),
             cdc_mem_tier_max_bytes: default_cdc_mem_tier_max_bytes(),
             cdc_mem_tier_shards: default_cdc_mem_tier_shards(),
             cdc_mem_tier_max_age_ms: default_cdc_mem_tier_max_age_ms(),
             cdc_mem_tier_min_flush_bytes: default_cdc_mem_tier_min_flush_bytes(),
             cdc_mem_tier_checkpoint_interval_ms: default_cdc_mem_tier_checkpoint_interval_ms(),
+            dynamic_tuning: false,
+            pinned_tuning_actuators: PinnedTuningActuators::default(),
             // Directory listing stays the scan's file source by default; the
             // manifest is a dual-source supplement until proven complete.
             scan_from_manifest: false,
-            ..Default::default()
+            schema_evolution: SchemaEvolutionMode::default(),
+            goal_replication_lag_secs: None,
+            goal_freshness_secs: None,
+            goal_query_latency_ms: None,
+            goal_qph: None,
+            goal_convergence_window_secs: None,
+            data_storage_class: StorageClass::default(),
+            metastore_storage_class: StorageClass::default(),
+            data_storage_write_mbps: None,
+            metastore_storage_write_mbps: None,
+            force_view_read_schema: false,
         }
     }
 }

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -713,6 +713,23 @@ pub struct VortexConfig {
     /// [`crate::provider::table::BAKE_DELETION_INDEX_TRIGGER`]).
     #[serde(default = "default_bake_deletion_index_trigger")]
     pub bake_deletion_index_trigger: usize,
+    /// Number of orphan-eligible key-based deletion vectors (count of
+    /// `cayenne_delete_file` rows, NOT masked rows) that must accumulate before a
+    /// cleanup sweep runs. A key DV is orphan-eligible once retention has emptied
+    /// the protected snapshot(s) it shadowed, raising the surviving-sequence floor
+    /// above its delete sequence so it shadows nothing.
+    ///
+    /// `0` disables orphaned-DV cleanup entirely — no background sweep is ever
+    /// spawned, so the file-based DELETE path acquires no extra locks and runs no
+    /// catalog scan (the pre-feature behavior, and the A/B baseline). A larger
+    /// value sweeps less often (cheaper, but orphaned `.arrow` files linger on disk
+    /// longer); a smaller value reclaims disk sooner. The sweep is lock-free and
+    /// runs off the write path on the dedicated compaction runtime, so this only
+    /// trades sweep frequency against lingering disk — never ingest latency.
+    ///
+    /// Defaults to `0` (disabled).
+    #[serde(default = "default_orphaned_dv_cleanup_min_files")]
+    pub orphaned_dv_cleanup_min_files: usize,
     /// Number of protected snapshots that can accumulate before snapshot-maintenance
     /// compaction is eligible to run. Kept separate from `compaction_trigger_files`
     /// so small-file compaction tuning does not silently change scan amplification
@@ -1019,6 +1036,13 @@ fn default_bake_deletion_index_trigger() -> usize {
     crate::provider::table::BAKE_DELETION_INDEX_TRIGGER
 }
 
+fn default_orphaned_dv_cleanup_min_files() -> usize {
+    // Ship disabled. Flip to a validated threshold once the SF-1000 CH-BenCHmark
+    // A/B confirms the lock-free off-path sweep reclaims orphaned DV files without
+    // regressing CDC ingest (tpmC) or staleness.
+    0
+}
+
 fn default_compaction_trigger_protected_snapshots() -> usize {
     8
 }
@@ -1225,6 +1249,7 @@ impl Default for VortexConfig {
             write_concurrency: None,
             compaction_trigger_files: default_compaction_trigger_files(),
             bake_deletion_index_trigger: default_bake_deletion_index_trigger(),
+            orphaned_dv_cleanup_min_files: default_orphaned_dv_cleanup_min_files(),
             compaction_trigger_protected_snapshots: default_compaction_trigger_protected_snapshots(
             ),
             compaction_trigger_snapshot_age_ms: default_compaction_trigger_snapshot_age_ms(),

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -16,6 +16,8 @@ limitations under the License.
 
 //! Data structures for Cayenne metadata.
 
+use std::num::NonZeroUsize;
+
 use arrow_schema::SchemaRef;
 use datafusion_table_providers::util::on_conflict::OnConflict;
 use serde::{Deserialize, Serialize};
@@ -294,12 +296,11 @@ pub enum CompressionStrategy {
 #[serde(try_from = "String", into = "String")]
 pub enum DeltaEncoding {
     /// Size-gated: light for small deltas, full for large writes.
-    Auto,
-    /// Fixed encoding level `0..=10` applied to every delta write.
-    Level(u8),
-}
-
-impl Default for DeltaEncoding {
+    /// Local micro A/B (2026-06-06) was neutral on the
+    /// upsert/bulk lanes; the aggregate CPU-per-delta benefit targets
+    /// production-scale CDC and is to be validated there. Set the
+    /// param to `7` to opt out (pre-feature behavior).
+    ///
     /// `Auto` — size-gated light encoding for small deltas. This is also what
     /// pre-feature stored table configs deserialize to via
     /// `#[serde(default)]`, so existing tables pick up the policy on upgrade
@@ -307,9 +308,10 @@ impl Default for DeltaEncoding {
     /// change never forces a table re-create). Set the
     /// `cayenne_delta_encoding` param to `7` to opt out (the full default
     /// cascade, byte-for-byte the pre-feature behavior).
-    fn default() -> Self {
-        Self::Auto
-    }
+    #[default]
+    Auto,
+    /// Fixed encoding level `0..=10` applied to every delta write.
+    Level(u8),
 }
 
 /// Maximum supported [`DeltaEncoding`] level.
@@ -726,10 +728,7 @@ pub struct VortexConfig {
     /// longer); a smaller value reclaims disk sooner. The sweep is lock-free and
     /// runs off the write path on the dedicated compaction runtime, so this only
     /// trades sweep frequency against lingering disk — never ingest latency.
-    ///
-    /// Defaults to `0` (disabled).
-    #[serde(default = "default_orphaned_dv_cleanup_min_files")]
-    pub orphaned_dv_cleanup_min_files: usize,
+    pub orphaned_dv_cleanup_min_files: Option<NonZeroUsize>,
     /// Number of protected snapshots that can accumulate before snapshot-maintenance
     /// compaction is eligible to run. Kept separate from `compaction_trigger_files`
     /// so small-file compaction tuning does not silently change scan amplification
@@ -1036,13 +1035,6 @@ fn default_bake_deletion_index_trigger() -> usize {
     crate::provider::table::BAKE_DELETION_INDEX_TRIGGER
 }
 
-fn default_orphaned_dv_cleanup_min_files() -> usize {
-    // Ship disabled. Flip to a validated threshold once the SF-1000 CH-BenCHmark
-    // A/B confirms the lock-free off-path sweep reclaims orphaned DV files without
-    // regressing CDC ingest (tpmC) or staleness.
-    0
-}
-
 fn default_compaction_trigger_protected_snapshots() -> usize {
     8
 }
@@ -1230,26 +1222,12 @@ impl VortexConfig {
 impl Default for VortexConfig {
     fn default() -> Self {
         Self {
-            footer_cache_mb: None,
             segment_cache_mb: 256,
             // Balanced file size for scan throughput and write amplification
             target_vortex_file_size_mb: 256,
-            // No sort columns by default
-            sort_columns: Vec::new(),
-            // Shard key derives from the primary key unless overridden
-            shard_key_columns: Vec::new(),
-            compression_strategy: CompressionStrategy::default(),
-            // `auto`: size-gated light encoding for small deltas (re-encoded
-            // by compaction). Local micro A/B (2026-06-06) was neutral on the
-            // upsert/bulk lanes; the aggregate CPU-per-delta benefit targets
-            // production-scale CDC and is to be validated there. Set the
-            // param to `7` to opt out (pre-feature behavior).
-            delta_encoding: DeltaEncoding::default(),
             upload_concurrency: default_upload_concurrency(),
-            write_concurrency: None,
             compaction_trigger_files: default_compaction_trigger_files(),
             bake_deletion_index_trigger: default_bake_deletion_index_trigger(),
-            orphaned_dv_cleanup_min_files: default_orphaned_dv_cleanup_min_files(),
             compaction_trigger_protected_snapshots: default_compaction_trigger_protected_snapshots(
             ),
             compaction_trigger_snapshot_age_ms: default_compaction_trigger_snapshot_age_ms(),
@@ -1262,31 +1240,15 @@ impl Default for VortexConfig {
             inline_flush_max_rows: default_inline_flush_max_rows(),
             inline_flush_max_segments: default_inline_flush_max_segments(),
             inline_flush_max_bytes: default_inline_flush_max_bytes(),
-            pk_conflict_detection: PkConflictDetection::default(),
-            pk_keyset_cache_mb: None,
-            deletion_mode: DeletionMode::default(),
-            cdc_durability: CdcDurability::default(),
             cdc_mem_tier_max_bytes: default_cdc_mem_tier_max_bytes(),
             cdc_mem_tier_shards: default_cdc_mem_tier_shards(),
             cdc_mem_tier_max_age_ms: default_cdc_mem_tier_max_age_ms(),
             cdc_mem_tier_min_flush_bytes: default_cdc_mem_tier_min_flush_bytes(),
             cdc_mem_tier_checkpoint_interval_ms: default_cdc_mem_tier_checkpoint_interval_ms(),
-            dynamic_tuning: false,
-            pinned_tuning_actuators: PinnedTuningActuators::default(),
             // Directory listing stays the scan's file source by default; the
             // manifest is a dual-source supplement until proven complete.
             scan_from_manifest: false,
-            schema_evolution: SchemaEvolutionMode::default(),
-            goal_replication_lag_secs: None,
-            goal_freshness_secs: None,
-            goal_query_latency_ms: None,
-            goal_qph: None,
-            goal_convergence_window_secs: None,
-            data_storage_class: StorageClass::default(),
-            metastore_storage_class: StorageClass::default(),
-            data_storage_write_mbps: None,
-            metastore_storage_write_mbps: None,
-            force_view_read_schema: false,
+            ..Default::default()
         }
     }
 }

--- a/crates/cayenne/src/provider/delete.rs
+++ b/crates/cayenne/src/provider/delete.rs
@@ -54,5 +54,5 @@ pub(crate) use filter_exec::{
 };
 pub(crate) use vector_io::{
     DeletionIdentifier, DeletionVectorWriteResult, DeletionVectorWriteSpec, DeletionVectorWriter,
-    detect_deletion_type_and_read,
+    MissingKeyDeletionVector, detect_deletion_type_and_read,
 };

--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -439,13 +439,17 @@ impl DeletionSink for FileBasedDeletionSink {
         }
 
         // Clean up emptied protected snapshots: catalog, in-memory map, and directory.
-        // Removing snapshots raises the surviving sequence floor, which can orphan
-        // key-based deletion vectors that only shadowed the now-deleted rows, so
-        // sweep those afterwards (issue #9388).
+        // Removing snapshots raises the surviving-sequence floor, which can orphan
+        // key-based deletion vectors that only shadowed the now-deleted rows (issue
+        // #9388). The actual orphaned-DV sweep runs OFF this critical section — it is
+        // a lock-free, throttled background pass on the dedicated compaction runtime
+        // (`schedule_orphan_dv_sweep`), so it never extends the `write_lock` /
+        // `listing_fence` window that CDC ingest and scans contend on here. We only
+        // signal it; it no-ops when the `orphaned_dv_cleanup_min_files` knob is 0.
         if !result.emptied_snapshot_ids.is_empty() {
             self.cleanup_emptied_snapshots(&result.emptied_snapshot_ids)
                 .await;
-            self.cleanup_orphaned_deletion_vectors().await;
+            self.provider.schedule_orphan_dv_sweep();
         }
 
         Ok(result.total_deleted_rows)
@@ -504,168 +508,5 @@ impl FileBasedDeletionSink {
                 self.table_name
             );
         }
-    }
-
-    /// Remove key-based deletion vectors orphaned by snapshot removal (issue #9388).
-    ///
-    /// A key-based DV with `sequence_number = D` only shadows data in snapshots
-    /// whose threshold sequence is strictly `< D` (a delete applies to data files
-    /// with `data_sequence_number < D` — see [`crate::metadata::DeleteFile::sequence_number`]).
-    /// Once every surviving snapshot has threshold `>= D`, the DV shadows nothing
-    /// and is a query-time no-op. When retention empties protected snapshots the
-    /// surviving floor rises, which can orphan the DVs that masked those snapshots'
-    /// rows — e.g. an upsert's supersede of a row whose old copy has now expired.
-    /// Such DVs live in the base snapshot's `deletions/` dir (written via
-    /// `current_snapshot_id`), so the per-snapshot directory cleanup above never
-    /// removes them; left in place they only inflate the in-memory deletion cache
-    /// and add load-time I/O on restart.
-    ///
-    /// This is purely a startup-cache / storage optimization with no query-time
-    /// effect. It is conservative: a DV is removed only once *no* surviving
-    /// snapshot could be shadowed by it, so it can never resurrect a live row. An
-    /// orphan masking a snapshot that lingers (out-of-order/backfill data) is
-    /// collected on a later retention pass once that snapshot ages out too.
-    ///
-    /// Only key-based DVs (those with no `source_data_file_path`) are considered;
-    /// position-based DVs are tied to specific data files and cleaned up by their
-    /// own path. Errors are logged as warnings — the data files are already gone,
-    /// so cleanup is best-effort.
-    ///
-    /// # Current snapshot
-    ///
-    /// The protected-snapshot map does NOT include the current/genesis snapshot,
-    /// which the scan applies ALL key DVs to (the full deletion view, not the
-    /// `delete_seq > threshold` partial filter). Normally that snapshot is genesis
-    /// or compaction output and holds no row a surviving DV shadows, but a
-    /// plain-append current snapshot (tagged `[0, current_seq]`) or a
-    /// position-then-PK migration can, so the floor must also account for it or a
-    /// prune could resurrect a live current-snapshot row. We fold the current
-    /// snapshot's manifest into the floor here. (`CayenneTableProvider` solves the
-    /// identical problem for the seq-prefix bake in `bake_clean_prefix_holds`;
-    /// rather than call that — its `selected_set` semantics differ — we reproduce
-    /// its current-snapshot clause inline: empty manifest is genesis-clean,
-    /// otherwise the floor is capped at the smallest file `min_sequence`.)
-    ///
-    /// # In-memory deletion index
-    ///
-    /// Removing the catalog rows + `.arrow` files reclaims only restart cost; the
-    /// orphaned tombstones also sit in the in-memory PK deletion index for the
-    /// life of the process. After the rows are removed we therefore prune the
-    /// index of every tombstone at or below the same floor via
-    /// [`CayenneTableProvider::prune_deletion_index_at_or_below`] (which the
-    /// seq-prefix bake also uses), reclaiming the memory immediately. This is
-    /// sound for the same reason the row removal is: the floor proves no surviving
-    /// snapshot is shadowed, so those tombstones (and their paired re-insert
-    /// records, removed with the same DV rows) affect no live row.
-    async fn cleanup_orphaned_deletion_vectors(&self) {
-        // Floor = minimum threshold over all surviving protected snapshots. For
-        // PK/upsert tables every PROTECTED data-bearing snapshot is tracked here.
-        // If none survive, the protected side imposes no bound (i64::MAX) and the
-        // current-snapshot manifest below becomes the only constraint.
-        let protected_floor = self
-            .protected_snapshots
-            .load()
-            .values()
-            .copied()
-            .min()
-            .unwrap_or(i64::MAX);
-
-        // Fold in the current snapshot: a key DV with delete sequence D deletes a
-        // current-snapshot row iff that row's sequence is `< D`, so the snapshot is
-        // safe against pruning D only when its smallest row sequence is `>= D`. An
-        // empty manifest is genesis (no rows to resurrect). If the manifest cannot
-        // be read we cannot prove safety, so skip the sweep this pass.
-        let current_snapshot_id = self.provider.get_current_snapshot_id();
-        let current_floor = match self
-            .catalog
-            .get_snapshot_files(&self.table_id, &current_snapshot_id)
-            .await
-        {
-            Ok(files) => files
-                .iter()
-                .map(|f| f.min_sequence)
-                .min()
-                .unwrap_or(i64::MAX),
-            Err(e) => {
-                tracing::warn!(
-                    "Retention: failed to read current snapshot manifest for orphaned DV cleanup on table {}: {e}",
-                    self.table_name
-                );
-                return;
-            }
-        };
-
-        let floor = protected_floor.min(current_floor);
-
-        let delete_files = match self.catalog.get_table_delete_files(&self.table_id).await {
-            Ok(files) => files,
-            Err(e) => {
-                tracing::warn!(
-                    "Retention: failed to list delete files for orphaned DV cleanup on table {}: {e}",
-                    self.table_name
-                );
-                return;
-            }
-        };
-
-        // Key-based DVs (no source file) whose delete sequence is at or below the
-        // surviving floor shadow nothing live. `source_data_file_path` is the
-        // reliable key-vs-position discriminator (the catalog does not persist
-        // `deletion_type`).
-        let orphaned: Vec<(String, String, bool)> = delete_files
-            .into_iter()
-            .filter(|df| df.source_data_file_path.is_none() && df.sequence_number <= floor)
-            .map(|df| (df.delete_file_id, df.path, df.path_is_relative))
-            .collect();
-
-        if orphaned.is_empty() {
-            return;
-        }
-
-        let ids: Vec<String> = orphaned.iter().map(|(id, _, _)| id.clone()).collect();
-
-        // Remove catalog rows FIRST. The loader reads these rows and opens each
-        // referenced file, so removing the row is what reclaims the startup cost —
-        // and ordering it before the unlink ensures a crash can never leave a
-        // catalog row pointing at a missing `.arrow` file (which the loader would
-        // error on). Bail without unlinking if the catalog write fails.
-        if let Err(e) = self.catalog.remove_delete_files(&self.table_id, &ids).await {
-            tracing::warn!(
-                "Retention: failed to remove {} orphaned delete-file row(s) for table {}: {e}",
-                ids.len(),
-                self.table_name
-            );
-            return;
-        }
-
-        // Best-effort unlink of the now-unreferenced `.arrow` files.
-        for (_, path, path_is_relative) in &orphaned {
-            if *path_is_relative {
-                // Relative paths are object-store keys, not local filesystem
-                // paths; the catalog row removal already prevents them being
-                // loaded, so leave object-store cleanup out of this local sweep.
-                continue;
-            }
-            match tokio::fs::remove_file(path).await {
-                Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => tracing::warn!(
-                    "Retention: failed to delete orphaned DV file {path} for table {}: {e}",
-                    self.table_name
-                ),
-            }
-        }
-
-        // Reclaim the memory now: drop the just-removed tombstones from the
-        // in-memory PK deletion index (no-op for position-based tables). Safe at
-        // `floor` for the same reason the catalog removal is — see the doc above.
-        self.provider.prune_deletion_index_at_or_below(floor);
-
-        tracing::debug!(
-            table = %self.table_name,
-            floor,
-            "Retention: cleaned up {} orphaned key-based deletion vector(s)",
-            ids.len()
-        );
     }
 }

--- a/crates/cayenne/src/provider/delete/vector_io.rs
+++ b/crates/cayenne/src/provider/delete/vector_io.rs
@@ -54,6 +54,19 @@ struct KeyDeletionReadState {
     reinsert_sequence: Option<i64>,
 }
 
+/// A key-based deletion-vector whose catalog row exists but whose `.arrow` file is
+/// missing on disk. Reported (instead of erroring) by [`detect_deletion_type_and_read`]
+/// so the async loader can discriminate a self-healable orphan (the file-first
+/// orphaned-DV sweep unlinked the file but a crash interrupted the row removal)
+/// from genuine data loss, by comparing `sequence_number` against the
+/// surviving-sequence floor. Position-based DVs are never reported here.
+#[derive(Debug, Clone)]
+pub struct MissingKeyDeletionVector {
+    pub delete_file_id: String,
+    pub path: String,
+    pub sequence_number: i64,
+}
+
 /// Directory under the table snapshot where deletion vectors are stored.
 const DELETION_DIR_NAME: &str = "deletions";
 /// File extension used for deletion-vector files.
@@ -416,8 +429,12 @@ pub fn detect_deletion_type_and_read(
     HashMap<String, RoaringBitmap>,
     HashMap<Box<[u8]>, i64>,
     HashMap<Box<[u8]>, i64>,
+    Vec<MissingKeyDeletionVector>,
 )> {
     let mut per_file_row_ids: HashMap<String, RoaringBitmap> = HashMap::new();
+    // Key-based DV rows whose `.arrow` file is missing — reported, not errored, so
+    // the async loader can self-heal provable orphans (see `MissingKeyDeletionVector`).
+    let mut missing_key_dvs: Vec<MissingKeyDeletionVector> = Vec::new();
     // Metadata-only publish: keep delete and reinsert sequence state in one map
     // while reading key-based vectors. This avoids cloning every key in the hot
     // read loop just to update a second map; the legacy return shape is derived
@@ -438,12 +455,32 @@ pub fn detect_deletion_type_and_read(
         let path = std::path::Path::new(&delete_file.path);
         tracing::debug!("detect_deletion_type_and_read: reading file {:?}", path);
 
-        let file = std::fs::File::open(path).map_err(|e| {
-            datafusion_common::DataFusionError::Execution(format!(
-                "Failed to open deletion vector file {}: {e}",
-                path.display()
-            ))
-        })?;
+        let file = match std::fs::File::open(path) {
+            Ok(file) => file,
+            // A missing KEY-based DV file is tolerated and reported: the file-first
+            // orphaned-DV sweep unlinks the file before removing its catalog row, so
+            // a crash in that window leaves a discoverable dangling row. The async
+            // loader decides self-heal vs error against the floor. Position-based DVs
+            // (source_data_file_path = Some) are tied to a live data file, so a
+            // missing one is still a hard error.
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound
+                    && delete_file.source_data_file_path.is_none() =>
+            {
+                missing_key_dvs.push(MissingKeyDeletionVector {
+                    delete_file_id: delete_file.delete_file_id.clone(),
+                    path: delete_file.path.clone(),
+                    sequence_number: delete_file.sequence_number,
+                });
+                continue;
+            }
+            Err(e) => {
+                return Err(datafusion_common::DataFusionError::Execution(format!(
+                    "Failed to open deletion vector file {}: {e}",
+                    path.display()
+                )));
+            }
+        };
 
         let reader = FileReader::try_new(file, None).map_err(|e| {
             datafusion_common::DataFusionError::Execution(format!(
@@ -565,7 +602,12 @@ pub fn detect_deletion_type_and_read(
         file_count
     );
 
-    Ok((per_file_row_ids, deleted_row_keys, reinserted_row_keys))
+    Ok((
+        per_file_row_ids,
+        deleted_row_keys,
+        reinserted_row_keys,
+        missing_key_dvs,
+    ))
 }
 
 // ============================================================================

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -9711,9 +9711,9 @@ impl CayenneTableProvider {
             } else {
                 return Err(CatalogError::InvalidOperationNoSource {
                     message: format!(
-                        "Deletion vector file missing but still within the surviving-sequence \
-                         floor (delete_file_id={}, path={}, sequence={} > floor={}): possible \
-                         data loss",
+                        "Deletion vector file is missing and its delete sequence is above the \
+                         surviving-sequence floor (delete_file_id={}, path={}, sequence={} > \
+                         floor={}), so it may still shadow live data: possible data loss",
                         m.delete_file_id, m.path, m.sequence_number, floor
                     ),
                 });
@@ -9781,15 +9781,19 @@ impl CayenneTableProvider {
             }
         };
 
-        // Bounded fetch of orphan-eligible key DVs (source NULL, sequence <= floor).
-        // The cap bounds the per-sweep working set; if more remain, the next
-        // retention pass re-arms the sweep. `max(min_files)` guarantees the gate
-        // below can fire even for an unusually large threshold.
-        const ORPHAN_DV_SWEEP_MAX_BATCH: usize = 50_000;
-        let fetch_limit = ORPHAN_DV_SWEEP_MAX_BATCH.max(min_files);
+        // Hard per-sweep cap on the orphan working set. This is a fixed upper bound
+        // (NOT `max(min_files)`, which would let a large knob defeat the cap): it
+        // bounds the fetch allocation, the unlink loop, AND — critically — the
+        // single `remove_delete_files` DELETE, which binds one parameter per id and
+        // would exceed the metastore's bound-parameter limit (e.g. SQLite's
+        // ~32766) on a huge batch. The effective threshold is clamped to the cap so
+        // the gate below can still fire; a backlog beyond the cap drains on later
+        // retention passes.
+        const ORPHAN_DV_SWEEP_MAX_BATCH: usize = 4096;
+        let effective_min = min_files.min(ORPHAN_DV_SWEEP_MAX_BATCH);
         let orphaned = match self
             .catalog
-            .get_orphan_eligible_delete_files(table_id, floor, fetch_limit)
+            .get_orphan_eligible_delete_files(table_id, floor, ORPHAN_DV_SWEEP_MAX_BATCH)
             .await
         {
             Ok(files) => files,
@@ -9804,7 +9808,7 @@ impl CayenneTableProvider {
 
         // Throttle: only sweep once enough orphans have accumulated to amortize the
         // pass. Below the threshold, leave them — a later retention pass rechecks.
-        if orphaned.len() < min_files {
+        if orphaned.len() < effective_min {
             return;
         }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1378,6 +1378,12 @@ pub struct CayenneTableProvider {
     /// does not spawn one background compaction task per append while a prior
     /// notification is still pending.
     post_write_compaction_scheduled: Arc<AtomicBool>,
+    /// Coalesces orphaned-deletion-vector cleanup sweeps. Set when file-based
+    /// retention empties a protected snapshot (raising the surviving-sequence
+    /// floor, which can orphan key DVs); a single lock-free sweep on the dedicated
+    /// compaction runtime drains it. Mirrors `post_write_compaction_scheduled` so a
+    /// burst of retention passes spawns at most one in-flight sweep.
+    orphan_dv_sweep_scheduled: Arc<AtomicBool>,
     /// Coalesces write-driven listing refreshes and table-statistics updates
     /// so CDC catch-up bursts do not synchronously pay metastore/listing work
     /// on every append.
@@ -3997,9 +4003,13 @@ impl CayenneTableProvider {
         // Returns the fully constructed PkDeletionStrategy with embedded caches.
         let table_id = table_metadata.table_id.clone();
         let catalog_for_load = Arc::clone(&catalog);
-        let pk_deletion_strategy =
-            Self::load_deletion_vectors_all(&table_id, catalog_for_load, pk_deletion_strategy_kind)
-                .await?;
+        let pk_deletion_strategy = Self::load_deletion_vectors_all(
+            &table_id,
+            &table_metadata.current_snapshot_id,
+            catalog_for_load,
+            pk_deletion_strategy_kind,
+        )
+        .await?;
 
         let listing_table = Self::create_listing_table(
             &snapshot_dir_url,
@@ -4196,6 +4206,7 @@ impl CayenneTableProvider {
             last_moved_snapshot_files: Arc::new(ParkingMutex::new(None)),
             compaction_lock: Arc::new(tokio::sync::Mutex::new(())),
             post_write_compaction_scheduled: Arc::new(AtomicBool::new(false)),
+            orphan_dv_sweep_scheduled: Arc::new(AtomicBool::new(false)),
             post_write_maintenance: Arc::new(PostWriteMaintenance::default()),
             maintained_aggregates,
             maintained_aggregate_epoch: Arc::new(AtomicU64::new(0)),
@@ -4940,6 +4951,7 @@ impl CayenneTableProvider {
             // attempts on the same table coordinate, even across clones.
             compaction_lock: Arc::clone(&self.compaction_lock),
             post_write_compaction_scheduled: Arc::clone(&self.post_write_compaction_scheduled),
+            orphan_dv_sweep_scheduled: Arc::clone(&self.orphan_dv_sweep_scheduled),
             post_write_maintenance: Arc::clone(&self.post_write_maintenance),
             maintained_aggregates: Arc::clone(&self.maintained_aggregates),
             maintained_aggregate_epoch: Arc::clone(&self.maintained_aggregate_epoch),
@@ -9598,6 +9610,259 @@ impl CayenneTableProvider {
         });
     }
 
+    /// Signal that orphaned key-based deletion vectors may now exist (file-based
+    /// retention emptied a protected snapshot, raising the surviving-sequence
+    /// floor). Spawns at most one lock-free [`Self::sweep_orphaned_deletion_vectors`]
+    /// pass on the dedicated compaction runtime, coalescing a burst of retention
+    /// passes into a single in-flight sweep — mirroring
+    /// [`Self::schedule_post_write_compaction`].
+    ///
+    /// No-op when the `orphaned_dv_cleanup_min_files` knob is 0: nothing is
+    /// spawned, no lock is taken, and no catalog query runs (the pre-feature
+    /// behavior, and the SF-1000 CH-BenCHmark A/B baseline).
+    pub(crate) fn schedule_orphan_dv_sweep(&self) {
+        if self
+            .table_metadata
+            .vortex_config
+            .orphaned_dv_cleanup_min_files
+            == 0
+        {
+            return;
+        }
+        // Coalesce: at most one in-flight sweep per table.
+        if self.orphan_dv_sweep_scheduled.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let table = self.clone_for_write();
+        super::compaction::spawn_compaction(async move {
+            tokio::task::yield_now().await;
+            table.sweep_orphaned_deletion_vectors().await;
+            table
+                .orphan_dv_sweep_scheduled
+                .store(false, Ordering::Release);
+        });
+    }
+
+    /// Synchronously run one orphaned-DV sweep. Test-only deterministic drain for
+    /// the otherwise background [`Self::schedule_orphan_dv_sweep`] path.
+    #[doc(hidden)]
+    pub async fn drain_orphan_dv_sweep(&self) {
+        self.sweep_orphaned_deletion_vectors().await;
+    }
+
+    /// Surviving-sequence floor for orphaned-DV cleanup: the minimum data sequence
+    /// any live snapshot could hold, folding BOTH the protected snapshots' persisted
+    /// thresholds AND the current snapshot's manifest `min_sequence`. A key DV with
+    /// delete sequence `D` shadows only data with sequence `< D`, so it is orphaned
+    /// (shadows nothing live) exactly when `D <= floor`. Empty on both sides →
+    /// `i64::MAX` (genesis; nothing to protect). The current snapshot is folded in
+    /// because the scan applies ALL key DVs to it (the full deletion view), so a
+    /// plain-append or position-then-PK current snapshot could still hold a row a
+    /// sub-floor DV shadows — see the seq-prefix bake's `bake_clean_prefix_holds`.
+    async fn compute_orphan_dv_floor(
+        catalog: &dyn MetadataCatalog,
+        table_id: &str,
+        current_snapshot_id: &str,
+    ) -> CatalogResult<i64> {
+        let protected_floor = catalog
+            .get_all_snapshot_sequences(table_id)
+            .await?
+            .values()
+            .copied()
+            .min()
+            .unwrap_or(i64::MAX);
+        let current_floor = catalog
+            .get_snapshot_files(table_id, current_snapshot_id)
+            .await?
+            .iter()
+            .map(|f| f.min_sequence)
+            .min()
+            .unwrap_or(i64::MAX);
+        Ok(protected_floor.min(current_floor))
+    }
+
+    /// Reconcile key-based deletion vectors whose `.arrow` file is missing (the
+    /// file-first sweep crash window). For each: if its delete sequence is at or
+    /// below the surviving-sequence floor it is a provable orphan whose row removal
+    /// was interrupted — self-heal it (info log + remove the dangling row). If it is
+    /// ABOVE the floor it could still shadow live data, so a missing file is genuine
+    /// data loss and we error (a defensive improvement over a generic missing-file
+    /// failure). The floor is computed once here, only because ≥1 file was missing.
+    async fn reconcile_missing_key_deletion_vectors(
+        catalog: &dyn MetadataCatalog,
+        table_id: &str,
+        current_snapshot_id: &str,
+        missing: Vec<crate::provider::delete::MissingKeyDeletionVector>,
+    ) -> CatalogResult<()> {
+        let floor = Self::compute_orphan_dv_floor(catalog, table_id, current_snapshot_id).await?;
+
+        let mut orphaned_ids: Vec<String> = Vec::with_capacity(missing.len());
+        for m in missing {
+            if m.sequence_number <= floor {
+                tracing::info!(
+                    table_id,
+                    path = %m.path,
+                    sequence = m.sequence_number,
+                    floor,
+                    "Loader: encountered deleted orphaned DV in catalog (file already removed); self-healing the dangling row"
+                );
+                orphaned_ids.push(m.delete_file_id);
+            } else {
+                return Err(CatalogError::InvalidOperationNoSource {
+                    message: format!(
+                        "Deletion vector file missing but still within the surviving-sequence \
+                         floor (delete_file_id={}, path={}, sequence={} > floor={}): possible \
+                         data loss",
+                        m.delete_file_id, m.path, m.sequence_number, floor
+                    ),
+                });
+            }
+        }
+
+        if !orphaned_ids.is_empty() {
+            catalog.remove_delete_files(table_id, &orphaned_ids).await?;
+        }
+        Ok(())
+    }
+
+    /// Lock-free, throttled cleanup of orphaned key-based deletion vectors (issue
+    /// #9388). Reclaims the `.arrow` files (and their catalog rows) that file-based
+    /// retention leaves behind: an orphaned key DV lives in the CURRENT snapshot's
+    /// `deletions/` dir, which never rotates under sustained CDC, so nothing else
+    /// reaps it (compaction's bake reclaims the in-memory tombstone and the catalog
+    /// row, but not the physical file — the measured dir/byte leak).
+    ///
+    /// Runs entirely OFF the file-based DELETE critical section: it holds NO
+    /// `write_lock` and NO `listing_fence`. This is sound because (a) orphaned DVs
+    /// are query-time no-ops, (b) scans never read DV `.arrow` files lazily (they
+    /// are materialized into the in-memory index only at load/refresh), so a
+    /// runtime unlink is invisible to scans, and (c) the floor is monotonic on the
+    /// live timeline — concurrent writes only ever take HIGHER sequences, so they
+    /// can never make a `D <= floor` DV needed again.
+    ///
+    /// The in-memory deletion index is deliberately NOT pruned here — compaction's
+    /// seq-prefix bake (`prune_deletion_caches_after_full_rewrite`) owns that, and
+    /// the orphaned tombstones (query-time no-ops) even push its size trigger.
+    ///
+    /// INVARIANT (restore): safe to delete these files because Acceleration
+    /// Snapshot restore is a wholesale, self-contained, offline re-extraction — it
+    /// brings back its OWN archived DV files and never reuses the live table's
+    /// (potentially GC'd) files. If restore ever becomes an in-place flip of
+    /// `current_snapshot_id` on a LIVE table reusing live files, it must account for
+    /// orphaned-DV deletion (keep DVs alive longer or reject restoring below the GC
+    /// point) — see the matching note on the snapshot set/restore code.
+    async fn sweep_orphaned_deletion_vectors(&self) {
+        let min_files = self
+            .table_metadata
+            .vortex_config
+            .orphaned_dv_cleanup_min_files;
+        if min_files == 0 {
+            return;
+        }
+
+        let table_id = &self.table_metadata.table_id;
+        let current_snapshot_id = self.get_current_snapshot_id();
+
+        let floor = match Self::compute_orphan_dv_floor(
+            self.catalog.as_ref(),
+            table_id,
+            &current_snapshot_id,
+        )
+        .await
+        {
+            Ok(floor) => floor,
+            Err(e) => {
+                tracing::warn!(
+                    table = self.table_metadata.table_name.as_str(),
+                    "Orphaned-DV sweep: failed to compute surviving-sequence floor: {e}"
+                );
+                return;
+            }
+        };
+
+        // Bounded fetch of orphan-eligible key DVs (source NULL, sequence <= floor).
+        // The cap bounds the per-sweep working set; if more remain, the next
+        // retention pass re-arms the sweep. `max(min_files)` guarantees the gate
+        // below can fire even for an unusually large threshold.
+        const ORPHAN_DV_SWEEP_MAX_BATCH: usize = 50_000;
+        let fetch_limit = ORPHAN_DV_SWEEP_MAX_BATCH.max(min_files);
+        let orphaned = match self
+            .catalog
+            .get_orphan_eligible_delete_files(table_id, floor, fetch_limit)
+            .await
+        {
+            Ok(files) => files,
+            Err(e) => {
+                tracing::warn!(
+                    table = self.table_metadata.table_name.as_str(),
+                    "Orphaned-DV sweep: failed to list orphan-eligible delete files: {e}"
+                );
+                return;
+            }
+        };
+
+        // Throttle: only sweep once enough orphans have accumulated to amortize the
+        // pass. Below the threshold, leave them — a later retention pass rechecks.
+        if orphaned.len() < min_files {
+            return;
+        }
+
+        // Unlink the `.arrow` file FIRST, then remove its catalog row. A crash in
+        // the non-atomic window leaves a DISCOVERABLE dangling row (file gone, row
+        // present) that the tolerant loader self-heals and the next sweep retries —
+        // never an untracked leaked file (which the reverse order would produce).
+        let mut removed_ids: Vec<String> = Vec::with_capacity(orphaned.len());
+        for df in &orphaned {
+            if df.path_is_relative {
+                // Relative paths are object-store keys, not local fs paths; the
+                // local unlink does not apply. Still drop the row so the loader
+                // stops referencing it (object-store GC is out of scope here).
+                removed_ids.push(df.delete_file_id.clone());
+                continue;
+            }
+            match tokio::fs::remove_file(&df.path).await {
+                Ok(()) => removed_ids.push(df.delete_file_id.clone()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Already gone (a prior interrupted sweep) — still drop the row.
+                    removed_ids.push(df.delete_file_id.clone());
+                }
+                Err(e) => {
+                    // Leave the row so a later sweep retries the unlink.
+                    tracing::warn!(
+                        table = self.table_metadata.table_name.as_str(),
+                        path = %df.path,
+                        "Orphaned-DV sweep: failed to unlink DV file: {e}"
+                    );
+                }
+            }
+        }
+
+        if removed_ids.is_empty() {
+            return;
+        }
+
+        if let Err(e) = self
+            .catalog
+            .remove_delete_files(table_id, &removed_ids)
+            .await
+        {
+            tracing::warn!(
+                table = self.table_metadata.table_name.as_str(),
+                "Orphaned-DV sweep: failed to remove {} delete-file row(s): {e}",
+                removed_ids.len()
+            );
+            return;
+        }
+
+        tracing::debug!(
+            table = self.table_metadata.table_name.as_str(),
+            floor,
+            "Orphaned-DV sweep: reclaimed {} orphaned key-based deletion vector(s)",
+            removed_ids.len()
+        );
+    }
+
     pub(crate) fn schedule_inline_checkpoint_if_memtable_pressure_exceeded(&self) {
         if self
             .inline_checkpoint_scheduled
@@ -12747,8 +13012,10 @@ impl CayenneTableProvider {
     ///
     /// Returns an error if deletion vectors cannot be loaded from the catalog.
     async fn refresh_deletion_cache(&self) -> CatalogResult<()> {
+        let current_snapshot_id = self.get_current_snapshot_id();
         let fresh_strategy = Self::load_deletion_vectors_all(
             &self.table_metadata.table_id,
+            &current_snapshot_id,
             Arc::clone(&self.catalog),
             self.pk_deletion_strategy.strategy(),
         )
@@ -13090,8 +13357,10 @@ impl CayenneTableProvider {
         // Reload deletion vectors from the catalog (SQLite) — the source of truth.
         // This picks up any deletions committed by writes that completed after the
         // source provider was opened.
+        let current_snapshot_id = self.get_current_snapshot_id();
         let fresh_strategy = Self::load_deletion_vectors_all(
             &self.table_metadata.table_id,
+            &current_snapshot_id,
             Arc::clone(&self.catalog),
             self.pk_deletion_strategy.strategy(),
         )
@@ -17189,6 +17458,7 @@ impl CayenneTableProvider {
     /// The fully constructed `PkDeletionStrategy` with all caches populated.
     async fn load_deletion_vectors_all(
         table_id: &str,
+        current_snapshot_id: &str,
         catalog: Arc<dyn MetadataCatalog>,
         strategy: PkDeletionStrategy,
     ) -> CatalogResult<PkDeletionStrategyWithCache> {
@@ -17284,7 +17554,7 @@ impl CayenneTableProvider {
         // HashMap<Box<[u8]>, i64>) where:
         // - per_file_row_ids: file path -> bitmap of deleted row positions
         // - deleted_row_keys: PK bytes -> max delete sequence
-        let (per_file_row_ids, deleted_row_keys, derived_reinserted) =
+        let (per_file_row_ids, deleted_row_keys, derived_reinserted, missing_key_dvs) =
             task::spawn_blocking(move || detect_deletion_type_and_read(delete_files))
                 .await
                 .map_err(|err| CatalogError::InvalidOperation {
@@ -17297,6 +17567,23 @@ impl CayenneTableProvider {
                         source: Box::new(err),
                     })
                 })?;
+
+        // Self-heal any key-based DV whose `.arrow` file is missing. The file-first
+        // orphaned-DV sweep unlinks the file before removing its catalog row, so a
+        // crash in that window leaves a dangling row. Provably-orphaned dangling
+        // rows (delete sequence at or below the surviving floor) are removed with an
+        // info log; a missing file still within the floor is genuine data loss and
+        // errors. Lazy: the floor queries run only when ≥1 file was missing, so the
+        // common (all-present) path pays nothing.
+        if !missing_key_dvs.is_empty() {
+            Self::reconcile_missing_key_deletion_vectors(
+                catalog.as_ref(),
+                table_id,
+                current_snapshot_id,
+                missing_key_dvs,
+            )
+            .await?;
+        }
 
         // Lever L1 (metadata-only publish): merge the per-key reinsert sequences
         // DERIVED from each delete vector's keys + its `reinsert_sequence` column

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -9636,11 +9636,20 @@ impl CayenneTableProvider {
 
         let table = self.clone_for_write();
         super::compaction::spawn_compaction(async move {
+            // Clear the coalescing flag on ANY exit — normal completion, early
+            // return, a panic during unwind, or the task being dropped on abort —
+            // so a stuck flag can never permanently suppress future sweeps on a
+            // long-lived provider.
+            struct ClearOnDrop(Arc<AtomicBool>);
+            impl Drop for ClearOnDrop {
+                fn drop(&mut self) {
+                    self.0.store(false, Ordering::Release);
+                }
+            }
+            let _clear = ClearOnDrop(Arc::clone(&table.orphan_dv_sweep_scheduled));
+
             tokio::task::yield_now().await;
             table.sweep_orphaned_deletion_vectors().await;
-            table
-                .orphan_dv_sweep_scheduled
-                .store(false, Ordering::Release);
         });
     }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -9762,6 +9762,16 @@ impl CayenneTableProvider {
     /// orphaned-DV deletion (keep DVs alive longer or reject restoring below the GC
     /// point) — see the matching note on the snapshot set/restore code.
     async fn sweep_orphaned_deletion_vectors(&self) {
+        // Hard per-sweep cap on the orphan working set. This is a fixed upper bound
+        // (NOT `max(min_files)`, which would let a large knob defeat the cap): it
+        // bounds the fetch allocation, the unlink loop, AND — critically — the
+        // single `remove_delete_files` DELETE, which binds one parameter per id and
+        // would exceed the metastore's bound-parameter limit (e.g. SQLite's
+        // ~32766) on a huge batch. The effective threshold is clamped to the cap so
+        // the gate below can still fire; a backlog beyond the cap drains on later
+        // retention passes.
+        const ORPHAN_DV_SWEEP_MAX_BATCH: usize = 4096;
+
         let Some(min_files) = self
             .table_metadata
             .vortex_config
@@ -9791,15 +9801,6 @@ impl CayenneTableProvider {
             }
         };
 
-        // Hard per-sweep cap on the orphan working set. This is a fixed upper bound
-        // (NOT `max(min_files)`, which would let a large knob defeat the cap): it
-        // bounds the fetch allocation, the unlink loop, AND — critically — the
-        // single `remove_delete_files` DELETE, which binds one parameter per id and
-        // would exceed the metastore's bound-parameter limit (e.g. SQLite's
-        // ~32766) on a huge batch. The effective threshold is clamped to the cap so
-        // the gate below can still fire; a backlog beyond the cap drains on later
-        // retention passes.
-        const ORPHAN_DV_SWEEP_MAX_BATCH: usize = 4096;
         let effective_min = min_files.min(ORPHAN_DV_SWEEP_MAX_BATCH);
         let orphaned = match self
             .catalog

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -9625,7 +9625,7 @@ impl CayenneTableProvider {
             .table_metadata
             .vortex_config
             .orphaned_dv_cleanup_min_files
-            == 0
+            .is_none()
         {
             return;
         }
@@ -9762,13 +9762,14 @@ impl CayenneTableProvider {
     /// orphaned-DV deletion (keep DVs alive longer or reject restoring below the GC
     /// point) — see the matching note on the snapshot set/restore code.
     async fn sweep_orphaned_deletion_vectors(&self) {
-        let min_files = self
+        let Some(min_files) = self
             .table_metadata
             .vortex_config
-            .orphaned_dv_cleanup_min_files;
-        if min_files == 0 {
+            .orphaned_dv_cleanup_min_files
+        else {
             return;
-        }
+        };
+        let min_files = min_files.get();
 
         let table_id = &self.table_metadata.table_id;
         let current_snapshot_id = self.get_current_snapshot_id();

--- a/crates/cayenne/tests/file_based_retention_delete_test.rs
+++ b/crates/cayenne/tests/file_based_retention_delete_test.rs
@@ -61,6 +61,10 @@ test_with_backends!(test_pk_file_based_retention_main_table_only_impl);
 test_with_backends!(test_orphaned_key_dv_cleaned_after_retention_impl);
 test_with_backends!(test_needed_key_dv_retained_after_retention_impl);
 test_with_backends!(test_all_snapshots_emptied_cleans_all_orphaned_dvs_impl);
+test_with_backends!(test_orphaned_dv_cleanup_disabled_when_knob_zero_impl);
+test_with_backends!(test_orphaned_dv_cleanup_below_threshold_retained_impl);
+test_with_backends!(test_loader_self_heals_orphaned_missing_dv_impl);
+test_with_backends!(test_loader_errors_on_missing_needed_dv_impl);
 
 // List-files cache maintenance tests
 test_with_backends!(test_cache_delta_applied_after_append_impl);
@@ -549,6 +553,7 @@ async fn test_pk_file_based_retention_main_table_only_impl(fixture: TestFixture)
         table_name,
         retention_seconds,
         false,
+        0, // no PK upsert here → no key DVs to clean up
         ctx.runtime_env(),
     )
     .await?;
@@ -655,6 +660,7 @@ async fn create_pk_retention_table(
     table_name: &str,
     retention_seconds: u64,
     with_upsert: bool,
+    cleanup_min_files: usize,
     runtime_env: Arc<RuntimeEnv>,
 ) -> Result<Arc<CayenneTableProvider>, Box<dyn std::error::Error>> {
     let table_dir = fixture.data_path.join(table_name);
@@ -670,8 +676,13 @@ async fn create_pk_retention_table(
         None
     };
 
+    // `cleanup_min_files` controls the orphaned-DV cleanup knob: 0 disables the
+    // sweep entirely; a positive value sweeps once that many orphan-eligible DVs
+    // accumulate. Tests drive the (otherwise background) sweep deterministically
+    // via `CayenneTableProvider::drain_orphan_dv_sweep`.
     let vortex_config = cayenne::metadata::VortexConfig {
         inline_max_rows: 0,
+        orphaned_dv_cleanup_min_files: cleanup_min_files,
         ..cayenne::metadata::VortexConfig::default()
     };
 
@@ -694,6 +705,23 @@ async fn create_pk_retention_table(
         CayenneTableProviderBuilder::new(catalog_arc, runtime_env)
             .with_time_retention_filter_builder(retention_builder)
             .create(table_options)
+            .await?,
+    ))
+}
+
+/// Reopen a table by constructing a fresh provider from the same catalog,
+/// simulating a process restart (runs the loader path, including missing-DV
+/// reconciliation).
+async fn reopen_table(
+    fixture: &TestFixture,
+    table_name: &str,
+    runtime_env: Arc<RuntimeEnv>,
+) -> Result<Arc<CayenneTableProvider>, Box<dyn std::error::Error>> {
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    Ok(Arc::new(
+        CayenneTableProviderBuilder::new(catalog, runtime_env)
+            .open(table_name)
             .await?,
     ))
 }
@@ -885,6 +913,29 @@ async fn count_key_based_delete_files(
         .count()
 }
 
+/// Physically delete every `.arrow` deletion-vector file under `root` (simulating
+/// the file-first sweep having unlinked the file but crashed before removing the
+/// catalog row). Returns the number deleted.
+fn delete_arrow_files(root: &std::path::Path) -> usize {
+    fn walk(dir: &std::path::Path, count: &mut usize) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.filter_map(std::result::Result::ok) {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, count);
+            } else if path.extension().is_some_and(|ext| ext == "arrow") {
+                std::fs::remove_file(&path).expect("remove .arrow file");
+                *count += 1;
+            }
+        }
+    }
+    let mut count = 0;
+    walk(root, &mut count);
+    count
+}
+
 /// Count `.arrow` deletion-vector files physically present anywhere under `root`.
 fn count_arrow_files(root: &std::path::Path) -> usize {
     fn walk(dir: &std::path::Path, count: &mut usize) {
@@ -929,6 +980,7 @@ async fn test_orphaned_key_dv_cleaned_after_retention_impl(fixture: TestFixture)
         table_name,
         retention_seconds,
         true,
+        1, // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -965,6 +1017,10 @@ async fn test_orphaned_key_dv_cleaned_after_retention_impl(fixture: TestFixture)
 
     // The surviving (re-upserted) row is unaffected.
     assert_table_contents(&ctx, &table, table_name, &[1], "after retention").await?;
+
+    // Drive the (otherwise background, dedicated-runtime) orphaned-DV sweep
+    // deterministically before asserting on its effects.
+    table.drain_orphan_dv_sweep().await;
 
     // The orphaned DV must be gone from both the catalog and disk.
     assert_eq!(
@@ -1004,6 +1060,7 @@ async fn test_needed_key_dv_retained_after_retention_impl(fixture: TestFixture) 
         table_name,
         retention_seconds,
         true,
+        1, // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -1039,6 +1096,10 @@ async fn test_needed_key_dv_retained_after_retention_impl(fixture: TestFixture) 
     // id=1 is gone; id=2 survives exactly once (the upserted copy).
     assert_table_contents(&ctx, &table, table_name, &[2], "after retention").await?;
 
+    // Run the sweep: it must NOT prune the still-needed DV (its delete sequence is
+    // above the surviving floor, so it is not orphan-eligible).
+    table.drain_orphan_dv_sweep().await;
+
     // The DV shadowing A's copy of id=2 is still needed → must be retained.
     assert_eq!(
         count_key_based_delete_files(&fixture, &table).await,
@@ -1067,6 +1128,7 @@ async fn test_all_snapshots_emptied_cleans_all_orphaned_dvs_impl(
         table_name,
         retention_seconds,
         true,
+        1, // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -1092,6 +1154,9 @@ async fn test_all_snapshots_emptied_cleans_all_orphaned_dvs_impl(
     let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
     assert_eq!(deleted, 2, "Retention should delete both expired copies");
 
+    // Drive the orphaned-DV sweep deterministically.
+    table.drain_orphan_dv_sweep().await;
+
     // All data is gone, and so is the orphaned DV (catalog + disk).
     assert_table_contents(&ctx, &table, table_name, &[], "after retention").await?;
     assert_eq!(
@@ -1103,6 +1168,201 @@ async fn test_all_snapshots_emptied_cleans_all_orphaned_dvs_impl(
         count_arrow_files(&base_dir),
         0,
         "All orphaned DV .arrow files should be removed from disk"
+    );
+
+    Ok(())
+}
+
+/// Test: with the knob set to 0, orphaned-DV cleanup is fully disabled — the
+/// orphaned DV (catalog row + `.arrow` file) is left in place. This is the A/B
+/// baseline that must reproduce pre-feature behavior (no sweep, no locks).
+async fn test_orphaned_dv_cleanup_disabled_when_knob_zero_impl(fixture: TestFixture) -> TestResult {
+    let retention_seconds = 60;
+    let table_name = "orphan_dv_disabled";
+    let ctx = SessionContext::new();
+    let table = create_pk_retention_table(
+        &fixture,
+        table_name,
+        retention_seconds,
+        true,
+        0, // cleanup DISABLED
+        ctx.runtime_env(),
+    )
+    .await?;
+    let table_id = table.metadata().table_id.clone();
+    let base_dir = fixture.data_path.join(table_name);
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us - 100_000_000).await?;
+    common::poll_inlined_data_count_zero(&fixture.catalog, &table_id).await?;
+    insert_row(&table, 1, now_us).await?;
+    common::poll_inlined_data_count_zero(&fixture.catalog, &table_id).await?;
+
+    assert_eq!(count_key_based_delete_files(&fixture, &table).await, 1);
+    assert_eq!(count_arrow_files(&base_dir), 1);
+
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(deleted, 1, "Retention should delete the expired row");
+
+    // Even after draining, a disabled sweep does nothing.
+    table.drain_orphan_dv_sweep().await;
+
+    assert_eq!(
+        count_key_based_delete_files(&fixture, &table).await,
+        1,
+        "Cleanup disabled (knob=0): orphaned DV row must remain in the catalog"
+    );
+    assert_eq!(
+        count_arrow_files(&base_dir),
+        1,
+        "Cleanup disabled (knob=0): orphaned DV .arrow file must remain on disk"
+    );
+
+    Ok(())
+}
+
+/// Test: when fewer orphan-eligible DVs accumulate than the configured threshold,
+/// the sweep does not run, so the orphan is retained until the threshold is met.
+async fn test_orphaned_dv_cleanup_below_threshold_retained_impl(
+    fixture: TestFixture,
+) -> TestResult {
+    let retention_seconds = 60;
+    let table_name = "orphan_dv_below_threshold";
+    let ctx = SessionContext::new();
+    let table = create_pk_retention_table(
+        &fixture,
+        table_name,
+        retention_seconds,
+        true,
+        2, // threshold of 2; the single orphan below is under it
+        ctx.runtime_env(),
+    )
+    .await?;
+    let table_id = table.metadata().table_id.clone();
+    let base_dir = fixture.data_path.join(table_name);
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us - 100_000_000).await?;
+    common::poll_inlined_data_count_zero(&fixture.catalog, &table_id).await?;
+    insert_row(&table, 1, now_us).await?;
+    common::poll_inlined_data_count_zero(&fixture.catalog, &table_id).await?;
+
+    assert_eq!(count_key_based_delete_files(&fixture, &table).await, 1);
+
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(deleted, 1, "Retention should delete the expired row");
+
+    table.drain_orphan_dv_sweep().await;
+
+    assert_eq!(
+        count_key_based_delete_files(&fixture, &table).await,
+        1,
+        "1 orphan-eligible DV is below the threshold of 2 → sweep must not run"
+    );
+    assert_eq!(
+        count_arrow_files(&base_dir),
+        1,
+        "Below-threshold orphan DV .arrow file must remain on disk"
+    );
+
+    Ok(())
+}
+
+/// Test: on reopen, the loader self-heals a provably-orphaned key DV whose `.arrow`
+/// file is missing (the file-first sweep crash window: file unlinked, row not yet
+/// removed). The dangling catalog row is dropped with an info log and the table
+/// opens normally; surviving data is intact.
+async fn test_loader_self_heals_orphaned_missing_dv_impl(fixture: TestFixture) -> TestResult {
+    let retention_seconds = 60;
+    let table_name = "loader_self_heal_orphan";
+    let ctx = SessionContext::new();
+    let table = create_pk_retention_table(
+        &fixture,
+        table_name,
+        retention_seconds,
+        true,
+        0, // disable the sweep so the orphan (row + file) lingers
+        ctx.runtime_env(),
+    )
+    .await?;
+    let table_id = table.metadata().table_id.clone();
+    let base_dir = fixture.data_path.join(table_name);
+
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us - 100_000_000).await?;
+    common::poll_inlined_data_count_zero(&fixture.catalog, &table_id).await?;
+    insert_row(&table, 1, now_us).await?;
+    common::poll_inlined_data_count_zero(&fixture.catalog, &table_id).await?;
+
+    // Retention empties M → the DV is orphaned (delete sequence at/below floor).
+    let deleted = execute_delete(&table, retention_delete_filter(retention_seconds)).await?;
+    assert_eq!(deleted, 1);
+    assert_eq!(count_key_based_delete_files(&fixture, &table).await, 1);
+    assert_eq!(count_arrow_files(&base_dir), 1);
+
+    // Simulate the file-first sweep: unlink the file but leave the catalog row.
+    assert_eq!(
+        delete_arrow_files(&base_dir),
+        1,
+        "should remove the orphaned DV .arrow file"
+    );
+    drop(table);
+
+    // Reopen: the loader self-heals the dangling row (no error).
+    let reopened = reopen_table(&fixture, table_name, ctx.runtime_env()).await?;
+    assert_eq!(
+        count_key_based_delete_files(&fixture, &reopened).await,
+        0,
+        "Loader should self-heal the orphaned dangling delete-file row on reopen"
+    );
+    assert_table_contents(&ctx, &reopened, table_name, &[1], "after reopen").await?;
+
+    Ok(())
+}
+
+/// Test: on reopen, a missing key DV whose delete sequence is still ABOVE the
+/// surviving floor (it could still shadow live data) is genuine data loss — the
+/// loader errors rather than silently dropping it.
+async fn test_loader_errors_on_missing_needed_dv_impl(fixture: TestFixture) -> TestResult {
+    let retention_seconds = 60;
+    let table_name = "loader_needed_missing";
+    let ctx = SessionContext::new();
+    let table = create_pk_retention_table(
+        &fixture,
+        table_name,
+        retention_seconds,
+        true,
+        0,
+        ctx.runtime_env(),
+    )
+    .await?;
+    let table_id = table.metadata().table_id.clone();
+    let base_dir = fixture.data_path.join(table_name);
+
+    // insert id=1 then upsert id=1 (both fresh, no retention): the DV shadows the
+    // surviving original copy, so its delete sequence is above the floor → NEEDED.
+    let now_us = chrono::Utc::now().timestamp_micros();
+    insert_row(&table, 1, now_us).await?;
+    common::poll_inlined_data_count_zero(&fixture.catalog, &table_id).await?;
+    insert_row(&table, 1, now_us).await?;
+    common::poll_inlined_data_count_zero(&fixture.catalog, &table_id).await?;
+    assert_eq!(count_key_based_delete_files(&fixture, &table).await, 1);
+    assert_eq!(count_arrow_files(&base_dir), 1);
+
+    // Delete the needed DV's file (genuine data loss), leaving the catalog row.
+    assert_eq!(delete_arrow_files(&base_dir), 1);
+    drop(table);
+
+    // Reopen must fail: a missing file still within the floor is not a self-healable
+    // orphan.
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let result = CayenneTableProviderBuilder::new(catalog, ctx.runtime_env())
+        .open(table_name)
+        .await;
+    assert!(
+        result.is_err(),
+        "Reopen must fail when a still-needed deletion-vector file is missing (data loss)"
     );
 
     Ok(())

--- a/crates/cayenne/tests/file_based_retention_delete_test.rs
+++ b/crates/cayenne/tests/file_based_retention_delete_test.rs
@@ -47,7 +47,7 @@ use datafusion_table_providers::util::{
     column_reference::ColumnReference, on_conflict::OnConflict,
 };
 use object_store::ObjectMeta;
-use std::num::NonZeroUsize;
+use std::num::{NonZero, NonZeroUsize};
 use std::sync::Arc;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -981,7 +981,7 @@ async fn test_orphaned_key_dv_cleaned_after_retention_impl(fixture: TestFixture)
         table_name,
         retention_seconds,
         true,
-        Some(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
+        NonZero::new(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -1061,7 +1061,7 @@ async fn test_needed_key_dv_retained_after_retention_impl(fixture: TestFixture) 
         table_name,
         retention_seconds,
         true,
-        Some(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
+        NonZero::new(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -1129,7 +1129,7 @@ async fn test_all_snapshots_emptied_cleans_all_orphaned_dvs_impl(
         table_name,
         retention_seconds,
         true,
-        Some(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
+        NonZero::new(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -1235,7 +1235,7 @@ async fn test_orphaned_dv_cleanup_below_threshold_retained_impl(
         table_name,
         retention_seconds,
         true,
-        Some(2), // threshold of 2; the single orphan below is under it
+        NonZero::new(2), // threshold of 2; the single orphan below is under it
         ctx.runtime_env(),
     )
     .await?;

--- a/crates/cayenne/tests/file_based_retention_delete_test.rs
+++ b/crates/cayenne/tests/file_based_retention_delete_test.rs
@@ -47,6 +47,7 @@ use datafusion_table_providers::util::{
     column_reference::ColumnReference, on_conflict::OnConflict,
 };
 use object_store::ObjectMeta;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -553,7 +554,7 @@ async fn test_pk_file_based_retention_main_table_only_impl(fixture: TestFixture)
         table_name,
         retention_seconds,
         false,
-        0, // no PK upsert here → no key DVs to clean up
+        None, // no PK upsert here → no key DVs to clean up
         ctx.runtime_env(),
     )
     .await?;
@@ -660,7 +661,7 @@ async fn create_pk_retention_table(
     table_name: &str,
     retention_seconds: u64,
     with_upsert: bool,
-    cleanup_min_files: usize,
+    orphaned_dv_cleanup_min_files: Option<NonZeroUsize>,
     runtime_env: Arc<RuntimeEnv>,
 ) -> Result<Arc<CayenneTableProvider>, Box<dyn std::error::Error>> {
     let table_dir = fixture.data_path.join(table_name);
@@ -682,7 +683,7 @@ async fn create_pk_retention_table(
     // via `CayenneTableProvider::drain_orphan_dv_sweep`.
     let vortex_config = cayenne::metadata::VortexConfig {
         inline_max_rows: 0,
-        orphaned_dv_cleanup_min_files: cleanup_min_files,
+        orphaned_dv_cleanup_min_files,
         ..cayenne::metadata::VortexConfig::default()
     };
 
@@ -980,7 +981,7 @@ async fn test_orphaned_key_dv_cleaned_after_retention_impl(fixture: TestFixture)
         table_name,
         retention_seconds,
         true,
-        1, // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
+        Some(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -1060,7 +1061,7 @@ async fn test_needed_key_dv_retained_after_retention_impl(fixture: TestFixture) 
         table_name,
         retention_seconds,
         true,
-        1, // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
+        Some(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -1128,7 +1129,7 @@ async fn test_all_snapshots_emptied_cleans_all_orphaned_dvs_impl(
         table_name,
         retention_seconds,
         true,
-        1, // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
+        Some(1), // enable orphaned-DV cleanup; the sweep is driven via drain_orphan_dv_sweep
         ctx.runtime_env(),
     )
     .await?;
@@ -1185,7 +1186,7 @@ async fn test_orphaned_dv_cleanup_disabled_when_knob_zero_impl(fixture: TestFixt
         table_name,
         retention_seconds,
         true,
-        0, // cleanup DISABLED
+        None, // cleanup DISABLED
         ctx.runtime_env(),
     )
     .await?;
@@ -1234,7 +1235,7 @@ async fn test_orphaned_dv_cleanup_below_threshold_retained_impl(
         table_name,
         retention_seconds,
         true,
-        2, // threshold of 2; the single orphan below is under it
+        Some(2), // threshold of 2; the single orphan below is under it
         ctx.runtime_env(),
     )
     .await?;
@@ -1281,7 +1282,7 @@ async fn test_loader_self_heals_orphaned_missing_dv_impl(fixture: TestFixture) -
         table_name,
         retention_seconds,
         true,
-        0, // disable the sweep so the orphan (row + file) lingers
+        None, // disable the sweep so the orphan (row + file) lingers
         ctx.runtime_env(),
     )
     .await?;
@@ -1332,7 +1333,7 @@ async fn test_loader_errors_on_missing_needed_dv_impl(fixture: TestFixture) -> T
         table_name,
         retention_seconds,
         true,
-        0,
+        None,
         ctx.runtime_env(),
     )
     .await?;

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -1537,6 +1537,17 @@ impl SnapshotManager {
 
     /// Attempts to download the latest snapshot, returning details if successful.
     ///
+    /// INVARIANT (Cayenne orphaned-DV cleanup): restore is wholesale and
+    /// self-contained — the downloaded archive carries its OWN data and
+    /// deletion-vector (`.arrow`) files plus metastore slice, and extraction
+    /// replaces the local table directory before the provider is (re)opened. It
+    /// never reuses the live table's files. Cayenne's orphaned-DV sweep
+    /// (`CayenneTableProvider::sweep_orphaned_deletion_vectors`) deletes DV files
+    /// once they fall below the surviving-sequence floor and depends on this: if
+    /// restore is ever changed to reuse the live table's files (e.g. an in-place
+    /// pointer flip without re-extraction), it must account for DV deletion —
+    /// keep orphaned DVs alive longer or restrict which snapshots can be restored.
+    ///
     /// # Errors
     ///
     /// - If there is an error communicating with the object store.

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,10 @@ ignore = [
   # and the unsoundness (custom-logger `rand::rng()`) is not exercised by this
   # transitive use. Owner: data connectors/runtime.
   "RUSTSEC-2026-0097",
+  # `document_parse` pulls `ttf-parser` through `pdf-extract`/`lopdf`; the author
+  # marked it unmaintained and there is no safe upgrade (the suggested `skrifa`
+  # alternative is not wired through `lopdf`/`pdf-extract`). Owner: document_parse.
+  "RUSTSEC-2026-0192",
 ]
 
 [bans]


### PR DESCRIPTION
Closes #9388.

## What

Re-lands orphaned key-based deletion-vector (DV) cleanup — originally #11425, reverted in #11487, re-landed as-is in #11501 — but **off the write path, behind a knob**, so it no longer regresses CDC ingestion.

## Why the previous approach regressed

The cleanup ran **inside `FileBasedDeletionSink::delete_from`**, on the explicit file-based DELETE path that CH-BenCHmark's retention DELETEs take. That path holds **both** hot-path locks for the file deletion:

- `write_lock` — which the CDC append path contends on, and
- `listing_fence` (write) — which every scan plan-build takes (read).

The cleanup tail piggybacked under those locks and, on **every emptied-snapshot pass**, did:

1. an **unbounded** `get_table_delete_files` scan (the full delete-file table, even when 0 DVs were orphaned), and
2. an **O(n) full rebuild** of the in-memory tombstone index (`prune_deletes_at_or_below`).

Holding `write_lock` across that stalled CDC append → **tpmC dropped**; the long critical section delayed checkpoint visibility → **staleness rose**. This showed up in the **SF-1000 CH-BenCHmark** run.

## Key realization

Of the three things an orphaned DV leaves behind, only **one truly leaks**:

| Artifact | Reclaimed by | Leaks under sustained CDC? |
|---|---|---|
| in-memory tombstone | compaction's seq-prefix bake | no |
| `cayenne_delete_file` row | compaction's fenced commit / overwrite / drop | no |
| **physical `.arrow` file** | only when its snapshot dir is retired+swept | **yes** — it lives in the *current* snapshot's `deletions/` dir, which never rotates under sustained CDC |

So the in-memory prune the regression paid for was **redundant with compaction**, and the unique necessary work is simply **unlinking the file**.

## New approach

- **Knob** — `VortexConfig.orphaned_dv_cleanup_min_files` (settable via spicepod params). `0` = **fully disabled**: no sweep is spawned, no lock is taken, no catalog query runs (pre-feature behavior, and the A/B baseline). A positive value sweeps once that many orphan-eligible DVs accumulate. Ships **disabled**; flip the default after the A/B.
- **Lock-free, throttled, off-path sweep** — `delete_from` now only calls `schedule_orphan_dv_sweep()`, which spawns one coalesced sweep on the **dedicated compaction runtime** (mirroring `schedule_post_write_compaction`). The sweep holds **no `write_lock` and no `listing_fence`**: compute the surviving-sequence floor → bounded SQL fetch of orphan-eligible key DVs → gate on the threshold → **unlink the `.arrow` file first, then remove its catalog row**. It does **not** prune the in-memory index (compaction owns that). Lock-free is sound because orphaned DVs are query-time no-ops, scans never read DV files lazily, and the floor is monotonic on the live timeline.
- **Self-healing loader** — file-first ordering is non-atomic, so a crash can leave a dangling row whose file is gone. The reader now **reports** missing key-DV files instead of erroring; the loader lazily computes the floor *only on a miss* and either self-heals a provable orphan (`delete_seq <= floor`: info log + drop the row) or **errors** on genuine data loss (`delete_seq > floor`) — a defensive improvement over the old generic missing-file error. **Zero common-path cost.**
- **Restore invariant documented** (no enforcement) at the GC sites and the snapshot set/restore code: Acceleration Snapshot restore is a wholesale, self-contained, offline re-extraction, so it never reuses GC'd live files. A future in-place restore would need to revisit DV deletion.

## Why it's better

The DELETE's lock window shrinks back to just the file deletion (pre-regression behavior); the cleanup moves entirely **off it** onto an isolated runtime, runs **rarely** (threshold-gated), **drops the redundant O(n) prune**, and can be **fully disabled** for an apples-to-apples A/B.

## Testing

- `cargo test -p cayenne --test file_based_retention_delete_test` — 14/14 pass.
- 3 existing orphaned-DV tests updated to drive the now-background sweep deterministically.
- 4 new tests: knob-disabled (no cleanup), below-threshold (retained), loader self-heal of an orphaned missing file, loader error on a still-needed missing file.
- `cargo clippy -p cayenne --no-deps` and `--tests --no-deps` clean.

**Acceptance**: SF-1000 CH-BenCHmark A/B, `orphaned_dv_cleanup_min_files = 0` vs a candidate `N`, comparing tpmC and staleness.
