### PR TITLE
perf(egress): stream /v1/sql JSON + pool-account query-result egress memory

### DIFF
--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1940,20 +1940,32 @@ fn write_to_json_value_with_arrow(
 fn write_to_json_bytes_with_arrow(
     data: &[RecordBatch],
 ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    let buf = Vec::new();
-    let mut writer = arrow_json::WriterBuilder::new()
-        .with_explicit_nulls(true)
-        .build::<_, JsonArray>(buf);
-
+    let mut writer = json_array_writer();
     writer.write_batches(data.iter().collect::<Vec<&RecordBatch>>().as_slice())?;
     writer.finish()?;
 
     Ok(writer.into_inner())
 }
 
+/// Creates a JSON-array writer over an owned buffer, using the same encoding as
+/// buffered responses. The buffer can be drained incrementally via
+/// `writer.get_mut()` to stream the array batch-by-batch (see the HTTP `/v1/sql`
+/// streaming path).
+pub(crate) fn json_array_writer() -> arrow_json::Writer<Vec<u8>, JsonArray> {
+    arrow_json::WriterBuilder::new()
+        .with_explicit_nulls(true)
+        .build::<Vec<u8>, JsonArray>(Vec::new())
+}
+
 fn record_batch_has_union_columns(batch: &RecordBatch) -> bool {
-    batch
-        .schema()
+    schema_has_union_columns(&batch.schema())
+}
+
+/// Returns `true` when any (possibly nested) field in `schema` is a union type.
+/// Union columns aren't rendered by the arrow-json array writer, so responses
+/// containing them fall back to the buffered JSON path.
+pub(crate) fn schema_has_union_columns(schema: &arrow::datatypes::Schema) -> bool {
+    schema
         .fields()
         .iter()
         .any(|field| data_type_contains_union(field.data_type()))

--- a/crates/runtime/src/egress.rs
+++ b/crates/runtime/src/egress.rs
@@ -1,0 +1,89 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Memory-pool accounting for query-result *egress* buffers — the encoded
+//! `FlightData` sitting in the Flight send channel and the serialized HTTP
+//! response chunks in flight. Historically these buffers were invisible to
+//! `runtime.query.memory_limit` (only execution operators reserved against the
+//! pool), so a burst of large concurrent results could grow memory past the
+//! limit unaccounted. [`EgressAccount`] charges those bytes against the same
+//! [`MemoryPool`] the query executed under and applies light back-pressure when
+//! the pool is under real pressure.
+
+use std::sync::Arc;
+
+use datafusion::execution::memory_pool::{MemoryConsumer, MemoryPool, MemoryReservation};
+
+/// Cooperative yields [`EgressAccount::reserve`] makes while the pool is full
+/// before it over-commits, so it never blocks egress waiting for pool space.
+const MAX_RESERVE_YIELDS: usize = 8;
+
+/// Charges query-result egress bytes against a [`MemoryPool`].
+///
+/// Reserve bytes when a chunk is buffered for send; release them once the chunk
+/// has been handed downstream (to tonic / hyper). The held reservation therefore
+/// reflects "egress bytes we are currently buffering," which — combined with the
+/// per-stream bounded send channel — bounds egress memory and makes it visible to
+/// `runtime.query.memory_limit`. Dropping the account frees any still-held bytes
+/// (RAII via [`MemoryReservation`]'s `Drop`), so a client disconnect can't leak a
+/// reservation.
+pub(crate) struct EgressAccount {
+    // `MemoryReservation` is `Send + Sync` and interior-mutable (its size is an
+    // atomic; grow/shrink take `&self`), so it needs no lock — reserve (producer)
+    // and release (consumer) can hit it from different threads on the Flight
+    // off-runtime path.
+    reservation: MemoryReservation,
+}
+
+impl EgressAccount {
+    /// Register a new egress consumer against `pool`.
+    pub(crate) fn register(pool: &Arc<dyn MemoryPool>, name: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self {
+            reservation: MemoryConsumer::new(name).register(pool),
+        })
+    }
+
+    /// Reserve `bytes` for a chunk about to be buffered for send.
+    ///
+    /// The `MemoryPool` is sync-only (no async wait-for-space), so back-pressure
+    /// is a short bounded yield loop: while the pool is full we yield to let
+    /// consumers drain and release memory. After a few attempts we over-commit
+    /// with the infallible `grow` rather than fail the query or block forever — a
+    /// single oversized result or a stalled client must never deadlock egress,
+    /// and the per-stream bounded channel still caps buffering.
+    pub(crate) async fn reserve(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        for _ in 0..MAX_RESERVE_YIELDS {
+            if self.reservation.try_grow(bytes).is_ok() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        self.reservation.grow(bytes);
+    }
+
+    /// Release `bytes` once the chunk has been handed downstream. Never shrinks
+    /// past the current reservation size (which would panic).
+    pub(crate) fn release(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        let to_free = bytes.min(self.reservation.size());
+        self.reservation.shrink(to_free);
+    }
+}

--- a/crates/runtime/src/flight/flightsql/statement_substrait_plan.rs
+++ b/crates/runtime/src/flight/flightsql/statement_substrait_plan.rs
@@ -179,6 +179,7 @@ pub(crate) async fn do_get(
         query_result,
         ipc_write_options,
         datafusion.cpu_runtime().cloned(),
+        &datafusion.ctx.runtime_env().memory_pool,
         Arc::clone(&context),
     );
     let timed_output = TimedStream::new(output, move || start);

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -21,6 +21,7 @@ use crate::datafusion::error::{SpiceExternalError, find_datafusion_root};
 use crate::datafusion::query::{self, QueryBuilder};
 use crate::datafusion::sql_validator::validate_sql_query_read_only;
 use crate::dataupdate::DataUpdateBroadcaster;
+use crate::egress::EgressAccount;
 use crate::opentelemetry::create_metrics_service;
 use crate::tls::TlsConfig;
 use crate::{Runtime, metrics as runtime_metrics};
@@ -42,6 +43,7 @@ use bytes::Bytes;
 use cache::result::{CacheStatus, query::QueryResult};
 use datafusion::common::ParamValues;
 use datafusion::error::DataFusionError;
+use datafusion::execution::memory_pool::MemoryPool;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::sql::sqlparser::parser::ParserError;
 use flight_client::Error as FlightClientError;
@@ -287,6 +289,7 @@ impl Service {
             query_result,
             ipc_write_options,
             datafusion.cpu_runtime().cloned(),
+            &datafusion.ctx.runtime_env().memory_pool,
             context,
         ))
     }
