### PR TITLE
Generic CDC replication-lag metric

### DIFF
--- a/crates/data-connectors/connector-mongodb/src/changes.rs
+++ b/crates/data-connectors/connector-mongodb/src/changes.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use data_components::{
     cdc::{
         ChangeEnvelope, ChangesStream, CommitChange, CommitError, NoOpCommitter, StreamError,
-        build_ready_signal_envelope, wrap_data_as_change_batch,
+        build_heartbeat_envelope, build_ready_signal_envelope, wrap_data_as_change_batch,
     },
     mongodb::stream::{
         change_events_to_change_batch, default_unnest_parameters, nullable_clone,
@@ -31,11 +31,11 @@ use datafusion::{
     physical_plan::SendableRecordBatchStream, prelude::SessionContext,
 };
 use datafusion_table_providers::mongodb::connection_pool::MongoDBConnectionPool;
-use futures::StreamExt as FuturesStreamExt;
+use futures::{Stream, StreamExt as FuturesStreamExt};
 use mongodb::{
-    Collection,
+    ClientSession, Collection,
     bson::Document,
-    change_stream::{ChangeStream, event::ChangeStreamEvent, event::ResumeToken},
+    change_stream::{event::ChangeStreamEvent, event::ResumeToken, session::SessionChangeStream},
     options::FullDocumentType,
 };
 use runtime::{
@@ -50,7 +50,11 @@ use runtime::{
     federated_table::FederatedTable,
     parameters::{ExposedParamLookup, Parameters},
 };
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    sync::atomic::{AtomicI64, Ordering},
+    time::Duration,
+};
 use tokio_stream::StreamExt as TokioStreamExt;
 
 const DEFAULT_CHANGE_STREAM_BATCH_MAX_SIZE: usize = 1_000;
@@ -82,10 +86,26 @@ pub fn build_changes_stream(
                 "Failed to connect to MongoDB Change Stream for dataset `{}` collection `{collection_name}`: {error}",
                 dataset.name
             )))?;
+
         let collection = connection
             .client
             .database(&connection.db_name)
             .collection::<Document>(&collection_name);
+
+        // Run the change stream under an EXPLICIT session so we can read the
+        // server's `operation_time` between getMores — including the empty ones
+        // emitted while idle. That timestamp drives the idle heartbeat's
+        // `source_commit_ts_ms` (see `mongodb_event_stream`): it advances only
+        // when the server actually replied, so a stalled cursor can't make the
+        // replication-lag gauge read falsely fresh the way wall-clock `now()` would.
+        let mut session = collection
+            .client()
+            .start_session()
+            .await
+            .map_err(|error| StreamError::External(format!(
+                "Failed to start MongoDB session for dataset `{}` collection `{collection_name}`: {error}",
+                dataset.name
+            )))?;
 
         let mongo_sys = if dataset.is_file_accelerated() {
             initialize_mongo_sys(&dataset).await
@@ -110,7 +130,7 @@ pub fn build_changes_stream(
                     dataset.name
                 )))?;
 
