### PR TITLE
fix(ci): bump Go version for ADBC BigQuery driver build to 1.26.1

### DIFF
--- a/.github/actions/setup-adbc-bigquery/action.yml
+++ b/.github/actions/setup-adbc-bigquery/action.yml
@@ -9,7 +9,7 @@ inputs:
   go_version:
     description: 'Go version to use for building'
     required: false
-    default: '1.24.1'
+    default: '1.26.1'
 
 runs:
   using: 'composite'

--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -460,13 +460,9 @@ fn maintained_aggregate_partial_input(plan: &Arc<dyn ExecutionPlan>) -> Option<&
         return Some(aggregate);
     }
 
-    if plan.downcast_ref::<RepartitionExec>().is_none()
-        && plan
-            .downcast_ref::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
-            .is_none()
-        && plan
-            .downcast_ref::<datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec>()
-            .is_none()
+    if !plan.is::<RepartitionExec>()
+        && !plan.is::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
+        && !plan.is::<datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec>()
     {
         return None;
     }
@@ -531,14 +527,10 @@ fn maintained_aggregate_source(
         ));
     }
 
-    if plan.downcast_ref::<RepartitionExec>().is_none()
-        && plan
-            .downcast_ref::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
-            .is_none()
-        && plan.downcast_ref::<SchemaCastScanExec>().is_none()
-        && plan
-            .downcast_ref::<datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec>()
-            .is_none()
+    if !plan.is::<RepartitionExec>()
+        && !plan.is::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
+        && !plan.is::<SchemaCastScanExec>()
+        && !plan.is::<datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec>()
     {
         return None;
     }
@@ -635,14 +627,10 @@ fn cayenne_scan_input(plan: &Arc<dyn ExecutionPlan>) -> Option<&CayenneAccelerat
         return Some(cayenne_scan);
     }
 
-    if plan.downcast_ref::<RepartitionExec>().is_none()
-        && plan
-            .downcast_ref::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
-            .is_none()
-        && plan.downcast_ref::<SchemaCastScanExec>().is_none()
-        && plan
-            .downcast_ref::<datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec>()
-            .is_none()
+    if !plan.is::<RepartitionExec>()
+        && !plan.is::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
+        && !plan.is::<SchemaCastScanExec>()
+        && !plan.is::<datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec>()
     {
         return None;
     }
