### PR TITLE
fix(cli): allow `spice trace` on dynamic MCP/custom tool_use tasks (fixes #10995)

### DIFF
--- a/bin/spice/src/commands/trace.rs
+++ b/bin/spice/src/commands/trace.rs
@@ -179,7 +179,16 @@ pub async fn execute(ctx: &RuntimeContext, args: &TraceArgs) -> Result<()> {
 }
 
 fn is_valid_trace_task(task: &str) -> bool {
+    // Built-in task types are matched exactly. Custom and MCP-proxied tools are recorded
+    // dynamically in task_history as `tool_use::<tool>` or `tool_use::<server>/<tool>`
+    // (via the `task_override` label emitted in runtime-tools), so the static allowlist
+    // can never enumerate them. Accept any `tool_use::`-prefixed task with a non-empty
+    // suffix; the SQL filter already quotes the value via `quote_sql_string`, so this does
+    // not introduce injection. See https://github.com/spiceai/spiceai/issues/10995.
     SUPPORTED_TRACE_TASKS.contains(&task)
+        || task
+            .strip_prefix("tool_use::")
+            .is_some_and(|suffix| !suffix.is_empty())
 }
 
 /// Quote a SQL string value (escape single quotes).
@@ -471,5 +480,46 @@ fn truncate_string(s: &str, max_len: Option<usize>) -> String {
             format!("{}... ({omitted} characters omitted)", &s[..max])
         }
         _ => s.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn built_in_trace_tasks_are_valid() {
+        for task in SUPPORTED_TRACE_TASKS {
+            assert!(is_valid_trace_task(task), "expected '{task}' to be valid");
+        }
+    }
+
+    #[test]
+    fn dynamic_mcp_tool_use_tasks_are_valid() {
+        // Regression for https://github.com/spiceai/spiceai/issues/10995: MCP and other
+        // custom tools are recorded with dynamic `tool_use::<server>/<tool>` task names.
+        assert!(is_valid_trace_task("tool_use::github/search_code"));
+        assert!(is_valid_trace_task("tool_use::my_catalog/my_tool"));
+        // A custom tool without a server segment is also valid.
+        assert!(is_valid_trace_task("tool_use::custom_tool"));
+    }
+
+    #[test]
+    fn invalid_trace_tasks_are_rejected() {
+        assert!(!is_valid_trace_task("bogus"));
+        assert!(!is_valid_trace_task(""));
+        // The bare prefix with no tool suffix is not a real task name.
+        assert!(!is_valid_trace_task("tool_use::"));
+    }
+
+    #[test]
+    fn dynamic_tool_task_produces_quoted_sql_filter() {
+        // The dynamic name must flow through unchanged and be single-quoted so it is a
+        // literal (not injected) in the generated SQL.
+        let filter = get_trace_filter("tool_use::github/search_code", None, None);
+        assert!(
+            filter.contains("task='tool_use::github/search_code'"),
+            "got: {filter}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`spice trace "tool_use::github/search_code"` fails with `Invalid argument: invalid trace type 'tool_use::github/search_code'`, even though that row is present in `runtime.task_history`.

MCP-proxied and other custom tools are recorded with **dynamic** task names — `tool_use::<server>/<tool>` (e.g. `tool_use::github/search_code`) or `tool_use::<tool>` — emitted via the `task_override` label in `runtime-tools` and picked up by the task-history exporter (`otel_exporter.rs`). But `bin/spice/src/commands/trace.rs` validated `args.task` against a **static** `SUPPORTED_TRACE_TASKS` allowlist that only contains the built-in tool names, so it can never match a dynamically-named tool and rejects the command before building any SQL.

Fixes #10995.

## Fix

Relax `is_valid_trace_task` to accept, in addition to the static allowlist, any task with the `tool_use::` prefix and a **non-empty** suffix. The downstream SQL filter already quotes the task value via `quote_sql_string`, so the dynamic name is bound as a string literal — no injection is introduced. The bare prefix `tool_use::` (no tool) is still rejected.

## Tests

Adds unit tests in `trace.rs`:
- all built-in `SUPPORTED_TRACE_TASKS` remain valid
- dynamic `tool_use::github/search_code`, `tool_use::my_catalog/my_tool`, and `tool_use::custom_tool` are accepted
- `bogus`, `""`, and the bare `tool_use::` prefix are rejected
- the dynamic name flows through into a single-quoted SQL filter (`task='tool_use::github/search_code'`)

## Validation

- `cargo test -p spice --lib commands::trace::` — 4/4 pass
- `cargo clippy -p spice --lib --no-deps` — clean on `trace.rs`
- `cargo fmt -p spice --check` — clean

The independent source analysis in the issue thread reached the same diagnosis and proposed this same narrow fix.

## Follow-up (out of scope)

The "Available:" list in the validation-failure message is static and can't surface MCP-discovered tool names; a future improvement could populate it from `SELECT DISTINCT task FROM runtime.task_history WHERE task LIKE 'tool_use::%'`.