-            match try_open_change_stream(&collection, &config, Some(resume_token)).await {
+            match try_open_change_stream(&collection, &config, Some(resume_token), &mut session).await {
                 Ok(stream) => {
                     tracing::info!(
                         dataset = %dataset.name,
@@ -158,6 +178,7 @@ pub fn build_changes_stream(
                 &dataset.name,
                 &collection_name,
                 None,
+                &mut session,
             )
             .await?;
             let resume_token = initial_change_stream.resume_token().ok_or_else(|| {
@@ -233,23 +254,74 @@ pub fn build_changes_stream(
                 &dataset.name,
                 &collection_name,
                 Some(resume_token),
+                &mut session,
             )
             .await?
         };
 
         let unnest_parameters = default_unnest_parameters(config.unnest_depth);
-        let event_batches = live_change_stream.chunks_timeout(
+
+        // Idle heartbeat: while the change stream produces no events, the source is
+        // caught up to the oplog head, so emit a zero-row heartbeat to keep the
+        // replication-lag gauge (`now - source_commit_ts_ms`) reading ~0 instead of
+        // freezing at the last real event's age.
+        //
+        // The heartbeat is stamped with the SERVER's `operation_time` (the cluster
+        // time the cursor has scanned through). Unlike wall-clock `now()`, it advances
+        // only when the server actually replied.
+        let heartbeat_interval = config.batch_max_duration.saturating_mul(2);
+
+        // Latest server operation time (ms since the Unix epoch)
+        let server_commit_ms = Arc::new(AtomicI64::new(0));
+        let event_stream = mongodb_event_stream(
+            live_change_stream,
+            session,
+            Arc::clone(&server_commit_ms),
+            dataset.name.clone(),
+        );
+        let event_batches = event_stream.chunks_timeout(
             config.batch_max_size,
             config.batch_max_duration,
         );
         tokio::pin!(event_batches);
 
-        while let Some(batch) = TokioStreamExt::next(&mut event_batches).await {
-            if batch.is_empty() {
+        loop {
+            let batch = match tokio::time::timeout(
+                heartbeat_interval,
+                TokioStreamExt::next(&mut event_batches),
+            )
+            .await
+            {
+                // Change stream ended.
+                Ok(None) => break,
+                Ok(Some(batch)) => batch,
+                // Idle window elapsed: the source is caught up. Emit a heartbeat
+                // stamped with the freshest server time observed, then keep tailing.
+                // Skip while it's still 0 (no getMore has replied yet) so we never
+                // emit a timestamp we can't vouch for.
+                Err(_elapsed) => {
+                    let server_ms = server_commit_ms.load(Ordering::Relaxed);
+                    if server_ms > 0 {
+                        match build_heartbeat_envelope(&schema, server_ms) {
+                            Ok(envelope) => yield envelope,
+                            Err(error) => tracing::warn!(
+                                dataset = %dataset.name,
+                                %error,
+                                "Failed to build MongoDB CDC heartbeat envelope; replication-lag gauge may go stale while the stream is idle"
+                            ),
+                        }
+                    }
+                    continue;
+                }
+            };
+
+            // Surface the first cursor error in the chunk (matches the previous
+            // `collect_change_events` short-circuit); the wrapper already tagged it
+            // with dataset context.
+            let events = batch.into_iter().collect::<Result<Vec<_>, _>>()?;
+            if events.is_empty() {
                 continue;
             }
-
-            let events = collect_change_events(batch, &dataset)?;
 
             let tail_token = events.last().map(|event| event.id.clone());
             let tail_cluster_time = events
@@ -476,7 +548,8 @@ async fn try_open_change_stream(
     collection: &Collection<Document>,
     config: &ChangeStreamConfig,
     resume_token: Option<ResumeToken>,
-) -> mongodb::error::Result<ChangeStream<ChangeStreamEvent<Document>>> {
+    session: &mut ClientSession,
+) -> mongodb::error::Result<SessionChangeStream<ChangeStreamEvent<Document>>> {
     let mut watch = collection
         .watch()
         .full_document(FullDocumentType::UpdateLookup)
@@ -487,7 +560,10 @@ async fn try_open_change_stream(
         watch = watch.resume_after(resume_token);
     }
 
-    watch.await
+    // Bind the watch to our explicit session so its getMores run on it and
+    // advance `session.operation_time()` (read by the idle heartbeat). The
+    // returned stream owns its cursor and does not retain the session borrow.
+    watch.session(session).await
 }
 
 async fn open_change_stream(
@@ -496,8 +572,9 @@ async fn open_change_stream(
     dataset_name: &datafusion::sql::TableReference,
     collection_name: &str,
     resume_token: Option<ResumeToken>,
-) -> Result<ChangeStream<ChangeStreamEvent<Document>>, StreamError> {
-    try_open_change_stream(collection, config, resume_token)
+    session: &mut ClientSession,
+) -> Result<SessionChangeStream<ChangeStreamEvent<Document>>, StreamError> {
+    try_open_change_stream(collection, config, resume_token, session)
         .await
         .map_err(|error| {
             StreamError::External(format!(
@@ -528,19 +605,33 @@ async fn snapshot_stream(
         .map_err(|error| data_components::cdc::StreamError::Arrow(error.to_string()))
 }
 
-fn collect_change_events(
-    batch: Vec<mongodb::error::Result<ChangeStreamEvent<Document>>>,
-    dataset: &Dataset,
-) -> Result<Vec<ChangeStreamEvent<Document>>, data_components::cdc::StreamError> {
-    batch
-        .into_iter()
-        .collect::<mongodb::error::Result<Vec<_>>>()
-        .map_err(|error| {
-            data_components::cdc::StreamError::External(format!(
-                "Failed to read MongoDB Change Stream event for dataset `{}`: {error}",
-                dataset.name
-            ))
-        })
+/// Adapt a session-bound change stream into a plain `Stream` of events so the
+/// caller can reuse `chunks_timeout` (a `SessionChangeStream` is not a `Stream`,
+/// since advancing it needs `&mut ClientSession`).
+fn mongodb_event_stream(
+    mut stream: SessionChangeStream<ChangeStreamEvent<Document>>,
+    mut session: ClientSession,
+    server_commit_ms: Arc<AtomicI64>,
+    dataset_name: datafusion::sql::TableReference,
+) -> impl Stream<Item = Result<ChangeStreamEvent<Document>, StreamError>> {
+    try_stream! {
+        while stream.is_alive() {
+            let maybe_event = stream.next_if_any(&mut session).await.map_err(|error| {
+                StreamError::External(format!(
+                    "Failed to read MongoDB Change Stream event for dataset `{dataset_name}`: {error}"
+                ))
+            })?;
+
+            if let Some(ts) = session.operation_time() {
+                server_commit_ms.store(i64::from(ts.time).saturating_mul(1000), Ordering::Relaxed);
+            }
+
+            if let Some(event) = maybe_event {
+                yield event;
+            }
+            // `None` => empty getMore: nothing to yield; the clock is already updated.
+        }
+    }
 }
 
 fn resolve_primary_keys(

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -220,14 +220,6 @@ impl CommitChange for NoOpCommitter {
     }
 }
 
-/// Construct an empty [`ChangeEnvelope`] whose only job is to flip
-/// `is_dataset_ready=true`. The batch contains zero rows and uses a no-op
-/// committer.
-///
-/// Connectors should emit one of these envelopes once they consider
-/// themselves caught up to the source if no real change events are available
-/// to carry the ready signal. See the [`ChangesStream`] documentation for the
-/// readiness contract.
 /// Build a zero-row [`ChangeBatch`] whose data struct is all-nullable so it
 /// coalesces (concats) with the truncate/snapshot/live change batches without an
 /// Arrow "arrays of different data types" error. Shared by the ready-signal and
@@ -273,6 +265,14 @@ fn empty_change_batch(schema: &SchemaRef) -> Result<ChangeBatch, ChangeBatchErro
     ChangeBatch::try_new(record)
 }
 
+/// Construct an empty [`ChangeEnvelope`] whose only job is to flip
+/// `is_dataset_ready=true`. The batch contains zero rows and uses a no-op
+/// committer.
+///
+/// Connectors should emit one of these envelopes once they consider themselves
+/// caught up to the source if no real change events are available to carry the
+/// ready signal. See the [`ChangesStream`] documentation for the readiness
+/// contract.
 pub fn build_ready_signal_envelope(schema: &SchemaRef) -> Result<ChangeEnvelope, ChangeBatchError> {
     Ok(ChangeEnvelope::new(
         Box::new(NoOpCommitter),

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -228,13 +228,17 @@ impl CommitChange for NoOpCommitter {
 /// themselves caught up to the source if no real change events are available
 /// to carry the ready signal. See the [`ChangesStream`] documentation for the
 /// readiness contract.
-pub fn build_ready_signal_envelope(schema: &SchemaRef) -> Result<ChangeEnvelope, ChangeBatchError> {
+/// Build a zero-row [`ChangeBatch`] whose data struct is all-nullable so it
+/// coalesces (concats) with the truncate/snapshot/live change batches without an
+/// Arrow "arrays of different data types" error. Shared by the ready-signal and
+/// heartbeat envelope builders.
+fn empty_change_batch(schema: &SchemaRef) -> Result<ChangeBatch, ChangeBatchError> {
     // Normalize fields to all-nullable so this empty barrier batch's struct type
     // matches the truncate/snapshot/live change batches it coalesces with. The
     // dataset schema may declare non-null columns (e.g. a `nullable: false`
     // primary key in the spicepod), but every other change batch uses the
     // nullable schema; without this, concat fails ("arrays of different data
-    // types") when the ready signal is coalesced with real data.
+    // types") when the batch is coalesced with real data.
     let nullable_schema = Schema::new(
         schema
             .fields()
@@ -266,12 +270,32 @@ pub fn build_ready_signal_envelope(schema: &SchemaRef) -> Result<ChangeEnvelope,
         vec![op_array, Arc::new(pk_list), Arc::new(data_struct)],
     )
     .context(ArrowSnafu)?;
-    let batch = ChangeBatch::try_new(record)?;
+    ChangeBatch::try_new(record)
+}
 
+pub fn build_ready_signal_envelope(schema: &SchemaRef) -> Result<ChangeEnvelope, ChangeBatchError> {
     Ok(ChangeEnvelope::new(
         Box::new(NoOpCommitter),
-        batch,
+        empty_change_batch(schema)?,
         true, // is_dataset_ready
+    ))
+}
+
+/// Build a zero-row "heartbeat" envelope carrying only an upstream commit
+/// timestamp (`source_commit_ts_ms`, ms since the Unix epoch). A CDC source emits
+/// it while its stream is idle (caught up to the source's change-log head) so the
+/// replication-lag gauge (`now - source_commit_ts_ms`) keeps reading ~0 when
+/// caught up instead of freezing at the last real event's age. It carries no
+/// rows, uses a [`NoOpCommitter`] (advances no source offset), and is NOT a
+/// readiness signal.
+pub fn build_heartbeat_envelope(
+    schema: &SchemaRef,
+    source_commit_ts_ms: i64,
+) -> Result<ChangeEnvelope, ChangeBatchError> {
+    Ok(ChangeEnvelope::new(
+        Box::new(NoOpCommitter),
+        empty_change_batch(schema)?.with_source_commit_ts_ms(Some(source_commit_ts_ms)),
+        false, // not a readiness signal
     ))
 }
 

--- a/crates/data_components/src/postgres_replication/client.rs
+++ b/crates/data_components/src/postgres_replication/client.rs
@@ -35,7 +35,7 @@ use super::{
     pgoutput::{DecodedMessage, Decoder},
     schema_evolution::RelationSchemaTracker,
 };
-use crate::cdc::{ChangeEnvelope, ChangesStream, StreamError};
+use crate::cdc::{ChangeEnvelope, ChangesStream, StreamError, build_heartbeat_envelope};
 
 pub struct WalStreamInput {
     pub params: ReplicationParams,
@@ -494,7 +494,7 @@ fn wal_stream(
                     metrics.set_confirmed_flush_lsn(applied);
                     client.update_applied_lsn(Lsn(applied));
                 }
-                ReplicationEvent::KeepAlive { wal_end, reply_requested: _, .. } => {
+                ReplicationEvent::KeepAlive { wal_end, server_time_micros, .. } => {
                     metrics.set_server_wal_end(wal_end.0);
                     // KeepAlive `wal_end` can advance even when this publication
                     // emitted no table changes. If no decoded transaction is
@@ -511,6 +511,31 @@ fn wal_stream(
                     );
                     metrics.set_confirmed_flush_lsn(applied);
                     client.update_applied_lsn(Lsn(applied));
+
+                    // Idle heartbeat: a keepalive means the server has sent us all
+                    // WAL through `wal_end`, so when no transaction is mid-buffer we
+                    // are caught up to the source. Emit a zero-row heartbeat stamped
+                    // with the server's own clock (`server_time_micros`) — a direct,
+                    // liveness-backed signal that only advances when the server
+                    // actually replied — so the replication-lag gauge reads ~0 while
+                    // idle instead of freezing at the last transaction's commit time.
+                    // Skipped while a transaction is buffered: we still owe its rows,
+                    // so the dataset is not caught up.
+                    if txn.is_none()
+                        && let Some(server_ts_ms) = pg_epoch_to_system_time(server_time_micros)
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .ok()
+                            .and_then(|d| i64::try_from(d.as_millis()).ok())
+                    {
+                        match build_heartbeat_envelope(&working_schema, server_ts_ms) {
+                            Ok(envelope) => yield envelope,
+                            Err(error) => tracing::warn!(
+                                dataset = %dataset_name,
+                                %error,
+                                "Failed to build Postgres CDC heartbeat envelope; replication-lag gauge may go stale while the stream is idle"
+                            ),
+                        }
+                    }
                 }
                 ReplicationEvent::Message { .. } => {}
                 ReplicationEvent::StoppedAt { reached } => {

--- a/crates/data_components/src/postgres_replication/client.rs
+++ b/crates/data_components/src/postgres_replication/client.rs
@@ -522,10 +522,9 @@ fn wal_stream(
                     // Skipped while a transaction is buffered: we still owe its rows,
                     // so the dataset is not caught up.
                     if txn.is_none()
-                        && let Some(server_ts_ms) = pg_epoch_to_system_time(server_time_micros)
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .ok()
-                            .and_then(|d| i64::try_from(d.as_millis()).ok())
+                        && let Some(server_ts_ms) = util::time::system_time_to_unix_ms(
+                            pg_epoch_to_system_time(server_time_micros),
+                        )
                     {
                         match build_heartbeat_envelope(&working_schema, server_ts_ms) {
                             Ok(envelope) => yield envelope,

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -97,7 +97,9 @@ use super::{
     config::ReplicationParams,
     pgoutput, resilience, slot,
 };
-use crate::cdc::{ChangeEnvelope, ChangesStream, CommitChange, CommitError, StreamError};
+use crate::cdc::{
+    ChangeEnvelope, ChangesStream, CommitChange, CommitError, StreamError, build_heartbeat_envelope,
+};
 use crate::postgres_replication::pgoutput::RelationId;
 
 /// Bounded per-member delivery queue. When one member's sink stops draining,
@@ -988,7 +990,11 @@ async fn run_pump(source: Arc<SharedSource>) {
                     source.for_each_member_metrics(|m| m.set_confirmed_flush_lsn(flush));
                     client.update_applied_lsn(Lsn(flush));
                 }
-                ReplicationEvent::KeepAlive { wal_end, .. } => {
+                ReplicationEvent::KeepAlive {
+                    wal_end,
+                    server_time_micros,
+                    ..
+                } => {
                     source.for_each_member_metrics(|m| m.set_server_wal_end(wal_end.0));
                     if !txn_open {
                         source.ack.credit_idle(wal_end.0);
@@ -996,6 +1002,40 @@ async fn run_pump(source: Arc<SharedSource>) {
                     let flush = source.ack.flush_lsn();
                     source.for_each_member_metrics(|m| m.set_confirmed_flush_lsn(flush));
                     client.update_applied_lsn(Lsn(flush));
+
+                    // Idle heartbeat: with no transaction mid-buffer the shared slot is
+                    // caught up to the source as of the keepalive's server clock. Fan a
+                    // zero-row heartbeat (stamped with `server_time_micros`, a direct
+                    // liveness-backed server signal) out to every live member so each
+                    // dataset's replication-lag gauge reads ~0 while idle instead of
+                    // freezing at its last commit. The `NoOpCommitter` inside
+                    // `build_heartbeat_envelope` advances no LSN — the idle credit above
+                    // already moved the slot forward.
+                    if !txn_open
+                        && let Some(server_ts_ms) =
+                            client::pg_epoch_to_system_time(server_time_micros)
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .ok()
+                                .and_then(|d| i64::try_from(d.as_millis()).ok())
+                    {
+                        for (member_key, member) in source.live_members() {
+                            match build_heartbeat_envelope(&member.schema, server_ts_ms) {
+                                Ok(envelope) => {
+                                    if member.sender.send(Ok(envelope)).await.is_err() {
+                                        source.detach_member(
+                                            &member_key,
+                                            "changes stream receiver dropped",
+                                        );
+                                    }
+                                }
+                                Err(error) => tracing::warn!(
+                                    dataset = %member.dataset_name,
+                                    %error,
+                                    "Failed to build Postgres CDC heartbeat envelope; replication-lag gauge may go stale while the stream is idle"
+                                ),
+                            }
+                        }
+                    }
                 }
                 ReplicationEvent::Message { .. } => {}
                 ReplicationEvent::StoppedAt { reached } => {

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -1012,11 +1012,9 @@ async fn run_pump(source: Arc<SharedSource>) {
                     // `build_heartbeat_envelope` advances no LSN — the idle credit above
                     // already moved the slot forward.
                     if !txn_open
-                        && let Some(server_ts_ms) =
-                            client::pg_epoch_to_system_time(server_time_micros)
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .ok()
-                                .and_then(|d| i64::try_from(d.as_millis()).ok())
+                        && let Some(server_ts_ms) = util::time::system_time_to_unix_ms(
+                            client::pg_epoch_to_system_time(server_time_micros),
+                        )
                     {
                         for (member_key, member) in source.live_members() {
                             match build_heartbeat_envelope(&member.schema, server_ts_ms) {

--- a/crates/dynamodb-streams/src/stream.rs
+++ b/crates/dynamodb-streams/src/stream.rs
@@ -52,6 +52,10 @@ const DEFAULT_SLEEP_DURATION: Duration = Duration::from_millis(500);
 
 impl DynamodbStreamProducer {
     async fn collect(&mut self) -> (DynamoDBStreamBatch, bool) {
+        // Captured BEFORE polling: when every shard comes back empty the stream is
+        // caught up, and the heartbeat watermark must reflect the moment this cycle started.
+        let cycle_start = SystemTime::now();
+
         let mut poll_results = Vec::new();
         let mut had_error = false;
 
@@ -96,7 +100,7 @@ impl DynamodbStreamProducer {
             }
         }
 
-        (combine_shard_batches(&poll_results), had_error)
+        (combine_shard_batches(&poll_results, cycle_start), had_error)
     }
 
     async fn initialize_shards_iterators(&mut self) -> bool {
@@ -191,7 +195,10 @@ impl DynamodbStreamProducer {
     }
 }
 
-fn combine_shard_batches(poll_results: &[ShardPollResult]) -> DynamoDBStreamBatch {
+fn combine_shard_batches(
+    poll_results: &[ShardPollResult],
+    cycle_start: SystemTime,
+) -> DynamoDBStreamBatch {
     // Collect records, checkpoints and watermarks
     let mut records = Vec::new();
     let mut shard_watermarks = Vec::new();
@@ -247,8 +254,10 @@ fn combine_shard_batches(poll_results: &[ShardPollResult]) -> DynamoDBStreamBatc
         tracing::trace!("Calculated watermark: {:?}", min_watermark);
         min_watermark
     } else if empty_shards_num == poll_results.len() {
-        tracing::trace!("All shards are empty, watermark is Now()");
-        Some(SystemTime::now())
+        // Caught up: no shard had records, so the freshest point we can
+        // attest to is the moment this poll cycle began.
+        tracing::trace!("All shards are empty, watermark is the start of this collect cycle");
+        Some(cycle_start)
     } else {
         tracing::trace!("No eligible shards with watermarks, watermark is None");
         None
@@ -315,14 +324,13 @@ mod tests {
         #[test]
         fn test_empty_poll_results() {
             let results: Vec<ShardPollResult> = vec![];
-            let batch = combine_shard_batches(&results);
+            let cycle_start = system_time_from_secs(1234);
+            let batch = combine_shard_batches(&results, cycle_start);
 
             assert!(batch.records.is_empty());
             assert!(batch.checkpoint.shards.is_empty());
-            let lag = SystemTime::now()
-                .duration_since(batch.watermark.expect("watermark"))
-                .expect("lag");
-            assert!(lag <= Duration::from_millis(100));
+            // No shards at all → caught up → watermark is the cycle start, not `now()`.
+            assert_eq!(batch.watermark, Some(cycle_start));
         }
 
         #[test]
@@ -336,7 +344,7 @@ mod tests {
                 current_watermark: Some(system_time_from_secs(1000)),
             }];
 
-            let batch = combine_shard_batches(&results);
+            let batch = combine_shard_batches(&results, SystemTime::now());
 
             assert_eq!(batch.records.len(), 2);
             assert_eq!(batch.checkpoint.shards.len(), 1);
@@ -353,14 +361,14 @@ mod tests {
                 current_watermark: Some(system_time_from_secs(1000)),
             }];
 
-            let batch = combine_shard_batches(&results);
+            let cycle_start = system_time_from_secs(1234);
+            let batch = combine_shard_batches(&results, cycle_start);
 
             assert!(batch.records.is_empty());
             assert_eq!(batch.checkpoint.shards.len(), 1);
-            let lag = SystemTime::now()
-                .duration_since(batch.watermark.expect("watermark"))
-                .expect("lag");
-            assert!(lag <= Duration::from_millis(100));
+            // The only shard was empty → caught up → watermark is the cycle start
+            // (the shard's `current_watermark` is not eligible for an empty poll).
+            assert_eq!(batch.watermark, Some(cycle_start));
         }
 
         #[test]
@@ -372,7 +380,7 @@ mod tests {
                 current_watermark: Some(system_time_from_secs(1000)),
             }];
 
-            let batch = combine_shard_batches(&results);
+            let batch = combine_shard_batches(&results, SystemTime::now());
 
             assert!(batch.records.is_empty());
             assert_eq!(batch.checkpoint.shards.len(), 1);
@@ -401,7 +409,7 @@ mod tests {
                 },
             ];
 
-            let batch = combine_shard_batches(&results);
+            let batch = combine_shard_batches(&results, SystemTime::now());
 
             assert_eq!(batch.records.len(), 3);
             assert_eq!(batch.checkpoint.shards.len(), 2);
@@ -432,7 +440,7 @@ mod tests {
                 },
             ];
 
-            let batch = combine_shard_batches(&results);
+            let batch = combine_shard_batches(&results, SystemTime::now());
 
             assert_eq!(batch.watermark, Some(system_time_from_secs(1000)));
         }
@@ -466,7 +474,7 @@ mod tests {
                 },
             ];
 
-            let batch = combine_shard_batches(&results);
+            let batch = combine_shard_batches(&results, SystemTime::now());
 
             // Only shard-1 (records) and shard-3 (failed) contribute
             // Minimum is 500 from shard-3
@@ -484,7 +492,7 @@ mod tests {
                 current_watermark: None, // No watermark
             }];
 
-            let batch = combine_shard_batches(&results);
+            let batch = combine_shard_batches(&results, SystemTime::now());
 
             assert!(!batch.records.is_empty());
             assert!(batch.watermark.is_none());
@@ -513,7 +521,7 @@ mod tests {
                 },
             ];
 
-            let batch = combine_shard_batches(&results);
+            let batch = combine_shard_batches(&results, SystemTime::now());
 
             assert_eq!(batch.checkpoint.shards.len(), 3);
             assert!(batch.checkpoint.shards.contains_key("shard-1"));
@@ -550,7 +558,7 @@ mod tests {
                 },
             ];
 
-            let batch = combine_shard_batches(&results);
+            let batch = combine_shard_batches(&results, SystemTime::now());
 
             // With the fix, duplicates are skipped, so we get exactly 1 checkpoint and 1 record
             let checkpoint_count = batch.checkpoint.shards.len();

--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -122,7 +122,17 @@ pub(crate) static CDC_REPLICATION_LAG_MS: LazyLock<Gauge<i64>> = LazyLock::new(|
     METER
         .i64_gauge("dataset_acceleration_cdc_replication_lag_ms")
         .with_description(
-            "CDC replication lag in milliseconds: wall-clock now minus the freshest applied upstream commit timestamp. Low/zero = caught up; growing = falling behind.",
+            "CDC replication lag in milliseconds: wall-clock now minus the upstream commit timestamp of the latest applied change batch. For multi-shard sources (e.g. DynamoDB) this tracks the slowest shard. Low/zero = caught up; growing = falling behind.",
+        )
+        .with_unit("ms")
+        .build()
+});
+
+pub(crate) static CDC_APPLIED_COMMIT_UNIX_TIME_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
+    METER
+        .i64_gauge("dataset_acceleration_cdc_applied_commit_unix_time_ms")
+        .with_description(
+            "Upstream commit timestamp (Unix epoch ms) of the latest applied CDC change batch — the source position the accelerator has caught up to. For multi-shard sources (e.g. DynamoDB) this is the slowest shard. Pair with wall-clock now to compute replication lag on your own clock.",
         )
         .with_unit("ms")
         .build()

--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -118,6 +118,16 @@ pub(crate) static INGESTION_LAG_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
         .build()
 });
 
+pub(crate) static CDC_REPLICATION_LAG_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
+    METER
+        .i64_gauge("dataset_acceleration_cdc_replication_lag_ms")
+        .with_description(
+            "CDC replication lag in milliseconds: wall-clock now minus the freshest applied upstream commit timestamp. Low/zero = caught up; growing = falling behind.",
+        )
+        .with_unit("ms")
+        .build()
+});
+
 pub(crate) static SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
         .u64_gauge("dataset_acceleration_size_bytes")

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1367,6 +1367,23 @@ impl RefreshTask {
             .record(u64::try_from(burst_bytes).unwrap_or(u64::MAX), &labels);
         metrics::CDC_APPLY_BURST_ROWS_TOTAL.add(burst_rows, &labels);
 
+        // CDC replication lag: wall-clock now minus the freshest upstream commit
+        // timestamp in this burst. `source_commit_ts_ms` is stamped by the source
+        // connector (Postgres commit time, MongoDB change-stream cluster time,
+        // Debezium source ts); the max over the burst is the most recent.
+        // Sources that don't stamp a timestamp leave it `None` and record nothing.
+        if let Some(max_commit_ts_ms) = burst
+            .iter()
+            .filter_map(|item| item.as_ref().ok())
+            .filter_map(|env| env.change_batch.source_commit_ts_ms())
+            .max()
+        {
+            metrics::CDC_REPLICATION_LAG_MS.record(
+                (util::time::now_unix_ms() - max_commit_ts_ms).max(0),
+                &labels,
+            );
+        }
+
         // Walk the burst preserving arrival order, processing contiguous
         // runs of Ok envelopes together and Err items individually so error
         // handling and ordering semantics match the pre-coalesce behavior.

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1367,22 +1367,19 @@ impl RefreshTask {
             .record(u64::try_from(burst_bytes).unwrap_or(u64::MAX), &labels);
         metrics::CDC_APPLY_BURST_ROWS_TOTAL.add(burst_rows, &labels);
 
-        // CDC replication lag: wall-clock now minus the freshest upstream commit
-        // timestamp in this burst. `source_commit_ts_ms` is stamped by the source
-        // connector (Postgres commit time, MongoDB change-stream cluster time,
-        // Debezium source ts); the max over the burst is the most recent.
-        // Sources that don't stamp a timestamp leave it `None` and record nothing.
-        if let Some(max_commit_ts_ms) = burst
+        // Freshest upstream commit timestamp in this burst, for the CDC
+        // replication-lag gauge. Computed here (before the burst is consumed by the
+        // apply loop below) but RECORDED only after the burst's Ok runs apply
+        // successfully — the gauge reflects APPLIED data, so a failed apply must not
+        // report artificially fresh lag. `source_commit_ts_ms` is stamped by the
+        // source connector (Postgres commit time, MongoDB change-stream cluster
+        // time, Debezium source ts); the max over the burst is the most recent.
+        // Sources that don't stamp a timestamp leave it `None`.
+        let max_commit_ts_ms = burst
             .iter()
             .filter_map(|item| item.as_ref().ok())
             .filter_map(|env| env.change_batch.source_commit_ts_ms())
-            .max()
-        {
-            metrics::CDC_REPLICATION_LAG_MS.record(
-                (util::time::now_unix_ms() - max_commit_ts_ms).max(0),
-                &labels,
-            );
-        }
+            .max();
 
         // Walk the burst preserving arrival order, processing contiguous
         // runs of Ok envelopes together and Err items individually so error
@@ -1425,6 +1422,17 @@ impl RefreshTask {
             }
         }
         metrics::CDC_APPLY_BURST_DURATION_MS.record(elapsed_ms(burst_start), &labels);
+
+        // Record replication lag only now that the burst's Ok runs have applied
+        // (the early `return false` above skips it, so a failed apply never reports
+        // fresh lag). Skip if the wall clock is unreadable (pre-epoch / overflow)
+        // rather than reporting a misleading 0ms.
+        if let (Some(max_commit_ts_ms), Some(now_ms)) = (
+            max_commit_ts_ms,
+            util::time::system_time_to_unix_ms(std::time::SystemTime::now()),
+        ) {
+            metrics::CDC_REPLICATION_LAG_MS.record((now_ms - max_commit_ts_ms).max(0), &labels);
+        }
         true
     }
 

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1423,15 +1423,18 @@ impl RefreshTask {
         }
         metrics::CDC_APPLY_BURST_DURATION_MS.record(elapsed_ms(burst_start), &labels);
 
-        // Record replication lag only now that the burst's Ok runs have applied
-        // (the early `return false` above skips it, so a failed apply never reports
-        // fresh lag). Skip if the wall clock is unreadable (pre-epoch / overflow)
-        // rather than reporting a misleading 0ms.
-        if let (Some(max_commit_ts_ms), Some(now_ms)) = (
-            max_commit_ts_ms,
-            util::time::system_time_to_unix_ms(std::time::SystemTime::now()),
-        ) {
-            metrics::CDC_REPLICATION_LAG_MS.record((now_ms - max_commit_ts_ms).max(0), &labels);
+        // Record CDC progress only now that the burst's Ok runs have applied (the
+        // early `return false` above skips it, so a failed apply never reports fresh
+        // progress). The raw applied-commit watermark is emitted whenever the burst
+        // carried a source timestamp; the derived lag additionally needs a readable
+        // wall clock (skipped on pre-epoch / overflow rather than reporting a
+        // misleading 0ms).
+        if let Some(max_commit_ts_ms) = max_commit_ts_ms {
+            metrics::CDC_APPLIED_COMMIT_UNIX_TIME_MS.record(max_commit_ts_ms, &labels);
+            if let Some(now_ms) = util::time::system_time_to_unix_ms(std::time::SystemTime::now()) {
+                metrics::CDC_REPLICATION_LAG_MS
+                    .record(now_ms.saturating_sub(max_commit_ts_ms).max(0), &labels);
+            }
         }
         true
     }

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -844,6 +844,16 @@ async fn changes_stream_from_checkpoint(
             msg.map(|(change_batch, checkpoint, watermark)| {
                 let lag = watermark.and_then(|v| SystemTime::now().duration_since(v).ok());
 
+                // Stamp the upstream commit timestamp onto the batch so the
+                // accelerator's unified CDC replication-lag metric can compute
+                // `now - source_commit_ts_ms`. The watermark is the oldest
+                // unprocessed shard's newest record commit time, or — when every
+                // shard is caught up — the start of the poll cycle, so an idle
+                // stream's empty heartbeat batch keeps the gauge fresh instead of
+                // freezing at the last real event's age.
+                let change_batch = change_batch
+                    .with_source_commit_ts_ms(watermark.and_then(util::time::system_time_to_unix_ms));
+
                 tracing::debug!(
                     dataset = %dataset_name,
                     watermark = watermark.map_or_else(|| "-".to_string(), |w| humantime::format_rfc3339(w).to_string()),

--- a/crates/runtime/tests/postgres/replication.rs
+++ b/crates/runtime/tests/postgres/replication.rs
@@ -32,6 +32,7 @@ use std::time::Duration;
 
 use arrow::array::AsArray;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use data_components::cdc::{ChangeEnvelope, ChangesStream};
 use data_components::postgres_replication::{
     ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput, config,
     start_replication_stream,
@@ -48,6 +49,28 @@ fn dataset_schema() -> SchemaRef {
         Field::new("id", DataType::Int32, false),
         Field::new("name", DataType::Utf8, true),
     ]))
+}
+
+/// Read the next real change envelope, skipping idle heartbeat envelopes
+/// (zero-row, not a readiness signal) that interleave with real changes on any
+/// Postgres keepalive. The total wait is bounded by `timeout_secs` so a genuinely
+/// missing change still times out instead of looping on heartbeats forever.
+async fn next_change(
+    stream: &mut ChangesStream,
+    timeout_secs: u64,
+    what: &str,
+) -> Result<ChangeEnvelope, anyhow::Error> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        let envelope = tokio::time::timeout_at(deadline, stream.next())
+            .await
+            .map_err(|_| anyhow::anyhow!("timed out waiting for {what}"))?
+            .ok_or_else(|| anyhow::anyhow!("stream ended waiting for {what}"))??;
+        if envelope.change_batch.record.num_rows() == 0 && !envelope.is_dataset_ready() {
+            continue;
+        }
+        return Ok(envelope);
+    }
 }
 
 fn params_for(port: u16, slot_name: &str, publication_name: &str) -> ReplicationParams {
@@ -119,9 +142,7 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
     let mut stream = start_replication_stream(input);
 
     // --- 1. Bootstrap envelope: two rows, op="c" ---
-    let envelope = tokio::time::timeout(Duration::from_secs(30), stream.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("bootstrap envelope missing"))??;
+    let envelope = next_change(&mut stream, 30, "bootstrap envelope").await?;
     let (committer, change_batch, is_ready) = envelope.into_parts();
     let ops = change_batch
         .record
@@ -142,9 +163,7 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
         .simple_query("INSERT INTO public.repl_users VALUES (3, 'Charlie')")
         .await?;
 
-    let envelope = tokio::time::timeout(Duration::from_secs(15), stream.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("insert envelope missing"))??;
+    let envelope = next_change(&mut stream, 15, "insert envelope").await?;
     let (committer, change_batch, _) = envelope.into_parts();
     let ops = change_batch
         .record
@@ -166,9 +185,7 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
     source
         .simple_query("UPDATE public.repl_users SET name = 'Alicia' WHERE id = 1")
         .await?;
-    let envelope = tokio::time::timeout(Duration::from_secs(15), stream.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("update envelope missing"))??;
+    let envelope = next_change(&mut stream, 15, "update envelope").await?;
     let (committer, change_batch, _) = envelope.into_parts();
     let ops = change_batch
         .record
@@ -182,9 +199,7 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
     source
         .simple_query("DELETE FROM public.repl_users WHERE id = 2")
         .await?;
-    let envelope = tokio::time::timeout(Duration::from_secs(15), stream.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("delete envelope missing"))??;
+    let envelope = next_change(&mut stream, 15, "delete envelope").await?;
     let (committer, change_batch, _) = envelope.into_parts();
     let ops = change_batch
         .record
@@ -216,9 +231,7 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
         metrics: ReplicationMetricsCollector::new(),
     };
     let mut stream = start_replication_stream(input);
-    let envelope = tokio::time::timeout(Duration::from_secs(30), stream.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("forced resume snapshot missing"))??;
+    let envelope = next_change(&mut stream, 30, "forced resume snapshot").await?;
     let (committer, change_batch, is_ready) = envelope.into_parts();
     assert_eq!(
         change_batch.record.num_rows(),
@@ -269,12 +282,8 @@ async fn two_replicas_have_independent_slots() -> Result<(), anyhow::Error> {
     // mirrors real runtime usage — otherwise confirmed_flush_lsn never
     // advances and the slot state can become inconsistent (source of flaky
     // WAL-retention / cleanup timing behavior).
-    let env_a = tokio::time::timeout(Duration::from_secs(30), stream_a.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("bootstrap a missing"))??;
-    let env_b = tokio::time::timeout(Duration::from_secs(30), stream_b.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("bootstrap b missing"))??;
+    let env_a = next_change(&mut stream_a, 30, "bootstrap a").await?;
+    let env_b = next_change(&mut stream_b, 30, "bootstrap b").await?;
     assert_eq!(env_a.change_batch.record.num_rows(), 2);
     assert_eq!(env_b.change_batch.record.num_rows(), 2);
     env_a.commit().await?;
@@ -285,12 +294,8 @@ async fn two_replicas_have_independent_slots() -> Result<(), anyhow::Error> {
         .simple_query("INSERT INTO public.repl_users VALUES (4, 'Derek')")
         .await?;
 
-    let live_a = tokio::time::timeout(Duration::from_secs(15), stream_a.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("live a missing"))??;
-    let live_b = tokio::time::timeout(Duration::from_secs(15), stream_b.next())
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("live b missing"))??;
+    let live_a = next_change(&mut stream_a, 15, "live a").await?;
+    let live_b = next_change(&mut stream_b, 15, "live b").await?;
     assert_eq!(live_a.change_batch.record.num_rows(), 1);
     assert_eq!(live_b.change_batch.record.num_rows(), 1);
     live_a.commit().await?;

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -227,11 +227,22 @@ async fn next_envelope(
     stream: &mut ChangesStream,
     what: &str,
 ) -> Result<ChangeEnvelope, anyhow::Error> {
-    tokio::time::timeout(Duration::from_secs(30), stream.next())
-        .await
-        .map_err(|_| anyhow::anyhow!("timed out waiting for {what}"))?
-        .ok_or_else(|| anyhow::anyhow!("stream ended waiting for {what}"))?
-        .map_err(|e| anyhow::anyhow!("stream error waiting for {what}: {e}"))
+    // Skip idle heartbeat envelopes (zero-row, not a readiness signal): they carry
+    // only a replication-lag timestamp and interleave with real changes on any
+    // Postgres keepalive. Bound the TOTAL wait so a genuinely missing change still
+    // times out instead of looping on heartbeats forever.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let envelope = tokio::time::timeout_at(deadline, stream.next())
+            .await
+            .map_err(|_| anyhow::anyhow!("timed out waiting for {what}"))?
+            .ok_or_else(|| anyhow::anyhow!("stream ended waiting for {what}"))?
+            .map_err(|e| anyhow::anyhow!("stream error waiting for {what}: {e}"))?;
+        if envelope.change_batch.record.num_rows() == 0 && !envelope.is_dataset_ready() {
+            continue;
+        }
+        return Ok(envelope);
+    }
 }
 
 fn ops_of(envelope: &ChangeEnvelope) -> Vec<String> {

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -28,6 +28,7 @@ pub mod levenshtein;
 pub mod retry_strategy;
 #[cfg(feature = "datafusion")]
 pub mod security;
+pub mod time;
 pub mod topological_ordering;
 pub use backoff::Error as RetryError;
 pub use backoff::ExponentialBackoff;

--- a/crates/util/src/time.rs
+++ b/crates/util/src/time.rs
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Small wall-clock time helpers shared across crates.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Milliseconds since the Unix epoch for a wall-clock [`SystemTime`].
+///
+/// Returns `None` for pre-epoch times or if the millisecond count overflows
+/// `i64`. Used to derive `source_commit_ts_ms`-style timestamps for the CDC
+/// replication-lag metric (`now_ms - source_commit_ts_ms`).
+#[must_use]
+pub fn system_time_to_unix_ms(t: SystemTime) -> Option<i64> {
+    i64::try_from(t.duration_since(UNIX_EPOCH).ok()?.as_millis()).ok()
+}
+
+/// Current wall-clock time in milliseconds since the Unix epoch. Used to compute
+/// CDC replication lag as `now_unix_ms() - source_commit_ts_ms`. Falls back to `0`
+/// only in the impossible cases the clock is pre-epoch or the value overflows
+/// `i64`.
+#[must_use]
+pub fn now_unix_ms() -> i64 {
+    system_time_to_unix_ms(SystemTime::now()).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn epoch_is_zero() {
+        assert_eq!(system_time_to_unix_ms(UNIX_EPOCH), Some(0));
+    }
+
+    #[test]
+    fn known_offset_round_trips() {
+        let t = UNIX_EPOCH + Duration::from_millis(1_700_000_000_123);
+        assert_eq!(system_time_to_unix_ms(t), Some(1_700_000_000_123));
+    }
+
+    #[test]
+    fn pre_epoch_is_none() {
+        let t = UNIX_EPOCH - Duration::from_millis(1);
+        assert_eq!(system_time_to_unix_ms(t), None);
+    }
+}

--- a/crates/util/src/time.rs
+++ b/crates/util/src/time.rs
@@ -28,15 +28,6 @@ pub fn system_time_to_unix_ms(t: SystemTime) -> Option<i64> {
     i64::try_from(t.duration_since(UNIX_EPOCH).ok()?.as_millis()).ok()
 }
 
-/// Current wall-clock time in milliseconds since the Unix epoch. Used to compute
-/// CDC replication lag as `now_unix_ms() - source_commit_ts_ms`. Falls back to `0`
-/// only in the impossible cases the clock is pre-epoch or the value overflows
-/// `i64`.
-#[must_use]
-pub fn now_unix_ms() -> i64 {
-    system_time_to_unix_ms(SystemTime::now()).unwrap_or(0)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Description

Adds `dataset_acceleration_cdc_replication_lag_ms` — wall-clock now minus the freshest *applied* upstream commit timestamp per dataset. ~0 = caught up; a growing value = falling behind the CDC source.

`ChangeBatch::source_commit_ts_ms` already existed (stamped by Debezium, Postgres, and MongoDB). This PR turns it into a metric and closes two gaps:

### Idle heartbeats
A caught-up source emits no events, so the raw timestamp freezes and lag would falsely climb. Connectors now emit zero-row heartbeat envelopes while idle, each stamped with a source-attested, liveness-backed timestamp (never a blind `now()`):
- **MongoDB** — session `operation_time` (the change stream now runs under an explicit session).
- **Postgres logical replication** — WAL keepalive server clock (per-dataset and shared-slot paths).
- **DynamoDB** — empty-shard watermark = the poll-cycle start.

### Debezium
Already stamps the source commit time, so it feeds the metric — but has no idle heartbeat (a synthetic timestamp can't be trusted across the Kafka boundary), so its lag can read stale while a topic is idle.
