### PR TITLE
ci(chbench): drop postgres-arrow and tuned (non-memory) from scheduled HTAP runs

### DIFF
--- a/.github/workflows/testoperator_dispatch_htap.yml
+++ b/.github/workflows/testoperator_dispatch_htap.yml
@@ -6,8 +6,8 @@ on:
     # configs (cdc-tuned-memory + adaptive) for frequent tuned-vs-adaptive trend data
     # (spiceai-dev-xlarge-runners).
     - cron: '0 */3 * * *'
-    # htap-sf1000 (other configs), once daily (0100) — the remaining SF1000 configs (cdc-tuned,
-    # cdc-tuned-turso, cdc-tuned-memory-ivm, adaptive-turso, duckdb baseline) on the xlarge pool.
+    # htap-sf1000 (other configs), once daily (0100) — the remaining SF1000 configs
+    # (cdc-tuned-turso, cdc-tuned-memory-ivm, adaptive-turso, duckdb baseline) on the xlarge pool.
     - cron: '0 1 * * *'
     # htap-sf1, twice daily (0600, 1800) — HTAP CH-benCHmark SF1 (spiceai-dev-large-runners)
     - cron: '0 6,18 * * *'

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-arrow.yaml
@@ -1,8 +1,0 @@
-tests:
-  htap:
-    spicepod_path: accelerated/postgres-arrow.yaml
-    runner_type: spiceai-dev-large-runners
-    scale_factor: 1
-    duration: 600
-    ready_wait: 60
-    rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,8 +1,0 @@
-tests:
-  htap:
-    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-sf1.yaml
-    runner_type: spiceai-dev-large-runners
-    scale_factor: 1
-    duration: 600
-    ready_wait: 60
-    rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-cdc-tuned.yaml
@@ -1,9 +1,0 @@
-tests:
-  htap:
-    spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
-    runner_type: spiceai-dev-xlarge-runners
-    scale_factor: 1000
-    terminals: 100
-    duration: 600
-    ready_wait: 900
-    rate: 10000


### PR DESCRIPTION
## Summary

Slims the scheduled CH-benCHmark/HTAP batches down to the configs we act on:

- **Remove `postgres-arrow`** from the twice-daily SF1 batch (the only scheduled batch that ran it).
- **Remove `postgres-cayenne[file]-cdc-tuned`** (tuned, file durability / non-memory) from the SF1 and daily SF1000 batches. For file mode we rely on the non-tuned `postgres-cayenne[file]` baseline; tuned coverage continues via the `cdc-tuned-memory*` variants.
- Update the daily-SF1000 cron comment in `testoperator_dispatch_htap.yml` to match. No cron/job logic changes — the dispatcher runs whatever is in each directory.

## Scheduled coverage after this change

| Batch | Configs |
|---|---|
| SF1 (06:00, 18:00) | non-tuned file, adaptive, duckdb |
| SF1000 daily (01:00) | cdc-tuned-turso, cdc-tuned-memory-ivm, adaptive-turso, duckdb |
| SF1000 3-hourly | adaptive, cdc-tuned-memory |
| SF1000-cold daily (08:00) | cdc-tuned-memory-cold |

## Notes

- `cdc-tuned-turso` stays in the daily SF1000 batch: it covers the Turso metastore axis, not the tuned-file datapoint.
- Manual-dispatch-only dirs (`sf10`, `sf100`) and the spicepods under `test/spicepods/chbench/` are untouched — the tuned-memory/-ivm/-turso pods document themselves as diffs against the base tuned pod, and manual dispatch of the removed configs remains possible there.