### PR TITLE
fix: cluster filtered COUNT(*) on append-only tables returns unfiltered total (fixes #11599)

### DIFF
--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -485,8 +485,28 @@ impl FlightSQLTable {
         let exec = exec.with_token(self.token.clone());
         // Project the table-level statistics onto the scan's (projected) output
         // schema so the column-statistics list lines up with the output columns.
+        //
+        // When filters are pushed down to the remote scan, the stamped statistics
+        // still describe the *unfiltered* slice the executor reported (they are the
+        // whole-table row count / column bounds, not the filtered subset). Every
+        // pushdown-eligible filter is reported `Exact` (see
+        // `supports_filters_pushdown`), so DataFusion drops the coordinator-side
+        // `FilterExec` — and if the stamped `num_rows`/bounds stay `Exact`, the
+        // `aggregate_statistics` optimizer rule folds `COUNT(*)`/`MIN`/`MAX` to
+        // those unfiltered values, silently ignoring the predicate (e.g. a filtered
+        // `COUNT(*)` returns the full table count — issue #11599). Marking the
+        // statistics inexact when any filter is applied disables that fold while
+        // keeping the bounds usable for join sizing.
         let exec = match &self.statistics {
-            Some(stats) => exec.with_statistics(stats.clone().project(projections)),
+            Some(stats) => {
+                let stats = stats.clone().project(projections);
+                let stats = if filters.is_empty() {
+                    stats
+                } else {
+                    stats.to_inexact()
+                };
+                exec.with_statistics(stats)
+            }
             None => exec,
         };
         Ok(Arc::new(exec))
@@ -1327,6 +1347,94 @@ mod tests {
 
     fn has_metric(metrics: &datafusion::physical_plan::metrics::MetricsSet, name: &str) -> bool {
         metrics.sum_by_name(name).is_some()
+    }
+
+    /// A `FlightSqlClient` connected lazily to a non-routable address: enough to
+    /// build a `FlightSQLTable`/scan plan without ever attempting a connection.
+    fn lazy_client() -> FlightSqlClient {
+        use arrow_flight::flight_service_client::FlightServiceClient;
+        use arrow_flight::sql::client::FlightSqlServiceClient;
+        use tonic::transport::Endpoint;
+
+        let channel = Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
+        let cookie_channel = CookieService::new(channel, Arc::new(CookieStore::new()));
+        FlightSqlServiceClient::new_from_inner(FlightServiceClient::new(cookie_channel))
+    }
+
+    /// Regression test for #11599: a cluster leaf scan carries the executor's
+    /// *unfiltered* row-count/bounds as stamped statistics. Because pushed-down
+    /// filters are reported `Exact` (dropping the `FilterExec`), leaving those
+    /// statistics `Exact` lets `aggregate_statistics` fold a filtered `COUNT(*)`
+    /// to the unfiltered total. The scan must therefore mark its statistics
+    /// inexact whenever a filter is pushed to it, while leaving them exact for an
+    /// unfiltered scan.
+    #[tokio::test]
+    async fn scan_marks_stamped_statistics_inexact_when_filter_pushed() {
+        use datafusion::catalog::TableProvider;
+        use datafusion::common::stats::Precision;
+        use datafusion::common::{ColumnStatistics, ScalarValue, Statistics};
+        use datafusion::physical_plan::ExecutionPlan;
+        use datafusion::prelude::{SessionContext, col, lit};
+
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
+        let stats = Statistics {
+            num_rows: Precision::Exact(150_000),
+            total_byte_size: Precision::Exact(1_200_000),
+            column_statistics: vec![ColumnStatistics {
+                null_count: Precision::Exact(0),
+                max_value: Precision::Exact(ScalarValue::Int64(Some(149_999))),
+                min_value: Precision::Exact(ScalarValue::Int64(Some(0))),
+                sum_value: Precision::Absent,
+                distinct_count: Precision::Absent,
+                byte_size: Precision::Exact(1_200_000),
+            }],
+        };
+
+        let table = FlightSQLTable::create_with_schema(
+            "flightsql",
+            "executor-1",
+            lazy_client(),
+            TableReference::bare("customer"),
+            Arc::clone(&schema),
+            Arc::new(CookieStore::new()),
+        )
+        .with_statistics(Some(stats));
+
+        let session = SessionContext::new().state();
+
+        // No filter → stamped statistics stay exact (folding a bare COUNT(*) is correct).
+        let plan = table
+            .scan(&session, None, &[], None)
+            .await
+            .expect("unfiltered scan should build");
+        let unfiltered = plan
+            .partition_statistics(None)
+            .expect("statistics should be available");
+        assert_eq!(
+            unfiltered.num_rows,
+            Precision::Exact(150_000),
+            "unfiltered scan must keep exact num_rows"
+        );
+
+        // With a pushed-down filter → statistics must be inexact so the
+        // aggregate-statistics rule cannot fold the (now filtered) COUNT(*).
+        let filter = col("v").eq(lit(0_i64));
+        let plan = table
+            .scan(&session, None, std::slice::from_ref(&filter), None)
+            .await
+            .expect("filtered scan should build");
+        let filtered = plan
+            .partition_statistics(None)
+            .expect("statistics should be available");
+        assert_eq!(
+            filtered.num_rows,
+            Precision::Inexact(150_000),
+            "filtered scan must degrade num_rows to inexact (issue #11599)"
+        );
+        assert!(
+            matches!(filtered.column_statistics[0].max_value, Precision::Inexact(_)),
+            "filtered scan must degrade column bounds to inexact so MIN/MAX are not folded"
+        );
     }
 
     fn build_exec(client: FlightSqlClient, cookie_store: Arc<CookieStore>) -> FlightSqlExec {

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -1370,10 +1370,10 @@ mod tests {
     /// unfiltered scan.
     #[tokio::test]
     async fn scan_marks_stamped_statistics_inexact_when_filter_pushed() {
+        use super::FlightSQLTable;
         use datafusion::catalog::TableProvider;
         use datafusion::common::stats::Precision;
         use datafusion::common::{ColumnStatistics, ScalarValue, Statistics};
-        use datafusion::physical_plan::ExecutionPlan;
         use datafusion::prelude::{SessionContext, col, lit};
 
         let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
@@ -1432,7 +1432,10 @@ mod tests {
             "filtered scan must degrade num_rows to inexact (issue #11599)"
         );
         assert!(
-            matches!(filtered.column_statistics[0].max_value, Precision::Inexact(_)),
+            matches!(
+                filtered.column_statistics[0].max_value,
+                Precision::Inexact(_)
+            ),
             "filtered scan must degrade column bounds to inexact so MIN/MAX are not folded"
         );
     }


### PR DESCRIPTION
## Summary

On a cluster (distributed) deployment, `SELECT COUNT(*) ... WHERE <row-level predicate>` against an append-only Cayenne catalog table returned the **unfiltered** total row count — the planner folded the aggregate to a constant from table statistics while the pushed-down filter was silently dropped. No error, no warning.

Fixes #11599

## Root cause

The coordinator represents every cluster table as per-executor **FlightSQL leaf scans** (`FlightSQLTable`), which stamp the executor-reported, *unfiltered* `num_rows`/column bounds onto each scan. Two things then combine in `crates/data_components/src/flightsql.rs`:

1. `FlightSQLTable::supports_filters_pushdown` returns `Exact` for any SQL-convertible filter (the predicate is shipped to and applied by the remote executor), so DataFusion drops the coordinator-side `FilterExec`.
2. `create_physical_plan` stamped the statistics **unconditionally**, so the scan reported the unfiltered `num_rows` as `Exact` even with a filter present.

With an exact row count on a scan whose filter was "exactly pushed down", DataFusion's `aggregate_statistics` rule folds `COUNT(*)` (and `MIN`/`MAX`) to the unfiltered value — the observed `ProjectionExec: expr=[150000 as count(*)]`. This single leaf is common to both mechanisms named in the issue, so fixing it here covers filtered `COUNT(*)` **and** the filtered `MIN`/`MAX` folds.

## Changes

- `FlightSQLTable::create_physical_plan`: mark the stamped statistics inexact (`Statistics::to_inexact()`) whenever `filters` is non-empty. This disables the constant-fold (the aggregate then executes over the actually-filtered remote stream) while the bounds remain `Inexact` and still usable for join sizing. Unfiltered scans keep exact statistics, preserving the fast bare-`COUNT(*)` fold.

Chosen over degrading the wrapper's pushdown claim because it's provider-agnostic and a single edit at the shared leaf.

## Test plan

- `make lint`
- `make test`
- New regression test `scan_marks_stamped_statistics_inexact_when_filter_pushed` (in `flightsql.rs`): stamps exact stats on a `FlightSQLTable`, asserts `num_rows`/column bounds stay `Exact` for an unfiltered scan and degrade to `Inexact` once a filter is pushed — fails on old code, passes on new.

## Performance impact

None on the fast path: unfiltered scans keep exact statistics, so bare `COUNT(*)` still folds. Only filtered scans lose the (incorrect) fold and instead execute the aggregate over the remote stream, which is the correct behavior.

## Checklist

- [x] Root cause identified and fixed at the shared leaf
- [x] Regression test added (fails on old code, passes on new)
- [x] Crate-scoped `cargo test`/`clippy`/`fmt` green
- [ ] Full `make lint` + `make test` green in CI