### PR TITLE
cherry-pick: Updates to `release/2.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,7 +239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cc",
  "jni",
  "libc",
@@ -276,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "ansi_colors"
-version = "2.1.0"
+version = "2.1.0-unstable"
 
 [[package]]
 name = "anstream"
@@ -395,7 +404,7 @@ checksum = "fca387cdc0a1f9c7a7c26556d584aa2d07fc529843082e4861003cde4ab914ed"
 
 [[package]]
 name = "app"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "serde",
  "snafu",
@@ -701,7 +710,7 @@ name = "arrow-schema"
 version = "58.3.0"
 source = "git+https://github.com/spiceai/arrow-rs.git?rev=18a40370d014a0f8eed12ee0d5a914e8cb2070d8#18a40370d014a0f8eed12ee0d5a914e8cb2070d8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "serde",
  "serde_core",
  "serde_json",
@@ -738,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_sql_gen"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -752,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_tools"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -1544,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-credential-bridge"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2613,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -2627,10 +2636,10 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2647,10 +2656,10 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2667,10 +2676,10 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2743,9 +2752,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmaps"
@@ -2841,6 +2850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3190,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3274,7 +3292,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -3481,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "cayenne"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "aegis",
  "arc-swap",
@@ -3555,7 +3573,7 @@ dependencies = [
 
 [[package]]
 name = "cayenne-flightsql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "cayenne",
@@ -3580,6 +3598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -3670,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "chbench-driver"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3769,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "chunking"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "criterion 0.7.0",
  "snafu",
@@ -3991,6 +4018,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4065,7 +4101,7 @@ checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 
 [[package]]
 name = "connector-clickhouse"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "clickhouse-rs",
@@ -4084,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "connector-databricks"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "async-trait",
@@ -4109,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "connector-delta-lake"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "aws-sdk-credential-bridge",
@@ -4127,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "connector-dremio"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4145,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "connector-duckdb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4160,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "connector-elasticsearch"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4176,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "connector-flightsql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4192,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "connector-ftp"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "linkme",
  "paste",
@@ -4204,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "connector-graphql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "async-trait",
@@ -4222,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "connector-imap"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4238,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "connector-mongodb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4261,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "connector-mssql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4275,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "connector-mysql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4306,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "connector-odbc"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4321,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "connector-oracle"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4337,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "connector-postgres"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4357,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "connector-scylladb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4375,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "connector-sftp"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "linkme",
  "paste",
@@ -4387,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "connector-sharepoint"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4407,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "connector-smb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "linkme",
  "paste",
@@ -4419,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "connector-snowflake"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4436,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "connector-spark"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4587,6 +4623,15 @@ name = "core_detect"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "cpp_demangle"
@@ -4882,6 +4927,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.8.2",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4896,6 +4966,16 @@ name = "criterion-plot"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -5006,7 +5086,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -5414,7 +5494,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data_components"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5528,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "dataformat-json"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5546,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5598,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5622,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5646,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5671,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "futures",
  "log",
@@ -5681,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5718,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5741,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5763,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5785,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5814,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ddl"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5824,7 +5904,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-dml"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5834,12 +5914,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5860,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5882,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5934,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5965,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5985,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6009,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6033,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6048,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6064,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6073,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6083,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "chrono",
@@ -6101,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer-rules"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -6134,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6155,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6169,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "chrono",
@@ -6185,13 +6265,14 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
+ "datafusion-functions-aggregate",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
@@ -6204,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6236,7 +6317,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "chrono",
@@ -6265,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6277,7 +6358,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6292,7 +6373,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6305,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6333,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6351,7 +6432,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953#c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953"
+source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6370,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=465bbba54e5e09ece6649fa78b690b5315c5dece#465bbba54e5e09ece6649fa78b690b5315c5dece"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=ec1d9e651230d85034374ef5f2ebd1b5d72656b3#ec1d9e651230d85034374ef5f2ebd1b5d72656b3"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -6435,7 +6516,7 @@ checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "db_connection_pool"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-odbc",
@@ -6823,7 +6904,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -6872,7 +6953,7 @@ checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document_parse"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "bytes",
  "calamine",
@@ -7000,7 +7081,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duration-parse"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "snafu",
 ]
@@ -7035,7 +7116,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamodb-streams"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
@@ -7052,11 +7133,11 @@ dependencies = [
 
 [[package]]
 name = "ecb"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
 dependencies = [
- "cipher 0.4.4",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -7114,7 +7195,7 @@ dependencies = [
 
 [[package]]
 name = "elasticsearch"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7255,6 +7336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -7272,6 +7354,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
+ "jiff",
  "log",
 ]
 
@@ -7375,7 +7458,7 @@ dependencies = [
 
 [[package]]
 name = "event_stream"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "futures",
  "snafu",
@@ -7649,7 +7732,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "rustc_version",
 ]
 
@@ -7667,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "flight-cookie-server"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow-array",
  "arrow-flight",
@@ -7685,7 +7768,7 @@ dependencies = [
 
 [[package]]
 name = "flight_client"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7706,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "flightpublisher"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7719,7 +7802,7 @@ dependencies = [
 
 [[package]]
 name = "flightsubscriber"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow-flight",
  "clap",
@@ -8300,8 +8383,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -8416,7 +8499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -8426,7 +8509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -8447,7 +8530,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -8481,7 +8564,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "ignore",
  "walkdir",
 ]
@@ -8500,7 +8583,7 @@ dependencies = [
 
 [[package]]
 name = "google-genai"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "bytes",
  "futures",
@@ -8761,7 +8844,7 @@ dependencies = [
 
 [[package]]
 name = "hash-index"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -9405,7 +9488,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9440,7 +9523,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9891,7 +9974,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -9911,7 +9994,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -9921,6 +10004,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -10003,7 +10087,7 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
 ]
@@ -10364,7 +10448,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -10658,7 +10742,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.8.1",
@@ -10726,7 +10810,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -10819,7 +10903,7 @@ dependencies = [
 
 [[package]]
 name = "llms"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -10950,29 +11034,41 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
+version = "0.43.0"
 dependencies = [
- "aes 0.8.4",
- "bitflags 2.12.1",
- "cbc",
+ "aes 0.9.1",
+ "bitflags 2.13.0",
+ "cbc 0.2.1",
+ "chrono",
+ "clap",
+ "criterion 0.8.2",
  "ecb",
  "encoding_rs",
+ "env_logger",
  "flate2",
  "getrandom 0.4.2",
+ "image 0.25.10",
  "indexmap 2.14.0",
  "itoa",
+ "jiff",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "nom 8.0.0",
  "rand 0.10.1",
  "rangemap",
- "sha2 0.10.9",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "shellexpand",
  "stringprep",
+ "tempfile",
  "thiserror 2.0.18",
+ "time",
+ "tokio",
  "ttf-parser",
- "weezl",
+ "wasm-bindgen-test",
+ "weezl 0.2.1",
 ]
 
 [[package]]
@@ -11341,7 +11437,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -11405,6 +11501,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
 ]
 
 [[package]]
@@ -11711,7 +11817,7 @@ dependencies = [
 
 [[package]]
 name = "model_components"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "arrow",
@@ -11775,7 +11881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bson",
  "derive-where",
  "derive_more",
@@ -11949,7 +12055,7 @@ checksum = "fbb9f371618ce723f095c61fbcdc36e8936956d2b62832f9c7648689b338e052"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "btoi",
  "byteorder",
  "bytes",
@@ -12039,7 +12145,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -12090,7 +12196,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -12102,7 +12208,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -12114,7 +12220,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -12187,7 +12293,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -12205,7 +12311,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -12231,7 +12337,7 @@ dependencies = [
 
 [[package]]
 name = "ns_lookup"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "hickory-resolver",
  "snafu",
@@ -12469,7 +12575,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -12485,7 +12591,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -12509,7 +12615,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -12521,7 +12627,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -12562,7 +12668,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -12575,7 +12681,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -12610,7 +12716,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -12622,7 +12728,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "objc2 0.6.4",
@@ -12636,7 +12742,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -12668,7 +12774,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -12700,7 +12806,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -12950,7 +13056,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -13192,7 +13298,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -13434,7 +13540,7 @@ dependencies = [
 
 [[package]]
 name = "otel-arrow"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -13446,7 +13552,7 @@ dependencies = [
 
 [[package]]
 name = "otelpublisher"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "clap",
  "opentelemetry-proto",
@@ -13534,7 +13640,7 @@ dependencies = [
 
 [[package]]
 name = "package"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "bytes",
  "futures",
@@ -13554,6 +13660,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -13632,7 +13748,7 @@ dependencies = [
 
 [[package]]
 name = "parsley"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "bytes",
  "chunking",
@@ -13757,8 +13873,6 @@ dependencies = [
 [[package]]
 name = "pdf-extract"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
 dependencies = [
  "adobe-cmap-parser",
  "cff-parser",
@@ -13767,8 +13881,11 @@ dependencies = [
  "log",
  "lopdf",
  "postscript",
+ "simple_logger",
+ "test-log",
  "type1-encoding-parser",
  "unicode-normalization",
+ "ureq",
 ]
 
 [[package]]
@@ -13982,6 +14099,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14020,7 +14143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.5.0",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -14054,7 +14177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
  "aes 0.8.4",
- "cbc",
+ "cbc 0.1.2",
  "der",
  "des",
  "pbkdf2 0.12.2",
@@ -14134,7 +14257,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -14255,9 +14378,12 @@ dependencies = [
 
 [[package]]
 name = "postscript"
-version = "0.14.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
+checksum = "9a2238e788cf2c9b6edc23b83cf8ccdd4a6380cc9bf0598cc220fac42a55def6"
+dependencies = [
+ "typeface",
+]
 
 [[package]]
 name = "potential_utf"
@@ -14291,7 +14417,7 @@ dependencies = [
 
 [[package]]
 name = "pr-builds"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "clap",
@@ -14491,8 +14617,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -14526,7 +14652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14597,7 +14723,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -14608,7 +14734,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -14854,7 +14980,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14892,7 +15018,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -15215,7 +15341,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -15364,7 +15490,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -15373,7 +15499,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -15494,7 +15620,7 @@ dependencies = [
 
 [[package]]
 name = "repl"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ansi_colors",
  "arrow",
@@ -16036,7 +16162,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -16265,7 +16391,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-acceleration"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "arrow",
@@ -16305,7 +16431,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-api-types"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "serde",
  "serde_json",
@@ -16314,7 +16440,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-async"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "futures",
  "libc",
@@ -16327,7 +16453,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-auth"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "axum",
@@ -16344,7 +16470,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-cluster"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "arrow",
@@ -16388,7 +16514,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-datafusion"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -16430,7 +16556,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-datafusion-index"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow_tools",
  "async-trait",
@@ -16444,7 +16570,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-datafusion-udfs"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -16486,7 +16612,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-object-store"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -16516,11 +16642,11 @@ dependencies = [
 
 [[package]]
 name = "runtime-parameter-spec"
-version = "2.1.0"
+version = "2.1.0-unstable"
 
 [[package]]
 name = "runtime-parameters"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "itertools 0.14.0",
  "runtime-parameter-spec",
@@ -16534,7 +16660,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-proto"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "datafusion",
  "datafusion-common",
@@ -16549,7 +16675,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-query-engine"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -16561,7 +16687,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-rate-control"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "futures",
  "governor",
@@ -16577,7 +16703,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-request-context"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "async-trait",
@@ -16599,7 +16725,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-search"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "arrow",
@@ -16642,7 +16768,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-secrets"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -16675,7 +16801,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-table-partition"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -16699,7 +16825,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tools"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "arrow",
@@ -16742,7 +16868,7 @@ name = "rusqlite"
 version = "0.40.1"
 source = "git+https://github.com/spiceai/rusqlite.git?rev=e39c9c46dea1f0983cd8d87dabb69b41c9efe1fd#e39c9c46dea1f0983cd8d87dabb69b41c9efe1fd"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "chrono",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
@@ -16900,7 +17026,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -16913,7 +17039,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -17027,7 +17153,7 @@ version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -17063,7 +17189,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3_vectors"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -17076,7 +17202,7 @@ dependencies = [
 
 [[package]]
 name = "s3_vectors_metadata_filter"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "aws-smithy-types",
  "datafusion",
@@ -17200,7 +17326,7 @@ dependencies = [
 
 [[package]]
 name = "scheduler"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17402,7 +17528,7 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "search"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -17464,7 +17590,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -17477,7 +17603,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -17500,7 +17626,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cssparser",
  "derive_more",
  "log",
@@ -17568,7 +17694,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -17853,6 +17979,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17988,6 +18123,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_logger"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7038d0e96661bf9ce647e1a6f6ef6d6f3663f66d9bf741abf14ba4876071c17"
+dependencies = [
+ "colored",
+ "log",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "simsimd"
 version = "6.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18054,7 +18200,7 @@ checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
 name = "smb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "aes 0.8.4",
  "bytes",
@@ -18109,7 +18255,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -18263,7 +18409,7 @@ dependencies = [
 
 [[package]]
 name = "spice"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ansi_colors",
  "arrow",
@@ -18317,7 +18463,7 @@ dependencies = [
 
 [[package]]
 name = "spice-cloud"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -18332,7 +18478,7 @@ dependencies = [
 
 [[package]]
 name = "spice-cloud-client"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "reqwest 0.13.4",
  "serde",
@@ -18373,7 +18519,7 @@ dependencies = [
 
 [[package]]
 name = "spiced"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "clap",
@@ -18435,7 +18581,7 @@ dependencies = [
 
 [[package]]
 name = "spicepod"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "aws-sdk-credential-bridge",
@@ -18459,7 +18605,7 @@ dependencies = [
 
 [[package]]
 name = "spicepod-validator"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "clap",
@@ -18469,7 +18615,7 @@ dependencies = [
 
 [[package]]
 name = "spicepodschema"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "connector-clickhouse",
  "connector-delta-lake",
@@ -18501,7 +18647,7 @@ dependencies = [
 
 [[package]]
 name = "spiceschema"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "clap",
  "runtime",
@@ -18511,7 +18657,7 @@ dependencies = [
 
 [[package]]
 name = "spidapter"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "arrow",
@@ -18642,7 +18788,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "libssh2-sys",
  "parking_lot",
@@ -18705,6 +18851,12 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "string-interner"
@@ -19084,7 +19236,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -19152,7 +19304,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -19362,7 +19514,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "telemetry"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -19470,7 +19622,7 @@ checksum = "d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9"
 
 [[package]]
 name = "test-framework"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "app",
@@ -19554,7 +19706,7 @@ dependencies = [
 
 [[package]]
 name = "testoperator"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -19661,7 +19813,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",
@@ -19768,7 +19920,7 @@ checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
 dependencies = [
  "flate2",
  "jpeg-decoder",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -19781,7 +19933,7 @@ dependencies = [
  "flate2",
  "half",
  "quick-error 2.0.1",
- "weezl",
+ "weezl 0.1.12",
  "zune-jpeg",
 ]
 
@@ -19880,6 +20032,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19916,7 +20079,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token_provider"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "secrecy",
  "sha2 0.10.9",
@@ -20348,7 +20511,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "rmcp",
@@ -20398,7 +20561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -20429,7 +20592,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tpc-extension"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "duckdb",
@@ -20735,8 +20898,13 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "base64 0.22.1",
+ "core_maths",
+ "pico-args",
+ "tiny-skia-path",
+ "xmlwriter",
+]
 
 [[package]]
 name = "tungstenite"
@@ -20787,7 +20955,7 @@ dependencies = [
 
 [[package]]
 name = "turso-shared"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "rand 0.10.1",
 ]
@@ -20804,7 +20972,7 @@ dependencies = [
  "antithesis_sdk",
  "arc-swap",
  "bigdecimal",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "branches",
  "bumpalo",
  "bytemuck",
@@ -20885,7 +21053,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b94707e5605411cddbd5a1bd6cc2d6b72181b02223b36b37ba350ed6b71877"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "memchr",
  "miette",
  "strum 0.26.3",
@@ -21025,6 +21193,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeface"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f6b49e025f4dc953a29b83e4f5a905089117d09fa53491015d7678951b8be1"
 
 [[package]]
 name = "typeid"
@@ -21406,7 +21580,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "util"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -21743,7 +21917,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datafusion"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "arrow-schema",
@@ -22294,6 +22468,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22367,7 +22580,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -22379,7 +22592,7 @@ version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "semver",
@@ -22392,7 +22605,7 @@ version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "semver",
 ]
@@ -22416,7 +22629,7 @@ checksum = "af4eccc0728f061979efa8ff4c962cff7041fead4baadb74973f01b9c47158a4"
 dependencies = [
  "addr2line",
  "async-trait",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -22676,6 +22889,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "weezl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ca08e5ef825b65b056d9efbd95c8750683f0a6d0466d02e96dc2e4e360f3d2"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22750,7 +22969,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -23217,7 +23436,7 @@ checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
  "android-activity",
  "atomic-waker",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "calloop",
  "cfg_aliases",
@@ -23376,7 +23595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -23408,7 +23627,7 @@ dependencies = [
 
 [[package]]
 name = "workers"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -23506,7 +23725,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",
@@ -23532,6 +23751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23539,7 +23764,7 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yaml"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "indexmap 2.14.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,41 +389,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c94202b4b6c6d8da2a4f87bfdd6e4a21dad8a953" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,14 @@ ignore = [
   # marked it unmaintained and there is no safe upgrade (the suggested `skrifa`
   # alternative is not wired through `lopdf`/`pdf-extract`). Owner: document_parse.
   "RUSTSEC-2026-0192",
+  # `quick-xml` quadratic duplicate-attribute check on start tags (DoS). Pulled
+  # transitively in several versions (via vortex, AWS-XML, and serialization
+  # dependencies); no single safe upgrade across all pins yet. Owner: data components/runtime.
+  "RUSTSEC-2026-0194",
+  # `quick-xml` unbounded namespace-declaration allocation in `NsReader`
+  # (memory-exhaustion DoS), same transitive chain as RUSTSEC-2026-0194; no safe
+  # upgrade yet. Owner: data components/runtime.
+  "RUSTSEC-2026-0195",
 ]
 
 [bans]


### PR DESCRIPTION
Cherry-picks `1727cddabf97ccc5cb2eb72c1c57715cc6fb8e55` (Bump datafusion to include spiceai/datafusion#181 (#11563)) from trunk onto release/2.1.

Conflict in `Cargo.toml`/`Cargo.lock` resolved by taking the incoming revision (`db1d14222c`) — includes both datafusion#177 (already on release/2.1 via #11541) and datafusion#181.