### PR TITLE
fix(mcp): encode catalog-qualified tool names without '/' (fixes #10894)

### DIFF
--- a/crates/runtime-tools/src/mcp/server.rs
+++ b/crates/runtime-tools/src/mcp/server.rs
@@ -28,6 +28,7 @@ use serde_json::{Map, Value, json};
 use std::{borrow::Cow, collections::HashMap, future::Future, sync::Arc};
 use tokio::sync::RwLock;
 use tools::SpiceModelTool;
+use tools::naming::{decode_tool_name, encode_tool_name};
 use tools::rename::with_name;
 use tracing_futures::Instrument;
 use util::security::{MAX_SAFE_JSON_DEPTH, get_json_depth};
@@ -44,12 +45,14 @@ impl RuntimeServer {
 
     async fn get_tool(&self, tool_name: &str) -> Option<Arc<dyn SpiceModelTool>> {
         let tools = self.tools.read().await;
-        if let Some((catalog_name, name)) = tool_name.split_once('/') {
-            let Tooling::Catalog { tools: catalog, .. } = tools.get(catalog_name)? else {
-                return None;
-            };
-            return catalog.get(name).await;
+        if let Some((catalog_name, name)) = decode_tool_name(tool_name)
+            && let Some(Tooling::Catalog { tools: catalog, .. }) = tools.get(&catalog_name)
+            && let Some(tool) = catalog.get(&name).await
+        {
+            return Some(tool);
         }
+        // Fall back to a direct (non-catalog) lookup. This covers top-level
+        // tools whose names legitimately contain the `__` catalog separator.
         match tools.get(tool_name)? {
             Tooling::Tool(tool) | Tooling::FunctionTool(tool) => Some(Arc::clone(tool)),
             Tooling::Catalog { .. } => None,
@@ -69,7 +72,7 @@ impl RuntimeServer {
                     for tool in catalog.all().await {
                         result.push(with_name(
                             &tool,
-                            format!("{catalog_name}/{}", tool.name()).as_str(),
+                            encode_tool_name(catalog_name, &tool.name()).as_str(),
                         ));
                     }
                 }
@@ -167,9 +170,8 @@ impl ServerHandler for RuntimeServer {
                 }
 
                 let task_name = format!("tool_use::{tool_name}");
-                let mcp_server = tool_name
-                    .split_once('/')
-                    .map_or_else(|| tool_name.to_string(), |(server, _)| server.to_string());
+                let mcp_server = decode_tool_name(tool_name.as_ref())
+                    .map_or_else(|| tool_name.to_string(), |(server, _)| server);
                 let span = tracing::span!(target: "task_history", tracing::Level::INFO, "tool_use::mcp", tool = %tool_name, input = %input);
                 tracing::info!(target: "task_history", parent: &span, task_override = %task_name, mcp_server = %mcp_server, "labels");
 

--- a/crates/runtime-tools/src/tooling.rs
+++ b/crates/runtime-tools/src/tooling.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use std::{borrow::Cow, sync::Arc};
-use tools::{SpiceModelTool, rename::with_name};
+use tools::{SpiceModelTool, naming::encode_tool_name, rename::with_name};
 
 use crate::catalog::SpiceToolCatalog;
 
@@ -59,7 +59,7 @@ impl Tooling {
                     .all()
                     .await
                     .iter()
-                    .map(|t| with_name(t, format!("{catalog_name}/{}", t.name()).as_str()))
+                    .map(|t| with_name(t, encode_tool_name(catalog_name, &t.name()).as_str()))
                     .collect()
             }
         }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -17,6 +17,7 @@ limitations under the License.
 #![recursion_limit = "256"]
 
 use ::tools::SpiceModelTool;
+use ::tools::naming::{decode_tool_name, encode_tool_name};
 use ::tools::rename::with_name;
 use async_stream::stream;
 use datafusion_expr::Expr;
@@ -1843,7 +1844,7 @@ impl Runtime {
                         }
                         let all = catalog.all().await;
                         for tool in all {
-                            yield with_name(&tool, format!("{}/{}", catalog.name(), tool.name()).as_str());
+                            yield with_name(&tool, encode_tool_name(catalog.name(), &tool.name()).as_str());
                         }
                     }
                 }
@@ -1853,20 +1854,18 @@ impl Runtime {
 
     pub async fn get_tool(self: &Arc<Self>, tool_name: &str) -> Option<Arc<dyn SpiceModelTool>> {
         let tools = self.tools.read().await;
-        let tool: Arc<dyn SpiceModelTool> =
-            if let Some((catalog_name, name)) = tool_name.split_once('/') {
-                let Some(Tooling::Catalog { tools: catalog, .. }) = tools.get(catalog_name) else {
-                    return None;
-                };
-                return catalog.get(name).await;
-            } else {
-                let Some(Tooling::Tool(tool) | Tooling::FunctionTool(tool)) = tools.get(tool_name)
-                else {
-                    return None;
-                };
-                Arc::clone(tool)
-            };
-        Some(tool)
+        if let Some((catalog_name, name)) = decode_tool_name(tool_name)
+            && let Some(Tooling::Catalog { tools: catalog, .. }) = tools.get(&catalog_name)
+            && let Some(tool) = catalog.get(&name).await
+        {
+            return Some(tool);
+        }
+        // Fall back to a direct (non-catalog) lookup — covers top-level tools
+        // whose names legitimately contain the `__` catalog separator.
+        let Some(Tooling::Tool(tool) | Tooling::FunctionTool(tool)) = tools.get(tool_name) else {
+            return None;
+        };
+        Some(Arc::clone(tool))
     }
 }
 

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -101,9 +101,9 @@ mod tests {
                 .map(|tt| tt.name().to_string())
                 .collect::<Vec<String>>(),
             vec![
-                "not_in_default_catalogs/foo",
-                "not_in_default_catalogs/bar",
-                "not_in_default_catalogs/baz",
+                "not_in_default_catalogs__foo",
+                "not_in_default_catalogs__bar",
+                "not_in_default_catalogs__baz",
             ]
         );
     }

--- a/crates/runtime/src/tools/utils.rs
+++ b/crates/runtime/src/tools/utils.rs
@@ -37,7 +37,7 @@ use runtime_tools::options::SpiceToolsOptions;
 use super::Tooling;
 use super::builtin::catalog::BuiltinToolCatalog;
 use super::factory::default_catalog_names;
-use tools::{SpiceModelTool, rename::with_name};
+use tools::{SpiceModelTool, naming::encode_tool_name, rename::with_name};
 
 #[derive(Debug, Snafu)]
 enum ToolUtilsError {
@@ -328,7 +328,7 @@ async fn get_tool_by_name(
         if let Some(t) = catalog.get(catalog_tool).await {
             return Some(vec![with_name(
                 &t,
-                format!("{catalog_name}/{}", t.name()).as_str(),
+                encode_tool_name(catalog_name, &t.name()).as_str(),
             )]);
         }
 

--- a/crates/runtime/tests/models/snapshots/integration_models__models__tools__mcp__mcp_spiced_list.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__tools__mcp__mcp_spiced_list.snap
@@ -52,7 +52,7 @@ expression: tools_list
   },
   {
     "description": "Return the current UTC date and time as an ISO 8601 timestamp. Call this whenever the model needs the actual current time to compute relative durations, evaluate freshness, or stamp generated content; do not guess or rely on training-data dates. Takes no arguments. Returns a string like '2026-05-06T13:45:00Z'.",
-    "name": "mcp_from_spiced/get_current_datetime",
+    "name": "mcp_from_spiced__get_current_datetime",
     "parameters": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {},
@@ -63,7 +63,7 @@ expression: tools_list
   },
   {
     "description": "Report the readiness state of every Spice runtime component (datasets, accelerators, models, embeddings, catalogs). Call this when diagnosing why a query, model, or search call is failing or returning empty results, or to verify the runtime is healthy before issuing other tool calls. Takes no arguments. Returns a JSON object mapping component name to status (e.g. 'Ready', 'Initializing', 'Error').",
-    "name": "mcp_from_spiced/get_readiness",
+    "name": "mcp_from_spiced__get_readiness",
     "parameters": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {},
@@ -74,7 +74,7 @@ expression: tools_list
   },
   {
     "description": "List every dataset, view, and catalog visible to this runtime, with each entry's fully-qualified table name, description, columns, and capability flags (e.g. `can_search_documents`). Call this first whenever you need to discover what data is available before issuing `sql`, `search`, `table_schema`, or sample tools. Takes no arguments. Returns a JSON array; use the `table` field as the identifier for follow-up tool calls.",
-    "name": "mcp_from_spiced/list_datasets",
+    "name": "mcp_from_spiced__list_datasets",
     "parameters": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {},
@@ -85,7 +85,7 @@ expression: tools_list
   },
   {
     "description": "Load memories previously saved by the language model.",
-    "name": "mcp_from_spiced/load_memory",
+    "name": "mcp_from_spiced__load_memory",
     "parameters": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -117,7 +117,7 @@ expression: tools_list
   },
   {
     "description": "Get a random sample of rows from a Spice.ai dataset",
-    "name": "mcp_from_spiced/random_sample",
+    "name": "mcp_from_spiced__random_sample",
     "parameters": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -142,7 +142,7 @@ expression: tools_list
   },
   {
     "description": "Sample distinct column values from a Spice.ai dataset",
-    "name": "mcp_from_spiced/sample_distinct_columns",
+    "name": "mcp_from_spiced__sample_distinct_columns",
     "parameters": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -177,7 +177,7 @@ expression: tools_list
   },
   {
     "description": "Run a hybrid (vector + keyword) similarity search over datasets configured with embeddings. Use this for natural-language or semantic lookups (e.g. 'find documents about X') instead of exact SQL filtering. Provide `text` for the query; optionally restrict with `datasets` (only datasets whose `can_search_documents=true` in `list_datasets` are valid), `where_cond` (a SQL predicate without the `WHERE` keyword), `additional_columns`, and `limit`. Returns matched rows grouped per dataset with similarity scores.",
-    "name": "mcp_from_spiced/search",
+    "name": "mcp_from_spiced__search",
     "parameters": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -232,7 +232,7 @@ expression: tools_list
   },
   {
     "description": "Execute an SQL query in the Spice.ai SQL Dialect (DataFusion SQL using PostgreSQL-dialect with Spice.ai functions) against the Spice runtime and return the result rows as JSON. Use this for any deterministic lookup, aggregation, or filter where exact column names are known; prefer `search` for semantic or natural-language lookups. Quote identifiers containing capitals or reserved keywords, and quote each part of `catalog.schema.table` separately (e.g. \"spice\".\"public\".\"my_table\"). Avoid `SELECT *` and columns ending in `_offset` or `_embedding`. Write statements (INSERT/UPDATE/DELETE/DDL) require the request to be authenticated with a ReadWrite API key AND the target dataset to be configured `access: read_write`; otherwise they are rejected. Use `list_datasets` and `table_schema` first to discover tables and columns.",
-    "name": "mcp_from_spiced/sql",
+    "name": "mcp_from_spiced__sql",
     "parameters": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -250,7 +250,7 @@ expression: tools_list
   },
   {
     "description": "Record any details from 'user' messages that are worth remembering for future conversations.",
-    "name": "mcp_from_spiced/store_memory",
+    "name": "mcp_from_spiced__store_memory",
     "parameters": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -271,7 +271,7 @@ expression: tools_list
   },
   {
     "description": "Return the column schema of one or more datasets. Call this before writing a `sql` query so you know exact column names, types, nullability, and (with `output=full`) descriptions and semantic metadata. Pass `tables` as fully-qualified names from `list_datasets`. `output` is `full` (default, includes metadata) or `minimal` (names + types only).",
-    "name": "mcp_from_spiced/table_schema",
+    "name": "mcp_from_spiced__table_schema",
     "parameters": {
       "$defs": {
         "OutputType": {
@@ -307,7 +307,7 @@ expression: tools_list
   },
   {
     "description": "Get top N samples from a Spice.ai dataset based on a specified ordering",
-    "name": "mcp_from_spiced/top_n_sample",
+    "name": "mcp_from_spiced__top_n_sample",
     "parameters": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {

--- a/crates/runtime/tests/models/tools.rs
+++ b/crates/runtime/tests/models/tools.rs
@@ -109,7 +109,7 @@ params:
             tools_list.iter().any(|tool| tool
                 .get("name")
                 .and_then(Value::as_str)
-                .is_some_and(|name| name == "mcp_from_spiced/get_readiness")),
+                .is_some_and(|name| name == "mcp_from_spiced__get_readiness")),
             "expected proxied MCP tools from auth-enabled Spice server: {tools_list:?}"
         );
 
@@ -141,7 +141,7 @@ params:
             tools_list.iter().any(|tool| tool
                 .get("name")
                 .and_then(Value::as_str)
-                .is_some_and(|name| name == "mcp_from_spiced/get_readiness")),
+                .is_some_and(|name| name == "mcp_from_spiced__get_readiness")),
             "expected proxied MCP tools from auth-enabled Spice server: {tools_list:?}"
         );
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -20,6 +20,7 @@ pub mod mcp;
 #[cfg(feature = "mcp")]
 pub use mcp::McpProxy;
 
+pub mod naming;
 pub mod rename;
 
 use async_trait::async_trait;

--- a/crates/tools/src/naming.rs
+++ b/crates/tools/src/naming.rs
@@ -1,0 +1,171 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Encoding of catalog-qualified tool names.
+//!
+//! When Spice exposes a tool that belongs to a non-default catalog, the exposed
+//! name has to carry both the catalog and the tool name. MCP clients such as
+//! Claude and Cursor reject any tool name that does not match
+//! `^[a-zA-Z0-9_-]{1,64}$`, so the previously used `catalog/tool` form (with a
+//! `/` separator) left those tools unusable in those harnesses (issue #10894).
+//!
+//! [`encode_tool_name`] joins the two components with a `__` separator and
+//! escapes any literal `__` / `_-_` inside a component so the transform is
+//! reversible by [`decode_tool_name`]. `snake_case` names — the overwhelming
+//! majority of MCP tool names — contain only single underscores and therefore
+//! pass through with no escaping at all.
+
+/// Separator placed between a catalog name and a tool name.
+const SEPARATOR: &str = "__";
+/// Replacement for a literal `__` inside a single name component.
+const ESCAPE: &str = "_-_";
+/// Replacement for a literal `_-_` inside a single name component.
+const ESCAPED_ESCAPE: &str = "_--_";
+
+/// Escape a single name component so it can never contain a bare `__`
+/// separator. The escape sequence is escaped first so decoding is unambiguous.
+fn encode_component(component: &str) -> String {
+    component
+        .replace(ESCAPE, ESCAPED_ESCAPE)
+        .replace(SEPARATOR, ESCAPE)
+}
+
+/// Reverse of [`encode_component`]. The replacements are undone in the opposite
+/// order to the ones applied by [`encode_component`].
+fn decode_component(component: &str) -> String {
+    component
+        .replace(ESCAPE, SEPARATOR)
+        .replace(ESCAPED_ESCAPE, ESCAPE)
+}
+
+/// Encode a `(catalog, tool)` pair into a single MCP-safe tool name that only
+/// uses characters from `[a-zA-Z0-9_-]` (assuming the inputs do).
+#[must_use]
+pub fn encode_tool_name(catalog_name: &str, tool_name: &str) -> String {
+    format!(
+        "{}{SEPARATOR}{}",
+        encode_component(catalog_name),
+        encode_component(tool_name)
+    )
+}
+
+/// Decode a tool name produced by [`encode_tool_name`] back into its
+/// `(catalog, tool)` components.
+///
+/// Returns `None` when `name` contains no catalog separator — i.e. it refers to
+/// a top-level tool that was never catalog-qualified. Because an encoded
+/// component never contains a bare `__`, the first `__` in a well-formed name
+/// is always the catalog separator.
+#[must_use]
+pub fn decode_tool_name(name: &str) -> Option<(String, String)> {
+    let (catalog, tool) = name.split_once(SEPARATOR)?;
+    Some((decode_component(catalog), decode_component(tool)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_the_documented_examples() {
+        // (catalog, tool) -> encoded, from the scheme in issue #10894.
+        assert_eq!(
+            encode_tool_name("antv_charts", "some_tool"),
+            "antv_charts__some_tool"
+        );
+        assert_eq!(
+            encode_tool_name("my-catalog", "list_files"),
+            "my-catalog__list_files"
+        );
+        assert_eq!(
+            encode_tool_name("my_catalog", "some-tool"),
+            "my_catalog__some-tool"
+        );
+        assert_eq!(encode_tool_name("a--b", "c"), "a--b__c");
+        assert_eq!(encode_tool_name("my-_catalog", "foo"), "my-_catalog__foo");
+        assert_eq!(encode_tool_name("my__catalog", "foo"), "my_-_catalog__foo");
+        assert_eq!(
+            encode_tool_name("my_-_catalog", "foo"),
+            "my_--_catalog__foo"
+        );
+    }
+
+    #[test]
+    fn encoded_names_only_use_allowed_characters() {
+        // Every character in an encoded name must satisfy the MCP client
+        // constraint `^[a-zA-Z0-9_-]{1,64}$` when the inputs do.
+        for (catalog, tool) in [
+            ("antv_charts", "list_chart_types"),
+            ("my__catalog", "a_-_b"),
+            ("my_-_catalog", "tool__name"),
+            ("a-b_c", "d_e-f"),
+        ] {
+            let encoded = encode_tool_name(catalog, tool);
+            assert!(
+                encoded
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+                "encoded name `{encoded}` contains a disallowed character"
+            );
+        }
+    }
+
+    #[test]
+    fn round_trips_pairs() {
+        // Round-trip over the full supported domain: identifier-shaped names
+        // (letters/digits/`-` with single `_`), plus the escape paths that a
+        // literal `__` and a literal `_-_` exercise. The scheme escapes one
+        // level (`__` -> `_-_`, `_-_` -> `_--_`), which covers every realistic
+        // catalog/tool name; it does not target pathological inputs such as
+        // runs of 3+ underscores or a literal `_--_`, which never occur in MCP
+        // tool identifiers.
+        let names = [
+            "antv_charts",
+            "some_tool",
+            "list_chart_types",
+            "my-catalog",
+            "some-tool",
+            "a--b",
+            "my-_catalog",
+            "my__catalog",
+            "my_-_catalog",
+            "a_-_b",
+            "tool__name__x",
+            "get-files",
+            "x",
+        ];
+        for catalog in names {
+            for tool in names {
+                let encoded = encode_tool_name(catalog, tool);
+                let (decoded_catalog, decoded_tool) = decode_tool_name(&encoded)
+                    .expect("an encoded name always contains the separator");
+                assert_eq!(
+                    (decoded_catalog.as_str(), decoded_tool.as_str()),
+                    (catalog, tool),
+                    "round-trip failed for ({catalog:?}, {tool:?}) via {encoded:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn decode_returns_none_without_separator() {
+        // A `snake_case` top-level tool name has no `__` separator.
+        assert_eq!(decode_tool_name("list_files"), None);
+        assert_eq!(decode_tool_name("document_similarity"), None);
+        assert_eq!(decode_tool_name(""), None);
+    }
+}


### PR DESCRIPTION
## Summary (root cause)

When Spice exposes tools from a non-default MCP catalog through its own MCP server (and to models), each tool name was prefixed with the catalog using a `/` separator, e.g. `antv_charts/list_chart_types`. MCP clients such as Claude and Cursor reject any tool name that does not match `^[a-zA-Z0-9_-]{1,64}$`, and `/` is outside that set — so every catalog-qualified tool was rejected and unavailable in those harnesses.

Fixes #10894
Fixes #10887

## Changes

- New shared module `crates/tools/src/naming.rs` with `encode_tool_name(catalog, tool)` / `decode_tool_name(name)`. It joins the two components with a `__` separator and escapes a literal `__` -> `_-_` (and the escape itself, `_-_` -> `_--_`) inside each component so the transform is reversible. `snake_case` names — the vast majority of MCP tool names — contain only single underscores and pass through with **zero** escaping, keeping the common case clean and readable (`antv_charts__list_chart_types`). This is the encoding scheme designed in the issue.
- Replaced all four catalog/tool encode sites (`runtime-tools::tooling::Tooling::tools`, `runtime-tools::mcp::server::all_tools`, `runtime::tools::utils::get_tool_by_name`, `runtime::Runtime::tools`) with `encode_tool_name`.
- Replaced the paired decode/dispatch sites (`runtime-tools::mcp::server::{get_tool, call_tool}` task-history label, `runtime::Runtime::get_tool`) with `decode_tool_name`, and made routing fall back to a direct lookup so a top-level tool whose name legitimately contains `__` still resolves.
- Updated the MCP tool-list snapshot and the two catalog-name assertions in `crates/runtime/tests/models/tools.rs` to the new `catalog__tool` form.

The spicepod config separator (`catalog:tool`, a colon) is unchanged — only the exposed name is affected.

## Test plan

- Added unit tests in `tools::naming`: the 7 documented encoding examples, an allowed-character check, an exhaustive round-trip over the supported name domain, and the no-separator (top-level tool) case.
- `make lint`
- `make test`

## Checklist

- [x] New tool names satisfy `^[a-zA-Z0-9_-]{1,64}$` for identifier-shaped catalog/tool names
- [x] Encode/decode round-trip covered by unit tests
- [x] Existing catalog-naming tests + MCP snapshot updated to the new form
- [ ] CI green