### PR TITLE
feat(spidapter): tuned + adaptive MongoDB CDC spicepods with scenario selection

### DIFF
--- a/tools/spidapter/scenarios/mongodb-streams.yaml
+++ b/tools/spidapter/scenarios/mongodb-streams.yaml
@@ -13,6 +13,8 @@ source:
     connect:
       uri: ${MONGODB_ATLAS_URI}
 # Optional: deploy a full tuned/adaptive spicepod verbatim instead of generating one.
-# Set MONGO_SPICEPOD_PATH to a scenarios/pods/mongo/*.yaml path (baked into the spidapter
-# image). Empty/unset → generate the default pod (previous behaviour).
+# Set MONGO_SPICEPOD_PATH to an ABSOLUTE path to a pods/mongo/*.yaml — in the spidapter
+# image that is /app/scenarios/pods/mongo/<pod>.yaml (e.g. mongo-sf100-tuned.yaml).
+# A relative value is resolved against the scenario base path (--scenario-base-path),
+# NOT the process CWD. Empty/unset → generate the default pod (previous behaviour).
 spicepod: ${MONGO_SPICEPOD_PATH:-}

--- a/tools/spidapter/scenarios/mongodb-streams.yaml
+++ b/tools/spidapter/scenarios/mongodb-streams.yaml
@@ -12,3 +12,7 @@ source:
   mongodb_streams:
     connect:
       uri: ${MONGODB_ATLAS_URI}
+# Optional: deploy a full tuned/adaptive spicepod verbatim instead of generating one.
+# Set MONGO_SPICEPOD_PATH to a scenarios/pods/mongo/*.yaml path (baked into the spidapter
+# image). Empty/unset → generate the default pod (previous behaviour).
+spicepod: ${MONGO_SPICEPOD_PATH:-}

--- a/tools/spidapter/scenarios/pods/mongo/mongo-adaptive.yaml
+++ b/tools/spidapter/scenarios/pods/mongo/mongo-adaptive.yaml
@@ -1,0 +1,463 @@
+version: v1
+kind: Spicepod
+name: mongo-adaptive
+# MongoDB CDC pod with Cayenne closed-loop ADAPTIVE tuning. The 7 tunable
+# actuators (write_concurrency, cdc_mem_tier_max_bytes, target_file_size,
+# compaction cadence/trigger, inline_flush) are LEFT UNSET so the on-box
+# controller sizes them from real cores/RAM and adapts over the run. Shares the
+# capacity-independent knobs (memory durability, key deletes, CDC coalescing) with
+# the hand-tuned pods so the comparison isolates the actuator tuning.
+runtime:
+  flight:
+    ipc_compression: lz4_frame
+  params:
+    cdc_prefetch_buffer: "16384"
+    cdc_max_coalesced_envelopes: "16384"
+    cdc_max_coalesced_bytes: "134217728"
+    cdc_max_coalesce_age_ms: "250"
+    cdc_commit_timeout_ms: "60000"
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: "mongodb:lineitem"
+    name: lineitem
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: adaptive
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: l_orderkey
+        type: Int64
+        nullable: true
+      - name: l_partkey
+        type: Int64
+        nullable: true
+      - name: l_suppkey
+        type: Int64
+        nullable: true
+      - name: l_linenumber
+        type: Int32
+        nullable: true
+      - name: l_quantity
+        type: Float64
+        nullable: true
+      - name: l_extendedprice
+        type: Float64
+        nullable: true
+      - name: l_discount
+        type: Float64
+        nullable: true
+      - name: l_tax
+        type: Float64
+        nullable: true
+      - name: l_returnflag
+        type: Utf8
+        nullable: true
+      - name: l_linestatus
+        type: Utf8
+        nullable: true
+      - name: l_shipdate
+        type: Date32
+        nullable: true
+      - name: l_commitdate
+        type: Date32
+        nullable: true
+      - name: l_receiptdate
+        type: Date32
+        nullable: true
+      - name: l_shipinstruct
+        type: Utf8
+        nullable: true
+      - name: l_shipmode
+        type: Utf8
+        nullable: true
+      - name: l_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:orders"
+    name: orders
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: adaptive
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: o_orderkey
+        type: Int64
+        nullable: true
+      - name: o_custkey
+        type: Int64
+        nullable: true
+      - name: o_orderstatus
+        type: Utf8
+        nullable: true
+      - name: o_totalprice
+        type: Float64
+        nullable: true
+      - name: o_orderdate
+        type: Date32
+        nullable: true
+      - name: o_orderpriority
+        type: Utf8
+        nullable: true
+      - name: o_clerk
+        type: Utf8
+        nullable: true
+      - name: o_shippriority
+        type: Int32
+        nullable: true
+      - name: o_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:partsupp"
+    name: partsupp
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: adaptive
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: ps_partkey
+        type: Int64
+        nullable: true
+      - name: ps_suppkey
+        type: Int64
+        nullable: true
+      - name: ps_availqty
+        type: Int32
+        nullable: true
+      - name: ps_supplycost
+        type: Float64
+        nullable: true
+      - name: ps_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:customer"
+    name: customer
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: adaptive
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: c_custkey
+        type: Int64
+        nullable: true
+      - name: c_name
+        type: Utf8
+        nullable: true
+      - name: c_address
+        type: Utf8
+        nullable: true
+      - name: c_nationkey
+        type: Int64
+        nullable: true
+      - name: c_phone
+        type: Utf8
+        nullable: true
+      - name: c_acctbal
+        type: Float64
+        nullable: true
+      - name: c_mktsegment
+        type: Utf8
+        nullable: true
+      - name: c_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:part"
+    name: part
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: adaptive
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: p_partkey
+        type: Int64
+        nullable: true
+      - name: p_name
+        type: Utf8
+        nullable: true
+      - name: p_mfgr
+        type: Utf8
+        nullable: true
+      - name: p_brand
+        type: Utf8
+        nullable: true
+      - name: p_type
+        type: Utf8
+        nullable: true
+      - name: p_size
+        type: Int32
+        nullable: true
+      - name: p_container
+        type: Utf8
+        nullable: true
+      - name: p_retailprice
+        type: Float64
+        nullable: true
+      - name: p_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:supplier"
+    name: supplier
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: adaptive
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: s_suppkey
+        type: Int64
+        nullable: true
+      - name: s_name
+        type: Utf8
+        nullable: true
+      - name: s_address
+        type: Utf8
+        nullable: true
+      - name: s_nationkey
+        type: Int64
+        nullable: true
+      - name: s_phone
+        type: Utf8
+        nullable: true
+      - name: s_acctbal
+        type: Float64
+        nullable: true
+      - name: s_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:nation"
+    name: nation
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: adaptive
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: n_nationkey
+        type: Int64
+        nullable: true
+      - name: n_name
+        type: Utf8
+        nullable: true
+      - name: n_regionkey
+        type: Int64
+        nullable: true
+      - name: n_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:region"
+    name: region
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: adaptive
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: r_regionkey
+        type: Int64
+        nullable: true
+      - name: r_name
+        type: Utf8
+        nullable: true
+      - name: r_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true