@@ -945,7 +933,7 @@ fn count_hash_joins(plan: &Arc<dyn ExecutionPlan>) -> usize {
 }
 
 fn count_hash_joins_inner(plan: &Arc<dyn ExecutionPlan>, count: &mut usize) {
-    if plan.downcast_ref::<HashJoinExec>().is_some() {
+    if plan.is::<HashJoinExec>() {
         *count += 1;
     }
     for child in plan.children() {
@@ -1480,10 +1468,7 @@ fn flatten_transparent_nodes(plan: &Arc<dyn ExecutionPlan>) -> &Arc<dyn Executio
 fn hash_join_build_side_is_cayenne(join: &HashJoinExec) -> bool {
     let build_side = flatten_transparent_nodes(join.left());
 
-    if build_side
-        .downcast_ref::<CayenneAccelerationExec>()
-        .is_some()
-    {
+    if build_side.is::<CayenneAccelerationExec>() {
         true
     } else if let Some(nested_join) = build_side.downcast_ref::<HashJoinExec>() {
         // Recursively check the build side of the nested join
@@ -1509,10 +1494,7 @@ fn is_cayenne_backed_join(hash_join: &HashJoinExec) -> bool {
     // Check the probe side first (right child)
     let probe_side = flatten_transparent_nodes(hash_join.right());
 
-    if probe_side
-        .downcast_ref::<CayenneAccelerationExec>()
-        .is_some()
-    {
+    if probe_side.is::<CayenneAccelerationExec>() {
         return true;
     }
 
@@ -1704,11 +1686,7 @@ mod tests {
         let optimized = CayenneMaintainedAggregateRewriter::new()
             .optimize(aggregate, &ConfigOptions::default())?;
 
-        assert!(
-            optimized
-                .downcast_ref::<MaintainedAggregateExec>()
-                .is_some()
-        );
+        assert!(optimized.is::<MaintainedAggregateExec>());
         Ok(())
     }
 
@@ -1739,7 +1717,7 @@ mod tests {
             .optimize(Arc::clone(&aggregate), &ConfigOptions::default())?;
 
         assert!(
-            optimized.downcast_ref::<AggregateExec>().is_some(),
+            optimized.is::<AggregateExec>(),
             "stale maintained aggregate state must not rewrite"
         );
         Ok(())
@@ -1869,7 +1847,7 @@ mod tests {
             .optimize(aggregate, &ConfigOptions::default())?;
 
         assert!(
-            optimized.downcast_ref::<AggregateExec>().is_some(),
+            optimized.is::<AggregateExec>(),
             "a filtered view must not answer an unfiltered query"
         );
         Ok(())
@@ -1915,7 +1893,7 @@ mod tests {
             .optimize(Arc::clone(&aggregate), &ConfigOptions::default())?;
 
         assert!(
-            optimized.downcast_ref::<AggregateExec>().is_some(),
+            optimized.is::<AggregateExec>(),
             "a filtered scan must not fold from whole-file stats"
         );
         Ok(())
@@ -1942,7 +1920,7 @@ mod tests {
             .optimize(Arc::clone(&aggregate), &ConfigOptions::default())?;
 
         assert!(
-            optimized.downcast_ref::<AggregateExec>().is_some(),
+            optimized.is::<AggregateExec>(),
             "a base+delta union with an unknown-stat delta must not fold"
         );
         Ok(())
@@ -2548,7 +2526,7 @@ mod tests {
 
         let optimized = optimize_anti_join_sort_merge(join);
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "same-source Cayenne LeftSemi join should use sort-merge join"
         );
     }
@@ -2574,11 +2552,11 @@ mod tests {
 
         assert_eq!(JoinType::LeftAnti, sort_merge.join_type());
         assert!(
-            sort_merge.left().downcast_ref::<SortExec>().is_some(),
+            sort_merge.left().is::<SortExec>(),
             "left anti-join input should be explicitly sorted"
         );
         assert!(
-            sort_merge.right().downcast_ref::<SortExec>().is_some(),
+            sort_merge.right().is::<SortExec>(),
             "right anti-join input should be explicitly sorted"
         );
     }
@@ -2694,7 +2672,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "inner joins should stay as hash joins unless a more targeted rule proves a win"
         );
     }
@@ -2716,7 +2694,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "outer joins should stay as hash joins unless a more targeted rule proves a win"
         );
     }
@@ -2737,7 +2715,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "multi-key same-source Cayenne anti join should use sort-merge join"
         );
     }
@@ -2759,7 +2737,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "anti joins over unrelated sources should stay as hash joins"
         );
     }
@@ -2781,7 +2759,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "inner joins over unrelated sources should stay as hash joins"
         );
     }
@@ -2807,7 +2785,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "same-source anti joins at or below the large-input threshold should stay as hash joins"
         );
     }
@@ -2829,7 +2807,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "null-equal anti joins should stay as hash joins"
         );
     }
@@ -2856,7 +2834,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "configured min-row threshold should keep smaller build sides as hash joins"
         );
     }
@@ -2889,7 +2867,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "low-row-count + wide-row build exceeding the byte gate should be rewritten to sort-merge"
         );
     }
@@ -2912,7 +2890,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "estimated build side within the configured memory fraction should stay a hash join"
         );
     }
@@ -2935,7 +2913,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "estimated build side above the configured memory fraction should use sort-merge"
         );
     }
@@ -2961,7 +2939,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "same-source anti joins with inexact preserved-side stats should stay as hash joins"
         );
     }
@@ -2983,7 +2961,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "same-source anti joins with unknown preserved-side stats should stay as hash joins"
         );
     }
@@ -3005,7 +2983,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "RightAnti should gate on the left build side, not the right preserved side"
         );
     }
@@ -3027,7 +3005,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge(join);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "RightAnti should stay hash join when the left build side has unknown stats"
         );
     }
@@ -3042,7 +3020,7 @@ mod tests {
         }
         for child in plan.children() {
             let filters = cayenne_scan_dynamic_filters(child);
-            if !filters.is_empty() || child.downcast_ref::<CayenneAccelerationExec>().is_some() {
+            if !filters.is_empty() || child.is::<CayenneAccelerationExec>() {
                 return filters;
             }
         }
@@ -3169,7 +3147,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "a large inner hash join over the memory gate should become a sort-merge join"
         );
     }
@@ -3193,7 +3171,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "a large full-outer hash join over the memory gate should become a sort-merge join"
         );
     }
@@ -3223,7 +3201,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "an inexact-but-large inner build side should still be rewritten under the memory gate"
         );
     }
@@ -3248,7 +3226,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<SortMergeJoinExec>().is_some(),
+            optimized.is::<SortMergeJoinExec>(),
             "different-source inner joins are eligible under the memory gate"
         );
     }
