### PR TITLE
ci(chbench): lower tuned SF1000 mem-tier max age to 15s for scheduled HTAP runs

### DIFF
--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-cold-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-cold-sf1000.yaml
@@ -99,7 +99,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '1073741824' # 1 GiB
         cayenne_cdc_mem_tier_min_flush_bytes: '268435456'
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
         cayenne_cdc_mem_tier_shards: '4'
@@ -275,7 +275,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
@@ -325,7 +325,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-ivm-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-ivm-sf1000.yaml
@@ -66,7 +66,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '1073741824' # 1 GiB
         cayenne_cdc_mem_tier_min_flush_bytes: '268435456'
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
         cayenne_cdc_mem_tier_shards: '4'
@@ -253,7 +253,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
@@ -303,7 +303,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
@@ -66,7 +66,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '1073741824' # 1 GiB
         cayenne_cdc_mem_tier_min_flush_bytes: '268435456'
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
         cayenne_cdc_mem_tier_shards: '4'
@@ -222,7 +222,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
@@ -272,7 +272,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '30000'
+        cayenne_cdc_mem_tier_max_age_ms: '15000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'


### PR DESCRIPTION
## What

Lowers `cayenne_cdc_mem_tier_max_age_ms` from `30000` (30s) to `15000` (15s) in the three tuned SF1000 CH-benCHmark spicepods that feed the scheduled HTAP dispatches:

- `postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml`
- `postgres-cayenne[file]-cdc-tuned-memory-ivm-sf1000.yaml`
- `postgres-cayenne[file]-cdc-tuned-memory-cold-sf1000.yaml`

Each has 3 accel blocks updated (9 lines total).

## Scope / not changed

- **SF100** tuned config left as-is (out of scope).
- Other `30000` params in these files (`cayenne_compaction_trigger_snapshot_age_ms`, `cayenne_cold_tier_background_interval_ms`) are unrelated settings and unchanged.

These configs map to the scheduled dispatches in `testoperator_dispatch_htap.yml`: `sf1000-tuned-adaptive` (every 3h) and the daily `sf1000` / `sf1000-cold` groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)