### PR TITLE
fix(ci): bump Go version for ADBC BigQuery driver build to 1.26.1

### DIFF
--- a/.github/actions/setup-adbc-bigquery/action.yml
+++ b/.github/actions/setup-adbc-bigquery/action.yml
@@ -9,7 +9,7 @@ inputs:
   go_version:
     description: 'Go version to use for building'
     required: false
-    default: '1.24.1'
+    default: '1.26.1'
 
 runs:
   using: 'composite'


### PR DESCRIPTION
## Summary

- The `adbc-drivers/bigquery` driver at the pinned commit (`fe83ac26`) requires Go >= 1.26.1 in its `go.mod`
- The `setup-adbc-bigquery` action was using Go 1.24.1, causing the build to fail immediately
- `actions/setup-go` sets `GOTOOLCHAIN=local`, which prevents auto-downloading a newer toolchain

## Root cause

```
go: go.mod requires go >= 1.26.1 (running go 1.24.1; GOTOOLCHAIN=local)
```

Failing run: https://github.com/spiceai/spiceai/actions/runs/28650128916/job/84965897793

## Change

Bumped the default `go_version` input in `.github/actions/setup-adbc-bigquery/action.yml` from `1.24.1` to `1.26.1`.