### PR TITLE
perf(cayenne): off-write_lock N>1 mem-tier checkpoint + adaptive query-admission throttle

### DIFF
--- a/crates/cayenne/benches/checkpoint_fence_stall.rs
+++ b/crates/cayenne/benches/checkpoint_fence_stall.rs
@@ -262,9 +262,116 @@ fn bench_mem_tier_checkpoint_fence_stall(c: &mut Criterion) {
     group.finish();
 }
 
+// ---------------------------------------------------------------------------
+// Off-`write_lock` N>1 checkpoint: at N>1 (mem-tier sharding) the checkpoint used
+// to hold the table `write_lock` across the WHOLE checkpoint — the all-shards
+// capture + the off-fence Vortex ENCODE + the metastore COMMIT — for
+// deadlock-safety (a concurrent apply racing the per-shard clear). But CDC applies
+// also take `write_lock`, so at N>1 every sharded apply stalled for the full
+// encode+commit of every checkpoint — re-serializing exactly the cost the in-memory
+// tier exists to defer, and the reason order_line/stock never drained at SF1000.
+//
+// The fix holds `write_lock` ONLY for the all-shards capture and releases it before
+// the encode; the deadlock that forced the long hold is removed by PIPELINING the
+// per-shard sequence reservation (the apply reserves its (delete, data) pair once up
+// front, so `append_to_shard` never holds a publish lock across an await — the
+// clear's index-order lock walk can no longer form a cycle with an apply).
+//
+// This bench measures the WRITE_LOCK-held duration — the exact stall a concurrent
+// sharded apply sees per checkpoint — BEFORE vs AFTER. Same `sleep` model and
+// held-span methodology as the listing-fence lanes above; single-task and
+// deterministic, so the timed span is purely the write_lock-held section. The
+// all-shards capture (snapshot N `ArcSwap`s + reserve one sequence) is in-process
+// and sub-millisecond, modeled by the same no-op symbol.
+//
+//   - encode_commit_under_write_lock/<rtt> (BEFORE): write_lock held across capture
+//     + encode + commit  ⇒ sharded-apply stall ≈ encode + commit.
+//   - capture_only_under_write_lock/<rtt>  (AFTER):  write_lock held for the capture
+//     only; encode + commit run off the lock  ⇒ sharded-apply stall ≈ µs.
+//
+// The ratio of the two lanes is the per-checkpoint sharded-apply-stall reduction,
+// which recurs at the background checkpoint cadence for every N>1 memory-mode table
+// — the lever that lets the heavy CDC tables keep draining at N>1.
+use refresh_listing_table_no_op as capture_no_op;
+
+async fn encode_commit_under_write_lock(write_lock: &RwLock<()>, commit_rtt: Duration) -> Duration {
+    let started = Instant::now();
+    let _guard = write_lock.write().await;
+    capture_no_op(); // all-shards capture (snapshot + seq reserve) — UNDER write_lock
+    tokio::time::sleep(ENCODE).await; // Vortex encode — UNDER write_lock (before)
+    tokio::time::sleep(commit_rtt).await; // BEGIN IMMEDIATE commit — UNDER write_lock (before)
+    started.elapsed()
+}
+
+async fn capture_only_under_write_lock(write_lock: &RwLock<()>, _commit_rtt: Duration) -> Duration {
+    // Real after-flow: acquire write_lock → capture → RELEASE → encode → commit. The
+    // sharded-apply stall is the write_lock-held capture window only; the encode +
+    // commit that follow run with write_lock free (concurrent applies proceed), so
+    // they do not count toward the stall — mirror `swap_only_under_fence` and time
+    // just the held span.
+    let started = Instant::now();
+    let _guard = write_lock.write().await; // write_lock taken ONLY for the capture
+    capture_no_op();
+    started.elapsed() // guard drops here; encode + commit are off-lock
+}
+
+fn bench_mem_tier_checkpoint_write_lock_stall(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+    let write_lock = Arc::new(RwLock::new(()));
+
+    let mut group = c.benchmark_group("mem_tier_checkpoint_write_lock_stall");
+    for &(label, rtt) in RTTS {
+        let wl_a = Arc::clone(&write_lock);
+        group.bench_with_input(
+            BenchmarkId::new("encode_commit_under_write_lock", label),
+            &rtt,
+            |b, &rtt| {
+                let write_lock = Arc::clone(&wl_a);
+                b.to_async(&rt).iter_custom(|iters| {
+                    let write_lock = Arc::clone(&write_lock);
+                    async move {
+                        let mut held = Duration::ZERO;
+                        for _ in 0..iters {
+                            held += encode_commit_under_write_lock(&write_lock, rtt).await;
+                        }
+                        // The before lane must hold write_lock across at least the
+                        // encode it serializes — guards the model from measuring nothing.
+                        assert!(
+                            held >= ENCODE.saturating_mul(u32::try_from(iters).unwrap_or(u32::MAX)),
+                            "before lane must hold write_lock across the encode"
+                        );
+                        held
+                    }
+                });
+            },
+        );
+
+        let wl_b = Arc::clone(&write_lock);
+        group.bench_with_input(
+            BenchmarkId::new("capture_only_under_write_lock", label),
+            &rtt,
+            |b, &rtt| {
+                let write_lock = Arc::clone(&wl_b);
+                b.to_async(&rt).iter_custom(|iters| {
+                    let write_lock = Arc::clone(&write_lock);
+                    async move {
+                        let mut held = Duration::ZERO;
+                        for _ in 0..iters {
+                            held += capture_only_under_write_lock(&write_lock, rtt).await;
+                        }
+                        held
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_checkpoint_fence_stall,
-    bench_mem_tier_checkpoint_fence_stall
+    bench_mem_tier_checkpoint_fence_stall,
+    bench_mem_tier_checkpoint_write_lock_stall
 );
 criterion_main!(benches);

--- a/crates/cayenne/src/lib.rs
+++ b/crates/cayenne/src/lib.rs
@@ -98,6 +98,6 @@ pub use provider::{
     global_mem_tier_total, global_qph, record_global_query, record_query_latency,
     register_query_observations, set_compaction_runtime_env, set_compaction_runtime_handle,
     set_cpu_burstable, set_global_encode_concurrency, set_global_mem_tier_bytes,
-    set_global_memory_budget, update_global_mem_tier_total,
+    set_global_memory_budget, set_query_admission_governor, update_global_mem_tier_total,
 };
 pub use schema::transform_schema_for_vortex;

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -169,6 +169,9 @@ impl CayenneContext {
             write_concurrency: wc_init,
             mem_tier_max_bytes: config.cdc_mem_tier_max_bytes,
             target_vortex_file_size_bytes: target_file_size_bytes_init,
+            // Starts at 0 (no queries shed). Only a violated lag/freshness goal
+            // under CPU contention drives it up — inert otherwise.
+            query_admission_reserve: 0,
         }));
         // Bounds keep the controller within sane, memory-/cpu-safe ranges. The
         // memtable and mem-tier ceilings are derived from the runtime-installed
@@ -233,6 +236,11 @@ impl CayenneContext {
             } else {
                 tuning::adaptive_target_file_size_bounds(target_file_size_bytes_init)
             },
+            // Reserve up to `cores` query-admission slots for CDC apply under
+            // contention; the process-global governor re-clamps the reported demand
+            // to the real admission pool's `max - 1`, so this cores-scale ceiling is
+            // a safe upper bound regardless of `runtime.query.max_concurrent_queries`.
+            query_admission_reserve: (0, cores),
         };
         // Register (idempotently) this table's query-observations handle in the
         // process-global registry so the runtime's query tracker can push p99
@@ -670,6 +678,14 @@ impl CayenneContext {
     #[must_use]
     pub(crate) fn live_actuator_values(&self) -> tuning::ActuatorValues {
         self.live_actuators.values()
+    }
+
+    /// Whether closed-loop dynamic tuning is active for this table (an SLO goal is
+    /// set / `cayenne_tuning: adaptive`). Gates the per-tick query-admission reserve
+    /// report so it is a strict no-op for non-adaptive tables.
+    #[must_use]
+    pub(crate) fn dynamic_tuning_enabled(&self) -> bool {
+        self.dynamic_tuning
     }
 
     /// The operator-configured tuning goals (for telemetry/observability — the

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -93,6 +93,7 @@ pub(crate) mod on_conflict;
 pub(crate) mod overwrite;
 pub mod partitioned_wal;
 pub(crate) mod pk_index;
+pub(crate) mod query_admission;
 pub(crate) mod retention;
 pub(crate) mod scan;
 pub(crate) mod sink;
@@ -113,6 +114,7 @@ pub use mem_tier_budget::{
 };
 pub use overwrite::PreparedOverwrite;
 pub use partitioned_wal::{PARTITIONED_WAL_DIR, PartitionedWal, PartitionedWalEntry};
+pub use query_admission::set_query_admission_governor;
 pub use retention::TimeRetentionFilterBuilder;
 pub use scan::CayenneAccelerationExec;
 pub use staging_wal::{CayenneStagedAppend, PreparedStagedAppend};

--- a/crates/cayenne/src/provider/query_admission.rs
+++ b/crates/cayenne/src/provider/query_admission.rs
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Process-global query-admission throttle, driven by the per-table adaptive
+//! CDC controller.
+//!
+//! The runtime already bounds concurrently-executing analytical queries with a
+//! single count-based admission `Semaphore`
+//! (`runtime.query.max_concurrent_queries`). This governor lets the closed-loop
+//! CDC tuner SHED some of that concurrency when a `cdc_durability: memory` table
+//! is behind its freshness / replication-lag SLO **and CPU is the contended
+//! resource** — handing cores back to the CDC apply so it can keep up — then
+//! restore it when the table catches up. Count-based admission (whole queries,
+//! never partitions) is deadlock-safe: a query either runs with all its
+//! parallelism or waits, so throttling can never wedge a partially-admitted plan.
+//!
+//! ## Mechanism: held permits (reversible), NOT `forget_permits`
+//!
+//! The throttle holds live `OwnedSemaphorePermit`s on the SAME `Arc<Semaphore>`
+//! the runtime acquires from: while the governor holds `R` permits, at most
+//! `max - R` queries run concurrently. The query path (`query.rs`) is unchanged —
+//! it just finds fewer permits. Releasing is a `Vec::pop` (drop), which returns
+//! the permit instantly. Growing uses NON-BLOCKING `try_acquire_owned`, grabbing
+//! only what is free right now and converging over later ticks as running queries
+//! finish — it never waits, so a tick can't stall behind a long query.
+//!
+//! This deliberately differs from [`super::write_budget`], which is static
+//! precisely because dynamic resizing there was unsafe: (1) `forget_permits` can
+//! only remove *available* permits and cannot be un-forgotten, and a pending
+//! `acquire_many` clamped to the old cap could stall forever; (2) uncoordinated
+//! per-table controllers mutating one global semaphore would break the
+//! one-bounded-move-per-tick safety design. Held permits sidestep BOTH: they are
+//! fully reversible (drop restores capacity) and never block; and the governor is
+//! the SINGLE mutator — per-table controllers only REPORT their reserve demand,
+//! and the governor reconciles to the MAX across tables (the most-behind table
+//! wins). Each per-table move is one bounded step per tick, so the governor only
+//! ever adjusts its held set by that bounded delta.
+//!
+//! When unset (unit tests, embedders that don't wire it up) every entry point is
+//! a no-op, preserving the prior unbounded behavior.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+
+use parking_lot::Mutex;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+struct QueryAdmissionGovernor {
+    /// The SAME admission semaphore the runtime query path acquires from. Holding
+    /// permits on it reduces what queries can acquire (an `Arc` clone of the
+    /// runtime's handle, so both observe the same available count).
+    semaphore: Arc<Semaphore>,
+    /// The total admission permit count at install time (no queries running yet,
+    /// so it equals the semaphore's capacity). Used only for the `max - 1` clamp
+    /// below, never to resize the semaphore.
+    max: usize,
+    /// Permits currently held to throttle queries. `held.len()` is the live
+    /// reserve; dropping a permit (pop) instantly returns it to the query pool.
+    held: Vec<OwnedSemaphorePermit>,
+    /// Each memory-mode table's current reserve demand (its
+    /// `query_admission_reserve` actuator). The effective reserve is the MAX over
+    /// tables — the most-behind table's demand wins; a caught-up table reporting 0
+    /// never lowers a lagging table's throttle.
+    per_table_demand: HashMap<Arc<str>, usize>,
+}
+
+impl QueryAdmissionGovernor {
+    /// Reconcile `held` to the current demand. Grows with non-blocking
+    /// `try_acquire_owned` (takes only free permits now; converges as queries
+    /// finish) and shrinks by dropping held permits (instant release). Always
+    /// leaves at least one query slot (`max - 1`) so queries are never fully
+    /// starved by the throttle.
+    fn reconcile_held(&mut self) {
+        let demand = self.per_table_demand.values().copied().max().unwrap_or(0);
+        let target = demand.min(self.max.saturating_sub(1));
+        let before = self.held.len();
+        while self.held.len() < target {
+            match Arc::clone(&self.semaphore).try_acquire_owned() {
+                Ok(permit) => self.held.push(permit),
+                // No permit free right now (queries hold them) — stop. A later tick
+                // re-runs this and grabs more as queries release. Never blocks.
+                Err(_) => break,
+            }
+        }
+        while self.held.len() > target {
+            // Drop one held permit → instantly available to queries again.
+            self.held.pop();
+        }
+        if self.held.len() != before {
+            tracing::debug!(
+                target: "cayenne::query_admission",
+                reserved = self.held.len(),
+                target_reserve = target,
+                max = self.max,
+                "Adjusted reserved query-admission permits (CDC-apply throttle)"
+            );
+        }
+    }
+}
+
+/// Process-wide query-admission governor, injected once at startup by the runtime
+/// with the admission semaphore + its permit count. Replaceable so a test binary
+/// that builds and drops multiple runtimes does not retain a stale handle
+/// (replacing drops the old governor, releasing any permits it held).
+static GLOBAL_QUERY_ADMISSION: LazyLock<Mutex<Option<QueryAdmissionGovernor>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+/// Install (or replace) the process-global query-admission governor. Called once
+/// at startup with the runtime's admission `Semaphore` and its permit count
+/// (`max`). At startup no queries are running, so the caller passes
+/// `semaphore.available_permits()` as `max`. A later call replaces the previous
+/// governor, dropping it (and releasing every permit it held).
+pub fn set_query_admission_governor(semaphore: Arc<Semaphore>, max: usize) {
+    let governor = QueryAdmissionGovernor {
+        semaphore,
+        max,
+        held: Vec::new(),
+        per_table_demand: HashMap::new(),
+    };
+    *GLOBAL_QUERY_ADMISSION.lock() = Some(governor);
+}
+
+/// Report `table`'s current query-admission reserve demand (its
+/// `query_admission_reserve` actuator value) to the governor and reconcile the
+/// held permits to the new MAX across all tables. Idempotent and cheap; safe to
+/// call every background tick (the reconcile re-tries any permits that were busy
+/// last time). A no-op when no governor is installed.
+pub(crate) fn set_table_admission_reserve(table: &str, demand: usize) {
+    let mut guard = GLOBAL_QUERY_ADMISSION.lock();
+    let Some(governor) = guard.as_mut() else {
+        return;
+    };
+    // Update in place when the table is already tracked (the steady-state case —
+    // avoids re-allocating the `Arc<str>` key every tick).
+    if let Some(slot) = governor.per_table_demand.get_mut(table) {
+        *slot = demand;
+    } else {
+        governor.per_table_demand.insert(Arc::from(table), demand);
+    }
+    governor.reconcile_held();
+}
+
+/// The number of query-admission permits currently reserved for CDC apply (held
+/// by the governor). `0` when no governor is installed. Test-only accessor; the
+/// live held-count is also emitted by `reconcile_held`'s debug log.
+#[cfg(test)]
+#[must_use]
+pub(crate) fn query_admission_reserved() -> usize {
+    GLOBAL_QUERY_ADMISSION
+        .lock()
+        .as_ref()
+        .map_or(0, |g| g.held.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // One test fn (not several) because the governor is process-global: separate
+    // `#[test]`s run in parallel and would race the single `GLOBAL_QUERY_ADMISSION`.
+    #[test]
+    fn governor_reserves_releases_and_clamps() {
+        let sem = Arc::new(Semaphore::new(4));
+        set_query_admission_governor(Arc::clone(&sem), 4);
+
+        // No demand yet → nothing reserved, all permits available to queries.
+        assert_eq!(query_admission_reserved(), 0);
+        assert_eq!(sem.available_permits(), 4);
+
+        // A behind table demands 2 → 2 held, 2 left for queries.
+        set_table_admission_reserve("order_line", 2);
+        assert_eq!(query_admission_reserved(), 2);
+        assert_eq!(sem.available_permits(), 2);
+
+        // A second, less-behind table: the MAX wins (most-behind table), not the sum.
+        set_table_admission_reserve("stock", 1);
+        assert_eq!(query_admission_reserved(), 2, "max(2,1) = 2, not the sum");
+        assert_eq!(sem.available_permits(), 2);
+
+        // The lagging table catches up (demand 0); the other still wants 1.
+        set_table_admission_reserve("order_line", 0);
+        assert_eq!(query_admission_reserved(), 1, "now max(0,1) = 1");
+        assert_eq!(sem.available_permits(), 3);
+
+        // A huge demand is clamped to max-1 so queries are never fully starved.
+        set_table_admission_reserve("order_line", 100);
+        assert_eq!(query_admission_reserved(), 3, "clamped to max-1 = 3");
+        assert_eq!(sem.available_permits(), 1, "always >= 1 query slot");
+
+        // Everyone caught up → all permits released back to queries.
+        set_table_admission_reserve("order_line", 0);
+        set_table_admission_reserve("stock", 0);
+        assert_eq!(query_admission_reserved(), 0);
+        assert_eq!(sem.available_permits(), 4);
+
+        // Re-install (test-binary semantics): old governor dropped, state cleared.
+        let sem2 = Arc::new(Semaphore::new(2));
+        set_query_admission_governor(Arc::clone(&sem2), 2);
+        assert_eq!(query_admission_reserved(), 0);
+        assert_eq!(
+            sem.available_permits(),
+            4,
+            "old semaphore's held permits freed"
+        );
+    }
+}

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -7169,6 +7169,20 @@ impl CayenneTableProvider {
         let apply_epoch = self
             .mem_tier_apply_epoch
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        // Reserve ONE (delete, data) sequence pair for the WHOLE apply, here under
+        // `write_lock` (the caller holds it for the entire apply), and share it
+        // across every shard's append below. The shards' key spaces are disjoint
+        // (PK-sharded), so a single `delete < data` point is correct for all of
+        // them. Pulling this `.await` OUT of each shard's publish lock is the
+        // pipelining that makes `append_to_shard` synchronous while it holds that
+        // lock — the property the off-`write_lock` checkpoint relies on to clear
+        // the shard tiers without deadlocking a concurrent apply. `write_lock`
+        // serializes this reservation against the checkpoint capture's
+        // snapshot-sequence reservation (the capture also takes `write_lock` at
+        // N>1), so the publish lock is not needed for the ordering here. Bonus: it
+        // cuts the per-apply metastore seq reservations from 2N to 2.
+        let base_sequence = self.reserve_sequences_local(2).await?;
+        let reserved_sequences = (base_sequence, base_sequence + 1);
         let append_futures = per_shard_validated.iter().enumerate().filter_map(
             |(s, (filtered_batches, deletions, kept))| {
                 let has_rows = filtered_batches.iter().any(|b| b.num_rows() > 0);
@@ -7187,6 +7201,7 @@ impl CayenneTableProvider {
                     kept,
                     // Upsert path: maintained-aggregate retraction is DELETE-driven.
                     None,
+                    Some(reserved_sequences),
                 ))
             },
         );
@@ -15620,6 +15635,10 @@ impl CayenneTableProvider {
             let apply_epoch = self
                 .mem_tier_apply_epoch
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // One shared (delete, data) pair, reserved here under `write_lock` and
+            // passed in so the shard append's lock-held region stays synchronous
+            // (see `validate_and_append_sharded` / `append_to_shard`).
+            let base_sequence = self.reserve_sequences_local(2).await?;
             let no_keys: HashSet<OwnedRow> = HashSet::new();
             self.append_to_shard(
                 0,
@@ -15630,6 +15649,7 @@ impl CayenneTableProvider {
                 Some(apply_epoch),
                 &no_keys,
                 None,
+                Some((base_sequence, base_sequence + 1)),
             )
             .await?;
             return Ok(apply_epoch);
@@ -15668,6 +15688,12 @@ impl CayenneTableProvider {
         let apply_epoch = self
             .mem_tier_apply_epoch
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        // One shared (delete, data) pair for the whole apply, reserved here under
+        // `write_lock` and passed into every shard's append so each shard's
+        // publish-lock-held region is synchronous — the property the off-`write_lock`
+        // checkpoint relies on (see `validate_and_append_sharded`).
+        let base_sequence = self.reserve_sequences_local(2).await?;
+        let reserved_sequences = (base_sequence, base_sequence + 1);
         let no_keys: HashSet<OwnedRow> = HashSet::new();
         let append_futures = per_shard
             .iter()
@@ -15686,6 +15712,7 @@ impl CayenneTableProvider {
                     &no_keys,
                     // N>1 sharded delete: no maintained-aggregate retraction (see append_to_shard).
                     None,
+                    Some(reserved_sequences),
                 ))
             });
         futures::future::try_join_all(append_futures).await?;
@@ -15938,6 +15965,10 @@ impl CayenneTableProvider {
             None,
             &no_keys,
             maintained_aggregate_delete_rows,
+            // N=1 / legacy path: reserve the (delete, data) pair under the publish
+            // lock inside `append_to_shard` (the N=1 checkpoint takes no write_lock,
+            // so that lock is what serializes it against the checkpoint).
+            None,
         )
         .await
     }
@@ -15977,6 +16008,21 @@ impl CayenneTableProvider {
         // — so a maintained aggregate over an N>1 table does not retract on the
         // sharded path (a known limit of the opt-in N>1 path).
         maintained_aggregate_delete_rows: Option<&RecordBatch>,
+        // Pre-reserved `(delete_sequence, data_sequence)` pair for this apply, or
+        // `None` to reserve it here under the publish lock. `Some` ONLY on the N>1
+        // sharded callers (`validate_and_append_sharded` /
+        // `append_delete_intents_sharded`), which reserve ONE pair per apply up
+        // front under `write_lock` and share it across all shards (their key spaces
+        // are disjoint, so one `delete < data` point is correct). Passing it in
+        // keeps this lock-held region fully SYNCHRONOUS — no `reserve_sequences_local`
+        // `.await` while holding the publish lock — which is what lets the
+        // off-`write_lock` checkpoint clear take the shard locks without deadlocking
+        // a concurrent apply (a lock held across the reserve-await was the
+        // apply-vs-clear cycle). `None` on the N=1 / legacy callers reserves under
+        // the lock exactly as before (byte-identical: at N=1 the checkpoint takes no
+        // `write_lock`, so this lock is the only thing serializing the reservation
+        // against the checkpoint's snapshot-sequence reservation).
+        reserved_sequences: Option<(i64, i64)>,
     ) -> Result<u64> {
         // INVARIANT: at N>1 every mem-tier append MUST carry a `source_position` (the
         // per-apply `apply_epoch` slot-ack axis). A `None`-stamped append on a sharded
@@ -16045,17 +16091,30 @@ impl CayenneTableProvider {
             );
             let fence_work_start = Instant::now();
 
-            // Reserve the (delete, data) pair INSIDE the publish lock: append
-            // sequence assignment must be mutually exclusive with a checkpoint's
-            // snapshot-sequence reservation — see the capture block in
-            // `checkpoint_mem_tier` for the full ordering invariant (an
-            // unserialized reserve permanently over-counts). Both the append and
-            // the checkpoint capture now reserve under THIS lock (no longer the
-            // listing fence). delete below data so new rows survive their own
-            // tombstones; shared durable allocator for monotonicity.
-            let base_sequence = self.reserve_sequences_local(2).await?;
-            let delete_sequence = base_sequence;
-            let data_sequence = base_sequence + 1;
+            // Sequence assignment. `delete` below `data` so new rows survive their
+            // own tombstones; the shared durable allocator keeps one monotone domain.
+            //
+            // `None` (N=1 / legacy callers): reserve the (delete, data) pair HERE,
+            // INSIDE the publish lock. The N=1 checkpoint takes no `write_lock`, so
+            // this lock is the ONLY thing serializing this reservation against the
+            // checkpoint's snapshot-sequence reservation (both reserve under it) —
+            // an unserialized reserve permanently over-counts (§2.3d). This `.await`
+            // under the lock is harmless at N=1: there is exactly one publish lock,
+            // so no cross-lock hold-and-wait can form.
+            //
+            // `Some` (N>1 sharded callers): the pair was reserved ONCE for the whole
+            // apply under `write_lock`. At N>1 `write_lock` already excludes the
+            // checkpoint capture (which also takes `write_lock`), so the publish lock
+            // is not needed to serialize the reservation — and NOT awaiting here is
+            // what keeps the lock-held region synchronous, so an append never holds a
+            // publish lock across an await and the off-`write_lock` checkpoint clear
+            // cannot deadlock it.
+            let (delete_sequence, data_sequence) = if let Some(pair) = reserved_sequences {
+                pair
+            } else {
+                let base_sequence = self.reserve_sequences_local(2).await?;
+                (base_sequence, base_sequence + 1)
+            };
             // STAMP the off-lock-built key set with the reserved delete sequence
             // (O(1) — only the scalar is set; the keys were built off-lock). This
             // is the single sequence applied to EVERY superseded key in this apply
@@ -16295,16 +16354,28 @@ impl CayenneTableProvider {
         // covers rows never captured.
         let n = self.mem_tier.shard_count();
         let capture_start = Instant::now();
-        // LOAD-BEARING: at N>1 `write_lock` is held across the WHOLE checkpoint
-        // (capture + off-fence encode + commit + clear), NOT just the capture.
-        // Scoping it to the capture alone (releasing before the encode) DEADLOCKED
-        // under sustained N>1 load — a concurrent apply racing the checkpoint's clear
-        // hung spiced after ~57 checkpoints in the SF-100 N=4 run (20-min log silence,
-        // health endpoint dead). So this serialization is required for deadlock-safety.
-        // It does NOT cause the WAL-drain stall: with this hold in place, checkpoints
-        // still fire ~57× yet the source slot does not advance — the real stall is
-        // downstream in the slot-ack watermark (under investigation), not here.
-        let _capture_write_guard = if acquire_write_lock_for_capture && n > 1 {
+        // At N>1 the capture takes `write_lock` so it observes an apply's N shard
+        // appends as all-or-none (the torn-capture guard above). It is held ONLY for
+        // the capture and RELEASED before the off-fence encode (see the drop after
+        // the capture timer below), so concurrent CDC applies run IN PARALLEL with
+        // the durable encode — the off-`write_lock` checkpoint that lets the heavy
+        // tables (order_line/stock) keep draining at N>1 instead of stalling behind
+        // every checkpoint's encode.
+        //
+        // A prior attempt to release here DEADLOCKED: a concurrent apply held a shard
+        // publish lock across its `reserve_sequences_local().await` while the clear
+        // walked the shard locks in index order → a cross-lock cycle. That is now
+        // structurally impossible — the sharded apply reserves its (delete, data)
+        // pair ONCE up front (under `write_lock`) and passes it down, so
+        // `append_to_shard` holds a publish lock only for a synchronous swap, never
+        // across an await (see `validate_and_append_sharded` / `append_to_shard`).
+        // With no lock-across-await on the apply side, the clear's index-order
+        // acquisition cannot form a cycle with an apply.
+        //
+        // When the caller already holds `write_lock` (the inline-spill / `evolve_schema`
+        // path, `acquire_write_lock_for_capture == false`), this is `None` and the
+        // caller's lock correctly stays held through the whole checkpoint.
+        let mut capture_write_guard = if acquire_write_lock_for_capture && n > 1 {
             Some(self.write_lock.lock().await)
         } else {
             None
@@ -16393,17 +16464,24 @@ impl CayenneTableProvider {
             )
         };
         // The all-shards-atomic capture window: the per-shard snapshot load +
-        // sequence reservation under the publish locks. At N>1 `write_lock` is held
-        // from before this span through the WHOLE checkpoint (capture + encode +
-        // commit — see the LOAD-BEARING note above; the encode is NOT off-write_lock
-        // here), so this metric isolates the CAPTURE portion of that hold. The encode
-        // portion is `mem_tier_checkpoint` (total) minus this; comparing the two
-        // localizes a per-checkpoint apply-stall to the capture vs the encode.
+        // sequence reservation under the publish locks (and `write_lock` at N>1).
+        // The encode/commit below run OUTSIDE this window, so this metric isolates
+        // the CAPTURE portion; the encode portion is `mem_tier_checkpoint` (total)
+        // minus this.
         record_cayenne_write_phase(
             &self.table_metadata.table_name,
             "mem_tier_checkpoint_capture",
             capture_start,
         );
+        // Capture complete — RELEASE `write_lock` before the off-fence encode/commit
+        // so concurrent applies proceed IN PARALLEL with the durable encode (the
+        // off-`write_lock` checkpoint). Everything below reads only the immutable
+        // captured `shard_snapshots`/`snapshot` (Arc clones) and the already-reserved
+        // `snapshot_sequence`, which pins the ordering invariant — a post-capture
+        // apply reserves strictly above it and its new segment is preserved by the
+        // clear's `retain_after`. A no-op when the caller holds `write_lock`
+        // (spill/evolve): `capture_write_guard` is None.
+        drop(capture_write_guard.take());
         // Emptiness must be judged on the REAL captured shard snapshots, not the
         // synthetic union view: `union_snapshot_view` carries the cross-shard
         // tombstone union + the summed byte/row counts but ALWAYS has empty
@@ -20759,6 +20837,20 @@ impl super::compaction::CompactionRunner for CayenneTableProvider {
                 "Cayenne dynamic auto-tune adjustment applied",
             );
         }
+
+        // Report this table's query-admission reserve demand to the process-global
+        // governor EVERY tick (not only when `retune` moved it): the governor holds
+        // permits on the shared admission semaphore to shed concurrent queries when
+        // this table is behind under CPU contention, and it converges its held set
+        // over ticks as running queries free permits — so it must see the current
+        // demand each tick. Gated on dynamic tuning so it is a strict no-op for
+        // non-adaptive tables (and a no-op when no governor is installed).
+        if self.context.dynamic_tuning_enabled() {
+            super::query_admission::set_table_admission_reserve(
+                table.as_str(),
+                self.context.live_actuator_values().query_admission_reserve,
+            );
+        }
     }
 
     fn background_interval_hint(&self) -> Option<std::time::Duration> {
@@ -24518,6 +24610,140 @@ mod tests {
                 "shard {s} drained by the background tick at N>1"
             );
         }
+    }
+
+    /// REGRESSION + STRESS (off-`write_lock` N>1 checkpoint — the apply-vs-clear
+    /// deadlock). The checkpoint releases `write_lock` right after the all-shards
+    /// capture, so a concurrent CDC apply runs IN PARALLEL with the off-fence
+    /// encode and the per-shard clear. The clear walks the shard publish locks in
+    /// index order while an apply takes those same locks via its fan-out. What makes
+    /// that safe is the PIPELINED sequence reservation: the sharded apply reserves
+    /// its `(delete, data)` pair ONCE up front (under `write_lock`) and passes it
+    /// down, so `append_to_shard` holds a publish lock only for a synchronous swap —
+    /// never across an `.await`. If an append held a lock across its
+    /// `reserve_sequences_local().await` (the pre-pipeline shape) it would form a
+    /// cross-lock cycle with the clear's index-order walk and hang spiced (the
+    /// SF-100 N=4 ~57-checkpoint deadlock). This test hammers a sharded (N=4) table
+    /// with concurrent writers while a checkpoint loop drains it, all under a
+    /// timeout: a deadlock hangs and trips the timeout. It also asserts LWW
+    /// correctness (disjoint per-writer key ranges — latest round wins, identical to
+    /// a serial run) and that the tier fully drains + the slot advances to the final
+    /// apply epoch despite the concurrent clears.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sharded_cdc_concurrent_applies_and_checkpoint_no_deadlock() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        const N: usize = 4;
+        const WRITERS: i64 = 4;
+        const ROUNDS: i64 = 40;
+        const KEYS_PER_WRITER: i64 = 8;
+
+        let ctx = SessionContext::new();
+        let runtime_env = ctx.runtime_env();
+        let (provider, _catalog, _tmp) =
+            create_sharded_cdc_upsert_table("concurrent_ckpt_n4", Arc::clone(&runtime_env), N)
+                .await;
+        let provider = Arc::new(provider);
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        let durable = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        provider.install_slot_advancer(Arc::new(EpochRecorder(Arc::clone(&durable))));
+
+        // Background checkpoint loop: fire the production drain trigger repeatedly so
+        // a checkpoint's off-fence encode/clear overlaps the writers' applies — the
+        // exact window the fix must keep deadlock-free. Stops when the writers do.
+        let stop = Arc::new(AtomicBool::new(false));
+        let ckpt = {
+            let provider = Arc::clone(&provider);
+            let stop = Arc::clone(&stop);
+            tokio::spawn(async move {
+                while !stop.load(Ordering::Relaxed) {
+                    provider.run_mem_tier_checkpoint_tick().await;
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        // Concurrent writers, each on a DISJOINT key range so the converged state is
+        // deterministic regardless of interleaving: every key is written by exactly
+        // one writer and that writer's rounds are sequential, so the latest round
+        // (highest sequence) is the LWW winner. Writers still collide on shards and
+        // race the checkpoint clear — the contention the fix targets.
+        let writers: Vec<_> = (0..WRITERS)
+            .map(|w| {
+                let provider = Arc::clone(&provider);
+                let schema = Arc::clone(&schema);
+                let ctx = ctx.clone();
+                tokio::spawn(async move {
+                    let mut max_epoch = 0_u64;
+                    for r in 0..ROUNDS {
+                        let rows: Vec<(i64, i64)> =
+                            (0..KEYS_PER_WRITER).map(|i| (w * 1000 + i, r)).collect();
+                        if let Some(e) =
+                            apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), &rows).await
+                        {
+                            max_epoch = max_epoch.max(e);
+                        }
+                    }
+                    max_epoch
+                })
+            })
+            .collect();
+
+        // A deadlock would hang in `join_all`; the timeout turns that into a clear,
+        // non-flaky failure (the fix can only ever pass — no deadlock is reachable).
+        let results = tokio::time::timeout(
+            std::time::Duration::from_mins(1),
+            futures::future::join_all(writers),
+        )
+        .await
+        .expect(
+            "concurrent applies + checkpoint deadlocked at N>1 — the apply-vs-clear cycle \
+             (a publish lock held across the reserve-await racing the clear's index-order walk)",
+        );
+        let global_max_epoch = results
+            .into_iter()
+            .map(|r| r.expect("writer task panicked"))
+            .max()
+            .expect("at least one writer");
+        assert!(
+            global_max_epoch > 0,
+            "the writers actually applied to the tier"
+        );
+
+        // Stop the checkpoint loop, then drain whatever is still resident.
+        stop.store(true, Ordering::Relaxed);
+        ckpt.await.expect("checkpoint loop task panicked");
+        provider
+            .checkpoint_mem_tier()
+            .await
+            .expect("final drain checkpoint");
+
+        // The tier fully drained and the slot advanced to the final apply epoch — the
+        // WAL-drain property holds even with applies racing the clears.
+        for s in 0..N {
+            assert!(
+                provider.mem_tier.shard(s).load().is_empty(),
+                "shard {s} fully drained after the final checkpoint"
+            );
+        }
+        assert_eq!(
+            durable.load(Ordering::SeqCst),
+            global_max_epoch,
+            "the slot must advance to the latest apply epoch once everything is durable",
+        );
+
+        // LWW correctness: every key shows its LAST round's value (ROUNDS-1),
+        // identical to a serial run — no apply was lost or reordered by a concurrent
+        // checkpoint/clear, and the shared per-apply sequence pair preserved ordering.
+        let mut expected: Vec<(i64, i64)> = (0..WRITERS)
+            .flat_map(|w| (0..KEYS_PER_WRITER).map(move |i| (w * 1000 + i, ROUNDS - 1)))
+            .collect();
+        expected.sort_unstable();
+        assert_eq!(
+            collect_id_value_pairs(&ctx, &provider, "concurrent_ckpt_n4").await,
+            expected,
+            "concurrent sharded applies under a checkpoint loop converge to the serial LWW result",
+        );
     }
 
     /// REGRESSION (SF-100 N=4 WAL-drain stall, ROOT CAUSE). The `!pending_pk_deletions`

--- a/crates/cayenne/src/provider/tuning.rs
+++ b/crates/cayenne/src/provider/tuning.rs
@@ -4652,7 +4652,7 @@ mod tests {
     /// The query-admission reserve is BUDGETED by the query SLOs: the CDC apply may
     /// borrow query cores while QPH (and query-latency) have headroom, but not
     /// through their targets — exactly "QPH target met + lag missed ⇒ redirect
-    /// resources to ingest, but only down to the QPH floor." QPH is HigherBetter, so
+    /// resources to ingest, but only down to the QPH floor." QPH is `HigherBetter`, so
     /// against a 1000 target: comfortably met at ≥1500 (headroom), violated at <800.
     #[test]
     fn query_admission_reserve_is_budgeted_by_the_query_slos() {

--- a/crates/cayenne/src/provider/tuning.rs
+++ b/crates/cayenne/src/provider/tuning.rs
@@ -1849,19 +1849,41 @@ impl Goals {
     }
 
     /// Are the ingest-side goals (replication-lag + freshness) comfortably met?
-    /// The RELEASE gate for the query-admission reserve. That lever throttles
-    /// QUERIES, so its release must key on the INGEST goals (+ CPU), NEVER the
-    /// query-latency/QPH goals: gating release on a query goal being met would
-    /// self-perpetuate — the reserve suppresses queries, keeping query latency
-    /// high, so the query goal would never read "met" and the reserve would never
-    /// release. Keyed on lag/freshness, the reserve unwinds the moment its
-    /// justification (CDC behind) is gone.
+    /// One of the RELEASE triggers for the query-admission reserve — the reserve's
+    /// justification (CDC behind) is gone, so hand the query slots back.
+    ///
+    /// The reserve's release must NEVER be gated on a query goal being MET: the
+    /// reserve suppresses queries, so a query goal (QPH/latency) could stay below
+    /// "met" *because of the throttle itself*, and the reserve would never release
+    /// (self-perpetuation). Releasing on a query goal being VIOLATED is the OPPOSITE
+    /// direction and is safe — see [`Self::query_comfortably_met`] and the release
+    /// tier — because throttling moves a query goal TOWARD violation, so
+    /// "release on violated" is a stable negative-feedback brake, not a latch.
     fn ingest_comfortably_met(self, s: &IngestSnapshot) -> bool {
         self.replication_lag
             .is_none_or(|g| g.comfortably_met(s.replication_lag_secs))
             && self
                 .freshness
                 .is_none_or(|g| g.comfortably_met(s.freshness_secs))
+    }
+
+    /// Are the query-side goals (query-latency-p99 + QPH) comfortably met? The
+    /// HEADROOM gate for GROWING the query-admission reserve. That lever sheds
+    /// analytical queries to hand cores to the CDC apply, trading query throughput
+    /// for ingest freshness — so it should only spend query capacity it demonstrably
+    /// HAS: grow the reserve while the query SLOs sit comfortably above target, and
+    /// stop once throttling has consumed that headroom. This makes the query SLOs
+    /// the reserve's BUDGET — the apply may borrow query cores down to (but not
+    /// through) the QPH/latency targets. `None` (unset) query goals read as
+    /// comfortably met, so with no query SLO configured the reserve grows purely on
+    /// the ingest+CPU signals (the prior behavior). Safe as a GROW gate — it only
+    /// makes throttling LESS aggressive, never a latch: the self-perpetuation trap
+    /// on [`Self::ingest_comfortably_met`] is specific to gating RELEASE on a query
+    /// goal being met; this gates GROW, the opposite move.
+    fn query_comfortably_met(self, s: &IngestSnapshot) -> bool {
+        self.query_latency_p99
+            .is_none_or(|g| g.comfortably_met(s.query_latency_p99_ms))
+            && self.qph.is_none_or(|g| g.comfortably_met(s.qph))
     }
 }
 
@@ -2349,25 +2371,42 @@ fn decide_goal(
         );
     let mutation_heavy = s.delete_fraction > MUTATION_HEAVY_FRACTION;
 
-    // (1b) Release the query-admission reserve as soon as its justification is
-    // gone: CPU is no longer contended (nothing to relieve), OR the lag/freshness
-    // goal is comfortably met (the apply has caught up). Checked BEFORE the query
-    // and ingest tiers — handing query slots back is high priority — and keyed on
-    // the INGEST goal + CPU, NEVER the query goal (see `ingest_comfortably_met`):
-    // the reserve suppresses queries, so gating its release on a query goal would
-    // self-perpetuate. Fast handback (legacy ±⅓ step); the bound floor is 0.
+    // (1b) Release the query-admission reserve as soon as its justification is gone
+    // OR it has overshot a query SLO. Three triggers, all safe/stable:
+    //   - CPU no longer contended (`cpu_ok`) — shedding queries can't help the apply
+    //     if CPU isn't the bottleneck, so nothing to relieve;
+    //   - the ingest goal is comfortably met (`ingest_comfortably_met`) — the apply
+    //     caught up, the reserve's whole reason is gone;
+    //   - a query SLO (QPH or query-latency) is now VIOLATED (`query_violated`) — the
+    //     throttle has borrowed too much query capacity and pushed a query goal past
+    //     target, so back off. This is the QUERY-SLO BRAKE: throttling moves QPH/
+    //     latency toward violation, so releasing ON violation is stable negative
+    //     feedback (never a latch). It is NOT the self-perpetuation trap documented
+    //     on `ingest_comfortably_met` — that prohibits releasing on a query goal
+    //     being MET; braking on VIOLATED is the opposite, safe direction.
+    // Checked BEFORE the query and ingest tiers — handing query slots back (and
+    // honoring the query SLOs) is high priority. Fast handback (legacy ±⅓ step);
+    // the bound floor is 0.
     if cur.query_admission_reserve > 0
-        && (cpu_ok || goals.ingest_comfortably_met(s))
+        && (cpu_ok || goals.ingest_comfortably_met(s) || query_violated)
         && let Some(v) = clamp_move_usize(
             cur.query_admission_reserve,
             shrink_usize(cur.query_admission_reserve),
             b.query_admission_reserve,
         )
     {
+        // Attribute the release: a query-SLO overshoot is the interesting case (the
+        // throttle traded away too much), distinct from the reserve simply no longer
+        // being needed.
+        let reason = if query_violated {
+            "query SLO (QPH/latency) at target — stop borrowing query capacity: release a reserved query-admission slot"
+        } else {
+            "CPU uncontended or ingest goal met: release a reserved query-admission slot"
+        };
         return Some(Adjustment {
             actuator: Actuator::QueryAdmissionReserve,
             new_value: u64::try_from(v).unwrap_or(0),
-            reason: "CPU uncontended or lag goal met: release a reserved query-admission slot",
+            reason,
         });
     }
 
@@ -2554,15 +2593,27 @@ fn decide_goal(
                 reason: "replication-lag goal: compact more to keep the snapshot lean",
             });
         }
-        // CPU is the contended resource and ingest is behind: shed concurrent
-        // analytical queries to hand cores back to the CDC apply. The complement of
-        // the CPU-gated levers above — raising write shards and compacting more are
-        // WITHHELD under CPU contention (`cpu_ok`), so when queries are what's
-        // starving the apply, admitting fewer of them is the only lever left.
-        // Released again by tier (1b) the moment CPU frees or the lag goal is met.
-        // Bounded step like every other goal move; the governor re-clamps the
-        // reported demand to the real admission pool's `max - 1`.
+        // CPU is the contended resource, ingest is behind, AND the query SLOs have
+        // headroom to spend: shed concurrent analytical queries to hand cores back to
+        // the CDC apply. Three conjuncts:
+        //   - `!cpu_ok` — shedding queries only helps when CPU is the contention (the
+        //     complement of the CPU-gated levers above: raising write shards and
+        //     compacting more are WITHHELD under contention, so admitting fewer
+        //     queries is the only lever left);
+        //   - `ingest_violated` (this tier's guard) — there is a lag/freshness goal to
+        //     serve;
+        //   - `query_comfortably_met` — the query SLOs (QPH + query-latency) sit
+        //     comfortably above target, so we can borrow query capacity WITHOUT
+        //     breaching them. This makes the query SLOs the reserve's BUDGET: the apply
+        //     borrows query cores down to (not through) the QPH/latency targets, and
+        //     tier (1b) brakes the moment throttling pushes a query goal to violation.
+        //     Exactly the "QPH target met + lag target missed ⇒ redirect resources to
+        //     ingest" trade — and, since unset query goals read as met, a strict no-op
+        //     versus the prior ingest+CPU-only behavior when no query SLO is configured.
+        // Bounded step like every other goal move; the governor re-clamps the reported
+        // demand to the real admission pool's `max - 1`.
         if !cpu_ok
+            && goals.query_comfortably_met(s)
             && let Some(v) = clamp_move_usize(
                 cur.query_admission_reserve,
                 goal_grow_usize(
@@ -2576,7 +2627,7 @@ fn decide_goal(
             return Some(Adjustment {
                 actuator: Actuator::QueryAdmissionReserve,
                 new_value: u64::try_from(v).unwrap_or(0),
-                reason: "replication-lag goal under CPU contention: reserve query-admission slots for CDC apply (shed concurrent analytical queries)",
+                reason: "ingest goal behind under CPU contention with query-SLO headroom: reserve query-admission slots for CDC apply (shed concurrent analytical queries)",
             });
         }
     }
@@ -4595,6 +4646,107 @@ mod tests {
         assert!(
             (adj.new_value as usize) < 3,
             "released once the lag goal is met"
+        );
+    }
+
+    /// The query-admission reserve is BUDGETED by the query SLOs: the CDC apply may
+    /// borrow query cores while QPH (and query-latency) have headroom, but not
+    /// through their targets — exactly "QPH target met + lag missed ⇒ redirect
+    /// resources to ingest, but only down to the QPH floor." QPH is HigherBetter, so
+    /// against a 1000 target: comfortably met at ≥1500 (headroom), violated at <800.
+    #[test]
+    fn query_admission_reserve_is_budgeted_by_the_query_slos() {
+        // freshness goal 5s + QPH goal 1000.
+        let goals =
+            Goals::from_targets(None, Some(5.0), None, Some(1000.0), Duration::from_mins(1));
+        let b = bounds();
+        // Higher-priority ingest buffers already maxed, so the reserve is the lever
+        // in play (mirrors the sibling test's setup).
+        let buffers_maxed = ActuatorValues {
+            inline_flush_max_bytes: b.inline_flush_max_bytes.1,
+            mem_tier_max_bytes: b.mem_tier_max_bytes.1,
+            ..actuators()
+        };
+
+        // GROW: freshness behind (60s) + CPU contended (0.95) + QPH comfortably met
+        // (1600 ≥ 1.5×1000 ⇒ headroom) ⇒ shed queries for the apply. The exact
+        // "hitting QPH, missing lag ⇒ redirect to ingest" case.
+        let behind_qph_headroom = IngestSnapshot {
+            freshness_secs: Some(60.0),
+            cpu_pressure: Some(0.95),
+            qph: Some(1600.0),
+            ..snap()
+        };
+        let adj = decide_with_goals(
+            &behind_qph_headroom,
+            &buffers_maxed,
+            &b,
+            ms(60_000),
+            ms(30_000),
+            0,
+            &goals,
+        )
+        .expect("lag behind + CPU contended + QPH headroom ⇒ reserve query slots");
+        assert_eq!(adj.actuator, Actuator::QueryAdmissionReserve);
+        assert!(
+            adj.new_value > 0,
+            "grows while QPH has headroom (got {})",
+            adj.new_value
+        );
+
+        // HOLD (headroom spent): same lag + CPU, but QPH now in the deadband
+        // (1100: 0.8×1000=800 ≤ 1100 < 1.5×1000=1500 ⇒ neither met nor violated).
+        // The reserve must NOT keep growing — that would eat into the QPH SLO.
+        let behind_qph_deadband = IngestSnapshot {
+            freshness_secs: Some(60.0),
+            cpu_pressure: Some(0.95),
+            qph: Some(1100.0),
+            ..snap()
+        };
+        let adj = decide_with_goals(
+            &behind_qph_deadband,
+            &buffers_maxed,
+            &b,
+            ms(60_000),
+            ms(30_000),
+            0,
+            &goals,
+        );
+        assert!(
+            !matches!(adj, Some(a) if a.actuator == Actuator::QueryAdmissionReserve && a.new_value > 0),
+            "must NOT grow the reserve once QPH headroom is spent (got {adj:?})"
+        );
+
+        // BRAKE (QPH violated): a reserve is held, lag still behind, CPU still
+        // contended — but throttling has pushed QPH below target (700 < 0.8×1000=800
+        // ⇒ violated). Tier (1b) releases to stop borrowing past the QPH SLO, and
+        // wins over the query-health tier. This is the safe direction (release ON
+        // violated), NOT the self-perpetuation trap (release on met).
+        let reserve_held = ActuatorValues {
+            query_admission_reserve: 3,
+            ..actuators()
+        };
+        let behind_qph_violated = IngestSnapshot {
+            freshness_secs: Some(60.0),
+            cpu_pressure: Some(0.95),
+            qph: Some(700.0),
+            ..snap()
+        };
+        let adj = decide_with_goals(
+            &behind_qph_violated,
+            &reserve_held,
+            &b,
+            ms(60_000),
+            ms(30_000),
+            0,
+            &goals,
+        )
+        .expect("QPH violated ⇒ release to honor the query SLO");
+        assert_eq!(adj.actuator, Actuator::QueryAdmissionReserve);
+        assert!(
+            (adj.new_value as usize) < 3,
+            "released to stop breaching the QPH SLO (got {})",
+            adj.new_value
         );
     }
 

--- a/crates/cayenne/src/provider/tuning.rs
+++ b/crates/cayenne/src/provider/tuning.rs
@@ -1205,6 +1205,13 @@ pub(crate) struct LiveActuators {
     /// per-file stats and compression for scans, less fan-out to probe), bounded
     /// by the static config (storage-tier-aware). `<= 0` keeps size-rolling off.
     target_vortex_file_size_bytes: AtomicI64,
+    /// Query-admission permits to reserve for CDC apply (the CPU-fairness lever).
+    /// Reported each background tick to the process-global query-admission
+    /// governor, which holds that many permits on the shared admission semaphore so
+    /// that many fewer analytical queries run concurrently — handing CPU back to
+    /// the apply when it is behind under contention. `0` (the default) reserves
+    /// nothing, so the lever is inert unless a lag/freshness goal drives it up.
+    query_admission_reserve: AtomicUsize,
     /// Observed bytes-per-row, seeded from the initial (schema-aware) config and
     /// then *relearned* from live ingest (EWMA bytes ÷ rows) so the row cap a byte
     /// budget implies tracks the table's real row width — not a stale static
@@ -1233,6 +1240,7 @@ impl LiveActuators {
             write_concurrency: AtomicUsize::new(init.write_concurrency),
             mem_tier_max_bytes: AtomicI64::new(init.mem_tier_max_bytes),
             target_vortex_file_size_bytes: AtomicI64::new(init.target_vortex_file_size_bytes),
+            query_admission_reserve: AtomicUsize::new(init.query_admission_reserve),
             bytes_per_row: AtomicI64::new(
                 (init.inline_flush_max_bytes / init.inline_flush_max_rows.max(1)).max(1),
             ),
@@ -1258,6 +1266,7 @@ impl LiveActuators {
             target_vortex_file_size_bytes: self
                 .target_vortex_file_size_bytes
                 .load(Ordering::Relaxed),
+            query_admission_reserve: self.query_admission_reserve.load(Ordering::Relaxed),
         }
     }
 
@@ -1348,6 +1357,12 @@ impl LiveActuators {
                     Ordering::Relaxed,
                 );
             }
+            Actuator::QueryAdmissionReserve => {
+                self.query_admission_reserve.store(
+                    usize::try_from(adj.new_value).unwrap_or(usize::MAX),
+                    Ordering::Relaxed,
+                );
+            }
         }
     }
 }
@@ -1364,6 +1379,7 @@ pub(crate) struct ActuatorValues {
     pub write_concurrency: usize,
     pub mem_tier_max_bytes: i64,
     pub target_vortex_file_size_bytes: i64,
+    pub query_admission_reserve: usize,
 }
 
 /// Static `[floor, ceiling]` per dynamically-tuned actuator, derived by the static
@@ -1378,6 +1394,7 @@ pub(crate) struct TuningBounds {
     pub write_concurrency: (usize, usize),
     pub mem_tier_max_bytes: (i64, i64),
     pub target_vortex_file_size_bytes: (i64, i64),
+    pub query_admission_reserve: (usize, usize),
 }
 
 // ---------------------------------------------------------------------------
@@ -1394,6 +1411,13 @@ pub(crate) enum Actuator {
     BakeDeletionIndexTrigger,
     WriteConcurrency,
     TargetVortexFileSize,
+    /// Number of query-admission permits to RESERVE for CDC apply (shed that many
+    /// concurrent analytical queries). The CPU-fairness lever: GROWN when a
+    /// lag/freshness goal is unmet AND CPU is the contended resource (queries are
+    /// starving the apply); RELEASED as soon as CPU frees or the lag goal is met.
+    /// Reported to the process-global [`super::query_admission`] governor, which
+    /// holds that many permits on the shared admission semaphore.
+    QueryAdmissionReserve,
 }
 
 impl Actuator {
@@ -1408,6 +1432,7 @@ impl Actuator {
             Self::BakeDeletionIndexTrigger => "bake_deletion_index_trigger",
             Self::WriteConcurrency => "write_concurrency",
             Self::TargetVortexFileSize => "target_vortex_file_size_bytes",
+            Self::QueryAdmissionReserve => "query_admission_reserve",
         }
     }
 }
@@ -1821,6 +1846,22 @@ impl Goals {
                 .query_latency_p99
                 .is_none_or(|g| g.comfortably_met(s.query_latency_p99_ms))
             && self.qph.is_none_or(|g| g.comfortably_met(s.qph))
+    }
+
+    /// Are the ingest-side goals (replication-lag + freshness) comfortably met?
+    /// The RELEASE gate for the query-admission reserve. That lever throttles
+    /// QUERIES, so its release must key on the INGEST goals (+ CPU), NEVER the
+    /// query-latency/QPH goals: gating release on a query goal being met would
+    /// self-perpetuate — the reserve suppresses queries, keeping query latency
+    /// high, so the query goal would never read "met" and the reserve would never
+    /// release. Keyed on lag/freshness, the reserve unwinds the moment its
+    /// justification (CDC behind) is gone.
+    fn ingest_comfortably_met(self, s: &IngestSnapshot) -> bool {
+        self.replication_lag
+            .is_none_or(|g| g.comfortably_met(s.replication_lag_secs))
+            && self
+                .freshness
+                .is_none_or(|g| g.comfortably_met(s.freshness_secs))
     }
 }
 