--- a/tools/spidapter/scenarios/pods/mongo/mongo-sf10-tuned.yaml
+++ b/tools/spidapter/scenarios/pods/mongo/mongo-sf10-tuned.yaml
@@ -1,0 +1,537 @@
+version: v1
+kind: Spicepod
+name: mongo-sf10-tuned
+# Hand-tuned MongoDB CDC pod (mongo-sf10-tuned). Cayenne tuning=auto (static hardware-seeded
+# warm-start, no closed loop): the actuator values below are PINNED starting points
+# seeded from the CH-benCHmark postgres-cayenne[file]-cdc-tuned-memory-* pods —
+# tune per-table for best performance. Benchmark against mongo-adaptive.yaml.
+runtime:
+  flight:
+    ipc_compression: lz4_frame
+  params:
+    cdc_prefetch_buffer: "16384"
+    cdc_max_coalesced_envelopes: "16384"
+    cdc_max_coalesced_bytes: "536870912"
+    cdc_max_coalesce_age_ms: "4000"
+    cdc_commit_timeout_ms: "60000"
+    cayenne_sort_merge_min_rows: "50000000"
+    cayenne_footer_cache_mb: "1024"
+    cayenne_metastore_cache_mb: "1024"
+    cayenne_metastore_mmap_mb: "4096"
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: "mongodb:lineitem"
+    name: lineitem
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "4"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "256"
+        cayenne_cdc_mem_tier_max_bytes: "536870912"
+        cayenne_cdc_mem_tier_min_flush_bytes: "67108864"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: l_orderkey
+        type: Int64
+        nullable: true
+      - name: l_partkey
+        type: Int64
+        nullable: true
+      - name: l_suppkey
+        type: Int64
+        nullable: true
+      - name: l_linenumber
+        type: Int32
+        nullable: true
+      - name: l_quantity
+        type: Float64
+        nullable: true
+      - name: l_extendedprice
+        type: Float64
+        nullable: true
+      - name: l_discount
+        type: Float64
+        nullable: true
+      - name: l_tax
+        type: Float64
+        nullable: true
+      - name: l_returnflag
+        type: Utf8
+        nullable: true
+      - name: l_linestatus
+        type: Utf8
+        nullable: true
+      - name: l_shipdate
+        type: Date32
+        nullable: true
+      - name: l_commitdate
+        type: Date32
+        nullable: true
+      - name: l_receiptdate
+        type: Date32
+        nullable: true
+      - name: l_shipinstruct
+        type: Utf8
+        nullable: true
+      - name: l_shipmode
+        type: Utf8
+        nullable: true
+      - name: l_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:orders"
+    name: orders
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "4"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "256"
+        cayenne_cdc_mem_tier_max_bytes: "536870912"
+        cayenne_cdc_mem_tier_min_flush_bytes: "67108864"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: o_orderkey
+        type: Int64
+        nullable: true
+      - name: o_custkey
+        type: Int64
+        nullable: true
+      - name: o_orderstatus
+        type: Utf8
+        nullable: true
+      - name: o_totalprice
+        type: Float64
+        nullable: true
+      - name: o_orderdate
+        type: Date32
+        nullable: true
+      - name: o_orderpriority
+        type: Utf8
+        nullable: true
+      - name: o_clerk
+        type: Utf8
+        nullable: true
+      - name: o_shippriority
+        type: Int32
+        nullable: true
+      - name: o_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:partsupp"
+    name: partsupp
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "4"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "256"
+        cayenne_cdc_mem_tier_max_bytes: "536870912"
+        cayenne_cdc_mem_tier_min_flush_bytes: "67108864"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: ps_partkey
+        type: Int64
+        nullable: true
+      - name: ps_suppkey
+        type: Int64
+        nullable: true
+      - name: ps_availqty
+        type: Int32
+        nullable: true
+      - name: ps_supplycost
+        type: Float64
+        nullable: true
+      - name: ps_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:customer"
+    name: customer
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "4"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "256"
+        cayenne_cdc_mem_tier_max_bytes: "536870912"
+        cayenne_cdc_mem_tier_min_flush_bytes: "67108864"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: c_custkey
+        type: Int64
+        nullable: true
+      - name: c_name
+        type: Utf8
+        nullable: true
+      - name: c_address
+        type: Utf8
+        nullable: true
+      - name: c_nationkey
+        type: Int64
+        nullable: true
+      - name: c_phone
+        type: Utf8
+        nullable: true
+      - name: c_acctbal
+        type: Float64
+        nullable: true
+      - name: c_mktsegment
+        type: Utf8
+        nullable: true
+      - name: c_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:part"
+    name: part
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "4"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "256"
+        cayenne_cdc_mem_tier_max_bytes: "536870912"
+        cayenne_cdc_mem_tier_min_flush_bytes: "67108864"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: p_partkey
+        type: Int64
+        nullable: true
+      - name: p_name
+        type: Utf8
+        nullable: true
+      - name: p_mfgr
+        type: Utf8
+        nullable: true
+      - name: p_brand
+        type: Utf8
+        nullable: true
+      - name: p_type
+        type: Utf8
+        nullable: true
+      - name: p_size
+        type: Int32
+        nullable: true
+      - name: p_container
+        type: Utf8
+        nullable: true
+      - name: p_retailprice
+        type: Float64
+        nullable: true
+      - name: p_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:supplier"
+    name: supplier
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "256"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: s_suppkey
+        type: Int64
+        nullable: true
+      - name: s_name
+        type: Utf8
+        nullable: true
+      - name: s_address
+        type: Utf8
+        nullable: true
+      - name: s_nationkey
+        type: Int64
+        nullable: true
+      - name: s_phone
+        type: Utf8
+        nullable: true
+      - name: s_acctbal
+        type: Float64
+        nullable: true
+      - name: s_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:nation"
+    name: nation
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "256"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: n_nationkey
+        type: Int64
+        nullable: true
+      - name: n_name
+        type: Utf8
+        nullable: true
+      - name: n_regionkey
+        type: Int64
+        nullable: true
+      - name: n_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:region"
+    name: region
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "256"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: r_regionkey
+        type: Int64
+        nullable: true
+      - name: r_name
+        type: Utf8
+        nullable: true
+      - name: r_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true

