### PR TITLE
chore(cluster): bump ballista pin for the null-aware anti-join fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0f6d5d9980b9a4ed84bdecf877e5c1346435f3da#0f6d5d9980b9a4ed84bdecf877e5c1346435f3da"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0a99d7c0a44488a202b893d0e53ada35ba96a9a6#0a99d7c0a44488a202b893d0e53ada35ba96a9a6"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0f6d5d9980b9a4ed84bdecf877e5c1346435f3da#0f6d5d9980b9a4ed84bdecf877e5c1346435f3da"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0a99d7c0a44488a202b893d0e53ada35ba96a9a6#0a99d7c0a44488a202b893d0e53ada35ba96a9a6"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0f6d5d9980b9a4ed84bdecf877e5c1346435f3da#0f6d5d9980b9a4ed84bdecf877e5c1346435f3da"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0a99d7c0a44488a202b893d0e53ada35ba96a9a6#0a99d7c0a44488a202b893d0e53ada35ba96a9a6"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,9 +149,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0f6d5d9980b9a4ed84bdecf877e5c1346435f3da" } # branch: spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0f6d5d9980b9a4ed84bdecf877e5c1346435f3da" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0f6d5d9980b9a4ed84bdecf877e5c1346435f3da" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0a99d7c0a44488a202b893d0e53ada35ba96a9a6" } # branch: spiceai-54
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0a99d7c0a44488a202b893d0e53ada35ba96a9a6" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "0a99d7c0a44488a202b893d0e53ada35ba96a9a6" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"


### PR DESCRIPTION
Bumps the Ballista pin to `spiceai/datafusion-ballista@0a99d7c0` (spiceai-54), which merges spiceai/datafusion-ballista#58.

## Why

Ballista's scheduler-side `JoinSelection` swapped a null-aware `LeftAnti` join (from a `NOT IN` subquery) to `RightAnti` to put the smaller input on the build side. `null_aware` is only valid for `LeftAnti`, so `HashJoinExec` rejects the swapped join during stage resolution (`null_aware can only be true for LeftAnti joins, got RightAnti`); the stage never completes and the distributed query hangs until the client times out.

spiceai/datafusion-ballista#58 guards the swap, builds null-aware anti joins in `CollectLeft` mode, and preserves the `null_aware` flag on rebuild.

## Validation

- spiceai/datafusion-ballista#58: CI green, approved, merged.
- Full local SF100 distributed TPC-H run is green with this pin — 28/28 query families, including q16, which exercises the `NOT IN` anti join.

## Change

Pin bump only: `Cargo.toml` (3 lines) + `Cargo.lock`.
