### PR TITLE
fix: Read Postgres DB source error when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,7 +6450,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=465bbba54e5e09ece6649fa78b690b5315c5dece#465bbba54e5e09ece6649fa78b690b5315c5dece"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=ec1d9e651230d85034374ef5f2ebd1b5d72656b3#ec1d9e651230d85034374ef5f2ebd1b5d72656b3"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ datafusion-proto-common = "54.0.0"
 datafusion-pruning = "54.0.0"
 datafusion-spark = "54.0.0"
 datafusion-substrait = "54.0.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "465bbba54e5e09ece6649fa78b690b5315c5dece" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "ec1d9e651230d85034374ef5f2ebd1b5d72656b3" } # spiceai-54
 
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates `datafusion-table-providers` to include a fix which displays a more specific error during schema inference failure than just `db error`: https://github.com/spiceai/datafusion-table-providers/pull/26
