### PR TITLE
fix(search): cosine_distance returns NULL not NaN for zero-magnitude vectors

### DIFF
--- a/crates/runtime-datafusion-udfs/src/cosine_distance.rs
+++ b/crates/runtime-datafusion-udfs/src/cosine_distance.rs
@@ -196,10 +196,16 @@ fn compute_cosine_distance(
         return exec_err!("Both arrays must have the same length");
     }
 
-    Ok(Some(cosine_distance(&float_vals1, &float_vals2)))
+    Ok(cosine_distance(&float_vals1, &float_vals2))
 }
 
-fn cosine_distance(x: &Float64Array, y: &Float64Array) -> f64 {
+/// Computes the cosine distance between two equal-length vectors.
+///
+/// Returns `None` when either vector has zero magnitude (e.g. an all-zero or
+/// failed embedding): cosine similarity is undefined there (`0.0 / 0.0` is
+/// `NaN`), and a `NaN` score sorts ahead of every real score in
+/// `ORDER BY _score DESC`, surfacing failed embeddings as top matches.
+fn cosine_distance(x: &Float64Array, y: &Float64Array) -> Option<f64> {
     let mut x_length: f64 = 0.0;
     let mut y_length: f64 = 0.0;
 
@@ -219,8 +225,15 @@ fn cosine_distance(x: &Float64Array, y: &Float64Array) -> f64 {
 
     let similarity = sum_squares / (x_length.sqrt() * y_length.sqrt());
 
+    // A zero-magnitude vector makes `similarity` NaN (and a non-finite value can
+    // otherwise only arise from overflow). Guard it so callers get a NULL score
+    // rather than a NaN that would sort to the top of `ORDER BY _score DESC`.
+    if !similarity.is_finite() {
+        return None;
+    }
+
     // Convert cosine similarity [-1.0, 1.0] to cosine distance [0.0, 1.0]
-    (1.0 - similarity) / 2.0
+    Some((1.0 - similarity) / 2.0)
 }
 
 /// Converts an array of any numeric type to a `Float64Array`.
@@ -249,32 +262,84 @@ fn convert_to_f64_array(array: &ArrayRef) -> DataFusionResult<Float64Array> {
 
 #[cfg(test)]
 mod tests {
-    use arrow::array::Float64Array;
+    use std::sync::Arc;
 
-    use super::cosine_distance;
+    use arrow::array::{ArrayRef, Float64Array};
 
-    #[expect(clippy::float_cmp)]
+    use super::{compute_cosine_distance, cosine_distance};
+
     #[test]
     fn test_cosine_distance() {
-        assert_eq!(
-            0.0,
+        // Identical vectors -> similarity 1 -> distance 0.
+        assert!(matches!(
             cosine_distance(
                 &Float64Array::from(vec![1.0, 2.0, 3.0]),
-                &Float64Array::from(vec![1.0, 2.0, 3.0])
-            )
-        );
+                &Float64Array::from(vec![1.0, 2.0, 3.0]),
+            ),
+            Some(d) if d.abs() < f64::EPSILON
+        ));
 
-        assert_eq!(
-            1.0,
+        // Opposite vectors -> similarity -1 -> distance 1.
+        assert!(matches!(
             cosine_distance(
                 &Float64Array::from(vec![1.0, 2.0, 3.0]),
-                &Float64Array::from(vec![-1.0, -2.0, -3.0])
+                &Float64Array::from(vec![-1.0, -2.0, -3.0]),
+            ),
+            Some(d) if (d - 1.0).abs() < f64::EPSILON
+        ));
+
+        // Arbitrary vectors stay within the normalized [0, 1] range.
+        assert!(matches!(
+            cosine_distance(
+                &Float64Array::from(vec![1000.0, 2000.0, 30.0]),
+                &Float64Array::from(vec![-42.0, 123.0, -3.0]),
+            ),
+            Some(d) if (0.0..=1.0).contains(&d)
+        ));
+    }
+
+    #[test]
+    fn test_cosine_distance_zero_vector_is_null() {
+        // A zero-magnitude vector has no defined direction; the distance must be
+        // NULL (None) rather than NaN so failed/empty embeddings do not sort to
+        // the top of `ORDER BY _score DESC`.
+        assert_eq!(
+            None,
+            cosine_distance(
+                &Float64Array::from(vec![0.0, 0.0, 0.0]),
+                &Float64Array::from(vec![1.0, 2.0, 3.0]),
             )
         );
-        let dist = cosine_distance(
-            &Float64Array::from(vec![1000.0, 2000.0, 30.0]),
-            &Float64Array::from(vec![-42.0, 123.0, -3.0]),
+        assert_eq!(
+            None,
+            cosine_distance(
+                &Float64Array::from(vec![1.0, 2.0, 3.0]),
+                &Float64Array::from(vec![0.0, 0.0, 0.0]),
+            )
         );
-        assert!((0.0..=1.0).contains(&dist));
+        assert_eq!(
+            None,
+            cosine_distance(
+                &Float64Array::from(vec![0.0, 0.0]),
+                &Float64Array::from(vec![0.0, 0.0]),
+            )
+        );
+    }
+
+    #[test]
+    fn test_compute_cosine_distance_zero_vector_propagates_null() {
+        // Exercise the production wrapper: a zero-magnitude vector must surface
+        // as `Ok(None)` (SQL NULL), not `Ok(Some(NaN))`.
+        let zero: ArrayRef = Arc::new(Float64Array::from(vec![0.0, 0.0, 0.0]));
+        let nonzero: ArrayRef = Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0]));
+
+        let result = compute_cosine_distance(Some(zero), Some(nonzero));
+        assert!(matches!(result, Ok(None)));
+
+        // A normal pair still yields a finite distance.
+        let a: ArrayRef = Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0]));
+        let b: ArrayRef = Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0]));
+        let result = compute_cosine_distance(Some(a), Some(b));
+        assert!(matches!(result, Ok(Some(d)) if d.is_finite()));
     }
 }


