### PR TITLE
feat(cayenne): cold object-store tier with read-optimized clustering

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -125,6 +125,10 @@ libc = "0.2"
 
 [[bench]]
 harness = false
+name = "zorder_clustering"
+
+[[bench]]
+harness = false
 name = "metastore_operations"
 
 [[bench]]

--- a/crates/cayenne/benches/zorder_clustering.rs
+++ b/crates/cayenne/benches/zorder_clustering.rs
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Cold-tier Z-order clustering benchmark.
+//!
+//! Two things are reported:
+//!  1. **Clustering effectiveness** — the fraction of cold "files" a point query
+//!     must scan when the data is laid out by a single-column sort vs. a
+//!     multi-column Z-order, on a 2-D grid. This is the read-optimization the
+//!     cold tier exists to deliver: Z-order tightens the per-file zone maps on
+//!     *every* clustering dimension at once, so a selective predicate on any of
+//!     them prunes most files (single-column sort only helps the leading column).
+//!  2. **Kernel throughput** — how fast `zorder_keys` produces the interleaved
+//!     keys, so the clustering cost stays a rounding error against the cold write.
+
+#![allow(clippy::expect_used, clippy::cast_precision_loss)]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, BinaryArray, Int64Array};
+use cayenne::__bench_zorder::zorder_keys;
+use criterion::{Criterion, Throughput, black_box};
+
+/// Grid side length: `GRID * GRID` points.
+const GRID: i64 = 64;
+/// Number of cold "files" the sorted rows are split into.
+const FILES: usize = 64;
+const ROWS_PER_FILE: usize = (GRID * GRID) as usize / FILES;
+
+fn build_grid() -> (Vec<i64>, Vec<i64>) {
+    let mut d0 = Vec::with_capacity((GRID * GRID) as usize);
+    let mut d1 = Vec::with_capacity((GRID * GRID) as usize);
+    for a in 0..GRID {
+        for b in 0..GRID {
+            d0.push(a);
+            d1.push(b);
+        }
+    }
+    (d0, d1)
+}
+
+fn argsort_binary(keys: &BinaryArray) -> Vec<usize> {
+    let mut idx: Vec<usize> = (0..keys.len()).collect();
+    idx.sort_by(|&a, &b| keys.value(a).cmp(keys.value(b)));
+    idx
+}
+
+/// Average fraction of files a point query on dimension `which` (0 or 1) must
+/// scan under `order`, given per-file zone-map (min/max) pruning, averaged over
+/// every possible query value.
+fn avg_files_scanned(order: &[usize], d0: &[i64], d1: &[i64], which: usize) -> f64 {
+    let dim = if which == 0 { d0 } else { d1 };
+    let mut total = 0usize;
+    for v in 0..GRID {
+        let mut touched = 0usize;
+        for f in 0..FILES {
+            let rows = &order[f * ROWS_PER_FILE..(f + 1) * ROWS_PER_FILE];
+            let mut mn = i64::MAX;
+            let mut mx = i64::MIN;
+            for &r in rows {
+                mn = mn.min(dim[r]);
+                mx = mx.max(dim[r]);
+            }
+            if v >= mn && v <= mx {
+                touched += 1;
+            }
+        }
+        total += touched;
+    }
+    total as f64 / (GRID as f64 * FILES as f64)
+}
+
+fn print_clustering_effectiveness() {
+    let (d0, d1) = build_grid();
+
+    // Single-column layout: sort by d0 only (what `cayenne_sort_columns` does).
+    let mut single: Vec<usize> = (0..d0.len()).collect();
+    single.sort_by_key(|&i| d0[i]);
+
+    // Z-order layout over (d0, d1).
+    let cols: Vec<ArrayRef> = vec![
+        Arc::new(Int64Array::from(d0.clone())),
+        Arc::new(Int64Array::from(d1.clone())),
+    ];
+    let keys = zorder_keys(&cols).expect("zorder keys");
+    let zorder = argsort_binary(&keys);
+
+    println!(
+        "\n=== Cold-tier clustering effectiveness ({GRID}x{GRID} grid, {FILES} files, point-query file pruning) ==="
+    );
+    for which in 0..2 {
+        let s = avg_files_scanned(&single, &d0, &d1, which);
+        let z = avg_files_scanned(&zorder, &d0, &d1, which);
+        let speedup = if z > 0.0 { s / z } else { f64::INFINITY };
+        println!(
+            "  query on dim{which}: single-column-sort scans {:>5.1}% of files | Z-order scans {:>5.1}% of files | {:>4.1}x fewer files",
+            s * 100.0,
+            z * 100.0,
+            speedup
+        );
+    }
+    println!(
+        "  (single-column sort cannot prune the non-leading dimension at all; Z-order prunes both.)\n"
+    );
+}
+
+fn bench_kernel(c: &mut Criterion) {
+    let n = 100_000i64;
+    let d0: Vec<i64> = (0..n).collect();
+    let d1: Vec<i64> = (0..n).map(|i| (i * 7) % 1000).collect();
+    let d2: Vec<i64> = (0..n).map(|i| i % 50).collect();
+    let two: Vec<ArrayRef> = vec![
+        Arc::new(Int64Array::from(d0.clone())),
+        Arc::new(Int64Array::from(d1.clone())),
+    ];
+    let three: Vec<ArrayRef> = vec![
+        Arc::new(Int64Array::from(d0)),
+        Arc::new(Int64Array::from(d1)),
+        Arc::new(Int64Array::from(d2)),
+    ];
+
+    let mut group = c.benchmark_group("zorder_keys");
+    group.throughput(Throughput::Elements(n as u64));
+    group.bench_function("2cols_100k", |b| {
+        b.iter(|| black_box(zorder_keys(black_box(&two)).expect("keys")));
+    });
+    group.bench_function("3cols_100k", |b| {
+        b.iter(|| black_box(zorder_keys(black_box(&three)).expect("keys")));
+    });
+    group.finish();
+}
+
+fn main() {
+    print_clustering_effectiveness();
+    let mut criterion = Criterion::default().configure_from_args();
+    bench_kernel(&mut criterion);
+    criterion.final_summary();
+}

--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -21,7 +21,7 @@ limitations under the License.
 //! (`SQLite`, Turso, etc.).
 
 use super::metadata::{
-    CreateTableOptions, DeleteFile, InlinedData, InlinedDataStats, InlinedDelete,
+    ColdTierFile, CreateTableOptions, DeleteFile, InlinedData, InlinedDataStats, InlinedDelete,
     PartitionMetadata, SnapshotFile, SnapshotFileStatistics, TableMetadata, TableStatistics,
 };
 use arrow_schema::SchemaRef;
@@ -680,6 +680,28 @@ pub trait MetadataCatalog: Send + Sync {
 
     /// Clear all manifest rows for a table.
     async fn clear_snapshot_files(&self, table_id: &str) -> CatalogResult<()>;
+
+    /// List every cold-tier file for a table (the cold scan's file source).
+    /// Read under the scan's listing fence so the cold file set is captured
+    /// consistently with the warm snapshot and deletion snapshot.
+    async fn list_cold_tier_files(&self, table_id: &str) -> CatalogResult<Vec<ColdTierFile>>;
+
+    /// Atomically graduate the table's durable content to the cold tier. In ONE
+    /// transaction: insert the cold-file rows AND perform the overwrite clear
+    /// (drop the warm `cayenne_snapshot_file` manifest, delete files, insert
+    /// records, inline data, snapshot sequences, per-file/table stats, pk index)
+    /// + repoint `current_snapshot_id` to `new_snapshot_id` (a fresh empty warm
+    /// snapshot). All-or-nothing, so a crash mid-promotion never leaves rows in
+    /// BOTH tiers (double-count) or NEITHER (loss). The deletion state is cleared
+    /// because the cold files were written with all deletes already applied
+    /// (single-version) — exactly the semantics of `commit_overwrite`, whose new
+    /// content here lives on the cold object store instead of a warm snapshot.
+    async fn commit_overwrite_to_cold(
+        &self,
+        table_id: &str,
+        new_snapshot_id: &str,
+        cold_files: &[ColdTierFile],
+    ) -> CatalogResult<()>;
 
     /// Upsert the persisted primary-key existence index (a bloom checkpoint),
     /// tagged with the snapshot id it covers. Stored in the metastore so it is

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -18,9 +18,9 @@ limitations under the License.
 
 use super::catalog::{CatalogError, CatalogResult, MetadataCatalog, SnapshotSequenceCommit};
 use super::metadata::{
-    CreateTableOptions, DeleteFile, DeletionType, InlinedData, InlinedDataStats, InlinedDelete,
-    PartitionMetadata, PkConflictDetection, SnapshotFile, SnapshotFileStatistics, TableMetadata,
-    TableStatistics,
+    ColdTierFile, CreateTableOptions, DeleteFile, DeletionType, InlinedData, InlinedDataStats,
+    InlinedDelete, PartitionMetadata, PkConflictDetection, SnapshotFile, SnapshotFileStatistics,
+    TableMetadata, TableStatistics,
 };
 use super::metastore::sqlite::SqliteMetastore;
 #[cfg(feature = "turso")]
@@ -636,6 +636,58 @@ impl CayenneCatalog {
     ///
     /// # Errors
     ///
+    /// In-transaction body of [`MetadataCatalog::commit_overwrite_to_cold`]: the
+    /// cold-tier graduation's per-attempt work, factored out so the retry loop
+    /// mirrors [`Self::commit_overwrite`]. In one transaction it (a) clears the
+    /// prior cold generation, (b) inserts the new cold-file rows, then (c) runs
+    /// the standard overwrite clear + snapshot flip via
+    /// [`Self::commit_overwrite_in_txn`].
+    ///
+    /// Replace-all (a): v1 promotion re-materializes the WHOLE visible table
+    /// (warm + any prior cold, via the cross-tier scan) into this new cold
+    /// generation, so the prior cold rows are duplicated in `cold_files`; clearing
+    /// them first makes a repeated promotion non-double-counting. The superseded
+    /// physical cold objects are unreferenced afterward and reclaimed by GC.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first failing statement's error (which rolls back the whole
+    /// transaction at the caller).
+    async fn commit_overwrite_to_cold_in_txn(
+        &self,
+        txn: &mut dyn MetastoreTransaction,
+        table_id: &str,
+        new_snapshot_id: &str,
+        cold_files: &[ColdTierFile],
+    ) -> CatalogResult<()> {
+        txn.execute(ExecuteParams {
+            sql: "DELETE FROM cayenne_cold_tier_file WHERE table_id = ?1",
+            params: vec![MetastoreValue::Text(table_id.to_string())],
+        })
+        .await?;
+        for f in cold_files {
+            txn.execute(ExecuteParams {
+                sql: "INSERT OR REPLACE INTO cayenne_cold_tier_file \
+                      (table_id, file_url, row_count, file_size_bytes, min_sequence, max_sequence, statistics_blob) \
+                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params: vec![
+                    MetastoreValue::Text(f.table_id.clone()),
+                    MetastoreValue::Text(f.file_url.clone()),
+                    MetastoreValue::Integer(f.row_count),
+                    MetastoreValue::Integer(f.file_size_bytes),
+                    MetastoreValue::Integer(f.min_sequence),
+                    MetastoreValue::Integer(f.max_sequence),
+                    MetastoreValue::Blob(f.statistics_blob.clone()),
+                ],
+            })
+            .await?;
+        }
+        // The proven overwrite clear, reused so cold graduation is exactly an
+        // overwrite whose new content lives on the cold store.
+        self.commit_overwrite_in_txn(txn, table_id, new_snapshot_id)
+            .await
+    }
+
     /// Returns [`CatalogError::InvalidOperationNoSource`] if either UUID is
     /// malformed.
     /// Returns [`CatalogError::FailedToSetCurrentSnapshot`] if the
@@ -2819,6 +2871,93 @@ impl MetadataCatalog for CayenneCatalog {
             .await
     }
 
+    async fn list_cold_tier_files(&self, table_id: &str) -> CatalogResult<Vec<ColdTierFile>> {
+        self.metastore
+            .query_helper(
+                QueryParams {
+                    sql: r"
+                    SELECT table_id, file_url, row_count, file_size_bytes, min_sequence, max_sequence, statistics_blob
+                    FROM cayenne_cold_tier_file
+                    WHERE table_id = ?1
+                    ",
+                    params: vec![MetastoreValue::Text(table_id.to_string())],
+                },
+                |row| {
+                    Ok(ColdTierFile {
+                        table_id: row.get_string(0)?,
+                        file_url: row.get_string(1)?,
+                        row_count: row.get_i64(2)?,
+                        file_size_bytes: row.get_i64(3)?,
+                        min_sequence: row.get_i64(4)?,
+                        max_sequence: row.get_i64(5)?,
+                        statistics_blob: row.get_blob(6)?,
+                    })
+                },
+            )
+            .await
+    }
+
+    async fn commit_overwrite_to_cold(
+        &self,
+        table_id: &str,
+        new_snapshot_id: &str,
+        cold_files: &[ColdTierFile],
+    ) -> CatalogResult<()> {
+        // Atomic warm→cold graduation with the same retry-on-conflict shape as
+        // commit_compaction/commit_overwrite; the per-attempt work lives in
+        // commit_overwrite_to_cold_in_txn below. Promotion runs on the
+        // maintenance path so a transient write conflict just retries.
+        let max_attempts = DEFAULT_CONCURRENT_WRITE_MAX_ATTEMPTS;
+        if max_attempts == 0 {
+            return Err(CatalogError::InvalidOperationNoSource {
+                message: "commit_overwrite_to_cold requires at least one attempt".to_string(),
+            });
+        }
+
+        for attempt in 1..=max_attempts {
+            let mut tx =
+                self.begin_transaction()
+                    .await
+                    .map_err(|e| CatalogError::InvalidOperation {
+                        message: "Failed to begin cold-tier promotion transaction.".to_string(),
+                        source: Box::new(e),
+                    })?;
+
+            match self
+                .commit_overwrite_to_cold_in_txn(&mut *tx, table_id, new_snapshot_id, cold_files)
+                .await
+            {
+                Ok(()) => match tx.commit().await {
+                    Ok(()) => return Ok(()),
+                    Err(e) if attempt < max_attempts && is_retryable_write_conflict(&e) => {
+                        let delay = retry_backoff_delay(attempt);
+                        tracing::debug!(
+                            attempt,
+                            max_attempts,
+                            ?delay,
+                            "Retrying cold-tier promotion transaction after commit conflict"
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                    Err(e) => {
+                        return Err(CatalogError::InvalidOperation {
+                            message: "Failed to commit cold-tier promotion transaction.".to_string(),
+                            source: Box::new(e),
+                        });
+                    }
+                },
+                // Drop `tx` → automatic rollback; leaves the catalog unchanged.
+                Err(e) => return Err(e),
+            }
+        }
+
+        Err(CatalogError::InvalidOperationNoSource {
+            message: format!(
+                "commit_overwrite_to_cold exhausted {max_attempts} attempts without success or a terminal error"
+            ),
+        })
+    }
+
     async fn upsert_pk_index(
         &self,
         table_id: &str,
@@ -3848,6 +3987,23 @@ impl MetadataCatalog for CayenneCatalog {
             .await
             .map_err(|e| CatalogError::InvalidOperation {
                 message: "Failed to delete snapshot file manifest.".to_string(),
+                source: Box::new(e),
+            })?;
+
+        // 5d. Delete the cold-tier object-store manifest. Like every sibling
+        // table it is cleared explicitly (rather than relying on the
+        // ON DELETE CASCADE FK) so a crash before the final `cayenne_table`
+        // delete cannot leave orphan cold-file rows. NOTE: this removes the
+        // catalog rows only — the physical cold objects are swept separately by
+        // the table-drop physical cleanup (they live on the cold object store).
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_cold_tier_file WHERE table_id = ?1",
+                params: vec![MetastoreValue::Text(table_id.clone())],
+            })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to delete cold-tier file manifest.".to_string(),
                 source: Box::new(e),
             })?;
 

--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -688,6 +688,8 @@ impl CayenneCatalog {
             .await
     }
 
+    /// # Errors
+    ///
     /// Returns [`CatalogError::InvalidOperationNoSource`] if either UUID is
     /// malformed.
     /// Returns [`CatalogError::FailedToSetCurrentSnapshot`] if the
@@ -2941,7 +2943,8 @@ impl MetadataCatalog for CayenneCatalog {
                     }
                     Err(e) => {
                         return Err(CatalogError::InvalidOperation {
-                            message: "Failed to commit cold-tier promotion transaction.".to_string(),
+                            message: "Failed to commit cold-tier promotion transaction."
+                                .to_string(),
                             source: Box::new(e),
                         });
                     }

--- a/crates/cayenne/src/lib.rs
+++ b/crates/cayenne/src/lib.rs
@@ -69,6 +69,12 @@ pub mod logical_optimizer;
 pub mod maintained_aggregate;
 pub mod metadata;
 pub mod metastore;
+
+/// Z-order clustering kernel, re-exported for benchmarks only. Not a stable API.
+#[doc(hidden)]
+pub mod __bench_zorder {
+    pub use crate::provider::zorder::zorder_keys;
+}
 pub mod optimizer_rules;
 #[cfg(feature = "partition-table-provider")]
 pub(crate) mod partition_creator;

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -984,6 +984,47 @@ pub struct VortexConfig {
     /// with `cayenne_force_view_types: true`).
     #[serde(skip)]
     pub force_view_read_schema: bool,
+
+    // ---- Cold object-store tier (storage-cascade bottom tier; cascade model) ----
+    /// Absolute object-store URL prefix for the cold tier (e.g.
+    /// `s3://bucket/prefix`). `None`/empty (the default) disables the cold tier.
+    /// Set from the `cayenne_cold_tier_location` spicepod param. Persisted so a
+    /// reopened table knows where its cold files live; NOT compared by
+    /// `configuration_matches`, so toggling it never recreates the table (the
+    /// cold tier is a strict superset of behavior over an unchanged warm tier).
+    pub cold_tier_location: Option<String>,
+    /// Liquid-clustering key columns for cold files (multi-column Z-order).
+    /// Empty = fall back to `sort_columns`, then the primary key. Set from
+    /// `cayenne_cold_clustering_columns`.
+    pub cold_clustering_columns: Vec<String>,
+    /// Target size for cold Vortex files in MB. Larger than the warm
+    /// `target_vortex_file_size_mb` because object stores favor fewer, larger
+    /// objects and cold scans are range reads. Set from
+    /// `cayenne_cold_target_file_size_mb`. Defaults to 512.
+    pub cold_target_file_size_mb: usize,
+    /// Promotion fires only once the warm tier exceeds this many bytes
+    /// (`<= 0` disables the byte trigger). Set from
+    /// `cayenne_cold_tier_warm_max_bytes`.
+    pub cold_tier_warm_max_bytes: i64,
+    /// Promotion fires only once the warm tier exceeds this many files
+    /// (`0` disables the file-count trigger). Set from
+    /// `cayenne_cold_tier_warm_max_files`.
+    pub cold_tier_warm_max_files: usize,
+    /// How often (ms) the background loop evaluates the cold-promotion trigger.
+    /// Cold tiering is not latency-critical, so this is much coarser than the
+    /// compaction interval. Set from `cayenne_cold_tier_background_interval_ms`.
+    /// Defaults to 60s.
+    pub cold_tier_background_interval_ms: u64,
+}
+
+impl VortexConfig {
+    /// Whether the cold object-store tier is enabled (a non-empty location set).
+    #[must_use]
+    pub fn cold_tier_enabled(&self) -> bool {
+        self.cold_tier_location
+            .as_ref()
+            .is_some_and(|s| !s.trim().is_empty())
+    }
 }
 
 /// Evolution set permitted when a widening schema difference is detected at
@@ -1286,6 +1327,12 @@ impl Default for VortexConfig {
             data_storage_write_mbps: None,
             metastore_storage_write_mbps: None,
             force_view_read_schema: false,
+            cold_tier_location: None,
+            cold_clustering_columns: Vec::new(),
+            cold_target_file_size_mb: 512,
+            cold_tier_warm_max_bytes: 0,
+            cold_tier_warm_max_files: 0,
+            cold_tier_background_interval_ms: 60_000,
         }
     }
 }
