### PR TITLE
feat(testoperator): emit P99 + Max replication lag and staleness telemetry for HTAP

### DIFF
--- a/tools/testoperator/src/commands/htap/reporting.rs
+++ b/tools/testoperator/src/commands/htap/reporting.rs
@@ -74,6 +74,10 @@ pub(super) fn emit_replication_metrics(
     for (metric_name, map) in gauge_metrics {
         if let Some(samples) = metrics.samples.get(metric_name) {
             for sample in samples {
+                // Skip NaN samples so the map holds the last observed *real* value
+                if sample.value.is_nan() {
+                    continue;
+                }
                 let dataset = sample
                     .labels
                     .get("name")

--- a/tools/testoperator/src/commands/htap/reporting.rs
+++ b/tools/testoperator/src/commands/htap/reporting.rs
@@ -99,6 +99,36 @@ pub(super) fn emit_replication_metrics(
         }
     }
 
+    // Full lag_ms time series per dataset (every scraped sample), used to compute
+    // P99 and max over the under-load window. The last-value gauge above only
+    // captures the pipeline state when the scraper stopped, which understates the
+    // worst lag seen during the run.
+    let mut lag_ms_series: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    if let Some(samples) = metrics.samples.get("dataset_postgres_replication_lag_ms") {
+        for sample in samples {
+            if sample.value.is_nan() {
+                continue;
+            }
+            let dataset = sample
+                .labels
+                .get("name")
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            lag_ms_series.entry(dataset).or_default().push(sample.value);
+        }
+    }
+    // (p99, max) of the lag_ms series for a dataset, or (0, 0) if no samples.
+    let lag_p99_max = |dataset: &String| -> (f64, f64) {
+        match lag_ms_series.get(dataset) {
+            Some(values) if !values.is_empty() => {
+                let mut sorted = values.clone();
+                sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                (percentile(&sorted, 0.99), *sorted.last().unwrap_or(&0.0))
+            }
+            _ => (0.0, 0.0),
+        }
+    };
+
     if lag_ms.is_empty()
         && lag_bytes.is_empty()
         && inserts.is_empty()
@@ -113,9 +143,11 @@ pub(super) fn emit_replication_metrics(
     println!("\nReplication Metrics ({phase})");
     // Header
     println!(
-        "  {:<14} {:>10} {:>12} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "  {:<14} {:>10} {:>10} {:>10} {:>12} {:>10} {:>10} {:>10} {:>10} {:>10}",
         "dataset",
         "lag_ms",
+        "lag_p99_ms",
+        "lag_max_ms",
         "lag_bytes",
         "inserts",
         "updates",
@@ -135,8 +167,11 @@ pub(super) fn emit_replication_metrics(
         .collect();
 
     let mut worst_lag_ms: f64 = 0.0;
+    let mut worst_lag_p99: f64 = 0.0;
+    let mut worst_lag_max: f64 = 0.0;
     for dataset in &all_datasets {
         let l_ms = lag_ms.get(*dataset).copied().unwrap_or(0.0);
+        let (l_p99, l_max) = lag_p99_max(dataset);
         let l_bytes = lag_bytes.get(*dataset).copied().unwrap_or(0.0);
         let ins = inserts.get(*dataset).copied().unwrap_or(0.0);
         let upd = updates.get(*dataset).copied().unwrap_or(0.0);
@@ -144,22 +179,32 @@ pub(super) fn emit_replication_metrics(
         let recv = recv_errors.get(*dataset).copied().unwrap_or(0.0);
         let reconn = reconnects.get(*dataset).copied().unwrap_or(0.0);
         println!(
-            "  {dataset:<14} {l_ms:>10.0} {l_bytes:>12.0} {ins:>10.0} {upd:>10.0} {del:>10.0} {recv:>10.0} {reconn:>10.0}",
+            "  {dataset:<14} {l_ms:>10.0} {l_p99:>10.0} {l_max:>10.0} {l_bytes:>12.0} {ins:>10.0} {upd:>10.0} {del:>10.0} {recv:>10.0} {reconn:>10.0}",
         );
 
         if record_telemetry {
-            crate::metrics::REPLICATION_LAG_MS
-                .record(l_ms, &[KeyValue::new("dataset", (*dataset).clone())]);
+            let attributes = [KeyValue::new("dataset", (*dataset).clone())];
+            crate::metrics::REPLICATION_LAG_MS.record(l_ms, &attributes);
+            crate::metrics::REPLICATION_LAG_P99_MS.record(l_p99, &attributes);
+            crate::metrics::REPLICATION_LAG_MAX_MS.record(l_max, &attributes);
         }
         if l_ms > worst_lag_ms {
             worst_lag_ms = l_ms;
         }
+        if l_p99 > worst_lag_p99 {
+            worst_lag_p99 = l_p99;
+        }
+        if l_max > worst_lag_max {
+            worst_lag_max = l_max;
+        }
     }
     println!();
 
-    // Headline: worst replication lag across all datasets.
+    // Headline: worst replication lag across all datasets (last value, P99, and max).
     if record_telemetry {
         crate::metrics::REPLICATION_LAG_MS.record(worst_lag_ms, &[]);
+        crate::metrics::REPLICATION_LAG_P99_MS.record(worst_lag_p99, &[]);
+        crate::metrics::REPLICATION_LAG_MAX_MS.record(worst_lag_max, &[]);
     }
 }
 

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -50,8 +50,8 @@ pub struct StalenessReport {
     pub tables: HashMap<String, StalenessStats>,
     /// Ordered list of probed table names (for consistent output).
     pub probe_tables: Vec<String>,
-    /// Worst-case P99 across all tables.
-    pub worst_p99: Duration,
+    /// Worst-case max across all tables.
+    pub worst_max: Duration,
 }
 
 impl StalenessReport {
@@ -62,7 +62,6 @@ impl StalenessReport {
             "  {:<14} {:>10} {:>10} {:>10} {:>10}",
             "dataset", "p50_ms", "p99_ms", "max_ms", "samples"
         );
-        let mut worst_max = Duration::ZERO;
         for table in &self.probe_tables {
             if let Some(stats) = self.tables.get(table.as_str()) {
                 println!(
@@ -80,21 +79,11 @@ impl StalenessReport {
                 let max_ms = stats.max.as_millis() as f64;
                 crate::metrics::DATA_FRESHNESS_P99.record(p99_ms, &attributes);
                 crate::metrics::DATA_FRESHNESS_MAX.record(max_ms, &attributes);
-                if stats.max > worst_max {
-                    worst_max = stats.max;
-                }
             }
         }
-        println!(
-            "  worst P99:     {}ms    worst max: {}ms",
-            self.worst_p99.as_millis(),
-            worst_max.as_millis(),
-        );
+        println!("  worst max: {}ms", self.worst_max.as_millis());
         #[expect(clippy::cast_precision_loss)]
-        let worst_p99_ms = self.worst_p99.as_millis() as f64;
-        #[expect(clippy::cast_precision_loss)]
-        let worst_max_ms = worst_max.as_millis() as f64;
-        crate::metrics::DATA_FRESHNESS_P99.record(worst_p99_ms, &[]);
+        let worst_max_ms = self.worst_max.as_millis() as f64;
         crate::metrics::DATA_FRESHNESS_MAX.record(worst_max_ms, &[]);
     }
 }
@@ -220,7 +209,7 @@ pub(super) async fn query_max_bench_ts_spice(
 /// Build the final report from raw gap samples (in microseconds).
 fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -> StalenessReport {
     let mut tables = HashMap::new();
-    let mut worst_p99 = Duration::ZERO;
+    let mut worst_max = Duration::ZERO;
 
     for (table, mut gaps) in samples {
         if gaps.is_empty() {
@@ -254,8 +243,8 @@ fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -
         let p99 = Duration::from_micros(gaps[pct(0.99)].cast_unsigned());
         let max = Duration::from_micros(gaps[n - 1].cast_unsigned());
 
-        if p99 > worst_p99 {
-            worst_p99 = p99;
+        if max > worst_max {
+            worst_max = max;
         }
 
         tables.insert(
@@ -272,6 +261,6 @@ fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -
     StalenessReport {
         tables,
         probe_tables,
-        worst_p99,
+        worst_max,
     }
 }

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -50,6 +50,8 @@ pub struct StalenessReport {
     pub tables: HashMap<String, StalenessStats>,
     /// Ordered list of probed table names (for consistent output).
     pub probe_tables: Vec<String>,
+    /// Worst-case P99 across all tables.
+    pub worst_p99: Duration,
     /// Worst-case max across all tables.
     pub worst_max: Duration,
 }
@@ -81,9 +83,13 @@ impl StalenessReport {
                 crate::metrics::DATA_FRESHNESS_MAX.record(max_ms, &attributes);
             }
         }
+        println!("  worst P99: {}ms", self.worst_p99.as_millis());
         println!("  worst max: {}ms", self.worst_max.as_millis());
         #[expect(clippy::cast_precision_loss)]
+        let worst_p99_ms = self.worst_p99.as_millis() as f64;
+        #[expect(clippy::cast_precision_loss)]
         let worst_max_ms = self.worst_max.as_millis() as f64;
+        crate::metrics::DATA_FRESHNESS_P99.record(worst_p99_ms, &[]);
         crate::metrics::DATA_FRESHNESS_MAX.record(worst_max_ms, &[]);
     }
 }
@@ -209,6 +215,7 @@ pub(super) async fn query_max_bench_ts_spice(
 /// Build the final report from raw gap samples (in microseconds).
 fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -> StalenessReport {
     let mut tables = HashMap::new();
+    let mut worst_p99 = Duration::ZERO;
     let mut worst_max = Duration::ZERO;
 
     for (table, mut gaps) in samples {
@@ -243,6 +250,9 @@ fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -
         let p99 = Duration::from_micros(gaps[pct(0.99)].cast_unsigned());
         let max = Duration::from_micros(gaps[n - 1].cast_unsigned());
 
+        if p99 > worst_p99 {
+            worst_p99 = p99;
+        }
         if max > worst_max {
             worst_max = max;
         }
@@ -261,6 +271,7 @@ fn build_report(samples: HashMap<String, Vec<i64>>, probe_tables: Vec<String>) -
     StalenessReport {
         tables,
         probe_tables,
+        worst_p99,
         worst_max,
     }
 }

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -62,6 +62,7 @@ impl StalenessReport {
             "  {:<14} {:>10} {:>10} {:>10} {:>10}",
             "dataset", "p50_ms", "p99_ms", "max_ms", "samples"
         );
+        let mut worst_max = Duration::ZERO;
         for table in &self.probe_tables {
             if let Some(stats) = self.tables.get(table.as_str()) {
                 println!(
@@ -72,16 +73,29 @@ impl StalenessReport {
                     stats.max.as_millis(),
                     stats.samples,
                 );
+                let attributes = [KeyValue::new("dataset", table.clone())];
                 #[expect(clippy::cast_precision_loss)]
                 let p99_ms = stats.p99.as_millis() as f64;
-                crate::metrics::DATA_FRESHNESS_P99
-                    .record(p99_ms, &[KeyValue::new("dataset", table.clone())]);
+                #[expect(clippy::cast_precision_loss)]
+                let max_ms = stats.max.as_millis() as f64;
+                crate::metrics::DATA_FRESHNESS_P99.record(p99_ms, &attributes);
+                crate::metrics::DATA_FRESHNESS_MAX.record(max_ms, &attributes);
+                if stats.max > worst_max {
+                    worst_max = stats.max;
+                }
             }
         }
-        println!("  worst P99:     {}ms", self.worst_p99.as_millis());
+        println!(
+            "  worst P99:     {}ms    worst max: {}ms",
+            self.worst_p99.as_millis(),
+            worst_max.as_millis(),
+        );
         #[expect(clippy::cast_precision_loss)]
-        let worst_ms = self.worst_p99.as_millis() as f64;
-        crate::metrics::DATA_FRESHNESS_P99.record(worst_ms, &[]);
+        let worst_p99_ms = self.worst_p99.as_millis() as f64;
+        #[expect(clippy::cast_precision_loss)]
+        let worst_max_ms = worst_max.as_millis() as f64;
+        crate::metrics::DATA_FRESHNESS_P99.record(worst_p99_ms, &[]);
+        crate::metrics::DATA_FRESHNESS_MAX.record(worst_max_ms, &[]);
     }
 }
 

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -538,10 +538,38 @@ pub static DATA_FRESHNESS_P99: LazyLock<Gauge<f64>> = LazyLock::new(|| {
         .build()
 });
 
+pub static DATA_FRESHNESS_MAX: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("data_freshness_max_ms")
+        .with_description("Max data freshness gap between source and accelerator per dataset.")
+        .with_unit("ms")
+        .build()
+});
+
 pub static REPLICATION_LAG_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
     meter()
         .f64_gauge("replication_lag_ms")
-        .with_description("Replication lag from source to accelerator per dataset.")
+        .with_description("Replication lag from source to accelerator per dataset (last observed).")
+        .with_unit("ms")
+        .build()
+});
+
+pub static REPLICATION_LAG_P99_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("replication_lag_p99_ms")
+        .with_description(
+            "P99 replication lag from source to accelerator per dataset over the under-load window.",
+        )
+        .with_unit("ms")
+        .build()
+});
+
+pub static REPLICATION_LAG_MAX_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("replication_lag_max_ms")
+        .with_description(
+            "Max replication lag from source to accelerator per dataset over the under-load window.",
+        )
         .with_unit("ms")
         .build()
 });


### PR DESCRIPTION
## 📝 Summary

Report  Max and P99 replication lag and staleness per-table telemetry for the HTAP/CH-benCHmark run.

- **Replication lag**: previously only a last-value snapshot gauge. Now computes P99 and Max per dataset over the full under-load window (1s-resolution samples from the background scraper) and emits both, plus worst-across-datasets headlines. New metrics: `replication_lag_p99_ms`, `replication_lag_max_ms`
  (`replication_lag_ms` last-value kept for back-compat).
- **Staleness / data freshness**: Max was computed but never emitted. Now recorded
  alongside P99. New metric: `data_freshness_max_ms`.
- **Query latency**: already emits `max_duration` + `p99_duration` — no change.

Console reports gain matching `lag_p99_ms` / `lag_max_ms` columns and a "worst max" freshness line.

## Notes

- P99/Max cover the under-load run only (scraper stops before the post-drain phase,
  where `lag_ms` inflates with idle time). The post-drain diagnostic re-scrape is a
  single snapshot and emits nothing to telemetry.
- Emission-only; dashboard panels are arranged separately in Grafana.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
