### PR TITLE
fix(cayenne): gate metastore reinsert_sequence schema behind a user_version (fixes #11291)

### DIFF
--- a/crates/cayenne/src/catalog.rs
+++ b/crates/cayenne/src/catalog.rs
@@ -119,6 +119,11 @@ pub enum CatalogError {
     SchemaMismatch { table: String },
 
     #[snafu(display(
+        "Cayenne acceleration metadata was written by a newer version of Spice (metadata schema version {found}, this build supports up to {supported}). Opening it with this build could silently drop rows from query results. Upgrade Spice to a build that supports metadata schema version {found} or newer, or clear the Cayenne acceleration data (delete the Cayenne metadata directory) so it can be recreated from the source. See: https://spiceai.org/docs/components/data-accelerators"
+    ))]
+    IncompatibleSchemaVersion { found: i64, supported: i64 },
+
+    #[snafu(display(
         "Deletion vectors require non-negative row IDs, found negative values: {row_ids}"
     ))]
     NegativeRowId { row_ids: String },

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -28,8 +28,53 @@ pub mod turso;
 
 use std::fmt::Display;
 
-use super::catalog::CatalogResult;
+use super::catalog::{CatalogError, CatalogResult};
 use async_trait::async_trait;
+
+/// The Cayenne metastore schema version stamped into the backing database's
+/// `user_version` header by [`Metastore::init_schema`] on every open.
+///
+/// Bump this whenever a schema change makes a catalog written by the new code
+/// **unsafe to open with an older binary** — i.e. the older binary would return
+/// silently wrong results rather than fail cleanly.
+///
+/// Version history:
+/// - `1` — metadata-only upsert publish (#11260): upsert commits stop writing
+///   per-key `cayenne_insert_record` rows and instead stamp `reinsert_sequence`
+///   on key-based delete files. A pre-#11260 binary reads an empty insert-record
+///   table for post-upgrade upserts and silently filters out the current version
+///   of every upserted row. The gate below turns that latent silent-row-loss into
+///   a loud [`CatalogError::IncompatibleSchemaVersion`] on any future downgrade to
+///   a build whose max supported version is lower than the stamped one (#11291).
+pub const CAYENNE_METASTORE_SCHEMA_VERSION: i64 = 1;
+
+/// Guard against opening a metastore that was written by a **newer** Spice build
+/// than this one supports.
+///
+/// `stored_version` is the `user_version` header read from the catalog before any
+/// migration runs. A stored version greater than [`CAYENNE_METASTORE_SCHEMA_VERSION`]
+/// means the catalog carries a schema this build does not understand; continuing
+/// would risk silently wrong results (see the version history above), so we refuse
+/// to open it with a loud error instead. A stored version less than or equal to the
+/// current one is a legacy or same-version catalog and is safe to migrate forward
+/// (each backend re-stamps `user_version` to the current value after migrating).
+///
+/// A stamp of `0` — a fresh database, or any catalog written before this gate
+/// existed — is always accepted.
+///
+/// # Errors
+///
+/// Returns [`CatalogError::IncompatibleSchemaVersion`] if `stored_version` is
+/// greater than [`CAYENNE_METASTORE_SCHEMA_VERSION`].
+pub fn ensure_supported_schema_version(stored_version: i64) -> CatalogResult<()> {
+    if stored_version > CAYENNE_METASTORE_SCHEMA_VERSION {
+        return Err(CatalogError::IncompatibleSchemaVersion {
+            found: stored_version,
+            supported: CAYENNE_METASTORE_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
 
 /// Expected column definitions for a metadata table.
 ///
@@ -835,6 +880,44 @@ mod tests {
         assert!(
             msg.contains("cayenne_table"),
             "Error message should name the mismatched table: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_ensure_supported_schema_version_accepts_legacy_and_current() {
+        // A fresh/legacy database reads user_version 0; a same-version catalog
+        // reads the current version. Both are safe to migrate forward and open.
+        ensure_supported_schema_version(0).expect("legacy (v0) catalog must open");
+        ensure_supported_schema_version(CAYENNE_METASTORE_SCHEMA_VERSION)
+            .expect("same-version catalog must open");
+    }
+
+    #[test]
+    fn test_ensure_supported_schema_version_rejects_newer() {
+        // A catalog stamped by a newer build must be refused loudly rather than
+        // opened and read with silently-wrong (dropped-row) results (#11291).
+        let newer = CAYENNE_METASTORE_SCHEMA_VERSION + 1;
+        let err =
+            ensure_supported_schema_version(newer).expect_err("a newer catalog must be rejected");
+        match err {
+            CatalogError::IncompatibleSchemaVersion { found, supported } => {
+                assert_eq!(found, newer, "reported version must be the stored one");
+                assert_eq!(
+                    supported, CAYENNE_METASTORE_SCHEMA_VERSION,
+                    "reported supported version must be this build's max"
+                );
+            }
+            other => panic!("expected IncompatibleSchemaVersion, got: {other}"),
+        }
+        // The message must be actionable and free of internal jargon.
+        let msg = CatalogError::IncompatibleSchemaVersion {
+            found: newer,
+            supported: CAYENNE_METASTORE_SCHEMA_VERSION,
+        }
+        .to_string();
+        assert!(
+            msg.contains("newer version of Spice") && msg.contains("Upgrade Spice"),
+            "message should tell the user to upgrade: {msg}"
         );
     }
 }

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -863,6 +863,18 @@ impl MetastoreBackend for SqliteMetastore {
     async fn init_schema(&self) -> CatalogResult<()> {
         let guard = self.pool().await?.acquire().await;
 
+        // Refuse to open a catalog written by a newer, incompatible Spice build
+        // BEFORE running any migration against it (a fresh/legacy DB reads 0).
+        let stored_version = guard
+            .call(|conn| conn.query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0)))
+            .await
+            .map_err(
+                |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                    message: format!("Failed to read metastore schema version: {e}"),
+                },
+            )?;
+        super::ensure_supported_schema_version(stored_version)?;
+
         guard
             .call(|conn| {
                 // Create tables in a transaction
@@ -908,8 +920,10 @@ impl MetastoreBackend for SqliteMetastore {
                 // cayenne_insert_record, so adding the column is forward-upgrade safe.
                 // (DOWNGRADE is NOT safe: an older binary on a catalog with this
                 // column reads an empty insert-record table for new commits and would
-                // drop the re-inserts — rebuild the catalog before downgrading. A
-                // user_version gate is the productionization follow-up.)
+                // drop the re-inserts — rebuild the catalog before downgrading. The
+                // `user_version` gate at the top/bottom of this fn — bumped to
+                // CAYENNE_METASTORE_SCHEMA_VERSION here — turns that into a loud
+                // failure on any downgrade to a build with a lower max version.)
                 let _ = conn.execute(
                     "ALTER TABLE cayenne_delete_file ADD COLUMN reinsert_sequence BIGINT",
                     [],
@@ -1028,6 +1042,24 @@ impl MetastoreBackend for SqliteMetastore {
             .map_err(
                 |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
                     message: duplicate_delete_file_index_error_message("SQLite", e),
+                },
+            )?;
+
+        // Stamp the current schema version now that all migrations have succeeded,
+        // so a later downgrade to a build with a lower max version fails loudly at
+        // the gate above instead of returning silently wrong results.
+        guard
+            .call(|conn| {
+                conn.pragma_update(
+                    None,
+                    "user_version",
+                    super::CAYENNE_METASTORE_SCHEMA_VERSION,
+                )
+            })
+            .await
+            .map_err(
+                |e: tokio_rusqlite::Error<rusqlite::Error>| CatalogError::Database {
+                    message: format!("Failed to stamp metastore schema version: {e}"),
                 },
             )?;
 
@@ -2195,5 +2227,107 @@ mod tests {
             false,
         )
         .await;
+    }
+
+    async fn read_user_version(metastore: &SqliteMetastore) -> i64 {
+        metastore
+            .query_row(
+                QueryRowParams {
+                    sql: "PRAGMA user_version",
+                    params: vec![],
+                },
+                |row| row.get_i64(0),
+            )
+            .await
+            .expect("read user_version")
+    }
+
+    /// A fresh catalog is stamped with the current schema version, and re-running
+    /// `init_schema` on it is idempotent (no downgrade, no error).
+    #[tokio::test]
+    async fn test_init_schema_stamps_and_preserves_user_version() {
+        let (_dir, metastore) = temp_metastore();
+        metastore.init_schema().await.expect("first init schema");
+        assert_eq!(
+            read_user_version(&metastore).await,
+            crate::metastore::CAYENNE_METASTORE_SCHEMA_VERSION,
+            "fresh catalog must be stamped with the current schema version"
+        );
+
+        metastore
+            .init_schema()
+            .await
+            .expect("re-running init schema is idempotent");
+        assert_eq!(
+            read_user_version(&metastore).await,
+            crate::metastore::CAYENNE_METASTORE_SCHEMA_VERSION,
+            "re-init must leave the stamp at the current version"
+        );
+    }
+
+    /// A legacy catalog (`user_version` 0, written before this gate existed) opens
+    /// cleanly and is migrated forward to the current stamp.
+    #[tokio::test]
+    async fn test_init_schema_upgrades_legacy_zero_version() {
+        let (_dir, metastore) = temp_metastore();
+        metastore.init_schema().await.expect("init schema");
+        // Simulate a pre-gate catalog by resetting the stamp to 0.
+        metastore
+            .execute(ExecuteParams {
+                sql: "PRAGMA user_version = 0",
+                params: vec![],
+            })
+            .await
+            .expect("reset user_version to legacy 0");
+        assert_eq!(read_user_version(&metastore).await, 0, "precondition");
+
+        metastore
+            .init_schema()
+            .await
+            .expect("legacy (v0) catalog must open and migrate");
+        assert_eq!(
+            read_user_version(&metastore).await,
+            crate::metastore::CAYENNE_METASTORE_SCHEMA_VERSION,
+            "legacy catalog must be re-stamped to the current version"
+        );
+    }
+
+    /// A catalog stamped by a NEWER build must be refused loudly rather than
+    /// opened and read with silently-wrong (dropped-row) results (#11291).
+    #[tokio::test]
+    async fn test_init_schema_rejects_newer_user_version() {
+        let (_dir, metastore) = temp_metastore();
+        metastore.init_schema().await.expect("first init schema");
+        // Simulate a catalog written by a future, incompatible build.
+        let newer = crate::metastore::CAYENNE_METASTORE_SCHEMA_VERSION + 1;
+        metastore
+            .execute(ExecuteParams {
+                sql: &format!("PRAGMA user_version = {newer}"),
+                params: vec![],
+            })
+            .await
+            .expect("bump user_version to a future version");
+
+        let err = metastore
+            .init_schema()
+            .await
+            .expect_err("a newer catalog must be rejected");
+        match err {
+            CatalogError::IncompatibleSchemaVersion { found, supported } => {
+                assert_eq!(found, newer);
+                assert_eq!(
+                    supported,
+                    crate::metastore::CAYENNE_METASTORE_SCHEMA_VERSION
+                );
+            }
+            other => panic!("expected IncompatibleSchemaVersion, got: {other}"),
+        }
+
+        // The rejected open must NOT have mutated the stamp (no silent downgrade).
+        assert_eq!(
+            read_user_version(&metastore).await,
+            newer,
+            "a refused open must leave the newer stamp untouched"
+        );
     }
 }

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -570,6 +570,24 @@ impl MetastoreBackend for TursoMetastore {
     async fn init_schema(&self) -> CatalogResult<()> {
         let conn = self.pool().await?.acquire().await;
 
+        // Refuse to open a catalog written by a newer, incompatible Spice build
+        // BEFORE running any migration against it (a fresh/legacy DB reads 0).
+        let mut version_rows =
+            conn.query("PRAGMA user_version", ())
+                .await
+                .map_err(|e| CatalogError::Database {
+                    message: format!("Failed to read metastore schema version: {e}"),
+                })?;
+        let stored_version = match version_rows.next().await {
+            Ok(Some(row)) => match row.get_value(0) {
+                Ok(TursoValue::Integer(v)) => v,
+                _ => 0,
+            },
+            _ => 0,
+        };
+        drop(version_rows);
+        super::ensure_supported_schema_version(stored_version)?;
+
         // Create tables
         let schema_sql = format!(
             "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
@@ -637,6 +655,8 @@ impl MetastoreBackend for TursoMetastore {
         // Metadata-only publish: per-commit reinsert sequence on delete-file rows;
         // NULL on legacy rows falls back to cayenne_insert_record. Forward-upgrade
         // safe; downgrade requires a catalog rebuild (see the sqlite backfill note).
+        // The `user_version` gate at the top / stamp at the bottom of this fn turns
+        // an unsafe downgrade into a loud failure instead of silent row loss.
         let _ = conn
             .execute(
                 "ALTER TABLE cayenne_delete_file ADD COLUMN reinsert_sequence BIGINT",
@@ -804,6 +824,21 @@ impl MetastoreBackend for TursoMetastore {
             .map_err(|e| CatalogError::Database {
                 message: format!("Failed to create inlined_delete unpublished index: {e}"),
             })?;
+
+        // Stamp the current schema version now that all migrations have succeeded,
+        // so a later downgrade to a build with a lower max version fails loudly at
+        // the gate above instead of returning silently wrong results.
+        conn.execute(
+            &format!(
+                "PRAGMA user_version = {}",
+                super::CAYENNE_METASTORE_SCHEMA_VERSION
+            ),
+            (),
+        )
+        .await
+        .map_err(|e| CatalogError::Database {
+            message: format!("Failed to stamp metastore schema version: {e}"),
+        })?;
 
         // Validate that existing tables match the expected schema.
         // This catches incompatible metadata databases from previous versions.


### PR DESCRIPTION
## Summary (root cause)

Since #11260, Cayenne upsert commits stop writing per-key `cayenne_insert_record` rows and instead reconstruct re-inserts from a `reinsert_sequence` column stamped on key-based delete files. That schema change is **forward-safe but downgrade-unsafe**: an older binary (or an older instance in a mixed-version deployment sharing one metastore) reads an empty insert-record table for post-upgrade upserts and ignores `reinsert_sequence`, so the current version of every upserted key silently drops out of query results — rows vanish with no error.

The `reinsert_sequence` backfill landed **without any version gate** (both `sqlite.rs` and `turso.rs` carried a `// A user_version gate is the productionization follow-up.` note). This PR adds that gate.

Fixes #11291

## Changes

- New shared constant `CAYENNE_METASTORE_SCHEMA_VERSION` (= `1`) plus a pure `ensure_supported_schema_version()` guard in `crates/cayenne/src/metastore.rs`, with the version history documented (v1 = metadata-only upsert publish, #11260).
- New `CatalogError::IncompatibleSchemaVersion { found, supported }` variant — a loud, actionable, jargon-free message pointing the operator to upgrade Spice or clear the acceleration data.
- Both metastore backends (`sqlite.rs`, `turso.rs`) now, on every `init_schema`:
  1. read `PRAGMA user_version` **before** running any migration and refuse to open a catalog stamped newer than this build supports (returns `IncompatibleSchemaVersion` instead of silently-wrong results);
  2. stamp `PRAGMA user_version = CAYENNE_METASTORE_SCHEMA_VERSION` **after** all migrations succeed.
- Verified `turso_core` 0.6.1 supports `PRAGMA user_version` read + write, so the gate is symmetric across both backends.
- Legacy/fresh catalogs read `0` → always accepted and migrated forward, so no existing deployment is disrupted; the gate only ever refuses a genuinely-newer catalog.
- Replaced the two stale "productionization follow-up" comments.

## Behavior / compatibility

This establishes the version mechanism going forward: from now on, any downgrade to a build whose max supported version is lower than the catalog's stamp fails loudly. (It cannot retroactively protect against *already-released* pre-gate binaries, which never read `user_version` — that is inherent and is exactly what #11291 asked to productionize.)

## Test plan

- `make lint`
- `make test`

New tests:
- `metastore.rs`: `ensure_supported_schema_version` accepts v0/current, rejects newer (with `IncompatibleSchemaVersion` and an actionable message).
- `sqlite.rs` (exercise the real `init_schema` DB path): fresh catalog is stamped + idempotent re-init; legacy `user_version = 0` opens and is migrated forward; a newer stamp is refused loudly and the refused open does **not** mutate the stamp.

## Checklist

- [ ] `make lint` clean
- [ ] `make test` clean
- [ ] Reviewed by a maintainer
