### PR TITLE
fix: ignore transitive quick-xml advisories (RUSTSEC-2026-0194/0195) in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,14 @@ ignore = [
   # marked it unmaintained and there is no safe upgrade (the suggested `skrifa`
   # alternative is not wired through `lopdf`/`pdf-extract`). Owner: document_parse.
   "RUSTSEC-2026-0192",
+  # `quick-xml` quadratic duplicate-attribute check on start tags (DoS). Pulled
+  # transitively in several versions (via vortex, AWS-XML, and serialization
+  # dependencies); no single safe upgrade across all pins yet. Owner: data components/runtime.
+  "RUSTSEC-2026-0194",
+  # `quick-xml` unbounded namespace-declaration allocation in `NsReader`
+  # (memory-exhaustion DoS), same transitive chain as RUSTSEC-2026-0194; no safe
+  # upgrade yet. Owner: data components/runtime.
+  "RUSTSEC-2026-0195",
 ]
 
 [bans]


### PR DESCRIPTION
## 📝 Summary

Suppresses two recently-published transitive `quick-xml` advisories in `deny.toml` so the `Check Rust Advisories` (cargo-deny) job passes:

- **RUSTSEC-2026-0194** — quadratic runtime when checking a start tag for duplicate attribute names (DoS).
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS).

`quick-xml` is pulled **transitively** in several versions (via vortex, AWS-XML, and serialization dependencies); there is no single safe upgrade across all pins. Both IDs are added to `[advisories].ignore` with a comment + owner, matching how the file already suppresses other transitive advisories (e.g. `RUSTSEC-2026-0098/-0099/-0104/-0174`).

These advisories were recently added to the RUSTSEC database and fail the advisories check on `trunk` regardless of any feature work — cargo-deny pulls the live database, so previously-green trees go red the moment an advisory lands.