--- a/tools/spidapter/scenarios/pods/mongo/mongo-sf100-tuned.yaml
+++ b/tools/spidapter/scenarios/pods/mongo/mongo-sf100-tuned.yaml
@@ -1,0 +1,537 @@
+version: v1
+kind: Spicepod
+name: mongo-sf100-tuned
+# Hand-tuned MongoDB CDC pod (mongo-sf100-tuned). Cayenne tuning=auto (static hardware-seeded
+# warm-start, no closed loop): the actuator values below are PINNED starting points
+# seeded from the CH-benCHmark postgres-cayenne[file]-cdc-tuned-memory-* pods —
+# tune per-table for best performance. Benchmark against mongo-adaptive.yaml.
+runtime:
+  flight:
+    ipc_compression: lz4_frame
+  params:
+    cdc_prefetch_buffer: "16384"
+    cdc_max_coalesced_envelopes: "16384"
+    cdc_max_coalesced_bytes: "134217728"
+    cdc_max_coalesce_age_ms: "250"
+    cdc_commit_timeout_ms: "60000"
+    cayenne_sort_merge_min_rows: "50000000"
+    cayenne_footer_cache_mb: "1024"
+    cayenne_metastore_cache_mb: "1024"
+    cayenne_metastore_mmap_mb: "4096"
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: "mongodb:lineitem"
+    name: lineitem
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "1073741824"
+        cayenne_cdc_mem_tier_min_flush_bytes: "134217728"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: l_orderkey
+        type: Int64
+        nullable: true
+      - name: l_partkey
+        type: Int64
+        nullable: true
+      - name: l_suppkey
+        type: Int64
+        nullable: true
+      - name: l_linenumber
+        type: Int32
+        nullable: true
+      - name: l_quantity
+        type: Float64
+        nullable: true
+      - name: l_extendedprice
+        type: Float64
+        nullable: true
+      - name: l_discount
+        type: Float64
+        nullable: true
+      - name: l_tax
+        type: Float64
+        nullable: true
+      - name: l_returnflag
+        type: Utf8
+        nullable: true
+      - name: l_linestatus
+        type: Utf8
+        nullable: true
+      - name: l_shipdate
+        type: Date32
+        nullable: true
+      - name: l_commitdate
+        type: Date32
+        nullable: true
+      - name: l_receiptdate
+        type: Date32
+        nullable: true
+      - name: l_shipinstruct
+        type: Utf8
+        nullable: true
+      - name: l_shipmode
+        type: Utf8
+        nullable: true
+      - name: l_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:orders"
+    name: orders
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "1073741824"
+        cayenne_cdc_mem_tier_min_flush_bytes: "134217728"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: o_orderkey
+        type: Int64
+        nullable: true
+      - name: o_custkey
+        type: Int64
+        nullable: true
+      - name: o_orderstatus
+        type: Utf8
+        nullable: true
+      - name: o_totalprice
+        type: Float64
+        nullable: true
+      - name: o_orderdate
+        type: Date32
+        nullable: true
+      - name: o_orderpriority
+        type: Utf8
+        nullable: true
+      - name: o_clerk
+        type: Utf8
+        nullable: true
+      - name: o_shippriority
+        type: Int32
+        nullable: true
+      - name: o_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:partsupp"
+    name: partsupp
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "1073741824"
+        cayenne_cdc_mem_tier_min_flush_bytes: "134217728"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: ps_partkey
+        type: Int64
+        nullable: true
+      - name: ps_suppkey
+        type: Int64
+        nullable: true
+      - name: ps_availqty
+        type: Int32
+        nullable: true
+      - name: ps_supplycost
+        type: Float64
+        nullable: true
+      - name: ps_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:customer"
+    name: customer
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "1073741824"
+        cayenne_cdc_mem_tier_min_flush_bytes: "134217728"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: c_custkey
+        type: Int64
+        nullable: true
+      - name: c_name
+        type: Utf8
+        nullable: true
+      - name: c_address
+        type: Utf8
+        nullable: true
+      - name: c_nationkey
+        type: Int64
+        nullable: true
+      - name: c_phone
+        type: Utf8
+        nullable: true
+      - name: c_acctbal
+        type: Float64
+        nullable: true
+      - name: c_mktsegment
+        type: Utf8
+        nullable: true
+      - name: c_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:part"
+    name: part
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "1073741824"
+        cayenne_cdc_mem_tier_min_flush_bytes: "134217728"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: p_partkey
+        type: Int64
+        nullable: true
+      - name: p_name
+        type: Utf8
+        nullable: true
+      - name: p_mfgr
+        type: Utf8
+        nullable: true
+      - name: p_brand
+        type: Utf8
+        nullable: true
+      - name: p_type
+        type: Utf8
+        nullable: true
+      - name: p_size
+        type: Int32
+        nullable: true
+      - name: p_container
+        type: Utf8
+        nullable: true
+      - name: p_retailprice
+        type: Float64
+        nullable: true
+      - name: p_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:supplier"
+    name: supplier
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: s_suppkey
+        type: Int64
+        nullable: true
+      - name: s_name
+        type: Utf8
+        nullable: true
+      - name: s_address
+        type: Utf8
+        nullable: true
+      - name: s_nationkey
+        type: Int64
+        nullable: true
+      - name: s_phone
+        type: Utf8
+        nullable: true
+      - name: s_acctbal
+        type: Float64
+        nullable: true
+      - name: s_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:nation"
+    name: nation
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: n_nationkey
+        type: Int64
+        nullable: true
+      - name: n_name
+        type: Utf8
+        nullable: true
+      - name: n_regionkey
+        type: Int64
+        nullable: true
+      - name: n_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:region"
+    name: region
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "256"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: r_regionkey
+        type: Int64
+        nullable: true
+      - name: r_name
+        type: Utf8
+        nullable: true
+      - name: r_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true