@@ -1542,6 +1589,43 @@ pub struct SnapshotFile {
     pub min_sequence: i64,
     /// Inclusive maximum commit sequence of the rows in this file.
     pub max_sequence: i64,
+}
+
+/// One row of the cold-tier object-store manifest (`cayenne_cold_tier_file`).
+///
+/// The cold tier is the bottom of the storage cascade (RAM mem-tier →
+/// local-disk warm Vortex snapshot → object-store cold). A background promotion
+/// stage rewrites settled/aged warm files as read-optimized (Z-order clustered)
+/// Vortex files on the cold object store and records one row here per file.
+///
+/// Unlike [`SnapshotFile`], cold files are **table-scoped** (not a member of any
+/// snapshot directory) and append-only: a promoted file is referenced only from
+/// this table, never from `cayenne_snapshot_file`. `file_url` is the *absolute*
+/// object-store URL (e.g. `s3://bucket/prefix/{table_id}/cold/<id>.vortex`),
+/// because the cold location may differ from the table's warm path. The embedded
+/// `statistics_blob` (serialized Vortex [`FileStatistics`]: per-column min/max/
+/// null/sum) lets the scan prune cold files at listing time with no object-store
+/// round-trip. `min_sequence`/`max_sequence` carry the file's commit-seq range
+/// (cold files hold the oldest, fully-superseded data — below all protected
+/// snapshots and retention at promotion time).
+#[derive(Debug, Clone)]
+pub struct ColdTierFile {
+    /// Table this cold file belongs to (`UUIDv7`).
+    pub table_id: String,
+    /// Absolute object-store URL of the `.vortex` data file on the cold store.
+    pub file_url: String,
+    /// Live row count in the file (post-merge, single-version-per-key).
+    pub row_count: i64,
+    /// `ObjectMeta::size` of the file in bytes.
+    pub file_size_bytes: i64,
+    /// Inclusive minimum commit sequence of the rows in this file.
+    pub min_sequence: i64,
+    /// Inclusive maximum commit sequence of the rows in this file.
+    pub max_sequence: i64,
+    /// Serialized Vortex `FileStatistics` flatbuffer (per-column min/max/null/
+    /// sum). Always populated at promotion (copied from the written footer) so
+    /// listing-time pruning never falls back to a full scan.
+    pub statistics_blob: Vec<u8>,
 }
 
 /// Table-level statistics stored as a serialized Vortex [`FileStatistics`] blob.

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -147,6 +147,23 @@ pub const EXPECTED_TABLES: &[ExpectedTable] = &[
         ],
     },
     ExpectedTable {
+        // Cold-tier object-store manifest. Table-scoped (no snapshot_id),
+        // append-only. Carries each cold file's stats blob inline (one row, no
+        // join) so listing-time pruning needs no object-store round-trip.
+        // Column order MUST match the DDL in `sqlite.rs`/`turso.rs` and the
+        // export/import column order.
+        name: "cayenne_cold_tier_file",
+        columns: &[
+            "table_id",
+            "file_url",
+            "row_count",
+            "file_size_bytes",
+            "min_sequence",
+            "max_sequence",
+            "statistics_blob",
+        ],
+    },
+    ExpectedTable {
         name: "cayenne_pk_index",
         columns: &["table_id", "snapshot_id", "index_blob"],
     },

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -654,6 +654,29 @@ impl SqliteMetastore {
         )
     ";
 
+    /// Cold-tier object-store manifest (storage-cascade bottom tier). One row
+    /// per Vortex file promoted to the cold object store. Table-scoped (no
+    /// `snapshot_id`) and append-only: a promoted file is referenced only here,
+    /// never from `cayenne_snapshot_file`. `file_url` is the absolute
+    /// object-store URL (the cold location may differ from the warm table path).
+    /// `statistics_blob` is the file's serialized Vortex `FileStatistics`
+    /// (NOT NULL — always captured at promotion) so the scan prunes cold files
+    /// at listing time without re-reading any footer. Captured in metastore
+    /// snapshots via `EXPECTED_TABLES`.
+    const COLD_TIER_FILE_TABLE_DDL: &'static str = r"
+        CREATE TABLE IF NOT EXISTS cayenne_cold_tier_file (
+            table_id TEXT NOT NULL,
+            file_url TEXT NOT NULL,
+            row_count BIGINT NOT NULL DEFAULT 0,
+            file_size_bytes BIGINT NOT NULL DEFAULT 0,
+            min_sequence BIGINT NOT NULL DEFAULT 0,
+            max_sequence BIGINT NOT NULL DEFAULT 0,
+            statistics_blob BLOB NOT NULL,
+            FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
+            PRIMARY KEY (table_id, file_url)
+        )
+    ";
+
     /// Schema for the `cayenne_pk_index` table.
     ///
     /// One row per table holding the serialized primary-key existence bloom
