### PR TITLE
feat(cayenne): wire orphaned-DV cleanup knob to spicepod params + doc sync

### DIFF
--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -721,13 +721,17 @@ pub struct VortexConfig {
     /// the protected snapshot(s) it shadowed, raising the surviving-sequence floor
     /// above its delete sequence so it shadows nothing.
     ///
-    /// `0` disables orphaned-DV cleanup entirely — no background sweep is ever
-    /// spawned, so the file-based DELETE path acquires no extra locks and runs no
-    /// catalog scan (the pre-feature behavior, and the A/B baseline). A larger
-    /// value sweeps less often (cheaper, but orphaned `.arrow` files linger on disk
-    /// longer); a smaller value reclaims disk sooner. The sweep is lock-free and
-    /// runs off the write path on the dedicated compaction runtime, so this only
-    /// trades sweep frequency against lingering disk — never ingest latency.
+    /// `None` (unset/null, the default) disables orphaned-DV cleanup entirely — no
+    /// background sweep is ever spawned, so the file-based DELETE path acquires no
+    /// extra locks and runs no catalog scan (the pre-feature behavior, and the A/B
+    /// baseline). `Some(n)` enables it with threshold `n >= 1`. The `NonZeroUsize`
+    /// type makes a misconfigured `0` unrepresentable; the spicepod param
+    /// (`cayenne_orphaned_dv_cleanup_min_files`) maps `0` (or unset) to `None`. A
+    /// larger value sweeps less often (cheaper, but orphaned `.arrow` files linger
+    /// on disk longer); a smaller value reclaims disk sooner. The sweep is
+    /// lock-free and runs off the write path on the dedicated compaction runtime,
+    /// so this only trades sweep frequency against lingering disk — never ingest
+    /// latency.
     pub orphaned_dv_cleanup_min_files: Option<NonZeroUsize>,
     /// Number of protected snapshots that can accumulate before snapshot-maintenance
     /// compaction is eligible to run. Kept separate from `compaction_trigger_files`
@@ -1241,8 +1245,9 @@ impl Default for VortexConfig {
             write_concurrency: None,
             compaction_trigger_files: default_compaction_trigger_files(),
             bake_deletion_index_trigger: default_bake_deletion_index_trigger(),
-            // Orphaned-DV cleanup disabled by default (pre-feature behavior, and
-            // the A/B baseline); opt in with `cayenne_orphaned_dv_cleanup_min_files`.
+            // Orphaned-DV cleanup disabled by default (None = pre-feature behavior,
+            // and the A/B baseline); opt in by setting the spicepod param
+            // `cayenne_orphaned_dv_cleanup_min_files` to a value >= 1.
             orphaned_dv_cleanup_min_files: None,
             compaction_trigger_protected_snapshots: default_compaction_trigger_protected_snapshots(
             ),

--- a/crates/cayenne/src/provider/delete/sink/file_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/file_based.rs
@@ -445,7 +445,7 @@ impl DeletionSink for FileBasedDeletionSink {
         // a lock-free, throttled background pass on the dedicated compaction runtime
         // (`schedule_orphan_dv_sweep`), so it never extends the `write_lock` /
         // `listing_fence` window that CDC ingest and scans contend on here. We only
-        // signal it; it no-ops when the `orphaned_dv_cleanup_min_files` knob is 0.
+        // signal it; it no-ops when `orphaned_dv_cleanup_min_files` is unset (None).
         if !result.emptied_snapshot_ids.is_empty() {
             self.cleanup_emptied_snapshots(&result.emptied_snapshot_ids)
                 .await;

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -9730,9 +9730,9 @@ impl CayenneTableProvider {
     /// passes into a single in-flight sweep — mirroring
     /// [`Self::schedule_post_write_compaction`].
     ///
-    /// No-op when the `orphaned_dv_cleanup_min_files` knob is 0: nothing is
-    /// spawned, no lock is taken, and no catalog query runs (the pre-feature
-    /// behavior, and the SF-1000 CH-BenCHmark A/B baseline).
+    /// No-op when the `orphaned_dv_cleanup_min_files` knob is unset (`None`):
+    /// nothing is spawned, no lock is taken, and no catalog query runs (the
+    /// pre-feature behavior, and the SF-1000 CH-BenCHmark A/B baseline).
     pub(crate) fn schedule_orphan_dv_sweep(&self) {
         if self
             .table_metadata

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -1210,6 +1210,17 @@ impl CayenneAccelerator {
                 &["cayenne_bake_deletion_index_trigger"],
                 config.bake_deletion_index_trigger,
             );
+            // Orphaned-DV cleanup threshold. Parsed as a usize and mapped through
+            // NonZeroUsize so 0 (or unset) means disabled (None) and >= 1 enables
+            // the sweep — see VortexConfig::orphaned_dv_cleanup_min_files.
+            config.orphaned_dv_cleanup_min_files =
+                std::num::NonZeroUsize::new(autotune::auto_or_usize(
+                    acceleration,
+                    &["cayenne_orphaned_dv_cleanup_min_files"],
+                    config
+                        .orphaned_dv_cleanup_min_files
+                        .map_or(0, std::num::NonZeroUsize::get),
+                ));
             config.compaction_trigger_protected_snapshots = autotune::auto_or_usize(
                 acceleration,
                 &["cayenne_compaction_trigger_protected_snapshots"],
@@ -1840,8 +1851,8 @@ fn wrap_with_native_vector_indexes(
 const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
     ParameterSpec,
     S3_PARAMS_LEN,
-    46,
-    { S3_PARAMS_LEN + 46 },
+    47,
+    { S3_PARAMS_LEN + 47 },
 >(
     S3_PARAMETERS,
     [
@@ -1897,6 +1908,8 @@ const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
             .description("Minimum number of small Vortex files in the current snapshot before tiered compaction runs. A 'small' file is one whose size is below cayenne_target_file_size_mb / 4. Default: 4 for refresh_mode: caching, changes, or append with refresh_check_interval <= 5m; 8 otherwise."),
         ParameterSpec::component("bake_deletion_index_trigger")
             .description("Deletion-index size (count of live primary-key tombstones) at or above which the seq-prefix bake (key-delete merge-on-read compaction) runs. The bake consolidates the settled older prefix of protected snapshots so their tombstones drop out of the live deletion index, lowering per-query merge-on-read probe cost at the cost of write amplification. A larger value bakes less often (bounds write-amp); a smaller value bakes more often (smaller index, cheaper probe). Key-delete tables only. Default: 50000."),
+        ParameterSpec::component("orphaned_dv_cleanup_min_files")
+            .description("Number of orphan-eligible key-based deletion vectors (cayenne_delete_file rows) that must accumulate before a background cleanup sweep reclaims their .arrow files. A key deletion vector becomes orphaned once time-based retention empties the protected snapshot(s) it shadowed. The sweep is lock-free and runs off the write path on the dedicated compaction runtime, so this only trades sweep frequency against lingering disk — never ingest latency. Set to 0 (or leave unset) to disable cleanup entirely (the default, pre-feature behavior); a value >= 1 enables it. Default: 0 (disabled)."),
         ParameterSpec::component("compaction_trigger_protected_snapshots")
             .description("Number of protected snapshots before snapshot-maintenance compaction runs. This is separate from compaction_trigger_files so small-file tuning does not silently change scan amplification behavior. Default: 4 for refresh_mode: caching, changes, or append with refresh_check_interval <= 5m; 8 otherwise."),
         ParameterSpec::component("compaction_trigger_snapshot_age_ms")
@@ -4293,6 +4306,10 @@ mod tests {
                     "cayenne_compaction_background_interval_ms".to_string(),
                     "45000".to_string(),
                 ),
+                (
+                    "cayenne_orphaned_dv_cleanup_min_files".to_string(),
+                    "2500".to_string(),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -4307,6 +4324,54 @@ mod tests {
         assert_eq!(config.compaction_max_levels, 5);
         assert_eq!(config.compaction_max_files_per_pick, 64);
         assert_eq!(config.compaction_background_interval_ms, 45_000);
+        assert_eq!(
+            config.orphaned_dv_cleanup_min_files,
+            std::num::NonZeroUsize::new(2500),
+            "cayenne_orphaned_dv_cleanup_min_files param should resolve to Some(2500)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_orphaned_dv_cleanup_param_zero_and_unset_disable() {
+        let app = Arc::new(AppBuilder::new("test").build());
+        let rt = Arc::new(crate::Runtime::builder().build().await);
+
+        // Unset → disabled (None).
+        let unset = DatasetBuilder::try_new("orphan_unset".to_string(), "orphan_unset")
+            .expect("dataset builder")
+            .with_app(Arc::clone(&app))
+            .with_runtime(Arc::clone(&rt))
+            .build()
+            .expect("dataset");
+        let unset_config = CayenneAccelerator::get_vortex_config("orphan_unset", &unset).await;
+        assert_eq!(
+            unset_config.orphaned_dv_cleanup_min_files, None,
+            "unset param must disable orphaned-DV cleanup"
+        );
+
+        // Explicit 0 → disabled (None), since NonZeroUsize cannot represent 0.
+        let mut zero = DatasetBuilder::try_new("orphan_zero".to_string(), "orphan_zero")
+            .expect("dataset builder")
+            .with_app(app)
+            .with_runtime(rt)
+            .build()
+            .expect("dataset");
+        zero.acceleration = Some(Acceleration {
+            engine: Engine::Cayenne,
+            mode: Mode::File,
+            params: [(
+                "cayenne_orphaned_dv_cleanup_min_files".to_string(),
+                "0".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        });
+        let zero_config = CayenneAccelerator::get_vortex_config("orphan_zero", &zero).await;
+        assert_eq!(
+            zero_config.orphaned_dv_cleanup_min_files, None,
+            "explicit 0 must disable orphaned-DV cleanup"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #11517 (now merged), addressing its two open review comments on the
`orphaned_dv_cleanup_min_files` knob.

## 1. Wire the knob into spicepod params (the important one)

`cayenne_orphaned_dv_cleanup_min_files` was referenced only in a doc comment — it
was **not parsed** in the runtime Cayenne accelerator, so it was not actually
settable via spicepod `params`. That blocks the SF-1000 CH-BenCHmark A/B (which
configures via a spicepod), contradicting #11517's acceptance plan.

- Parse it in `get_vortex_config_with_footer_cache`, mapping the `usize` through
  `NonZeroUsize::new` so **`0` (or unset) → `None` (disabled)** and **`>= 1` →
  enabled** — recovering the intuitive "0 disables" UX at the spicepod layer while
  keeping the `NonZeroUsize` internal guarantee.
- Register a `ParameterSpec::component("orphaned_dv_cleanup_min_files")` (bumps the
  cayenne `PARAMETERS` array length 46 → 47).
- Tests: the param resolves to `Some(2500)`; `0` and unset both resolve to `None`.

## 2. Doc sync to `Option<NonZeroUsize>`

The knob's type is `Option<NonZeroUsize>` (`None` disables), but several docs still
said "`0` disables". Updated the field doc, the `Default` comment, the sink comment,
and `schedule_orphan_dv_sweep` to say "unset/null disables; a value ≥ 1 enables".

## Testing

- `cargo test -p runtime --lib` — the two new param tests pass, plus the existing
  `test_compaction_thresholds_are_resolved_from_acceleration_params` (extended to
  assert the new param).
- `cargo clippy -p runtime --no-deps` — no new warnings (the 2 pre-existing ones
  are in unrelated files).