--- a/tools/spidapter/scenarios/pods/mongo/mongo-sf1000-tuned.yaml
+++ b/tools/spidapter/scenarios/pods/mongo/mongo-sf1000-tuned.yaml
@@ -1,0 +1,537 @@
+version: v1
+kind: Spicepod
+name: mongo-sf1000-tuned
+# Hand-tuned MongoDB CDC pod (mongo-sf1000-tuned). Cayenne tuning=auto (static hardware-seeded
+# warm-start, no closed loop): the actuator values below are PINNED starting points
+# seeded from the CH-benCHmark postgres-cayenne[file]-cdc-tuned-memory-* pods —
+# tune per-table for best performance. Benchmark against mongo-adaptive.yaml.
+runtime:
+  flight:
+    ipc_compression: lz4_frame
+  params:
+    cdc_prefetch_buffer: "16384"
+    cdc_max_coalesced_envelopes: "16384"
+    cdc_max_coalesced_bytes: "134217728"
+    cdc_max_coalesce_age_ms: "250"
+    cdc_commit_timeout_ms: "60000"
+    cayenne_sort_merge_min_rows: "50000000"
+    cayenne_footer_cache_mb: "1024"
+    cayenne_metastore_cache_mb: "1024"
+    cayenne_metastore_mmap_mb: "4096"
+  caching:
+    sql_results:
+      enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: "mongodb:lineitem"
+    name: lineitem
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "1024"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "2147483648"
+        cayenne_cdc_mem_tier_min_flush_bytes: "268435456"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: l_orderkey
+        type: Int64
+        nullable: true
+      - name: l_partkey
+        type: Int64
+        nullable: true
+      - name: l_suppkey
+        type: Int64
+        nullable: true
+      - name: l_linenumber
+        type: Int32
+        nullable: true
+      - name: l_quantity
+        type: Float64
+        nullable: true
+      - name: l_extendedprice
+        type: Float64
+        nullable: true
+      - name: l_discount
+        type: Float64
+        nullable: true
+      - name: l_tax
+        type: Float64
+        nullable: true
+      - name: l_returnflag
+        type: Utf8
+        nullable: true
+      - name: l_linestatus
+        type: Utf8
+        nullable: true
+      - name: l_shipdate
+        type: Date32
+        nullable: true
+      - name: l_commitdate
+        type: Date32
+        nullable: true
+      - name: l_receiptdate
+        type: Date32
+        nullable: true
+      - name: l_shipinstruct
+        type: Utf8
+        nullable: true
+      - name: l_shipmode
+        type: Utf8
+        nullable: true
+      - name: l_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:orders"
+    name: orders
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "1024"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "2147483648"
+        cayenne_cdc_mem_tier_min_flush_bytes: "268435456"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: o_orderkey
+        type: Int64
+        nullable: true
+      - name: o_custkey
+        type: Int64
+        nullable: true
+      - name: o_orderstatus
+        type: Utf8
+        nullable: true
+      - name: o_totalprice
+        type: Float64
+        nullable: true
+      - name: o_orderdate
+        type: Date32
+        nullable: true
+      - name: o_orderpriority
+        type: Utf8
+        nullable: true
+      - name: o_clerk
+        type: Utf8
+        nullable: true
+      - name: o_shippriority
+        type: Int32
+        nullable: true
+      - name: o_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:partsupp"
+    name: partsupp
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "1024"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "2147483648"
+        cayenne_cdc_mem_tier_min_flush_bytes: "268435456"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: ps_partkey
+        type: Int64
+        nullable: true
+      - name: ps_suppkey
+        type: Int64
+        nullable: true
+      - name: ps_availqty
+        type: Int32
+        nullable: true
+      - name: ps_supplycost
+        type: Float64
+        nullable: true
+      - name: ps_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:customer"
+    name: customer
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "1024"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "2147483648"
+        cayenne_cdc_mem_tier_min_flush_bytes: "268435456"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: c_custkey
+        type: Int64
+        nullable: true
+      - name: c_name
+        type: Utf8
+        nullable: true
+      - name: c_address
+        type: Utf8
+        nullable: true
+      - name: c_nationkey
+        type: Int64
+        nullable: true
+      - name: c_phone
+        type: Utf8
+        nullable: true
+      - name: c_acctbal
+        type: Float64
+        nullable: true
+      - name: c_mktsegment
+        type: Utf8
+        nullable: true
+      - name: c_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:part"
+    name: part
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "1024"
+        cayenne_write_concurrency: "8"
+        cayenne_segment_cache_mb: "1024"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "2147483648"
+        cayenne_cdc_mem_tier_min_flush_bytes: "268435456"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: p_partkey
+        type: Int64
+        nullable: true
+      - name: p_name
+        type: Utf8
+        nullable: true
+      - name: p_mfgr
+        type: Utf8
+        nullable: true
+      - name: p_brand
+        type: Utf8
+        nullable: true
+      - name: p_type
+        type: Utf8
+        nullable: true
+      - name: p_size
+        type: Int32
+        nullable: true
+      - name: p_container
+        type: Utf8
+        nullable: true
+      - name: p_retailprice
+        type: Float64
+        nullable: true
+      - name: p_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:supplier"
+    name: supplier
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "1024"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: s_suppkey
+        type: Int64
+        nullable: true
+      - name: s_name
+        type: Utf8
+        nullable: true
+      - name: s_address
+        type: Utf8
+        nullable: true
+      - name: s_nationkey
+        type: Int64
+        nullable: true
+      - name: s_phone
+        type: Utf8
+        nullable: true
+      - name: s_acctbal
+        type: Float64
+        nullable: true
+      - name: s_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:nation"
+    name: nation
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "1024"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: n_nationkey
+        type: Int64
+        nullable: true
+      - name: n_name
+        type: Utf8
+        nullable: true
+      - name: n_regionkey
+        type: Int64
+        nullable: true
+      - name: n_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true
+  - from: "mongodb:region"
+    name: region
+    params:
+      mongodb_connection_string: "${secrets:MONGO_CONNECTION_STRING}"
+      change_stream_batch_size: "10000"
+      change_stream_batch_max_size: "10000"
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      refresh_on_startup: auto
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+      params:
+        cayenne_tuning: auto
+        cayenne_metastore: sqlite
+        cayenne_force_view_types: "false"
+        cayenne_deletion_mode: key
+        cayenne_cdc_durability: memory
+        cayenne_cdc_mem_tier_max_age_ms: "30000"
+        cayenne_cdc_mem_tier_shards: "4"
+        cayenne_compaction_background_interval_ms: "3000"
+        cayenne_compaction_trigger_snapshot_age_ms: "15000"
+        cayenne_compaction_max_files_per_pick: "64"
+        cdc_max_coalesce_age_ms: "3000"
+        cdc_max_coalesced_bytes: "536870912"
+        cayenne_pk_keyset_cache_mb: "1024"
+        cayenne_write_concurrency: "2"
+        cayenne_segment_cache_mb: "64"
+        cayenne_target_file_size_mb: "512"
+        cayenne_cdc_mem_tier_max_bytes: "268435456"
+        cayenne_cdc_mem_tier_min_flush_bytes: "33554432"
+    columns:
+      - name: _id
+        type: Utf8
+        nullable: true
+      - name: r_regionkey
+        type: Int64
+        nullable: true
+      - name: r_name
+        type: Utf8
+        nullable: true
+      - name: r_comment
+        type: Utf8
+        nullable: true
+      - name: __created_at
+        type: "Timestamp(Microsecond, None)"
+        nullable: true

