### PR TITLE
feat(testoperator): capture under-load EXPLAIN plans as HTAP artifacts

### DIFF
--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -59,7 +59,7 @@ on:
       collect_diagnostics:
         description: 'Capture additional diagnostics'
         required: false
-        default: true
+        default: false
         type: boolean
 
 # Serialize ALL SF100 + SF1000 CH-benCHmark runs across every variant (sqlite/turso cdc-tuned,

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -56,6 +56,11 @@ on:
         options:
           - 'spiceai-dev-large-runners'
           - 'spiceai-dev-xlarge-runners'
+      collect_diagnostics:
+        description: 'Capture additional diagnostics'
+        required: false
+        default: true
+        type: boolean
 
 # Serialize ALL SF100 + SF1000 CH-benCHmark runs across every variant (sqlite/turso cdc-tuned,
 # adaptive, duckdb): they share ONE concurrency group keyed only by scale factor, so
@@ -159,6 +164,20 @@ jobs:
             TESTOP_PREFIX="taskset -c 32-39,96-103"
             echo "CPU pinning: spiced -> 64 logical CPUs, testoperator -> 16 logical CPUs"
           fi
+
+          # Optionally capture under-load troubleshooting artifacts
+          DIAG_DIR="${GITHUB_WORKSPACE}/htap-diagnostics"
+          DIAG_PIDS=""
+          if [ "${{ github.event.inputs.collect_diagnostics }}" = "true" ]; then
+            mkdir -p "$DIAG_DIR"
+            OUTDIR="$DIAG_DIR" HTTP_HOST=localhost HTTP_PORT=8090 \
+              EXPLAIN_QUERIES=all EXPLAIN_INTERVAL=30 READY_TIMEOUT=3600 \
+              bash scripts/htap-explain-probe.sh > "$DIAG_DIR/explain-probe.log" 2>&1 &
+            DIAG_PIDS="$DIAG_PIDS $!"
+            echo "diagnostics probes backgrounded (pids$DIAG_PIDS) -> $DIAG_DIR"
+          fi
+
+          set +e
           $TESTOP_PREFIX testoperator run htap \
             -s "${SPICED_BIN}" \
             -p '${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}' \