@@ -843,7 +866,7 @@ impl MetastoreBackend for SqliteMetastore {
             .call(|conn| {
                 // Create tables in a transaction
                 conn.execute_batch(&format!(
-                    "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
+                    "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
                     Self::TABLE_TABLE_DDL,
                     Self::TABLE_NAME_UNIQUE_INDEX_DDL,
                     Self::DELETE_FILE_TABLE_DDL,
@@ -853,6 +876,7 @@ impl MetastoreBackend for SqliteMetastore {
                     Self::TABLE_STATISTICS_DDL,
                     Self::SNAPSHOT_FILE_STATISTICS_TABLE_DDL,
                     Self::SNAPSHOT_FILE_TABLE_DDL,
+                    Self::COLD_TIER_FILE_TABLE_DDL,
                     Self::INLINED_DATA_TABLE_DDL,
                     Self::INLINED_DELETE_TABLE_DDL,
                     Self::PK_INDEX_TABLE_DDL

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -357,6 +357,23 @@ impl TursoMetastore {
         )
     ";
 
+    /// Cold-tier object-store manifest. Mirrors the `SQLite`
+    /// `COLD_TIER_FILE_TABLE_DDL`: table-scoped, append-only, stats blob inline.
+    /// Plain-rowid and pragma-free for Turso/libSQL portability.
+    const COLD_TIER_FILE_TABLE_DDL: &'static str = r"
+        CREATE TABLE IF NOT EXISTS cayenne_cold_tier_file (
+            table_id TEXT NOT NULL,
+            file_url TEXT NOT NULL,
+            row_count BIGINT NOT NULL DEFAULT 0,
+            file_size_bytes BIGINT NOT NULL DEFAULT 0,
+            min_sequence BIGINT NOT NULL DEFAULT 0,
+            max_sequence BIGINT NOT NULL DEFAULT 0,
+            statistics_blob BLOB NOT NULL,
+            FOREIGN KEY (table_id) REFERENCES cayenne_table(table_id) ON DELETE CASCADE,
+            PRIMARY KEY (table_id, file_url)
+        )
+    ";
+
     /// Schema for the `cayenne_pk_index` table. Mirrors the `SQLite` definition;
     /// captured in metastore snapshots via `EXPECTED_TABLES`.
     const PK_INDEX_TABLE_DDL: &'static str = r"
@@ -554,7 +571,7 @@ impl MetastoreBackend for TursoMetastore {
 
         // Create tables
         let schema_sql = format!(
-            "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
+            "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
             Self::TABLE_TABLE_DDL,
             Self::TABLE_NAME_UNIQUE_INDEX_DDL,
             Self::DELETE_FILE_TABLE_DDL,
@@ -564,6 +581,7 @@ impl MetastoreBackend for TursoMetastore {
             Self::TABLE_STATISTICS_DDL,
             Self::SNAPSHOT_FILE_STATISTICS_TABLE_DDL,
             Self::SNAPSHOT_FILE_TABLE_DDL,
+            Self::COLD_TIER_FILE_TABLE_DDL,
             Self::INLINED_DATA_TABLE_DDL,
             Self::INLINED_DELETE_TABLE_DDL,
             Self::PK_INDEX_TABLE_DDL

--- a/crates/cayenne/src/provider/compaction.rs
+++ b/crates/cayenne/src/provider/compaction.rs
@@ -706,6 +706,100 @@ impl Drop for BackgroundMemTierCheckpointer {
     }
 }
 
+/// Periodic driver for the cold-tier promotion worker (storage-cascade bottom
+/// tier). Implemented by `CayenneTableProvider`; mirrors [`MemTierCheckpointRunner`]
+/// so the scheduler is decoupled from the provider and unit-testable with a stub.
+#[async_trait::async_trait]
+pub(crate) trait ColdTierPromotionRunner: Send + Sync {
+    /// Run one promotion tick. A no-op when the cold tier is disabled or the warm
+    /// tier has not crossed its promotion threshold. Errors are logged by the
+    /// implementation (a failed promotion leaves the warm tier intact and the
+    /// next tick retries).
+    async fn run_cold_tier_promotion_tick(&self);
+
+    /// Identifier used in log messages.
+    fn cold_tier_promotion_target_name(&self) -> &str;
+
+    /// The (possibly re-read) interval for the NEXT wake. `None` keeps the
+    /// spawn-time interval.
+    fn cold_tier_promotion_interval_hint(&self) -> Option<Duration> {
+        None
+    }
+}
+
+/// Per-table background cold-tier promoter (storage-cascade bottom tier).
+///
+/// Owns a tokio task that wakes every `interval` and runs ONE promotion tick
+/// (`run_cold_tier_promotion_tick`), which graduates the warm tier to the cold
+/// object store when its size/file thresholds are crossed. Modeled exactly on
+/// [`BackgroundMemTierCheckpointer`]: a `Weak` runner so the task never pins the
+/// provider, a `select!` over `sleep(interval)` vs a shutdown `Notify`, the
+/// interval re-read each wake, and `Drop`-fires-shutdown + a bounded detached
+/// drain. Runs on the shared low-priority compaction runtime via
+/// [`spawn_compaction`], on its OWN cadence — so the heavy whole-table
+/// graduation never blocks the compaction tick or the query/refresh runtimes.
+pub(crate) struct BackgroundColdTierPromoter {
+    handle: Option<tokio::task::JoinHandle<()>>,
+    shutdown: Arc<Notify>,
+}
+
+impl BackgroundColdTierPromoter {
+    /// Spawn the periodic promotion task. Returns `None` if `interval` is zero
+    /// (the task is disabled).
+    pub(crate) fn spawn(
+        runner: Weak<dyn ColdTierPromotionRunner>,
+        interval: Duration,
+    ) -> Option<Self> {
+        if interval.is_zero() {
+            return None;
+        }
+
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_task = Arc::clone(&shutdown);
+
+        let handle = spawn_compaction(async move {
+            let mut current = interval;
+            loop {
+                tokio::select! {
+                    () = tokio::time::sleep(current) => {}
+                    () = shutdown_task.notified() => break,
+                }
+
+                let Some(runner) = runner.upgrade() else {
+                    break;
+                };
+
+                if let Some(next) = runner.cold_tier_promotion_interval_hint() {
+                    current = next;
+                }
+
+                tracing::trace!(
+                    target: "cayenne::compaction",
+                    table = runner.cold_tier_promotion_target_name(),
+                    "Periodic cold-tier promotion wake",
+                );
+
+                runner.run_cold_tier_promotion_tick().await;
+            }
+        });
+
+        Some(Self {
+            handle: Some(handle),
+            shutdown,
+        })
+    }
+}
+
+impl Drop for BackgroundColdTierPromoter {
+    fn drop(&mut self) {
+        self.shutdown.notify_one();
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        spawn_checkpointer_drain_thread(handle);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -111,8 +111,10 @@ pub struct CayenneDeletionSink {
     pk_row_converter: Option<Arc<RowConverter>>,
     /// Indices of primary key columns in the table schema.
     pk_column_indices: Vec<usize>,
-    /// Additional listing tables from protected snapshots that should also be scanned for deletions.
-    protected_snapshot_tables: Vec<Arc<ListingTable>>,
+    /// Extra listing tables to also scan for deletion keys, beyond the main
+    /// listing table — the protected snapshots and (for cold-tier tables) the
+    /// cold-tier files. The sink treats every entry uniformly.
+    additional_scan_tables: Vec<Arc<ListingTable>>,
     /// Shared `RuntimeEnv` for S3 object store access.
     runtime_env: Arc<RuntimeEnv>,
     /// Shared write lock to prevent concurrent writes/refreshes from racing with deletions.
@@ -150,7 +152,7 @@ impl CayenneDeletionSink {
         table_memory: Arc<CayenneMemoryAccount>,
         pk_row_converter: Option<Arc<RowConverter>>,
         pk_column_indices: Vec<usize>,
-        protected_snapshot_tables: Vec<Arc<ListingTable>>,
+        additional_scan_tables: Vec<Arc<ListingTable>>,
         runtime_env: Arc<RuntimeEnv>,
         write_lock: Option<Arc<TokioMutex<()>>>,
         seq_allocator: Arc<TokioMutex<super::super::table::SeqAllocator>>,
@@ -165,7 +167,7 @@ impl CayenneDeletionSink {
             table_memory,
             pk_row_converter,
             pk_column_indices,
-            protected_snapshot_tables,
+            additional_scan_tables,
             runtime_env,
             write_lock,
             seq_allocator,
@@ -954,10 +956,11 @@ impl DeletionSink for CayenneDeletionSink {
         // operation), so we never observe a torn swap here.
         let listing_table = self.listing_table.load_full();
 
-        // Collect all tables to scan: main listing table + protected snapshots
+        // Collect all tables to scan: main listing table + the extra tables
+        // (protected snapshots and, for cold-tier tables, the cold-tier files).
         let mut all_tables = vec![Arc::clone(&listing_table)];
-        for protected_table in &self.protected_snapshot_tables {
-            all_tables.push(Arc::clone(protected_table));
+        for extra_table in &self.additional_scan_tables {
+            all_tables.push(Arc::clone(extra_table));
         }
 
         if self.filters.is_empty() {

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -104,6 +104,7 @@ pub(crate) mod tuning;
 pub(crate) mod utils;
 pub(crate) mod vortex_format;
 pub(crate) mod write_budget;
+pub(crate) mod zorder;
 
 // Re-export the main type at the module level for convenience
 pub use compaction::{set_compaction_runtime_env, set_compaction_runtime_handle};

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1010,6 +1010,12 @@ pub struct CayenneTableProvider {
     /// Optional object store configuration for remote storage (e.g., S3 Express One Zone).
     /// When set, this object store is registered with `SessionContext` for data file operations.
     object_store_config: Option<crate::metadata::ObjectStoreConfig>,
+    /// Optional object store for the COLD tier (storage-cascade bottom tier).
+    /// When set, the cross-tier scan reads promoted Vortex files from here and
+    /// the promotion stage writes them here. May target a different
+    /// bucket/endpoint than `object_store_config` (the warm tier). Registered
+    /// with the query `RuntimeEnv` at scan time via `register_object_store_if_needed`.
+    cold_object_store_config: Option<crate::metadata::ObjectStoreConfig>,
     /// `RuntimeEnv` identities where `object_store_config` has already been
     /// verified/registered. This avoids probing the registry on every scan in
     /// the common case while still handling distinct query runtimes correctly.
@@ -1439,6 +1445,12 @@ pub struct CayenneTableProvider {
     /// `None`/never-spawned in file mode (and when the interval is 0).
     background_mem_tier_checkpointer:
         Arc<std::sync::OnceLock<super::compaction::BackgroundMemTierCheckpointer>>,
+    /// Per-table background cold-tier promoter (storage-cascade bottom tier).
+    /// `None` until armed; runs on its own `cold_tier_background_interval_ms`
+    /// cadence via the same internal worker infra as the mem-tier checkpointer,
+    /// decoupled from the compaction tick.
+    background_cold_tier_promoter:
+        Arc<std::sync::OnceLock<super::compaction::BackgroundColdTierPromoter>>,
 }
 
 /// Builder for constructing a `CayenneTableProvider` with optional configuration.
@@ -1467,6 +1479,7 @@ pub struct CayenneTableProviderBuilder {
     retention_filters: Vec<Expr>,
     time_retention_filter_builder: Option<super::retention::TimeRetentionFilterBuilder>,
     object_store_config: Option<crate::metadata::ObjectStoreConfig>,
+    cold_object_store_config: Option<crate::metadata::ObjectStoreConfig>,
     context: Option<Arc<CayenneContext>>,
     maintained_aggregates: Vec<MaintainedAggregateSpec>,
 }
@@ -1505,6 +1518,7 @@ struct CayenneTableProviderOpenOptions {
     retention_filters: Vec<Expr>,
     time_retention_filter_builder: Option<super::retention::TimeRetentionFilterBuilder>,
     object_store_config: Option<crate::metadata::ObjectStoreConfig>,
+    cold_object_store_config: Option<crate::metadata::ObjectStoreConfig>,
     context: Option<Arc<CayenneContext>>,
     maintained_aggregate_specs: Vec<MaintainedAggregateSpec>,
 }
@@ -1519,6 +1533,7 @@ impl CayenneTableProviderBuilder {
             retention_filters: Vec::new(),
             time_retention_filter_builder: None,
             object_store_config: None,
+            cold_object_store_config: None,
             context: None,
             maintained_aggregates: Vec::new(),
         }
@@ -1556,6 +1571,17 @@ impl CayenneTableProviderBuilder {
         self
     }
 
+    /// Set the object store for the cold tier (storage-cascade bottom tier).
+    ///
+    /// When set (together with `cayenne_cold_tier_location`), the promotion
+    /// stage writes read-optimized Vortex files here and the cross-tier scan
+    /// reads them. May target a different bucket/endpoint than the warm store.
+    #[must_use]
+    pub fn with_cold_object_store(mut self, config: crate::metadata::ObjectStoreConfig) -> Self {
+        self.cold_object_store_config = Some(config);
+        self
+    }
+
     /// Set a shared [`CayenneContext`] for this table provider.
     ///
     /// Use this to share a single context (with caches) across multiple table providers
@@ -1584,6 +1610,7 @@ impl CayenneTableProviderBuilder {
             retention_filters: self.retention_filters,
             time_retention_filter_builder: self.time_retention_filter_builder,
             object_store_config: self.object_store_config,
+            cold_object_store_config: self.cold_object_store_config,
             context: self.context,
             maintained_aggregate_specs: self.maintained_aggregates,
         };
@@ -1605,6 +1632,7 @@ impl CayenneTableProviderBuilder {
             retention_filters: self.retention_filters,
             time_retention_filter_builder: self.time_retention_filter_builder,
             object_store_config: self.object_store_config,
+            cold_object_store_config: self.cold_object_store_config,
             context: self.context,
             maintained_aggregate_specs: self.maintained_aggregates,
         };
@@ -2032,7 +2060,7 @@ impl CayenneTableProvider {
 
     /// Returns the table ID from the catalog.
     #[must_use]
-    pub(crate) fn table_id(&self) -> &str {
+    pub fn table_id(&self) -> &str {
         &self.table_metadata.table_id
     }
 
@@ -3989,6 +4017,7 @@ impl CayenneTableProvider {
             retention_filters,
             time_retention_filter_builder,
             object_store_config,
+            cold_object_store_config,
             context,
             maintained_aggregate_specs,
         } = options;
@@ -4203,6 +4232,7 @@ impl CayenneTableProvider {
             visibility_lock: Arc::new(tokio::sync::Mutex::new(())),
             scan_state_lock: Arc::new(tokio::sync::RwLock::new(())),
             object_store_config,
+            cold_object_store_config,
             object_store_registered_runtime_envs: Arc::new(ParkingMutex::new(
                 object_store_registered_runtime_envs,
             )),
@@ -4283,6 +4313,7 @@ impl CayenneTableProvider {
             maintained_aggregate_tx,
             background_compactor: Arc::new(std::sync::OnceLock::new()),
             background_mem_tier_checkpointer: Arc::new(std::sync::OnceLock::new()),
+            background_cold_tier_promoter: Arc::new(std::sync::OnceLock::new()),
         };
 
         provider.refresh_deletion_memory_accounting();
@@ -4990,6 +5021,7 @@ impl CayenneTableProvider {
             visibility_lock: Arc::clone(&self.visibility_lock),
             scan_state_lock: Arc::clone(&self.scan_state_lock),
             object_store_config: self.object_store_config.clone(),
+            cold_object_store_config: self.cold_object_store_config.clone(),
             object_store_registered_runtime_envs: Arc::clone(
                 &self.object_store_registered_runtime_envs,
             ),
@@ -5056,6 +5088,7 @@ impl CayenneTableProvider {
             // Shared so the single periodic checkpoint task (spawned on the
             // original `Arc`) survives writer clones and its drop signal is shared.
             background_mem_tier_checkpointer: Arc::clone(&self.background_mem_tier_checkpointer),
+            background_cold_tier_promoter: Arc::clone(&self.background_cold_tier_promoter),
         }
     }
 
@@ -11840,6 +11873,308 @@ impl CayenneTableProvider {
         let plan = TableProvider::scan(self, &state, None, &[], None).await?;
         let stream = datafusion_physical_plan::execute_stream(plan, state.task_ctx())?;
         Ok((stream, generation_before))
+    }
+
+    /// Resolve the cold-tier clustering columns to schema indices:
+    /// `cayenne_cold_clustering_columns` → else `cayenne_sort_columns` → else the
+    /// primary key. Returns the indices that exist in the schema (empty = no
+    /// clustering, promotion writes unsorted).
+    fn resolve_cold_clustering_indices(&self) -> Vec<usize> {
+        let schema = self.table_schema();
+        let vc = &self.table_metadata.vortex_config;
+        let names: Vec<String> = if !vc.cold_clustering_columns.is_empty() {
+            vc.cold_clustering_columns.clone()
+        } else if !self.context.sort_columns().is_empty() {
+            self.context.sort_columns().to_vec()
+        } else {
+            self.table_metadata.primary_key.clone()
+        };
+        names
+            .iter()
+            .filter_map(|n| schema.index_of(n).ok())
+            .collect()
+    }
+
+    /// Z-order (Morton) cluster a stream by appending a transient interleaved-bits
+    /// key column, sorting on it via the proven external `SortExec` path
+    /// (`util::stream_utils::sort_stream`, disk-spilling), then stripping the key.
+    /// Empty `clustering_indices` returns the stream unchanged.
+    fn zorder_sort_stream(
+        &self,
+        stream: SendableRecordBatchStream,
+        clustering_indices: Vec<usize>,
+        task_ctx: &Arc<datafusion_execution::TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        if clustering_indices.is_empty() {
+            return Ok(stream);
+        }
+        let original_schema = stream.schema();
+        let augmented_schema = super::zorder::zorder_augmented_schema(&original_schema);
+        let idx = clustering_indices;
+        let augmented = stream
+            .map(move |res| res.and_then(|b| super::zorder::append_zorder_key_column(&b, &idx)));
+        let augmented_stream: SendableRecordBatchStream = Box::pin(
+            RecordBatchStreamAdapter::new(Arc::clone(&augmented_schema), augmented),
+        );
+        let sort_cols = vec![super::zorder::ZORDER_COLUMN_NAME.to_string()];
+        let sorted = util::stream_utils::sort_stream(augmented_stream, &sort_cols, task_ctx)
+            .map_err(|e| Error::Internal {
+                table: self.table_metadata.table_name.clone(),
+                message: format!("cold-tier Z-order sort failed: {e}"),
+            })?;
+        let orig = Arc::clone(&original_schema);
+        let stripped = sorted
+            .map(move |res| res.and_then(|b| super::zorder::strip_zorder_key_column(&b, &orig)));
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            original_schema,
+            stripped,
+        )))
+    }
+
+    /// Write a (Z-ordered, deletes-applied) stream to the cold object store as
+    /// read-optimized Vortex files, returning one [`ColdTierFile`] per written
+    /// file with accurate per-file footer statistics (for listing-time pruning).
+    ///
+    /// Single ordered run (`target_partitions = 1`) so the Z-order survives across
+    /// cold files — each file is a contiguous slice of the sorted order, giving
+    /// tight, non-overlapping zone maps.
+    async fn write_stream_to_cold(
+        &self,
+        cold_location: &str,
+        cold_config: Option<&crate::metadata::ObjectStoreConfig>,
+        stream: SendableRecordBatchStream,
+        max_sequence: i64,
+    ) -> Result<(Vec<crate::metadata::ColdTierFile>, u64)> {
+        let promotion_id = uuid::Uuid::now_v7().to_string();
+        let cold_base = cold_location.trim_end_matches('/');
+        let cold_dir_url = format!(
+            "{cold_base}/{}/cold/{promotion_id}/",
+            self.table_metadata.table_id
+        );
+
+        // A local `file://` cold tier needs its target directory created before
+        // the object-store write. Reuse the warm helper so cold dir creation gets
+        // the same fsync-the-parent crash-safety (and error propagation) instead
+        // of a bare create_dir_all. S3/object stores need no mkdir.
+        if !cold_base.starts_with("s3://") {
+            let local = cold_dir_url
+                .strip_prefix("file://")
+                .unwrap_or(cold_dir_url.as_str());
+            Self::ensure_snapshot_dir_exists(std::path::Path::new(local)).await?;
+        }
+
+        let target_size_bytes =
+            self.table_metadata.vortex_config.cold_target_file_size_mb * 1024 * 1024;
+        let write_format = self.write_shard_format(1, target_size_bytes, None);
+        let cold_listing_table = Self::create_listing_table(
+            &cold_dir_url,
+            self.table_schema(),
+            &write_format,
+            &self.pk_deletion_strategy,
+        )?;
+
+        // Session context with the COLD object store registered when configured
+        // (S3 cold; may be a different bucket/endpoint than the warm store). A
+        // local `file://` cold location needs no config — the default local
+        // store in the registry resolves it.
+        let ctx = self.create_compaction_session_context();
+        if let Some(cold_config) = cold_config {
+            let cold_renv = ctx.runtime_env();
+            Self::register_object_store_if_needed(&cold_renv, cold_config);
+        }
+        let session_state = Arc::new(ctx.state());
+
+        let schema = self.table_schema();
+        let writer_input: Arc<dyn ExecutionPlan> = Arc::new(StreamingExec::new(
+            Arc::clone(&schema),
+            Box::pin(RecordBatchStreamAdapter::new(Arc::clone(&schema), stream)),
+        ));
+        let insert_plan = cold_listing_table
+            .insert_into(session_state.as_ref(), writer_input, InsertOp::Append)
+            .await?;
+        collect(insert_plan, session_state.task_ctx()).await?;
+
+        // List the written cold files and read each footer for accurate per-file
+        // stats + row counts (so listing-time pruning is exact).
+        let cold_table_url = ListingTableUrl::parse(&cold_dir_url)?;
+        let store = session_state.runtime_env().object_store(&cold_table_url)?;
+        let object_store_url_str = cold_table_url.object_store().as_str().to_string();
+        let format = self.context.file_format();
+        let prefix = cold_table_url.prefix().clone();
+
+        let mut listing = store.list(Some(&prefix));
+        let mut cold_files = Vec::new();
+        let mut total_rows = 0u64;
+        while let Some(meta) = listing.next().await {
+            let meta = meta.map_err(|e| Error::Internal {
+                table: self.table_metadata.table_name.clone(),
+                message: format!("cold-tier file listing failed: {e}"),
+            })?;
+            if !meta.location.to_string().ends_with(".vortex") || meta.size == 0 {
+                continue;
+            }
+            let stats = format
+                .infer_stats(
+                    session_state.as_ref(),
+                    &store,
+                    self.table_schema(),
+                    &meta,
+                )
+                .await?;
+            let row_count = stats
+                .num_rows
+                .get_value()
+                .copied()
+                .and_then(|v| i64::try_from(v).ok())
+                .unwrap_or(0);
+            total_rows += u64::try_from(row_count.max(0)).unwrap_or(0);
+            let statistics_blob =
+                crate::stats::statistics_to_persisted_blob(&stats, &self.table_metadata.schema)
+                    .unwrap_or_default();
+            cold_files.push(crate::metadata::ColdTierFile {
+                table_id: self.table_metadata.table_id.clone(),
+                file_url: format!("{object_store_url_str}{}", meta.location),
+                row_count,
+                file_size_bytes: i64::try_from(meta.size).unwrap_or(i64::MAX),
+                // v1 promotion re-materializes the whole table, so a per-file
+                // lower bound isn't meaningful; 0 keeps the cold file always
+                // eligible for the phase-2 max_sequence-keyed GC/retention reader.
+                min_sequence: 0,
+                max_sequence,
+                statistics_blob,
+            });
+        }
+
+        Ok((cold_files, total_rows))
+    }
+
+    /// Cold-tier graduation (storage-cascade bottom tier; v1 = whole-table).
+    ///
+    /// When the warm tier has grown past `cayenne_cold_tier_warm_max_bytes` /
+    /// `_files`, graduate the table's whole durable content to the cold object
+    /// store: flush the in-RAM/inline tiers, read the canonical visible stream
+    /// (all deletes applied, single-version per key — the proven rewrite read),
+    /// Z-order cluster it, write read-optimized Vortex to the cold store, then
+    /// atomically register the cold files + overwrite-clear the warm tier + flip
+    /// to a fresh empty warm snapshot. Subsequent CDC writes accumulate in warm
+    /// again until the next graduation. Reuses `commit_overwrite` semantics, so a
+    /// crash is all-or-nothing.
+    ///
+    /// Returns `Ok(true)` if a graduation committed, `Ok(false)` if the cold tier
+    /// is disabled, unsupported (position-delete), or not yet triggered.
+    ///
+    /// Holds `write_lock` for the whole graduation (mirrors `begin_overwrite`), so
+    /// no append races the capture→write→commit and the generation fence is
+    /// unnecessary. Heavy + infrequent (gated by the warm-size thresholds).
+    pub async fn promote_warm_to_cold(&self) -> Result<bool> {
+        let vc = &self.table_metadata.vortex_config;
+        if !vc.cold_tier_enabled() {
+            return Ok(false);
+        }
+        // `cold_tier_enabled()` guarantees a non-empty location.
+        let cold_location = vc.cold_tier_location.clone().unwrap_or_default();
+        // v1: key-mode only. Position deletes are file-path scoped and cannot
+        // survive the warm→cold rewrite (mirrors the full-rewrite serialization).
+        if self.should_capture_positions() || self.pk_deletion_strategy.is_position_based() {
+            return Ok(false);
+        }
+
+        // Trigger: warm tier large/numerous enough to graduate.
+        let current_snapshot_id = self.get_current_snapshot_id();
+        let warm = self
+            .list_compaction_candidate_files_with_sizes(&current_snapshot_id)
+            .await?;
+        if warm.is_empty() {
+            return Ok(false);
+        }
+        let warm_bytes: i64 = warm
+            .iter()
+            .map(|(_, s)| i64::try_from(*s).unwrap_or(i64::MAX))
+            .sum();
+        let warm_files = warm.len();
+        let over_bytes = vc.cold_tier_warm_max_bytes > 0 && warm_bytes >= vc.cold_tier_warm_max_bytes;
+        let over_files = vc.cold_tier_warm_max_files > 0 && warm_files >= vc.cold_tier_warm_max_files;
+        if !(over_bytes || over_files) {
+            return Ok(false);
+        }
+
+        tracing::info!(
+            target: "cayenne::compaction",
+            table = self.table_metadata.table_name.as_str(),
+            warm_bytes,
+            warm_files,
+            "Promoting warm tier to cold object store (Z-order clustered graduation)"
+        );
+
+        // Exclude writers for the whole graduation (mirrors begin_overwrite).
+        let _write_guard = self.write_lock_arc().lock_owned().await;
+
+        // Flush the in-RAM mem tier + inline into durable so the canonical visible
+        // read below captures the whole live set.
+        if self.cdc_durability().is_memory() {
+            self.checkpoint_mem_tier_holding_write_lock().await?;
+        }
+        if self.cached_inlined_row_count() > 0 {
+            self.checkpoint_inlined_data().await?;
+        }
+
+        let max_sequence = self.sequence_high_water().await;
+
+        // Canonical visible read (all tiers, all deletes applied, single-version
+        // per key) — reuses the proven rewrite read so cold is correct by
+        // construction.
+        let ctx = self.create_compaction_session_context();
+        let (stream, _generation_before) = self.visible_file_stream_for_rewrite(&ctx).await?;
+
+        // Z-order cluster for a read-optimized cold layout.
+        let clustering = self.resolve_cold_clustering_indices();
+        let task_ctx = ctx.task_ctx();
+        let stream = self.zorder_sort_stream(stream, clustering, &task_ctx)?;
+
+        // Write the clustered, deletes-applied rows to the cold object store.
+        let (cold_files, total_rows) = self
+            .write_stream_to_cold(
+                &cold_location,
+                self.cold_object_store_config.as_ref(),
+                stream,
+                max_sequence,
+            )
+            .await?;
+        if total_rows == 0 || cold_files.is_empty() {
+            // Nothing live to promote (e.g. every row deleted). Leave warm as-is;
+            // the empty cold write produced no files to clean up.
+            return Ok(false);
+        }
+
+        // Commit: atomically register cold files + overwrite-clear warm + flip to
+        // a fresh empty warm snapshot, then sync the in-memory state.
+        let new_snapshot_id = uuid::Uuid::now_v7().to_string();
+        if !self.table_metadata.path.starts_with("s3://") {
+            let dir = self.snapshot_dir_path_for(&new_snapshot_id);
+            Self::ensure_snapshot_dir_exists(&dir).await?;
+        }
+        self.catalog
+            .commit_overwrite_to_cold(&self.table_metadata.table_id, &new_snapshot_id, &cold_files)
+            .await?;
+        self.publish_overwrite_snapshot(&new_snapshot_id).await?;
+        if let Err(error) = self.prune_snapshot_manifest_to(&new_snapshot_id).await {
+            tracing::warn!(
+                target: "cayenne::compaction",
+                table = self.table_metadata.table_name.as_str(),
+                %error,
+                "Failed to prune stale manifest rows after cold-tier promotion"
+            );
+        }
+        self.trigger_old_snapshot_cleanup(&new_snapshot_id).await;
+
+        tracing::info!(
+            target: "cayenne::compaction",
+            table = self.table_metadata.table_name.as_str(),
+            cold_files = cold_files.len(),
+            total_rows,
+            "Cold-tier promotion committed"
+        );
+        Ok(true)
     }
 
     /// Fast, write-lock-free consolidation of a size-tiered subset of the
@@ -18784,6 +19119,160 @@ impl CayenneTableProvider {
             .await
     }
 
+    /// Build the cold object-store tier scan branch, or `Ok(None)` when the cold
+    /// tier is disabled or empty (no added plan nodes — byte-identical to a
+    /// warm-only scan).
+    ///
+    /// Cold files come from the `cayenne_cold_tier_file` metastore manifest
+    /// (table-scoped, absolute object-store URLs), and each row carries its
+    /// serialized Vortex `FileStatistics` blob — so listing-time pruning runs
+    /// with NO object-store round-trip. The returned plan is a Vortex
+    /// `DataSourceExec`; the caller wraps it with the key-based (`Ignore`)
+    /// deletion filter and unions it into the scan tree.
+    async fn build_cold_tier_scan_plan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+        scan_config: &SessionConfig,
+        read_schema_override: Option<SchemaRef>,
+    ) -> datafusion_common::Result<Option<Arc<dyn ExecutionPlan>>> {
+        // Cold tier disabled (no location) → no branch. The object store for the
+        // cold URLs is resolved from the session registry: the default local
+        // store for `file://` cold, or the cold S3 store registered at scan top.
+        if !self.table_metadata.vortex_config.cold_tier_enabled() {
+            return Ok(None);
+        }
+
+        let cold_files = self
+            .catalog
+            .list_cold_tier_files(&self.table_metadata.table_id)
+            .await
+            .map_err(|e| {
+                // No directory-listing fallback exists for cold (unlike the warm
+                // manifest), so a metastore error must fail the query rather than
+                // silently drop cold rows.
+                datafusion_common::DataFusionError::Execution(format!(
+                    "Failed to list cold-tier files for table {}: {e}",
+                    self.table_metadata.table_name
+                ))
+            })?;
+        // No early all-empty guard needed: the per-file loop skips zero-size
+        // files and the `object_store_url is None` / `kept.is_empty()` checks
+        // below both return `Ok(None)` when nothing survives.
+
+        let base_schema = read_schema_override.unwrap_or_else(|| self.table_schema());
+        let options = Self::create_listing_options(
+            self.context.file_format(),
+            &self.pk_deletion_strategy,
+            scan_config,
+        );
+        let scan_schema = Self::snapshot_scan_schema(&base_schema, &options);
+
+        // Data-column pruning predicate (cold tier is never partitioned — gated
+        // at config time — so every filter is a data filter). Reuses the warm
+        // path's predicate + pruner; stats come from the persisted blob, so
+        // pruning costs no object-store round-trip.
+        let listing_pruning_predicate = if filters.is_empty() {
+            None
+        } else {
+            super::file_pruning::build_listing_pruning_predicate(&scan_schema, filters)?
+        };
+
+        let table_name = self.table_metadata.table_name.clone();
+        let mut object_store_url: Option<ListingTableUrl> = None;
+        let mut kept: Vec<PartitionedFile> = Vec::with_capacity(cold_files.len());
+        for file in &cold_files {
+            if file.file_size_bytes <= 0 {
+                continue;
+            }
+            // Absolute cold URL -> (object-store URL, bucket-relative path) — the
+            // same derivation DataFusion uses to resolve a file against a store.
+            // All cold files share one configured cold location, so the first
+            // file's object-store URL identifies the store for the whole branch.
+            let listing_url = ListingTableUrl::parse(&file.file_url)?;
+            if object_store_url.is_none() {
+                object_store_url = Some(listing_url.clone());
+            }
+            let object_meta = ObjectMeta {
+                location: listing_url.prefix().clone(),
+                last_modified: chrono::DateTime::UNIX_EPOCH,
+                size: u64::try_from(file.file_size_bytes).unwrap_or(0),
+                e_tag: None,
+                version: None,
+            };
+            let mut part_file = PartitionedFile::from(object_meta);
+            if let Some(stats) = crate::stats::statistics_from_persisted_blob(
+                &file.statistics_blob,
+                &self.table_metadata.schema,
+                file.row_count,
+            ) {
+                part_file = part_file.with_statistics(stats);
+            }
+            if let Some(ref predicate) = listing_pruning_predicate
+                && super::file_pruning::should_prune_partitioned_file(
+                    &part_file,
+                    &scan_schema,
+                    predicate,
+                )?
+            {
+                tracing::debug!(
+                    table = %table_name,
+                    file = %file.file_url,
+                    "Pruned cold-tier file at listing time via persisted footer statistics"
+                );
+                continue;
+            }
+            kept.push(part_file);
+        }
+
+        let Some(table_url) = object_store_url else {
+            return Ok(None);
+        };
+        if kept.is_empty() {
+            // Every cold file pruned for this query.
+            return Ok(None);
+        }
+
+        // Key-based deletion (cold tier is key-mode only) filters ABOVE the
+        // Vortex scan, so a pushed row-count limit would under-deliver; suppress
+        // it and rely on the outer GlobalLimitExec (mirror
+        // create_snapshot_scan_plan_with_config).
+        let scan_pushdown_limit =
+            if self.has_pending_deletions() && !self.pk_deletion_strategy.is_position_based() {
+                None
+            } else {
+                limit
+            };
+
+        let file_groups = FileGroup::new(kept).split_files(options.target_partitions);
+        let (file_groups, statistics) =
+            compute_all_files_statistics(file_groups, Arc::clone(&scan_schema), true, false)?;
+
+        let file_source = options
+            .format
+            .file_source(Self::snapshot_file_table_schema(&base_schema, &options));
+
+        let plan = options
+            .format
+            .create_physical_plan(
+                state,
+                FileScanConfigBuilder::new(table_url.object_store(), file_source)
+                    .with_file_groups(file_groups)
+                    .with_constraints(Constraints::default())
+                    .with_statistics(statistics)
+                    .with_projection_indices(projection.cloned())?
+                    .with_limit(scan_pushdown_limit)
+                    // Cold files are an unsorted internal union branch — never
+                    // advertise an ordering.
+                    .with_output_ordering(Vec::new())
+                    .build(),
+            )
+            .await?;
+        Ok(Some(plan))
+    }
+
     /// Resolve a snapshot's data files from the manifest (`cayenne_snapshot_file`)
     /// instead of by listing the snapshot directory.
     ///
@@ -19818,6 +20307,13 @@ impl TableProvider for CayenneTableProvider {
         if let Some(ref config) = self.object_store_config {
             self.register_object_store_for_runtime(state.runtime_env(), config);
         }
+        // Register the cold-tier object store too (may be a different bucket).
+        // Uses the URL-keyed idempotent path, NOT `register_object_store_for_runtime`,
+        // because that one dedups per runtime-env and would skip the cold store
+        // after the warm store already claimed the per-env slot.
+        if let Some(ref cold_config) = self.cold_object_store_config {
+            Self::register_object_store_if_needed(state.runtime_env(), cold_config);
+        }
 
         // Warm the inlined cache before taking the consistency guards so the
         // read under `scan_state_lock` is a cheap cache hit in the common case.
@@ -20177,6 +20673,27 @@ impl TableProvider for CayenneTableProvider {
             })
             .await?;
 
+        // Build the COLD object-store tier branch (storage-cascade bottom tier).
+        // Cold files hold OLD, fully-superseded data, so they take the
+        // `Ignore`-re-inserts deletion treatment (`apply_deletion_filter`) — the
+        // same camp as protected snapshots. Using the `Apply` variant here would
+        // resurrect a stale cold row for a key re-inserted after deletion.
+        // `Ok(None)` (disabled / empty / all-pruned) adds zero plan nodes.
+        let cold_plan: Option<Arc<dyn ExecutionPlan>> = self
+            .build_cold_tier_scan_plan(
+                state,
+                effective_projection.as_ref(),
+                scan_filters,
+                limit,
+                scan_listing_config,
+                Some(Arc::clone(&read_schema)),
+            )
+            .await?
+            .map(|cold| {
+                self.apply_deletion_filter(cold, &pk_indices_in_projection, &deletion_snapshot)
+            })
+            .transpose()?;
+
         // Build a MemoryExec plan for the inlined data captured under the
         // read guard above (consistent with the deletion view used for the
         // file-backed deletion filter).
@@ -20290,6 +20807,17 @@ impl TableProvider for CayenneTableProvider {
             let mut all_plans = vec![filtered_main_plan];
             all_plans.extend(protected_snapshot_plans);
             UnionExec::try_new(all_plans)?
+        };
+
+        // Union the cold object-store tier if present. Added as its own union
+        // step (NOT by changing `main_plan`'s filter) so the warm-only and
+        // protected-snapshot arms above stay byte-identical. The cold branch is a
+        // Vortex `DataSourceExec`, so FilterPushdown still pushes the scan
+        // predicate into it and the redundant top FilterExec is still removed.
+        let plan: Arc<dyn ExecutionPlan> = if let Some(cold_exec) = cold_plan {
+            UnionExec::try_new(vec![plan, cold_exec])?
+        } else {
+            plan
         };
 
         // Union inlined data if present
@@ -20527,10 +21055,10 @@ impl TableProvider for CayenneTableProvider {
                 self.checkpoint_inlined_data_if_present_for_delete().await?;
             }
 
-            return self.delete_using_deletion_vectors(&filters);
+            return self.delete_using_deletion_vectors(&filters).await;
         }
 
-        let file_sink = self.build_deletion_vector_sink(&filters, None)?;
+        let file_sink = self.build_deletion_vector_sink(&filters, None).await?;
         Ok(Arc::new(DeletionExec::new(Arc::new(
             InlineAwareDeletionSink {
                 table: self.clone_for_write(),
@@ -20646,12 +21174,14 @@ impl CayenneTableProvider {
     }
 
     /// Main deletion-vector path via [`CayenneDeletionSink`].
-    fn delete_using_deletion_vectors(
+    async fn delete_using_deletion_vectors(
         &self,
         filters: &[Expr],
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        let sink: Arc<dyn DeletionSink> =
-            Arc::new(self.build_deletion_vector_sink(filters, Some(Arc::clone(&self.write_lock)))?);
+        let sink: Arc<dyn DeletionSink> = Arc::new(
+            self.build_deletion_vector_sink(filters, Some(Arc::clone(&self.write_lock)))
+                .await?,
+        );
         Ok(Arc::new(DeletionExec::new(Arc::new(
             PkKeysetInvalidatingDeletionSink {
                 table: self.clone_for_write(),
@@ -20660,16 +21190,79 @@ impl CayenneTableProvider {
         ))))
     }
 
-    fn build_deletion_vector_sink(
+    /// Build a `ListingTable` per distinct live cold-file directory (storage-
+    /// cascade bottom tier), so a key-based DELETE scan finds cold-resident keys
+    /// and records their tombstones. Empty when the cold tier is disabled/empty.
+    ///
+    /// Dirs are derived from the `cayenne_cold_tier_file` manifest URLs (the
+    /// authoritative live set), NOT a directory scan — so a superseded physical
+    /// cold generation left behind by replace-all promotion is never scanned.
+    async fn build_cold_tier_listing_tables(
+        &self,
+    ) -> datafusion_common::Result<Vec<Arc<ListingTable>>> {
+        if !self.table_metadata.vortex_config.cold_tier_enabled() {
+            return Ok(Vec::new());
+        }
+        // Register the cold store on the provider's context runtime env (S3
+        // cold); a local `file://` cold needs no registration.
+        if let Some(ref cold_config) = self.cold_object_store_config {
+            Self::register_object_store_if_needed(self.context.runtime_env(), cold_config);
+        }
+        let cold_files = self
+            .catalog
+            .list_cold_tier_files(&self.table_metadata.table_id)
+            .await
+            .map_err(|e| {
+                datafusion_common::DataFusionError::Execution(format!(
+                    "Failed to list cold-tier files for delete on table {}: {e}",
+                    self.table_metadata.table_name
+                ))
+            })?;
+        let mut dirs: Vec<String> = Vec::new();
+        for f in &cold_files {
+            if f.file_size_bytes <= 0 {
+                continue;
+            }
+            if let Some(idx) = f.file_url.rfind('/') {
+                let dir = &f.file_url[..=idx];
+                if !dirs.iter().any(|d| d == dir) {
+                    dirs.push(dir.to_string());
+                }
+            }
+        }
+        let mut tables = Vec::with_capacity(dirs.len());
+        for dir in dirs {
+            let table = Self::create_listing_table(
+                &dir,
+                self.table_schema(),
+                self.context.file_format(),
+                &self.pk_deletion_strategy,
+            )
+            .map_err(|e| {
+                datafusion_common::DataFusionError::Execution(format!(
+                    "Failed to create cold-tier listing table for delete: {e}"
+                ))
+            })?;
+            tables.push(table);
+        }
+        Ok(tables)
+    }
+
+    async fn build_deletion_vector_sink(
         &self,
         filters: &[Expr],
         write_lock: Option<Arc<tokio::sync::Mutex<()>>>,
     ) -> datafusion_common::Result<CayenneDeletionSink> {
-        let snapshot_tables: Vec<Arc<ListingTable>> = self
+        let mut snapshot_tables: Vec<Arc<ListingTable>> = self
             .build_protected_snapshot_listing_tables()?
             .into_iter()
             .map(|(_, table)| table)
             .collect();
+        // Also scan the cold tier so a key-delete of a cold-resident row is
+        // found and tombstoned (the cross-tier scan then hides it via the shared
+        // key-delete filter). Cold uses key-based deletes, so this is only ever
+        // non-empty for key-delete tables.
+        snapshot_tables.extend(self.build_cold_tier_listing_tables().await?);
 
         Ok(CayenneDeletionSink::new(
             self.table_metadata.clone(),
@@ -20876,6 +21469,13 @@ impl super::compaction::CompactionRunner for CayenneTableProvider {
         // `compact_protected_snapshots_subset`, because their tombstones are
         // file-path scoped and would otherwise be lost if they target a file
         // that is swapped away by the merge.
+
+        // NOTE: cold-tier graduation (storage-cascade bottom tier) does NOT run
+        // here. It is a heavy whole-table rewrite + object-store upload, so it
+        // runs on its OWN dedicated background worker (`BackgroundColdTierPromoter`
+        // → `run_cold_tier_promotion_tick` → `promote_warm_to_cold`) on the
+        // `cold_tier_background_interval_ms` cadence, decoupled from this
+        // compaction tick so it never stalls regular size-tier compaction.
 
         // Seq-prefix BAKE (Stage 2) — runs FIRST, gated on the deletion-index
         // size (the very quantity it shrinks). The bake exists to keep the
@@ -21143,6 +21743,63 @@ impl CayenneTableProvider {
         self.background_mem_tier_checkpointer
             .set(checkpointer)
             .is_ok()
+    }
+
+    /// Spawn the periodic cold-tier promotion task for this provider, if the cold
+    /// tier is enabled, the configured interval is non-zero, and no task is
+    /// already spawned. Must be called after the provider is wrapped in an `Arc`
+    /// (the scheduler holds a `Weak<Self>`); the task is owned by the provider
+    /// (stored in `background_cold_tier_promoter`) and aborts when the last `Arc`
+    /// drops. A no-op (`false`) when the cold tier is disabled.
+    ///
+    /// Returns `true` if a task was spawned by this call, `false` otherwise.
+    #[must_use]
+    pub fn spawn_background_cold_tier_promotion(self: &Arc<Self>) -> bool {
+        if self.background_cold_tier_promoter.get().is_some() {
+            return false;
+        }
+        if !self.table_metadata.vortex_config.cold_tier_enabled() {
+            return false;
+        }
+        let interval = std::time::Duration::from_millis(
+            self.table_metadata
+                .vortex_config
+                .cold_tier_background_interval_ms,
+        );
+        let Some(promoter) = super::compaction::BackgroundColdTierPromoter::spawn(
+            Arc::downgrade(self) as std::sync::Weak<dyn super::compaction::ColdTierPromotionRunner>,
+            interval,
+        ) else {
+            return false;
+        };
+        self.background_cold_tier_promoter.set(promoter).is_ok()
+    }
+}
+
+#[async_trait::async_trait]
+impl super::compaction::ColdTierPromotionRunner for CayenneTableProvider {
+    async fn run_cold_tier_promotion_tick(&self) {
+        match self.promote_warm_to_cold().await {
+            Ok(true) => {
+                tracing::debug!(
+                    target: "cayenne::compaction",
+                    table = self.table_metadata.table_name.as_str(),
+                    "Cold-tier promotion tick graduated the warm tier to the cold object store"
+                );
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    target: "cayenne::compaction",
+                    table = self.table_metadata.table_name.as_str(),
+                    "Cold-tier promotion tick failed (warm tier left intact; retry next tick): {e}"
+                );
+            }
+        }
+    }
+
+    fn cold_tier_promotion_target_name(&self) -> &str {
+        &self.table_metadata.table_name
     }
 }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -11928,9 +11928,10 @@ impl CayenneTableProvider {
         let idx = clustering_indices;
         let augmented = stream
             .map(move |res| res.and_then(|b| super::zorder::append_zorder_key_column(&b, &idx)));
-        let augmented_stream: SendableRecordBatchStream = Box::pin(
-            RecordBatchStreamAdapter::new(Arc::clone(&augmented_schema), augmented),
-        );
+        let augmented_stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&augmented_schema),
+            augmented,
+        ));
         let sort_cols = vec![super::zorder::ZORDER_COLUMN_NAME.to_string()];
         let sorted = util::stream_utils::sort_stream(augmented_stream, &sort_cols, task_ctx)
             .map_err(|e| Error::Internal {
@@ -12029,12 +12030,7 @@ impl CayenneTableProvider {
                 continue;
             }
             let stats = format
-                .infer_stats(
-                    session_state.as_ref(),
-                    &store,
-                    self.table_schema(),
-                    &meta,
-                )
+                .infer_stats(session_state.as_ref(), &store, self.table_schema(), &meta)
                 .await?;
             let row_count = stats
                 .num_rows
@@ -12045,7 +12041,15 @@ impl CayenneTableProvider {
             total_rows += u64::try_from(row_count.max(0)).unwrap_or(0);
             let statistics_blob =
                 crate::stats::statistics_to_persisted_blob(&stats, &self.table_metadata.schema)
-                    .unwrap_or_default();
+                    .unwrap_or_else(|| {
+                        tracing::warn!(
+                            target: "cayenne::compaction",
+                            table = self.table_metadata.table_name.as_str(),
+                            file = %meta.location,
+                            "Cold-tier file statistics could not be serialized; listing-time pruning cannot skip this file"
+                        );
+                        Vec::new()
+                    });
             cold_files.push(crate::metadata::ColdTierFile {
                 table_id: self.table_metadata.table_id.clone(),
                 file_url: format!("{object_store_url_str}{}", meta.location),
@@ -12078,6 +12082,11 @@ impl CayenneTableProvider {
     /// Returns `Ok(true)` if a graduation committed, `Ok(false)` if the cold tier
     /// is disabled, unsupported (position-delete), or not yet triggered.
     ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing the mem/inline tiers, the canonical visible
+    /// read, the cold object-store write, or the atomic catalog commit fails.
+    ///
     /// Holds `write_lock` for the whole graduation (mirrors `begin_overwrite`), so
     /// no append races the capture→write→commit and the generation fence is
     /// unnecessary. Heavy + infrequent (gated by the warm-size thresholds).
@@ -12107,8 +12116,10 @@ impl CayenneTableProvider {
             .map(|(_, s)| i64::try_from(*s).unwrap_or(i64::MAX))
             .sum();
         let warm_files = warm.len();
-        let over_bytes = vc.cold_tier_warm_max_bytes > 0 && warm_bytes >= vc.cold_tier_warm_max_bytes;
-        let over_files = vc.cold_tier_warm_max_files > 0 && warm_files >= vc.cold_tier_warm_max_files;
+        let over_bytes =
+            vc.cold_tier_warm_max_bytes > 0 && warm_bytes >= vc.cold_tier_warm_max_bytes;
+        let over_files =
+            vc.cold_tier_warm_max_files > 0 && warm_files >= vc.cold_tier_warm_max_files;
         if !(over_bytes || over_files) {
             return Ok(false);
         }
@@ -12155,9 +12166,12 @@ impl CayenneTableProvider {
                 max_sequence,
             )
             .await?;
-        if total_rows == 0 || cold_files.is_empty() {
-            // Nothing live to promote (e.g. every row deleted). Leave warm as-is;
-            // the empty cold write produced no files to clean up.
+        if cold_files.is_empty() {
+            // Nothing live to promote (e.g. every row deleted): the writer
+            // produced no cold files, so there is nothing to register or clean
+            // up. Gate on files-written rather than `total_rows` — a file that
+            // was written but whose footer row count couldn't be inferred must
+            // still be committed, not silently orphaned in the cold store.
             return Ok(false);
         }
 

--- a/crates/cayenne/src/provider/zorder.rs
+++ b/crates/cayenne/src/provider/zorder.rs
@@ -1,0 +1,379 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Z-order (Morton) multi-column clustering key for the cold object-store tier.
+//!
+//! The cold-tier promotion stage rewrites settled warm data as read-optimized
+//! Vortex files. To make a file's per-column zone maps (footer min/max) tight on
+//! *every* clustering dimension at once — so a selective predicate on any of
+//! them prunes most cold files — the rows are sorted by a **Z-order curve** over
+//! the clustering columns (liquid-clustering-style multi-dimensional locality),
+//! rather than a single-column lexicographic sort that only tightens the leading
+//! column.
+//!
+//! ## How it works
+//!
+//! Each clustering column value is mapped to an **order-preserving** fixed-width
+//! (`BYTES_PER_COLUMN`-byte) unsigned key: comparing two keys as big-endian
+//! unsigned integers reproduces the column's natural ordering (NULLs sort
+//! first). The per-column keys are then **bit-interleaved** most-significant-bit
+//! first across the K columns into one `8*K`-byte key. Sorting those interleaved
+//! keys ascending (plain lexicographic byte order) walks the Z-order space-
+//! filling curve, so adjacent rows are close in all K dimensions.
+//!
+//! The key is a pure kernel ([`zorder_keys`]). The promotion path appends it as
+//! a transient column ([`append_zorder_key_column`]), sorts on it, then strips it
+//! ([`strip_zorder_key_column`]) — so the key is never materialized into the
+//! written cold file.
+//!
+//! v1 uses Z-order; a Hilbert curve (better locality, materially more complex
+//! encode) is a behind-the-key phase-2 swap that keeps every caller unchanged.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, AsArray, BinaryArray, RecordBatch};
+use arrow::compute::cast;
+use arrow::datatypes::{Float64Type, Int64Type, UInt64Type};
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
+use datafusion_common::{DataFusionError, Result as DFResult};
+
+/// Number of order-preserving key bytes extracted per clustering column. 8 bytes
+/// = 64 bits captures the full precision of every integer/temporal type and a
+/// useful prefix of strings, which is what zone-map pruning keys on.
+const BYTES_PER_COLUMN: usize = 8;
+
+/// Name of the transient Z-order key column appended before the clustering sort
+/// and stripped immediately after — it is NEVER written into a cold file.
+pub const ZORDER_COLUMN_NAME: &str = "__cayenne_zorder_key";
+
+/// Map a signed integer to an order-preserving `u64` (flip the sign bit so the
+/// most-negative value maps to `0x0000…` and the most-positive to `0xFFFF…`).
+#[inline]
+fn key_from_i64(v: i64) -> [u8; BYTES_PER_COLUMN] {
+    ((v as u64) ^ (1u64 << 63)).to_be_bytes()
+}
+
+/// Unsigned integers are already order-preserving as big-endian bytes.
+#[inline]
+fn key_from_u64(v: u64) -> [u8; BYTES_PER_COLUMN] {
+    v.to_be_bytes()
+}
+
+/// Total-ordering transform for IEEE-754 doubles: negatives get all bits
+/// flipped, non-negatives get just the sign bit flipped. The result compares as
+/// an unsigned big-endian integer in the same order as the floats (NaN sorts at
+/// the high end, which is acceptable for clustering).
+#[inline]
+fn key_from_f64(v: f64) -> [u8; BYTES_PER_COLUMN] {
+    let bits = v.to_bits();
+    let transformed = if bits >> 63 == 1 {
+        !bits
+    } else {
+        bits ^ (1u64 << 63)
+    };
+    transformed.to_be_bytes()
+}
+
+/// Lexicographic prefix key for variable-length bytes/strings: take the first
+/// `BYTES_PER_COLUMN` bytes, right-padded with zeros.
+#[inline]
+fn key_from_bytes(s: &[u8]) -> [u8; BYTES_PER_COLUMN] {
+    let mut key = [0u8; BYTES_PER_COLUMN];
+    let n = s.len().min(BYTES_PER_COLUMN);
+    key[..n].copy_from_slice(&s[..n]);
+    key
+}
+
+/// `(0..n)` → per-row key, mapping NULL rows (a `None` from `key`) to the
+/// all-zero "sorts-first" key. Owns the null/range/collect boilerplate shared by
+/// every [`column_order_keys`] arm so each arm is just its downcast + key fn.
+fn keys_with_nulls(
+    n: usize,
+    key: impl Fn(usize) -> Option<[u8; BYTES_PER_COLUMN]>,
+) -> Vec<[u8; BYTES_PER_COLUMN]> {
+    (0..n)
+        .map(|i| key(i).unwrap_or([0u8; BYTES_PER_COLUMN]))
+        .collect()
+}
+
+/// Compute one order-preserving `BYTES_PER_COLUMN`-byte key per row of `array`.
+///
+/// NULLs (and any unsupported column type) map to the all-zero key, which sorts
+/// first — the "reserved minimal code". Supported types: all signed/unsigned
+/// integers, floats, booleans, dates, times, timestamps, durations, and the
+/// utf8/binary families (incl. their `View`/`Large` variants).
+fn column_order_keys(array: &dyn Array) -> DFResult<Vec<[u8; BYTES_PER_COLUMN]>> {
+    let n = array.len();
+
+    let keys = match array.data_type() {
+        DataType::Boolean => {
+            let a = array.as_boolean();
+            keys_with_nulls(n, |i| {
+                (!a.is_null(i)).then(|| key_from_i64(i64::from(a.value(i))))
+            })
+        }
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Timestamp(_, _)
+        | DataType::Duration(_) => {
+            let arr = cast(array, &DataType::Int64)?;
+            let a = arr.as_primitive::<Int64Type>();
+            keys_with_nulls(n, |i| (!a.is_null(i)).then(|| key_from_i64(a.value(i))))
+        }
+        DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
+            let arr = cast(array, &DataType::UInt64)?;
+            let a = arr.as_primitive::<UInt64Type>();
+            keys_with_nulls(n, |i| (!a.is_null(i)).then(|| key_from_u64(a.value(i))))
+        }
+        DataType::Float16 | DataType::Float32 | DataType::Float64 => {
+            let arr = cast(array, &DataType::Float64)?;
+            let a = arr.as_primitive::<Float64Type>();
+            keys_with_nulls(n, |i| (!a.is_null(i)).then(|| key_from_f64(a.value(i))))
+        }
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+            let arr = cast(array, &DataType::Utf8)?;
+            let a = arr.as_string::<i32>();
+            keys_with_nulls(n, |i| {
+                (!a.is_null(i)).then(|| key_from_bytes(a.value(i).as_bytes()))
+            })
+        }
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {
+            let arr = cast(array, &DataType::Binary)?;
+            let a = arr.as_binary::<i32>();
+            keys_with_nulls(n, |i| (!a.is_null(i)).then(|| key_from_bytes(a.value(i))))
+        }
+        // Unsupported type: contribute nothing to the curve (all rows equal on
+        // this dimension) rather than failing the whole promotion.
+        _ => vec![[0u8; BYTES_PER_COLUMN]; n],
+    };
+
+    Ok(keys)
+}
+
+/// Compute the interleaved Z-order key for each row across `columns`.
+///
+/// Returns a [`BinaryArray`] of `8 * columns.len()`-byte keys; sorting it
+/// ascending walks the Z-order curve over the columns. All `columns` must be the
+/// same length.
+///
+/// # Errors
+///
+/// Returns an error if `columns` is empty, the columns differ in length, or a
+/// supported column fails to cast to its canonical key type.
+pub fn zorder_keys(columns: &[ArrayRef]) -> DFResult<BinaryArray> {
+    let k = columns.len();
+    if k == 0 {
+        return Err(DataFusionError::Internal(
+            "zorder_keys requires at least one clustering column".to_string(),
+        ));
+    }
+    let n = columns[0].len();
+
+    let mut col_keys: Vec<Vec<[u8; BYTES_PER_COLUMN]>> = Vec::with_capacity(k);
+    for c in columns {
+        if c.len() != n {
+            return Err(DataFusionError::Internal(
+                "zorder_keys columns must all have the same length".to_string(),
+            ));
+        }
+        col_keys.push(column_order_keys(c.as_ref())?);
+    }
+
+    let width = BYTES_PER_COLUMN * k;
+    let total_bits = BYTES_PER_COLUMN * 8 * k;
+    let mut flat = vec![0u8; width * n];
+
+    // `col_keys` is column-major (`[dim][row]`) while the output is row-major, so
+    // iterate the output row chunks and gather each row's per-column keys across
+    // dimensions. Taking `row` from `enumerate()` (not a range) also keeps this
+    // transpose out of `needless_range_loop`. `row_keys` is reused across rows to
+    // avoid a per-row heap allocation on multi-million-row cold rewrites.
+    let mut row_keys = vec![0u64; k];
+    for (row, out) in flat.chunks_mut(width).enumerate() {
+        // Pre-decode this row's per-column keys to u64 once.
+        for (dim, rk) in row_keys.iter_mut().enumerate() {
+            *rk = u64::from_be_bytes(col_keys[dim][row]);
+        }
+        // Interleave most-significant-bit-first: output bit j takes bit
+        // (63 - j/k) of column (j % k). Lexicographic byte order over the
+        // packed output then equals Morton (Z-order) order.
+        for j in 0..total_bits {
+            let round = j / k;
+            let dim = j % k;
+            let bit = (row_keys[dim] >> (63 - round)) & 1;
+            if bit == 1 {
+                out[j / 8] |= 1 << (7 - (j % 8));
+            }
+        }
+    }
+
+    Ok(BinaryArray::from_iter_values(
+        (0..n).map(|r| &flat[r * width..(r + 1) * width]),
+    ))
+}
+
+/// The schema produced by [`append_zorder_key_column`] for `base`: `base` plus a
+/// trailing `Binary` [`ZORDER_COLUMN_NAME`] column.
+#[must_use]
+pub fn zorder_augmented_schema(base: &Schema) -> SchemaRef {
+    let mut fields: Vec<Arc<Field>> = base.fields().iter().map(Arc::clone).collect();
+    fields.push(Arc::new(Field::new(ZORDER_COLUMN_NAME, DataType::Binary, false)));
+    Arc::new(Schema::new(Fields::from(fields)))
+}
+
+/// Append the Z-order clustering key as a trailing `Binary` column
+/// ([`ZORDER_COLUMN_NAME`]). Sorting the resulting batches ascending by that
+/// column clusters rows in Z-order across `clustering_indices` (the proven
+/// `SortExec` path is reused via `util::stream_utils::sort_stream`); the column
+/// is stripped right after the sort with [`strip_zorder_key_column`], so it is
+/// never written to a cold file.
+///
+/// # Errors
+///
+/// Returns an error if the key kernel or batch construction fails.
+pub fn append_zorder_key_column(
+    batch: &RecordBatch,
+    clustering_indices: &[usize],
+) -> DFResult<RecordBatch> {
+    let cols: Vec<ArrayRef> = clustering_indices
+        .iter()
+        .map(|&i| Arc::clone(batch.column(i)))
+        .collect();
+    let key = Arc::new(zorder_keys(&cols)?) as ArrayRef;
+    let schema = zorder_augmented_schema(batch.schema_ref());
+    let mut arrays = batch.columns().to_vec();
+    arrays.push(key);
+    RecordBatch::try_new(schema, arrays).map_err(DataFusionError::from)
+}
+
+/// Drop the trailing Z-order key column, returning a batch in `original` schema.
+///
+/// # Errors
+///
+/// Returns an error if batch construction fails.
+pub fn strip_zorder_key_column(
+    batch: &RecordBatch,
+    original: &SchemaRef,
+) -> DFResult<RecordBatch> {
+    let n = original.fields().len();
+    let arrays = batch.columns()[..n].to_vec();
+    RecordBatch::try_new(Arc::clone(original), arrays)
+        .map_err(DataFusionError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+
+    /// Argsort: indices that would sort `keys` ascending lexicographically.
+    fn argsort(keys: &BinaryArray) -> Vec<usize> {
+        let mut idx: Vec<usize> = (0..keys.len()).collect();
+        idx.sort_by(|&a, &b| keys.value(a).cmp(keys.value(b)));
+        idx
+    }
+
+    #[test]
+    fn single_column_preserves_order_including_negatives() {
+        let col: ArrayRef = Arc::new(Int64Array::from(vec![3, -1, 2, 0, -5]));
+        let keys = zorder_keys(&[col]).expect("keys");
+        let order = argsort(&keys);
+        // Sorted by key == ascending by value: -5, -1, 0, 2, 3 → original idx 4,1,3,2,0
+        assert_eq!(order, vec![4, 1, 3, 2, 0]);
+    }
+
+    #[test]
+    fn two_bit_grid_is_morton_order() {
+        // 2x2 grid points (x, y); Morton code = (x<<1)|y → order (0,0),(0,1),(1,0),(1,1).
+        let x: ArrayRef = Arc::new(Int64Array::from(vec![1, 0, 1, 0]));
+        let y: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 0, 0]));
+        let keys = zorder_keys(&[x, y]).expect("keys");
+        let order = argsort(&keys);
+        // Expected ascending Morton: (0,0)=idx3, (0,1)=idx1, (1,0)=idx2, (1,1)=idx0
+        assert_eq!(order, vec![3, 1, 2, 0]);
+    }
+
+    #[test]
+    fn key_width_is_eight_times_column_count() {
+        let a: ArrayRef = Arc::new(Int64Array::from(vec![1, 2]));
+        let b: ArrayRef = Arc::new(StringArray::from(vec!["x", "y"]));
+        let keys = zorder_keys(&[a, b]).expect("keys");
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys.value(0).len(), BYTES_PER_COLUMN * 2);
+    }
+
+    #[test]
+    fn nulls_sort_first() {
+        let col: ArrayRef = Arc::new(Int64Array::from(vec![Some(5), None, Some(-3)]));
+        let keys = zorder_keys(&[col]).expect("keys");
+        let order = argsort(&keys);
+        // null → all-zero key → first; then -3, then 5.
+        assert_eq!(order, vec![1, 2, 0]);
+    }
+
+    #[test]
+    fn empty_columns_is_error() {
+        let err = zorder_keys(&[]).expect_err("must reject empty");
+        assert!(err.to_string().contains("at least one"));
+    }
+
+    #[test]
+    fn append_then_strip_roundtrips_and_clusters() {
+        use arrow::datatypes::{DataType, Field, Schema};
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("x", DataType::Int64, false),
+            Field::new("y", DataType::Int64, false),
+        ]));
+        // Same 2x2 grid as the Morton test.
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 0, 1, 0])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![1, 1, 0, 0])) as ArrayRef,
+            ],
+        )
+        .expect("batch");
+
+        let augmented = append_zorder_key_column(&batch, &[0, 1]).expect("append");
+        assert_eq!(augmented.num_columns(), 3);
+        assert_eq!(
+            augmented.schema().field(2).name(),
+            ZORDER_COLUMN_NAME,
+            "zorder key appended as the trailing column"
+        );
+
+        // Sorting by the appended key yields Morton order over (x, y).
+        let key = augmented
+            .column(2)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .expect("binary key");
+        let mut order: Vec<usize> = (0..key.len()).collect();
+        order.sort_by(|&a, &b| key.value(a).cmp(key.value(b)));
+        assert_eq!(order, vec![3, 1, 2, 0]);
+
+        // Stripping restores the original schema and column data.
+        let stripped = strip_zorder_key_column(&augmented, &schema).expect("strip");
+        assert_eq!(stripped.schema(), schema);
+        assert_eq!(stripped.num_columns(), 2);
+    }
+}

--- a/crates/cayenne/src/provider/zorder.rs
+++ b/crates/cayenne/src/provider/zorder.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -63,7 +63,9 @@ pub const ZORDER_COLUMN_NAME: &str = "__cayenne_zorder_key";
 /// most-negative value maps to `0x0000…` and the most-positive to `0xFFFF…`).
 #[inline]
 fn key_from_i64(v: i64) -> [u8; BYTES_PER_COLUMN] {
-    ((v as u64) ^ (1u64 << 63)).to_be_bytes()
+    // Reinterpret the two's-complement bits as unsigned (no value change), then
+    // flip the sign bit so the ordering becomes unsigned-big-endian monotonic.
+    (v.cast_unsigned() ^ (1u64 << 63)).to_be_bytes()
 }
 
 /// Unsigned integers are already order-preserving as big-endian bytes.
@@ -149,16 +151,37 @@ fn column_order_keys(array: &dyn Array) -> DFResult<Vec<[u8; BYTES_PER_COLUMN]>>
             let a = arr.as_primitive::<Float64Type>();
             keys_with_nulls(n, |i| (!a.is_null(i)).then(|| key_from_f64(a.value(i))))
         }
-        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
-            let arr = cast(array, &DataType::Utf8)?;
-            let a = arr.as_string::<i32>();
+        // String/binary families read the value's byte prefix directly per
+        // offset width — no cast to the `i32`-offset variant, which would fail
+        // (or truncate) once a `Large`/`View` array's data exceeds `i32::MAX`.
+        DataType::Utf8 => {
+            let a = array.as_string::<i32>();
             keys_with_nulls(n, |i| {
                 (!a.is_null(i)).then(|| key_from_bytes(a.value(i).as_bytes()))
             })
         }
-        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {
-            let arr = cast(array, &DataType::Binary)?;
-            let a = arr.as_binary::<i32>();
+        DataType::LargeUtf8 => {
+            let a = array.as_string::<i64>();
+            keys_with_nulls(n, |i| {
+                (!a.is_null(i)).then(|| key_from_bytes(a.value(i).as_bytes()))
+            })
+        }
+        DataType::Utf8View => {
+            let a = array.as_string_view();
+            keys_with_nulls(n, |i| {
+                (!a.is_null(i)).then(|| key_from_bytes(a.value(i).as_bytes()))
+            })
+        }
+        DataType::Binary => {
+            let a = array.as_binary::<i32>();
+            keys_with_nulls(n, |i| (!a.is_null(i)).then(|| key_from_bytes(a.value(i))))
+        }
+        DataType::LargeBinary => {
+            let a = array.as_binary::<i64>();
+            keys_with_nulls(n, |i| (!a.is_null(i)).then(|| key_from_bytes(a.value(i))))
+        }
+        DataType::BinaryView => {
+            let a = array.as_binary_view();
             keys_with_nulls(n, |i| (!a.is_null(i)).then(|| key_from_bytes(a.value(i))))
         }
         // Unsupported type: contribute nothing to the curve (all rows equal on
@@ -236,7 +259,11 @@ pub fn zorder_keys(columns: &[ArrayRef]) -> DFResult<BinaryArray> {
 #[must_use]
 pub fn zorder_augmented_schema(base: &Schema) -> SchemaRef {
     let mut fields: Vec<Arc<Field>> = base.fields().iter().map(Arc::clone).collect();
-    fields.push(Arc::new(Field::new(ZORDER_COLUMN_NAME, DataType::Binary, false)));
+    fields.push(Arc::new(Field::new(
+        ZORDER_COLUMN_NAME,
+        DataType::Binary,
+        false,
+    )));
     Arc::new(Schema::new(Fields::from(fields)))
 }
 
@@ -270,14 +297,10 @@ pub fn append_zorder_key_column(
 /// # Errors
 ///
 /// Returns an error if batch construction fails.
-pub fn strip_zorder_key_column(
-    batch: &RecordBatch,
-    original: &SchemaRef,
-) -> DFResult<RecordBatch> {
+pub fn strip_zorder_key_column(batch: &RecordBatch, original: &SchemaRef) -> DFResult<RecordBatch> {
     let n = original.fields().len();
     let arrays = batch.columns()[..n].to_vec();
-    RecordBatch::try_new(Arc::clone(original), arrays)
-        .map_err(DataFusionError::from)
+    RecordBatch::try_new(Arc::clone(original), arrays).map_err(DataFusionError::from)
 }
 
 #[cfg(test)]

--- a/crates/cayenne/tests/cold_tier_test.rs
+++ b/crates/cayenne/tests/cold_tier_test.rs
@@ -158,7 +158,10 @@ async fn test_cold_tier_promotion_cross_tier_scan_and_delete_impl(
     );
 
     // Cold files are registered in the metastore manifest with the full row set.
-    let cold = fixture.catalog.list_cold_tier_files(table.table_id()).await?;
+    let cold = fixture
+        .catalog
+        .list_cold_tier_files(table.table_id())
+        .await?;
     assert!(
         !cold.is_empty(),
         "expected cold-tier files registered after promotion"
@@ -244,10 +247,13 @@ async fn test_cold_tier_promotion_cross_tier_scan_and_delete_impl(
             .is_empty(),
         "the delete stays applied across a second promotion"
     );
-    let cold2 = fixture.catalog.list_cold_tier_files(table.table_id()).await?;
-    let cold2_rows: i64 = cold2.iter().map(|f| f.row_count).sum();
+    let cold2 = fixture
+        .catalog
+        .list_cold_tier_files(table.table_id())
+        .await?;
+    let regraduated_rows: i64 = cold2.iter().map(|f| f.row_count).sum();
     assert_eq!(
-        cold2_rows, 202,
+        regraduated_rows, 202,
         "cold manifest holds exactly the live row set after replace-all promotion"
     );
 

--- a/crates/cayenne/tests/cold_tier_test.rs
+++ b/crates/cayenne/tests/cold_tier_test.rs
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::expect_used)]
+
+//! Integration tests for the cold object-store tier (storage-cascade bottom
+//! tier): whole-table promotion to a (local `file://`) cold store, cross-tier
+//! scan correctness, and the key-delete-after-promotion invariant.
+
+mod common;
+
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use cayenne::metadata::{CreateTableOptions, DeletionMode, VortexConfig};
+use cayenne::{CayenneTableProvider, MetadataCatalog};
+use datafusion::datasource::TableProvider;
+use datafusion::prelude::*;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+test_with_backends!(test_cold_tier_promotion_cross_tier_scan_and_delete_impl);
+
+async fn row_count(ctx: &SessionContext, table: &str) -> TestResult<i64> {
+    let results = ctx
+        .sql(&format!("SELECT COUNT(*) AS c FROM {table}"))
+        .await?
+        .collect()
+        .await?;
+    Ok(results
+        .first()
+        .and_then(|b| b.column(0).as_any().downcast_ref::<Int64Array>())
+        .and_then(|a| a.values().first())
+        .copied()
+        .unwrap_or(0))
+}
+
+async fn collect_pairs(ctx: &SessionContext, sql: &str) -> TestResult<Vec<(i64, i64)>> {
+    let batches = ctx.sql(sql).await?.collect().await?;
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("id column Int64");
+        let values = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("value column Int64");
+        for row in 0..batch.num_rows() {
+            rows.push((ids.value(row), values.value(row)));
+        }
+    }
+    rows.sort_unstable();
+    Ok(rows)
+}
+
+async fn delete_id(table: &Arc<CayenneTableProvider>, id: i64) -> TestResult<u64> {
+    let ctx = SessionContext::new();
+    let plan = table
+        .delete_from(&ctx.state(), vec![col("id").eq(lit(id))])
+        .await?;
+    let results = datafusion::physical_plan::collect(plan, ctx.task_ctx()).await?;
+    Ok(results
+        .first()
+        .and_then(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+        })
+        .and_then(|a| a.values().first())
+        .copied()
+        .unwrap_or(0))
+}
+
+async fn test_cold_tier_promotion_cross_tier_scan_and_delete_impl(
+    fixture: common::TestFixture,
+) -> TestResult<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+
+    // Local `file://` cold tier — no object-store config needed (the default
+    // local store resolves it).
+    let cold_dir = fixture.temp_dir.path().join("cold");
+    std::fs::create_dir_all(&cold_dir)?;
+    let cold_url = format!("file://{}", cold_dir.to_string_lossy());
+
+    let table_options = CreateTableOptions {
+        table_name: "cold_t".to_string(),
+        schema: Arc::clone(&schema),
+        primary_key: vec!["id".to_string()],
+        on_conflict: None,
+        base_path: fixture.data_path.to_string_lossy().to_string(),
+        partition_column: None,
+        vortex_config: VortexConfig {
+            // Cold tier on the local fs, clustered by `id`, triggered by ANY
+            // warm file so the test is deterministic.
+            cold_tier_location: Some(cold_url),
+            cold_clustering_columns: vec!["id".to_string()],
+            cold_tier_warm_max_files: 1,
+            cold_target_file_size_mb: 16,
+            deletion_mode: DeletionMode::Key,
+            ..VortexConfig::default()
+        },
+    };
+
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let ctx = SessionContext::new();
+    let table = Arc::new(
+        CayenneTableProvider::create_table(catalog, table_options, ctx.runtime_env()).await?,
+    );
+    ctx.register_table("cold_t", Arc::clone(&table) as Arc<dyn TableProvider>)?;
+
+    // Insert 200 rows (value = id * 2) across two batches.
+    for range in [0i64..100, 100..200] {
+        let ids: Vec<i64> = range.collect();
+        let values: Vec<i64> = ids.iter().map(|i| i * 2).collect();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(Int64Array::from(values)),
+            ],
+        )?;
+        common::insert_batch(table.as_ref(), batch).await?;
+    }
+
+    // Flush the in-RAM/inline tiers to durable warm Vortex files so the
+    // promotion trigger (which reads the warm file set) fires.
+    let _ = table.checkpoint_inlined_data().await;
+    let _ = table.checkpoint_mem_tier().await;
+
+    // Graduate the warm tier to the cold object store (Z-order clustered).
+    let promoted = table.promote_warm_to_cold().await?;
+    assert!(
+        promoted,
+        "promotion should fire with cold_tier_warm_max_files = 1"
+    );
+
+    // Cold files are registered in the metastore manifest with the full row set.
+    let cold = fixture.catalog.list_cold_tier_files(table.table_id()).await?;
+    assert!(
+        !cold.is_empty(),
+        "expected cold-tier files registered after promotion"
+    );
+    let cold_rows: i64 = cold.iter().map(|f| f.row_count).sum();
+    assert_eq!(cold_rows, 200, "all 200 rows graduated to cold");
+    assert!(
+        cold.iter().all(|f| !f.statistics_blob.is_empty()),
+        "each cold file carries a footer statistics blob for listing-time pruning"
+    );
+
+    // The physical cold files exist on the local cold store.
+    let physical_cold_files = count_vortex_files(&cold_dir);
+    assert!(
+        physical_cold_files >= 1,
+        "expected at least one physical .vortex file on the cold store, got {physical_cold_files}"
+    );
+
+    // Cross-tier scan: warm is now an empty snapshot, so returning all rows
+    // proves the cold branch is read + unioned correctly.
+    assert_eq!(
+        row_count(&ctx, "cold_t").await?,
+        200,
+        "cross-tier scan returns all promoted rows from the cold tier"
+    );
+    assert_eq!(
+        collect_pairs(&ctx, "SELECT id, value FROM cold_t WHERE id = 42").await?,
+        vec![(42, 84)],
+        "point lookup over the cold tier returns the right row"
+    );
+    assert_eq!(
+        collect_pairs(&ctx, "SELECT id, value FROM cold_t ORDER BY id LIMIT 3").await?,
+        vec![(0, 0), (1, 2), (2, 4)],
+        "ordered cross-tier scan with a limit returns correct rows"
+    );
+
+    // Key-delete-after-promotion: a delete must hide a row that now lives ONLY
+    // in the cold tier (the cold branch applies the shared key-delete filter).
+    let deleted = delete_id(&table, 42).await?;
+    eprintln!("[cold_tier_test] DELETE id=42 reported rows-affected = {deleted}");
+    // The data-correctness invariant: the row is hidden and the live count drops,
+    // regardless of the reported rows-affected count (which is a separate concern).
+    assert!(
+        collect_pairs(&ctx, "SELECT id, value FROM cold_t WHERE id = 42")
+            .await?
+            .is_empty(),
+        "a delete after promotion hides the cold-resident row (Ignore-filter invariant)"
+    );
+    assert_eq!(
+        row_count(&ctx, "cold_t").await?,
+        199,
+        "exactly one row removed across the cold tier"
+    );
+
+    // Insert more warm rows, then promote AGAIN. Whole-table promotion
+    // re-materializes the entire visible table (warm + prior cold) into a new
+    // cold generation; replace-all in the commit must prevent gen-1 rows from
+    // being double-counted alongside gen-2.
+    let batch2 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![200i64, 201, 202])),
+            Arc::new(Int64Array::from(vec![400i64, 402, 404])),
+        ],
+    )?;
+    common::insert_batch(table.as_ref(), batch2).await?;
+    let _ = table.checkpoint_inlined_data().await;
+    let _ = table.checkpoint_mem_tier().await;
+    assert!(
+        table.promote_warm_to_cold().await?,
+        "second promotion should fire"
+    );
+
+    // 199 (post-delete) + 3 new = 202, with NO gen-1 duplication.
+    assert_eq!(
+        row_count(&ctx, "cold_t").await?,
+        202,
+        "repeated whole-table promotion must not double-count the prior cold generation"
+    );
+    assert!(
+        collect_pairs(&ctx, "SELECT id, value FROM cold_t WHERE id = 42")
+            .await?
+            .is_empty(),
+        "the delete stays applied across a second promotion"
+    );
+    let cold2 = fixture.catalog.list_cold_tier_files(table.table_id()).await?;
+    let cold2_rows: i64 = cold2.iter().map(|f| f.row_count).sum();
+    assert_eq!(
+        cold2_rows, 202,
+        "cold manifest holds exactly the live row set after replace-all promotion"
+    );
+
+    Ok(())
+}
+
+/// Recursively count `.vortex` files under `dir`.
+fn count_vortex_files(dir: &std::path::Path) -> usize {
+    let mut count = 0;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                count += count_vortex_files(&path);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("vortex") {
+                count += 1;
+            }
+        }
+    }
+    count
+}

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -1045,6 +1045,23 @@ impl CayenneAccelerator {
                 );
             }
 
+            // The cold object-store tier requires key-based deletes: position
+            // deletes are file-path scoped and cannot survive the warm→cold
+            // rewrite. Force key when the cold tier is enabled and a primary key
+            // exists (the engine additionally skips promotion for position-mode
+            // tables, so this keeps the cold tier from being silently inert).
+            if config.cold_tier_enabled()
+                && workload.has_primary_key
+                && config.deletion_mode != cayenne::metadata::DeletionMode::Key
+            {
+                if config.deletion_mode == cayenne::metadata::DeletionMode::Position {
+                    tracing::warn!(
+                        "Dataset '{table_name}': the cold object-store tier (cayenne_cold_tier_location) requires key-based deletes; overriding cayenne_deletion_mode 'position' -> 'key'."
+                    );
+                }
+                config.deletion_mode = cayenne::metadata::DeletionMode::Key;
+            }
+
             // CDC durability mode (file | memory). Memory mode appends CDC
             // batches to an in-RAM tier and defers the source slot ack to a
             // checkpoint; it is only meaningful for the small-write/CDC
@@ -1165,6 +1182,47 @@ impl CayenneAccelerator {
                     .filter(|s| !s.is_empty())
                     .collect();
             }
+
+            // Cold object-store tier (storage-cascade bottom tier). Presence of a
+            // non-empty `cayenne_cold_tier_location` enables it; the rest tune the
+            // clustering key, cold file size, and the warm→cold promotion trigger.
+            if let Some(loc) = acceleration.params.get("cayenne_cold_tier_location") {
+                let loc = loc.trim();
+                if !loc.is_empty() {
+                    config.cold_tier_location = Some(loc.to_string());
+                }
+            }
+            if let Some(cols) = acceleration.params.get("cayenne_cold_clustering_columns") {
+                config.cold_clustering_columns = cols
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            }
+            // Numeric cold knobs go through the same `auto_or_*` helpers as the
+            // warm tuning params, so they honor `auto`, warn on invalid input,
+            // and clamp consistently with the rest of the config surface.
+            config.cold_target_file_size_mb = autotune::auto_or_usize(
+                acceleration,
+                &["cayenne_cold_target_file_size_mb"],
+                config.cold_target_file_size_mb,
+            )
+            .max(1);
+            config.cold_tier_warm_max_bytes = autotune::auto_or_i64(
+                acceleration,
+                &["cayenne_cold_tier_warm_max_bytes"],
+                config.cold_tier_warm_max_bytes,
+            );
+            config.cold_tier_warm_max_files = autotune::auto_or_usize(
+                acceleration,
+                &["cayenne_cold_tier_warm_max_files"],
+                config.cold_tier_warm_max_files,
+            );
+            config.cold_tier_background_interval_ms = autotune::auto_or_u64(
+                acceleration,
+                &["cayenne_cold_tier_background_interval_ms"],
+                config.cold_tier_background_interval_ms,
+            );
 
             // Upload concurrency: `auto`/unset keeps the available-parallelism
             // default; 0 → warn + minimum 1. The aggregate across all tables is
@@ -1737,6 +1795,21 @@ impl CayenneAccelerator {
         if let Some(retention_builder) = time_retention_filter_builder {
             builder = builder.with_time_retention_filter_builder(retention_builder);
         }
+        // Cold tier: when enabled with an s3:// location, reuse the warm S3
+        // object store for the cold tier (v1: an s3:// cold location shares the
+        // warm bucket). A local `file://` cold tier needs no store — the default
+        // local store resolves it. Cloned before the warm store is moved below.
+        let cold_object_store = if table_options.vortex_config.cold_tier_enabled()
+            && table_options
+                .vortex_config
+                .cold_tier_location
+                .as_deref()
+                .is_some_and(|l| l.starts_with("s3://"))
+        {
+            object_store.clone()
+        } else {
+            None
+        };
         if let Some(object_store) = object_store {
             tracing::info!(
                 "Using S3 Express One Zone storage for {} acceleration: {}",
@@ -1750,6 +1823,9 @@ impl CayenneAccelerator {
                     "S3 Express One Zone storage detected but object store configuration is missing",
                 )),
             });
+        }
+        if let Some(cold) = cold_object_store {
+            builder = builder.with_cold_object_store(cold);
         }
         tracing::debug!("create_cayenne_table_provider: calling builder.create for {table_name}");
         let cayenne_table = builder
@@ -1770,6 +1846,15 @@ impl CayenneAccelerator {
         if provider.spawn_background_mem_tier_checkpoint() {
             tracing::debug!(
                 "Background mem-tier checkpoint task spawned for Cayenne table {table_name}",
+            );
+        }
+        // Cold-tier promotion (storage-cascade bottom tier); a no-op unless
+        // cayenne_cold_tier_location is set. Runs on the same internal
+        // background-worker infra as the mem-tier checkpointer, on its own
+        // cadence — no spicepod `workers:` section, nothing user-facing.
+        if provider.spawn_background_cold_tier_promotion() {
+            tracing::debug!(
+                "Background cold-tier promotion task spawned for Cayenne table {table_name}",
             );
         }
         Ok(provider)
@@ -1851,8 +1936,8 @@ fn wrap_with_native_vector_indexes(
 const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
     ParameterSpec,
     S3_PARAMS_LEN,
-    47,
-    { S3_PARAMS_LEN + 47 },
+    53,
+    { S3_PARAMS_LEN + 53 },
 >(
     S3_PARAMETERS,
     [
@@ -1881,6 +1966,18 @@ const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
             .description("When 'true' (default), Cayenne advertises and decodes string and binary columns as Arrow view types (Utf8View/BinaryView) on the query/scan path so DataFusion plans joins and aggregates on view arrays, avoiding the i32 2 GiB offset overflow in hash-join build-side batch concatenation at scale. The stored schema keeps Utf8/Binary for writes, CDC, and stats. Set 'false' to opt out.")
             .one_of(&["true", "false"])
             .default("true"),
+        ParameterSpec::component("cold_tier_location")
+            .description("Object-store URL prefix for the cold tier (storage-cascade bottom tier), e.g. 's3://bucket/prefix' or 'file:///mnt/cold'. When set, a background promotion stage graduates the warm local-disk tier to read-optimized, Z-order-clustered Vortex files on this store, and queries span warm + cold with per-tier pushdown. Unset (default) disables the cold tier. Requires key-based deletes and a primary key (auto-resolved). v1: an s3:// cold location must share the warm bucket; partitioned and position-delete tables are not supported."),
+        ParameterSpec::component("cold_clustering_columns")
+            .description("Comma-separated liquid-clustering key columns for cold files (multi-column Z-order), e.g. 'tenant_id,ts'. When unset, falls back to cayenne_sort_columns, then the primary key. Clustering tightens each cold file's per-column zone maps so selective queries on any clustering dimension prune at the storage layer."),
+        ParameterSpec::component("cold_target_file_size_mb")
+            .description("Target size for cold-tier Vortex files in MB. Larger than the warm cayenne_target_file_size_mb because object stores favor fewer, larger objects and cold scans are range reads. Default: 512."),
+        ParameterSpec::component("cold_tier_warm_max_bytes")
+            .description("The warm tier graduates to cold once its total Vortex bytes reach this threshold. 0 (default) disables the byte trigger; set with cold_tier_warm_max_files to bound warm-tier size."),
+        ParameterSpec::component("cold_tier_warm_max_files")
+            .description("The warm tier graduates to cold once its Vortex file count reaches this threshold. 0 (default) disables the file-count trigger."),
+        ParameterSpec::component("cold_tier_background_interval_ms")
+            .description("How often the background loop evaluates the warm→cold promotion trigger. Cold tiering is not latency-critical, so this is coarser than compaction. Default: 60000 (60s)."),
         ParameterSpec::component("sort_columns")
             .description("Comma-separated list of columns to sort data by during inserts (e.g., 'timestamp,user_id')."),
         ParameterSpec::component("shard_key_columns")


### PR DESCRIPTION
## What

Adds a third, colder storage tier below Cayenne's warm local-disk Vortex tier. Data cascades **RAM mem-tier → local-disk warm → object-store cold**; a row lives in exactly one tier. When enabled, queries **span all tiers** and push filters/projection/limit down to each, pruning cold files from stats.

Gated behind `cayenne_cold_tier_location` — **dormant and byte-identical to today when unset.**

## How it works

- **Promotion (write path).** A dedicated internal background worker (`BackgroundColdTierPromoter`, on its own cadence — no spicepod `workers:` section) graduates the warm tier once size/file thresholds are crossed. It re-materializes the whole visible table (all deletes applied, single-version per key), **Z-order clusters** it for tight multi-column zone maps, writes read-optimized Vortex at a larger cold file size, and **atomically** registers the cold files + overwrite-clears the warm tier in one transaction (replace-all, so repeated promotion never double-counts).
- **Cross-tier scan (read path).** A cold branch is unioned into `scan()` alongside the warm/inline/mem branches. It prunes cold files from the metastore stats blob (**no object-store round-trip on the query path**) and applies the shared, **tier-blind key-delete filter** with the old-data (`Ignore`) treatment — so a `DELETE` after promotion correctly hides a cold-resident row.
- **Correct by construction.** Cold graduation reuses the proven overwrite commit + visible-file rewrite, i.e. it's "an overwrite whose content lives on the cold store."

## Design choices

- **Cascade** tier model (promoted files leave the warm tier).
- **Z-order (Morton)** clustering: a new expr-based kernel (order-preserving per-column keys + MSB-first bit-interleave) applied via the existing `SortExec` path without materializing a clustering column.
- **Key-based deletes** required for cold-tier tables (auto-forced); partitioned and position-delete tables are unsupported in v1.
- **Config**: `cayenne_cold_tier_location` (presence enables it) + clustering columns, cold file size, and warm→cold promotion triggers — parsed through the shared `autotune::auto_or_*` helpers.
- **Metastore**: new table-scoped `cayenne_cold_tier_file` manifest (sqlite + turso + `EXPECTED_TABLES`), stats blob inline for zero-round-trip pruning.

## Testing

- **`cold_tier_test`** (sqlite + turso): promotion → cross-tier scan (count / point-lookup / ordered-limit) → key-delete-after-promotion → repeated-promotion replace-all.
- **Z-order unit tests** (Morton order incl. negatives, null-first, key width, append/strip round-trip).
- **Full cayenne suite**: 53 binaries, 1,381 passed, 0 failed on both backends.
- **`zorder_clustering` bench**: clustering effectiveness (**~8× fewer files pruned on non-leading dimensions** vs a single-column sort) + kernel throughput.

## Scope / follow-ups (v1)

Whole-table promotion (subset promotion deferred); physical GC of superseded cold generations deferred (queries/deletes use the manifest, so correctness holds); retention correctness holds at query time (keep-filter reaches the cold branch), physical reclamation of retention-expired cold rows deferred; adaptive clustering keys from query history, partitioned+cold, and S3-cold-on-a-different-bucket are phase-2.