--- a/tools/spidapter/src/scenario.rs
+++ b/tools/spidapter/src/scenario.rs
@@ -80,6 +80,13 @@ pub(crate) struct ScenarioConfig {
     pub compute: Option<ComputeConfig>,
     pub acceleration: Option<AccelerationEngine>,
     pub source: SourceConfig,
+    /// Optional path to a full spicepod to deploy verbatim instead of generating
+    /// one from the source + inferred schema. Used to select the hand-tuned /
+    /// adaptive Mongo CDC pods. Env-substituted at scenario load (e.g.
+    /// `spicepod: ${MONGO_SPICEPOD_PATH:-}`); an empty/unset value falls through
+    /// to generation. A `spicepod_path` in the setup metadata takes precedence.
+    #[serde(default)]
+    pub spicepod: Option<String>,
 }
 
 /// Cayenne-specific configuration nested under `source: direct: cayenne:`.

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -1036,6 +1036,21 @@ impl Handler for SpidapterHandler {
         };
 
         let mut setup_config = SetupConfig::from_metadata(&metadata).set_storage(storage);
+        // A scenario-level `spicepod:` path (e.g. the hand-tuned / adaptive Mongo CDC
+        // pods) deploys a full spicepod verbatim instead of generating one. An explicit
+        // `spicepod_path` in the setup metadata still wins; an empty scenario value
+        // (unset `${MONGO_SPICEPOD_PATH:-}`) falls through to generation.
+        if setup_config.spicepod_path.is_none()
+            && let Some(pod) = self
+                .scenario
+                .spicepod
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+        {
+            eprintln!("[stdio] Using scenario spicepod (skipping generation): {pod}");
+            setup_config.spicepod_path = Some(pod.to_string());
+        }
         // For non-direct sources, still honour the env AWS_REGION override.
         setup_config.aws_region_override = std::env::var("AWS_REGION").ok();
 
