### PR TITLE
Fix 'datafusion-table-providers' in MongoDB builds

### DIFF
--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -750,7 +750,7 @@ impl DataConnector for MongoDB {
     ) -> DataConnectorResult<Arc<dyn TableProvider>> {
         let provider = self
             .mongodb_factory
-            .table_provider(dataset.path().into(), dataset.schema.clone())
+            .table_provider(dataset.path().into(), dataset.schema.clone(), None)
             .await
             .context(UnableToGetReadProviderSnafu {
                 dataconnector: "mongodb",


### PR DESCRIPTION
## 📝 Summary
Upgrade for `datafusion-table-providers` (e.g. [#27](https://github.com/spiceai/datafusion-table-providers/pull/27)), pulled in [#25](https://github.com/spiceai/datafusion-table-providers/pull/25) that changed the signature for MongoDB. This was then used in #11555 (against `trunk`). 

We do not want this net-new functionality in `release/2.1` (and the v2.1.0 release), so simply fix compilation issues. This PR should not be added to `trunk`.