### PR TITLE
ci(e2e): tolerate empty-type DuckDB variant of the parquet-rename race

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -2008,10 +2008,15 @@ jobs:
           # `simulate_append_data.sh` rewrites `.spice/service_data.parquet`
           # every 3s; a refresh tick that races the rename observes a
           # half-published file and the runtime logs a WARN before
-          # retrying on the next tick. Tolerate that specific transient.
+          # retrying on the next tick. DuckDB surfaces the truncated read as
+          # one of two errors depending on which part of the file it reaches
+          # first: "TProtocolException: Invalid data" (corrupt Thrift footer)
+          # or "don't know what type:" with an empty type (schema element not
+          # yet written). Tolerate both variants of that specific transient.
           if grep -iE "(failed|error)" spice.log \
              | grep -vE "WARN +runtime::accelerated_table::refresh_task: Failed to load data for dataset" \
-             | grep -vE "^Invalid Error: TProtocolException: Invalid data$"; then
+             | grep -vE "^Invalid Error: TProtocolException: Invalid data$" \
+             | grep -vE "^Invalid Error: don't know what type: *$"; then
             echo "Failures detected in spice.log"
             exit 1
           fi
@@ -2046,10 +2051,12 @@ jobs:
           killall spice || true
           cat spice.log
           # See note above: tolerate transient parquet-rename races emitted
-          # at WARN level by the refresh task.
+          # at WARN level by the refresh task (both the "TProtocolException:
+          # Invalid data" and empty-type "don't know what type:" variants).
           if grep -iE "(failed|error)" spice.log \
              | grep -vE "WARN +runtime::accelerated_table::refresh_task: Failed to load data for dataset" \
-             | grep -vE "^Invalid Error: TProtocolException: Invalid data$"; then
+             | grep -vE "^Invalid Error: TProtocolException: Invalid data$" \
+             | grep -vE "^Invalid Error: don't know what type: *$"; then
             echo "Failures detected in spice.log"
             exit 1
           fi


### PR DESCRIPTION
## Problem

The `graceful_shutdown_test*` acceleration jobs in `e2e_test_ci.yml` run `simulate_append_data.sh`, which rewrites `.spice/service_data.parquet` every 3s. A refresh tick that races the rename reads a **half-published Parquet file**, which the `data_drop` dataset is deliberately set up to hit (its `on_conflict: drop` refresh is expected to fail-and-retry). The log-scan step already whitelists this documented transient — but only for the `TProtocolException: Invalid data` error DuckDB emits when it reaches a corrupt Thrift footer.

DuckDB surfaces the *same* truncated read a second way — `Invalid Error: don't know what type: ` with an **empty type** (a schema element that has not been written yet) — and that variant was never whitelisted. So whenever the race lands on the empty-type path, the job fails even though nothing is wrong. This intermittently reddens the `duckdb_append_with_pk.yaml` job (and its siblings) on PRs; the same job passes on `trunk` when the race happens to produce the whitelisted variant.

Example: https://github.com/spiceai/spiceai/actions/runs/28750176806/job/85251613356

## Fix

Extend both log-scan whitelists to also tolerate the empty-type variant of the same race. The added pattern is anchored to an empty type (`^Invalid Error: don't know what type: *$`), so a **genuine** unsupported-type error — which always names the offending type after the colon — still fails the job and is not masked.

## Validation

- No Rust code changed — this is a CI-workflow-only change, so the Rust `make lint` / `make test` gates do not apply.
- `.github/workflows/e2e_test_ci.yml` parses as valid YAML.
- Verified the grep pipeline against a synthetic `spice.log`: a log containing only the WARN + both transient variants produces no output (job passes), while adding a genuine `ERROR something genuinely broke` line still surfaces it (job fails). The empty-type anchor does not swallow real errors.