### PR TITLE
fix(ducklake): add opt-in automatic_migration to attach older catalogs (fixes #10899)

### DIFF
--- a/crates/data-connectors/connector-ducklake/src/lib.rs
+++ b/crates/data-connectors/connector-ducklake/src/lib.rs
@@ -20,8 +20,8 @@ limitations under the License.
 
 use async_trait::async_trait;
 use data_components::Read;
-use data_components::ducklake::DuckLakeS3Params;
 use data_components::ducklake::writer::DuckDbFederatedTableWriter;
+use data_components::ducklake::{DuckLakeS3Params, build_ducklake_attach_sql};
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::UnsupportedTypeAction;
@@ -165,12 +165,16 @@ const PARAMETERS: &[ParameterSpec] = &[
         .secret(),
     ParameterSpec::component("aws_allow_http")
         .description("Allow HTTP (non-TLS) connections to S3."),
+    ParameterSpec::component("automatic_migration").description(
+        "Automatically migrate an older DuckLake catalog schema to the version required by the ducklake extension on attach. Defaults to false; migration rewrites catalog metadata and cannot be undone.",
+    ),
 ];
 
 fn create_ducklake_factory(
     connection_string: &str,
     catalog_name: &str,
     open_path: Option<&str>,
+    automatic_migration: bool,
     params: &ConnectorParams,
 ) -> AnyErrorResult<(DuckDBTableFactory, Arc<DuckDbConnectionPool>, String)> {
     let pool = if let Some(path) = open_path {
@@ -282,10 +286,8 @@ fn create_ducklake_factory(
             source: Box::new(e),
         })?;
 
-    let escaped_connection_string = connection_string.replace('\'', "''");
-    let escaped_catalog_name = catalog_name.replace('"', "\"\"");
     let attach_sql =
-        format!("ATTACH 'ducklake:{escaped_connection_string}' AS \"{escaped_catalog_name}\"");
+        build_ducklake_attach_sql(connection_string, catalog_name, automatic_migration);
     duckdb_wrapper
         .conn
         .execute(&attach_sql, [])
@@ -336,12 +338,20 @@ impl DataConnectorFactory for DuckLakeFactory {
                 .ok()
                 .map(ToString::to_string);
 
+            let automatic_migration = params
+                .parameters
+                .get("automatic_migration")
+                .expose()
+                .ok()
+                .is_some_and(|v| v.eq_ignore_ascii_case("true"));
+
             let params_for_factory = params.clone();
             let (duckdb_factory, pool, catalog_name) = tokio::task::spawn_blocking(move || {
                 create_ducklake_factory(
                     &connection_string,
                     &catalog_name,
                     open_path.as_deref(),
+                    automatic_migration,
                     &params_for_factory,
                 )
             })

--- a/crates/data_components/src/ducklake/mod.rs
+++ b/crates/data_components/src/ducklake/mod.rs
@@ -96,3 +96,57 @@ pub fn configure_duckdb_httpfs(
 
     Ok(())
 }
+
+/// Builds the `ATTACH` statement used to attach a `DuckLake` catalog in `DuckDB`.
+///
+/// The connection string is escaped for a single-quoted literal and the catalog
+/// name for a double-quoted identifier. When `automatic_migration` is `true`, the
+/// `AUTOMATIC_MIGRATION` attach option is appended so that `DuckDB` migrates an
+/// older `DuckLake` catalog schema in place instead of failing with a
+/// `catalog version mismatch ... the extension requires version` error. Migration
+/// is disabled by default because it rewrites the catalog's metadata and cannot be
+/// undone, so it is gated behind an explicit opt-in.
+#[must_use]
+pub fn build_ducklake_attach_sql(
+    connection_string: &str,
+    catalog_name: &str,
+    automatic_migration: bool,
+) -> String {
+    let escaped_connection_string = connection_string.replace('\'', "''");
+    let escaped_catalog_name = catalog_name.replace('"', "\"\"");
+    let mut attach_sql =
+        format!("ATTACH 'ducklake:{escaped_connection_string}' AS \"{escaped_catalog_name}\"");
+    if automatic_migration {
+        attach_sql.push_str(" (AUTOMATIC_MIGRATION TRUE)");
+    }
+    attach_sql
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_ducklake_attach_sql;
+
+    #[test]
+    fn attach_sql_without_migration_is_unchanged() {
+        assert_eq!(
+            build_ducklake_attach_sql("metadata.ducklake", "ducklake", false),
+            "ATTACH 'ducklake:metadata.ducklake' AS \"ducklake\""
+        );
+    }
+
+    #[test]
+    fn attach_sql_with_migration_appends_option() {
+        assert_eq!(
+            build_ducklake_attach_sql("metadata.ducklake", "ducklake", true),
+            "ATTACH 'ducklake:metadata.ducklake' AS \"ducklake\" (AUTOMATIC_MIGRATION TRUE)"
+        );
+    }
+
+    #[test]
+    fn attach_sql_escapes_connection_string_and_catalog_name() {
+        assert_eq!(
+            build_ducklake_attach_sql("s3://b/o'brien.ducklake", "my\"lake", true),
+            "ATTACH 'ducklake:s3://b/o''brien.ducklake' AS \"my\"\"lake\" (AUTOMATIC_MIGRATION TRUE)"
+        );
+    }
+}

--- a/crates/runtime/src/catalogconnector/ducklake.rs
+++ b/crates/runtime/src/catalogconnector/ducklake.rs
@@ -26,8 +26,8 @@ use crate::{
 };
 use async_trait::async_trait;
 use data_components::RefreshableCatalogProvider;
-use data_components::ducklake::DuckLakeS3Params;
 use data_components::ducklake::provider::DuckLakeCatalogProvider;
+use data_components::ducklake::{DuckLakeS3Params, build_ducklake_attach_sql};
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use duckdb::AccessMode;
@@ -69,6 +69,9 @@ pub const PARAMETERS: &[ParameterSpec] = &[
         .secret(),
     ParameterSpec::component("aws_allow_http")
         .description("Allow HTTP (non-TLS) connections to S3."),
+    ParameterSpec::component("automatic_migration").description(
+        "Automatically migrate an older DuckLake catalog schema to the version required by the ducklake extension on attach. Defaults to false; migration rewrites catalog metadata and cannot be undone.",
+    ),
 ];
 
 fn configure_duckdb_httpfs(
@@ -195,6 +198,14 @@ impl CatalogConnector for DuckLakeCatalog {
             .ok()
             .map(ToString::to_string);
 
+        let automatic_migration = self
+            .params
+            .parameters
+            .get("automatic_migration")
+            .expose()
+            .ok()
+            .is_some_and(|v| v.eq_ignore_ascii_case("true"));
+
         // Get the catalog's access mode to determine writable/ddl_enabled flags
         let writable = catalog.access.allows_write();
         let ddl_enabled = catalog.access.allows_ddl();
@@ -316,10 +327,10 @@ impl CatalogConnector for DuckLakeCatalog {
                         source: Box::new(e),
                     })?;
 
-                let escaped_connection_string = connection_string_for_pool.replace('\'', "''");
-                let escaped_catalog_name = catalog_name_for_pool.replace('"', "\"\"");
-                let attach_sql = format!(
-                    "ATTACH 'ducklake:{escaped_connection_string}' AS \"{escaped_catalog_name}\""
+                let attach_sql = build_ducklake_attach_sql(
+                    &connection_string_for_pool,
+                    &catalog_name_for_pool,
+                    automatic_migration,
                 );
                 duckdb_wrapper
                     .conn


### PR DESCRIPTION
## Summary

Connecting to a DuckLake catalog created by an older DuckLake/DuckDB version fails at `ATTACH` with:

> Invalid Input Error: DuckLake catalog version mismatch: catalog version is 0.3, but the extension requires version 1.0. To automatically migrate, set AUTOMATIC_MIGRATION to TRUE when attaching.

Spice built the attach statement as `ATTACH 'ducklake:<cs>' AS "<name>"` with no options, so there was no way to opt into the in-place migration DuckLake supports. This adds an opt-in `automatic_migration` parameter (default `false`) to both DuckLake surfaces — the data connector and the catalog connector — which appends the `AUTOMATIC_MIGRATION TRUE` attach option when enabled.

Migration is left disabled by default because it rewrites the catalog's metadata and cannot be undone (see duckdb/ducklake#457); enabling it is an explicit, informed choice.

Fixes #10899

## Changes

- `crates/data_components/src/ducklake/mod.rs`: new shared, unit-tested `build_ducklake_attach_sql(connection_string, catalog_name, automatic_migration)` helper that centralizes the `ATTACH` construction (single-quote / double-quote escaping preserved) and appends `(AUTOMATIC_MIGRATION TRUE)` only when opted in.
- `crates/data-connectors/connector-ducklake/src/lib.rs`: new `automatic_migration` component parameter; read it (`true`, case-insensitive) and thread it into `create_ducklake_factory`, which now calls the shared helper.
- `crates/runtime/src/catalogconnector/ducklake.rs`: same new parameter and helper call for the catalog connector, so both DuckLake entry points behave identically (bug-class fix, not just one surface).

Behavior is default-preserving: with the parameter unset the emitted `ATTACH` is byte-for-byte identical to before.

## Test plan

- `make lint`
- `make test`
- Added unit tests (`data_components` `ducklake::tests`, gated behind the `duckdb` feature): attach SQL is unchanged when migration is off, appends `(AUTOMATIC_MIGRATION TRUE)` when on, and escaping of the connection string / catalog name is preserved with the option present.

## Checklist

- [x] Opt-in, default-preserving (no behavior change unless `automatic_migration: true`)
- [x] Both DuckLake surfaces (data connector + catalog connector) fixed via one shared helper
- [x] Unit tests for the new SQL construction
- [x] Generated `ATTACH` option syntax verified against DuckLake docs (`AUTOMATIC_MIGRATION` boolean, default false)