### PR TITLE
fix(postgres): shared replication slot drops WAL for partitioned tables (fixes #11290)

### DIFF
--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -404,6 +404,12 @@ async fn ensure_publication(
         .get(0);
 
     if exists {
+        // Repair publications created by an older Spice build (or a DBA)
+        // without `publish_via_partition_root`. Without it, pgoutput attributes
+        // a partitioned table's changes to each leaf partition, which the
+        // shared router — keyed by the parent's name — silently drops (#11290).
+        ensure_publish_via_partition_root(client, publication_name).await?;
+
         // Verify the publication includes our table; if not, add it.
         let has_table: bool = client
             .query_one(
@@ -430,7 +436,13 @@ async fn ensure_publication(
     }
 
     let stmt = format!(
-        "CREATE PUBLICATION {pub} FOR TABLE {schema}.{table}",
+        // `publish_via_partition_root = true` makes pgoutput report a
+        // partitioned table's changes under the parent relation (matching the
+        // shared router's parent-keyed members and the parent-table initial
+        // snapshot) instead of each leaf partition. No effect on regular
+        // tables. See #11290.
+        "CREATE PUBLICATION {pub} FOR TABLE {schema}.{table} \
+         WITH (publish_via_partition_root = true)",
         pub = quote_ident(publication_name),
         schema = quote_ident(schema_name),
         table = quote_ident(table_name),
@@ -451,6 +463,58 @@ async fn ensure_publication(
         ignore_duplicate_object(client.simple_query(&add).await)?;
     }
     Ok(true)
+}
+
+/// Ensure an existing publication publishes partitioned-table changes under the
+/// root (parent) relation. `CREATE PUBLICATION` sets this for publications we
+/// create; this repairs a publication created without it by an older Spice
+/// build or a DBA. It is a no-op once the option is set, and harmless for
+/// publications carrying only regular tables.
+///
+/// The `ALTER` requires ownership of the publication. When Spice does not own a
+/// pre-created publication the alter is skipped with a warning rather than
+/// failing setup: leaving `publish_via_partition_root` off is only a problem
+/// for partitioned source tables, so a non-owner with regular tables keeps
+/// working exactly as before.
+async fn ensure_publish_via_partition_root(
+    client: &tokio_postgres::Client,
+    publication_name: &str,
+) -> Result<()> {
+    let via_root: bool = client
+        .query_one(
+            "SELECT pubviaroot FROM pg_publication WHERE pubname = $1",
+            &[&publication_name],
+        )
+        .await
+        .context(SetupExecSnafu)?
+        .get(0);
+    if via_root {
+        return Ok(());
+    }
+
+    let stmt = format!(
+        "ALTER PUBLICATION {pub} SET (publish_via_partition_root = true)",
+        pub = quote_ident(publication_name),
+    );
+    match client.simple_query(&stmt).await {
+        Ok(_) => Ok(()),
+        // 42501 insufficient_privilege: a publication Spice does not own.
+        // Don't fail setup — only partitioned sources need the option.
+        Err(e)
+            if e.as_db_error()
+                .is_some_and(|db| db.code().code() == "42501") =>
+        {
+            tracing::warn!(
+                publication = %publication_name,
+                "Cannot set publish_via_partition_root on a publication Spice \
+                 does not own; changes to partitioned source tables may be \
+                 dropped. Recreate the publication with \
+                 WITH (publish_via_partition_root = true) or grant ownership."
+            );
+            Ok(())
+        }
+        Err(e) => Err(e).context(SetupExecSnafu),
+    }
 }
 
 /// Best-effort removal of a table from a (shared) publication. Used when a

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -689,3 +689,88 @@ async fn shared_slot_multiplexes_multiple_datasets() -> Result<(), anyhow::Error
         .await?;
     Ok(())
 }
+
+/// Regression for #11290: a partitioned source table on a shared slot. Without
+/// `publish_via_partition_root` on the publication, pgoutput attributes changes
+/// to each *leaf* partition, whose relation name has no registered member — so
+/// the shared router drops every post-snapshot change (and `credit_idle`
+/// advances the ack floor past them). The dataset boots with a correct snapshot
+/// and then silently never updates. The publication must therefore be created
+/// with the option so changes are reported under the parent relation the
+/// dataset subscribes to; the inserts/updates/deletes below all route through
+/// leaf partitions and must still reach the stream.
+#[tokio::test(flavor = "multi_thread")]
+async fn shared_slot_partitioned_source_table_streams_changes() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port = u16::try_from(port).expect("port fits in u16");
+    let source = pg_client(port).await?;
+
+    // Range-partitioned parent with two leaf partitions. The partition key is
+    // part of the primary key (required by Postgres for a partitioned PK),
+    // which also gives every leaf a replica identity for UPDATE/DELETE.
+    source
+        .simple_query(
+            "CREATE TABLE public.shared_repl_part (id int, name text, PRIMARY KEY (id)) \
+                 PARTITION BY RANGE (id); \
+             CREATE TABLE public.shared_repl_part_lo \
+                 PARTITION OF public.shared_repl_part FOR VALUES FROM (0) TO (100); \
+             CREATE TABLE public.shared_repl_part_hi \
+                 PARTITION OF public.shared_repl_part FOR VALUES FROM (100) TO (1000); \
+             INSERT INTO public.shared_repl_part VALUES (1, 'lo1'), (150, 'hi1');",
+        )
+        .await?;
+
+    // Snapshot of the parent covers rows across all partitions.
+    let mut stream = start_replication_stream(input_for(port, "shared_repl_part"));
+    let boot = next_envelope(&mut stream, "bootstrap partitioned").await?;
+    assert_eq!(
+        boot.change_batch.record.num_rows(),
+        2,
+        "bootstrap covers rows from both partitions"
+    );
+    assert!(boot.is_dataset_ready(), "bootstrap must mark ready");
+    boot.commit().await?;
+
+    // With publish_via_partition_root the publication lists the parent, not the
+    // leaves — which is also what keeps `has_table` true across restarts.
+    assert_eq!(
+        publication_tables(&source).await?,
+        HashSet::from(["shared_repl_part".to_string()]),
+        "publication lists the partitioned parent, not its leaves"
+    );
+    assert_eq!(slot_count(&source).await?, 1, "exactly one slot");
+
+    // The core regression: post-snapshot WAL changes must route to the dataset
+    // even though Postgres applies them via leaf partitions — one row per
+    // partition, covering insert/update/delete.
+    source
+        .simple_query("INSERT INTO public.shared_repl_part VALUES (50, 'lo50')")
+        .await?;
+    expect_single_change(&mut stream, "insert into low partition", "c", 50).await?;
+
+    source
+        .simple_query("INSERT INTO public.shared_repl_part VALUES (200, 'hi200')")
+        .await?;
+    expect_single_change(&mut stream, "insert into high partition", "c", 200).await?;
+
+    source
+        .simple_query("UPDATE public.shared_repl_part SET name = 'lo50x' WHERE id = 50")
+        .await?;
+    expect_single_change(&mut stream, "update in low partition", "u", 50).await?;
+
+    source
+        .simple_query("DELETE FROM public.shared_repl_part WHERE id = 200")
+        .await?;
+    expect_single_change(&mut stream, "delete in high partition", "d", 200).await?;
+
+    // --- Cleanup ---
+    drop(stream);
+    drop_replication_slot_when_inactive(&source, SLOT).await?;
+    source
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {PUBLICATION}"))
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary (root cause)

The shared-slot publication was created without `publish_via_partition_root = true` (`crates/data_components/src/postgres_replication/slot.rs`). For a partitioned source table, pgoutput therefore emits changes under each **leaf partition's** `(schema, name)`, while the shared router's `MemberKey` is the **parent** table's name. In `handle_decoded`, `source.member(&member_key)` finds no member for the leaf relation, the changes are dropped at DEBUG level, and `credit_idle` advances the ack floor past them. The initial snapshot (a `SELECT` on the parent) is correct, so the dataset boots with correct data and then silently never updates.

Masking bonus (also fixed): `pg_publication_tables` listed leaves rather than the parent, so `has_table` was false on every restart → a fresh snapshot each boot hid the staleness between restarts. With `publish_via_partition_root` the catalog lists the parent, so `has_table` is correct.

Fixes #11290

## Changes

- `CREATE PUBLICATION ... WITH (publish_via_partition_root = true)` when creating the shared publication. No effect on regular (non-partitioned) tables.
- New `ensure_publish_via_partition_root` helper repairs a publication created without the option by an older Spice build or a DBA (`ALTER PUBLICATION ... SET (...)`). It is a no-op once set; when Spice does not own a pre-created publication the `ALTER` (SQLSTATE 42501) is downgraded to a warning rather than failing setup, since the option only matters for partitioned sources.
- Regression test `shared_slot_partitioned_source_table_streams_changes` in `crates/runtime/tests/postgres/replication_shared.rs`: a range-partitioned parent with two leaf partitions asserts the snapshot covers both partitions, the publication lists the parent, and post-snapshot insert/update/delete (each routed through a leaf partition by Postgres) reach the stream. Fails on old code (changes dropped → timeout), passes on new.

## Test plan

- `make lint`
- `make test`

## Checklist

- [x] Root cause identified and fixed at the publication-creation site (single site; covers both shared and per-dataset paths)
- [x] Existing publications repaired in place (upgrade path), tolerant of non-owned publications
- [x] Regression test added that fails on old code and passes on new
- [x] `cargo check -p data_components` and `cargo check -p runtime --test integration --features postgres,postgres-accel` pass; `cargo clippy -p data_components --no-deps` clean; `cargo fmt` applied