@@ -173,11 +192,28 @@ jobs:
             ${{ github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners' && '--skip-prepare' || '' }} \
             --disable-progress-bars \
             --metrics
+          testop_exit=$?
+          set -e
+
+          # Stop the diagnostics probes (spiced exits after this step, so they
+          # self-terminate anyway); propagate testoperator's real exit code.
+          [ -n "$DIAG_PIDS" ] && kill $DIAG_PIDS 2>/dev/null || true
+          exit $testop_exit
         env:
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           # Dedicated in-cluster PG pod on xlarge; per-run docker container (loopback) elsewhere.
           CHBENCH_PG_HOST: ${{ github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners' && 'chbench-postgres.dataplatform.svc.cluster.local' || '127.0.0.1' }}
+
+      # Upload the under-load diagnostics dir
+      - name: Upload HTAP diagnostics
+        if: always() && github.event.inputs.collect_diagnostics == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: htap-diagnostics-sf${{ github.event.inputs.scale_factor }}-${{ github.run_id }}
+          path: htap-diagnostics/
+          if-no-files-found: ignore
+          retention-days: 14
 
       # The dedicated PG pod is long-lived and shared across runs, so a crashed
       # or cancelled run can leave inactive replication slots (which retain WAL

--- a/scripts/htap-explain-probe.sh
+++ b/scripts/htap-explain-probe.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# htap-explain-probe.sh — background sampler that captures EXPLAIN VERBOSE +
+# EXPLAIN ANALYZE plans for CH-benCH queries against a running spiced, on an
+# interval, for HTAP performance troubleshooting.
+#
+# Queries run through spiced's HTTP SQL API (/v1/sql). EXPLAIN VERBOSE only
+# plans (cheap), but EXPLAIN ANALYZE executes the full query, so this probe adds
+# analytical load and WILL perturb the run's QPH / latency numbers. It is a
+# diagnostic tool, not for clean throughput measurement.
+#
+# Output: appends timestamped sections to $OUTDIR/explain_ts.txt.
+#
+# Usage:
+#   scripts/htap-explain-probe.sh &        # background alongside the HTAP workload
+#   # ... run the workload ...
+#   kill %1                                 # or let it self-exit when spiced stops
+#
+# Configuration (environment variables, with defaults):
+#   OUTDIR=/tmp/htap-explain      output directory (explain_ts.txt written here)
+#   HTTP_HOST=localhost           spiced HTTP host
+#   HTTP_PORT=8090                spiced HTTP SQL port (serves /v1/sql, /v1/ready)
+#   CHBENCH_DIR=<repo>/crates/test-framework/src/queries/chbench   query .sql dir
+#   EXPLAIN_QUERIES=all           queries to probe: "all" (every q*.sql) or a
+#                                 space-separated list like "q5 q10 q18"
+#   EXPLAIN_INTERVAL=30           seconds between probe rounds
+#   READY_TIMEOUT=1800            max seconds to wait for spiced HTTP to answer
+#   CURL_MAX_TIME=300             per-request curl timeout (EXPLAIN ANALYZE is slow)
+
+set -u
+
+case "${1:-}" in -h|--help) sed -n '2,32p' "$0"; exit 0;; esac
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+OUTDIR="${OUTDIR:-/tmp/htap-explain}"
+HTTP_HOST="${HTTP_HOST:-localhost}"
+HTTP_PORT="${HTTP_PORT:-8090}"
+CHBENCH_DIR="${CHBENCH_DIR:-$REPO_ROOT/crates/test-framework/src/queries/chbench}"
+EXPLAIN_QUERIES="${EXPLAIN_QUERIES:-all}"
+EXPLAIN_INTERVAL="${EXPLAIN_INTERVAL:-30}"
+READY_TIMEOUT="${READY_TIMEOUT:-1800}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-300}"
+
+mkdir -p "$OUTDIR"
+OUT="$OUTDIR/explain_ts.txt"
+SQL_URL="http://${HTTP_HOST}:${HTTP_PORT}/v1/sql"
+READY_URL="http://${HTTP_HOST}:${HTTP_PORT}/v1/ready"
+
+# Resolve the query list. "all" enumerates q*.sql (version-sorted so q2 < q10).
+if [ "$EXPLAIN_QUERIES" = "all" ]; then
+  QUERIES=$(cd "$CHBENCH_DIR" 2>/dev/null && ls q*.sql 2>/dev/null | sed 's/\.sql$//' | sort -V)
+else
+  QUERIES="$EXPLAIN_QUERIES"
+fi
+if [ -z "$QUERIES" ]; then
+  echo "htap-explain-probe: no queries found in $CHBENCH_DIR" >&2
+  exit 0
+fi
+
+# post_explain <mode> <query-name> <sql-file> — one timestamped section.
+post_explain() {
+  local mode="$1" qname="$2" file="$3"
+  {
+    echo "===== [$(date -u +%Y-%m-%dT%H:%M:%SZ)] $qname (EXPLAIN $mode) ====="
+    curl -s -m "$CURL_MAX_TIME" -X POST "$SQL_URL" \
+      -H "Content-Type: text/plain" \
+      --data "EXPLAIN $mode $(cat "$file")"
+    echo
+  } >> "$OUT" 2>&1
+}
+
+# Wait for spiced HTTP to answer /v1/ready before the first round; spiced may
+# still be booting / seeding when this probe is backgrounded.
+deadline=$((SECONDS + READY_TIMEOUT))
+until curl -s -m 5 -o /dev/null "$READY_URL" 2>/dev/null; do
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "htap-explain-probe: spiced HTTP not ready after ${READY_TIMEOUT}s; giving up" >&2
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "htap-explain-probe: probing [$(echo "$QUERIES" | tr '\n' ' ')] every ${EXPLAIN_INTERVAL}s -> $OUT"
+
+# Probe until spiced exits. The parent harness normally kills this sampler when
+# the run ends; the pgrep check is a self-terminating fallback.
+while pgrep -x spiced >/dev/null 2>&1; do
+  for q in $QUERIES; do
+    f="$CHBENCH_DIR/$q.sql"
+    [ -f "$f" ] || continue
+    post_explain "VERBOSE" "$q" "$f"
+    post_explain "ANALYZE" "$q" "$f"
+  done
+  sleep "$EXPLAIN_INTERVAL"
+done

--- a/scripts/htap-explain-probe.sh
+++ b/scripts/htap-explain-probe.sh
@@ -9,7 +9,12 @@
 # analytical load and WILL perturb the run's QPH / latency numbers. It is a
 # diagnostic tool, not for clean throughput measurement.
 #
-# Output: appends timestamped sections to $OUTDIR/explain_ts.txt.
+# Output: one file per query, per mode, per round — timestamped in the filename:
+#   $OUTDIR/<query>_explain_<ts>.txt   (EXPLAIN VERBOSE — plan structure)
+#   $OUTDIR/<query>_analyze_<ts>.txt   (EXPLAIN ANALYZE — per-operator metrics)
+# e.g. q5_explain_20260702T182233Z.txt, q5_analyze_20260702T182240Z.txt.
+# Each round writes fresh files, so the timestamped set shows plan/timing drift
+# over the run.
 #
 # Usage:
 #   scripts/htap-explain-probe.sh &        # background alongside the HTAP workload
@@ -43,7 +48,6 @@ READY_TIMEOUT="${READY_TIMEOUT:-1800}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-300}"
 
 mkdir -p "$OUTDIR"
-OUT="$OUTDIR/explain_ts.txt"
 SQL_URL="http://${HTTP_HOST}:${HTTP_PORT}/v1/sql"
 READY_URL="http://${HTTP_HOST}:${HTTP_PORT}/v1/ready"
 
@@ -58,16 +62,27 @@ if [ -z "$QUERIES" ]; then
   exit 0
 fi
 
-# post_explain <mode> <query-name> <sql-file> — one timestamped section.
+# post_explain <sql-mode> <label> <query-name> <sql-file> — writes one capture to
+# a timestamped per-query file, e.g. q5_analyze_20260702T182240Z.txt.
+#   <sql-mode>: VERBOSE | ANALYZE  (forms "EXPLAIN <sql-mode> <query>")
+#   <label>:    filename tag (explain | analyze)
 post_explain() {
-  local mode="$1" qname="$2" file="$3"
+  local mode="$1" label="$2" qname="$3" file="$4"
+  local ts; ts=$(date -u +%Y%m%dT%H%M%SZ)   # colon-free for filesystem/artifact names
+  local out="$OUTDIR/${qname}_${label}_${ts}.txt"
   {
-    echo "===== [$(date -u +%Y-%m-%dT%H:%M:%SZ)] $qname (EXPLAIN $mode) ====="
-    curl -s -m "$CURL_MAX_TIME" -X POST "$SQL_URL" \
-      -H "Content-Type: text/plain" \
-      --data "EXPLAIN $mode $(cat "$file")"
+    echo "===== [$ts] $qname (EXPLAIN $mode) ====="
+    # Build "EXPLAIN <mode> <sql>" and stream it to curl via stdin:
+    #   - strip a trailing ';' (+ whitespace) so it is one clean statement
+    #   - --data-binary @- avoids curl's @/< arg interpretation and a large single arg
+    #   - Accept: text/plain -> pretty-printed plan table instead of JSON with \n-escaped text
+    { printf 'EXPLAIN %s ' "$mode"; sed -E 's/[[:space:]]*;[[:space:]]*$//' "$file"; } \
+      | curl -s -m "$CURL_MAX_TIME" -X POST "$SQL_URL" \
+          -H "Content-Type: text/plain" \
+          -H "Accept: text/plain" \
+          --data-binary @-
     echo
-  } >> "$OUT" 2>&1
+  } >> "$out" 2>&1
 }
 
 # Wait for spiced HTTP to answer /v1/ready before the first round; spiced may
@@ -81,16 +96,22 @@ until curl -s -m 5 -o /dev/null "$READY_URL" 2>/dev/null; do
   sleep 2
 done
 
-echo "htap-explain-probe: probing [$(echo "$QUERIES" | tr '\n' ' ')] every ${EXPLAIN_INTERVAL}s -> $OUT"
+echo "htap-explain-probe: probing [$(echo "$QUERIES" | tr '\n' ' ')] every ${EXPLAIN_INTERVAL}s -> $OUTDIR/<query>_{explain,analyze}_<ts>.txt"
 
 # Probe until spiced exits. The parent harness normally kills this sampler when
 # the run ends; the pgrep check is a self-terminating fallback.
+round=0
 while pgrep -x spiced >/dev/null 2>&1; do
+  round=$((round + 1))
+  round_start=$SECONDS
+  n=0
   for q in $QUERIES; do
     f="$CHBENCH_DIR/$q.sql"
     [ -f "$f" ] || continue
-    post_explain "VERBOSE" "$q" "$f"
-    post_explain "ANALYZE" "$q" "$f"
+    post_explain "VERBOSE" "explain" "$q" "$f"
+    post_explain "ANALYZE" "analyze" "$q" "$f"
+    n=$((n + 1))
   done
+  echo "htap-explain-probe: round $round captured $n queries in $((SECONDS - round_start))s ($(date -u +%H:%M:%SZ))"
   sleep "$EXPLAIN_INTERVAL"
 done


### PR DESCRIPTION
## 📝 Summary

Adds optional EXPLAIN VERBOSE + EXPLAIN ANALYZE capture to HTAP runs for performance troubleshooting.


- New `scripts/htap-explain-probe.sh`: background sampler that periodically runs `EXPLAIN VERBOSE` + `EXPLAIN ANALYZE` for CH-benCH queries against the live spiced (`/v1/sql`), appending timestamped plans to `$OUTDIR/explain_ts.txt`. Configurable via env (`EXPLAIN_QUERIES`, `EXPLAIN_INTERVAL`, `HTTP_PORT`, …).
- `testoperator_run_htap.yml`: new `collect_diagnostics` input (default `false`, opt-in) that backgrounds the probe into a shared `htap-diagnostics/` dir and uploads it as one artifact (`if: always()`). 

⚠️  `EXPLAIN ANALYZE` executes each query, so the probe adds analytical load and perturbs QPH/latency — a diagnostic aid, not a clean-throughput path. Disable with `collect_diagnostics=false`.

Example run: https://github.com/spiceai/spiceai/actions/runs/28620758261

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
