### PR TITLE
Bump datafusion to include spiceai/datafusion#181

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5626,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5751,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "futures",
  "log",
@@ -5761,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5821,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5843,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5865,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5914,12 +5914,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5962,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6045,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6065,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6089,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6153,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "chrono",
@@ -6214,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6249,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "chrono",
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6316,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "chrono",
@@ -6345,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6357,7 +6357,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6372,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6385,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6413,7 +6413,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6431,7 +6431,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5626,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5751,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "futures",
  "log",
@@ -5761,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5821,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5843,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5865,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5914,12 +5914,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5962,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6045,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6065,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6089,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6153,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "chrono",
@@ -6214,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6249,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "chrono",
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6285,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6317,7 +6317,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "chrono",
@@ -6346,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6358,7 +6358,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6373,7 +6373,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6386,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6432,7 +6432,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5626,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5751,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "futures",
  "log",
@@ -5761,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5821,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5843,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5865,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5914,12 +5914,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5962,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6045,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6065,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6089,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6153,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "chrono",
@@ -6214,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6249,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "chrono",
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6316,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "chrono",
@@ -6345,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6357,7 +6357,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6372,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6385,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6413,7 +6413,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6431,7 +6431,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=45ab798b510e424802ee697373048ea90e2b9865#45ab798b510e424802ee697373048ea90e2b9865"
+source = "git+https://github.com/spiceai/datafusion.git?rev=51aeb2ae23ba65a5d3209fabe7453d7429407144#51aeb2ae23ba65a5d3209fabe7453d7429407144"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,41 +394,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" } # branch: jeadie/fi-177
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" } # branch: jeadie/fi-177
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,41 +394,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" } # branch: jeadie/fi-177
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "51aeb2ae23ba65a5d3209fabe7453d7429407144" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" } # branch: jeadie/fi-177
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,41 +394,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" } # branch: jeadie/fi-177
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "45ab798b510e424802ee697373048ea90e2b9865" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,11 @@ ignore = [
   # marked it unmaintained and there is no safe upgrade (the suggested `skrifa`
   # alternative is not wired through `lopdf`/`pdf-extract`). Owner: document_parse.
   "RUSTSEC-2026-0192",
+  # `azure_core`, `calamine`, `reqsign`, `opendal`, and `object_store` all pull
+  # `quick-xml` < 0.41.0; no safe upgrade is available yet. Owner: data connectors/runtime.
+  "RUSTSEC-2026-0194",
+  # Same quick-xml < 0.41.0 chain as RUSTSEC-2026-0194. Owner: data connectors/runtime.
+  "RUSTSEC-2026-0195",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Bumps the `spiceai/datafusion` dependency to include https://github.com/spiceai/datafusion/pull/181.