@@ -3280,7 +3258,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "non-Cayenne joins are left to the prefer_hash_join knob, not the Cayenne rewriter"
         );
     }
@@ -3304,7 +3282,7 @@ mod tests {
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
         assert!(
-            optimized.downcast_ref::<HashJoinExec>().is_some(),
+            optimized.is::<HashJoinExec>(),
             "a lone inner join within the pool fraction should stay a hash join"
         );
     }
@@ -3342,7 +3320,7 @@ mod tests {
         assert_eq!(union.children().len(), 2, "union should keep both joins");
         for child in union.children() {
             assert!(
-                child.downcast_ref::<SortMergeJoinExec>().is_some(),
+                child.is::<SortMergeJoinExec>(),
                 "each concurrent inner join should be rewritten to sort-merge under fair-share"
             );
         }

--- a/crates/cayenne/src/provider/scan.rs
+++ b/crates/cayenne/src/provider/scan.rs
@@ -583,7 +583,7 @@ fn collect_file_scan_configs<'a>(
         return;
     }
 
-    if plan.downcast_ref::<UnionExec>().is_some() {
+    if plan.is::<UnionExec>() {
         for child in plan.children() {
             collect_file_scan_configs(child, configs);
         }
@@ -612,15 +612,11 @@ fn collect_file_scan_configs<'a>(
 /// it stops a future operator from silently being treated as transparent.
 #[expect(deprecated)]
 fn is_identity_preserving_wrapper(plan: &Arc<dyn ExecutionPlan>) -> bool {
-    if plan.downcast_ref::<ProjectionExec>().is_some()
-        || plan.downcast_ref::<RepartitionExec>().is_some()
-        || plan
-            .downcast_ref::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
-            .is_some()
-        || plan
-            .downcast_ref::<datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec>()
-            .is_some()
-        || plan.downcast_ref::<CayenneAccelerationExec>().is_some()
+    if plan.is::<ProjectionExec>()
+        || plan.is::<RepartitionExec>()
+        || plan.is::<datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec>()
+        || plan.is::<datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec>()
+        || plan.is::<CayenneAccelerationExec>()
     {
         return true;
     }
@@ -705,7 +701,7 @@ fn push_dynamic_filters_to_data_source(
         return Ok(None);
     }
 
-    let is_union = plan.downcast_ref::<UnionExec>().is_some();
+    let is_union = plan.is::<UnionExec>();
     if !is_union && !is_identity_preserving_wrapper(&plan) {
         return Ok(None);
     }
@@ -1017,11 +1013,7 @@ mod tests {
                 .partition_count(),
             4
         );
-        assert!(
-            repartitioned_plan
-                .downcast_ref::<RepartitionExec>()
-                .is_some()
-        );
+        assert!(repartitioned_plan.is::<RepartitionExec>());
     }
 
     #[test]
@@ -1051,7 +1043,7 @@ mod tests {
             .expect("inner plan should support projection swapping");
 
         assert!(
-            swapped.downcast_ref::<CayenneAccelerationExec>().is_some(),
+            swapped.is::<CayenneAccelerationExec>(),
             "projection-swapped Cayenne plan should stay wrapped for optimizer identification"
         );
     }

--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/aggregate_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/aggregate_pushdown.rs
@@ -251,7 +251,7 @@ fn walk_to_flight_exec(plan: &Arc<dyn ExecutionPlan>) -> Option<&FlightSqlExec> 
             return None;
         }
 
-        if current.downcast_ref::<RepartitionExec>().is_some()
+        if current.is::<RepartitionExec>()
             || PASS_THROUGH_EXEC_NAMES.contains(&current.name())
         {
             current = children[0];
@@ -473,10 +473,7 @@ mod tests {
         plan: Arc<dyn ExecutionPlan>,
         data: &mut impl Iterator<Item = Vec<RecordBatch>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        if plan
-            .downcast_ref::<PartialAggregationFlightSqlExec>()
-            .is_some()
-        {
+        if plan.is::<PartialAggregationFlightSqlExec>() {
             let schema = plan.schema();
             let partition_data = data.next().ok_or_else(|| {
                 datafusion::common::DataFusionError::Internal(

--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/broadcast_join.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/broadcast_join.rs
@@ -426,9 +426,7 @@ fn resolve_federated_side(plan: &Arc<dyn ExecutionPlan>) -> Option<FederatedSide
     // otherwise `collect_flight_execs` hits the multi-input `UnionExec`
     // mid-walk and bails.
     let mut scan_root = plan;
-    while scan_root.downcast_ref::<UnionExec>().is_none()
-        && scan_root.downcast_ref::<FlightSqlExec>().is_none()
-    {
+    while !scan_root.is::<UnionExec>() && !scan_root.is::<FlightSqlExec>() {
         if !is_single_input_wrapper(scan_root.as_ref()) {
             return None;
         }
@@ -500,8 +498,8 @@ fn walk_to_flight_exec(plan: &Arc<dyn ExecutionPlan>) -> Option<&FlightSqlExec> 
     reason = "DF53 deprecates CoalesceBatchesExec (arrow BatchCoalescer); kept for plan-shape recognition"
 )]
 fn is_single_input_wrapper(plan: &dyn ExecutionPlan) -> bool {
-    plan.downcast_ref::<RepartitionExec>().is_some()
-        || plan.downcast_ref::<CoalesceBatchesExec>().is_some()
+    plan.is::<RepartitionExec>()
+        || plan.is::<CoalesceBatchesExec>()
         || PASS_THROUGH_EXEC_NAMES.contains(&plan.name())
 }
 

--- a/crates/datafusion-optimizer-rules/src/physical_plan/http_subquery_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/http_subquery_pushdown.rs
@@ -228,7 +228,7 @@ fn http_join_param_column(join_exec: &HashJoinExec) -> Option<String> {
 
 /// Recursively check whether `plan` or any descendant is an `HttpExec`.
 fn contains_http_exec(plan: &Arc<dyn ExecutionPlan>) -> bool {
-    if plan.downcast_ref::<HttpExec>().is_some() {
+    if plan.is::<HttpExec>() {
         return true;
     }
     plan.children()
@@ -814,7 +814,7 @@ mod tests {
 
         // Should remain a HashJoinExec (no rewrite)
         assert!(
-            result.downcast_ref::<HashJoinExec>().is_some(),
+            result.is::<HashJoinExec>(),
             "expected HashJoinExec unchanged, got {}",
             result.name()
         );
@@ -842,7 +842,7 @@ mod tests {
             .expect("optimize should succeed");
 
         assert!(
-            result.downcast_ref::<HashJoinExec>().is_some(),
+            result.is::<HashJoinExec>(),
             "expected HashJoinExec unchanged when no HttpExec is present"
         );
     }

--- a/crates/runtime-datafusion/src/extension/bytes_processed.rs
+++ b/crates/runtime-datafusion/src/extension/bytes_processed.rs
@@ -90,7 +90,7 @@ impl PhysicalOptimizerRule for BytesProcessedPhysicalOptimizer {
         _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         plan.transform_down(|plan| {
-            if plan.downcast_ref::<BytesProcessedExec>().is_some() {
+            if plan.is::<BytesProcessedExec>() {
                 return Ok(Transformed::new(plan, false, TreeNodeRecursion::Jump));
             }
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -2755,8 +2755,7 @@ mod tests {
         assert!(
             indexed
                 .get_underlying()
-                .downcast_ref::<MetadataEnrichedTableProvider>()
-                .is_some()
+                .is::<MetadataEnrichedTableProvider>()
         );
 
         let wrapped_schema = wrapped.schema();

--- a/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_logical_codec.rs
@@ -338,7 +338,7 @@ impl LogicalExtensionCodec for SpiceLogicalCodec {
         buf: &mut Vec<u8>,
     ) -> Result<()> {
         // Check for ListUDFTable
-        if node.downcast_ref::<ListUDFTable>().is_some() {
+        if node.is::<ListUDFTable>() {
             let args = UdtfArgs::list_udfs();
             buf.extend_from_slice(&args.encode_to_vec());
             return Ok(());

--- a/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
+++ b/crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs
@@ -272,7 +272,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
                     SchemaCastScanExecNode { schema: schema_buf },
                 )),
             }
-        } else if node.downcast_ref::<BytesProcessedExec>().is_some() {
+        } else if node.is::<BytesProcessedExec>() {
             SpicePhysicalPlanNode {
                 node: Some(spice_physical_plan_node::Node::BytesProcessed(
                     BytesProcessedExecNode {},
@@ -349,7 +349,7 @@ impl PhysicalExtensionCodec for SpicePhysicalCodec {
             }
         } else {
             #[cfg(not(windows))]
-            if node.downcast_ref::<CayenneAccelerationExec>().is_some() {
+            if node.is::<CayenneAccelerationExec>() {
                 SpicePhysicalPlanNode {
                     node: Some(spice_physical_plan_node::Node::CayenneAcceleration(
                         CayenneAccelerationExecNode {},

--- a/crates/runtime/src/dataconnector/iceberg_cluster.rs
+++ b/crates/runtime/src/dataconnector/iceberg_cluster.rs
@@ -135,9 +135,7 @@ impl TableProvider for IcebergClusterTableProvider {
         // plan (it never should), in which case we also leave it untouched.
         // The scan arguments are captured so the executor can replay this exact
         // `scan()` call to re-derive an equivalent (identically bucketed) scan.
-        if session_is_distributed(state.config())
-            && plan.downcast_ref::<IcebergTableScan>().is_some()
-        {
+        if session_is_distributed(state.config()) && plan.is::<IcebergTableScan>() {
             return Ok(Arc::new(IcebergScanExec::new(
                 self.table_ref.clone(),
                 plan,

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -1379,9 +1379,7 @@ fn is_cayenne_accelerated_table_provider(provider: &dyn TableProvider) -> bool {
 
 #[cfg(not(windows))]
 fn is_cayenne_table_provider(provider: &dyn TableProvider) -> bool {
-    if provider.downcast_ref::<CayenneTableProvider>().is_some()
-        || has_cayenne_accelerator_metadata(provider)
-    {
+    if provider.is::<CayenneTableProvider>() || has_cayenne_accelerator_metadata(provider) {
         return true;
     }
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -5169,7 +5169,7 @@ mod tests {
             .expect("should resolve the accelerated table provider");
 
         assert!(
-            resolved.downcast_ref::<MemTable>().is_some(),
+            resolved.is::<MemTable>(),
             "get_accelerated_table_provider must peel MetadataEnrichedTableProvider to reach the inner provider"
         );
     }

--- a/crates/runtime/src/datafusion/planner/mod.rs
+++ b/crates/runtime/src/datafusion/planner/mod.rs
@@ -365,7 +365,7 @@ mod tests {
 
         let peeled = peel_table_provider_wrappers(&wrapped);
         assert!(
-            peeled.downcast_ref::<MemTable>().is_some(),
+            peeled.is::<MemTable>(),
             "peel must reach the inner provider through the metadata wrapper"
         );
     }
@@ -379,7 +379,7 @@ mod tests {
 
         let peeled = peel_table_provider_wrappers(&wrapped);
         assert!(
-            peeled.downcast_ref::<MemTable>().is_some(),
+            peeled.is::<MemTable>(),
             "peel must unwrap every nested metadata wrapper"
         );
     }
@@ -389,7 +389,7 @@ mod tests {
         let inner = mem_table();
         let peeled = peel_table_provider_wrappers(&inner);
         assert!(
-            peeled.downcast_ref::<MemTable>().is_some(),
+            peeled.is::<MemTable>(),
             "an unwrapped provider must be returned unchanged"
         );
     }

--- a/crates/runtime/tests/cayenne/mod.rs
+++ b/crates/runtime/tests/cayenne/mod.rs
@@ -584,10 +584,7 @@ async fn test_cayenne_s3_express_multi_zone_live() -> Result<(), String> {
                 .get_accelerated_table_provider(&table_name)
                 .await
                 .map_err(|e| format!("failed to resolve accelerated provider: {e}"))?;
-            if accelerated_provider
-                .downcast_ref::<AcceleratedTable>()
-                .is_none()
-            {
+            if !accelerated_provider.is::<AcceleratedTable>() {
                 return Err(format!(
                     "Expected provider for {table_name} to be AcceleratedTable in {zone_count}-zone scenario"
                 ));

--- a/crates/vortex/src/persistent/metrics.rs
+++ b/crates/vortex/src/persistent/metrics.rs
@@ -211,7 +211,7 @@ mod tests {
             &mut self,
             plan: &dyn datafusion_physical_plan::ExecutionPlan,
         ) -> Result<bool, Self::Error> {
-            if plan.downcast_ref::<DataSourceExec>().is_some() {
+            if plan.is::<DataSourceExec>() {
                 self.0 += 1;
                 Ok(false)
             } else {


### PR DESCRIPTION
## Summary

- The `adbc-drivers/bigquery` driver at the pinned commit (`fe83ac26`) requires Go >= 1.26.1 in its `go.mod`
- The `setup-adbc-bigquery` action was using Go 1.24.1, causing the build to fail immediately
- `actions/setup-go` sets `GOTOOLCHAIN=local`, which prevents auto-downloading a newer toolchain

## Root cause

```
go: go.mod requires go >= 1.26.1 (running go 1.24.1; GOTOOLCHAIN=local)
```

Failing run: https://github.com/spiceai/spiceai/actions/runs/28650128916/job/84965897793

## Change

Bumped the default `go_version` input in `.github/actions/setup-adbc-bigquery/action.yml` from `1.24.1` to `1.26.1`.