### PR TITLE
fix(search): RRF chained FULL JOIN mis-keys docs absent from the first stream (fixes #11265)

### DIFF
--- a/crates/runtime-search/src/rrf.rs
+++ b/crates/runtime-search/src/rrf.rs
@@ -1013,9 +1013,6 @@ impl ReciprocalRankFusion {
 
     // Reduces 2 or more search subquery DFs into a single one
     fn fold_join(a: DataFrame, b: DataFrame, join_key: &str) -> Result<DataFrame> {
-        let (tbl_a, id_a) = Self::first_qualified_field(&a, join_key)?;
-        let (tbl_b, id_b) = Self::first_qualified_field(&b, join_key)?;
-
         // Drop embedding columns before the full outer join — they are non-nullable
         // in Arrow but the join produces nulls for unmatched rows, causing a schema
         // violation. They are excluded from the final projection anyway.
@@ -1037,10 +1034,43 @@ impl ReciprocalRankFusion {
         let a = drop_embedding_cols(a)?;
         let b = drop_embedding_cols(b)?;
 
+        // `a` is the accumulator of every stream fused so far and therefore holds
+        // one qualified copy of the join key per stream (`search_0.pk`,
+        // `search_1.pk`, ...). Keying the next join on only the *first* stream's
+        // copy is wrong under a FULL OUTER JOIN: that copy is NULL for any
+        // document absent from stream 0, so a document present in later streams
+        // but not stream 0 never matches and splits into one row per stream. The
+        // downstream `max(_fused_score)` aggregation then keeps a single stream's
+        // partial contribution instead of the RRF sum, roughly halving the fused
+        // score and corrupting the top-K. Coalescing across every already-joined
+        // copy of the key keeps one row per document. Needs >=3 fused streams to
+        // trigger; see issue #11265.
+        let a_keys: Vec<Expr> = a
+            .schema()
+            .qualified_fields_with_unqualified_name(join_key)
+            .into_iter()
+            .filter_map(|(maybe_tr, f)| {
+                maybe_tr.map(|tr| col_qualified!(tr.clone(), f.name().clone()))
+            })
+            .collect();
+        let a_key = match a_keys.len() {
+            0 => {
+                return Err(DataFusionError::Execution(format!(
+                    "{RRF_UDF_NAME}: Cannot resolve column {join_key} when fusing results"
+                )));
+            }
+            1 => a_keys
+                .into_iter()
+                .next()
+                .expect("a_keys has exactly one element"),
+            _ => coalesce(a_keys),
+        };
+        let (tbl_b, id_b) = Self::first_qualified_field(&b, join_key)?;
+
         a.join_on(
             b,
             JoinType::Full,
-            vec![col_qualified!(tbl_a, id_a).eq(col_qualified!(tbl_b, id_b))],
+            vec![a_key.eq(col_qualified!(tbl_b, id_b))],
         )
     }
 
@@ -1319,7 +1349,7 @@ impl TableProvider for ReciprocalRankFusion {
 
 #[cfg(test)]
 mod tests {
-    use crate::rrf::ReciprocalRankFusionArgs;
+    use crate::rrf::{ReciprocalRankFusion, ReciprocalRankFusionArgs};
     use datafusion::arrow::datatypes::DataType;
 
     use datafusion::logical_expr::Expr;
@@ -1497,6 +1527,55 @@ mod tests {
             parsed.rrf_subquery_arguments[0].rank_weight,
             Some(2.5),
             "rank_weight should be 2.5"
+        );
+    }
+
+    /// Regression test for #11265: with >=3 fused streams, keying every chained
+    /// FULL OUTER JOIN on the first stream's copy of the join key split a
+    /// document present in later streams but absent from stream 0 into one row
+    /// per stream. `fold_join` must instead key on the COALESCE of the key
+    /// across every already-joined stream so each document produces exactly one
+    /// row. Document `C` below is in streams 1 & 2 but not stream 0 — the
+    /// pre-fix code emitted 5 rows (a duplicate `C`); the fix emits 4.
+    #[tokio::test]
+    async fn fold_join_dedups_doc_absent_from_first_stream_11265() {
+        use datafusion::arrow::array::{RecordBatch, StringArray};
+        use datafusion::arrow::datatypes::{Field, Schema};
+        use datafusion::datasource::MemTable;
+        use datafusion::prelude::SessionContext;
+
+        fn table(ids: &[&str]) -> Arc<MemTable> {
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(StringArray::from(ids.to_vec()))],
+            )
+            .expect("record batch");
+            Arc::new(MemTable::try_new(schema, vec![vec![batch]]).expect("mem table"))
+        }
+
+        let ctx = SessionContext::new();
+        ctx.register_table("search_0", table(&["A", "B"]))
+            .expect("register search_0");
+        ctx.register_table("search_1", table(&["B", "C"]))
+            .expect("register search_1");
+        ctx.register_table("search_2", table(&["C", "D"]))
+            .expect("register search_2");
+
+        let s0 = ctx.table("search_0").await.expect("read search_0");
+        let s1 = ctx.table("search_1").await.expect("read search_1");
+        let s2 = ctx.table("search_2").await.expect("read search_2");
+
+        let j01 = ReciprocalRankFusion::fold_join(s0, s1, "id").expect("fold streams 0,1");
+        let j012 = ReciprocalRankFusion::fold_join(j01, s2, "id").expect("fold streams 01,2");
+
+        let batches = j012.collect().await.expect("collect fused rows");
+        let rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+
+        assert_eq!(
+            rows, 4,
+            "fold_join must produce exactly one row per document {{A,B,C,D}}; the \
+             pre-fix first-stream-keyed join split C into a second row (#11265)"
         );
     }
 }

--- a/crates/search/src/aggregation/reciprocal_rank.rs
+++ b/crates/search/src/aggregation/reciprocal_rank.rs
@@ -393,23 +393,40 @@ async fn reciprocal_rank_fusion_plan(
 
     let mut builder = LogicalPlanBuilder::from(first_plan.clone());
 
-    // 3) FULL OUTER JOIN remaining tables on primary key columns
+    // 3) FULL OUTER JOIN remaining tables on primary key columns.
+    //
+    // Each new table is keyed against the COALESCE of the primary key across
+    // *every* table already joined, not just the first stream. Keying only on
+    // the first stream's PK (which is NULL for any document absent from that
+    // stream) is wrong under a FULL OUTER JOIN: a document matched by streams 2+
+    // but not stream 1 fails the equality and lands in its own row per stream.
+    // With no aggregation afterward, the API then returns the same primary key
+    // multiple times, each row carrying only part of the RRF sum, displacing
+    // legitimate results within `limit`. Coalescing the already-joined keys
+    // keeps one row per document so the per-row RRF sum below is complete. Needs
+    // >=3 fused streams to trigger; see issue #11265.
+    let mut joined_tables: Vec<TableReference> = vec![first_table_name.clone()];
     for (table_name, plan) in ranked_plans.iter().skip(1) {
-        builder = builder.join(
-            plan.clone(),
-            JoinType::Full,
-            (
-                primary_key
+        let on_exprs: Vec<LogicalExpr> = primary_key
+            .iter()
+            .map(|pk| {
+                let left_keys: Vec<LogicalExpr> = joined_tables
                     .iter()
-                    .map(|pk| pk.clone().with_relation(first_table_name.clone()))
-                    .collect(),
-                primary_key
-                    .iter()
-                    .map(|pk| pk.clone().with_relation(table_name.clone()))
-                    .collect(),
-            ),
-            None,
-        )?;
+                    .map(|t| col(pk.clone().with_relation(t.clone())))
+                    .collect();
+                let left = if left_keys.len() == 1 {
+                    left_keys
+                        .into_iter()
+                        .next()
+                        .expect("left_keys has exactly one element")
+                } else {
+                    coalesce(left_keys)
+                };
+                left.eq(col(pk.clone().with_relation(table_name.clone())))
+            })
+            .collect();
+        builder = builder.join_on(plan.clone(), JoinType::Full, on_exprs)?;
+        joined_tables.push(table_name.clone());
     }
 
     // 4) Build the RRF score: SUM(COALESCE(1.0/(rank + k), 0)) across all tables
@@ -663,6 +680,109 @@ mod tests {
         assert!(
             result.is_ok(),
             "Utf8 and LargeUtf8 should be considered semantically equivalent"
+        );
+    }
+
+    /// Regression test for #11265: with >=3 fused streams, the chained FULL OUTER
+    /// JOIN keyed every table against the *first* stream's primary key. That key
+    /// is NULL for any document absent from stream 1, so a document matched by
+    /// streams 2+ but not stream 1 failed the equality and split into one row per
+    /// stream — each carrying only part of the RRF sum, and with no aggregation
+    /// afterward the API returned the same primary key more than once. The fix
+    /// keys each join on the COALESCE of the key across every already-joined
+    /// stream, so each document produces exactly one row carrying the full RRF
+    /// sum. Document `C` is present in streams 2 & 3 but absent from stream 1.
+    #[tokio::test]
+    async fn rrf_plan_dedups_doc_absent_from_first_stream_11265() {
+        use arrow::array::{Float64Array, RecordBatch, StringArray};
+
+        // A ranked-input table with (id, _score, _value) rows. `_value` mirrors
+        // `id` here; only its presence matters (the plan projects one per stream).
+        fn make_table(rows: &[(&str, f64)]) -> Arc<MemTable> {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Utf8, false),
+                Field::new(SEARCH_SCORE_COLUMN_NAME, DataType::Float64, false),
+                Field::new(SEARCH_VALUE_COLUMN_NAME, DataType::Utf8, false),
+            ]));
+            let ids = StringArray::from(rows.iter().map(|(id, _)| *id).collect::<Vec<_>>());
+            let scores = Float64Array::from(rows.iter().map(|(_, s)| *s).collect::<Vec<_>>());
+            let values = StringArray::from(rows.iter().map(|(id, _)| *id).collect::<Vec<_>>());
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(ids), Arc::new(scores), Arc::new(values)],
+            )
+            .expect("record batch");
+            Arc::new(MemTable::try_new(schema, vec![vec![batch]]).expect("mem table"))
+        }
+
+        let ctx = SessionContext::new();
+        // Stream 1: A,B ; Stream 2: B,C ; Stream 3: C,D. Higher `_score` ranks
+        // first. `C` is in streams 2 & 3 but NOT stream 1 (the #11265 case).
+        ctx.register_table("t0", make_table(&[("A", 0.9), ("B", 0.8)]))
+            .expect("register t0");
+        ctx.register_table("t1", make_table(&[("B", 0.9), ("C", 0.7)]))
+            .expect("register t1");
+        ctx.register_table("t2", make_table(&[("C", 0.95), ("D", 0.6)]))
+            .expect("register t2");
+
+        let tables = vec![
+            TableReference::bare("t0"),
+            TableReference::bare("t1"),
+            TableReference::bare("t2"),
+        ];
+        let primary_key = vec![Column::from_name("id")];
+        let k = DEFAULT_RRF_K;
+
+        let plan = reciprocal_rank_fusion_plan(&ctx, &tables, &primary_key, &[], k, 100)
+            .await
+            .expect("build RRF plan");
+        let batches = ctx
+            .execute_logical_plan(plan)
+            .await
+            .expect("execute plan")
+            .collect()
+            .await
+            .expect("collect");
+
+        // Map each output document id to its fused score, asserting no id repeats.
+        let mut scores: HashMap<String, f64> = HashMap::new();
+        let mut total_rows = 0usize;
+        for batch in &batches {
+            let ids = batch
+                .column_by_name("id")
+                .expect("id column present")
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("id column is Utf8");
+            let sc = batch
+                .column_by_name(SEARCH_SCORE_COLUMN_NAME)
+                .expect("score column present")
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("score column is Float64");
+            for i in 0..batch.num_rows() {
+                total_rows += 1;
+                let prev = scores.insert(ids.value(i).to_string(), sc.value(i));
+                assert!(
+                    prev.is_none(),
+                    "document {} appeared more than once — the chained RRF join \
+                     failed to dedup (#11265)",
+                    ids.value(i)
+                );
+            }
+        }
+
+        // Exactly one row per distinct document; the pre-fix join emitted a
+        // second row for C (present in streams 2 & 3 but not stream 1).
+        assert_eq!(total_rows, 4, "expected exactly one row per document");
+
+        // C's fused score is the full RRF sum of both stream contributions
+        // (rank 2 in stream 2 + rank 1 in stream 3), not a single split fragment.
+        let expected_c = 1.0 / (2.0 + k) + 1.0 / (1.0 + k);
+        let actual_c = *scores.get("C").expect("C present in fused output");
+        assert!(
+            (actual_c - expected_c).abs() < 1e-9,
+            "C fused score {actual_c} != expected RRF sum {expected_c}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Reciprocal Rank Fusion (RRF) chained a FULL OUTER JOIN across candidate streams but keyed **every** join on the **first stream's** copy of the primary key. Under a FULL OUTER JOIN that key is NULL for any document absent from stream 1, so a document matched by streams 2+ but not stream 1 failed the equality (`NULL != key`) and split into **one row per stream**, each carrying only part of the RRF sum. The bug needs **≥3 fused streams** to trigger (with exactly 2 the chained join degenerates correctly).

Two sites shared the flaw:

- **`crates/search/src/aggregation/reciprocal_rank.rs`** (the multi-column `/v1/search` plan): each subsequent table FULL-joined against `first_table_name`'s PK. There is **no aggregation afterward**, so the API returned the same primary key more than once, each row understating the score — displacing legitimate results within `limit`.
- **`crates/runtime-search/src/rrf.rs`** (the `rrf()` UDTF): `fold_join` resolved the join key via `first_qualified_field`, which always returns `search_0`'s column, so a document in q1∩q2 but not q0 split into two rows. The later `aggregate(join_key, max(_fused_score))` re-merged them but took `max` of the two partial contributions instead of their sum — roughly half the correct fused score, wrong final top-K.

## Root cause

Keying a chained FULL OUTER JOIN on a single stream's key is only correct when that stream is a superset of all others. RRF streams are independent candidate sets, so the "anchor" key is NULL for any document that stream missed.

## Changes

Both sites now key each join on the **COALESCE of the primary key across every already-joined stream**, so the folded key is non-NULL whenever the document appeared in *any* prior stream. Each document therefore produces exactly one row, and the per-row RRF sum (already computed downstream) is complete. This is the "join on COALESCE-folded keys" fix suggested in the issue; it needs no post-join aggregation change (site 1) and makes the existing `max` aggregation a no-op over single-row groups (site 2).

## Test plan
- [x] Added regression test `rrf_plan_dedups_doc_absent_from_first_stream_11265` (site 1): 3 streams where document C is in streams 2 & 3 but not stream 1; asserts exactly one row per document (pre-fix emitted a duplicate C row) and that C's fused score equals the full RRF sum `1/(2+k) + 1/(1+k)`, not a split fragment.
- [x] Added regression test `fold_join_dedups_doc_absent_from_first_stream_11265` (site 2): folds 3 streams and asserts `fold_join` produces exactly 4 rows for documents {A,B,C,D} (pre-fix emitted 5, duplicating C).
- [x] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy)
- [x] `make test` passes

Fixes #11265