### PR TITLE
Revert "ci(chbench): lower tuned SF1000 mem-tier max age to 15s for scheduled HTAP runs"

### DIFF
--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-cold-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-cold-sf1000.yaml
@@ -99,7 +99,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '1073741824' # 1 GiB
         cayenne_cdc_mem_tier_min_flush_bytes: '268435456'
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
         cayenne_cdc_mem_tier_shards: '4'
@@ -275,7 +275,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
@@ -325,7 +325,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-ivm-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-ivm-sf1000.yaml
@@ -66,7 +66,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '1073741824' # 1 GiB
         cayenne_cdc_mem_tier_min_flush_bytes: '268435456'
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
         cayenne_cdc_mem_tier_shards: '4'
@@ -253,7 +253,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
@@ -303,7 +303,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
@@ -66,7 +66,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '1073741824' # 1 GiB
         cayenne_cdc_mem_tier_min_flush_bytes: '268435456'
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
         cayenne_cdc_mem_tier_shards: '4'
@@ -222,7 +222,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
@@ -272,7 +272,7 @@ datasets:
         cayenne_cdc_durability: memory
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
-        cayenne_cdc_mem_tier_max_age_ms: '15000'
+        cayenne_cdc_mem_tier_max_age_ms: '30000'
         cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'


### PR DESCRIPTION
Reverts spiceai/spiceai#11618

Can now be 30s with https://github.com/spiceai/spiceai/pull/11622