### PR TITLE
perf(cayenne): concurrent per-shard mem-tier checkpoint encode (drain parallelism)

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -372,6 +372,10 @@ name = "delta_encoding_sweep"
 
 [[bench]]
 harness = false
+name = "compaction_write_amplification"
+
+[[bench]]
+harness = false
 name = "scan_under_write_attribution"
 
 [[bench]]

--- a/crates/cayenne/benches/compaction_write_amplification.rs
+++ b/crates/cayenne/benches/compaction_write_amplification.rs
@@ -97,7 +97,13 @@ fn delta_batch(delta_index: usize) -> RecordBatch {
     let ids: Vec<i64> = (0..ROWS_PER_DELTA as i64).map(|i| base + i).collect();
     let values: Vec<i64> = ids.iter().map(|id| id * 7).collect();
     let names: Vec<String> = (0..ROWS_PER_DELTA)
-        .map(|i| format!("row_prefix_{:03}_{}", i % 64, entropy_suffix(base as usize + i)))
+        .map(|i| {
+            format!(
+                "row_prefix_{:03}_{}",
+                i % 64,
+                entropy_suffix(base as usize + i)
+            )
+        })
         .collect();
     RecordBatch::try_new(
         test_schema(),
@@ -130,7 +136,10 @@ struct Fixture {
 /// absorbed inline — the file-tier analog of the mem-tier checkpoint's light
 /// delta. The background compactor is pinned far out so only the explicit
 /// `compact_protected_snapshots_subset` call runs.
-async fn setup_table(table_name: &str, runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>) -> Fixture {
+async fn setup_table(
+    table_name: &str,
+    runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+) -> Fixture {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let data_path = temp_dir.path().join("data");
     tokio::fs::create_dir_all(&data_path)
@@ -148,7 +157,9 @@ async fn setup_table(table_name: &str, runtime_env: Arc<datafusion::execution::r
             table_name: table_name.to_string(),
             schema: test_schema(),
             primary_key: vec!["id".to_string()],
-            on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec!["id".to_string()]))),
+            on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+                "id".to_string(),
+            ]))),
             base_path: data_path.to_string_lossy().to_string(),
             partition_column: None,
             vortex_config: VortexConfig {
@@ -228,7 +239,10 @@ fn vortex_bytes_and_files(dir: &Path) -> (u64, usize) {
 }
 
 /// Accumulate `DELTAS` light protected snapshots into a fresh table.
-async fn accumulate_deltas(table: &str, runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>) -> Fixture {
+async fn accumulate_deltas(
+    table: &str,
+    runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+) -> Fixture {
     let fixture = setup_table(table, runtime_env).await;
     for d in 0..DELTAS {
         let rows = write_delta(&fixture, delta_batch(d)).await;
@@ -272,12 +286,25 @@ fn bench_compaction_write_amplification(c: &mut Criterion) {
     let full_ratio = full_bytes as f64 / denom;
     #[expect(clippy::cast_precision_loss)]
     let write_amp = (light_bytes + full_bytes) as f64 / denom;
-    eprintln!("{:<22} {:>14} {:>8} {:>10}", "phase", "vortex_bytes", "files", "bytes/logical");
-    eprintln!("{:<22} {light_bytes:>14} {light_files:>8} {light_ratio:>10.3}", "light deltas (K)");
-    eprintln!("{:<22} {full_bytes:>14} {full_files:>8} {full_ratio:>10.3}", "full compacted (1)");
+    eprintln!(
+        "{:<22} {:>14} {:>8} {:>10}",
+        "phase", "vortex_bytes", "files", "bytes/logical"
+    );
+    eprintln!(
+        "{:<22} {light_bytes:>14} {light_files:>8} {light_ratio:>10.3}",
+        "light deltas (K)"
+    );
+    eprintln!(
+        "{:<22} {full_bytes:>14} {full_files:>8} {full_ratio:>10.3}",
+        "full compacted (1)"
+    );
     eprintln!(
         "write-amp (light+full)/logical = {write_amp:.3}  |  light-vs-full on-disk = {:.2}x\n",
-        if full_bytes > 0 { light_bytes as f64 / full_bytes as f64 } else { 0.0 }
+        if full_bytes > 0 {
+            light_bytes as f64 / full_bytes as f64
+        } else {
+            0.0
+        }
     );
 
     // --- Timed: the full-cascade re-encode (compaction duration). Throughput in
@@ -292,7 +319,10 @@ fn bench_compaction_write_amplification(c: &mut Criterion) {
             || {
                 lane += 1;
                 let ctx = SessionContext::new();
-                runtime.block_on(accumulate_deltas(&format!("wamp_{lane}"), ctx.runtime_env()))
+                runtime.block_on(accumulate_deltas(
+                    &format!("wamp_{lane}"),
+                    ctx.runtime_env(),
+                ))
             },
             |fixture| {
                 let merged = runtime.block_on(

--- a/crates/cayenne/benches/compaction_write_amplification.rs
+++ b/crates/cayenne/benches/compaction_write_amplification.rs
@@ -1,0 +1,316 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Compaction WRITE AMPLIFICATION + re-encode DURATION for the CDC delta →
+//! compaction lifecycle — the mechanism behind the observed read/write-amp and
+//! compaction-duration growth on the memory-durability SF1000 runs.
+//!
+//! Every row on this path is written to disk TWICE. A delta / mem-tier
+//! checkpoint (`WriteClass::Delta`) writes each protected snapshot with a LIGHT
+//! encoding — it skips the `BtrBlocks` per-column strategy search + FSST
+//! symbol-table training that dominate small-write encode cost (see
+//! `provider::delta_encoding`, `effective_level` returns `AUTO_LIGHT_LEVEL` for
+//! a small/unknown-size `auto` delta). Those light files are LESS compressed, so
+//! they inflate on-disk bytes (read-amp in bytes) until compaction folds them.
+//! Compaction (`WriteClass::Maintenance`) then RE-ENCODES the merged corpus with
+//! the FULL cascade — the expensive strategy search + FSST it skipped — so the
+//! logical data is compressed properly but every byte is rewritten.
+//!
+//! This bench quantifies both halves that unit tests (which assert the *level
+//! selection* in `delta_encoding.rs`, not the byte/latency cost) don't:
+//!   - Pre-pass table: light delta bytes vs full compacted bytes vs the raw
+//!     Arrow size ⇒ the write-amplification ratio `(light + full) / logical` and
+//!     the light-vs-full compression gap that drives read-amp-in-bytes.
+//!   - Timed lane `compact_reencode`: the wall-clock of the full-cascade
+//!     re-encode of K accumulated light protected snapshots — the compaction
+//!     duration that climbs as the drain produces more small files.
+//!
+//! Bench discipline (Tiger Style): setup outside the timed closure; every loop
+//! bounded; every `expect` carries a message; the write/compaction outcomes are
+//! asserted; data generation is deterministic (no RNG).
+
+#![allow(clippy::expect_used)]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use cayenne::metadata::{CreateTableOptions, VortexConfig};
+use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use datafusion::prelude::SessionContext;
+use datafusion_table_providers::util::column_reference::ColumnReference;
+use datafusion_table_providers::util::on_conflict::OnConflict;
+use std::hint::black_box;
+
+/// Rows per delta. Small enough that each write is a light "hot-path" delta, but
+/// carrying a mixed-compressibility string so light-vs-full actually diverges.
+const ROWS_PER_DELTA: usize = 8_000;
+/// Number of light protected snapshots to accumulate before compacting. Above
+/// the trigger floor so the merge is real; representative of a handful of
+/// mem-tier checkpoints piling up between compaction passes.
+const DELTAS: usize = 8;
+const COMPACTION_TRIGGER: usize = 4;
+
+fn test_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]))
+}
+
+/// Deterministic pseudo-entropy suffix (xorshift on the row index) so the string
+/// column carries both a repetitive (FSST/dict-friendly) prefix and a
+/// high-entropy tail — the shape where the full BtrBlocks cascade beats the
+/// light scheme, i.e. where re-encode write-amp is real.
+fn entropy_suffix(row: usize) -> String {
+    let mut state = (row as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut out = String::with_capacity(48);
+    for _ in 0..4 {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.push_str(&format!("{state:016x}"));
+    }
+    out
+}
+
+/// One delta's batch, keyed on a disjoint id range so each write publishes a NEW
+/// protected snapshot (no on-conflict merge) — K deltas ⇒ K light files.
+fn delta_batch(delta_index: usize) -> RecordBatch {
+    let base = (delta_index * ROWS_PER_DELTA) as i64;
+    let ids: Vec<i64> = (0..ROWS_PER_DELTA as i64).map(|i| base + i).collect();
+    let values: Vec<i64> = ids.iter().map(|id| id * 7).collect();
+    let names: Vec<String> = (0..ROWS_PER_DELTA)
+        .map(|i| format!("row_prefix_{:03}_{}", i % 64, entropy_suffix(base as usize + i)))
+        .collect();
+    RecordBatch::try_new(
+        test_schema(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(values)),
+            Arc::new(StringArray::from(names)),
+        ],
+    )
+    .expect("build delta batch")
+}
+
+/// Logical Arrow bytes of the full K-delta corpus (the write-amp denominator).
+fn logical_arrow_bytes() -> u64 {
+    (0..DELTAS)
+        .map(|d| delta_batch(d).get_array_memory_size() as u64)
+        .fold(0u64, u64::saturating_add)
+}
+
+struct Fixture {
+    _temp_dir: tempfile::TempDir,
+    catalog: Arc<dyn MetadataCatalog>,
+    provider: CayenneTableProvider,
+    data_path: std::path::PathBuf,
+    table_id: String,
+}
+
+/// An upsert table with the inline memtable DISABLED, so every insert lands in a
+/// file-backed protected snapshot (compaction's domain) rather than being
+/// absorbed inline — the file-tier analog of the mem-tier checkpoint's light
+/// delta. The background compactor is pinned far out so only the explicit
+/// `compact_protected_snapshots_subset` call runs.
+async fn setup_table(table_name: &str, runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>) -> Fixture {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let data_path = temp_dir.path().join("data");
+    tokio::fs::create_dir_all(&data_path)
+        .await
+        .expect("create data dir");
+    let db_path = temp_dir.path().join("catalog.db");
+    let catalog = Arc::new(
+        CayenneCatalog::new(format!("sqlite://{}", db_path.to_string_lossy())).expect("catalog"),
+    ) as Arc<dyn MetadataCatalog>;
+    catalog.init().await.expect("catalog init");
+
+    let provider = CayenneTableProvider::create_table(
+        Arc::clone(&catalog),
+        CreateTableOptions {
+            table_name: table_name.to_string(),
+            schema: test_schema(),
+            primary_key: vec!["id".to_string()],
+            on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec!["id".to_string()]))),
+            base_path: data_path.to_string_lossy().to_string(),
+            partition_column: None,
+            vortex_config: VortexConfig {
+                inline_max_rows: 0,
+                compaction_trigger_protected_snapshots: COMPACTION_TRIGGER,
+                compaction_background_interval_ms: 3_600_000,
+                ..VortexConfig::default()
+            },
+        },
+        runtime_env,
+    )
+    .await
+    .expect("create table");
+
+    let table_id = catalog
+        .get_table(table_name)
+        .await
+        .expect("get table")
+        .table_id;
+    Fixture {
+        _temp_dir: temp_dir,
+        catalog,
+        provider,
+        data_path,
+        table_id,
+    }
+}
+
+/// Write one delta via the real `insert_into` path (light-encoded protected
+/// snapshot). Returns rows written.
+async fn write_delta(fixture: &Fixture, batch: RecordBatch) -> u64 {
+    use datafusion::datasource::TableProvider;
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::logical_expr::dml::InsertOp;
+    use datafusion::physical_plan::collect;
+
+    let ctx = SessionContext::new();
+    let schema = batch.schema();
+    let input =
+        MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).expect("memory source");
+    let plan = fixture
+        .provider
+        .insert_into(&ctx.state(), input, InsertOp::Append)
+        .await
+        .expect("insert plan");
+    let results = collect(plan, ctx.task_ctx()).await.expect("insert");
+    results
+        .first()
+        .and_then(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+                .map(|c| c.value(0))
+        })
+        .unwrap_or(0)
+}
+
+/// Total on-disk `.vortex` bytes + file count under a snapshot data dir.
+fn vortex_bytes_and_files(dir: &Path) -> (u64, usize) {
+    let mut bytes = 0;
+    let mut files = 0;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return (0, 0);
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let (b, f) = vortex_bytes_and_files(&path);
+            bytes += b;
+            files += f;
+        } else if path.extension().is_some_and(|ext| ext == "vortex") {
+            bytes += entry.metadata().map(|m| m.len()).unwrap_or(0);
+            files += 1;
+        }
+    }
+    (bytes, files)
+}
+
+/// Accumulate `DELTAS` light protected snapshots into a fresh table.
+async fn accumulate_deltas(table: &str, runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>) -> Fixture {
+    let fixture = setup_table(table, runtime_env).await;
+    for d in 0..DELTAS {
+        let rows = write_delta(&fixture, delta_batch(d)).await;
+        assert_eq!(rows as usize, ROWS_PER_DELTA, "delta {d} row count");
+    }
+    fixture
+}
+
+fn bench_compaction_write_amplification(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let logical = logical_arrow_bytes();
+
+    // --- Pre-pass: the write-amp + compression ledger (bytes half of the
+    // matrix; wall-clock alone can't show it). ---
+    eprintln!(
+        "\n=== compaction_write_amplification: {DELTAS} deltas x {ROWS_PER_DELTA} rows, {logical} logical Arrow bytes ==="
+    );
+    let (light_bytes, light_files, full_bytes, full_files) = runtime.block_on(async {
+        let ctx = SessionContext::new();
+        let fixture = accumulate_deltas("wamp_prepass", ctx.runtime_env()).await;
+        let dir = fixture.data_path.join(&fixture.table_id);
+        let (light_bytes, light_files) = vortex_bytes_and_files(&dir);
+        let merged = fixture
+            .provider
+            .compact_protected_snapshots_subset(usize::MAX)
+            .await
+            .expect("compaction runs");
+        assert!(merged, "the accumulated deltas must merge");
+        let (full_bytes, full_files) = vortex_bytes_and_files(&dir);
+        // The catalog is used by the compaction commit; keep it alive.
+        black_box(&fixture.catalog);
+        (light_bytes, light_files, full_bytes, full_files)
+    });
+    let denom = logical.max(1) as f64;
+    #[expect(clippy::cast_precision_loss)]
+    let light_ratio = light_bytes as f64 / denom;
+    #[expect(clippy::cast_precision_loss)]
+    let full_ratio = full_bytes as f64 / denom;
+    #[expect(clippy::cast_precision_loss)]
+    let write_amp = (light_bytes + full_bytes) as f64 / denom;
+    eprintln!("{:<22} {:>14} {:>8} {:>10}", "phase", "vortex_bytes", "files", "bytes/logical");
+    eprintln!("{:<22} {light_bytes:>14} {light_files:>8} {light_ratio:>10.3}", "light deltas (K)");
+    eprintln!("{:<22} {full_bytes:>14} {full_files:>8} {full_ratio:>10.3}", "full compacted (1)");
+    eprintln!(
+        "write-amp (light+full)/logical = {write_amp:.3}  |  light-vs-full on-disk = {:.2}x\n",
+        if full_bytes > 0 { light_bytes as f64 / full_bytes as f64 } else { 0.0 }
+    );
+
+    // --- Timed: the full-cascade re-encode (compaction duration). Throughput in
+    // logical bytes ⇒ MB/s of compaction re-encode. Setup (accumulate K light
+    // deltas) is OUTSIDE the timed closure. ---
+    let mut group = c.benchmark_group("compaction_write_amplification");
+    group.sample_size(10);
+    group.throughput(Throughput::Bytes(logical));
+    let mut lane = 0u64;
+    group.bench_function("compact_reencode", |b| {
+        b.iter_batched(
+            || {
+                lane += 1;
+                let ctx = SessionContext::new();
+                runtime.block_on(accumulate_deltas(&format!("wamp_{lane}"), ctx.runtime_env()))
+            },
+            |fixture| {
+                let merged = runtime.block_on(
+                    fixture
+                        .provider
+                        .compact_protected_snapshots_subset(usize::MAX),
+                );
+                assert!(
+                    matches!(merged, Ok(true)),
+                    "timed compaction must merge the accumulated deltas"
+                );
+                black_box(&fixture.catalog);
+            },
+            criterion::BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_compaction_write_amplification);
+criterion_main!(benches);

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4779,14 +4779,19 @@ impl CayenneTableProvider {
     /// operation, which is what lets the highest-volume tables keep the source WAL
     /// drained under load.
     ///
-    /// Each unit uses `target_partitions = 1`: one output file, one encode permit,
-    /// so the N units fit the process-global encode budget concurrently (rather
-    /// than each fanning out internally and over-subscribing it) and the
-    /// per-checkpoint file count stays ~N (compaction folds them). Filenames never
-    /// collide — every `write_to_snapshot` mints a fresh `write_id` (uuid) prefix
-    /// for its files — so N writes into one dir produce disjoint files, all
-    /// discovered by the post-write listing refresh (the commit is dir-based).
-    /// Returns the summed file count and the merged column-stats accumulator.
+    /// Each unit is capped at `ceil(unit_bytes / target_size)` encode shards, so a
+    /// shard no larger than one target Vortex file stays a SINGLE file+permit (the
+    /// common case — the N units then fit the process-global encode budget
+    /// concurrently rather than each fanning out internally and over-subscribing it,
+    /// and the per-checkpoint file count stays ~N, which compaction folds), while a
+    /// shard LARGER than one target file rolls into just enough files to honor the
+    /// target size (never one oversized file). The parallelism is the N spawned
+    /// tasks, NOT intra-shard fan-out — the single coordinated stream serializes
+    /// that (the very cost this restructure avoids). Filenames never collide — every
+    /// `write_to_snapshot` mints a fresh `write_id` (uuid) prefix for its files — so
+    /// N writes into one dir produce disjoint files, all discovered by the
+    /// post-write listing refresh (the commit is dir-based). Returns the summed file
+    /// count and the merged column-stats accumulator.
     async fn encode_snapshot_shards_concurrently(
         &self,
         snapshot_id: &str,
@@ -4802,11 +4807,11 @@ impl CayenneTableProvider {
             let snapshot_id = snapshot_id.to_string();
             let schema = Arc::clone(schema);
             handles.push(tokio::spawn(async move {
-                let estimated_bytes = Some(
-                    unit.iter()
-                        .map(|b| b.get_array_memory_size() as u64)
-                        .fold(0u64, u64::saturating_add),
-                );
+                let unit_bytes = unit
+                    .iter()
+                    .map(|b| b.get_array_memory_size() as u64)
+                    .fold(0u64, u64::saturating_add);
+                let estimated_bytes = Some(unit_bytes);
                 let exec = datafusion::datasource::memory::MemorySourceConfig::try_new_exec(
                     &[unit],
                     Arc::clone(&schema),
@@ -4814,16 +4819,21 @@ impl CayenneTableProvider {
                 )?;
                 let ctx = provider.create_session_context();
                 let stream = datafusion_physical_plan::execute_stream(exec, ctx.task_ctx())?;
-                // `target_partitions = 1`: one file + one encode permit per shard.
-                // The parallelism is the N spawned tasks, NOT internal fan-out
-                // (which the single coordinated stream serializes — the very cost
-                // this restructure avoids).
+                // Cap this shard's encode fan-out so no output file exceeds the
+                // target Vortex file size: a shard no larger than one target file
+                // stays a SINGLE file (the common case — the cross-shard
+                // parallelism is the N spawned tasks, not intra-shard fan-out, which
+                // the single coordinated stream serializes), while a larger shard
+                // rolls into `ceil(bytes / target)` files instead of one oversized
+                // file. `write_to_snapshot` clamps the actual fan-out to the budget.
+                let shard_target_partitions =
+                    Self::shard_encode_target_partitions(unit_bytes, target_size_bytes);
                 provider
                     .write_to_snapshot(
                         stream,
                         target_size_bytes,
                         &snapshot_id,
-                        1,
+                        shard_target_partitions,
                         estimated_bytes,
                         super::delta_encoding::WriteClass::Delta,
                     )
@@ -4845,6 +4855,26 @@ impl CayenneTableProvider {
             merged_stats.merge_from(stats.as_ref());
         }
         Ok((total_files, merged_stats))
+    }
+
+    /// The per-shard encode fan-out for the concurrent checkpoint encode: how many
+    /// files a shard of `unit_bytes` (uncompressed Arrow) must split into so no
+    /// output file exceeds the target Vortex file size — `ceil(unit_bytes / target)`,
+    /// min 1. A shard no larger than one target file stays a single file; a larger
+    /// shard rolls into just enough files to honor the target. Arrow over-counts vs
+    /// the compressed on-disk size, the safe direction (files land under the target
+    /// with margin). `write_to_snapshot` further clamps the result to the write
+    /// budget. `target_size_bytes == 0` means size rolling is DISABLED (one file per
+    /// write is intended — see the config warning), so the shard stays a single
+    /// file, matching the pre-roll behavior.
+    fn shard_encode_target_partitions(unit_bytes: u64, target_size_bytes: usize) -> usize {
+        if target_size_bytes == 0 {
+            return 1;
+        }
+        let target = u64::try_from(target_size_bytes).unwrap_or(u64::MAX);
+        usize::try_from(unit_bytes.div_ceil(target))
+            .unwrap_or(usize::MAX)
+            .max(1)
     }
 
     /// Effective number of concurrent shard writers the Vortex sink will use for
@@ -17094,8 +17124,7 @@ impl CayenneTableProvider {
                 // extra unit. Filenames never collide (each write mints a fresh
                 // `write_id` uuid prefix) and the commit below is dir-based, so the N
                 // files are all discovered by the post-write listing refresh.
-                let mut units: Vec<Vec<RecordBatch>> =
-                    Vec::with_capacity(shard_groups.len() + 1);
+                let mut units: Vec<Vec<RecordBatch>> = Vec::with_capacity(shard_groups.len() + 1);
                 if !inline_batches.is_empty() {
                     units.push(inline_batches);
                 }
@@ -24551,6 +24580,31 @@ mod tests {
             trigger_after - trigger_before >= non_empty_shards,
             "checkpoint file count ({non_empty_shards}) must advance new_files_since_last_compaction ({trigger_before} -> {trigger_after})"
         );
+    }
+
+    /// TARGET FILE SIZE HONORED per shard. The concurrent per-shard checkpoint
+    /// encode caps each shard's fan-out at `ceil(unit_bytes / target)`, so a shard
+    /// larger than one target Vortex file rolls into multiple target-sized files
+    /// instead of one oversized file (the `target_partitions = 1` hazard). This
+    /// unit-tests the fan-out arithmetic directly; the end-to-end roll of a large
+    /// write into multiple files is covered by
+    /// `protected_snapshot_subset_compaction_parallelizes_large_merges`.
+    #[test]
+    fn shard_encode_target_partitions_honors_target_file_size() {
+        let mb: usize = 1024 * 1024;
+        let f = CayenneTableProvider::shard_encode_target_partitions;
+        // A shard no larger than one target file stays a SINGLE file (common case).
+        assert_eq!(f(0, 512 * mb), 1);
+        assert_eq!(f((300 * mb) as u64, 512 * mb), 1);
+        assert_eq!(f((512 * mb) as u64, 512 * mb), 1);
+        // A shard larger than one target file rolls into ceil(bytes / target) files
+        // — never one oversized file.
+        assert_eq!(f((512 * mb + 1) as u64, 512 * mb), 2);
+        assert_eq!(f((1024 * mb) as u64, 512 * mb), 2);
+        assert_eq!(f((1024 * mb + 1) as u64, 512 * mb), 3);
+        // A 0 target disables size rolling -> a single file, never a div-by-zero.
+        assert_eq!(f((10 * mb) as u64, 0), 1);
+        assert!(f(0, 0) >= 1);
     }
 
     /// §3.5 SHARD-KEY GUARD — the one normative spec fix. For an Int64 PK, the

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4718,14 +4718,16 @@ impl CayenneTableProvider {
         let total_rows = total_rows_written.load(Ordering::Relaxed);
         // Files added ≈ number of concurrent shard writers (each writes ≥1 file
         // when it receives rows). Drives only the compaction-trigger heuristic.
-        // Must use the SAME size-aware count `write_shard_format` used above, so
-        // a small write that produced a single file reports `1` here (not the
-        // full write concurrency), keeping the heuristic accurate.
-        let writer_ops = if total_rows > 0 {
-            self.snapshot_shard_count(target_partitions, target_size_bytes, estimated_bytes)
-        } else {
-            0
-        };
+        // This is `encode_shards` — the size-aware request ALREADY CLAMPED to
+        // `target_partitions` (the Vortex sink clamps to it via `build_shard_spec`),
+        // so it matches the files actually produced. Using the raw
+        // `snapshot_shard_count` would over-count whenever `target_partitions` caps
+        // the fan-out below the size-based request — e.g. the concurrent per-shard
+        // checkpoint encode pins `target_partitions = 1` (one file per shard), where
+        // the raw request would report the full write concurrency and over-trigger
+        // compaction by the fan-out ratio. For every caller whose `target_partitions`
+        // already meets the size-based count, this is unchanged.
+        let writer_ops = if total_rows > 0 { encode_shards } else { 0 };
 
         // Log final summary for S3 Express uploads
         if is_s3_storage {
@@ -4759,6 +4761,90 @@ impl CayenneTableProvider {
         }
 
         Ok((total_rows, writer_ops, stats_accumulator))
+    }
+
+    /// Encode each captured mem-tier shard (plus the inline corpus) as its OWN
+    /// Vortex file on its OWN task, CONCURRENTLY, into one snapshot directory —
+    /// the N>1 mem-tier checkpoint drain-parallelism lever.
+    ///
+    /// The merged single-stream encode (`write_to_snapshot` over one concatenated
+    /// `MemorySource`) pins a checkpoint at ~one core no matter how high
+    /// `cayenne_write_concurrency` is: that knob shards only the OUTPUT FILE
+    /// LAYOUT, and the writer input is a single coordinated stream (see
+    /// `write_to_snapshot`'s "no upstream repartition" note), so the compression
+    /// runs serially. The captured shards are already disjoint and materialized,
+    /// so encoding them as N independent streams — each `tokio::spawn`ed so the
+    /// CPU-bound encode lands on its own worker (a plain `join_all` would poll them
+    /// on one thread and serialize them) — turns the drain into an ~N-core
+    /// operation, which is what lets the highest-volume tables keep the source WAL
+    /// drained under load.
+    ///
+    /// Each unit uses `target_partitions = 1`: one output file, one encode permit,
+    /// so the N units fit the process-global encode budget concurrently (rather
+    /// than each fanning out internally and over-subscribing it) and the
+    /// per-checkpoint file count stays ~N (compaction folds them). Filenames never
+    /// collide — every `write_to_snapshot` mints a fresh `write_id` (uuid) prefix
+    /// for its files — so N writes into one dir produce disjoint files, all
+    /// discovered by the post-write listing refresh (the commit is dir-based).
+    /// Returns the summed file count and the merged column-stats accumulator.
+    async fn encode_snapshot_shards_concurrently(
+        &self,
+        snapshot_id: &str,
+        units: Vec<Vec<RecordBatch>>,
+        target_size_bytes: usize,
+        schema: &SchemaRef,
+    ) -> Result<(usize, Arc<ColumnStatsAccumulator>)> {
+        let mut handles = Vec::with_capacity(units.len());
+        for unit in units {
+            // A shallow writer clone (all Arc fields) so the encode can run on its
+            // own task; it shares the table's catalog / object store / budget.
+            let provider = self.clone_for_write();
+            let snapshot_id = snapshot_id.to_string();
+            let schema = Arc::clone(schema);
+            handles.push(tokio::spawn(async move {
+                let estimated_bytes = Some(
+                    unit.iter()
+                        .map(|b| b.get_array_memory_size() as u64)
+                        .fold(0u64, u64::saturating_add),
+                );
+                let exec = datafusion::datasource::memory::MemorySourceConfig::try_new_exec(
+                    &[unit],
+                    Arc::clone(&schema),
+                    None,
+                )?;
+                let ctx = provider.create_session_context();
+                let stream = datafusion_physical_plan::execute_stream(exec, ctx.task_ctx())?;
+                // `target_partitions = 1`: one file + one encode permit per shard.
+                // The parallelism is the N spawned tasks, NOT internal fan-out
+                // (which the single coordinated stream serializes — the very cost
+                // this restructure avoids).
+                provider
+                    .write_to_snapshot(
+                        stream,
+                        target_size_bytes,
+                        &snapshot_id,
+                        1,
+                        estimated_bytes,
+                        super::delta_encoding::WriteClass::Delta,
+                    )
+                    .await
+            }));
+        }
+        // Fold the N independent writes back into the single (file_count, stats)
+        // pair the checkpoint commit expects. A task panic surfaces as a checkpoint
+        // error (so the slot is NOT advanced and the tier is not cleared); the
+        // already-written shard files are unreferenced and swept as orphans.
+        let mut total_files = 0usize;
+        let merged_stats = Arc::new(ColumnStatsAccumulator::new(schema));
+        for handle in handles {
+            let (_rows, files, stats) = handle.await.map_err(|source| Error::Internal {
+                table: self.table_name().to_string(),
+                message: format!("mem-tier checkpoint shard encode task failed: {source}"),
+            })??;
+            total_files = total_files.saturating_add(files);
+            merged_stats.merge_from(stats.as_ref());
+        }
+        Ok((total_files, merged_stats))
     }
 
     /// Effective number of concurrent shard writers the Vortex sink will use for
@@ -16794,19 +16880,36 @@ impl CayenneTableProvider {
         // The inline removal map is the WHOLE-TIER tombstone union (carried on
         // `snapshot.tombstones` — shard 0's at N==1, the cross-shard union at N>1),
         // so the global inline corpus is hidden by every shard's deletes.
-        let mut batches = self.pruned_inlined_batches(&inlined_view, &snapshot, None)?;
-        // Visible mem-tier rows: concatenate every captured shard's visible batches
-        // (disjoint keys ⇒ a concatenation, each shard applying its OWN tombstones —
-        // §2.3e). At N==1 this is exactly `visible_mem_tier_batches(shard 0)`.
-        let mut mem_batches: Vec<RecordBatch> = Vec::new();
+        let inline_batches = self.pruned_inlined_batches(&inlined_view, &snapshot, None)?;
+        // Visible mem-tier rows, kept as PER-SHARD groups so the N>1 checkpoint can
+        // encode one INDEPENDENT stream per shard concurrently (the drain-parallelism
+        // lever — see `encode_snapshot_shards_concurrently`). Disjoint keys ⇒ the
+        // groups concatenate, each shard applying its OWN tombstones (§2.3e). At N==1
+        // this is exactly `[visible_mem_tier_batches(shard 0)]`.
+        let mut shard_groups: Vec<Vec<RecordBatch>> = Vec::new();
         for shard in &shard_snapshots {
             if shard.is_empty() || shard.segments.is_empty() {
                 continue;
             }
-            mem_batches.extend(self.visible_mem_tier_batches(shard, None)?);
+            let group = self.visible_mem_tier_batches(shard, None)?;
+            if !group.is_empty() {
+                shard_groups.push(group);
+            }
         }
-        let flushed_mem_rows: usize = mem_batches.iter().map(RecordBatch::num_rows).sum();
-        batches.extend(mem_batches);
+        let flushed_mem_rows: usize = shard_groups
+            .iter()
+            .flat_map(|group| group.iter())
+            .map(RecordBatch::num_rows)
+            .sum();
+        // The merged corpus (inline + every shard) drives the shard-count-independent
+        // bookkeeping below — emptiness, `corpus_keys`, `total_rows` — and, at N==1,
+        // IS the single-stream encode input (byte-identical to the pre-sharding
+        // path). The N>1 encode reads `inline_batches` + `shard_groups` directly
+        // instead. Building this from Arc clones keeps both views available.
+        let mut batches = inline_batches.clone();
+        for group in &shard_groups {
+            batches.extend(group.iter().cloned());
+        }
 
         // PK membership of the flushed corpus, driving the reinserted vs
         // pure-delete tombstone split at durable-commit time (see
@@ -16964,16 +17067,47 @@ impl CayenneTableProvider {
             };
             let new_snapshot_id = uuid::Uuid::now_v7().to_string();
             let target_size_bytes = self.context.target_file_size_bytes();
-            let (_rows, checkpoint_file_count, stats) = self
-                .write_to_snapshot(
-                    stream,
-                    target_size_bytes,
+            let (checkpoint_file_count, stats) = if n == 1 {
+                // N==1: the single coordinated encode over the merged corpus —
+                // byte-identical to the pre-sharding path.
+                let (_rows, files, stats) = self
+                    .write_to_snapshot(
+                        stream,
+                        target_size_bytes,
+                        &new_snapshot_id,
+                        ctx.state().config().target_partitions(),
+                        estimated_bytes,
+                        super::delta_encoding::WriteClass::Delta,
+                    )
+                    .await?;
+                (files, stats)
+            } else {
+                // N>1: encode each captured shard as its OWN Vortex file on its OWN
+                // task, CONCURRENTLY, into the SAME snapshot dir — THE drain
+                // parallelism lever. The merged single-stream encode above pins the
+                // whole checkpoint at ~one core regardless of `cayenne_write_concurrency`
+                // (that knob shards only the OUTPUT FILE LAYOUT; the writer input is
+                // one coordinated stream). N disjoint shard streams each get their
+                // own encoder ⇒ ~N-core drain, so the highest-volume tables
+                // (order_line/stock) keep the WAL drained instead of falling behind.
+                // The inline corpus (usually empty in memory-mode CDC) rides as one
+                // extra unit. Filenames never collide (each write mints a fresh
+                // `write_id` uuid prefix) and the commit below is dir-based, so the N
+                // files are all discovered by the post-write listing refresh.
+                let mut units: Vec<Vec<RecordBatch>> =
+                    Vec::with_capacity(shard_groups.len() + 1);
+                if !inline_batches.is_empty() {
+                    units.push(inline_batches);
+                }
+                units.extend(shard_groups);
+                self.encode_snapshot_shards_concurrently(
                     &new_snapshot_id,
-                    ctx.state().config().target_partitions(),
-                    estimated_bytes,
-                    super::delta_encoding::WriteClass::Delta,
+                    units,
+                    target_size_bytes,
+                    &schema,
                 )
-                .await?;
+                .await?
+            };
 
             let is_s3 = self.table_metadata.path.starts_with("s3://");
             if !is_s3 {
@@ -24277,6 +24411,146 @@ mod tests {
                 "sharded result at N={n} must equal the serial (N=1) result row-for-row"
             );
         }
+    }
+
+    /// CONCURRENT PER-SHARD CHECKPOINT ENCODE equivalence — the drain-parallelism
+    /// lever's correctness guard. At N>1 the mem-tier checkpoint encodes each
+    /// captured shard as its OWN Vortex file, CONCURRENTLY, into one snapshot dir
+    /// (`encode_snapshot_shards_concurrently`), instead of the serial single-stream
+    /// encode over the merged corpus. This asserts that concurrent per-shard encode
+    /// produces a DURABLE result row-for-row identical to the serial (N=1) encode,
+    /// and that the tier fully drains — so a filename collision, a lost shard file,
+    /// or a bad stats/row merge would fail here. Replays the SAME schedule at
+    /// N ∈ {1, 4, 8}, flushes to durable, and reads the converged view back from
+    /// the file(s).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sharded_cdc_concurrent_checkpoint_encode_equals_serial() {
+        async fn replay_then_checkpoint(
+            table: &str,
+            applies: &[Vec<(i64, i64)>],
+            n: usize,
+        ) -> Vec<(i64, i64)> {
+            let ctx = SessionContext::new();
+            let runtime_env = ctx.runtime_env();
+            let (provider, _catalog, _tmp) =
+                create_sharded_cdc_upsert_table(table, Arc::clone(&runtime_env), n).await;
+            let schema = Arc::clone(&provider.table_metadata.schema);
+            for burst in applies {
+                apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), burst).await;
+            }
+            // Flush the RAM tier to durable Vortex. At N>1 this drives the
+            // concurrent per-shard encode under test; at N=1 the byte-identical
+            // single-stream path.
+            provider
+                .checkpoint_mem_tier()
+                .await
+                .expect("checkpoint drains the mem tier");
+            // Every shard's tier must be empty after the checkpoint (the flush
+            // covered the whole captured prefix and cleared it).
+            assert!(
+                provider.mem_tier.is_empty(),
+                "N={n}: mem tier fully drained after the checkpoint"
+            );
+            // The converged view now comes entirely from the durable file(s).
+            collect_id_value_pairs(&ctx, &provider, table).await
+        }
+
+        let applies = random_pk_version_applies();
+        let serial = replay_then_checkpoint("ckpt_eq_n1", &applies, 1).await;
+        assert!(
+            !serial.is_empty(),
+            "the serial checkpoint replay produced durable rows"
+        );
+
+        for &n in &[4_usize, 8] {
+            let table = format!("ckpt_eq_n{n}");
+            let sharded = replay_then_checkpoint(&table, &applies, n).await;
+            assert_eq!(
+                sharded, serial,
+                "N={n}: concurrent per-shard checkpoint encode must equal the serial durable result row-for-row"
+            );
+        }
+    }
+
+    /// Recursively count `.vortex` files under a directory — the physical
+    /// read-amp signal (the number of files a scan must open).
+    fn count_vortex_files_under(dir: &std::path::Path) -> usize {
+        let mut count = 0;
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return 0;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                count += count_vortex_files_under(&path);
+            } else if path.extension().is_some_and(|ext| ext == "vortex") {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// CONCURRENT PER-SHARD CHECKPOINT FILE COUNT + compaction-trigger wiring.
+    /// The N>1 concurrent encode writes ONE Vortex file per non-empty shard
+    /// (`target_partitions = 1`), NOT the merged `write_concurrency` fan-out the
+    /// single-stream path produced — fewer, PK-clustered files = lower read-amp.
+    /// And the checkpoint's file count must advance `new_files_since_last_compaction`,
+    /// so accumulated checkpoint files eventually trigger a read-amp-collapsing
+    /// compaction (the write-amp/read-amp feedback the SF1000 runs surfaced).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sharded_cdc_checkpoint_writes_one_file_per_shard_and_feeds_compaction_trigger() {
+        use std::sync::atomic::Ordering;
+        let n = 4_usize;
+        let ctx = SessionContext::new();
+        let runtime_env = ctx.runtime_env();
+        let (provider, _catalog, tmp) =
+            create_sharded_cdc_upsert_table("ckpt_filecount", Arc::clone(&runtime_env), n).await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        for burst in &random_pk_version_applies() {
+            apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), burst).await;
+        }
+
+        // The checkpoint encodes one file per shard with a NON-EMPTY captured
+        // prefix — mirrors the `shard.is_empty() || shard.segments.is_empty()`
+        // skip in `checkpoint_mem_tier_inner`.
+        let non_empty_shards = (0..n)
+            .filter(|&s| {
+                let tier = provider.mem_tier.shard(s).load();
+                !tier.is_empty() && !tier.segments.is_empty()
+            })
+            .count();
+        assert!(
+            non_empty_shards > 1,
+            "the schedule must populate multiple shards to exercise the concurrent encode (got {non_empty_shards})"
+        );
+
+        let files_before = count_vortex_files_under(tmp.path());
+        let trigger_before = provider
+            .new_files_since_last_compaction
+            .load(Ordering::Relaxed);
+
+        provider.checkpoint_mem_tier().await.expect("checkpoint");
+
+        // (a) Physical file count: exactly one Vortex file per non-empty shard —
+        // the concurrent per-shard encode, NOT one merged stream fanned to
+        // `write_concurrency` files.
+        let files_written = count_vortex_files_under(tmp.path()) - files_before;
+        assert_eq!(
+            files_written, non_empty_shards,
+            "N>1 checkpoint must write exactly one Vortex file per non-empty shard (concurrent per-shard encode)"
+        );
+
+        // (b) The compaction-trigger wiring: the checkpoint's file count advanced
+        // `new_files_since_last_compaction`, so accumulated checkpoint files feed
+        // the read-amp-collapsing compaction trigger.
+        let trigger_after = provider
+            .new_files_since_last_compaction
+            .load(Ordering::Relaxed);
+        assert!(
+            trigger_after - trigger_before >= non_empty_shards,
+            "checkpoint file count ({non_empty_shards}) must advance new_files_since_last_compaction ({trigger_before} -> {trigger_after})"
+        );
     }
 
     /// §3.5 SHARD-KEY GUARD — the one normative spec fix. For an Int64 PK, the


### PR DESCRIPTION
## Problem

The in-memory CDC mem-tier checkpoint is Cayenne's hot→cold **drain**: it encodes the captured mem-tier to a durable Vortex snapshot and advances the Postgres replication slot. At `cayenne_cdc_mem_tier_shards > 1` the apply already partitions a table's rows across N disjoint PK shards — but the checkpoint **merged them back into one coordinated stream and encoded that serially** (`checkpoint_mem_tier_inner`: a `for shard` loop → one concatenated `MemorySourceConfig` → one `execute_stream` → one `write_to_snapshot`).

Consequence at SF1000: on a many-core host a large `order_line` checkpoint drains on **~1 effective core** regardless of `cayenne_write_concurrency` — that knob shards only the *output file layout*, not the encode, because the writer input is a single coordinated stream (`write_to_snapshot`: "no upstream repartition"). The apply keeps up (freshness sub-second) but the **drain — which acks the source slot — falls behind under load, so retained WAL climbs.** This is the order_line WAL-drain regression.

The ceiling is measured (paired bench): raising `write_concurrency` 1→8 over an order_line-shaped corpus is **dead flat** (~226 MiB/s, 1→8 files) while N *independent* `tokio::spawn`ed streams scale **6.85× at K=8** on a 16-core box — proving the single coordinated feed is the cap, not memory bandwidth.

## Fix

Encode each captured shard as its **own** Vortex file on its **own** `tokio::spawn`ed task, concurrently, into the same snapshot directory (new `encode_snapshot_shards_concurrently`), then fold the results (`ColumnStatsAccumulator::merge_from` + summed file count). `spawn` (not `join_all`) is load-bearing — a plain `join_all` polls the CPU-bound encodes on one worker and serializes them. Each unit uses `target_partitions = 1` (one output file + one encode permit per shard) so the N units fit the process-global encode budget concurrently and the per-checkpoint file count stays ~N (not N×fan-out).

**`N=1` keeps the byte-identical single-stream path.**

Also fixes `write_to_snapshot`'s `writer_ops = encode_shards` (the `target_partitions`-clamped count, not the raw size-based request) so the `tp=1` per-shard writes don't over-count the compaction trigger — a no-op for every existing caller (whose `target_partitions` already meets the size-based count).

## Correctness

- **No filename collision** — each `write_to_snapshot` mints a fresh `write_id` uuid prefix, so N writes into one dir produce disjoint files.
- **Dir-based commit** — the post-write listing refresh discovers all N files; the metastore commit is unchanged (registers the snapshot id, not a file list).
- **No deadlock** — the encode semaphore acquires atomically (all-or-nothing, clamped to the budget); `Delta` skips the maintenance gate.
- **No data loss on failure** — a shard-encode panic/error returns `Err` *before* the commit / tier-clear / `fire_slot_advancer`, so the tier is intact and the orphan files are swept.
- The all-shards-atomic capture, `flushed_epoch`/`durable_epoch`, tombstone union, and row-count handling are untouched.

## Validation

- `cargo check` clean; clippy **both CI gates green**.
- **`sharded_cdc` 13/13 + `mem_tier` 41/41**, incl. two new tests:
  - `sharded_cdc_concurrent_checkpoint_encode_equals_serial` — replay at N∈{1,4,8}, checkpoint, assert the durable result is **row-for-row identical to serial** and the tier drains.
  - `sharded_cdc_checkpoint_writes_one_file_per_shard_and_feeds_compaction_trigger` — the physical file count (~N) + the `new_files_since_last_compaction` wiring.
- **Local SF10 CH-benCH sweep at N∈{1,2,4,8}** — all 7 tables **Δ0.0000%**, 22/22 (21/22 advisory) queries, the sharded path engages at N>1 (2,184 sharded applies), WAL drains, no crash/OOM, disk-state gate PASSED at every N.

## Caveat — where the throughput win shows

On the local 16-core box every core is oversubscribed (PG + generator + spiced + terminals + OLAP), so N>1 *regresses* QPH and the per-checkpoint duration is flat — the concurrent encoders have no idle cores. **The drain-throughput win is an idle-core property** and should be A/B'd at SF1000 on the m7a (64 cores, ~49 idle at 23.5% CPU), the regime this targets. This PR is the correctness-and-engagement foundation; the follow-up is a headroom-adaptive drain-fan-out actuator.

## Also

Adds a `compaction_write_amplification` bench (light-delta → full-recompact write amplification + compaction re-encode duration) — the previously-unmeasured half of the delta-encoding cost model.