@@ -1701,6 +1716,7 @@ pub async fn run_stdio_server(args: &StdioArgs) -> anyhow::Result<()> {
             compute: None,
             acceleration: None,
             source: SourceConfig::Direct(DirectConfig::default()),
+            spicepod: None,
         }
     };
 
@@ -2429,5 +2445,44 @@ mod tests {
                 .contains("only a single partition column is supported"),
             "unexpected error: {err}"
         );
+    }
+
+    /// The bundled tuned/adaptive Mongo CDC pods must parse through the same loader
+    /// used at runtime (`load_spicepod_from_path`), have all 8 TPC-H datasets, and
+    /// carry Cayenne CDC acceleration. Guards against a param key / column type /
+    /// structure that the `SpicepodDefinition` deserializer rejects.
+    #[test]
+    fn bundled_mongo_spicepods_parse() {
+        let pods: [(&str, &str); 4] = [
+            ("mongo-sf10-tuned", include_str!("../scenarios/pods/mongo/mongo-sf10-tuned.yaml")),
+            ("mongo-sf100-tuned", include_str!("../scenarios/pods/mongo/mongo-sf100-tuned.yaml")),
+            ("mongo-sf1000-tuned", include_str!("../scenarios/pods/mongo/mongo-sf1000-tuned.yaml")),
+            ("mongo-adaptive", include_str!("../scenarios/pods/mongo/mongo-adaptive.yaml")),
+        ];
+        let run_id = Uuid::nil();
+        for (name, yaml) in pods {
+            let pod = parse_and_rename_spicepod(yaml, &run_id)
+                .unwrap_or_else(|e| panic!("pod `{name}` failed to parse: {e}"));
+            assert_eq!(
+                pod.datasets.len(),
+                8,
+                "pod `{name}` should declare all 8 TPC-H datasets"
+            );
+            for ds in &pod.datasets {
+                let spicepod::component::ComponentOrReference::Component(ds) = ds else {
+                    panic!("pod `{name}` dataset must be an inline component");
+                };
+                let accel = ds
+                    .acceleration
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("pod `{name}` dataset `{}` missing acceleration", ds.name));
+                assert_eq!(
+                    accel.engine.as_deref(),
+                    Some("cayenne"),
+                    "pod `{name}` dataset `{}` must use the cayenne engine",
+                    ds.name
+                );
+            }
+        }
     }
 }

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -1048,8 +1048,20 @@ impl Handler for SpidapterHandler {
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
         {
-            eprintln!("[stdio] Using scenario spicepod (skipping generation): {pod}");
-            setup_config.spicepod_path = Some(pod.to_string());
+            // Resolve a relative scenario `spicepod:` against the scenario base path
+            // (where the scenario YAML and its `pods/` live) so resolution doesn't
+            // depend on the process CWD. Absolute paths — the common case:
+            // `MONGO_SPICEPOD_PATH` locally or the in-image `/app/scenarios/...` path —
+            // are used as-is. `load_spicepod_from_path` then reads the resolved path.
+            let pod_path = match self.args.scenario_base_path.as_deref() {
+                Some(base) if std::path::Path::new(pod).is_relative() => std::path::Path::new(base)
+                    .join(pod)
+                    .to_string_lossy()
+                    .into_owned(),
+                _ => pod.to_string(),
+            };
+            eprintln!("[stdio] Using scenario spicepod (skipping generation): {pod_path}");
+            setup_config.spicepod_path = Some(pod_path);
         }
         // For non-direct sources, still honour the env AWS_REGION override.
         setup_config.aws_region_override = std::env::var("AWS_REGION").ok();
@@ -2447,9 +2459,11 @@ mod tests {
         );
     }
 
