### PR TITLE
fix(cayenne): don't bump mem-tier version on seal (QPH regression from #11622)

### DIFF
--- a/crates/cayenne/src/provider/mem_tier.rs
+++ b/crates/cayenne/src/provider/mem_tier.rs
@@ -612,10 +612,10 @@ impl MemTier {
     /// to `sealed_through` — recording that `segments[0..sealed_through]` are now
     /// durably shadowed. Monotone and clamped: never lowers the boundary and never
     /// exceeds `segments.len()` (a concurrent append only grows the tail, so the
-    /// captured `sealed_through` stays valid). Bumps `version` (the sealed/active
-    /// split is content the merged-scan memo need not distinguish, but a version
-    /// bump keeps "a store happened" observable and is cheap). O(1): clones only
-    /// the `Arc` segment/​tombstone pointers, never the payload.
+    /// captured `sealed_through` stays valid). Preserves `version`: the
+    /// sealed/active split is read-transparent, so seals must not invalidate
+    /// version-keyed merge-on-read memos. O(1): clones only the `Arc`
+    /// segment/tombstone pointers, never the payload.
     #[must_use]
     pub(crate) fn mark_sealed_through(&self, sealed_through: usize) -> Self {
         let sealed_segments = sealed_through
@@ -629,7 +629,7 @@ impl MemTier {
             superseded: self.superseded,
             epoch: self.epoch,
             oldest_append: self.oldest_append,
-            version: self.version + 1,
+            version: self.version,
             sealed_segments,
         }
     }
@@ -1269,9 +1269,26 @@ mod tests {
         // Segment payloads and aggregates are untouched by a seal (O(1) rebrand).
         assert_eq!(sealed.segments.len(), 2);
         assert_eq!(sealed.rows, tier.rows);
-        assert!(
-            sealed.version > tier.version,
-            "seal bumps the content version"
+        assert_eq!(
+            sealed.version, tier.version,
+            "seal preserves the content version"
+        );
+
+        let other_shard = Arc::new(MemTier::empty().append_segment(
+            Arc::new(vec![batch(&[42])]),
+            1,
+            SegmentTombstones::default(),
+            16,
+            1,
+            0,
+        ));
+        let before_hash =
+            ShardedMemTier::version_hash_of(&[Arc::new(tier.clone()), Arc::clone(&other_shard)]);
+        let after_hash =
+            ShardedMemTier::version_hash_of(&[Arc::new(sealed.clone()), Arc::clone(&other_shard)]);
+        assert_eq!(
+            after_hash, before_hash,
+            "seal is transparent to the version-keyed scan memo"
         );
 
         // A later append is active again (boundary unchanged by the append).

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -27883,6 +27883,97 @@ mod tests {
         );
     }
 
+    /// Regression: the durable seal pipeline is read-transparent. It must not bump
+    /// any shard's content version, because the scan path keys both merge-on-read
+    /// memos by the per-shard version vector. This drives the real N>1 CDC writer,
+    /// warms both scan memos, seals via `seal_mem_tier_durable`, then verifies the
+    /// next scan reuses the exact same memo entries.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn mem_tier_seal_pipeline_preserves_scan_memos() {
+        let n = 4_usize;
+        let ctx = SessionContext::new();
+        let runtime_env = ctx.runtime_env();
+        let (provider, _catalog, _tmp) =
+            create_sharded_cdc_upsert_table("seal_memo_stable", Arc::clone(&runtime_env), n).await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        let base: Vec<(i64, i64)> = (0..16).map(|k| (k, k * 10)).collect();
+        apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), &base).await;
+        provider
+            .checkpoint_mem_tier()
+            .await
+            .expect("flush base to a durable file");
+
+        apply_upsert_burst(&ctx, &provider, Arc::clone(&schema), &[(3, 333)]).await;
+        let mut expected = base.clone();
+        if let Some(slot) = expected.iter_mut().find(|(id, _)| *id == 3) {
+            slot.1 = 333;
+        }
+
+        assert_eq!(
+            collect_id_value_pairs(&ctx, &provider, "seal_memo_stable").await,
+            expected,
+            "initial scan builds the correct file+RAM merge view"
+        );
+        let merged_before = provider
+            .merged_scan_deletions
+            .load_full()
+            .expect("initial scan stored the merged-deletions memo");
+        let visible_before = provider
+            .mem_tier_visible_memo
+            .load_full()
+            .expect("initial scan stored the visible-batch memo");
+        let shards_before: Vec<_> = provider
+            .mem_tier
+            .shards()
+            .iter()
+            .map(ArcSwap::load_full)
+            .collect();
+        let version_before =
+            crate::provider::mem_tier::ShardedMemTier::version_hash_of(&shards_before);
+
+        let sealed = provider
+            .seal_mem_tier_durable()
+            .await
+            .expect("durable seal");
+        assert!(sealed > 0, "the seal shadowed the active RAM delta");
+
+        let shards_after: Vec<_> = provider
+            .mem_tier
+            .shards()
+            .iter()
+            .map(ArcSwap::load_full)
+            .collect();
+        let version_after =
+            crate::provider::mem_tier::ShardedMemTier::version_hash_of(&shards_after);
+        assert_eq!(
+            version_after, version_before,
+            "the seal pipeline must not perturb the scan memo version key"
+        );
+
+        assert_eq!(
+            collect_id_value_pairs(&ctx, &provider, "seal_memo_stable").await,
+            expected,
+            "scan results stay unchanged after the seal"
+        );
+        let merged_after = provider
+            .merged_scan_deletions
+            .load_full()
+            .expect("merged-deletions memo still present");
+        let visible_after = provider
+            .mem_tier_visible_memo
+            .load_full()
+            .expect("visible-batch memo still present");
+        assert!(
+            Arc::ptr_eq(&merged_before, &merged_after),
+            "a seal must not force the merged-deletions memo to rebuild"
+        );
+        assert!(
+            Arc::ptr_eq(&visible_before, &visible_after),
+            "a seal must not force the visible-batch memo to rebuild"
+        );
+    }
+
     #[tokio::test]
     async fn test_write_shard_format_unsorted_round_robin() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));


