### PR TITLE
docs: add clang/lld to arm64 Linux build prerequisites (fixes #11120)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,12 @@ spice run
 sudo apt update
 sudo apt install build-essential curl openssl libssl-dev pkg-config protobuf-compiler cmake
 
+# On arm64 (aarch64) also install clang and lld — the build uses the clang/lld
+# linker for aarch64 targets (see .cargo/config.toml), and omitting them fails
+# with `clang: error: invalid linker name in argument '-fuse-ld=lld'`.
+# See docs/DISTRIBUTIONS.md ("Linux arm64 Notes") for details.
+sudo apt install clang lld
+
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y # install unattended
 source $HOME/.cargo/env


### PR DESCRIPTION
## Summary

The Ubuntu build instructions in `CONTRIBUTING.md` omit `clang` and `lld`. On arm64 (aarch64) hosts these are required: `.cargo/config.toml` sets the linker to `clang` with `-Clink-arg=-fuse-ld=lld` for `aarch64-unknown-linux-gnu`, so following the guide verbatim on an ARM64 machine (e.g. a DGX Spark, Ubuntu ARM64) fails at link time with:

```
clang: error: invalid linker name in argument '-fuse-ld=lld'
```

Installing `lld` resolves it, as the reporter confirmed. `docs/DISTRIBUTIONS.md` already documents this under **Linux arm64 Notes** (`sudo apt-get install -y clang lld`); this PR brings the contributor build steps in line with it. Confirmed by maintainer @Jeadie on the issue.

## Changes

- `CONTRIBUTING.md`: add a `sudo apt install clang lld` step (with an explanatory comment) to the Linux (Ubuntu) build instructions.

## Test plan

Documentation-only change — a single Markdown file, no Rust code touched, so `make lint` / `make test` have nothing to exercise and are not run locally (per the repo's guidance to avoid unnecessary full builds). Correctness verified by inspection against `.cargo/config.toml` (lines 9-11, the aarch64 `clang`/`fuse-ld=lld` linker config) and `docs/DISTRIBUTIONS.md` ("Linux arm64 Notes"). CI lint/build on the PR confirm nothing is broken.

## Checklist

- [x] Fix matches the maintainer-confirmed remedy on the issue
- [x] Mirrors the existing requirement already documented in `docs/DISTRIBUTIONS.md`

Fixes #11120