### PR TITLE
test(bucket): guard frozen partition-hash output against silent ahash drift (addresses #11277)

### DIFF
--- a/crates/runtime-datafusion-udfs/src/bucket.rs
+++ b/crates/runtime-datafusion-udfs/src/bucket.rs
@@ -563,7 +563,7 @@ mod tests {
     /// lifetime of a persisted dataset, or an equality-filter prune silently
     /// skips the partition that holds the matching rows — missing-row data loss
     /// (#11277). The hash is therefore part of the on-disk format, and
-    /// `vendored_hash.rs` freezes it to DataFusion 53's `ahash`. But that module
+    /// `vendored_hash.rs` freezes it to `DataFusion` 53's `ahash`. But that module
     /// still delegates the actual hashing to the external `ahash` crate, pinned
     /// only as `^0.8` — and ahash gives **no** cross-version output guarantee, so
     /// a routine `cargo update` (or a build that enables ahash's AES path) can

--- a/crates/runtime-datafusion-udfs/src/bucket.rs
+++ b/crates/runtime-datafusion-udfs/src/bucket.rs
@@ -555,6 +555,103 @@ mod tests {
         );
     }
 
+    /// Golden-value guard that pins `bucket()`'s output for a representative
+    /// value of every non-string Arrow type the partition transform hashes.
+    ///
+    /// `bucket(n, value) = hash(value) % n` is the partition transform behind
+    /// `runtime-table-partition`: a value MUST map to the same bucket for the
+    /// lifetime of a persisted dataset, or an equality-filter prune silently
+    /// skips the partition that holds the matching rows — missing-row data loss
+    /// (#11277). The hash is therefore part of the on-disk format, and
+    /// `vendored_hash.rs` freezes it to DataFusion 53's `ahash`. But that module
+    /// still delegates the actual hashing to the external `ahash` crate, pinned
+    /// only as `^0.8` — and ahash gives **no** cross-version output guarantee, so
+    /// a routine `cargo update` (or a build that enables ahash's AES path) can
+    /// silently re-bucket every existing partitioned dataset.
+    ///
+    /// These goldens make that drift LOUD: any change here fails CI instead of
+    /// silently corrupting pruning. The pre-existing snapshot tests only locked
+    /// the string (`bucket_scalar`/`bucket_array`) and decimal paths; the integer,
+    /// unsigned, boolean, float, and binary paths — the common partition keys,
+    /// e.g. `bucket(50, org_id)` or `bucket(3, user_id)` — had no guard at all.
+    ///
+    /// A large modulus (`MAX_NUM_BUCKETS`) is used so the assertion captures the
+    /// low 6 decimal digits of the hash, not just a handful of low bits. Edge
+    /// values fill each integer width so every width's hashing path is distinct.
+    ///
+    /// If a value here ever needs to change, that is a breaking change to the
+    /// on-disk partition format: regenerate the goldens **and** version/migrate
+    /// the format — do not blindly update them to make CI green.
+    #[test]
+    fn test_bucket_hash_stability_golden_values() {
+        // (type label, input value, expected `bucket(MAX_NUM_BUCKETS, value)`).
+        let cases: [(&str, ScalarValue, i64); 14] = [
+            ("Int8", ScalarValue::Int8(Some(-128)), 924_318),
+            ("Int16", ScalarValue::Int16(Some(-12_345)), 180_632),
+            ("Int32", ScalarValue::Int32(Some(-1_234_567)), 143_530),
+            ("Int64", ScalarValue::Int64(Some(-123_456_789_012)), 397_203),
+            ("UInt8", ScalarValue::UInt8(Some(255)), 670_181),
+            ("UInt16", ScalarValue::UInt16(Some(65_535)), 162_628),
+            ("UInt32", ScalarValue::UInt32(Some(4_000_000_000)), 663_368),
+            (
+                "UInt64",
+                ScalarValue::UInt64(Some(18_000_000_000_000_000_000)),
+                279_638,
+            ),
+            ("Boolean_true", ScalarValue::Boolean(Some(true)), 719_061),
+            ("Boolean_false", ScalarValue::Boolean(Some(false)), 627_404),
+            ("Float32", ScalarValue::Float32(Some(1.5)), 157_006),
+            ("Float64", ScalarValue::Float64(Some(-2.5)), 749_390),
+            (
+                "Utf8",
+                ScalarValue::Utf8(Some("user_42".to_string())),
+                594_815,
+            ),
+            (
+                "Binary",
+                ScalarValue::Binary(Some(vec![0x00, 0x01, 0x02, 0xff])),
+                682_122,
+            ),
+        ];
+
+        for (label, value, expected) in cases {
+            let bucket = compute_bucket(&value, MAX_NUM_BUCKETS, &DataType::Int64)
+                .expect("compute_bucket should succeed for a supported type");
+            let ScalarValue::Int64(Some(actual)) = bucket else {
+                panic!("expected an Int64 bucket for {label}, got {bucket:?}");
+            };
+            assert_eq!(
+                actual, expected,
+                "bucket() output for {label} drifted from the frozen on-disk value \
+                 {expected} to {actual}. The partition hash must not change (see \
+                 #11277 and vendored_hash.rs); if this is an intentional, \
+                 format-versioned migration, update the golden AND bump the format."
+            );
+        }
+
+        // The vectorized array path must agree with the scalar path (it shares
+        // `create_hashes`); lock it for a non-string type — the existing
+        // `bucket_array` snapshot only covers strings. Element 0 reuses the
+        // Int64 scalar value above and must match its golden (397_203).
+        let arr: ArrayRef = std::sync::Arc::new(arrow::array::Int64Array::from(vec![
+            -123_456_789_012_i64,
+            0,
+            9_999_999_999,
+        ]));
+        let bucketed = compute_bucket_array(&arr, MAX_NUM_BUCKETS, &DataType::Int64)
+            .expect("compute_bucket_array should succeed for Int64");
+        let bucketed = bucketed
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .expect("bucket array should be Int64");
+        assert_eq!(
+            bucketed.values(),
+            &[397_203_i64, 627_404, 929_657],
+            "vectorized bucket() output for an Int64 column drifted from its frozen \
+             on-disk values (see #11277)"
+        );
+    }
+
     #[test]
     fn test_first_arg_wrong_scalar_type_error_message() {
         // Test error message when first argument is a scalar but wrong type

--- a/crates/runtime-datafusion-udfs/src/vendored_hash.rs
+++ b/crates/runtime-datafusion-udfs/src/vendored_hash.rs
@@ -31,6 +31,16 @@
 //!
 //! `bucket()` only ever hashes a single column, so the multi-column
 //! `combine_hashes` path is intentionally omitted.
+//!
+//! Caveat: this module freezes the *seed and the hashing loop*, but still
+//! delegates the actual byte hashing to the external `ahash` crate (pinned only
+//! as `^0.8`). ahash gives **no** cross-version output guarantee, so a routine
+//! `cargo update` — or a build that enables ahash's AES path — could still
+//! silently change these hashes (#11277). `bucket::tests::
+//! test_bucket_hash_stability_golden_values` pins the current output for every
+//! supported type so any such drift fails CI loudly instead of silently
+//! re-bucketing persisted data. Keep that guard passing; only regenerate its
+//! goldens as part of a deliberate, format-versioned migration.
 
 #![allow(clippy::pedantic)]
 


### PR DESCRIPTION
## Summary (root cause)

`bucket(n, value) = hash(value) % n` is the partition transform behind `runtime-table-partition`. For persisted partitioned datasets, a value **must** map to the same bucket forever, or an equality-filter partition prune skips the partition that actually holds the matching rows — silent missing-row data loss (#11277).

`crates/runtime-datafusion-udfs/src/vendored_hash.rs` was created precisely to freeze this hash to DataFusion 53's `ahash` so a DataFusion upgrade can't re-bucket existing data. But that module only froze the **seed and the hashing loop** — it still delegates the actual byte hashing to the external `ahash` crate, which is pinned only as `^0.8` (`Cargo.toml`). ahash gives **no** cross-version output guarantee, so a routine `cargo update` within `0.8.x` (or a build that enables ahash's AES path) can silently change the hash and re-bucket every existing partitioned dataset.

The existing golden coverage only locked the **string** (`bucket_scalar`/`bucket_array`) and **decimal** paths. The integer, unsigned, boolean, float, and binary paths — the common partition keys, e.g. the issue's own `bucket(50, org_id)` / `bucket(3, user_id)` — had **no** guard, so drift there would be completely silent.

Note the issue's suggested fix (switch to Murmur3) is intentionally **not** taken: changing the hash would itself re-bucket all existing persisted data — the exact regression `vendored_hash.rs` exists to prevent. The correct non-breaking fix is to make the freeze enforceable.

## Changes

- `crates/runtime-datafusion-udfs/src/bucket.rs`: add `test_bucket_hash_stability_golden_values`, a golden-value regression test pinning `bucket()`'s output for the full supported type matrix (Int8/16/32/64, UInt8/16/32/64, Boolean, Float32/64, Utf8, Binary) plus the vectorized `compute_bucket_array` path for an Int64 column. It exercises the production `compute_bucket`/`compute_bucket_array` functions with a large modulus (`MAX_NUM_BUCKETS`) so the assertion captures the low 6 decimal digits of the hash, and edge values that fill each integer width.
- `crates/runtime-datafusion-udfs/src/vendored_hash.rs`: document the residual ahash-crate dependency and point to the new guard.

No behavior change: the goldens capture current output, so existing partitioned data is untouched. Any future drift (dependency bump or AES-path build) now fails CI loudly instead of silently corrupting partition pruning.

## Scope — what this does and does NOT resolve

- **ahash version/algorithm bump** (a `cargo update` within `^0.8`): fully guarded — the goldens turn it into a loud CI failure.
- **Cross-architecture portability** (a build with `+aes` / `target-cpu=native` on a different CPU): only guarded on the arch CI runs on, not at runtime. Fully closing that needs forcing ahash's platform-stable fallback or a format-versioned hash migration — a maintainer / on-disk-format decision.

So this is a non-breaking mitigation that closes the realistic silent-drift vector; #11277 stays **open** for the deeper portability/format decision.

## Performance impact

None — test and documentation only; no production code paths change.

## Test plan

- New `cargo test -p runtime-datafusion-udfs --lib bucket` — all 13 bucket tests pass (including the new golden test).
- `cargo clippy -p runtime-datafusion-udfs --all-targets --no-deps` — clean (the one warning is a pre-existing unfulfilled lint-expectation in the unrelated `ai_concurrency` integration test).
- `cargo fmt` (toolchain 1.95.0) — clean.
- Full-workspace `make lint` / `make test` run in CI (this change is test + doc only, in a single crate).

## Checklist

- [x] Fix is minimal and in scope (test + doc only)
- [x] No hash output changes — existing persisted partitioned data is untouched
- [x] Regression test exercises the production `compute_bucket`/`compute_bucket_array` path
- [x] Covers the previously-unguarded integer/unsigned/bool/float/binary paths
- [x] No `.unwrap()` (uses `.expect(...)`)

Addresses #11277
