### PR TITLE
Rename mongo `num_docs_to_infer_schema` (deprecated) -> `schema_infer_max_records`

### DIFF
--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -124,7 +124,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("schema_infer_max_records")
         .description("Number of documents to use to infer the schema. Defaults to 400."),
     ParameterSpec::component("num_docs_to_infer_schema")
-        .description("Deprecated: use 'schema_infer_max_records' instead. Number of documents to use to infer the schema. Defaults to 400."),
+        .description("Number of documents to use to infer the schema. Defaults to 400.")
+        .deprecated("Use 'schema_infer_max_records' instead."),
     ParameterSpec::component("pool_min")
         .description("The minimum number of connections to keep open in the pool, lazily created when requested.")
         .default(DEFAULT_CONNECTION_POOL_MIN_STR),

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -121,8 +121,10 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("Time zone to use for interpreting and returning timestamp values (e.g., 'UTC', 'America/Los_Angeles')."),
     ParameterSpec::component("unnest_depth")
         .description("Maximum nesting depth for unnesting embedded documents into a flattened structure. Higher values expand deeper nested fields."),
-    ParameterSpec::component("num_docs_to_infer_schema")
+    ParameterSpec::component("schema_infer_max_records")
         .description("Number of documents to use to infer the schema. Defaults to 400."),
+    ParameterSpec::component("num_docs_to_infer_schema")
+        .description("Deprecated: use 'schema_infer_max_records' instead. Number of documents to use to infer the schema. Defaults to 400."),
     ParameterSpec::component("pool_min")
         .description("The minimum number of connections to keep open in the pool, lazily created when requested.")
         .default(DEFAULT_CONNECTION_POOL_MIN_STR),
@@ -261,6 +263,30 @@ impl DataConnectorFactory for MongoDBFactory {
                 params
                     .parameters
                     .insert("pool_max".to_string(), pool_max.to_string().into());
+            }
+
+            // `schema_infer_max_records` is the preferred, cross-connector name and is
+            // the key the connection pool reads. `num_docs_to_infer_schema` is deprecated:
+            // when it's set (and the new name isn't), map it onto the new key so existing
+            // configs keep working. `schema_infer_max_records` always takes precedence.
+            let has_schema_infer_max_records = params
+                .parameters
+                .get("schema_infer_max_records")
+                .ok()
+                .is_some();
+            let legacy_num_docs = params
+                .parameters
+                .get("num_docs_to_infer_schema")
+                .ok()
+                .map(|s| s.expose_secret().to_string());
+            if !has_schema_infer_max_records && let Some(value) = legacy_num_docs {
+                tracing::warn!(
+                    "The 'num_docs_to_infer_schema' parameter is deprecated for the {component}; use 'schema_infer_max_records' instead.",
+                    component = params.component
+                );
+                params
+                    .parameters
+                    .insert("schema_infer_max_records".to_string(), value.into());
             }
 
             let pool = match MongoDBConnectionPool::new(params.parameters.to_secret_map()).await {

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -281,10 +281,6 @@ impl DataConnectorFactory for MongoDBFactory {
                 .ok()
                 .map(|s| s.expose_secret().to_string());
             if !has_schema_infer_max_records && let Some(value) = legacy_num_docs {
-                tracing::warn!(
-                    "The 'num_docs_to_infer_schema' parameter is deprecated for the {component}; use 'schema_infer_max_records' instead.",
-                    component = params.component
-                );
                 params
                     .parameters
                     .insert("schema_infer_max_records".to_string(), value.into());

--- a/tools/spicepodschema/tests/spicepod.all.yaml
+++ b/tools/spicepodschema/tests/spicepod.all.yaml
@@ -806,7 +806,7 @@ datasets:
       mongodb_direct_connection: 'false'
       mongodb_time_zone: UTC
       mongodb_unnest_depth: '3'
-      mongodb_num_docs_to_infer_schema: '100'
+      mongodb_schema_infer_max_records: '100'
       mongodb_pool_min: '1'
       mongodb_pool_max: '10'
 


### PR DESCRIPTION
## 📝 Summary

Closes https://github.com/spiceai/spiceai/issues/6999

Adds `schema_infer_max_records` as the MongoDB connector's schema-inference document-count parameter and deprecates `num_docs_to_infer_schema`, aligning the name with the other connectors (e.g. DynamoDB).

- **`schema_infer_max_records`** (new) is the key the connection pool actually reads.
- **`num_docs_to_infer_schema`** is now deprecated: when it's set (and the new name isn't), its value is mapped onto `schema_infer_max_records` so existing configs keep working, with a deprecation warning. `schema_infer_max_records` takes precedence when both are provided.

This also closes a latent gap: the pinned `datafusion-table-providers` rev reads **only** `schema_infer_max_records`, so `num_docs_to_infer_schema` was being silently ignored (advertised by the connector but dropped by the pool). The backfill restores its behavior while steering users to the new name.