### PR DESCRIPTION
# fix(cayenne): don't bump the mem-tier `version` on a seal

## Problem — QPH regression from #11622

The periodic mem-tier **seal** added in #11622 (`cdc_durability: memory`, default 2 s) advances each shard's ingestion/immutable split via `MemTier::mark_sealed_through`, which **bumped the tier's content `version` on every fire**. Under live CDC that is a version bump roughly every 2 s, per shard.

But `version` is the *sole* key for the two merge-on-read scan memos consulted on **every scan**:

- `merged_scan_deletions` — the merged tombstone snapshot
- `mem_tier_visible_memo` — the deletion-filtered visible batches (added by #11631)

Both key on `version_hash_of(shards)` (`table.rs:16392`, `18611`), which moves whenever *any* shard's `.version` moves. So every seal invalidated both memos, and the next scan paid a full **O(resident-tier)** merged-deletion + visible-batch rebuild — the churn-coupled collapse the append path is specifically engineered to avoid:

> Bumping here … forced every concurrent scan into a full metastore rebuild per append … the churn-coupled **175-247x collapse** the `mem_tier_join_shapes` live lanes measure. — `table.rs:17407-17435`

The append path avoids this by keeping the memo *current* (lockstep `extended_by_delta` at N==1) or relying on quiescent re-hits (at N>1). The seal did neither — it bumped `version` with no lockstep extend, re-introducing the collapse every 2 s.

## Root cause

A seal is **invisible to reads**. `mark_sealed_through` changes only `sealed_segments`; the scan unions both halves identically, and the durable shadow is deliberately unpublished:

- the inline BLOB skips `publish_inlined_mutation` → no `inlined_generation` / `inlined_structural_epoch` bump (`table.rs:18344`)
- the tombstone commit drops its in-memory update (`let _unpublished`, `table.rs:18377`) → `pk_deletion_snapshot` is not swapped, so `file_index_ptr` is unchanged

So of the memo key's three components — `tier_version`, `file_index_ptr`, `structural_epoch` — the seal disturbed **only `tier_version`**, via a `version + 1` that the field's own contract says is unnecessary ("Cache keys … key on this", `mem_tier.rs`).

## Fix

`mark_sealed_through` now **preserves `version`**. The seal becomes fully memo-transparent, and the N==1 append lockstep-extend keeps firing across seals (its `memo.tier_version == cur.version` guard stays satisfied).

## Correctness — N=1 and N>1

`version_hash_of` (`mem_tier.rs:870`) is the memo key in both regimes:

- **N==1** → returns `shards[0].version` verbatim. The seal preserves shard 0's version → key stable → memo hits.
- **N>1** → hashes the per-shard version *vector*. The seal loops `mark_shard_sealed_through` over each shard (`table.rs:18392`); each preserves its shard's version, so every vector element is unchanged → the combined hash is invariant **across the entire sequential seal loop** (no torn key mid-loop). N>1 took the full damage before, since the append path skips the lockstep-extend there and relied entirely on quiescent-rescan hits that the 2 s bumps destroyed.

Preserving `version` cannot serve stale data: `sealed_segments` does not affect the visible set, so a memo computed at the pre-seal version is a valid materialization of the post-seal tier.

## Testing

- `mark_sealed_through_advances_split_monotone_and_clamped` now asserts the seal **preserves** `version`, and adds a **2-shard `version_hash_of` guard** proving the seal is transparent to the memo key (exercises the real N>1 hash path, not the N==1 passthrough).
- Existing seal correctness suite unchanged and passing: `mem_tier_seal_advances_slot_and_preserves_ram_reads` (N==1), `mem_tier_seal_all_shards_advances_slot_and_recovers` (N=4), and `seal_is_transparent_to_the_converged_result`.
- `cargo test -p cayenne --lib mem_tier` and `cargo clippy -p cayenne --no-deps --tests`.

## Scope

Seal cadence stays at **2 s** — correct for the <5 s replication-lag SLO; this fix makes the cadence QPH-neutral so it can be sized purely on lag↔WAL. The SF1000 bench max-age experiment (15 s) was reverted separately in #11648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
