### PR TITLE
Unified JSON nesting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,7 +6450,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=465bbba54e5e09ece6649fa78b690b5315c5dece#465bbba54e5e09ece6649fa78b690b5315c5dece"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=cf58b2784190b504515a9c948fa6c6d792477c39#cf58b2784190b504515a9c948fa6c6d792477c39"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ datafusion-proto-common = "54.0.0"
 datafusion-pruning = "54.0.0"
 datafusion-spark = "54.0.0"
 datafusion-substrait = "54.0.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "465bbba54e5e09ece6649fa78b690b5315c5dece" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "cf58b2784190b504515a9c948fa6c6d792477c39" } # spiceai-54
 
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",

--- a/crates/data-connectors/connector-mongodb/src/changes.rs
+++ b/crates/data-connectors/connector-mongodb/src/changes.rs
@@ -47,6 +47,7 @@ use runtime::{
         OpenOption,
         mongodb::{MongoCheckpointMetadata, MongoSys},
     },
+    dataconnector::schema_projection::{ProjectionPolicy, parse_schema_projection},
     federated_table::FederatedTable,
     parameters::{ExposedParamLookup, Parameters},
 };
@@ -71,6 +72,14 @@ pub fn build_changes_stream(
         let table_provider = federated_table.table_provider().await;
         let schema = table_provider.schema();
         let primary_keys = resolve_primary_keys(&dataset.name, dataset.acceleration.as_ref(), &schema)?;
+        // JSON-nesting projection, matching the scan path. `_id` is MongoDB's
+        // only primary key and must stay a declared column (never folded into
+        // the catch-all). `schema` is already the projected (exposed) schema.
+        let projection = parse_schema_projection(
+            &dataset,
+            &ProjectionPolicy::new("mongodb").with_required_columns(vec!["_id".to_string()]),
+        )
+        .map_err(|e| StreamError::External(e.to_string()))?;
         let config = ChangeStreamConfig::from_params(&params)?;
         let invalid_token_behavior = ResumeTokenInvalidBehavior::from_params(&params)?;
         let collection_name = dataset.path().to_string();
@@ -262,6 +271,7 @@ pub fn build_changes_stream(
                 &schema,
                 &primary_keys,
                 &unnest_parameters,
+                projection.as_ref(),
             )
             .map_err(StreamError::MongoDB)? {
                 // MongoDB change-stream cluster time is whole seconds (BSON

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -34,6 +34,7 @@ use datafusion_table_providers::mongodb::{
 use mongodb::bson::{Bson, Document, doc};
 use runtime::component::dataset::Dataset;
 use runtime::component::dataset::acceleration::RefreshMode;
+use runtime::dataconnector::schema_projection::{ProjectionPolicy, parse_schema_projection};
 use runtime::dataconnector::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
     DataConnectorResult,
@@ -748,9 +749,15 @@ impl DataConnector for MongoDB {
         &self,
         dataset: &Dataset,
     ) -> DataConnectorResult<Arc<dyn TableProvider>> {
+        // JSON-nesting / declared-schema projection. `_id` is MongoDB's only
+        // primary key and must stay a declared column when a catch-all is used.
+        let projection = parse_schema_projection(
+            dataset,
+            &ProjectionPolicy::new("mongodb").with_required_columns(vec!["_id".to_string()]),
+        )?;
         let provider = self
             .mongodb_factory
-            .table_provider(dataset.path().into(), dataset.schema.clone())
+            .table_provider(dataset.path().into(), dataset.schema.clone(), projection)
             .await
             .context(UnableToGetReadProviderSnafu {
                 dataconnector: "mongodb",

--- a/crates/data_components/benches/mongodb_change_stream.rs
+++ b/crates/data_components/benches/mongodb_change_stream.rs
@@ -110,6 +110,7 @@ fn bench_mongodb_change_stream_conversion(c: &mut Criterion) {
                         black_box(&schema),
                         black_box(&primary_keys),
                         black_box(&unnest_parameters),
+                        None,
                     )
                     .expect("conversion should succeed")
                     .expect("batch should not be empty");
@@ -130,6 +131,7 @@ fn bench_mongodb_change_stream_conversion(c: &mut Criterion) {
                         black_box(&schema),
                         black_box(&primary_keys),
                         black_box(&unnest_parameters),
+                        None,
                     )
                     .expect("conversion should succeed")
                     .expect("batch should not be empty");

--- a/crates/data_components/src/debezium/arrow/changes.rs
+++ b/crates/data_components/src/debezium/arrow/changes.rs
@@ -21,6 +21,7 @@ use crate::{
         arrow::downcast_builder,
         change_event::{ChangeEvent, Op},
     },
+    schema_projection::SchemaProjection,
 };
 use arrow::{
     array::{ArrayBuilder, ListBuilder, RecordBatch, StringBuilder},
@@ -33,12 +34,19 @@ pub fn to_change_batch(
     table_schema: &SchemaRef,
     primary_key: &[String],
     change: &ChangeEvent,
+    projection: Option<&SchemaProjection>,
 ) -> super::Result<ChangeBatch> {
     let schema = changes_schema(table_schema);
 
     let mut struct_builder = StructBuilder::from_fields(schema.fields().clone(), 1);
 
-    append_change_event(&mut struct_builder, &schema, primary_key, change)?;
+    append_change_event(
+        &mut struct_builder,
+        &schema,
+        primary_key,
+        change,
+        projection,
+    )?;
 
     let struct_array = struct_builder.finish();
     let record_batch: RecordBatch = struct_array.into();
@@ -56,13 +64,20 @@ pub fn vector_to_change_batch(
     table_schema: &SchemaRef,
     primary_key: &[String],
     changes: &[&ChangeEvent],
+    projection: Option<&SchemaProjection>,
 ) -> super::Result<ChangeBatch> {
     let schema = changes_schema(table_schema);
 
     let mut struct_builder = StructBuilder::from_fields(schema.fields().clone(), changes.len());
 
     for change in changes {
-        append_change_event(&mut struct_builder, &schema, primary_key, change)?;
+        append_change_event(
+            &mut struct_builder,
+            &schema,
+            primary_key,
+            change,
+            projection,
+        )?;
     }
 
     let struct_array = struct_builder.finish();
@@ -82,6 +97,7 @@ fn append_change_event(
     schema: &Schema,
     primary_key: &[String],
     change: &ChangeEvent,
+    projection: Option<&SchemaProjection>,
 ) -> super::Result<()> {
     if primary_key.is_empty() && matches!(change.payload.op, Op::Update) {
         let before = change
@@ -89,13 +105,14 @@ fn append_change_event(
             .before
             .clone()
             .context(super::UpdateOpWithoutBeforeFieldSnafu)?;
-        append_change_row(struct_builder, schema, primary_key, "d", before)?;
+        append_change_row(struct_builder, schema, primary_key, "d", before, projection)?;
         append_change_row(
             struct_builder,
             schema,
             primary_key,
             "c",
             change.payload.after.clone(),
+            projection,
         )?;
         return Ok(());
     }
@@ -110,7 +127,14 @@ fn append_change_event(
         _ => change.payload.after.clone(),
     };
 
-    append_change_row(struct_builder, schema, primary_key, &op, change_data)
+    append_change_row(
+        struct_builder,
+        schema,
+        primary_key,
+        &op,
+        change_data,
+        projection,
+    )
 }
 
 fn append_change_row(
@@ -119,8 +143,16 @@ fn append_change_row(
     primary_key: &[String],
     op: &str,
     change_data: serde_json::Value,
+    projection: Option<&SchemaProjection>,
 ) -> super::Result<()> {
     struct_builder.append(true);
+    // Apply JSON nesting: fold non-declared fields of the `before`/`after`
+    // row into the catch-all column before Arrow conversion. Type-only
+    // projections (no catch-all) leave the row unchanged.
+    let change_data = match projection.filter(|p| p.has_catch_all()) {
+        Some(projection) => projection.project_row(change_data),
+        None => change_data,
+    };
     let mut change_data = Some(change_data);
 
     for (idx, field) in schema.fields().iter().enumerate() {
@@ -165,4 +197,91 @@ fn append_change_row(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema_projection::{ColumnSource, ProjectedColumn, SchemaProjection};
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field as ArrowField};
+    use std::sync::Arc;
+
+    fn change_event(after: &serde_json::Value) -> ChangeEvent {
+        // Minimal Debezium create event; only `payload.after`/`op` matter here.
+        let value = serde_json::json!({
+            "schema": {"type": "struct", "fields": [], "optional": false, "name": "s"},
+            "payload": {
+                "before": null,
+                "after": after.clone(),
+                "source": {
+                    "version": "x", "connector": "x", "name": "x", "ts_ms": 0,
+                    "snapshot": "false", "db": "x", "table": "x"
+                },
+                "op": "c",
+                "ts_ms": 0,
+                "transaction": null
+            }
+        });
+        serde_json::from_value(value).expect("valid change event")
+    }
+
+    /// A `json_object` catch-all column folds every non-declared `after` field
+    /// into one sorted-JSON string column on the Debezium change path.
+    #[test]
+    fn json_nesting_folds_into_catch_all() {
+        // Projected (exposed) data schema: declared `id` + catch-all `data`.
+        let table_schema: SchemaRef = Arc::new(Schema::new(vec![
+            ArrowField::new("id", DataType::Utf8, true),
+            ArrowField::new("data", DataType::Utf8, true),
+        ]));
+        let projection = SchemaProjection::new(
+            vec![
+                ProjectedColumn {
+                    output_name: "id".to_string(),
+                    source: ColumnSource::Field,
+                    declared_type: Some(DataType::Utf8),
+                    nullable: true,
+                },
+                ProjectedColumn {
+                    output_name: "data".to_string(),
+                    source: ColumnSource::JsonObject,
+                    declared_type: None,
+                    nullable: true,
+                },
+            ],
+            &["id".to_string()],
+        )
+        .expect("projection");
+
+        let change = change_event(&serde_json::json!({
+            "id": "row1",
+            "zeta": 2,
+            "alpha": 1
+        }));
+
+        let batch = to_change_batch(
+            &table_schema,
+            &["id".to_string()],
+            &change,
+            Some(&projection),
+        )
+        .expect("change batch");
+        let data = batch.data(0);
+
+        let id = data
+            .column(data.schema().index_of("id").expect("id col"))
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("id utf8");
+        assert_eq!(id.value(0), "row1");
+
+        let catch_all = data
+            .column(data.schema().index_of("data").expect("data col"))
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("data utf8");
+        // non-declared fields, alphabetically sorted
+        assert_eq!(catch_all.value(0), r#"{"alpha":1,"zeta":2}"#);
+    }
 }

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -26,6 +26,7 @@ use crate::{
         change_event::{ChangeEvent, ChangeEventKey},
     },
     kafka::{Error, KafkaConsumer},
+    schema_projection::SchemaProjection,
 };
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
@@ -47,6 +48,9 @@ pub struct DebeziumKafka {
     consumer: &'static KafkaConsumer,
     batching: (usize, Duration),
     offset_commit_hook: Option<Arc<dyn KafkaOffsetCommitHook>>,
+    /// JSON-nesting / declared-schema projection applied to each change row's
+    /// `before`/`after` payload before Arrow conversion. `None` ⇒ passthrough.
+    projection: Option<SchemaProjection>,
 }
 
 impl std::fmt::Debug for DebeziumKafka {
@@ -66,6 +70,7 @@ impl DebeziumKafka {
         primary_keys: Vec<String>,
         consumer: KafkaConsumer,
         batching: (usize, Duration),
+        projection: Option<SchemaProjection>,
     ) -> Self {
         let Ok(df_schema) = DFSchema::try_from(Arc::clone(&schema)) else {
             unreachable!("DFSchema::try_from is infallible as of DataFusion 38")
@@ -93,6 +98,7 @@ impl DebeziumKafka {
             consumer: Box::leak(Box::new(consumer)),
             batching,
             offset_commit_hook: None,
+            projection,
         }
     }
 
@@ -117,6 +123,7 @@ impl DebeziumKafka {
         let consumer = self.consumer;
         let metrics = Arc::clone(self.consumer.metrics());
         let offset_commit_hook = self.offset_commit_hook.clone();
+        let projection = self.projection.clone();
         let inner = self
             .consumer
             .stream_json::<ChangeEventKey, ChangeEvent>()
@@ -155,9 +162,10 @@ impl DebeziumKafka {
                     })
                     .max();
 
-                let rb = changes::vector_to_change_batch(&schema, &pk, &changes)
-                    .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))?
-                    .with_source_commit_ts_ms(source_commit_ts_ms);
+                let rb =
+                    changes::vector_to_change_batch(&schema, &pk, &changes, projection.as_ref())
+                        .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))?
+                        .with_source_commit_ts_ms(source_commit_ts_ms);
 
                 let committer = MessageBatchCommitter::from_messages(consumer, &messages)
                     .with_offset_commit_hook(offset_commit_hook.clone());

--- a/crates/data_components/src/dynamodb/json_nest.rs
+++ b/crates/data_components/src/dynamodb/json_nest.rs
@@ -1,58 +1,8 @@
-use crate::dynamodb::{DynamoDBRow, JsonSerializationSnafu, Result};
+use crate::dynamodb::DynamoDBRow;
 use aws_sdk_dynamodb::types::AttributeValue;
 use base64::{Engine as _, engine::general_purpose};
 use serde_json::{Value, json};
-use snafu::ResultExt;
-use std::collections::BTreeMap;
-use std::collections::{HashMap, HashSet};
-
-#[derive(Debug, Clone)]
-pub struct JsonNesting {
-    pub static_fields: HashSet<String>,
-    pub json_field_name: String,
-}
-/// With the following configuration: `JsonNesting` {`static_fields`: {"PK", "SK", "Baz"}, `json_field_name`: "Data"}
-///
-/// This schema:
-/// PK (string) | SK (string) | Foo (Map) | Bar (List) | Baz (string)
-///
-/// Becomes this:
-/// PK (string) | SK (string) | Baz (string) | Data ({"Foo": <map>, "Bar": <list>})
-pub fn json_nest_except_fields(
-    rows: Vec<DynamoDBRow>,
-    json_nesting: &JsonNesting,
-) -> Result<Vec<DynamoDBRow>> {
-    rows.into_iter()
-        .map(|row| json_nest_row_except_fields(row, json_nesting))
-        .collect()
-}
-
-pub fn json_nest_row_except_fields(
-    row: DynamoDBRow,
-    json_nesting: &JsonNesting,
-) -> Result<DynamoDBRow> {
-    let mut result = HashMap::new();
-    // To make fields sorted alphabetically
-    let mut data_map = BTreeMap::new();
-
-    for (key, value) in row {
-        if json_nesting.static_fields.contains(&key) {
-            result.insert(key, value);
-        } else {
-            data_map.insert(key, attribute_value_to_json(&value));
-        }
-    }
-
-    if !data_map.is_empty() {
-        let json_string = serde_json::to_string(&data_map).context(JsonSerializationSnafu)?;
-        result.insert(
-            json_nesting.json_field_name.clone(),
-            AttributeValue::S(json_string),
-        );
-    }
-
-    Ok(result)
-}
+use std::collections::HashMap;
 
 fn attribute_value_to_json(attr: &AttributeValue) -> Value {
     match attr {
@@ -88,409 +38,53 @@ fn attribute_value_to_json(attr: &AttributeValue) -> Value {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use aws_sdk_dynamodb::types::AttributeValue;
-    use serde_json::Value;
-    use std::collections::{HashMap, HashSet};
+/// `RowShape` adapter for `DynamoDB`. A row (`HashMap<String, AttributeValue>`)
+/// is viewed as an `AttributeValue::M`; nested objects are nested `M` values.
+/// This lets the generic [`crate::schema_projection`] core reshape `DynamoDB`
+/// rows without any DynamoDB-specific projection logic.
+///
+/// `RowShape` is defined in the `datafusion-table-providers` fork, and
+/// `AttributeValue` is also a foreign type, so the impl goes on this local
+/// newtype to satisfy the orphan rule.
+struct AttrShape(AttributeValue);
 
-    fn make_string_attr(s: &str) -> AttributeValue {
-        AttributeValue::S(s.to_string())
-    }
-
-    fn make_number_attr(n: &str) -> AttributeValue {
-        AttributeValue::N(n.to_string())
-    }
-
-    fn make_bool_attr(b: bool) -> AttributeValue {
-        AttributeValue::Bool(b)
-    }
-
-    fn make_list_attr(items: Vec<AttributeValue>) -> AttributeValue {
-        AttributeValue::L(items)
-    }
-
-    fn make_map_attr(items: HashMap<String, AttributeValue>) -> AttributeValue {
-        AttributeValue::M(items)
-    }
-
-    fn extract_data_field(row: &DynamoDBRow) -> Option<Value> {
-        if let Some(AttributeValue::S(json_str)) = row.get("Data") {
-            serde_json::from_str(json_str).ok()
-        } else {
-            None
+impl crate::schema_projection::RowShape for AttrShape {
+    fn into_object(self) -> std::result::Result<Vec<(String, Self)>, Self> {
+        match self.0 {
+            AttributeValue::M(map) => Ok(map.into_iter().map(|(k, v)| (k, AttrShape(v))).collect()),
+            other => Err(AttrShape(other)),
         }
     }
 
-    #[test]
-    fn test_basic_nesting() {
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert("SK".to_string(), make_string_attr("sk1"));
-        row.insert("Foo".to_string(), make_string_attr("foo_value"));
-        row.insert("Bar".to_string(), make_string_attr("bar_value"));
-
-        let static_fields: HashSet<String> =
-            ["PK".to_string(), "SK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        assert_eq!(result.len(), 1);
-        let result_row = &result[0];
-
-        // Check static fields are at top level
-        assert_eq!(result_row.get("PK"), Some(&make_string_attr("pk1")));
-        assert_eq!(result_row.get("SK"), Some(&make_string_attr("sk1")));
-
-        // Check nested fields are in Data
-        let data = extract_data_field(result_row).expect("Data field should exist");
-        assert_eq!(data["Foo"], "foo_value");
-        assert_eq!(data["Bar"], "bar_value");
+    fn from_object(entries: Vec<(String, Self)>) -> Self {
+        AttrShape(AttributeValue::M(
+            entries.into_iter().map(|(k, v)| (k, v.0)).collect(),
+        ))
     }
 
-    #[test]
-    fn test_all_static_fields() {
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert("SK".to_string(), make_string_attr("sk1"));
-
-        let static_fields: HashSet<String> =
-            ["PK".to_string(), "SK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        assert_eq!(result.len(), 1);
-        let result_row = &result[0];
-
-        // All fields should be at top level
-        assert_eq!(result_row.get("PK"), Some(&make_string_attr("pk1")));
-        assert_eq!(result_row.get("SK"), Some(&make_string_attr("sk1")));
-
-        // No Data field should exist
-        assert!(result_row.get("Data").is_none());
+    fn to_json(&self) -> Value {
+        attribute_value_to_json(&self.0)
     }
 
-    #[test]
-    fn test_no_static_fields() {
-        let mut row = HashMap::new();
-        row.insert("Foo".to_string(), make_string_attr("foo_value"));
-        row.insert("Bar".to_string(), make_string_attr("bar_value"));
-
-        let static_fields: HashSet<String> = HashSet::new();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        assert_eq!(result.len(), 1);
-        let result_row = &result[0];
-
-        // All fields should be nested in Data
-        let data = extract_data_field(result_row).expect("Data field should exist");
-        assert_eq!(data["Foo"], "foo_value");
-        assert_eq!(data["Bar"], "bar_value");
-
-        // Only Data field should exist
-        assert_eq!(result_row.len(), 1);
+    fn from_json_string(json: String) -> Self {
+        AttrShape(AttributeValue::S(json))
     }
+}
 
-    #[test]
-    fn test_empty_rows() {
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        assert_eq!(result.len(), 0);
-    }
-
-    #[test]
-    fn test_multiple_rows() {
-        let mut row1 = HashMap::new();
-        row1.insert("PK".to_string(), make_string_attr("pk1"));
-        row1.insert("Foo".to_string(), make_string_attr("foo1"));
-
-        let mut row2 = HashMap::new();
-        row2.insert("PK".to_string(), make_string_attr("pk2"));
-        row2.insert("Foo".to_string(), make_string_attr("foo2"));
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row1, row2],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        assert_eq!(result.len(), 2);
-
-        // Check first row
-        assert_eq!(result[0].get("PK"), Some(&make_string_attr("pk1")));
-        let data1 = extract_data_field(&result[0]).expect("Data field should exist");
-        assert_eq!(data1["Foo"], "foo1");
-
-        // Check second row
-        assert_eq!(result[1].get("PK"), Some(&make_string_attr("pk2")));
-        let data2 = extract_data_field(&result[1]).expect("Data field should exist");
-        assert_eq!(data2["Foo"], "foo2");
-    }
-
-    #[test]
-    fn test_different_attribute_types() {
-        let mut inner_map = HashMap::new();
-        inner_map.insert("nested_key".to_string(), make_string_attr("nested_value"));
-
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert("StringField".to_string(), make_string_attr("string_value"));
-        row.insert("NumberField".to_string(), make_number_attr("42.5"));
-        row.insert("BoolField".to_string(), make_bool_attr(true));
-        row.insert(
-            "ListField".to_string(),
-            make_list_attr(vec![make_string_attr("item1"), make_string_attr("item2")]),
-        );
-        row.insert("MapField".to_string(), make_map_attr(inner_map));
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        assert_eq!(result.len(), 1);
-        let result_row = &result[0];
-
-        assert_eq!(result_row.get("PK"), Some(&make_string_attr("pk1")));
-
-        let data = extract_data_field(result_row).expect("Data field should exist");
-
-        // Check different types
-        assert_eq!(data["StringField"], "string_value");
-        assert_eq!(data["NumberField"], 42.5);
-        assert_eq!(data["BoolField"], true);
-        assert_eq!(data["ListField"], json!(["item1", "item2"]));
-        assert_eq!(data["MapField"]["nested_key"], "nested_value");
-    }
-
-    #[test]
-    fn test_null_attribute() {
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert("NullField".to_string(), AttributeValue::Null(true));
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        let data = extract_data_field(&result[0]).expect("Data field should exist");
-        assert_eq!(data["NullField"], Value::Null);
-    }
-
-    #[test]
-    fn test_string_set() {
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert(
-            "StringSet".to_string(),
-            AttributeValue::Ss(vec![
-                "value1".to_string(),
-                "value2".to_string(),
-                "value3".to_string(),
-            ]),
-        );
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        let data = extract_data_field(&result[0]).expect("Data field should exist");
-        assert_eq!(data["StringSet"], json!(["value1", "value2", "value3"]));
-    }
-
-    #[test]
-    fn test_number_set() {
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert(
-            "NumberSet".to_string(),
-            AttributeValue::Ns(vec!["1".to_string(), "2".to_string(), "3".to_string()]),
-        );
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        let data = extract_data_field(&result[0]).expect("Data field should exist");
-        assert_eq!(data["NumberSet"], json!(["1", "2", "3"]));
-    }
-
-    #[test]
-    fn test_binary_data() {
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert(
-            "BinaryField".to_string(),
-            AttributeValue::B(aws_smithy_types::Blob::new(vec![1, 2, 3, 4])),
-        );
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        let data = extract_data_field(&result[0]).expect("Data field should exist");
-
-        // Verify it's a base64 encoded string
-        if let Value::String(encoded) = &data["BinaryField"] {
-            let decoded = general_purpose::STANDARD.decode(encoded).expect("result");
-            assert_eq!(decoded, vec![1, 2, 3, 4]);
-        } else {
-            panic!("BinaryField should be a string");
-        }
-    }
-
-    #[test]
-    fn test_case_sensitive_field_names() {
-        let mut row = HashMap::new();
-        row.insert("pk".to_string(), make_string_attr("lowercase"));
-        row.insert("PK".to_string(), make_string_attr("uppercase"));
-        row.insert("Pk".to_string(), make_string_attr("mixedcase"));
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        let result_row = &result[0];
-
-        // Only exact match "PK" should be static
-        assert_eq!(result_row.get("PK"), Some(&make_string_attr("uppercase")));
-
-        // Others should be nested
-        let data = extract_data_field(result_row).expect("Data field should exist");
-        assert_eq!(data["pk"], "lowercase");
-        assert_eq!(data["Pk"], "mixedcase");
-    }
-
-    #[test]
-    fn test_deeply_nested_structures() {
-        let mut level2_map = HashMap::new();
-        level2_map.insert("deep".to_string(), make_string_attr("value"));
-
-        let mut level1_map = HashMap::new();
-        level1_map.insert("level2".to_string(), make_map_attr(level2_map));
-
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert("NestedMap".to_string(), make_map_attr(level1_map));
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        let data = extract_data_field(&result[0]).expect("Data field should exist");
-        assert_eq!(data["NestedMap"]["level2"]["deep"], "value");
-    }
-
-    #[test]
-    fn test_number_parsing() {
-        let mut row = HashMap::new();
-        row.insert("PK".to_string(), make_string_attr("pk1"));
-        row.insert("IntNum".to_string(), make_number_attr("42"));
-        row.insert(
-            "FloatNum".to_string(),
-            make_number_attr("3.141592653589793"),
-        );
-        row.insert("ScientificNum".to_string(), make_number_attr("1.23e10"));
-
-        let static_fields: HashSet<String> = ["PK".to_string()].into_iter().collect();
-
-        let result = json_nest_except_fields(
-            vec![row],
-            &JsonNesting {
-                static_fields,
-                json_field_name: "Data".to_string(),
-            },
-        )
-        .expect("result");
-
-        let data = extract_data_field(&result[0]).expect("Data field should exist");
-        assert_eq!(data["IntNum"], 42.0);
-        assert_eq!(data["FloatNum"], std::f64::consts::PI);
-        assert_eq!(data["ScientificNum"], 1.23e10);
+/// Reshape one `DynamoDB` row through a [`SchemaProjection`], preserving the
+/// `HashMap` row type. Wraps the row as an `AttributeValue::M`, projects, and
+/// unwraps. A non-`M` result (only possible for a non-object row, which a
+/// `DynamoDB` item never is) yields an empty row.
+///
+/// [`SchemaProjection`]: crate::schema_projection::SchemaProjection
+#[must_use]
+pub fn project_dynamodb_row(
+    row: DynamoDBRow,
+    projection: &crate::schema_projection::SchemaProjection,
+) -> DynamoDBRow {
+    let wrapped = AttrShape(AttributeValue::M(row.into_iter().collect()));
+    match projection.project_row(wrapped).0 {
+        AttributeValue::M(map) => map.into_iter().collect(),
+        _ => HashMap::new(),
     }
 }

--- a/crates/data_components/src/dynamodb/json_nest.rs
+++ b/crates/data_components/src/dynamodb/json_nest.rs
@@ -88,3 +88,141 @@ pub fn project_dynamodb_row(
         _ => HashMap::new(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_smithy_types::Blob;
+    use serde_json::json;
+
+    fn decode_b64(v: &Value) -> Vec<u8> {
+        general_purpose::STANDARD
+            .decode(v.as_str().expect("base64 string"))
+            .expect("valid base64")
+    }
+
+    #[test]
+    fn string_becomes_json_string() {
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::S("hello".to_string())),
+            json!("hello")
+        );
+    }
+
+    #[test]
+    fn number_parses_int_and_float() {
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::N("42".to_string())),
+            json!(42.0)
+        );
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::N("3.14".to_string())),
+            json!(3.14)
+        );
+    }
+
+    #[test]
+    fn number_falls_back_to_string_when_not_f64_parseable() {
+        // DynamoDB numbers can exceed f64 range / be non-numeric text; those are
+        // preserved verbatim as a JSON string rather than lost.
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::N("not-a-number".to_string())),
+            json!("not-a-number")
+        );
+    }
+
+    #[test]
+    fn bool_becomes_json_bool() {
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::Bool(true)),
+            json!(true)
+        );
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::Bool(false)),
+            json!(false)
+        );
+    }
+
+    #[test]
+    fn map_becomes_object() {
+        let map = HashMap::from([
+            ("name".to_string(), AttributeValue::S("Alice".to_string())),
+            ("age".to_string(), AttributeValue::N("30".to_string())),
+        ]);
+        let v = attribute_value_to_json(&AttributeValue::M(map));
+        assert_eq!(v["name"], json!("Alice"));
+        assert_eq!(v["age"], json!(30.0));
+    }
+
+    #[test]
+    fn list_becomes_array_preserving_element_types() {
+        let list = vec![
+            AttributeValue::S("a".to_string()),
+            AttributeValue::N("1".to_string()),
+            AttributeValue::Bool(true),
+        ];
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::L(list)),
+            json!(["a", 1.0, true])
+        );
+    }
+
+    #[test]
+    fn string_set_becomes_array_of_strings() {
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::Ss(vec!["x".to_string(), "y".to_string()])),
+            json!(["x", "y"])
+        );
+    }
+
+    #[test]
+    fn number_set_is_preserved_as_strings() {
+        // Number sets keep their string representation (unlike a scalar `N`, which
+        // is parsed to a JSON number).
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::Ns(vec!["1".to_string(), "2".to_string()])),
+            json!(["1", "2"])
+        );
+    }
+
+    #[test]
+    fn binary_becomes_base64_string() {
+        let v = attribute_value_to_json(&AttributeValue::B(Blob::new(vec![1u8, 2, 3, 4])));
+        assert_eq!(decode_b64(&v), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn binary_set_becomes_array_of_base64_strings() {
+        let v = attribute_value_to_json(&AttributeValue::Bs(vec![
+            Blob::new(vec![0u8]),
+            Blob::new(vec![255u8]),
+        ]));
+        let arr = v.as_array().expect("array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(decode_b64(&arr[0]), vec![0]);
+        assert_eq!(decode_b64(&arr[1]), vec![255]);
+    }
+
+    #[test]
+    fn null_becomes_json_null() {
+        assert_eq!(
+            attribute_value_to_json(&AttributeValue::Null(true)),
+            Value::Null
+        );
+    }
+
+    #[test]
+    fn nested_map_and_list_recurse() {
+        let inner = HashMap::from([("deep".to_string(), AttributeValue::S("value".to_string()))]);
+        let map = HashMap::from([
+            ("nested".to_string(), AttributeValue::M(inner)),
+            (
+                "items".to_string(),
+                AttributeValue::L(vec![AttributeValue::N("1".to_string())]),
+            ),
+        ]);
+        let v = attribute_value_to_json(&AttributeValue::M(map));
+        assert_eq!(v["nested"]["deep"], json!("value"));
+        assert_eq!(v["items"], json!([1.0]));
+    }
+}

--- a/crates/data_components/src/dynamodb/json_nest.rs
+++ b/crates/data_components/src/dynamodb/json_nest.rs
@@ -116,8 +116,8 @@ mod tests {
             json!(42.0)
         );
         assert_eq!(
-            attribute_value_to_json(&AttributeValue::N("3.14".to_string())),
-            json!(3.14)
+            attribute_value_to_json(&AttributeValue::N("2.5".to_string())),
+            json!(2.5)
         );
     }
 

--- a/crates/data_components/src/dynamodb/mod.rs
+++ b/crates/data_components/src/dynamodb/mod.rs
@@ -32,7 +32,7 @@ mod table_schema;
 mod unnest;
 mod utils;
 
-pub use json_nest::JsonNesting;
+pub use json_nest::project_dynamodb_row;
 
 type DynamoDBRow = HashMap<String, AttributeValue>;
 

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -25,7 +25,7 @@ use crate::dynamodb::arrow::dynamodb_items_to_arrow;
 use crate::dynamodb::dml::delete::DynamoDBDeletionSink;
 use crate::dynamodb::dml::insert::DynamoDBInsertSink;
 use crate::dynamodb::dml::update::{DynamoDBUpdateExec, UpdateConfig};
-use crate::dynamodb::json_nest::{JsonNesting, json_nest_except_fields};
+use crate::dynamodb::json_nest::project_dynamodb_row;
 use crate::dynamodb::request_builder::DynamoDBRequestPlanBuilder;
 use crate::dynamodb::request_plan::{DynamoDBRequestPlan, QueryParams, ScanParams};
 use crate::dynamodb::schema::infer_arrow_schema_from_rows;
@@ -33,6 +33,7 @@ use crate::dynamodb::stream::{StreamError, process_batch, record_batch_to_change
 use crate::dynamodb::table_schema::DynamoDBTableSchema;
 use crate::dynamodb::unnest::unnest_dynamodb_rows;
 use crate::schema_discovery::merge_inferred_and_declared_schemas;
+use crate::schema_projection::SchemaProjection;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use aws_config::SdkConfig;
@@ -86,7 +87,7 @@ pub struct DynamoDBTableProvider {
     config_partitions: Option<usize>,
     table_total_item_count: Option<i64>,
     pub ready_lag: Duration,
-    json_nesting: Option<JsonNesting>,
+    projection: Option<SchemaProjection>,
     write_parallelism: usize,
     streams_enabled: bool,
 }
@@ -122,7 +123,7 @@ impl DynamoDBTableProvider {
         time_format: String,
         ready_lag: Duration,
         metrics_collector: Arc<MetricsCollector>,
-        json_nesting: Option<&JsonNesting>,
+        projection: Option<&SchemaProjection>,
         write_parallelism: usize,
         declared_schema: Option<SchemaRef>,
     ) -> Result<Self, Error> {
@@ -149,16 +150,17 @@ impl DynamoDBTableProvider {
             unnest_depth,
             schema_infer_max_records,
             &time_format,
-            json_nesting,
+            projection,
             declared_schema,
         )
         .await?;
 
-        // Check that all static fields are present in the table schema
-        if let Some(static_fields) =
-            json_nesting.map(|json_nesting| json_nesting.static_fields.clone())
-        {
-            let missing_fields: Vec<String> = static_fields
+        // When JSON nesting is configured, every declared (static) column must
+        // be present in the table schema. (Pure type-pinning projections, with
+        // no catch-all, may legitimately declare columns absent from the source.)
+        if let Some(projection) = projection.filter(|p| p.has_catch_all()) {
+            let missing_fields: Vec<String> = projection
+                .static_fields()
                 .iter()
                 .filter(|field_name| table_schema.index_of(field_name).is_err())
                 .cloned()
@@ -209,7 +211,7 @@ impl DynamoDBTableProvider {
             config_partitions,
             table_total_item_count,
             ready_lag,
-            json_nesting: json_nesting.cloned(),
+            projection: projection.cloned(),
             write_parallelism,
             streams_enabled,
         })
@@ -283,7 +285,7 @@ impl DynamoDBTableProvider {
             config_partitions,
             table_total_item_count: None,
             ready_lag,
-            json_nesting: None,
+            projection: None,
             write_parallelism,
             streams_enabled: false,
         })
@@ -341,7 +343,7 @@ impl DynamoDBTableProvider {
         unnest_depth: Option<usize>,
         schema_infer_max_records: i32,
         time_format: &str,
-        json_nesting: Option<&JsonNesting>,
+        projection: Option<&SchemaProjection>,
         declared_schema: Option<SchemaRef>,
     ) -> Result<TableMetadata> {
         let response = db_client
@@ -426,9 +428,14 @@ impl DynamoDBTableProvider {
             Some(depth) => unnest_dynamodb_rows(rows, depth)?,
         };
 
-        let final_rows = match json_nesting {
+        // Apply JSON nesting (only when a catch-all is configured); type-only
+        // projections leave rows untouched.
+        let final_rows = match projection.filter(|p| p.has_catch_all()) {
             None => unnested_rows,
-            Some(json_nesting) => json_nest_except_fields(unnested_rows, json_nesting)?,
+            Some(projection) => unnested_rows
+                .into_iter()
+                .map(|row| project_dynamodb_row(row, projection))
+                .collect(),
         };
 
         tracing::debug!(
@@ -490,7 +497,7 @@ impl DynamoDBTableProvider {
         let primary_keys = self.table_schema.primary_keys().clone();
         let unnest_depth = self.unnest_depth;
         let time_format = Arc::clone(&self.table_schema.time_format());
-        let json_nesting = self.json_nesting.clone();
+        let projection = self.projection.clone();
 
         let stream = self
             .streams_client
@@ -504,7 +511,7 @@ impl DynamoDBTableProvider {
                     &primary_keys,
                     unnest_depth,
                     &time_format,
-                    json_nesting.as_ref(),
+                    projection.as_ref(),
                 )
                 .map_err(crate::cdc::StreamError::DynamoDB)
             });
@@ -615,10 +622,15 @@ impl TableProvider for DynamoDBTableProvider {
             projected_schema = SchemaRef::from(self.table_schema.schema().project(&[idx])?);
         }
 
+        // Pushing a projection expression down to DynamoDB is incompatible with
+        // JSON nesting: the catch-all needs every non-declared attribute, so we
+        // must fetch the whole item. Signal "nesting on" with the static set
+        // (its presence, not contents, gates pushdown in build_request_plan).
         let json_nesting_static_fields = self
-            .json_nesting
+            .projection
             .as_ref()
-            .map(|json_nesting| json_nesting.static_fields.clone());
+            .filter(|p| p.has_catch_all())
+            .map(|p| p.static_fields().clone());
 
         let request_plan = self.request_plan_builder.build_request_plan(
             filters,
@@ -656,7 +668,7 @@ impl TableProvider for DynamoDBTableProvider {
             projected_schema,
             total_partitions,
             self.table_schema.time_format(),
-            self.json_nesting.clone(),
+            self.projection.clone(),
         )))
     }
 
@@ -738,7 +750,7 @@ pub struct DynamoDBTableProviderExec {
     unnest_depth: Option<usize>,
     time_format: Arc<String>,
     properties: Arc<PlanProperties>,
-    json_nesting: Option<JsonNesting>,
+    projection: Option<SchemaProjection>,
 }
 
 impl DynamoDBTableProviderExec {
@@ -750,7 +762,7 @@ impl DynamoDBTableProviderExec {
         projected_schema: SchemaRef,
         partitions: usize,
         time_format: Arc<String>,
-        json_nesting: Option<JsonNesting>,
+        projection: Option<SchemaProjection>,
     ) -> Self {
         Self {
             client,
@@ -758,7 +770,7 @@ impl DynamoDBTableProviderExec {
             projected_schema: Arc::clone(&projected_schema),
             unnest_depth,
             time_format,
-            json_nesting,
+            projection,
             properties: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(projected_schema),
                 Partitioning::UnknownPartitioning(partitions),
@@ -822,7 +834,7 @@ impl ExecutionPlan for DynamoDBTableProviderExec {
         let request_plan = self.request_plan.clone();
         let unnest_depth = self.unnest_depth;
         let time_format = Arc::clone(&self.time_format);
-        let json_nesting = self.json_nesting.clone();
+        let projection = self.projection.clone();
 
         let total_partitions = match self.properties.partitioning {
             Partitioning::RoundRobinBatch(_) | Partitioning::Hash(_, _) => 1,
@@ -858,10 +870,12 @@ impl ExecutionPlan for DynamoDBTableProviderExec {
                     Some(depth) => unnest_dynamodb_rows(rows, depth).map_err(to_execution_error)?,
                 };
 
-                let final_rows = match json_nesting.clone() {
+                let final_rows = match projection.as_ref().filter(|p| p.has_catch_all()) {
                     None => unnested_rows,
-                    Some(ref json_nesting) => json_nest_except_fields(unnested_rows, json_nesting)
-                        .map_err(to_execution_error)?,
+                    Some(projection) => unnested_rows
+                        .into_iter()
+                        .map(|row| project_dynamodb_row(row, projection))
+                        .collect(),
                 };
 
                 let batch = dynamodb_items_to_arrow(&final_rows, Arc::clone(&schema), &time_format)

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -13,12 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use super::{Error, JsonNesting, Result};
+use super::{Error, Result};
 use crate::arrow::struct_builder::StructBuilder;
 use crate::cdc::{ChangeBatch, ChangeBatchError, changes_schema};
 use crate::dynamodb::arrow::append_item_to_struct_builder;
-use crate::dynamodb::json_nest::json_nest_row_except_fields;
+use crate::dynamodb::json_nest::project_dynamodb_row;
 use crate::dynamodb::unnest::unnest_dynamodb_row;
+use crate::schema_projection::SchemaProjection;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
 use arrow_array::builder::{ArrayBuilder, ListBuilder, StringBuilder, make_builder};
@@ -124,7 +125,7 @@ pub fn process_batch(
     primary_keys: &[String],
     unnest_depth: Option<usize>,
     time_format: &str,
-    json_nesting: Option<&JsonNesting>,
+    projection: Option<&SchemaProjection>,
 ) -> Result<(ChangeBatch, Checkpoint, Option<SystemTime>), StreamError> {
     let records = batch.records;
 
@@ -151,12 +152,9 @@ pub fn process_batch(
                             .context(FailedToUnnestSnafu)?,
                     };
 
-                    let final_streams_item = match json_nesting {
+                    let final_streams_item = match projection.filter(|p| p.has_catch_all()) {
                         None => unnested_streams_item,
-                        Some(json_nesting) => {
-                            json_nest_row_except_fields(unnested_streams_item, json_nesting)
-                                .context(FailedToUnnestSnafu)?
-                        }
+                        Some(projection) => project_dynamodb_row(unnested_streams_item, projection),
                     };
 
                     let op = if matches!(event_name, OperationType::Insert) {
@@ -315,6 +313,28 @@ mod tests {
 
     mod process_batch {
         use super::*;
+        use crate::schema_projection::{ColumnSource, ProjectedColumn, SchemaProjection};
+
+        /// Build a JSON-nesting `SchemaProjection`: the given names are kept as
+        /// static columns and `catch_all` collects the rest.
+        fn nesting_projection(static_fields: &[&str], catch_all: &str) -> SchemaProjection {
+            let mut columns: Vec<ProjectedColumn> = static_fields
+                .iter()
+                .map(|name| ProjectedColumn {
+                    output_name: (*name).to_string(),
+                    source: ColumnSource::Field,
+                    declared_type: None,
+                    nullable: true,
+                })
+                .collect();
+            columns.push(ProjectedColumn {
+                output_name: catch_all.to_string(),
+                source: ColumnSource::JsonObject,
+                declared_type: None,
+                nullable: true,
+            });
+            SchemaProjection::new(columns, &[]).expect("valid projection")
+        }
 
         #[test]
         fn test_process_batch_insert_operation() {
@@ -814,10 +834,7 @@ mod tests {
             ]));
             let primary_keys = vec!["id".to_string()];
 
-            let json_nesting = JsonNesting {
-                static_fields: HashSet::from(["id".to_string()]),
-                json_field_name: "Data".to_string(),
-            };
+            let projection = nesting_projection(&["id"], "Data");
 
             let result = process_batch(
                 create_stream_result(batch),
@@ -825,7 +842,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
-                Some(&json_nesting),
+                Some(&projection),
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -900,10 +917,7 @@ mod tests {
             ]));
             let primary_keys = vec!["PK".to_string(), "SK".to_string()];
 
-            let json_nesting = JsonNesting {
-                static_fields: HashSet::from(["PK".to_string(), "SK".to_string()]),
-                json_field_name: "Data".to_string(),
-            };
+            let projection = nesting_projection(&["PK", "SK"], "Data");
 
             let result = process_batch(
                 create_stream_result(batch),
@@ -911,7 +925,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
-                Some(&json_nesting),
+                Some(&projection),
             );
 
             let (change_batch, _checkpoint, _watermark) =
@@ -979,10 +993,7 @@ mod tests {
             ]));
             let primary_keys = vec!["id".to_string()];
 
-            let json_nesting = JsonNesting {
-                static_fields: HashSet::from(["id".to_string(), "name".to_string()]),
-                json_field_name: "Data".to_string(),
-            };
+            let projection = nesting_projection(&["id", "name"], "Data");
 
             let result = process_batch(
                 create_stream_result(batch),
@@ -990,7 +1001,7 @@ mod tests {
                 &primary_keys,
                 None,
                 TIME_FORMAT,
-                Some(&json_nesting),
+                Some(&projection),
             );
 
             let (change_batch, _checkpoint, _watermark) =

--- a/crates/data_components/src/http/json_nest.rs
+++ b/crates/data_components/src/http/json_nest.rs
@@ -47,8 +47,9 @@ limitations under the License.
 //! columns and the original HTTP metadata (e.g. for direct fetches via
 //! filter pushdown on `request_path`).
 
+use crate::schema_projection::SchemaProjection;
 use snafu::{ResultExt, Snafu};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -67,21 +68,22 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Clone)]
 pub struct HttpJsonNesting {
     /// Column order exactly as declared in the spicepod, used to build
-    /// the table schema. Includes `json_field_name` in its declared
+    /// the table schema. Includes the catch-all column in its declared
     /// position.
     pub column_order: Vec<String>,
-    /// Set of declared static field names (i.e. `column_order` minus
-    /// `json_field_name` and `metadata_fields`). These are extracted as
-    /// top-level keys from each JSON response row.
-    pub static_fields: HashSet<String>,
     /// Set of declared columns sourced from HTTP request/response
     /// metadata rather than from the JSON body. Names must match
     /// fields in [`HttpTableProvider::base_table_schema`].
     ///
     /// [`HttpTableProvider::base_table_schema`]: super::provider::HttpTableProvider::base_table_schema
     pub metadata_fields: HashSet<String>,
-    /// Name of the catch-all JSON column.
-    pub json_field_name: String,
+    /// Connector-agnostic projection (kept fields + catch-all) that performs the
+    /// actual object decomposition via [`SchemaProjection::project_row`]. This
+    /// is the shared core used by every nesting-capable connector; HTTP only
+    /// adds the string-parsing, raw-text-fallback, and metadata-field handling
+    /// around it. The static-field set and catch-all name are read back from it
+    /// via [`Self::static_fields`] / [`Self::json_field_name`].
+    projection: SchemaProjection,
 }
 
 impl HttpJsonNesting {
@@ -95,19 +97,32 @@ impl HttpJsonNesting {
         json_field_name: String,
         metadata_fields: HashSet<String>,
     ) -> Self {
-        let static_fields: HashSet<String> = column_order
+        let static_fields: Vec<String> = column_order
             .iter()
             .filter(|c| {
                 c.as_str() != json_field_name.as_str() && !metadata_fields.contains(c.as_str())
             })
             .cloned()
             .collect();
+        let projection = SchemaProjection::nesting(static_fields, json_field_name);
         Self {
             column_order,
-            static_fields,
             metadata_fields,
-            json_field_name,
+            projection,
         }
+    }
+
+    /// Declared static (kept-as-is) field names. Read from the shared
+    /// projection so there is a single source of truth.
+    #[must_use]
+    pub fn static_fields(&self) -> &HashSet<String> {
+        self.projection.static_fields()
+    }
+
+    /// Name of the catch-all JSON column. Read from the shared projection.
+    #[must_use]
+    pub fn json_field_name(&self) -> &str {
+        self.projection.catch_all_name().unwrap_or_default()
     }
 }
 
@@ -139,13 +154,12 @@ pub type DecomposedRow = HashMap<String, Option<String>>;
 /// [`HttpExec::parse_content`]: super::provider::HttpExec
 pub fn decompose_json_row(json_row: &str, nesting: &HttpJsonNesting) -> Result<DecomposedRow> {
     let mut out: DecomposedRow = HashMap::new();
-
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(json_row) else {
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json_row) else {
         // Not valid JSON: preserve the raw row instead of failing the
         // whole query. All declared static fields are NULL; the
         // catch-all keeps the raw text as a JSON string (NULL when the
         // body is empty/whitespace).
-        for name in &nesting.static_fields {
+        for name in nesting.static_fields() {
             out.insert(name.clone(), None);
         }
         let catchall = if json_row.trim().is_empty() {
@@ -156,58 +170,38 @@ pub fn decompose_json_row(json_row: &str, nesting: &HttpJsonNesting) -> Result<D
                     .context(JsonSerializeSnafu)?,
             )
         };
-        out.insert(nesting.json_field_name.clone(), catchall);
+        out.insert(nesting.json_field_name().to_string(), catchall);
         return Ok(out);
     };
 
-    match value {
-        serde_json::Value::Object(map) => {
-            // Use BTreeMap so the serialized catch-all has deterministic,
-            // sorted keys (matches DynamoDB's `json_nest` behavior).
-            let mut catchall: BTreeMap<String, serde_json::Value> = BTreeMap::new();
-
-            for (k, v) in map {
-                if nesting.metadata_fields.contains(&k) {
-                    // Body keys colliding with HTTP metadata names are
-                    // ignored here; the metadata column is populated
-                    // from the actual HTTP request/response, not from
-                    // the body. Drop the body key from both the static
-                    // and catch-all outputs.
-                    continue;
-                }
-                if nesting.static_fields.contains(&k) {
-                    out.insert(k, json_value_to_string(v));
-                } else {
-                    catchall.insert(k, v);
-                }
-            }
-
-            // Any declared static field that was absent from the row
-            // becomes explicit NULL rather than being missing from the
-            // batch.
-            for name in &nesting.static_fields {
-                out.entry(name.clone()).or_insert(None);
-            }
-
-            let catchall_str = if catchall.is_empty() {
-                None
-            } else {
-                Some(serde_json::to_string(&catchall).context(JsonSerializeSnafu)?)
-            };
-            out.insert(nesting.json_field_name.clone(), catchall_str);
-        }
-        other => {
-            // Non-object row: preserve it in the catch-all column so no
-            // data is lost. Static fields are NULL.
-            for name in &nesting.static_fields {
-                out.insert(name.clone(), None);
-            }
-            out.insert(
-                nesting.json_field_name.clone(),
-                Some(serde_json::to_string(&other).context(JsonSerializeSnafu)?),
-            );
-        }
+    // Body keys colliding with HTTP metadata names are dropped here: the
+    // metadata column is populated from the actual HTTP request/response, not
+    // from the body, and must not leak into the catch-all.
+    if let serde_json::Value::Object(map) = &mut value {
+        map.retain(|k, _| !nesting.metadata_fields.contains(k));
     }
+
+    // Delegate the static/catch-all partition + sorted-JSON serialization to the
+    // shared connector-agnostic core (`RowShape for serde_json::Value`).
+    let projected = nesting.projection.project_row(value);
+
+    let mut obj = match projected {
+        serde_json::Value::Object(map) => map,
+        // `project_row` always returns an object; this arm is unreachable.
+        _ => serde_json::Map::new(),
+    };
+
+    // Materialize one `Option<String>` per declared column. Absent declared
+    // fields (and an empty catch-all) become SQL NULL.
+    let mut out: DecomposedRow = HashMap::with_capacity(nesting.static_fields().len() + 1);
+    for name in nesting.static_fields() {
+        let value = obj.remove(name).and_then(json_value_to_string);
+        out.insert(name.clone(), value);
+    }
+    let catchall = obj
+        .remove(nesting.json_field_name())
+        .and_then(json_value_to_string);
+    out.insert(nesting.json_field_name().to_string(), catchall);
 
     Ok(out)
 }

--- a/crates/data_components/src/http/provider.rs
+++ b/crates/data_components/src/http/provider.rs
@@ -1899,7 +1899,7 @@ impl HttpExec {
             .filter(|f| !nesting.metadata_fields.contains(f.name()))
             .map(|f| f.name().as_str())
             .collect();
-        let catchall_projected = body_field_names.contains(&nesting.json_field_name.as_str());
+        let catchall_projected = body_field_names.contains(&nesting.json_field_name());
 
         // Build body-derived columns via string builders, in projected
         // (not full-schema) order, restricted to non-metadata fields.

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -160,6 +160,10 @@ pub mod s3_single_file_cached;
 #[cfg(feature = "s3_vectors")]
 pub mod s3_vectors;
 pub mod schema_discovery;
+/// Connector-agnostic schema projection (JSON nesting). The core lives in the
+/// `datafusion-table-providers` fork so providers defined there (`MongoDB`) can
+/// reuse it; re-exported here for the in-repo connectors (`DynamoDB`, Debezium).
+pub use datafusion_table_providers::schema_projection;
 #[cfg(feature = "scylladb")]
 pub mod scylladb;
 pub mod sql_expr;

--- a/crates/data_components/src/mongodb/stream.rs
+++ b/crates/data_components/src/mongodb/stream.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use crate::cdc::{ChangeBatch, ChangeBatchError, changes_schema};
+use crate::schema_projection::SchemaProjection;
 use arrow::{
     array::{ArrayRef, ListArray, RecordBatch, StringArray, StructArray, new_null_array},
     datatypes::{Field, Schema, SchemaRef},
@@ -22,6 +23,7 @@ use arrow::{
 use arrow_buffer::OffsetBuffer;
 use datafusion_table_providers::mongodb::{
     Error as MongoDBError,
+    projection::project_bson_document,
     utils::{
         arrow::mongo_docs_to_arrow,
         unnest::{UnnestBehavior, UnnestParameters, unnest_bson_documents},
@@ -74,6 +76,7 @@ pub fn change_events_to_change_batch(
     table_schema: &SchemaRef,
     primary_keys: &[String],
     unnest_parameters: &UnnestParameters,
+    projection: Option<&SchemaProjection>,
 ) -> Result<Option<ChangeBatch>> {
     let mut rows = Vec::with_capacity(events.len());
     let primary_keys = Arc::<[String]>::from(primary_keys.to_vec());
@@ -130,7 +133,7 @@ pub fn change_events_to_change_batch(
         return truncate_change_batch(table_schema).map(Some);
     }
 
-    build_change_batch(rows, table_schema, unnest_parameters).map(Some)
+    build_change_batch(rows, table_schema, unnest_parameters, projection).map(Some)
 }
 
 pub fn truncate_change_batch(table_schema: &SchemaRef) -> Result<ChangeBatch> {
@@ -174,6 +177,7 @@ fn build_change_batch(
     rows: Vec<ChangeRow>,
     table_schema: &SchemaRef,
     unnest_parameters: &UnnestParameters,
+    projection: Option<&SchemaProjection>,
 ) -> Result<ChangeBatch> {
     let change_data_schema = nullable_clone(table_schema);
     let row_count = rows.len();
@@ -183,6 +187,17 @@ fn build_change_batch(
     let documents = match unnest_parameters.behavior {
         UnnestBehavior::Depth(0) => documents,
         _ => unnest_bson_documents(documents, unnest_parameters).context(ConversionSnafu)?,
+    };
+
+    // Fold non-declared fields into the catch-all column when JSON nesting is
+    // configured, matching the scan path. The change-data schema is already the
+    // projected (declared + catch-all) schema.
+    let documents = match projection.filter(|p| p.has_catch_all()) {
+        Some(p) => documents
+            .into_iter()
+            .map(|d| project_bson_document(d, p))
+            .collect(),
+        None => documents,
     };
 
     let data_batch = mongo_docs_to_arrow(&documents, Arc::clone(&change_data_schema))
@@ -289,6 +304,7 @@ mod tests {
             &schema(),
             &["_id".to_string()],
             &default_unnest_parameters(0),
+            None,
         )
         .expect("change batch should build")
         .expect("batch should not be empty");
@@ -326,6 +342,7 @@ mod tests {
             &schema(),
             &["_id".to_string()],
             &default_unnest_parameters(0),
+            None,
         )
         .expect("change batch should build")
         .expect("batch should not be empty");
@@ -341,6 +358,7 @@ mod tests {
             &schema(),
             &["_id".to_string()],
             &default_unnest_parameters(0),
+            None,
         )
         .expect("empty change batch should not fail");
 
@@ -360,6 +378,7 @@ mod tests {
             &schema(),
             &["_id".to_string()],
             &default_unnest_parameters(0),
+            None,
         )
         .expect("change batch should build")
         .expect("batch should not be empty");
@@ -389,6 +408,7 @@ mod tests {
             &schema(),
             &["_id".to_string()],
             &default_unnest_parameters(0),
+            None,
         )
         .expect("change batch should build")
         .expect("batch should not be empty");
@@ -412,6 +432,7 @@ mod tests {
             &schema(),
             &["_id".to_string()],
             &default_unnest_parameters(0),
+            None,
         )
         .expect_err("missing fullDocument should fail");
 
@@ -431,6 +452,7 @@ mod tests {
             &schema(),
             &["_id".to_string()],
             &default_unnest_parameters(0),
+            None,
         )
         .expect_err("missing documentKey should fail");
 
@@ -451,6 +473,7 @@ mod tests {
             &schema(),
             &["_id".to_string()],
             &default_unnest_parameters(0),
+            None,
         )
         .expect_err("unsupported operation should fail");
 

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -24,6 +24,7 @@ use crate::component::dataset::acceleration::{Engine, RefreshMode};
 use crate::component::dataset::{Dataset, OnSchemaChange};
 use crate::component::metrics::MetricsProvider;
 use crate::dataaccelerator::spice_sys::{self, OpenOption, debezium_kafka::DebeziumKafkaSys};
+use crate::dataconnector::schema_projection::{ProjectionPolicy, parse_schema_projection};
 use crate::dataconnector::{
     ConnectorComponent,
     kafka::{SidecarOffsetCommitHook, SidecarOffsetStore},
@@ -487,6 +488,18 @@ impl DataConnector for Debezium {
             }
         };
 
+        // JSON-nesting / declared-schema projection. Primary-key (Kafka key)
+        // columns must be declared explicitly — never folded into the catch-all
+        // — so CDC UPDATE/DELETE apply keeps working.
+        let projection = parse_schema_projection(
+            dataset,
+            &ProjectionPolicy::new("debezium").with_required_columns(metadata.primary_keys.clone()),
+        )?;
+        let schema = match &projection {
+            Some(p) => p.project_schema(schema),
+            None => schema,
+        };
+
         ensure!(
             !metadata.primary_keys.is_empty()
                 || matches!(acceleration.engine.to_unpartitioned(), Engine::Arrow),
@@ -535,6 +548,7 @@ impl DataConnector for Debezium {
             metadata.primary_keys,
             kafka_consumer,
             self.batching,
+            projection,
         );
 
         if let Some(debezium_kafka_sys) = debezium_kafka_sys {

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -25,12 +25,13 @@ use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::metrics::{MetricSpec, MetricType, MetricsProvider, ObserveMetricCallback};
 use crate::dataaccelerator::spice_sys::OpenOption;
 use crate::dataaccelerator::spice_sys::dynamodb::{DynamoDBCheckpointMetadata, DynamoDBSys};
+use crate::dataconnector::schema_projection::{ProjectionPolicy, parse_schema_projection};
 use crate::federated_table::FederatedTable;
 use async_trait::async_trait;
 use data_components::cdc::{ChangeEnvelope, ChangesStream, CommitChange, CommitError, StreamError};
+use data_components::dynamodb::Error;
 use data_components::dynamodb::provider::DynamoDBTableProvider;
 use data_components::dynamodb::stream::StreamError as DynamoDBStreamError;
-use data_components::dynamodb::{Error, JsonNesting};
 use datafusion::datasource::TableProvider;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
@@ -40,10 +41,7 @@ use dynamodb_streams::{Checkpoint, Metrics, MetricsCollector};
 use futures::stream::{self, StreamExt};
 use opentelemetry::KeyValue;
 use runtime_parameters::ExposedParamLookup;
-use serde_json::Value;
 use snafu::ResultExt;
-use spicepod::semantic::Column;
-use std::collections::HashSet;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 use std::{any::Any, future::Future, pin::Pin, sync::Arc};
@@ -180,73 +178,6 @@ impl DataConnectorFactory for DynamoDBFactory {
     fn parameters(&self) -> &'static [ParameterSpec] {
         PARAMETERS
     }
-}
-
-fn parse_json_nesting_static_fields(
-    dataset: &Dataset,
-) -> Result<Option<JsonNesting>, DataConnectorError> {
-    // Find all columns that have json_object metadata defined
-    let json_object_columns: Vec<&Column> = dataset
-        .columns
-        .iter()
-        .filter(|col| col.metadata.contains_key("json_object"))
-        .collect();
-
-    // No json_object columns means no JSON nesting configuration
-    if json_object_columns.is_empty() {
-        return Ok(None);
-    }
-
-    // Error if multiple columns have json_object defined
-    if json_object_columns.len() > 1 {
-        let column_names: Vec<&str> = json_object_columns
-            .iter()
-            .map(|c| c.name.as_str())
-            .collect();
-        return Err(DataConnectorError::InvalidConfigurationNoSource {
-            dataconnector: "dynamodb".to_string(),
-            message: format!(
-                "Multiple columns have 'json_object' metadata defined: {}. Only one column can be configured as a JSON object column.",
-                column_names.join(", ")
-            ),
-            connector_component: ConnectorComponent::from(dataset),
-        });
-    }
-
-    let json_column = json_object_columns[0];
-    let Some(json_object_value) = json_column.metadata.get("json_object") else {
-        unreachable!("json_object key existence was checked above")
-    };
-
-    // Validate that json_object value is "*"
-    let is_wildcard = match json_object_value {
-        Value::String(s) => s == "*",
-        _ => false,
-    };
-
-    if !is_wildcard {
-        return Err(DataConnectorError::InvalidConfigurationNoSource {
-            dataconnector: "dynamodb".to_string(),
-            message: format!(
-                "Column '{}' has invalid 'json_object' value: {:?}. Only '*' is supported.",
-                json_column.name, json_object_value
-            ),
-            connector_component: ConnectorComponent::from(dataset),
-        });
-    }
-
-    // Collect all other columns as static fields
-    let static_fields: HashSet<String> = dataset
-        .columns
-        .iter()
-        .filter(|col| col.name != json_column.name)
-        .map(|col| col.name.clone())
-        .collect();
-
-    Ok(Some(JsonNesting {
-        static_fields,
-        json_field_name: json_column.name.clone(),
-    }))
 }
 
 #[async_trait]
@@ -400,7 +331,7 @@ impl DataConnector for DynamoDB {
             time_format.to_string(),
             ready_lag,
             Arc::clone(&self.metrics_collector),
-            parse_json_nesting_static_fields(dataset)?.as_ref(),
+            parse_schema_projection(dataset, &ProjectionPolicy::new("dynamodb"))?.as_ref(),
             write_parallelism,
             dataset.schema.clone(),
         )
@@ -1338,6 +1269,7 @@ mod tests {
     use super::*;
     use crate::component::dataset::builder::DatasetBuilder;
     use serde_json::json;
+    use spicepod::semantic::Column;
     use std::collections::HashMap;
 
     async fn test_dataset(columns: Vec<Column>) -> Dataset {
@@ -1354,7 +1286,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_no_json_object_columns_returns_none() {
+    async fn test_no_json_object_columns_is_identity() {
         let dataset = test_dataset(vec![
             Column::new("PK"),
             Column::new("SK"),
@@ -1362,8 +1294,13 @@ mod tests {
         ])
         .await;
 
-        let result = parse_json_nesting_static_fields(&dataset).expect("should return Ok");
-        assert!(result.is_none());
+        // Columns with no `json_object` marker yield an identity projection
+        // (no catch-all): rows pass through unchanged.
+        let result = parse_schema_projection(&dataset, &ProjectionPolicy::new("dynamodb"))
+            .expect("should return Ok")
+            .expect("columns present → Some");
+        assert!(!result.has_catch_all());
+        assert!(result.is_identity());
     }
 
     #[tokio::test]
@@ -1379,15 +1316,15 @@ mod tests {
         ])
         .await;
 
-        let result = parse_json_nesting_static_fields(&dataset)
+        let result = parse_schema_projection(&dataset, &ProjectionPolicy::new("dynamodb"))
             .expect("should return Ok")
             .expect("should return Some");
 
-        assert_eq!(result.json_field_name, "data_json");
-        assert_eq!(result.static_fields.len(), 3);
-        assert!(result.static_fields.contains("PK"));
-        assert!(result.static_fields.contains("SK"));
-        assert!(result.static_fields.contains("Baz"));
+        assert_eq!(result.catch_all_name(), Some("data_json"));
+        assert_eq!(result.static_fields().len(), 3);
+        assert!(result.static_fields().contains("PK"));
+        assert!(result.static_fields().contains("SK"));
+        assert!(result.static_fields().contains("Baz"));
     }
 
     #[tokio::test]
@@ -1405,13 +1342,9 @@ mod tests {
         ])
         .await;
 
-        let result = parse_json_nesting_static_fields(&dataset);
-        assert!(result.is_err());
-
-        let err = result
+        let err = parse_schema_projection(&dataset, &ProjectionPolicy::new("dynamodb"))
             .expect_err("should fail when multiple json_object columns defined")
             .to_string();
-        assert!(err.contains("Multiple columns"));
         assert!(err.contains("data1"));
         assert!(err.contains("data2"));
     }
@@ -1427,10 +1360,7 @@ mod tests {
         ])
         .await;
 
-        let result = parse_json_nesting_static_fields(&dataset);
-        assert!(result.is_err());
-
-        let err = result
+        let err = parse_schema_projection(&dataset, &ProjectionPolicy::new("dynamodb"))
             .expect_err("should fail when invalid value")
             .to_string();
         assert!(err.contains("invalid 'json_object' value"));

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -2871,14 +2871,14 @@ uGgYIHbi/F+GaiUPzDyqe5p9
         let nesting = parse_http_json_nesting(&dataset)
             .expect("parse should succeed")
             .expect("expected Some(nesting) when marker is present");
-        assert_eq!(nesting.json_field_name, "data");
+        assert_eq!(nesting.json_field_name(), "data");
         assert_eq!(
             nesting.column_order,
             vec!["id", "name", "data", "_fetched_at"]
         );
-        assert!(nesting.static_fields.contains("id"));
-        assert!(nesting.static_fields.contains("name"));
-        assert!(!nesting.static_fields.contains("data"));
+        assert!(nesting.static_fields().contains("id"));
+        assert!(nesting.static_fields().contains("name"));
+        assert!(!nesting.static_fields().contains("data"));
         assert!(
             nesting.metadata_fields.contains("_fetched_at"),
             "_fetched_at should be auto-injected into metadata_fields"
@@ -2964,7 +2964,7 @@ uGgYIHbi/F+GaiUPzDyqe5p9
         let nesting = parse_http_json_nesting(&dataset)
             .expect("parse should succeed")
             .expect("expected Some(nesting) when marker is present");
-        assert_eq!(nesting.json_field_name, "data");
+        assert_eq!(nesting.json_field_name(), "data");
         assert_eq!(
             nesting.column_order,
             vec![
@@ -2987,10 +2987,10 @@ uGgYIHbi/F+GaiUPzDyqe5p9
         );
         // Reserved-name columns must not also be treated as static body
         // fields, otherwise the body would shadow the HTTP metadata.
-        assert!(!nesting.static_fields.contains("request_path"));
-        assert!(!nesting.static_fields.contains("response_status"));
-        assert!(!nesting.static_fields.contains("_fetched_at"));
-        assert!(nesting.static_fields.contains("id"));
+        assert!(!nesting.static_fields().contains("request_path"));
+        assert!(!nesting.static_fields().contains("response_status"));
+        assert!(!nesting.static_fields().contains("_fetched_at"));
+        assert!(nesting.static_fields().contains("id"));
     }
 
     #[tokio::test]
@@ -3178,7 +3178,7 @@ uGgYIHbi/F+GaiUPzDyqe5p9
             "_fetched_at should be in metadata_fields"
         );
         assert!(
-            !nesting.static_fields.contains("_fetched_at"),
+            !nesting.static_fields().contains("_fetched_at"),
             "_fetched_at must not be a static body field"
         );
         // Auto-injected at the end, after user-declared columns.

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -178,6 +178,7 @@ pub mod iceberg;
 pub mod iceberg_cluster;
 pub mod parameters;
 pub mod s3;
+pub mod schema_projection;
 pub mod sink;
 pub mod spiceai;
 

--- a/crates/runtime/src/dataconnector/schema_projection.rs
+++ b/crates/runtime/src/dataconnector/schema_projection.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crates/runtime/src/dataconnector/schema_projection.rs
+++ b/crates/runtime/src/dataconnector/schema_projection.rs
@@ -1,0 +1,232 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Connector-agnostic parser that turns a dataset's `columns:` block into a
+//! [`SchemaProjection`]. Replaces and de-duplicates the per-connector
+//! `parse_json_nesting_static_fields` (`DynamoDB`) and `parse_http_json_nesting`
+//! (HTTP) helpers.
+
+use data_components::schema_projection::{
+    ColumnSource, JSON_OBJECT_MARKER, JSON_OBJECT_WILDCARD, ProjectedColumn, SchemaProjection,
+    SchemaProjectionError,
+};
+use serde_json::Value;
+
+use crate::component::dataset::Dataset;
+use crate::component::dataset::declared_type::parse_declared_type;
+use crate::dataconnector::{ConnectorComponent, DataConnectorError, DataConnectorResult};
+
+/// Per-connector knobs for parsing a projection.
+pub struct ProjectionPolicy<'a> {
+    /// Connector name, used only for error messages (e.g. `"dynamodb"`).
+    pub connector: &'a str,
+    /// Columns that must be declared explicitly (e.g. primary-key / CDC-key
+    /// columns) and may not be folded into the `json_object` catch-all.
+    pub required_columns: Vec<String>,
+}
+
+impl<'a> ProjectionPolicy<'a> {
+    #[must_use]
+    pub fn new(connector: &'a str) -> Self {
+        Self {
+            connector,
+            required_columns: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_required_columns(mut self, columns: Vec<String>) -> Self {
+        self.required_columns = columns;
+        self
+    }
+}
+
+/// Parse a dataset's `columns:` into a [`SchemaProjection`].
+///
+/// Returns `Ok(None)` when the dataset declares no columns at all (the
+/// projection would be a no-op and callers can keep their existing inference
+/// path). Otherwise every declared column becomes a [`ProjectedColumn`]:
+///
+/// - a column carrying `metadata.json_object: "*"` becomes the catch-all
+///   ([`ColumnSource::JsonObject`]); only `"*"` is accepted;
+/// - any other column becomes a kept [`ColumnSource::Field`] read by its name.
+///
+/// # Errors
+/// Returns an invalid-configuration error for a non-`"*"` catch-all marker, an
+/// unparseable declared `type`, or any structural problem surfaced by
+/// [`SchemaProjection::new`] (multiple catch-alls, duplicate names, a required
+/// column folded into the catch-all).
+pub fn parse_schema_projection(
+    dataset: &Dataset,
+    policy: &ProjectionPolicy<'_>,
+) -> DataConnectorResult<Option<SchemaProjection>> {
+    if dataset.columns.is_empty() {
+        return Ok(None);
+    }
+
+    let mut columns = Vec::with_capacity(dataset.columns.len());
+    for column in &dataset.columns {
+        let catch_all_marker = column.metadata.get(JSON_OBJECT_MARKER);
+
+        let declared_type = match column.r#type.as_deref() {
+            Some(type_str) => Some(parse_declared_type(type_str).map_err(|source| {
+                invalid(
+                    policy,
+                    dataset,
+                    format!("Column '{}' has an invalid 'type': {source}", column.name),
+                )
+            })?),
+            None => None,
+        };
+        let nullable = column.nullable.unwrap_or(true);
+
+        let source = if let Some(marker) = catch_all_marker {
+            // Validate the marker value is exactly "*".
+            let is_wildcard = matches!(marker, Value::String(s) if s == JSON_OBJECT_WILDCARD);
+            if !is_wildcard {
+                return Err(invalid(
+                    policy,
+                    dataset,
+                    format!(
+                        "Column '{}' has invalid '{JSON_OBJECT_MARKER}' value: {marker:?}. Only '{JSON_OBJECT_WILDCARD}' is supported.",
+                        column.name
+                    ),
+                ));
+            }
+            ColumnSource::JsonObject
+        } else {
+            ColumnSource::Field
+        };
+
+        columns.push(ProjectedColumn {
+            output_name: column.name.clone(),
+            source,
+            declared_type,
+            nullable,
+        });
+    }
+
+    let projection = SchemaProjection::new(columns, &policy.required_columns)
+        .map_err(|e| projection_error(policy, dataset, &e))?;
+    Ok(Some(projection))
+}
+
+fn invalid(
+    policy: &ProjectionPolicy<'_>,
+    dataset: &Dataset,
+    message: String,
+) -> DataConnectorError {
+    DataConnectorError::InvalidConfigurationNoSource {
+        dataconnector: policy.connector.to_string(),
+        connector_component: ConnectorComponent::from(dataset),
+        message,
+    }
+}
+
+fn projection_error(
+    policy: &ProjectionPolicy<'_>,
+    dataset: &Dataset,
+    err: &SchemaProjectionError,
+) -> DataConnectorError {
+    invalid(policy, dataset, err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::dataset::builder::DatasetBuilder;
+    use app::AppBuilder;
+    use spicepod::semantic::Column;
+    use std::collections::HashMap;
+
+    async fn dataset_with_columns(cols: Vec<Column>) -> Dataset {
+        let app = std::sync::Arc::new(AppBuilder::new("test").build());
+        let rt = std::sync::Arc::new(crate::Runtime::builder().build().await);
+        let mut ds = DatasetBuilder::try_new("dynamodb:tbl".to_string(), "tbl")
+            .expect("builder")
+            .with_app(app)
+            .with_runtime(rt)
+            .build()
+            .expect("dataset");
+        ds.columns = cols;
+        ds
+    }
+
+    fn catch_all_column(name: &str) -> Column {
+        let mut metadata = HashMap::new();
+        metadata.insert("json_object".to_string(), Value::String("*".to_string()));
+        Column::new(name).with_metadata(metadata)
+    }
+
+    #[tokio::test]
+    async fn no_columns_returns_none() {
+        let ds = dataset_with_columns(vec![]).await;
+        let policy = ProjectionPolicy::new("dynamodb");
+        assert!(parse_schema_projection(&ds, &policy).expect("ok").is_none());
+    }
+
+    #[tokio::test]
+    async fn parses_nesting() {
+        let ds = dataset_with_columns(vec![
+            Column::new("id").with_type("bigint"),
+            Column::new("title"),
+            catch_all_column("data"),
+        ])
+        .await;
+        let policy = ProjectionPolicy::new("dynamodb");
+        let proj = parse_schema_projection(&ds, &policy)
+            .expect("ok")
+            .expect("some");
+        assert!(proj.has_catch_all());
+        assert!(!proj.is_identity());
+        assert_eq!(proj.columns().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn rejects_non_wildcard_marker() {
+        let mut metadata = HashMap::new();
+        metadata.insert("json_object".to_string(), Value::String("nope".to_string()));
+        let ds = dataset_with_columns(vec![Column::new("data").with_metadata(metadata)]).await;
+        let policy = ProjectionPolicy::new("dynamodb");
+        parse_schema_projection(&ds, &policy).expect_err("non-'*' marker should error");
+    }
+
+    #[tokio::test]
+    async fn enforces_required_pk_declared() {
+        let ds = dataset_with_columns(vec![catch_all_column("data")]).await;
+        let policy =
+            ProjectionPolicy::new("debezium").with_required_columns(vec!["id".to_string()]);
+        // `id` is required but only the catch-all is declared.
+        parse_schema_projection(&ds, &policy)
+            .expect_err("required PK folded into catch-all should error");
+    }
+
+    #[tokio::test]
+    async fn identity_projection_for_typed_columns() {
+        let ds = dataset_with_columns(vec![
+            Column::new("id").with_type("bigint"),
+            Column::new("name").with_type("text"),
+        ])
+        .await;
+        let policy = ProjectionPolicy::new("dynamodb");
+        let proj = parse_schema_projection(&ds, &policy)
+            .expect("ok")
+            .expect("some");
+        // pure type-pinning, no catch-all → identity (rows untouched)
+        assert!(proj.is_identity());
+        assert!(!proj.has_catch_all());
+    }
+}

--- a/crates/runtime/tests/cdc_cayenne_debezium.rs
+++ b/crates/runtime/tests/cdc_cayenne_debezium.rs
@@ -59,8 +59,11 @@ use data_components::cdc::{
     ChangeBatch, ChangeEnvelope, ChangesStream, CommitChange, CommitError, StreamError,
     changes_schema,
 };
+#[cfg(feature = "debezium")]
 use data_components::debezium::arrow::changes::to_change_batch;
+#[cfg(feature = "debezium")]
 use data_components::debezium::change_event::ChangeEvent;
+#[cfg(feature = "debezium")]
 use data_components::schema_projection::SchemaProjection;
 use datafusion::datasource::TableProvider;
 use datafusion::physical_plan::collect;
@@ -447,6 +450,7 @@ async fn debezium_delete_then_reinsert_resurrects_row() {
 /// on-the-wire envelope shape the connector deserializes. The embedded `schema`
 /// block is intentionally minimal: `to_change_batch` projects against the
 /// caller-supplied table schema, not the event's self-description.
+#[cfg(feature = "debezium")]
 fn debezium_create_event(after: serde_json::Value) -> ChangeEvent {
     let value = serde_json::json!({
         "schema": { "type": "struct", "fields": [], "optional": false, "name": "test.Envelope" },
@@ -470,6 +474,7 @@ fn debezium_create_event(after: serde_json::Value) -> ChangeEvent {
 /// stays a top-level column while every other `after` field folds into one
 /// sorted-key JSON catch-all `data` column — then applied through the runtime
 /// changes stream into a keyed Cayenne accelerator and read back via SQL.
+#[cfg(feature = "debezium")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn debezium_json_nesting_folds_into_catch_all() {
     // The decomposed schema the dataset exposes: static `id` + catch-all `data`.
@@ -486,8 +491,12 @@ async fn debezium_json_nesting_folds_into_catch_all() {
     let pk = ["id".to_string()];
 
     let events = [
-        debezium_create_event(serde_json::json!({ "id": 1, "email": "alice@example.com", "age": 30 })),
-        debezium_create_event(serde_json::json!({ "id": 2, "email": "bob@example.com", "age": 25 })),
+        debezium_create_event(
+            serde_json::json!({ "id": 1, "email": "alice@example.com", "age": 30 }),
+        ),
+        debezium_create_event(
+            serde_json::json!({ "id": 2, "email": "bob@example.com", "age": 25 }),
+        ),
     ];
 
     let commits = Arc::new(TokioMutex::new(Vec::new()));
@@ -510,15 +519,27 @@ async fn debezium_json_nesting_folds_into_catch_all() {
         .collect();
     let stream = fstream::iter(envelopes).boxed();
 
-    let task = make_refresh_task(Arc::clone(&table) as Arc<dyn TableProvider>, "dbz_json_nest");
+    let task = make_refresh_task(
+        Arc::clone(&table) as Arc<dyn TableProvider>,
+        "dbz_json_nest",
+    );
     let refresh = Arc::new(RwLock::new(Refresh::default()));
-    task.start_changes_stream(refresh, stream, None, None, Arc::new(AtomicBool::new(false)))
-        .await
-        .expect("start_changes_stream");
+    task.start_changes_stream(
+        refresh,
+        stream,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .expect("start_changes_stream");
 
     // Read the accelerated table back and assert the decomposition.
     let ctx = SessionContext::new();
-    let plan = table.scan(&ctx.state(), None, &[], None).await.expect("scan");
+    let plan = table
+        .scan(&ctx.state(), None, &[], None)
+        .await
+        .expect("scan");
     let batches = collect(plan, ctx.task_ctx()).await.expect("collect");
 
     let mut rows: Vec<(i64, serde_json::Value)> = Vec::new();

--- a/crates/runtime/tests/cdc_cayenne_debezium.rs
+++ b/crates/runtime/tests/cdc_cayenne_debezium.rs
@@ -59,6 +59,9 @@ use data_components::cdc::{
     ChangeBatch, ChangeEnvelope, ChangesStream, CommitChange, CommitError, StreamError,
     changes_schema,
 };
+use data_components::debezium::arrow::changes::to_change_batch;
+use data_components::debezium::change_event::ChangeEvent;
+use data_components::schema_projection::SchemaProjection;
 use datafusion::datasource::TableProvider;
 use datafusion::physical_plan::collect;
 use datafusion::prelude::SessionContext;
@@ -184,6 +187,15 @@ fn stream_of(ops: &[Op<'_>], commits: &Arc<TokioMutex<Vec<i64>>>) -> ChangesStre
 async fn setup_keyed_cayenne(
     table_name: &str,
 ) -> (TempDir, Arc<CayenneCatalog>, Arc<CayenneTableProvider>) {
+    setup_keyed_cayenne_with_schema(table_name, data_schema()).await
+}
+
+/// Like [`setup_keyed_cayenne`] but with a caller-supplied data schema — e.g. the
+/// decomposed `{id, data}` schema a `json_object` Debezium dataset exposes.
+async fn setup_keyed_cayenne_with_schema(
+    table_name: &str,
+    schema: Arc<Schema>,
+) -> (TempDir, Arc<CayenneCatalog>, Arc<CayenneTableProvider>) {
     let temp = TempDir::new().expect("temp dir");
     let data_path = temp.path().join("data");
     tokio::fs::create_dir_all(&data_path)
@@ -195,7 +207,6 @@ async fn setup_keyed_cayenne(
     let catalog = Arc::new(CayenneCatalog::new(conn).expect("CayenneCatalog::new"));
     catalog.init().await.expect("catalog init");
 
-    let schema = data_schema();
     let ctx = SessionContext::new();
     let table = CayenneTableProvider::create_table(
         Arc::clone(&catalog) as Arc<dyn MetadataCatalog>,
@@ -430,4 +441,120 @@ async fn debezium_delete_then_reinsert_resurrects_row() {
         vec![(1, Some("v2".to_string()))],
         "the re-insert after the delete must win; id=1 is present with v2"
     );
+}
+
+/// Build a Debezium `create` change event with the given `after` payload, in the
+/// on-the-wire envelope shape the connector deserializes. The embedded `schema`
+/// block is intentionally minimal: `to_change_batch` projects against the
+/// caller-supplied table schema, not the event's self-description.
+fn debezium_create_event(after: serde_json::Value) -> ChangeEvent {
+    let value = serde_json::json!({
+        "schema": { "type": "struct", "fields": [], "optional": false, "name": "test.Envelope" },
+        "payload": {
+            "before": null,
+            "after": after,
+            "source": {
+                "version": "x", "connector": "x", "name": "x", "ts_ms": 0,
+                "snapshot": "false", "db": "x", "table": "x"
+            },
+            "op": "c",
+            "ts_ms": 0,
+            "transaction": null
+        }
+    });
+    serde_json::from_value(value).expect("valid Debezium change event")
+}
+
+/// JSON nesting (`json_object`) end-to-end for Debezium: real Debezium change
+/// events are decomposed by the connector's `to_change_batch` — the declared `id`
+/// stays a top-level column while every other `after` field folds into one
+/// sorted-key JSON catch-all `data` column — then applied through the runtime
+/// changes stream into a keyed Cayenne accelerator and read back via SQL.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn debezium_json_nesting_folds_into_catch_all() {
+    // The decomposed schema the dataset exposes: static `id` + catch-all `data`.
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("data", DataType::Utf8, true),
+    ]));
+    let (_temp, _catalog, table) =
+        setup_keyed_cayenne_with_schema("dbz_json_nest", Arc::clone(&schema)).await;
+
+    // `id` is the declared static (primary-key) column; every other `after` field
+    // folds into `data`.
+    let projection = SchemaProjection::nesting(vec!["id".to_string()], "data".to_string());
+    let pk = ["id".to_string()];
+
+    let events = [
+        debezium_create_event(serde_json::json!({ "id": 1, "email": "alice@example.com", "age": 30 })),
+        debezium_create_event(serde_json::json!({ "id": 2, "email": "bob@example.com", "age": 25 })),
+    ];
+
+    let commits = Arc::new(TokioMutex::new(Vec::new()));
+    let envelopes: Vec<Result<ChangeEnvelope, StreamError>> = events
+        .iter()
+        .enumerate()
+        .map(|(seq, event)| {
+            // The real decomposition: fold non-declared `after` fields into `data`.
+            let batch = to_change_batch(&schema, &pk, event, Some(&projection))
+                .expect("Debezium change event should decompose into a change batch");
+            Ok(ChangeEnvelope::new(
+                Box::new(RecordingCommitter {
+                    id: i64::try_from(seq).expect("seq fits i64"),
+                    commits: Arc::clone(&commits),
+                }),
+                batch,
+                true,
+            ))
+        })
+        .collect();
+    let stream = fstream::iter(envelopes).boxed();
+
+    let task = make_refresh_task(Arc::clone(&table) as Arc<dyn TableProvider>, "dbz_json_nest");
+    let refresh = Arc::new(RwLock::new(Refresh::default()));
+    task.start_changes_stream(refresh, stream, None, None, Arc::new(AtomicBool::new(false)))
+        .await
+        .expect("start_changes_stream");
+
+    // Read the accelerated table back and assert the decomposition.
+    let ctx = SessionContext::new();
+    let plan = table.scan(&ctx.state(), None, &[], None).await.expect("scan");
+    let batches = collect(plan, ctx.task_ctx()).await.expect("collect");
+
+    let mut rows: Vec<(i64, serde_json::Value)> = Vec::new();
+    for batch in &batches {
+        let ids = batch
+            .column_by_name("id")
+            .expect("id column")
+            .as_primitive::<Int64Type>();
+        let data = batch
+            .column_by_name("data")
+            .expect("catch-all data column")
+            .as_string::<i32>();
+        for row in 0..batch.num_rows() {
+            let catch_all: serde_json::Value =
+                serde_json::from_str(data.value(row)).expect("catch-all must be valid JSON");
+            rows.push((ids.value(row), catch_all));
+        }
+    }
+    rows.sort_by_key(|(id, _)| *id);
+
+    assert_eq!(rows.len(), 2, "two decomposed rows");
+
+    let (id0, data0) = &rows[0];
+    assert_eq!(*id0, 1);
+    assert_eq!(data0["email"], serde_json::json!("alice@example.com"));
+    assert!(
+        data0.get("age").is_some(),
+        "non-declared `age` must fold into the catch-all"
+    );
+    assert!(
+        data0.get("id").is_none(),
+        "declared static `id` must not leak into the catch-all"
+    );
+
+    let (id1, data1) = &rows[1];
+    assert_eq!(*id1, 2);
+    assert_eq!(data1["email"], serde_json::json!("bob@example.com"));
+    assert!(data1.get("id").is_none());
 }

--- a/crates/runtime/tests/cdc_cayenne_debezium.rs
+++ b/crates/runtime/tests/cdc_cayenne_debezium.rs
@@ -451,7 +451,7 @@ async fn debezium_delete_then_reinsert_resurrects_row() {
 /// block is intentionally minimal: `to_change_batch` projects against the
 /// caller-supplied table schema, not the event's self-description.
 #[cfg(feature = "debezium")]
-fn debezium_create_event(after: serde_json::Value) -> ChangeEvent {
+fn debezium_create_event(after: &serde_json::Value) -> ChangeEvent {
     let value = serde_json::json!({
         "schema": { "type": "struct", "fields": [], "optional": false, "name": "test.Envelope" },
         "payload": {
@@ -492,10 +492,10 @@ async fn debezium_json_nesting_folds_into_catch_all() {
 
     let events = [
         debezium_create_event(
-            serde_json::json!({ "id": 1, "email": "alice@example.com", "age": 30 }),
+            &serde_json::json!({ "id": 1, "email": "alice@example.com", "age": 30 }),
         ),
         debezium_create_event(
-            serde_json::json!({ "id": 2, "email": "bob@example.com", "age": 25 }),
+            &serde_json::json!({ "id": 2, "email": "bob@example.com", "age": 25 }),
         ),
     ];
 

--- a/crates/runtime/tests/http/mod.rs
+++ b/crates/runtime/tests/http/mod.rs
@@ -62,6 +62,14 @@ const SHOWS_JSON: &str = r#"[
     {"id": 3, "name": "Better Call Saul", "rating": 8.9}
 ]"#;
 
+/// A JSON array whose objects carry, beyond `id`/`name`, extra scalar (`email`,
+/// `age`), nested-document (`address`), and array (`tags`) fields — everything a
+/// `json_object` catch-all must fold in.
+const PEOPLE_JSON: &str = r#"[
+    {"id": 1, "name": "Alice", "email": "alice@example.com", "age": 30, "address": {"city": "NYC", "zip": "10001"}},
+    {"id": 2, "name": "Bob", "email": "bob@example.com", "tags": ["x", "y"]}
+]"#;
+
 const ITEMS_CSV: &str = "id,name,price\n1,Widget,9.99\n2,Gadget,19.99\n3,Doohickey,4.99\n";
 
 const HTTP_JSON_EDGE_CASES: &str = r#"[
@@ -193,6 +201,10 @@ async fn start_http_server() -> Result<
         .route(
             "/api/shows",
             get(|| async { ([("content-type", "application/json")], SHOWS_JSON) }),
+        )
+        .route(
+            "/api/people",
+            get(|| async { ([("content-type", "application/json")], PEOPLE_JSON) }),
         )
         .route(
             "/api/shows/{id}",
@@ -564,6 +576,116 @@ async fn test_http_json_api_dynamic() -> Result<(), String> {
                 )
                 .await?;
             }
+
+            tx.send(())
+                .map_err(|()| "Failed to send shutdown signal".to_string())?;
+            Ok(())
+        })
+        .await
+}
+
+/// JSON nesting (`json_object: "*"`) on the HTTP connector: declared static
+/// columns (`id`, `name`) stay top-level while every other field of each JSON
+/// row folds into one sorted-key JSON catch-all `Utf8` column (`data`),
+/// exercised end-to-end against a live endpoint returning a JSON array.
+#[tokio::test]
+async fn http_json_object_decomposition() -> Result<(), String> {
+    use arrow::array::{Array, StringArray};
+    use spicepod::semantic::Column;
+
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let (tx, addr, _) = start_http_server().await?;
+            tracing::debug!("HTTP test server started at {addr}");
+
+            // Declaring a `json_object` catch-all column switches the HTTP provider
+            // into decomposition mode; no `file_format` is needed (the extensionless
+            // URL takes the dynamic HTTP path).
+            let mut dataset = Dataset::new(format!("http://{addr}/api/people"), "people");
+            let mut catch_all_meta = HashMap::new();
+            catch_all_meta.insert("json_object".to_string(), json!("*"));
+            dataset.columns = vec![
+                Column::new("id"),
+                Column::new("name"),
+                Column::new("data").with_metadata(catch_all_meta),
+            ];
+
+            let app = AppBuilder::new("http_json_object_test")
+                .with_dataset(dataset)
+                .build();
+            let rt = load_runtime(app).await?;
+
+            let query_result = rt
+                .datafusion()
+                .query_builder("SELECT name, data FROM people ORDER BY id")
+                .build()
+                .run()
+                .await
+                .map_err(|e| format!("json_object query failed: {e}"))?;
+            let batches: Vec<RecordBatch> = query_result
+                .data
+                .try_collect()
+                .await
+                .map_err(|e| format!("failed to collect json_object results: {e}"))?;
+
+            let mut rows: Vec<(String, Value)> = Vec::new();
+            for batch in &batches {
+                let names = batch
+                    .column_by_name("name")
+                    .ok_or("missing `name` column")?
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or("`name` should be a static Utf8 column")?;
+                let data = batch
+                    .column_by_name("data")
+                    .ok_or("missing catch-all `data` column")?
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or("catch-all `data` should be a Utf8 JSON string")?;
+                for row in 0..batch.num_rows() {
+                    let catch_all: Value = serde_json::from_str(data.value(row))
+                        .map_err(|e| format!("catch-all must be valid JSON: {e}"))?;
+                    rows.push((names.value(row).to_string(), catch_all));
+                }
+            }
+
+            assert_eq!(rows.len(), 2, "expected two rows, got {}", rows.len());
+
+            // Row 0 (Alice): declared statics stay top-level; every other field
+            // (scalar, nested object) folds into the catch-all, and no static key
+            // leaks into it.
+            let (name0, data0) = &rows[0];
+            assert_eq!(name0, "Alice");
+            assert_eq!(data0["email"], json!("alice@example.com"));
+            assert!(
+                data0.get("age").is_some(),
+                "scalar `age` must be in the catch-all"
+            );
+            assert!(
+                data0["address"].is_object(),
+                "nested `address` must be preserved as JSON in the catch-all"
+            );
+            assert!(
+                data0.get("name").is_none(),
+                "static `name` must not leak into the catch-all"
+            );
+            assert!(
+                data0.get("id").is_none(),
+                "static `id` must not leak into the catch-all"
+            );
+
+            // Row 1 (Bob): an array field folds in as well.
+            let (name1, data1) = &rows[1];
+            assert_eq!(name1, "Bob");
+            assert_eq!(data1["email"], json!("bob@example.com"));
+            assert!(
+                data1["tags"].is_array(),
+                "array `tags` must be preserved in the catch-all"
+            );
+            assert!(data1.get("name").is_none());
 
             tx.send(())
                 .map_err(|()| "Failed to send shutdown signal".to_string())?;

--- a/crates/runtime/tests/mongo/mod.rs
+++ b/crates/runtime/tests/mongo/mod.rs
@@ -380,7 +380,7 @@ async fn mongodb_json_nesting_folds_into_catch_all() -> Result<(), anyhow::Error
                 () = tokio::time::sleep(std::time::Duration::from_mins(1)) => {
                     return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
                 }
-                () = cloned_rt.load_components() => {}
+                () = Arc::clone(&cloned_rt).load_components() => {}
             }
 
             let batches =
@@ -399,7 +399,9 @@ async fn mongodb_json_nesting_folds_into_catch_all() -> Result<(), anyhow::Error
                     .ok_or_else(|| anyhow::anyhow!("missing catch-all `data` column"))?
                     .as_any()
                     .downcast_ref::<StringArray>()
-                    .ok_or_else(|| anyhow::anyhow!("catch-all `data` should be a Utf8 JSON string"))?;
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("catch-all `data` should be a Utf8 JSON string")
+                    })?;
                 for row in 0..batch.num_rows() {
                     let catch_all: serde_json::Value = serde_json::from_str(data.value(row))
                         .map_err(|e| anyhow::anyhow!("catch-all must be valid JSON: {e}"))?;
@@ -415,7 +417,10 @@ async fn mongodb_json_nesting_folds_into_catch_all() -> Result<(), anyhow::Error
             let (name0, data0) = &rows[0];
             assert_eq!(name0, "Alice");
             assert_eq!(data0["email"], json!("alice@example.com"));
-            assert!(data0.get("age").is_some(), "scalar `age` must be in the catch-all");
+            assert!(
+                data0.get("age").is_some(),
+                "scalar `age` must be in the catch-all"
+            );
             assert!(
                 data0["address"].is_object(),
                 "nested `address` must be preserved as JSON in the catch-all"
@@ -433,7 +438,10 @@ async fn mongodb_json_nesting_folds_into_catch_all() -> Result<(), anyhow::Error
             let (name1, data1) = &rows[1];
             assert_eq!(name1, "Bob");
             assert_eq!(data1["email"], json!("bob@example.com"));
-            assert!(data1["tags"].is_array(), "array `tags` must be preserved in the catch-all");
+            assert!(
+                data1["tags"].is_array(),
+                "array `tags` must be preserved in the catch-all"
+            );
             assert!(data1.get("name").is_none());
 
             running_container.remove().await?;

--- a/crates/runtime/tests/mongo/mod.rs
+++ b/crates/runtime/tests/mongo/mod.rs
@@ -330,7 +330,7 @@ async fn init_mongodb_json_nesting_db(port: u16) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// JSON nesting (`json_object: "*"`) on a federated MongoDB dataset: the declared
+/// JSON nesting (`json_object: "*"`) on a federated `MongoDB` dataset: the declared
 /// static columns (`_id`, `name`) stay top-level, and every other document field
 /// is folded into one sorted-JSON catch-all `Utf8` column (`data`). Asserts both
 /// that non-declared fields (scalar, nested, array) land in the catch-all and

--- a/crates/runtime/tests/mongo/mod.rs
+++ b/crates/runtime/tests/mongo/mod.rs
@@ -47,6 +47,7 @@ use runtime::Runtime;
 use tracing::instrument;
 
 const MONGODB_PORT1: u16 = 27019;
+const MONGODB_JSON_NESTING_PORT: u16 = 27038;
 #[cfg(feature = "duckdb")]
 const MONGODB_CHANGE_STREAM_PORT: u16 = 27020;
 #[cfg(feature = "duckdb")]
@@ -294,6 +295,148 @@ async fn mongodb_integration_test() -> Result<(), String> {
                 e.to_string()
             })?;
 
+            Ok(())
+        })
+        .await
+}
+
+/// Seed a `nested` collection whose documents carry, beyond `_id`/`name`, extra
+/// scalar (`email`, `age`), nested-document (`address`), and array (`tags`)
+/// fields — everything a `json_object` catch-all must fold in.
+#[instrument]
+async fn init_mongodb_json_nesting_db(port: u16) -> Result<(), anyhow::Error> {
+    let client = get_mongodb_client(port).await?;
+    let database = client.database("testdb");
+    let collection: Collection<mongodb::bson::Document> = database.collection("nested");
+    collection.drop().await.ok();
+    collection
+        .insert_many(vec![
+            doc! {
+                "_id": 1,
+                "name": "Alice",
+                "email": "alice@example.com",
+                "age": 30,
+                "address": { "city": "NYC", "zip": "10001" },
+            },
+            doc! {
+                "_id": 2,
+                "name": "Bob",
+                "email": "bob@example.com",
+                "age": 25,
+                "tags": ["x", "y"],
+            },
+        ])
+        .await?;
+    Ok(())
+}
+
+/// JSON nesting (`json_object: "*"`) on a federated MongoDB dataset: the declared
+/// static columns (`_id`, `name`) stay top-level, and every other document field
+/// is folded into one sorted-JSON catch-all `Utf8` column (`data`). Asserts both
+/// that non-declared fields (scalar, nested, array) land in the catch-all and
+/// that static columns do **not** leak into it.
+#[tokio::test]
+async fn mongodb_json_nesting_folds_into_catch_all() -> Result<(), anyhow::Error> {
+    use arrow::array::{Array, StringArray};
+    use serde_json::json;
+    use spicepod::semantic::Column;
+    use std::collections::HashMap;
+
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let running_container =
+                start_mongodb_docker_container(MONGODB_JSON_NESTING_PORT).await?;
+
+            let retry_strategy = FibonacciBackoffBuilder::new().max_retries(Some(10)).build();
+            retry(retry_strategy, || async {
+                init_mongodb_json_nesting_db(MONGODB_JSON_NESTING_PORT)
+                    .await
+                    .map_err(RetryError::transient)
+            })
+            .await?;
+
+            let mut metadata = HashMap::new();
+            metadata.insert("json_object".to_string(), json!("*"));
+            let mut dataset =
+                make_mongodb_dataset("nested", "nested", MONGODB_JSON_NESTING_PORT, false);
+            dataset.columns = vec![
+                Column::new("_id"),
+                Column::new("name"),
+                Column::new("data").with_metadata(metadata),
+            ];
+
+            let app = AppBuilder::new("mongodb_json_nesting")
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_mins(1)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            let batches =
+                run_query(&cloned_rt, "SELECT name, data FROM nested ORDER BY _id").await?;
+
+            let mut rows: Vec<(String, serde_json::Value)> = Vec::new();
+            for batch in &batches {
+                let names = batch
+                    .column_by_name("name")
+                    .ok_or_else(|| anyhow::anyhow!("missing `name` column"))?
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or_else(|| anyhow::anyhow!("`name` should be a static Utf8 column"))?;
+                let data = batch
+                    .column_by_name("data")
+                    .ok_or_else(|| anyhow::anyhow!("missing catch-all `data` column"))?
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or_else(|| anyhow::anyhow!("catch-all `data` should be a Utf8 JSON string"))?;
+                for row in 0..batch.num_rows() {
+                    let catch_all: serde_json::Value = serde_json::from_str(data.value(row))
+                        .map_err(|e| anyhow::anyhow!("catch-all must be valid JSON: {e}"))?;
+                    rows.push((names.value(row).to_string(), catch_all));
+                }
+            }
+
+            assert_eq!(rows.len(), 2, "expected two documents, got {}", rows.len());
+
+            // Row 0 (_id=1, Alice): declared statics stay top-level; every other
+            // field (scalar, nested doc, array) is folded into the catch-all, and
+            // no static key leaks into it.
+            let (name0, data0) = &rows[0];
+            assert_eq!(name0, "Alice");
+            assert_eq!(data0["email"], json!("alice@example.com"));
+            assert!(data0.get("age").is_some(), "scalar `age` must be in the catch-all");
+            assert!(
+                data0["address"].is_object(),
+                "nested `address` must be preserved as JSON in the catch-all"
+            );
+            assert!(
+                data0.get("name").is_none(),
+                "static `name` must not leak into the catch-all"
+            );
+            assert!(
+                data0.get("_id").is_none(),
+                "static `_id` must not leak into the catch-all"
+            );
+
+            // Row 1 (_id=2, Bob): array field also folds in.
+            let (name1, data1) = &rows[1];
+            assert_eq!(name1, "Bob");
+            assert_eq!(data1["email"], json!("bob@example.com"));
+            assert!(data1["tags"].is_array(), "array `tags` must be preserved in the catch-all");
+            assert!(data1.get("name").is_none());
+
+            running_container.remove().await?;
             Ok(())
         })
         .await


### PR DESCRIPTION
## 📝 Summary

Adopts the connector-agnostic **schema-projection** core (added in spiceai/datafusion-table-providers#25) across the runtime's nesting-capable connectors, collapsing four separate, drifting implementations of the same `json_object` / declared-schema logic into one shared path.

**Shared parser.** A new `dataconnector::schema_projection` turns a dataset's `columns:` block — the `metadata.json_object: "*"` catch-all marker plus declared types — into a `SchemaProjection`, with a per-connector `ProjectionPolicy` for reserved names and required (primary-key) columns. This replaces the near-identical `parse_*` helpers each connector previously carried.

**Connectors migrated onto the core:**
- **DynamoDB** and **HTTP** drop their bespoke `JsonNesting` / `HttpJsonNesting` decomposition and route through the shared core — a large net deletion with behavior preserved.
- **MongoDB** and **Debezium** gain `json_object` nesting for the first time, on both the scan and CDC/change-stream paths.

**Tests.** A component test for the Debezium decomposition, plus end-to-end integration tests for MongoDB (`json_object` over a live collection) and Debezium (real change events → decomposition → Cayenne → SQL).

Datasets that don't declare a `json_object` column are unaffected: the projection is `None` and each connector takes its existing path.