@@ -2308,6 +2349,28 @@ fn decide_goal(
         );
     let mutation_heavy = s.delete_fraction > MUTATION_HEAVY_FRACTION;
 
+    // (1b) Release the query-admission reserve as soon as its justification is
+    // gone: CPU is no longer contended (nothing to relieve), OR the lag/freshness
+    // goal is comfortably met (the apply has caught up). Checked BEFORE the query
+    // and ingest tiers — handing query slots back is high priority — and keyed on
+    // the INGEST goal + CPU, NEVER the query goal (see `ingest_comfortably_met`):
+    // the reserve suppresses queries, so gating its release on a query goal would
+    // self-perpetuate. Fast handback (legacy ±⅓ step); the bound floor is 0.
+    if cur.query_admission_reserve > 0
+        && (cpu_ok || goals.ingest_comfortably_met(s))
+        && let Some(v) = clamp_move_usize(
+            cur.query_admission_reserve,
+            shrink_usize(cur.query_admission_reserve),
+            b.query_admission_reserve,
+        )
+    {
+        return Some(Adjustment {
+            actuator: Actuator::QueryAdmissionReserve,
+            new_value: u64::try_from(v).unwrap_or(0),
+            reason: "CPU uncontended or lag goal met: release a reserved query-admission slot",
+        });
+    }
+
     // (2) Query-health tier: a violated latency/QPH goal. Larger/fewer files and
     // more compaction help queries; shedding write shards cuts file fan-out.
     if query_violated {
@@ -2489,6 +2552,31 @@ fn decide_goal(
                 actuator: Actuator::CompactionIntervalMs,
                 new_value: v,
                 reason: "replication-lag goal: compact more to keep the snapshot lean",
+            });
+        }
+        // CPU is the contended resource and ingest is behind: shed concurrent
+        // analytical queries to hand cores back to the CDC apply. The complement of
+        // the CPU-gated levers above — raising write shards and compacting more are
+        // WITHHELD under CPU contention (`cpu_ok`), so when queries are what's
+        // starving the apply, admitting fewer of them is the only lever left.
+        // Released again by tier (1b) the moment CPU frees or the lag goal is met.
+        // Bounded step like every other goal move; the governor re-clamps the
+        // reported demand to the real admission pool's `max - 1`.
+        if !cpu_ok
+            && let Some(v) = clamp_move_usize(
+                cur.query_admission_reserve,
+                goal_grow_usize(
+                    cur.query_admission_reserve,
+                    b.query_admission_reserve,
+                    ingest_v,
+                ),
+                b.query_admission_reserve,
+            )
+        {
+            return Some(Adjustment {
+                actuator: Actuator::QueryAdmissionReserve,
+                new_value: u64::try_from(v).unwrap_or(0),
+                reason: "replication-lag goal under CPU contention: reserve query-admission slots for CDC apply (shed concurrent analytical queries)",
             });
         }
     }