### PR DESCRIPTION
## Summary (root cause)

`cosine_distance(x, y)` computed `similarity = sum_squares / (‖x‖ · ‖y‖)`. When either vector has zero magnitude — an all-zero or failed/empty embedding — the divisor is `0.0`, so `similarity` becomes `0.0 / 0.0 = NaN` and the function returned `Some(NaN)`.

Vector search scores each row as `_score = 1 - cosine_distance(...)` and sorts with `ORDER BY _score DESC`. `1 - NaN` is still `NaN`, and `NaN` sorts **ahead** of every real score, so rows backed by a failed or all-zero embedding surface as the **top** search matches instead of being pushed to the bottom.

This addresses the zero-vector portion of #11263.

## Changes

- `crates/runtime-datafusion-udfs/src/cosine_distance.rs`: guard the similarity for finiteness. When `similarity` is not finite (the only sources are a zero-magnitude vector → `NaN`, or an overflow → `±inf`), `cosine_distance` now returns `None`, which propagates as a SQL `NULL`. With `ORDER BY _score DESC NULLS LAST`, failed/empty embeddings sort last rather than first.
- The internal `cosine_distance` helper now returns `Option<f64>`; `compute_cosine_distance` forwards the `None` (it already returns `Ok(None)` for the NULL/empty-input cases, so this is consistent with existing behaviour).
- Distances for non-zero vectors are unchanged, so no existing search snapshots drift.

## What this PR deliberately does NOT change

The headline of #11263 — the local formula `(1 - sim) / 2` (range `[0, 1]`) diverging from DuckDB's `array_cosine_distance = 1 - sim` (range `[0, 2]`) that `cosine_distance` federates to — is **left for a maintainer decision**. Aligning them changes user-visible `_score` values on the local path and requires regenerating the entire "Test Models, AI & Search" snapshot suite against live embedding models, which can't be done correctly in an automated PR. Full analysis is posted on #11263. This PR keeps the existing `[0, 1]` normalization and only removes the `NaN`.

## Test plan

- `make lint`
- `make test`

New unit tests in `cosine_distance.rs`:
- `test_cosine_distance` — identical / opposite / arbitrary vectors stay in `[0, 1]` (converted to `matches!` guards so no `float_cmp`).
- `test_cosine_distance_zero_vector_is_null` — a zero vector on either side, and a zero/zero pair, all return `None`.
- `test_compute_cosine_distance_zero_vector_propagates_null` — the production wrapper surfaces `Ok(None)` for a zero vector and `Ok(Some(finite))` for a normal pair.

## Checklist

- [x] Fix is minimal and in scope
- [x] Distances for non-zero vectors unchanged (no snapshot drift)
- [x] Regression tests exercise the production path
- [x] `make lint` / `make test` green locally

Addresses the zero-vector NaN issue in #11263 (the issue stays open for the formula-divergence decision).