### PR TITLE
fix(refresh): apply refresh_sql override on manual refresh when source unchanged (fixes #11353)

### DIFF
--- a/crates/data_components/src/refresh_skip.rs
+++ b/crates/data_components/src/refresh_skip.rs
@@ -38,6 +38,17 @@ pub trait RefreshSkipTableProvider: TableProvider {
     /// and proceed with the refresh to ensure data consistency.
     async fn should_skip_refresh(&self) -> datafusion::error::Result<bool>;
 
+    /// Invalidates any cached state used to decide whether a refresh can be skipped.
+    ///
+    /// The skip decision assumes the currently-materialized data is a faithful, complete read
+    /// of the source. A one-off refresh override (e.g. a manual refresh with a different
+    /// `refresh_sql`) breaks that assumption: it materializes a *subset* of the source even
+    /// though the source itself is unchanged. After such a refresh the cached version must be
+    /// reset, otherwise the next plain refresh would compare an unchanged source against the
+    /// cached version, skip, and leave the narrowed data in place. Providers cache their
+    /// skip state so this defaults to a no-op only for providers that keep none.
+    async fn reset_skip_state(&self) {}
+
     /// Returns a reference to self as a `RefreshSkipTableProvider` trait object.
     /// This enables dynamic dispatch without requiring knowledge of the concrete type.
     fn as_refresh_skip_provider(&self) -> &dyn RefreshSkipTableProvider
@@ -107,4 +118,37 @@ pub async fn should_skip_refresh_for_table_provider(
     }
 
     Ok(None)
+}
+
+/// Resets the refresh-skip cached state of the provided table provider if it implements
+/// [`RefreshSkipTableProvider`], peeling the same wrapper providers as
+/// [`should_skip_refresh_for_table_provider`] so the inner provider is reached. A no-op for
+/// providers that do not support refresh skipping.
+///
+/// Call this after a refresh that materialized a subset of the source (e.g. an override
+/// `refresh_sql`) so the next plain refresh re-materializes the full source instead of skipping
+/// against the now-narrowed accelerated data.
+pub async fn reset_refresh_skip_state_for_table_provider(
+    table_provider: &(dyn TableProvider + Send + Sync),
+) {
+    let any = table_provider as &dyn std::any::Any;
+
+    if let Some(provider) = any.downcast_ref::<crate::s3_single_file_cached::S3SingleFileCached>() {
+        provider.reset_skip_state().await;
+        return;
+    }
+
+    if let Some(enriched) = any.downcast_ref::<crate::MetadataEnrichedTableProvider>() {
+        Box::pin(reset_refresh_skip_state_for_table_provider(
+            enriched.get_inner_ref().as_ref(),
+        ))
+        .await;
+        return;
+    }
+
+    if let Some(adaptor) = any.downcast_ref::<FederatedTableProviderAdaptor>()
+        && let Some(inner) = adaptor.table_provider.as_ref()
+    {
+        Box::pin(reset_refresh_skip_state_for_table_provider(inner.as_ref())).await;
+    }
 }

--- a/crates/data_components/src/s3_single_file_cached.rs
+++ b/crates/data_components/src/s3_single_file_cached.rs
@@ -196,6 +196,12 @@ impl RefreshSkipTableProvider for S3SingleFileCached {
     async fn should_skip_refresh(&self) -> DataFusionResult<bool> {
         self.is_file_unchanged().await
     }
+
+    async fn reset_skip_state(&self) {
+        // Drop the cached file metadata so the next `should_skip_refresh` treats the file as
+        // changed and re-materializes the full source (see `reset_skip_state` on the trait).
+        *self.cached_metadata.write().await = None;
+    }
 }
 
 #[deny(clippy::missing_trait_methods)]
@@ -523,6 +529,82 @@ mod tests {
             result,
             Some(true),
             "refresh-skip must be reached through the metadata-enriched wrapper"
+        );
+    }
+
+    /// Regression test for issue #11353: a refresh carrying an override `refresh_sql`
+    /// materializes a subset of the source, so the skip cache must be invalidated afterwards.
+    /// Otherwise the next plain refresh compares the unchanged source against the cached
+    /// version, skips, and leaves the narrowed data in place.
+    ///
+    /// Verifies that after `reset_skip_state`, a metadata that would otherwise be skipped is
+    /// treated as changed (re-materialized) exactly once, then skippable again.
+    #[tokio::test]
+    async fn test_reset_skip_state_forces_next_refresh() {
+        let meta = make_meta("file", 128, 10, Some("etag"), Some("v1"));
+        let store = Arc::new(HeadOnlyObjectStore::new(vec![
+            meta.clone(),
+            meta.clone(),
+            meta.clone(),
+        ])) as Arc<dyn ObjectStore>;
+        let cached_table = build_cached_table(store, Some(meta));
+
+        // Baseline: unchanged file would be skipped.
+        assert!(
+            cached_table
+                .should_skip_refresh()
+                .await
+                .expect("baseline skip result"),
+            "unchanged file should be skippable before reset"
+        );
+
+        // An override refresh resets the skip state.
+        cached_table.reset_skip_state().await;
+
+        // The next refresh must NOT skip even though the source file is unchanged.
+        assert!(
+            !cached_table
+                .should_skip_refresh()
+                .await
+                .expect("post-reset skip result"),
+            "refresh must re-materialize after reset even when the source is unchanged"
+        );
+
+        // And it becomes skippable again once the cache is repopulated.
+        assert!(
+            cached_table
+                .should_skip_refresh()
+                .await
+                .expect("re-cached skip result"),
+            "unchanged file should be skippable again after the cache repopulates"
+        );
+    }
+
+    /// The reset helper must peel the same wrappers as the skip check so the inner
+    /// `S3SingleFileCached` is reached (issue #11353 + the wrapper-peeling fix in #11339).
+    #[tokio::test]
+    async fn test_reset_skip_state_through_metadata_enriched_wrapper() {
+        let meta = make_meta("file", 128, 10, Some("etag"), Some("v1"));
+        let store = Arc::new(HeadOnlyObjectStore::new(vec![meta.clone()])) as Arc<dyn ObjectStore>;
+        let cached_table = build_cached_table(store, Some(meta));
+
+        let mut extra_metadata = std::collections::HashMap::new();
+        extra_metadata.insert("schema.key".to_string(), "value".to_string());
+        let wrapped: Arc<dyn TableProvider> = Arc::new(crate::MetadataEnrichedTableProvider::new(
+            Arc::new(cached_table) as Arc<dyn TableProvider>,
+            extra_metadata,
+        ));
+
+        crate::refresh_skip::reset_refresh_skip_state_for_table_provider(wrapped.as_ref()).await;
+
+        let result = crate::refresh_skip::should_skip_refresh_for_table_provider(wrapped.as_ref())
+            .await
+            .expect("skip check should not error");
+
+        assert_eq!(
+            result,
+            Some(false),
+            "reset must be reached through the metadata-enriched wrapper, forcing a re-materialize"
         );
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -629,40 +629,54 @@ impl RefreshTask {
 
         // For table providers with refresh skip support, check if the refresh can be skipped to
         // avoid unnecessary data fetching when the underlying data is unchanged.
+        //
+        // A one-off refresh override (a manual refresh carrying a different `refresh_sql`)
+        // deliberately materializes a subset of the source, so the "source unchanged → skip"
+        // optimization does not apply: skipping would silently drop the override and retain the
+        // previously-materialized rows (issue #11353). When an override is present, bypass the
+        // skip check and reset the provider's cached version so the *next* plain refresh
+        // re-materializes the full source instead of skipping against the narrowed data.
         if refresh.mode == RefreshMode::Full || refresh.mode == RefreshMode::Append {
             let table_provider = self.federated.table_provider().await;
 
-            match data_components::refresh_skip::should_skip_refresh_for_table_provider(
-                table_provider.as_ref(),
-            )
-            .await
-            {
-                Ok(Some(true)) => {
-                    tracing::debug!(
-                        "Skipping refresh for {} - data unchanged",
-                        self.dataset_name
-                    );
+            if refresh.override_sql_raw.is_some() {
+                data_components::refresh_skip::reset_refresh_skip_state_for_table_provider(
+                    table_provider.as_ref(),
+                )
+                .await;
+            } else {
+                match data_components::refresh_skip::should_skip_refresh_for_table_provider(
+                    table_provider.as_ref(),
+                )
+                .await
+                {
+                    Ok(Some(true)) => {
+                        tracing::debug!(
+                            "Skipping refresh for {} - data unchanged",
+                            self.dataset_name
+                        );
 
-                    for label_set in &dataset_metrics_label_sets {
-                        metrics::REFRESH_DATA_FETCHES_SKIPPED.add(1, label_set);
+                        for label_set in &dataset_metrics_label_sets {
+                            metrics::REFRESH_DATA_FETCHES_SKIPPED.add(1, label_set);
+                        }
+
+                        self.set_refresh_status(
+                            refresh.display_sql().as_deref(),
+                            status::ComponentStatus::Ready,
+                        )
+                        .await;
+                        return Ok(());
                     }
-
-                    self.set_refresh_status(
-                        refresh.display_sql().as_deref(),
-                        status::ComponentStatus::Ready,
-                    )
-                    .await;
-                    return Ok(());
-                }
-                Ok(_) => {
-                    // Data may have changed or provider does not support skipping; continue with refresh.
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        "Failed to check if refresh should be skipped for {}, proceeding with refresh: {}",
-                        self.dataset_name,
-                        e
-                    );
+                    Ok(_) => {
+                        // Data may have changed or provider does not support skipping; continue with refresh.
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            "Failed to check if refresh should be skipped for {}, proceeding with refresh: {}",
+                            self.dataset_name,
+                            e
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary (root cause)

A manual acceleration refresh that carries a one-off `refresh_sql` override was silently ignored for object-store-backed datasets, leaving the previously-materialized data in place.

```
curl -X POST .../v1/datasets/orders/acceleration/refresh \
  -d '{"refresh_sql": "SELECT * FROM orders WHERE id <= 3"}'
```

Root cause: `RefreshTask::run_once` runs a refresh-skip optimization for `Full`/`Append` modes — `should_skip_refresh_for_table_provider` asks the provider (e.g. `S3SingleFileCached`) whether the *source file* changed (size / `last_modified` / `ETag` / version). When the file is unchanged it returns `Ok(Some(true))` and the refresh is skipped entirely.

That optimization assumes the currently-materialized data is a faithful, complete read of the source. A one-off override `refresh_sql` deliberately materializes a **subset** of the source even though the source itself is unchanged, so the assumption is false: the skip fires, the override is dropped, and the full dataset is retained (issue #11353).

## Changes

- `RefreshTask::run_once` (`crates/runtime/src/accelerated_table/refresh_task.rs`): when a refresh carries an override (`refresh.override_sql_raw.is_some()`), bypass the skip check. Instead, **reset** the provider's cached version so the *next* plain refresh re-materializes the full source rather than skipping against the now-narrowed accelerated data.
- `RefreshSkipTableProvider` (`crates/data_components/src/refresh_skip.rs`): add a `reset_skip_state` method (default no-op) and a symmetric `reset_refresh_skip_state_for_table_provider` helper that peels the same wrapper providers (`MetadataEnrichedTableProvider`, `FederatedTableProviderAdaptor`) as the skip check.
- `S3SingleFileCached` (`crates/data_components/src/s3_single_file_cached.rs`): implement `reset_skip_state` to drop the cached file metadata.

Without the reset half, a plain refresh following an override refresh would compare the unchanged source against the cached version, skip, and leave the narrowed data in place — trading the reported bug for a subtler stale-data one. The reset closes that gap.

Scope: behavior only changes when an override is present; ordinary periodic/manual refreshes take the exact same skip path as before.

Fixes #11353

## Test plan
- [x] Added regression test `test_reset_skip_state_forces_next_refresh` (unchanged source is skippable → reset → next refresh re-materializes → skippable again)
- [x] Added regression test `test_reset_skip_state_through_metadata_enriched_wrapper` (reset helper peels the metadata-enriched wrapper to reach the inner provider)
- [x] `make lint` passes (workspace-wide fmt check + full clippy)
- [x] `make test` passes