@@ -2924,6 +3012,7 @@ mod tests {
             write_concurrency: (1, 16),
             mem_tier_max_bytes: (64 * 1024 * 1024, 2048 * 1024 * 1024),
             target_vortex_file_size_bytes: (64 * 1024 * 1024, 1024 * 1024 * 1024),
+            query_admission_reserve: (0, 16),
         }
     }
 
@@ -2938,6 +3027,7 @@ mod tests {
             write_concurrency: 4,
             mem_tier_max_bytes: 256 * 1024 * 1024,
             target_vortex_file_size_bytes: 256 * 1024 * 1024,
+            query_admission_reserve: 0,
         }
     }
 
@@ -3524,6 +3614,10 @@ mod tests {
                 Actuator::TargetVortexFileSize => (
                     b.target_vortex_file_size_bytes.0 as u64,
                     b.target_vortex_file_size_bytes.1 as u64,
+                ),
+                Actuator::QueryAdmissionReserve => (
+                    b.query_admission_reserve.0 as u64,
+                    b.query_admission_reserve.1 as u64,
                 ),
             };
             assert!(
@@ -4411,6 +4505,97 @@ mod tests {
             ..snap()
         };
         assert!(!goals.any_actionable_violation(&met, true));
+    }
+
+    #[test]
+    fn query_admission_reserve_grows_under_lag_with_cpu_contention_and_releases_when_clear() {
+        let goals = Goals::from_targets(None, Some(5.0), None, None, Duration::from_mins(1));
+        let b = bounds();
+
+        // GROW: freshness behind (60s vs 5s) AND CPU contended (0.95), with the
+        // higher-priority ingest buffers already maxed and the write-concurrency /
+        // compaction levers withheld under CPU contention — so shedding queries is
+        // the only lever left that helps the lag goal.
+        let buffers_maxed_reserve_zero = ActuatorValues {
+            inline_flush_max_bytes: b.inline_flush_max_bytes.1,
+            mem_tier_max_bytes: b.mem_tier_max_bytes.1,
+            ..actuators()
+        };
+        let behind_contended = IngestSnapshot {
+            freshness_secs: Some(60.0),
+            cpu_pressure: Some(0.95),
+            ..snap()
+        };
+        let adj = decide_with_goals(
+            &behind_contended,
+            &buffers_maxed_reserve_zero,
+            &b,
+            ms(60_000),
+            ms(30_000),
+            0,
+            &goals,
+        )
+        .expect("lag behind + CPU contended + buffers maxed ⇒ reserve query-admission slots");
+        assert_eq!(adj.actuator, Actuator::QueryAdmissionReserve);
+        assert!(
+            adj.new_value > 0,
+            "the reserve grows from 0 to shed concurrent queries (got {})",
+            adj.new_value
+        );
+
+        // RELEASE (CPU uncontended): a reserve is held but CPU is no longer the
+        // contended resource — nothing to relieve, so hand query slots back even
+        // though the lag goal is still violated. Tier (1b) runs before the ingest
+        // grow, so the release wins.
+        let reserve_held = ActuatorValues {
+            query_admission_reserve: 3,
+            ..actuators()
+        };
+        let behind_uncontended = IngestSnapshot {
+            freshness_secs: Some(60.0),
+            cpu_pressure: Some(0.10),
+            ..snap()
+        };
+        let adj = decide_with_goals(
+            &behind_uncontended,
+            &reserve_held,
+            &b,
+            ms(60_000),
+            ms(30_000),
+            0,
+            &goals,
+        )
+        .expect("CPU uncontended ⇒ release a reserved query-admission slot");
+        assert_eq!(adj.actuator, Actuator::QueryAdmissionReserve);
+        assert!(
+            (adj.new_value as usize) < 3,
+            "the reserve is released toward 0 (got {})",
+            adj.new_value
+        );
+
+        // RELEASE (lag goal met): CPU is still contended, but the apply has caught
+        // up — the reserve's justification is gone, so release it. Keyed on the
+        // INGEST goal, never the (here unset) query goal, so it can't self-perpetuate.
+        let met_contended = IngestSnapshot {
+            freshness_secs: Some(1.0),
+            cpu_pressure: Some(0.95),
+            ..snap()
+        };
+        let adj = decide_with_goals(
+            &met_contended,
+            &reserve_held,
+            &b,
+            ms(60_000),
+            ms(30_000),
+            0,
+            &goals,
+        )
+        .expect("lag goal met ⇒ release a reserved query-admission slot");
+        assert_eq!(adj.actuator, Actuator::QueryAdmissionReserve);
+        assert!(
+            (adj.new_value as usize) < 3,
+            "released once the lag goal is met"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1462,6 +1462,25 @@ impl DataFusion {
             "Cayenne global encode-concurrency budget active (caps aggregate write-encode shards across all tables)"
         );
 
+        // Install the process-global query-admission governor so the per-table
+        // adaptive CDC controller can SHED concurrent analytical queries when a
+        // memory-mode table is behind its freshness/lag SLO AND CPU is the
+        // contended resource — handing cores back to the CDC apply — then restore
+        // them when it catches up. Reuses the SAME count-based admission semaphore
+        // the query path acquires from (deadlock-safe: it admits whole queries, not
+        // partitions). A no-op when admission is unbounded
+        // (`runtime.query.max_concurrent_queries` unset → no semaphore).
+        if let Some(semaphore) = self.query_admission_semaphore.as_ref() {
+            // No queries run at install time, so `available_permits()` is the pool's
+            // full capacity (`max_concurrent_queries`).
+            let max = semaphore.available_permits();
+            cayenne::set_query_admission_governor(Arc::clone(semaphore), max);
+            tracing::info!(
+                max_concurrent_queries = max,
+                "Cayenne adaptive query-admission throttle active (controller sheds concurrent queries when CDC is behind its freshness/lag SLO under CPU contention)"
+            );
+        }
+
         // Install the process-global in-memory CDC tier byte budget: the hard
         // aggregate RAM ceiling for `cdc_durability: memory` across ALL Cayenne
         // tables. Per-table `cayenne_cdc_mem_tier_max_bytes` is sized in


### PR DESCRIPTION
## Why

Replication lag on `stock`/`order_line` stayed high at SF1000 CH-benCH and **mem-tier sharding (`cayenne_cdc_mem_tier_shards > 1`) did not help**. Root cause: the in-memory CDC tier is fast because the checkpoint runs the Vortex encode + `BEGIN IMMEDIATE` commit *outside* every apply-blocking lock — but that only held at N=1. At N>1 the checkpoint took the table `write_lock` and held it across the **whole** checkpoint (capture + encode + commit), and CDC applies also take `write_lock`, so every sharded apply stalled for the full encode of every checkpoint. `order_line` (largest encode) fell furthest behind and its WAL backlog never drained.

## Lever 1 — off-`write_lock` N>1 checkpoint (headline)

The deadlock that forced the long hold was `append_to_shard` holding a shard publish lock **across** `reserve_sequences_local().await` (the only await under that lock): releasing `write_lock` early let an apply's fan-out form a cross-lock cycle with the checkpoint clear's index-order lock walk (the historical SF-100 N=4 ~57-checkpoint hang).

**Fix — pipeline the sequence reservation.** `validate_and_append_sharded` / `append_delete_intents_sharded` reserve one `(delete, data)` pair per apply up front (under `write_lock`, shared across the PK-disjoint shards) and pass it into `append_to_shard`, so the publish-lock region is fully synchronous — no lock held across an await. With the cycle structurally impossible, `checkpoint_mem_tier_inner` releases `write_lock` right after the all-shards capture, so the encode runs in parallel with applies. Byte-identical at N=1. Bonus: metastore seq reservations drop 2N → 2 per apply.

**Bench** (new lanes in `checkpoint_fence_stall.rs`): per-checkpoint sharded-apply stall **~21.8 ms (10 ms RTT) / ~41.8 ms (30 ms RTT) → ~23 ns**.

## Lever 5 — CDC-SLO-aware adaptive query-admission throttle

Reuses the **existing count-based** query-admission semaphore (`runtime.query.max_concurrent_queries`) — deadlock-safe because it admits whole queries, never partitions. A new process-global governor (`provider/query_admission.rs`) **holds** permits on that semaphore to shed concurrent analytical queries when a memory-mode table is behind its freshness/lag SLO **and** CPU is contended, handing cores back to the CDC apply; releases when CPU frees or the ingest goal is met.

Held permits (reversible drop + non-blocking `try_acquire_owned`) sidestep the two hazards that make `write_budget` static: they can't stall a pending acquire, and the governor is the **single mutator** — per-table controllers only *report* demand and the governor reconciles to the **MAX** across tables (most-behind wins), clamped to `max - 1` so queries are never fully starved. Driven by a new `Actuator::QueryAdmissionReserve`: grow when the lag/freshness goal is violated under CPU contention; release keyed on the **ingest** goal + CPU (never the query goal, which would self-perpetuate). Installed at startup mirroring `set_global_encode_concurrency`; a strict no-op when admission is unbounded or dynamic tuning is off.

## Validation

- **12/12** `sharded_cdc` unit tests, incl. a new multi-threaded `sharded_cdc_concurrent_applies_and_checkpoint_no_deadlock` (concurrent writers + a background checkpoint loop under a timeout → asserts no deadlock, LWW equivalence, tier drain, slot advance).
- **90** tuning + governor tests; CI clippy (both `--lib` and `--tests` gates) clean.
- **Local single-node CH-benCH SF-100, N=4 shards:** all 7 tables **Δ0.0000%** (order_line 35.8M / stock 10M), **WAL drained to 56 bytes** on every slot, 22/22 queries match, no hang. Absolute freshness is oversubscription-bound on a single 16-core box; the absolute-lag win needs the 3-node / m7a venue.

## Notes

- **Lever 4** (parallel per-shard validate) already landed on trunk in #11463.
- Default `cayenne_cdc_mem_tier_shards` stays **1** (opt-in); the query-admission throttle is inert unless a freshness/lag goal is configured.
- Branch is based on `084d5ae68a`; trunk has since advanced (2 commits touch `table.rs`) — a trunk merge + CI check is the immediate next step.