### PR TITLE
Bump datafusion (spiceai/datafusion#182) and datafusion-table-providers (#27): fix q16 CollectLeft planning error and SQLite q6 wrong revenue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,7 +4023,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5626,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5751,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "futures",
  "log",
@@ -5761,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5821,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5843,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5865,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5914,12 +5914,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5962,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6045,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6065,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6089,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6153,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "chrono",
@@ -6214,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6249,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "chrono",
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6285,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6317,7 +6317,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "chrono",
@@ -6346,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6358,7 +6358,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6373,7 +6373,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6386,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6432,7 +6432,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=db1d14222c15d0bd95fa90ad110b78cd21120401#db1d14222c15d0bd95fa90ad110b78cd21120401"
+source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -8383,8 +8383,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -9488,7 +9488,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9523,7 +9523,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -14143,7 +14143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.5.0",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -14617,8 +14617,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -14652,7 +14652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14980,7 +14980,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15018,7 +15018,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -17694,7 +17694,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -18255,7 +18255,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -22969,7 +22969,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,41 +394,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" } # branch: jeadie/fi-177
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "db1d14222c15d0bd95fa90ad110b78cd21120401" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" } # branch: jeadie/fix-parallelize-sorts-collect-left-coalesce
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -144,6 +144,13 @@ pub static DEFAULT_DATAFUSION_CONFIG: LazyLock<RwLock<SessionConfig>> = LazyLock
     // https://docs.rs/datafusion/latest/datafusion/config/struct.ParquetOptions.html#structfield.pushdown_filters
     df_config.options_mut().execution.parquet.pushdown_filters = true;
 
+    // Parse decimal-text literals (e.g. `0.06`) as Decimal128 instead of Float64 so constant
+    // folding stays exact. With the Float64 default, TPC-H q6's `l_discount BETWEEN
+    // 0.06 - 0.01 AND 0.06 + 0.01` folds the upper bound to 0.06999999999999999, silently
+    // excluding l_discount = 0.07 rows whenever the filter is evaluated against a Float64
+    // column (e.g. accelerated/parquet data). Decimal folding yields exactly 0.07.
+    df_config.options_mut().sql_parser.parse_float_as_decimal = true;
+
     RwLock::new(df_config)
 });
 


### PR DESCRIPTION
## Summary

Fixes two TPC-H correctness bugs, both via dependency bumps carrying targeted fixes:

### q16 — execution error (spiceai/datafusion#182)

```
SanityCheckPlan: HashJoinExec: mode=CollectLeft, join_type=LeftAnti, ...
does not satisfy distribution requirements: SinglePartition
```

Under partial federation fallback (`on_zero_results/*-duckdb` configs), `EnforceSorting` removed the `CoalescePartitionsExec` that `EnforceDistribution` had inserted on the build side of a CollectLeft LeftAnti join: a coalesce-link from the probe-side fallback scan wrapper propagated through the join, and the removal only ever inspected the first child. Fixed in spiceai/datafusion#182 (with a unit regression test); this PR bumps the datafusion pin `db1d14222c` → `0054497233`.

### q6 — SQLite wrong revenue, ~61 % of expected (spiceai/datafusion-table-providers#27)

`file[parquet]-sqlite[memory|file]` benchmarks have failed q6 on every trunk run since ~Jun 15 (`expected: 123141078.2283, actual: 75207768.1855` — exactly the `l_discount = 0.07` bucket dropped), while release/2.0 kept passing.

Root cause: the SQLite BETWEEN → `decimal_cmp` rewrite computes bound arithmetic like `decimal('0.06') + decimal('0.01')` with SQLite's raw `+`, which coerces the decimal extension's TEXT output back to REAL — so the bound is f64 (`0.069999999999999993`) after all. This was masked on SQLite ≤ 3.50, whose REAL→TEXT conversion (used by `decimal_cmp` for REAL args) rounds to 15 significant digits (`'0.07'`). The rusqlite 0.37 → 0.40 bump in #11118 moved the bundled SQLite from 3.50.2 to 3.53.2, which renders shortest-round-trip digits (`'0.06999999999999999'`) — removing the accidental rescue. Reproduced byte-for-byte outside spiced: the same accelerated DB + the same `rewritten_executor_sql` returns 123141078.2283 linked against 3.50.2 and 75207768.1855 against 3.53.2.

Fixed in spiceai/datafusion-table-providers#27 by evaluating bound arithmetic inside the decimal extension (`decimal_add`/`decimal_sub`/`decimal_mul` — exact on all SQLite versions); this PR bumps the table-providers pin to that fix merged with the `spiceai-54` tip.

An earlier revision of this PR enabled `sql_parser.parse_float_as_decimal` for q6; that has been removed — it is a session-wide literal typing change and does not address the actual SQLite mechanism (the federated SQL ships the *unfolded* BETWEEN arithmetic on this path, so DataFusion literal folding is not involved).

## Testing

- q16: regression test in spiceai/datafusion#182 (red without the fix), plus the datafusion-federation partial-federation q16 integration test goes red → green.
- q6/sqlite: unit regression test in spiceai/datafusion-table-providers#27 asserting the rewritten SQL for the exact q6 shape; fix verified correct against both bundled SQLite 3.50.2 and 3.53.2 via a C harness on the real accelerated database.
- Suggested CI check: dispatch `bench - tpch - accelerated/file[parquet]-sqlite[memory].yaml` against this PR's binary with `update_snapshots=no` and `validate_results=true` (note: `update_snapshots=default` resolves to `always` on non-release branches, which rewrites snapshots instead of failing).

## Known remaining issue (not addressed here)

DuckDB scan-level filter pushdown over Float64-widened accelerated columns still carries DataFusion's f64-folded literal (`l_discount <= 0.06999999999999999`) into the scan SQL. This path needs a fix upstream of SQL generation (literal folding or acceleration schema typing) and is pinned by a red regression test in datafusion-federation (`test_q6_duckdb_scan_filter_pushdown_double_lineitem`).