-    /// The bundled tuned/adaptive Mongo CDC pods must parse through the same loader
-    /// used at runtime (`load_spicepod_from_path`), have all 8 TPC-H datasets, and
-    /// carry Cayenne CDC acceleration. Guards against a param key / column type /
+    /// The bundled tuned/adaptive Mongo CDC pods must parse through
+    /// `parse_and_rename_spicepod` — the parser `load_spicepod_from_path` applies
+    /// after reading the file — have all 8 TPC-H datasets, and carry Cayenne CDC
+    /// acceleration. The pod bytes are embedded with `include_str!` so the test
+    /// covers exactly the committed files. Guards against a param key / column type /
     /// structure that the `SpicepodDefinition` deserializer rejects.
     #[test]
     fn bundled_mongo_spicepods_parse() {

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -2468,10 +2468,22 @@ mod tests {
     #[test]
     fn bundled_mongo_spicepods_parse() {
         let pods: [(&str, &str); 4] = [
-            ("mongo-sf10-tuned", include_str!("../scenarios/pods/mongo/mongo-sf10-tuned.yaml")),
-            ("mongo-sf100-tuned", include_str!("../scenarios/pods/mongo/mongo-sf100-tuned.yaml")),
-            ("mongo-sf1000-tuned", include_str!("../scenarios/pods/mongo/mongo-sf1000-tuned.yaml")),
-            ("mongo-adaptive", include_str!("../scenarios/pods/mongo/mongo-adaptive.yaml")),
+            (
+                "mongo-sf10-tuned",
+                include_str!("../scenarios/pods/mongo/mongo-sf10-tuned.yaml"),
+            ),
+            (
+                "mongo-sf100-tuned",
+                include_str!("../scenarios/pods/mongo/mongo-sf100-tuned.yaml"),
+            ),
+            (
+                "mongo-sf1000-tuned",
+                include_str!("../scenarios/pods/mongo/mongo-sf1000-tuned.yaml"),
+            ),
+            (
+                "mongo-adaptive",
+                include_str!("../scenarios/pods/mongo/mongo-adaptive.yaml"),
+            ),
         ];
         let run_id = Uuid::nil();
         for (name, yaml) in pods {
@@ -2486,10 +2498,9 @@ mod tests {
                 let spicepod::component::ComponentOrReference::Component(ds) = ds else {
                     panic!("pod `{name}` dataset must be an inline component");
                 };
-                let accel = ds
-                    .acceleration
-                    .as_ref()
-                    .unwrap_or_else(|| panic!("pod `{name}` dataset `{}` missing acceleration", ds.name));
+                let accel = ds.acceleration.as_ref().unwrap_or_else(|| {
+                    panic!("pod `{name}` dataset `{}` missing acceleration", ds.name)
+                });
                 assert_eq!(
                     accel.engine.as_deref(),
                     Some("cayenne"),


### PR DESCRIPTION
## What

Adds four hand-editable MongoDB CDC spicepods under `tools/spidapter/scenarios/pods/mongo/` and a scenario-driven way to deploy them, for benchmarking Cayenne CDC-over-MongoDB-change-streams tuning:

- **`mongo-sf10-tuned` / `mongo-sf100-tuned` / `mongo-sf1000-tuned`** — pin Cayenne's tunable actuators (write_concurrency, `cdc_mem_tier_max_bytes`, `target_file_size`, compaction cadence) per scale factor, seeded from the CH-benCHmark `postgres-cayenne[file]-cdc-tuned-memory-*` pods, with a high/low volume tier. Values are starting points for manual tuning.
- **`mongo-adaptive`** — sets `cayenne_tuning: adaptive` and leaves those actuators unset so Cayenne's on-box controller sizes them from real cores/RAM. Shares the capacity-independent knobs (memory durability, key deletes, CDC coalescing) with the tuned pods so a comparison isolates the actuator tuning.

Selection reuses the existing `--scenario` dispatch: `ScenarioConfig` gains an optional `spicepod:` path (env-substituted, e.g. `${MONGO_SPICEPOD_PATH:-}`); when non-empty the pod is deployed verbatim instead of generated. Empty/unset preserves the previous generate behaviour, and a metadata `spicepod_path` still takes precedence.

## Validation

Verified end-to-end against a local MongoDB replica set (SF1, rowcount-only). The scenario selection deploys the pod and spiced accepts every tuning param (`outcome: success`). A three-way per-checkpoint E2E convergence-latency comparison (the CDC lag signal), 31 checkpoints:

| Config | median | mean | p95 | p99 / max | checkpoints ≥50 s | total convergence |
|---|---|---|---|---|---|---|
| baseline (generated) | 5.09 s | 22.2 s | 110.3 s | 118.4 s | 8 / 31 | 688 s |
| **sf10-tuned** | 5.69 s | **10.7 s** | **52.6 s** | 107.3 s | **2 / 31** | **331 s** |
| adaptive | 5.12 s | 33.3 s | 123.3 s | 124.9 s | 13 / 31 | 1034 s |

The hand-tuned pod (`deletion_mode: key` + compaction tuning) roughly halves the spiky tail (spiking checkpoints 8→2, mean/p95 ~−52%). Adaptive is worse in a short run — the closed-loop controller hasn't converged its actuators in ~15 min — so the hand-tuned pods stay for now; adaptive gets a fair test at larger scale/longer duration in CI. Numbers are single-run under background load; the spike-count pattern is the robust signal.

Covered by a new `bundled_mongo_spicepods_parse` test that loads all four pods through the runtime `load_spicepod_from_path` path.

## Cross-repo note

Consuming these in CI requires the spidapter image to be rebuilt from this branch (pods live at `/app/scenarios/pods/mongo/`) and the spicebench dispatch wiring (separate PR).