@@ -324,6 +327,7 @@ impl Service {
         query_result: QueryResult,
         ipc_write_options: IpcWriteOptions,
         cpu_runtime: Option<Handle>,
+        memory_pool: &Arc<dyn MemoryPool>,
         request_context: Arc<RequestContext>,
     ) -> (BoxStream<'static, Result<FlightData, Status>>, CacheStatus) {
         // Reuse the same options for all messages.
@@ -365,12 +369,20 @@ impl Service {
         let data_stream = query_result.data;
         let cache_status = query_result.cache_status;
 
+        // Charge the encoded FlightData buffered for send against the query
+        // memory pool so egress memory is visible to `runtime.query.memory_limit`
+        // and applies back-pressure under real pressure.
+        let account = EgressAccount::register(memory_pool, "flight_egress");
+
         // Without a dedicated CPU runtime, encode inline on the caller's (IO)
         // runtime as before. This preserves the historical behavior when
         // `runtime.params.dedicated_thread_pool=disabled`.
         let Some(cpu_handle) = cpu_runtime else {
             let flights_stream = try_stream! {
+                let schema_size = flight_data_size(&schema_flight_data);
+                account.reserve(schema_size).await;
                 yield schema_flight_data;
+                account.release(schema_size);
 
                 // Use fused stream for better performance
                 let mut data_stream = data_stream.fuse();
@@ -390,9 +402,15 @@ impl Service {
 
                             // Yield dictionaries first
                             for dict in dicts {
+                                let dict_size = flight_data_size(&dict);
+                                account.reserve(dict_size).await;
                                 yield dict;
+                                account.release(dict_size);
                             }
+                            let batch_size = flight_data_size(&batch_data);
+                            account.reserve(batch_size).await;
                             yield batch_data;
+                            account.release(batch_size);
                         }
                         Err(e) => {
                             let e = find_datafusion_root(e);
@@ -415,43 +433,51 @@ impl Service {
         let (tx, rx) = mpsc::channel::<Result<FlightData, Status>>(FLIGHT_ENCODE_CHANNEL_CAPACITY);
         let span = Span::current();
 
-        let encode_task = async move {
-            if tx.send(Ok(schema_flight_data)).await.is_err() {
-                return;
-            }
+        let encode_task = {
+            let account = Arc::clone(&account);
+            async move {
+                // Reserve when a message enters the channel; the consumer
+                // (`FlightEncodeStream`) releases it once handed to tonic.
+                account.reserve(flight_data_size(&schema_flight_data)).await;
+                if tx.send(Ok(schema_flight_data)).await.is_err() {
+                    return;
+                }
 
-            let mut data_stream = data_stream.fuse();
+                let mut data_stream = data_stream.fuse();
 
-            while let Some(batch_result) = data_stream.next().await {
-                match batch_result {
-                    Ok(batch) => match encode_flight_batch(
-                        batch,
-                        needs_view_cast,
-                        &schema,
-                        &encoder,
-                        &mut dict_tracker,
-                        &options,
-                        &mut compression_context,
-                    ) {
-                        Ok((dicts, batch_data)) => {
-                            for dict in dicts {
-                                if tx.send(Ok(dict)).await.is_err() {
+                while let Some(batch_result) = data_stream.next().await {
+                    match batch_result {
+                        Ok(batch) => match encode_flight_batch(
+                            batch,
+                            needs_view_cast,
+                            &schema,
+                            &encoder,
+                            &mut dict_tracker,
+                            &options,
+                            &mut compression_context,
+                        ) {
+                            Ok((dicts, batch_data)) => {
+                                for dict in dicts {
+                                    account.reserve(flight_data_size(&dict)).await;
+                                    if tx.send(Ok(dict)).await.is_err() {
+                                        return;
+                                    }
+                                }
+                                account.reserve(flight_data_size(&batch_data)).await;
+                                if tx.send(Ok(batch_data)).await.is_err() {
                                     return;
                                 }
                             }
-                            if tx.send(Ok(batch_data)).await.is_err() {
+                            Err(status) => {
+                                let _ = tx.send(Err(status)).await;
                                 return;
                             }
-                        }
-                        Err(status) => {
-                            let _ = tx.send(Err(status)).await;
+                        },
+                        Err(e) => {
+                            let e = find_datafusion_root(e);
+                            let _ = tx.send(Err(handle_datafusion_error(e))).await;
                             return;
                         }
-                    },
-                    Err(e) => {
-                        let e = find_datafusion_root(e);
-                        let _ = tx.send(Err(handle_datafusion_error(e))).await;
-                        return;
                     }
                 }
             }
@@ -463,6 +489,7 @@ impl Service {
             receiver: ReceiverStream::new(rx),
             encode_handle: Some(encode_handle),
             encode_error: None,
+            account,
         };
 
         (stream.boxed(), cache_status)
@@ -520,6 +547,12 @@ fn encode_flight_batch(
     ))
 }
 
+/// Heap/wire bytes a single [`FlightData`] message occupies while buffered for
+/// send — used to charge egress against the query memory pool.
+fn flight_data_size(flight_data: &FlightData) -> usize {
+    flight_data.data_header.len() + flight_data.data_body.len() + flight_data.app_metadata.len()
+}
+
 /// Response stream for the off-runtime Flight encode pipeline. Wraps the
 /// receiver of already-encoded [`FlightData`] and owns the encode task's
 /// [`JoinHandle`] so that:
@@ -533,6 +566,11 @@ struct FlightEncodeStream {
     receiver: ReceiverStream<Result<FlightData, Status>>,
     encode_handle: Option<JoinHandle<()>>,
     encode_error: Option<Status>,
+    /// Egress reservation shared with the encode task. The encode task reserves
+    /// each message's bytes before it enters the channel; we release them here
+    /// as each message is handed to tonic. Dropping this (client disconnect)
+    /// frees any still-buffered bytes via the reservation's `Drop`.
+    account: Arc<EgressAccount>,
 }
 
 impl Stream for FlightEncodeStream {
@@ -569,7 +607,12 @@ impl Stream for FlightEncodeStream {
             return Poll::Ready(Some(Err(err)));
         }
 
-        Pin::new(&mut this.receiver).poll_next(cx)
+        let polled = Pin::new(&mut this.receiver).poll_next(cx);
+        if let Poll::Ready(Some(Ok(flight_data))) = &polled {
+            // Message handed to tonic — release its egress reservation.
+            this.account.release(flight_data_size(flight_data));
+        }
+        polled
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -43,21 +43,26 @@ use crate::{
     datafusion::{
         DataFusion,
         query::{
-            Error as QueryError, QueryBuilder, is_cancellation_error, write_to_json_string,
-            write_to_json_value,
+            Error as QueryError, QueryBuilder, is_cancellation_error, json_array_writer,
+            schema_has_union_columns, write_to_json_string, write_to_json_value,
         },
     },
+    egress::EgressAccount,
     status::ComponentStatus,
 };
 use arrow::{array::RecordBatch, util::pretty::pretty_format_batches};
+use async_stream::try_stream;
 use axum::{
+    body::Body,
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 use axum_extra::TypedHeader;
+use bytes::Bytes;
 use cache::result::CacheStatus;
 use csv::Writer;
 use datafusion::common::ParamValues;
+use datafusion::execution::SendableRecordBatchStream;
 use headers_accept::Accept;
 use http::{
     HeaderValue,
@@ -67,7 +72,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use snafu::ResultExt;
 
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 
 use runtime_auth::AuthPrincipalRef;
 use runtime_request_context::{AsyncMarker, CacheNamespace, RequestContext};
@@ -237,7 +242,13 @@ fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
     }
 }
 
-// Runs query and converts query results to HTTP response (as JSON).
+// Runs a query and converts the results to an HTTP response.
+//
+// The default JSON format is streamed batch-by-batch via a chunked body, so the
+// full result set is never materialized in memory (previously it was buffered
+// twice — once as `Vec<RecordBatch>`, then again as the rendered `String`). The
+// other formats — csv, plain, the vnd.* envelopes, and JSON containing union
+// columns — still buffer via `to_http_response`.
 pub async fn sql_to_http_response(
     df: Arc<DataFusion>,
     sql: &str,
@@ -245,36 +256,119 @@ pub async fn sql_to_http_response(
     format: ResponseMimeType,
     read_only: bool,
 ) -> Response {
-    let (data, results_cache_status) =
-        match run_sql_with_read_only(df, sql, parameters, read_only).await {
-            Ok((data, results_cache_status)) => (data, results_cache_status),
-            Err(e) => {
-                let message = e.to_string();
-                tracing::debug!("Error executing query: {message}");
-                let status = if e
-                    .downcast_ref::<datafusion::error::DataFusionError>()
-                    .is_some_and(is_cancellation_error)
-                    || e.downcast_ref::<QueryError>()
-                        .is_some_and(|err| matches!(err, QueryError::QueryCancelled { .. }))
-                {
-                    // 499 Client Closed Request: used for cancelled queries so
-                    // clients can distinguish cancellation from a bad request.
-                    StatusCode::from_u16(499).unwrap_or(StatusCode::BAD_REQUEST)
-                } else {
-                    status_for_sql_error(&message)
-                };
-                return (status, message).into_response();
-            }
-        };
+    // Capture the query memory pool before `df` is moved into the builder, so a
+    // streamed body can charge its egress buffers against the pool the query ran
+    // under (see `EgressAccount`).
+    let memory_pool = Arc::clone(&df.ctx.runtime_env().memory_pool);
 
-    to_http_response(
-        data,
-        results_cache_status,
-        format,
-        ResponseMetadata::empty(),
-    )
-    .await
-    .into_response()
+    let query_res = match QueryBuilder::new(sql, df)
+        .parameters(parameters)
+        .read_only(read_only)
+        .build()
+        .run()
+        .await
+    {
+        Ok(res) => res,
+        Err(e) => {
+            let is_cancellation = matches!(e, QueryError::QueryCancelled { .. });
+            return sql_error_response(e.to_string(), is_cancellation);
+        }
+    };
+
+    let cache_status = query_res.cache_status;
+    let mut data_stream = query_res.data;
+
+    // Stream only the default JSON format with non-union columns; csv/plain/vnd
+    // buffer via `to_http_response`, and union columns (which the arrow-json array
+    // writer can't render) fall back to the buffered JSON path. Streamability is a
+    // schema property, so decide it before pulling any batch.
+    if !matches!(format, ResponseMimeType::Json) || schema_has_union_columns(&data_stream.schema())
+    {
+        return buffered_sql_response(data_stream, cache_status, format).await;
+    }
+
+    // Pull the first batch eagerly so the common immediate-execution error still
+    // yields a clean status code instead of a truncated 200 response.
+    let first = match data_stream.next().await {
+        Some(Ok(batch)) => Some(batch),
+        Some(Err(e)) => return sql_error_response(e.to_string(), is_cancellation_error(&e)),
+        None => None,
+    };
+
+    let headers = response_headers(format, cache_status).await;
+    let account = EgressAccount::register(&memory_pool, "http_egress");
+    let body = Body::from_stream(json_array_body_stream(first, data_stream, account));
+    (StatusCode::OK, headers, body).into_response()
+}
+
+/// Maps a query error message to an HTTP response, distinguishing cancellation
+/// (499 Client Closed Request) from other errors.
+fn sql_error_response(message: String, is_cancellation: bool) -> Response {
+    tracing::debug!("Error executing query: {message}");
+    let status = if is_cancellation {
+        StatusCode::from_u16(499).unwrap_or(StatusCode::BAD_REQUEST)
+    } else {
+        status_for_sql_error(&message)
+    };
+    (status, message).into_response()
+}
+
+/// Buffered (non-streaming) response path for formats that cannot stream.
+async fn buffered_sql_response(
+    data_stream: SendableRecordBatchStream,
+    cache_status: CacheStatus,
+    format: ResponseMimeType,
+) -> Response {
+    let data = match data_stream.try_collect::<Vec<RecordBatch>>().await {
+        Ok(data) => data,
+        Err(e) => return sql_error_response(e.to_string(), is_cancellation_error(&e)),
+    };
+    to_http_response(data, cache_status, format, ResponseMetadata::empty())
+        .await
+        .into_response()
+}
+
+/// Streams the query result as a single JSON array, one input batch at a time,
+/// charging each serialized chunk against the query memory pool via `account`.
+/// The bytes emitted are identical to the non-streamed `arrow_to_json` output.
+fn json_array_body_stream(
+    first: Option<RecordBatch>,
+    rest: SendableRecordBatchStream,
+    account: Arc<EgressAccount>,
+) -> impl futures::Stream<Item = Result<Bytes, std::io::Error>> + Send {
+    let mut batches =
+        futures::stream::iter(first.map(Ok::<_, datafusion::error::DataFusionError>)).chain(rest);
+    try_stream! {
+        // One JSON-array writer drives the whole response: it emits the opening
+        // `[`, the inter-row/inter-batch commas, and the closing `]`, so the
+        // streamed bytes match `arrow_to_json` exactly. Drain its buffer after
+        // each write to yield a chunk (zero-copy — `mem::take` moves the `Vec`).
+        let mut writer = json_array_writer();
+        while let Some(item) = batches.next().await {
+            let batch = item.map_err(|e| std::io::Error::other(e.to_string()))?;
+            writer
+                .write(&batch)
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
+            let chunk = std::mem::take(writer.get_mut());
+            if !chunk.is_empty() {
+                let size = chunk.len();
+                account.reserve(size).await;
+                yield Bytes::from(chunk);
+                account.release(size);
+            }
+        }
+        // Closes the array (`]`), or emits `[]` for an empty result.
+        writer
+            .finish()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        let tail = std::mem::take(writer.get_mut());
+        if !tail.is_empty() {
+            let size = tail.len();
+            account.reserve(size).await;
+            yield Bytes::from(tail);
+            account.release(size);
+        }
+    }
 }
 
 // Runs query and returns the results as a vector of `RecordBatch`.
@@ -306,15 +400,13 @@ pub async fn run_sql_with_read_only(
     ))
 }
 
-// Converts query result to HTTP response (as JSON).
+// Converts a buffered query result to an HTTP response.
 pub async fn to_http_response(
     data: Vec<RecordBatch>,
     cache_status: CacheStatus,
     format: ResponseMimeType,
     meta: ResponseMetadata,
 ) -> (StatusCode, HeaderMap, String) {
-    let mut headers = HeaderMap::new();
-
     let res = match format {
         ResponseMimeType::Json => arrow_to_json(&data),
         ResponseMimeType::Csv => arrow_to_csv(&data),
@@ -327,10 +419,26 @@ pub async fn to_http_response(
     let body = match res {
         Ok(body) => body,
         Err(e) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, headers, e.to_string());
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                HeaderMap::new(),
+                e.to_string(),
+            );
         }
     };
 
+    (
+        StatusCode::OK,
+        response_headers(format, cache_status).await,
+        body,
+    )
+}
+
+/// Builds the content-type + cache-metadata headers for a query response. These
+/// are computable before the body since `cache_status` is known once the query
+/// starts producing rows, so they can precede a streamed body.
+async fn response_headers(format: ResponseMimeType, cache_status: CacheStatus) -> HeaderMap {
+    let mut headers = HeaderMap::new();
     let request_context = RequestContext::current(AsyncMarker::new().await);
 
     if let Some(header_value) = format.to_accept_header() {
@@ -344,7 +452,7 @@ pub async fn to_http_response(
         &request_context,
     );
 
-    (StatusCode::OK, headers, body)
+    headers
 }
 
 fn attach_cache_headers(

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -96,6 +96,7 @@ pub mod dataconnector;
 pub mod datafusion;
 pub mod datasets_health_monitor;
 pub mod dataupdate;
+pub(crate) mod egress;
 pub mod embeddings;
 pub mod execution_plan;
 pub mod executor_table;


### PR DESCRIPTION
> Contains the Flight encode-offload commit from #11608 (its focused view) plus the two egress commits. Targets `trunk` so the full CI suite runs; if #11608 merges first, the shared commit is absorbed and this rebases to just the egress changes.

## What

Bounds and accounts query-result **egress** memory — the buffers that hold serialized results on their way to the client — which were previously invisible to `runtime.query.memory_limit` and, on the HTTP path, doubly buffered.

### 1. Stream the HTTP `/v1/sql` JSON response (perf/memory)
The HTTP path buffered the entire result **twice** — once as `Vec<RecordBatch>`, then again as the rendered `String` — before sending a byte. The default JSON format now **streams**: a chunked `Body::from_stream` drives a single `arrow_json` array writer batch-by-batch, so the full result is never materialized. The wire bytes are identical to the buffered output (same writer/framing). `csv`, `plain`, the `vnd.*` envelopes, and JSON with union columns still buffer via `to_http_response`. The first batch is pulled eagerly so the common immediate-execution error still returns a clean status instead of a truncated 200.

### 2. Pool-account egress buffers (memory)
New `EgressAccount` (`crates/runtime/src/egress.rs`) charges egress bytes against the query's `MemoryPool`:
- **Flight**: each `FlightData` is reserved as it enters the send channel and released as `FlightEncodeStream` hands it to tonic; the reservation frees on drop (client disconnect).
- **HTTP**: each streamed JSON chunk is reserved/released around its yield.

The DataFusion pool is sync-only, so `reserve()` applies bounded-yield back-pressure and then over-commits with the infallible `grow` rather than fail a legitimate large result or deadlock egress.

## Validation
- End-to-end: streamed JSON is byte-correct for small / 300k-row multi-batch / empty results; `Transfer-Encoding: chunked` (no `Content-Length`); content-type + cache headers preserved; csv/vnd buffered paths intact; bad SQL → clean 400; Flight at concurrency-16 serves 0 errors with exact rows.
- `cargo test -p runtime --lib` JSON tests: 24 passed.
- `make lint` clean (fmt + full-workspace clippy, lib/bins + tests).

## Notes
- Egress accounting makes `#11608`'s pipeline-buffering memory cost (and any large concurrent result burst) visible to `runtime.query.memory_limit` and back-pressured, rather than growing unaccounted.

