### PR TITLE
feat(cayenne): vendor versioned row_converter module (byte-compatible with arrow-row 58.3.0)

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -16,7 +16,6 @@ datafusion-dml = { path = "../datafusion-dml" }
 regex = "1.12.3"
 arrow-flight = { workspace = true }
 arrow-ipc = { workspace = true }
-arrow-row = { workspace = true }
 arrow-schema = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
@@ -103,6 +102,9 @@ duckdb-bench = ["dep:duckdb"]
 chdb-bench = ["dep:chdb-rust"]
 
 [dev-dependencies]
+# Kept only for the `row_converter` byte-identity equivalence test; Cayenne's runtime no
+# longer depends on arrow-row's (unstable) row format.
+arrow-row = { workspace = true }
 criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 datafusion-federation.workspace = true
 datafusion-functions-aggregate = { workspace = true }

--- a/crates/cayenne/src/lib.rs
+++ b/crates/cayenne/src/lib.rs
@@ -80,6 +80,7 @@ pub mod optimizer_rules;
 pub(crate) mod partition_creator;
 pub mod provider;
 pub(crate) mod resource_starvation;
+pub mod row_converter;
 pub(crate) mod schema;
 pub mod stats;
 pub mod stats_aggregate;

--- a/crates/cayenne/src/provider/delete/filter_exec.rs
+++ b/crates/cayenne/src/provider/delete/filter_exec.rs
@@ -69,8 +69,9 @@ limitations under the License.
 use crate::provider::deletion_index::{DeletionIndex, KeyDeletionIndex, Tombstone};
 use arrow::array::{ArrayRef, BooleanArray, BooleanBufferBuilder};
 use arrow::compute::{max as arrow_col_max, min as arrow_col_min};
-use arrow_row::RowConverter;
 use datafusion::config::ConfigOptions;
+
+use crate::row_converter::RowConverter;
 use datafusion_execution::SendableRecordBatchStream;
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_plan::DisplayAs;
@@ -1101,8 +1102,8 @@ impl datafusion_execution::RecordBatchStream for Int64PkDeletionFilterStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::row_converter::SortField;
     use arrow::{array::RecordBatch, datatypes::DataType};
-    use arrow_row::SortField;
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
     use futures::StreamExt;
     use std::collections::HashMap;
@@ -1360,7 +1361,7 @@ mod tests {
             InsertRecordHandling::Apply,
             vec![0],
             Arc::new(
-                RowConverter::new(vec![arrow_row::SortField::new(DataType::Int64)])
+                RowConverter::new(vec![crate::row_converter::SortField::new(DataType::Int64)])
                     .expect("Int64 row converter"),
             ),
             None,

--- a/crates/cayenne/src/provider/delete/sink.rs
+++ b/crates/cayenne/src/provider/delete/sink.rs
@@ -58,8 +58,9 @@ use crate::catalog::MetadataCatalog;
 use crate::metadata::TableMetadata;
 use arc_swap::ArcSwap;
 use arrow::array::ArrayRef;
-use arrow_row::RowConverter;
 use arrow_schema::SchemaRef;
+
+use crate::row_converter::RowConverter;
 use async_trait::async_trait;
 use data_components::delete::DeletionSink;
 use datafusion::datasource::listing::ListingTable;

--- a/crates/cayenne/src/provider/delete/sink/pk_filter_extract.rs
+++ b/crates/cayenne/src/provider/delete/sink/pk_filter_extract.rs
@@ -32,8 +32,9 @@ limitations under the License.
 //!
 
 use arrow::array::ArrayRef;
-use arrow_row::RowConverter;
 use arrow_schema::DataType;
+
+use crate::row_converter::RowConverter;
 use datafusion_common::ScalarValue;
 use datafusion_expr::Expr;
 use datafusion_expr::Operator;
@@ -376,9 +377,9 @@ fn find_scalar_for_column<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::row_converter::SortField;
     use arrow::array::{Int64Array, RecordBatch, StringArray};
     use arrow::datatypes::{Field, Schema};
-    use arrow_row::SortField;
     use data_components::pk_filter_expr::{
         balanced_binary, build_pk_in_list_from_batch, get_delete_where_expr_from_batch,
     };

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -30,7 +30,7 @@ use super::CayenneDeletionSink;
 use crate::provider::Error;
 use crate::provider::deletion_strategy::PositionDeletionVector;
 use crate::provider::utils::convert_to_u64_box;
-use arrow::row::{OwnedRow, RowConverter};
+use crate::row_converter::{OwnedRow, RowConverter};
 use datafusion::datasource::listing::ListingTable;
 use datafusion::execution::context::SessionContext;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter;

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -1214,7 +1214,7 @@ fn bloom_half(hash: u128) -> u64 {
 }
 
 /// Frozen deletion index for tables with a composite or non-integer primary key.
-/// Probe keys are the byte-encoded form produced by `arrow_row::RowConverter`.
+/// Probe keys are the byte-encoded form produced by `crate::row_converter::RowConverter`.
 ///
 /// Entries are keyed by the **seeded XXH3-128 hash of the key bytes**
 /// ([`hash_key_128`]) rather than the bytes themselves: the hash is the key's

--- a/crates/cayenne/src/provider/mem_tier.rs
+++ b/crates/cayenne/src/provider/mem_tier.rs
@@ -1283,7 +1283,7 @@ mod tests {
             0,
         ));
         let before_hash =
-            ShardedMemTier::version_hash_of(&[Arc::new(tier.clone()), Arc::clone(&other_shard)]);
+            ShardedMemTier::version_hash_of(&[Arc::new(tier), Arc::clone(&other_shard)]);
         let after_hash =
             ShardedMemTier::version_hash_of(&[Arc::new(sealed.clone()), Arc::clone(&other_shard)]);
         assert_eq!(

--- a/crates/cayenne/src/provider/mutation_writer.rs
+++ b/crates/cayenne/src/provider/mutation_writer.rs
@@ -1123,7 +1123,7 @@ impl<'a> AppendMutationWriter<'a> {
     ) -> Result<(
         u64,
         Arc<ColumnStatsAccumulator>,
-        std::collections::HashSet<arrow_row::OwnedRow>,
+        std::collections::HashSet<crate::row_converter::OwnedRow>,
         usize,
     )> {
         let new_snapshot_id = uuid::Uuid::now_v7().to_string();

--- a/crates/cayenne/src/provider/on_conflict.rs
+++ b/crates/cayenne/src/provider/on_conflict.rs
@@ -26,8 +26,9 @@ use super::pk_index::{CachedPkIndex, PkExistenceRef, ShardedPkIndex};
 use crate::metadata::InlinedData;
 
 use arrow::record_batch::RecordBatch;
-use arrow_row::{OwnedRow, RowConverter};
 use arrow_schema::SchemaRef;
+
+use crate::row_converter::{OwnedRow, RowConverter};
 use async_trait::async_trait;
 use data_components::delete::DeletionSink;
 use datafusion_catalog::Session;

--- a/crates/cayenne/src/provider/pk_index.rs
+++ b/crates/cayenne/src/provider/pk_index.rs
@@ -20,7 +20,7 @@ limitations under the License.
 //! provider maintains and probes these; the per-row location is recorded as a
 //! [`RowLocation`].
 
-use arrow_row::OwnedRow;
+use crate::row_converter::OwnedRow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -76,8 +76,9 @@ use crate::provider::{Error, Result};
 use crate::resource_starvation::ResourceStarvationTracker;
 use arrow::array::{Array, ArrayRef, BinaryArray, BooleanArray, Int64Array};
 use arrow::record_batch::RecordBatch;
-use arrow_row::{OwnedRow, RowConverter, SortField};
 use arrow_schema::{DataType, Field, SchemaBuilder, SchemaRef};
+
+use crate::row_converter::{OwnedRow, RowConverter, SortField};
 use arrow_tools::schema_evolution::{EvolutionContext, SchemaEvolution, WideningPlan, classify};
 use async_trait::async_trait;
 use data_components::delete::{DeletionExec, DeletionSink};
@@ -9561,7 +9562,7 @@ impl CayenneTableProvider {
     /// that `load_inlined_deletion_maps` / `deserialize_delete_keys_from_ipc`
     /// read: for `Int64Pk` tables each PK is its 8-byte big-endian encoding
     /// (`build_pk_deletion_row_keys` + `row_key_to_i64`); for `RowConverterBased`
-    /// tables each key is the already-encoded `arrow_row` bytes.
+    /// tables each key is the already-encoded `row_converter` bytes.
     ///
     /// `published` selects the durable activation state the tombstone is written
     /// with: the synchronous on-conflict path passes `true` (it publishes

--- a/crates/cayenne/src/row_converter/codec.rs
+++ b/crates/cayenne/src/row_converter/codec.rs
@@ -1,0 +1,223 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Version-agnostic framing engine and the per-column codec extension point.
+//!
+//! The framing here — how a row's column encodings are laid out, how offsets are tracked, and
+//! the null sentinel convention — is shared by every format version. Per-column encoding and
+//! decoding is delegated to a [`ColumnCodec`], so a new version only supplies a new set of
+//! column codecs (usually reusing most of the previous version's).
+//!
+//! Portions are derived from Apache Arrow's `arrow-row` crate (Apache-2.0), whose byte layout
+//! this reproduces.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef};
+use arrow_schema::{ArrowError, SortOptions};
+
+use super::SortField;
+use super::rows::{Row, Rows};
+
+/// Encodes and decodes a single column to and from the row format.
+///
+/// Each codec instance is built for one [`SortField`] and captures that field's
+/// [`SortOptions`] and data type. This is the extension point for the format: optimizing a
+/// data type means writing a new codec and routing that type to it, leaving every other
+/// column codec untouched.
+pub(crate) trait ColumnCodec: Debug + Send + Sync {
+    /// Contribute the per-row encoded length of `array` to `tracker`.
+    fn append_lengths(&self, array: &dyn Array, tracker: &mut LengthTracker);
+
+    /// Encode `array` into `data`, advancing each entry of `offsets[1..]` past the bytes
+    /// written for that row.
+    fn encode(&self, data: &mut [u8], offsets: &mut [usize], array: &dyn Array);
+
+    /// Decode this column from `rows`, advancing each slice past the bytes consumed.
+    fn decode(&self, rows: &mut [&[u8]], validate_utf8: bool) -> Result<ArrayRef, ArrowError>;
+}
+
+/// The shared row-encoding engine: a schema plus one [`ColumnCodec`] per column.
+///
+/// Wrapped by [`super::RowConverter`]; the enum variant records the format version, while this
+/// struct holds the built codecs and performs the version-agnostic framing.
+#[derive(Debug)]
+pub struct RowCodec {
+    fields: Arc<[SortField]>,
+    codecs: Vec<Box<dyn ColumnCodec>>,
+}
+
+impl RowCodec {
+    /// Build the per-column codecs for `fields` using a version-specific `build` function.
+    pub(crate) fn new(
+        fields: Vec<SortField>,
+        build: impl Fn(&SortField) -> Result<Box<dyn ColumnCodec>, ArrowError>,
+    ) -> Result<Self, ArrowError> {
+        let codecs = fields.iter().map(&build).collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            fields: fields.into(),
+            codecs,
+        })
+    }
+
+    pub(crate) fn convert_columns(&self, columns: &[ArrayRef]) -> Result<Rows, ArrowError> {
+        if columns.len() != self.fields.len() {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "Incorrect number of arrays provided to RowConverter, expected {} got {}",
+                self.fields.len(),
+                columns.len()
+            )));
+        }
+        for column in columns.iter().skip(1) {
+            if column.len() != columns[0].len() {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "RowConverter columns must all have the same length, expected {} got {}",
+                    columns[0].len(),
+                    column.len()
+                )));
+            }
+        }
+        for (column, field) in columns.iter().zip(self.fields.iter()) {
+            if !column.data_type().equals_datatype(&field.data_type) {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "RowConverter column schema mismatch, expected {} got {}",
+                    field.data_type,
+                    column.data_type()
+                )));
+            }
+        }
+
+        let num_rows = match columns.first() {
+            Some(c) => c.len(),
+            None => 0,
+        };
+        let mut offsets = Vec::with_capacity(num_rows + 1);
+        offsets.push(0usize);
+
+        let mut tracker = LengthTracker::new(num_rows);
+        for (column, codec) in columns.iter().zip(&self.codecs) {
+            codec.append_lengths(column.as_ref(), &mut tracker);
+        }
+        let total = tracker.extend_offsets(0, &mut offsets);
+        let mut buffer = vec![0u8; total];
+
+        for (column, codec) in columns.iter().zip(&self.codecs) {
+            codec.encode(
+                buffer.as_mut_slice(),
+                offsets.as_mut_slice(),
+                column.as_ref(),
+            );
+        }
+
+        debug_assert_eq!(offsets.last().copied(), Some(buffer.len()));
+        debug_assert!(
+            offsets.windows(2).all(|w| w[0] <= w[1]),
+            "offsets must be monotonic"
+        );
+
+        Ok(Rows { buffer, offsets })
+    }
+
+    pub(crate) fn convert_rows<'a>(
+        &self,
+        rows: impl IntoIterator<Item = Row<'a>>,
+    ) -> Result<Vec<ArrayRef>, ArrowError> {
+        let mut slices: Vec<&[u8]> = rows.into_iter().map(|row| row.data()).collect();
+        let mut columns = Vec::with_capacity(self.codecs.len());
+        for codec in &self.codecs {
+            columns.push(codec.decode(&mut slices, true)?);
+        }
+        Ok(columns)
+    }
+}
+
+/// The null sentinel byte: `0` when nulls sort first, `0xFF` when they sort last.
+#[inline]
+pub(crate) fn null_sentinel(options: SortOptions) -> u8 {
+    if options.nulls_first { 0 } else { 0xFF }
+}
+
+/// Tracks per-row encoded lengths, materializing a per-row vector only once a variable-length
+/// column is added.
+pub(crate) enum LengthTracker {
+    /// Every row has the same `length`.
+    Fixed { length: usize, num_rows: usize },
+    /// Row `i` has length `lengths[i] + fixed_length`.
+    Variable {
+        fixed_length: usize,
+        lengths: Vec<usize>,
+    },
+}
+
+impl LengthTracker {
+    pub(crate) fn new(num_rows: usize) -> Self {
+        Self::Fixed {
+            length: 0,
+            num_rows,
+        }
+    }
+
+    /// Add a column whose every row encodes to `new_length` bytes.
+    pub(crate) fn push_fixed(&mut self, new_length: usize) {
+        match self {
+            LengthTracker::Fixed { length, .. } => *length += new_length,
+            LengthTracker::Variable { fixed_length, .. } => *fixed_length += new_length,
+        }
+    }
+
+    /// Add a column whose row `i` encodes to `new_lengths.nth(i)` bytes.
+    pub(crate) fn push_variable(&mut self, new_lengths: impl ExactSizeIterator<Item = usize>) {
+        match self {
+            LengthTracker::Fixed { length, .. } => {
+                *self = LengthTracker::Variable {
+                    fixed_length: *length,
+                    lengths: new_lengths.collect(),
+                }
+            }
+            LengthTracker::Variable { lengths, .. } => {
+                assert_eq!(lengths.len(), new_lengths.len());
+                lengths
+                    .iter_mut()
+                    .zip(new_lengths)
+                    .for_each(|(length, new_length)| *length += new_length);
+            }
+        }
+    }
+
+    /// Initialize `offsets` (shifted down by one row) from the tracked lengths, returning the
+    /// total encoded byte length.
+    pub(crate) fn extend_offsets(&self, initial_offset: usize, offsets: &mut Vec<usize>) -> usize {
+        match self {
+            LengthTracker::Fixed { length, num_rows } => {
+                offsets.extend((0..*num_rows).map(|i| initial_offset + i * length));
+                initial_offset + num_rows * length
+            }
+            LengthTracker::Variable {
+                fixed_length,
+                lengths,
+            } => {
+                let mut acc = initial_offset;
+                offsets.extend(lengths.iter().map(|length| {
+                    let current = acc;
+                    acc += length + fixed_length;
+                    current
+                }));
+                acc
+            }
+        }
+    }
+}

--- a/crates/cayenne/src/row_converter/mod.rs
+++ b/crates/cayenne/src/row_converter/mod.rs
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A Cayenne-owned, **versioned** row-format converter.
+//!
+//! Cayenne encodes composite / non-`Int64` primary keys into a comparable byte
+//! sequence and **persists those bytes durably** — as the `row_key` column of on-disk
+//! deletion-vector files, as `cayenne_insert_record.pk_bytes` in the metastore, and inside
+//! inlined-delete blobs. On read (after a restart or compaction) Cayenne re-encodes fresh
+//! keys and byte-compares them against the stored bytes.
+//!
+//! This encoding is a copy of the format produced by Apache Arrow's `arrow-row` crate.
+//! Arrow explicitly documents that *"the encoding of the row format may change from release
+//! to release"* — it is designed as a transient sort/compare representation, not a storage
+//! format. Vendoring it here decouples Cayenne's durable data from arrow-rs's version cadence:
+//! a future arrow bump can no longer silently change the bytes Cayenne persists.
+//!
+//! # Versioning
+//!
+//! [`RowConverter`] is an enum whose variant is the wire-format version. [`RowConverter::new`]
+//! always builds the current version; older data is read by constructing the matching variant
+//! (see [`RowConverter::with_version`] and [`RowFormatVersion`]). [`RowFormatVersion::V1`] is
+//! **byte-identical** to `arrow-row` 58.3.0, so all previously-persisted data reads unchanged
+//! (it is implicitly version 1).
+//!
+//! # Extensibility
+//!
+//! Version-agnostic framing (offsets, null sentinels, column concatenation) lives in
+//! [`codec::RowCodec`]; per-column behavior lives behind the [`codec::ColumnCodec`] trait. A
+//! future version that optimizes a single data type adds one small codec and routes that type
+//! to it in a new `build_codec`, delegating every unchanged type to the previous version —
+//! it never re-implements the whole encoder/decoder.
+//!
+//! Only the Arrow types reachable as a Cayenne primary key are supported (all integer/float
+//! primitives, `Boolean`, the byte/string family including views, dates, times, microsecond
+//! timestamps, and decimals). Unsupported types return [`arrow_schema::ArrowError::NotYetImplemented`].
+
+mod codec;
+mod rows;
+mod v1;
+
+#[cfg(test)]
+mod tests;
+
+use arrow::array::ArrayRef;
+use arrow_schema::{ArrowError, DataType};
+
+pub use arrow_schema::SortOptions;
+
+pub use codec::RowCodec;
+pub use rows::{OwnedRow, Row, Rows, RowsIter};
+
+/// The wire-format version of a set of encoded row bytes.
+///
+/// The version determines how bytes are decoded, so older persisted data stays readable by
+/// selecting the version that produced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RowFormatVersion {
+    /// Byte-compatible with Apache Arrow `arrow-row` 58.3.0.
+    V1,
+}
+
+impl RowFormatVersion {
+    /// The version used for all newly-encoded data.
+    pub const CURRENT: Self = Self::V1;
+
+    /// A stable integer identifier, suitable for persisting alongside encoded bytes.
+    #[must_use]
+    pub const fn id(self) -> u16 {
+        match self {
+            Self::V1 => 1,
+        }
+    }
+
+    /// The version for a previously-persisted [`id`](Self::id), or `None` if unknown.
+    #[must_use]
+    pub const fn from_id(id: u16) -> Option<Self> {
+        match id {
+            1 => Some(Self::V1),
+            _ => None,
+        }
+    }
+}
+
+/// Configures the data type and sort order of one column of the row encoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SortField {
+    pub(crate) options: SortOptions,
+    pub(crate) data_type: DataType,
+}
+
+impl SortField {
+    /// Create a field for `data_type` with default [`SortOptions`] (ascending, nulls first).
+    #[must_use]
+    pub fn new(data_type: DataType) -> Self {
+        Self::new_with_options(data_type, SortOptions::default())
+    }
+
+    /// Create a field for `data_type` with explicit [`SortOptions`].
+    #[must_use]
+    pub fn new_with_options(data_type: DataType, options: SortOptions) -> Self {
+        Self { options, data_type }
+    }
+}
+
+/// A versioned, row-oriented encoder for a fixed sequence of [`SortField`] columns.
+///
+/// Each variant is a wire-format version. Construct with [`RowConverter::new`] (current
+/// version) or [`RowConverter::with_version`] (to read data written by an older version).
+#[derive(Debug)]
+pub enum RowConverter {
+    /// The [`RowFormatVersion::V1`] converter — byte-compatible with `arrow-row` 58.3.0.
+    Version1(RowCodec),
+}
+
+impl RowConverter {
+    /// Create a converter for the current format version ([`RowFormatVersion::CURRENT`]).
+    ///
+    /// # Errors
+    /// Returns [`ArrowError::NotYetImplemented`] if any field's data type is not a supported
+    /// primary-key type.
+    pub fn new(fields: Vec<SortField>) -> Result<Self, ArrowError> {
+        Self::with_version(RowFormatVersion::CURRENT, fields)
+    }
+
+    /// Create a converter for a specific format `version`.
+    ///
+    /// # Errors
+    /// Returns [`ArrowError::NotYetImplemented`] if any field's data type is not supported by
+    /// that version.
+    pub fn with_version(
+        version: RowFormatVersion,
+        fields: Vec<SortField>,
+    ) -> Result<Self, ArrowError> {
+        match version {
+            RowFormatVersion::V1 => Ok(Self::Version1(RowCodec::new(fields, v1::build_codec)?)),
+        }
+    }
+
+    /// The format version of this converter.
+    #[must_use]
+    pub fn version(&self) -> RowFormatVersion {
+        match self {
+            Self::Version1(_) => RowFormatVersion::V1,
+        }
+    }
+
+    fn codec(&self) -> &RowCodec {
+        match self {
+            Self::Version1(codec) => codec,
+        }
+    }
+
+    /// Encode `columns` into a [`Rows`] of comparable byte sequences.
+    ///
+    /// # Errors
+    /// Returns an error if `columns` does not match the schema this converter was built with.
+    pub fn convert_columns(&self, columns: &[ArrayRef]) -> Result<Rows, ArrowError> {
+        self.codec().convert_columns(columns)
+    }
+
+    /// Decode previously-encoded `rows` back into their column arrays.
+    ///
+    /// Cayenne does not decode at runtime; this exists for round-trip validation and future use.
+    ///
+    /// # Errors
+    /// Returns an error if the row bytes are malformed for this converter's schema.
+    pub fn convert_rows<'a>(
+        &self,
+        rows: impl IntoIterator<Item = Row<'a>>,
+    ) -> Result<Vec<ArrayRef>, ArrowError> {
+        self.codec().convert_rows(rows)
+    }
+}

--- a/crates/cayenne/src/row_converter/rows.rs
+++ b/crates/cayenne/src/row_converter/rows.rs
@@ -1,0 +1,226 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Owned and borrowed views over encoded row bytes.
+//!
+//! Equality, ordering, and hashing are defined purely over the raw encoded bytes — the row
+//! format is normalized so that byte comparison equals logical comparison of the values that
+//! produced the rows (when both come from the same converter).
+
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+
+/// A collection of encoded rows, stored as one contiguous buffer with per-row offsets.
+///
+/// Row `i` occupies `buffer[offsets[i]..offsets[i + 1]]`.
+#[derive(Debug)]
+pub struct Rows {
+    pub(crate) buffer: Vec<u8>,
+    pub(crate) offsets: Vec<usize>,
+}
+
+impl Rows {
+    /// Borrow row `i`.
+    ///
+    /// # Panics
+    /// Panics if `row` is out of bounds.
+    #[must_use]
+    pub fn row(&self, row: usize) -> Row<'_> {
+        assert!(row + 1 < self.offsets.len(), "row index out of bounds");
+        let start = self.offsets[row];
+        let end = self.offsets[row + 1];
+        Row {
+            data: &self.buffer[start..end],
+        }
+    }
+
+    /// The number of rows.
+    #[must_use]
+    pub fn num_rows(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
+    /// Iterate over the rows in order.
+    #[must_use]
+    pub fn iter(&self) -> RowsIter<'_> {
+        RowsIter {
+            rows: self,
+            start: 0,
+            end: self.num_rows(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Rows {
+    type Item = Row<'a>;
+    type IntoIter = RowsIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// A double-ended iterator over the rows of a [`Rows`].
+#[derive(Debug)]
+pub struct RowsIter<'a> {
+    rows: &'a Rows,
+    start: usize,
+    end: usize,
+}
+
+impl<'a> Iterator for RowsIter<'a> {
+    type Item = Row<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start >= self.end {
+            return None;
+        }
+        let row = self.rows.row(self.start);
+        self.start += 1;
+        Some(row)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.end - self.start;
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for RowsIter<'_> {}
+
+impl DoubleEndedIterator for RowsIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start >= self.end {
+            return None;
+        }
+        self.end -= 1;
+        Some(self.rows.row(self.end))
+    }
+}
+
+/// A borrowed, encoded row.
+///
+/// Compared, ordered, and hashed by its raw bytes.
+#[derive(Debug, Clone, Copy)]
+pub struct Row<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> Row<'a> {
+    /// The row's raw encoded bytes.
+    #[must_use]
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    /// Detach an owned copy of this row.
+    #[must_use]
+    pub fn owned(&self) -> OwnedRow {
+        OwnedRow {
+            data: self.data.into(),
+        }
+    }
+}
+
+impl PartialEq for Row<'_> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl Eq for Row<'_> {}
+
+impl PartialOrd for Row<'_> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Row<'_> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.data.cmp(other.data)
+    }
+}
+
+impl Hash for Row<'_> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.data.hash(state);
+    }
+}
+
+impl AsRef<[u8]> for Row<'_> {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.data
+    }
+}
+
+/// An owned, encoded row that can be moved and stored freely (e.g. as a hash-set key).
+///
+/// Holds only the bytes of a single row. Compared, ordered, and hashed by those bytes.
+#[derive(Debug, Clone)]
+pub struct OwnedRow {
+    data: Box<[u8]>,
+}
+
+impl OwnedRow {
+    /// Borrow this owned row as a [`Row`].
+    #[must_use]
+    pub fn row(&self) -> Row<'_> {
+        Row { data: &self.data }
+    }
+}
+
+impl PartialEq for OwnedRow {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl Eq for OwnedRow {}
+
+impl PartialOrd for OwnedRow {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OwnedRow {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.data.cmp(&other.data)
+    }
+}
+
+impl Hash for OwnedRow {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.data.hash(state);
+    }
+}
+
+impl AsRef<[u8]> for OwnedRow {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}

--- a/crates/cayenne/src/row_converter/tests.rs
+++ b/crates/cayenne/src/row_converter/tests.rs
@@ -1,0 +1,374 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Tests for the vendored row converter.
+//!
+//! The central guarantee is **byte-identity with `arrow-row`** for every supported type — this
+//! is what lets Cayenne keep reading data it persisted with the old converter. That is proven by
+//! [`assert_matches_arrow_row`], which encodes the same columns with both converters and compares
+//! the raw bytes of every row. Round-trip decoding is verified by re-encoding the decoded arrays
+//! and checking the bytes are unchanged (encoding is injective on logical values).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array,
+    Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Float32Array, Float64Array, Int8Array,
+    Int16Array, Int32Array, Int64Array, LargeBinaryArray, LargeStringArray, StringArray,
+    StringViewArray, Time32SecondArray, Time64NanosecondArray, TimestampMicrosecondArray,
+    UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::datatypes::{DataType, i256};
+use arrow_schema::SortOptions;
+
+use super::{OwnedRow, RowConverter, RowFormatVersion, SortField};
+
+/// Encode `columns` with both the vendored converter and `arrow-row` using `options` for every
+/// field, and assert the encoded bytes are identical row-for-row. Then verify round-trip decode.
+fn assert_matches_arrow_row_opts(columns: &[ArrayRef], options: SortOptions) {
+    let data_types: Vec<DataType> = columns.iter().map(|c| c.data_type().clone()).collect();
+
+    let ours = RowConverter::new(
+        data_types
+            .iter()
+            .map(|dt| SortField::new_with_options(dt.clone(), options))
+            .collect(),
+    )
+    .expect("vendored converter builds");
+
+    let theirs = arrow_row::RowConverter::new(
+        data_types
+            .iter()
+            .map(|dt| arrow_row::SortField::new_with_options(dt.clone(), options))
+            .collect(),
+    )
+    .expect("arrow-row converter builds");
+
+    let our_rows = ours.convert_columns(columns).expect("vendored encode");
+    let their_rows = theirs.convert_columns(columns).expect("arrow-row encode");
+
+    let num_rows = match columns.first() {
+        Some(c) => c.len(),
+        None => 0,
+    };
+    assert_eq!(our_rows.num_rows(), num_rows);
+
+    for i in 0..num_rows {
+        assert_eq!(
+            our_rows.row(i).as_ref(),
+            their_rows.row(i).data(),
+            "row {i} bytes differ from arrow-row for {data_types:?} with {options:?}"
+        );
+    }
+
+    // Round-trip: decoding then re-encoding must reproduce the original bytes exactly.
+    let decoded = ours.convert_rows(our_rows.iter()).expect("vendored decode");
+    assert_eq!(decoded.len(), columns.len());
+    let reencoded = ours.convert_columns(&decoded).expect("re-encode decoded");
+    for i in 0..num_rows {
+        assert_eq!(
+            our_rows.row(i).as_ref(),
+            reencoded.row(i).as_ref(),
+            "round-trip changed row {i} for {data_types:?}"
+        );
+    }
+}
+
+/// [`assert_matches_arrow_row_opts`] with default (ascending, nulls-first) options — the only
+/// options Cayenne uses.
+fn assert_matches_arrow_row(columns: &[ArrayRef]) {
+    assert_matches_arrow_row_opts(columns, SortOptions::default());
+}
+
+/// A long value that spans multiple encoding blocks (> 32 bytes).
+const LONG: &str = "a value long enough to require multiple 32-byte blocks in the row encoding!!";
+
+#[test]
+fn integers_match_arrow_row() {
+    assert_matches_arrow_row(&[Arc::new(Int8Array::from(vec![
+        Some(0),
+        None,
+        Some(-1),
+        Some(i8::MIN),
+        Some(i8::MAX),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(Int16Array::from(vec![
+        Some(0),
+        None,
+        Some(-1),
+        Some(i16::MIN),
+        Some(i16::MAX),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(Int32Array::from(vec![
+        Some(0),
+        None,
+        Some(-1),
+        Some(i32::MIN),
+        Some(i32::MAX),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(Int64Array::from(vec![
+        Some(0),
+        None,
+        Some(-1),
+        Some(i64::MIN),
+        Some(i64::MAX),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(UInt8Array::from(vec![
+        Some(0),
+        None,
+        Some(1),
+        Some(u8::MAX),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(UInt16Array::from(vec![
+        Some(0),
+        None,
+        Some(1),
+        Some(u16::MAX),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(UInt32Array::from(vec![
+        Some(0),
+        None,
+        Some(1),
+        Some(u32::MAX),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(UInt64Array::from(vec![
+        Some(0),
+        None,
+        Some(1),
+        Some(u64::MAX),
+    ]))]);
+}
+
+#[test]
+fn floats_match_arrow_row() {
+    assert_matches_arrow_row(&[Arc::new(Float32Array::from(vec![
+        Some(0.0),
+        Some(-0.0),
+        None,
+        Some(-1.5),
+        Some(f32::INFINITY),
+        Some(f32::NEG_INFINITY),
+        Some(f32::NAN),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(Float64Array::from(vec![
+        Some(0.0),
+        Some(-0.0),
+        None,
+        Some(-1.5),
+        Some(f64::INFINITY),
+        Some(f64::NEG_INFINITY),
+        Some(f64::NAN),
+    ]))]);
+}
+
+#[test]
+fn boolean_matches_arrow_row() {
+    assert_matches_arrow_row(&[Arc::new(BooleanArray::from(vec![
+        Some(true),
+        Some(false),
+        None,
+    ]))]);
+}
+
+#[test]
+fn strings_and_binary_match_arrow_row() {
+    let strings: Vec<Option<&str>> = vec![Some("a"), None, Some(""), Some("hello"), Some(LONG)];
+    assert_matches_arrow_row(&[Arc::new(StringArray::from(strings.clone()))]);
+    assert_matches_arrow_row(&[Arc::new(LargeStringArray::from(strings.clone()))]);
+    assert_matches_arrow_row(&[Arc::new(StringViewArray::from(strings.clone()))]);
+
+    let bytes: Vec<Option<&[u8]>> = vec![
+        Some(b"a".as_ref()),
+        None,
+        Some(b"".as_ref()),
+        Some(LONG.as_bytes()),
+    ];
+    assert_matches_arrow_row(&[Arc::new(BinaryArray::from(bytes.clone()))]);
+    assert_matches_arrow_row(&[Arc::new(LargeBinaryArray::from(bytes.clone()))]);
+    assert_matches_arrow_row(&[Arc::new(BinaryViewArray::from(bytes))]);
+}
+
+#[test]
+fn temporal_matches_arrow_row() {
+    assert_matches_arrow_row(&[Arc::new(Date32Array::from(vec![
+        Some(0),
+        None,
+        Some(-1),
+        Some(19_000),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(Date64Array::from(vec![
+        Some(0),
+        None,
+        Some(-1),
+        Some(1_600_000_000_000),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(Time32SecondArray::from(vec![
+        Some(0),
+        None,
+        Some(86_399),
+    ]))]);
+    assert_matches_arrow_row(&[Arc::new(Time64NanosecondArray::from(vec![
+        Some(0),
+        None,
+        Some(1),
+    ]))]);
+
+    let ts =
+        TimestampMicrosecondArray::from(vec![Some(0), None, Some(-1), Some(1_600_000_000_000_000)]);
+    assert_matches_arrow_row(&[Arc::new(ts.clone())]);
+    // With a timezone (the shape Cayenne normalizes timestamps to).
+    assert_matches_arrow_row(&[Arc::new(ts.with_timezone("UTC"))]);
+}
+
+#[test]
+fn decimals_match_arrow_row() {
+    let d128 = Decimal128Array::from(vec![Some(0), None, Some(-1), Some(123_456)])
+        .with_precision_and_scale(10, 2)
+        .expect("valid decimal128 precision/scale");
+    assert_matches_arrow_row(&[Arc::new(d128)]);
+
+    let d256 = Decimal256Array::from(vec![
+        Some(i256::from_i128(0)),
+        None,
+        Some(i256::from_i128(-1)),
+        Some(i256::from_i128(999)),
+    ])
+    .with_precision_and_scale(40, 3)
+    .expect("valid decimal256 precision/scale");
+    assert_matches_arrow_row(&[Arc::new(d256)]);
+}
+
+#[test]
+fn composite_keys_match_arrow_row() {
+    // The exact shape Cayenne exercises: (Int64, Utf8).
+    let ids: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), Some(2), None, Some(2)]));
+    let names: ArrayRef = Arc::new(StringArray::from(vec![
+        Some("a"),
+        Some(""),
+        Some("z"),
+        None,
+    ]));
+    assert_matches_arrow_row(&[Arc::clone(&ids), Arc::clone(&names)]);
+
+    // (Utf8, Int32) and a three-column mix.
+    let region: ArrayRef = Arc::new(StringArray::from(vec![Some("us"), Some("eu"), None]));
+    let n: ArrayRef = Arc::new(Int32Array::from(vec![Some(-5), None, Some(7)]));
+    let flag: ArrayRef = Arc::new(BooleanArray::from(vec![Some(true), None, Some(false)]));
+    assert_matches_arrow_row(&[Arc::clone(&region), Arc::clone(&n)]);
+    assert_matches_arrow_row(&[region, n, flag]);
+}
+
+#[test]
+fn matches_arrow_row_for_all_sort_options() {
+    let ids: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), Some(2), None, Some(-3)]));
+    let names: ArrayRef = Arc::new(StringArray::from(vec![
+        Some("a"),
+        None,
+        Some(LONG),
+        Some(""),
+    ]));
+    for descending in [false, true] {
+        for nulls_first in [false, true] {
+            assert_matches_arrow_row_opts(
+                &[Arc::clone(&ids), Arc::clone(&names)],
+                SortOptions {
+                    descending,
+                    nulls_first,
+                },
+            );
+        }
+    }
+}
+
+#[test]
+fn owned_row_equality_and_hashing() {
+    let converter = RowConverter::new(vec![
+        SortField::new(DataType::Int64),
+        SortField::new(DataType::Utf8),
+    ])
+    .expect("build converter");
+    let ids: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), Some(1), Some(2)]));
+    let names: ArrayRef = Arc::new(StringArray::from(vec![Some("x"), Some("x"), Some("x")]));
+    let rows = converter
+        .convert_columns(&[ids, names])
+        .expect("encode rows");
+
+    let owned: Vec<OwnedRow> = rows.iter().map(|r| r.owned()).collect();
+    assert_eq!(owned[0], owned[1], "identical keys must be equal");
+    assert_ne!(owned[0], owned[2], "different keys must differ");
+
+    let set: HashSet<OwnedRow> = owned.iter().cloned().collect();
+    assert_eq!(set.len(), 2, "hash-set dedups identical keys");
+
+    // Borrowed and owned views agree.
+    assert_eq!(owned[0].row().as_ref(), rows.row(0).as_ref());
+}
+
+#[test]
+fn unsupported_primary_key_types_error() {
+    for dt in [
+        DataType::FixedSizeBinary(4),
+        DataType::Interval(arrow::datatypes::IntervalUnit::DayTime),
+        DataType::Null,
+        DataType::List(Arc::new(arrow::datatypes::Field::new(
+            "item",
+            DataType::Int32,
+            true,
+        ))),
+    ] {
+        assert!(
+            RowConverter::new(vec![SortField::new(dt.clone())]).is_err(),
+            "expected {dt:?} to be rejected"
+        );
+    }
+}
+
+#[test]
+fn unsupported_type_does_not_reach_arrow_row() {
+    // Sanity: FixedSizeBinary is a valid arrow-row type but is not a Cayenne PK type, so we
+    // deliberately reject it even though arrow-row would accept it.
+    let fsb = FixedSizeBinaryArray::try_from_iter(vec![vec![1u8, 2, 3, 4]].into_iter())
+        .expect("build fixed-size-binary array");
+    assert!(
+        arrow_row::RowConverter::new(vec![arrow_row::SortField::new(fsb.data_type().clone())])
+            .is_ok(),
+        "arrow-row accepts FixedSizeBinary"
+    );
+    assert!(
+        RowConverter::new(vec![SortField::new(fsb.data_type().clone())]).is_err(),
+        "cayenne rejects FixedSizeBinary as a primary key"
+    );
+}
+
+#[test]
+fn version_identifiers_round_trip() {
+    assert_eq!(RowFormatVersion::CURRENT, RowFormatVersion::V1);
+    assert_eq!(RowFormatVersion::V1.id(), 1);
+    assert_eq!(RowFormatVersion::from_id(1), Some(RowFormatVersion::V1));
+    assert_eq!(RowFormatVersion::from_id(0), None);
+    assert_eq!(RowFormatVersion::from_id(2), None);
+
+    let converter =
+        RowConverter::new(vec![SortField::new(DataType::Int64)]).expect("build converter");
+    assert_eq!(converter.version(), RowFormatVersion::V1);
+}
+
+#[test]
+fn empty_input_is_handled() {
+    let empty: ArrayRef = Arc::new(Int64Array::from(Vec::<Option<i64>>::new()));
+    assert_matches_arrow_row(&[empty]);
+}

--- a/crates/cayenne/src/row_converter/tests.rs
+++ b/crates/cayenne/src/row_converter/tests.rs
@@ -35,7 +35,7 @@ use arrow::array::{
 use arrow::datatypes::{DataType, i256};
 use arrow_schema::SortOptions;
 
-use super::{OwnedRow, RowConverter, RowFormatVersion, SortField};
+use super::{OwnedRow, RowConverter, RowFormatVersion, Rows, SortField};
 
 /// Encode `columns` with both the vendored converter and `arrow-row` using `options` for every
 /// field, and assert the encoded bytes are identical row-for-row. Then verify round-trip decode.
@@ -371,4 +371,34 @@ fn version_identifiers_round_trip() {
 fn empty_input_is_handled() {
     let empty: ArrayRef = Arc::new(Int64Array::from(Vec::<Option<i64>>::new()));
     assert_matches_arrow_row(&[empty]);
+}
+
+#[test]
+fn decode_rejects_truncated_fixed_bytes() {
+    let converter =
+        RowConverter::new(vec![SortField::new(DataType::Int64)]).expect("build converter");
+    // A valid Int64 row is 9 bytes; provide only 3.
+    let rows = Rows {
+        buffer: vec![1u8, 0, 0],
+        offsets: vec![0, 3],
+    };
+    assert!(
+        converter.convert_rows(rows.iter()).is_err(),
+        "truncated fixed-width row must error, not panic"
+    );
+}
+
+#[test]
+fn decode_rejects_truncated_variable_bytes() {
+    let converter =
+        RowConverter::new(vec![SortField::new(DataType::Utf8)]).expect("build converter");
+    // Non-empty sentinel (2) claims a block, but no block bytes follow.
+    let rows = Rows {
+        buffer: vec![2u8],
+        offsets: vec![0, 1],
+    };
+    assert!(
+        converter.convert_rows(rows.iter()).is_err(),
+        "truncated variable-width row must error, not panic"
+    );
 }

--- a/crates/cayenne/src/row_converter/v1/fixed.rs
+++ b/crates/cayenne/src/row_converter/v1/fixed.rs
@@ -247,12 +247,19 @@ fn encode_boolean_not_null(
     }
 }
 
-/// Splits `len` bytes from the front of `src`, advancing it.
+/// Splits `len` bytes from the front of `src`, advancing it. Errors on a truncated row rather
+/// than panicking, so decoding malformed input returns an `ArrowError`.
 #[inline]
-fn split_off<'a>(src: &mut &'a [u8], len: usize) -> &'a [u8] {
-    let v = &src[..len];
-    *src = &src[len..];
-    v
+fn take<'a>(src: &mut &'a [u8], len: usize) -> Result<&'a [u8], ArrowError> {
+    if src.len() < len {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "row_converter: truncated row, expected at least {len} bytes, got {}",
+            src.len()
+        )));
+    }
+    let (head, tail) = src.split_at(len);
+    *src = tail;
+    Ok(head)
 }
 
 /// Codec for any primitive type whose native representation implements [`FixedLengthEncoding`].
@@ -314,7 +321,7 @@ where
         let encoded_len = <T::Native as FixedLengthEncoding>::ENCODED_LEN;
         let mut builder = PrimitiveBuilder::<T>::with_capacity(rows.len());
         for row in rows.iter_mut() {
-            let encoded = split_off(row, encoded_len);
+            let encoded = take(row, encoded_len)?;
             if encoded[0] == 1 {
                 let bytes = <<T::Native as FixedLengthEncoding>::Encoded as FromSlice>::from_slice(
                     &encoded[1..],
@@ -361,7 +368,7 @@ impl ColumnCodec for BooleanCodec {
         let true_val = if self.options.descending { !1u8 } else { 1u8 };
         let mut builder = BooleanBuilder::with_capacity(rows.len());
         for row in rows.iter_mut() {
-            let encoded = split_off(row, bool::ENCODED_LEN);
+            let encoded = take(row, bool::ENCODED_LEN)?;
             if encoded[0] == 1 {
                 builder.append_value(encoded[1] == true_val);
             } else {

--- a/crates/cayenne/src/row_converter/v1/fixed.rs
+++ b/crates/cayenne/src/row_converter/v1/fixed.rs
@@ -1,0 +1,373 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! V1 fixed-width codecs: primitives (via a single generic [`PrimitiveCodec`]) and booleans.
+//!
+//! The byte layout is copied from Apache Arrow's `arrow-row` crate (Apache-2.0):
+//! a fixed-width value is a `1` validity byte followed by the big-endian value (with the sign
+//! bit flipped for signed integers and floats total-ordered), or the null sentinel followed by
+//! zeroed value bytes. Descending order inverts all value bytes.
+
+use std::sync::Arc;
+
+use arrow::array::builder::{BooleanBuilder, PrimitiveBuilder};
+use arrow::array::{Array, ArrayRef, ArrowPrimitiveType, AsArray};
+use arrow::buffer::{BooleanBuffer, NullBuffer};
+use arrow::datatypes::i256;
+use arrow_schema::{ArrowError, DataType, SortOptions};
+
+use crate::row_converter::codec::{ColumnCodec, LengthTracker, null_sentinel};
+
+/// Reconstructs a fixed-width encoded value from its bytes, inverting first if `invert` is set.
+pub(crate) trait FromSlice {
+    fn from_slice(slice: &[u8], invert: bool) -> Self;
+}
+
+impl<const N: usize> FromSlice for [u8; N] {
+    #[inline]
+    fn from_slice(slice: &[u8], invert: bool) -> Self {
+        let mut t = [0u8; N];
+        t.copy_from_slice(slice);
+        if invert {
+            for o in &mut t {
+                *o = !*o;
+            }
+        }
+        t
+    }
+}
+
+/// A fixed-width value that encodes to an order-preserving byte sequence.
+pub(crate) trait FixedLengthEncoding: Copy {
+    const ENCODED_LEN: usize = 1 + std::mem::size_of::<Self::Encoded>();
+
+    type Encoded: Sized + Copy + FromSlice + AsRef<[u8]> + AsMut<[u8]>;
+
+    fn encode(self) -> Self::Encoded;
+
+    fn decode(encoded: Self::Encoded) -> Self;
+}
+
+impl FixedLengthEncoding for bool {
+    type Encoded = [u8; 1];
+
+    fn encode(self) -> [u8; 1] {
+        [u8::from(self)]
+    }
+
+    fn decode(encoded: Self::Encoded) -> Self {
+        encoded[0] != 0
+    }
+}
+
+macro_rules! encode_signed {
+    ($n:expr, $t:ty) => {
+        impl FixedLengthEncoding for $t {
+            type Encoded = [u8; $n];
+
+            fn encode(self) -> [u8; $n] {
+                let mut b = self.to_be_bytes();
+                // Toggle top "sign" bit to ensure consistent sort order
+                b[0] ^= 0x80;
+                b
+            }
+
+            fn decode(mut encoded: Self::Encoded) -> Self {
+                // Toggle top "sign" bit
+                encoded[0] ^= 0x80;
+                Self::from_be_bytes(encoded)
+            }
+        }
+    };
+}
+
+encode_signed!(1, i8);
+encode_signed!(2, i16);
+encode_signed!(4, i32);
+encode_signed!(8, i64);
+encode_signed!(16, i128);
+encode_signed!(32, i256);
+
+macro_rules! encode_unsigned {
+    ($n:expr, $t:ty) => {
+        impl FixedLengthEncoding for $t {
+            type Encoded = [u8; $n];
+
+            fn encode(self) -> [u8; $n] {
+                self.to_be_bytes()
+            }
+
+            fn decode(encoded: Self::Encoded) -> Self {
+                Self::from_be_bytes(encoded)
+            }
+        }
+    };
+}
+
+encode_unsigned!(1, u8);
+encode_unsigned!(2, u16);
+encode_unsigned!(4, u32);
+encode_unsigned!(8, u64);
+
+impl FixedLengthEncoding for f32 {
+    type Encoded = [u8; 4];
+
+    fn encode(self) -> [u8; 4] {
+        let s = self.to_bits().cast_signed();
+        let val = s ^ ((s >> 31).cast_unsigned() >> 1).cast_signed();
+        val.encode()
+    }
+
+    fn decode(encoded: Self::Encoded) -> Self {
+        let bits = i32::decode(encoded);
+        let val = bits ^ ((bits >> 31).cast_unsigned() >> 1).cast_signed();
+        Self::from_bits(val.cast_unsigned())
+    }
+}
+
+impl FixedLengthEncoding for f64 {
+    type Encoded = [u8; 8];
+
+    fn encode(self) -> [u8; 8] {
+        let s = self.to_bits().cast_signed();
+        let val = s ^ ((s >> 63).cast_unsigned() >> 1).cast_signed();
+        val.encode()
+    }
+
+    fn decode(encoded: Self::Encoded) -> Self {
+        let bits = i64::decode(encoded);
+        let val = bits ^ ((bits >> 63).cast_unsigned() >> 1).cast_signed();
+        Self::from_bits(val.cast_unsigned())
+    }
+}
+
+/// Fixed width types are encoded as a `1` validity byte (or the null sentinel) followed by the
+/// [`FixedLengthEncoding`] bytes.
+fn encode_fixed<T: FixedLengthEncoding>(
+    data: &mut [u8],
+    offsets: &mut [usize],
+    values: &[T],
+    nulls: &NullBuffer,
+    opts: SortOptions,
+) {
+    for (value_idx, is_valid) in nulls.iter().enumerate() {
+        let offset = &mut offsets[value_idx + 1];
+        let end_offset = *offset + T::ENCODED_LEN;
+        if is_valid {
+            let to_write = &mut data[*offset..end_offset];
+            to_write[0] = 1;
+            let mut encoded = values[value_idx].encode();
+            if opts.descending {
+                encoded.as_mut().iter_mut().for_each(|v| *v = !*v);
+            }
+            to_write[1..].copy_from_slice(encoded.as_ref());
+        } else {
+            data[*offset] = null_sentinel(opts);
+        }
+        *offset = end_offset;
+    }
+}
+
+/// Encoding for non-nullable fixed-width arrays: iterates values directly, skipping null checks.
+fn encode_fixed_not_null<T: FixedLengthEncoding>(
+    data: &mut [u8],
+    offsets: &mut [usize],
+    values: &[T],
+    opts: SortOptions,
+) {
+    for (value_idx, val) in values.iter().enumerate() {
+        let offset = &mut offsets[value_idx + 1];
+        let end_offset = *offset + T::ENCODED_LEN;
+        let to_write = &mut data[*offset..end_offset];
+        to_write[0] = 1;
+        let mut encoded = val.encode();
+        if opts.descending {
+            encoded.as_mut().iter_mut().for_each(|v| *v = !*v);
+        }
+        to_write[1..].copy_from_slice(encoded.as_ref());
+        *offset = end_offset;
+    }
+}
+
+fn encode_boolean(
+    data: &mut [u8],
+    offsets: &mut [usize],
+    values: &BooleanBuffer,
+    nulls: &NullBuffer,
+    opts: SortOptions,
+) {
+    for (idx, is_valid) in nulls.iter().enumerate() {
+        let offset = &mut offsets[idx + 1];
+        let end_offset = *offset + bool::ENCODED_LEN;
+        if is_valid {
+            let to_write = &mut data[*offset..end_offset];
+            to_write[0] = 1;
+            let mut encoded = values.value(idx).encode();
+            if opts.descending {
+                encoded.as_mut().iter_mut().for_each(|v| *v = !*v);
+            }
+            to_write[1..].copy_from_slice(encoded.as_ref());
+        } else {
+            data[*offset] = null_sentinel(opts);
+        }
+        *offset = end_offset;
+    }
+}
+
+fn encode_boolean_not_null(
+    data: &mut [u8],
+    offsets: &mut [usize],
+    values: &BooleanBuffer,
+    opts: SortOptions,
+) {
+    for (value_idx, val) in values.iter().enumerate() {
+        let offset = &mut offsets[value_idx + 1];
+        let end_offset = *offset + bool::ENCODED_LEN;
+        let to_write = &mut data[*offset..end_offset];
+        to_write[0] = 1;
+        let mut encoded = val.encode();
+        if opts.descending {
+            encoded.as_mut().iter_mut().for_each(|v| *v = !*v);
+        }
+        to_write[1..].copy_from_slice(encoded.as_ref());
+        *offset = end_offset;
+    }
+}
+
+/// Splits `len` bytes from the front of `src`, advancing it.
+#[inline]
+fn split_off<'a>(src: &mut &'a [u8], len: usize) -> &'a [u8] {
+    let v = &src[..len];
+    *src = &src[len..];
+    v
+}
+
+/// Codec for any primitive type whose native representation implements [`FixedLengthEncoding`].
+///
+/// A single generic covers every integer, float, temporal, and decimal type; optimizing one of
+/// them means adding a dedicated codec and routing that type to it, not editing this one.
+pub(crate) struct PrimitiveCodec<T: ArrowPrimitiveType>
+where
+    T::Native: FixedLengthEncoding,
+{
+    data_type: DataType,
+    options: SortOptions,
+    _marker: std::marker::PhantomData<fn() -> T>,
+}
+
+impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveCodec<T>
+where
+    T::Native: FixedLengthEncoding,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrimitiveCodec")
+            .field("data_type", &self.data_type)
+            .field("options", &self.options)
+            .finish()
+    }
+}
+
+impl<T: ArrowPrimitiveType> PrimitiveCodec<T>
+where
+    T::Native: FixedLengthEncoding,
+{
+    pub(crate) fn new(data_type: DataType, options: SortOptions) -> Self {
+        Self {
+            data_type,
+            options,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: ArrowPrimitiveType> ColumnCodec for PrimitiveCodec<T>
+where
+    T::Native: FixedLengthEncoding,
+{
+    fn append_lengths(&self, _array: &dyn Array, tracker: &mut LengthTracker) {
+        tracker.push_fixed(<T::Native as FixedLengthEncoding>::ENCODED_LEN);
+    }
+
+    fn encode(&self, data: &mut [u8], offsets: &mut [usize], array: &dyn Array) {
+        let column = array.as_primitive::<T>();
+        if let Some(nulls) = column.nulls().filter(|n| n.null_count() > 0) {
+            encode_fixed(data, offsets, column.values(), nulls, self.options);
+        } else {
+            encode_fixed_not_null(data, offsets, column.values(), self.options);
+        }
+    }
+
+    fn decode(&self, rows: &mut [&[u8]], _validate_utf8: bool) -> Result<ArrayRef, ArrowError> {
+        let encoded_len = <T::Native as FixedLengthEncoding>::ENCODED_LEN;
+        let mut builder = PrimitiveBuilder::<T>::with_capacity(rows.len());
+        for row in rows.iter_mut() {
+            let encoded = split_off(row, encoded_len);
+            if encoded[0] == 1 {
+                let bytes = <<T::Native as FixedLengthEncoding>::Encoded as FromSlice>::from_slice(
+                    &encoded[1..],
+                    self.options.descending,
+                );
+                builder.append_value(<T::Native as FixedLengthEncoding>::decode(bytes));
+            } else {
+                builder.append_null();
+            }
+        }
+        Ok(Arc::new(
+            builder.finish().with_data_type(self.data_type.clone()),
+        ))
+    }
+}
+
+/// Codec for `Boolean`.
+#[derive(Debug)]
+pub(crate) struct BooleanCodec {
+    options: SortOptions,
+}
+
+impl BooleanCodec {
+    pub(crate) fn new(options: SortOptions) -> Self {
+        Self { options }
+    }
+}
+
+impl ColumnCodec for BooleanCodec {
+    fn append_lengths(&self, _array: &dyn Array, tracker: &mut LengthTracker) {
+        tracker.push_fixed(bool::ENCODED_LEN);
+    }
+
+    fn encode(&self, data: &mut [u8], offsets: &mut [usize], array: &dyn Array) {
+        let column = array.as_boolean();
+        if let Some(nulls) = column.nulls().filter(|n| n.null_count() > 0) {
+            encode_boolean(data, offsets, column.values(), nulls, self.options);
+        } else {
+            encode_boolean_not_null(data, offsets, column.values(), self.options);
+        }
+    }
+
+    fn decode(&self, rows: &mut [&[u8]], _validate_utf8: bool) -> Result<ArrayRef, ArrowError> {
+        let true_val = if self.options.descending { !1u8 } else { 1u8 };
+        let mut builder = BooleanBuilder::with_capacity(rows.len());
+        for row in rows.iter_mut() {
+            let encoded = split_off(row, bool::ENCODED_LEN);
+            if encoded[0] == 1 {
+                builder.append_value(encoded[1] == true_val);
+            } else {
+                builder.append_null();
+            }
+        }
+        Ok(Arc::new(builder.finish()))
+    }
+}

--- a/crates/cayenne/src/row_converter/v1/mod.rs
+++ b/crates/cayenne/src/row_converter/v1/mod.rs
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Version 1 of the row format — byte-identical to Apache Arrow `arrow-row` 58.3.0.
+//!
+//! [`build_codec`] is the only version-specific piece: it maps each supported primary-key
+//! [`DataType`] to a [`ColumnCodec`]. A future version reuses this for unchanged types and only
+//! overrides the entry for a type whose encoding it optimizes.
+
+mod fixed;
+mod variable;
+
+use arrow::datatypes::{
+    Date32Type, Date64Type, Decimal128Type, Decimal256Type, Float32Type, Float64Type, Int8Type,
+    Int16Type, Int32Type, Int64Type, Time32MillisecondType, Time32SecondType,
+    Time64MicrosecondType, Time64NanosecondType, TimestampMicrosecondType,
+    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType, UInt8Type, UInt16Type,
+    UInt32Type, UInt64Type,
+};
+use arrow_schema::{ArrowError, DataType, TimeUnit};
+
+use self::fixed::{BooleanCodec, PrimitiveCodec};
+use self::variable::{VarKind, VariableCodec};
+use crate::row_converter::SortField;
+use crate::row_converter::codec::ColumnCodec;
+
+/// Build the V1 column codec for `field`, or an error if its type cannot be a Cayenne primary key.
+pub(crate) fn build_codec(field: &SortField) -> Result<Box<dyn ColumnCodec>, ArrowError> {
+    let opts = field.options;
+    let data_type = &field.data_type;
+
+    macro_rules! primitive {
+        ($t:ty) => {
+            Ok(Box::new(PrimitiveCodec::<$t>::new(data_type.clone(), opts))
+                as Box<dyn ColumnCodec>)
+        };
+    }
+    macro_rules! variable {
+        ($kind:expr) => {
+            Ok(Box::new(VariableCodec::new($kind, opts)) as Box<dyn ColumnCodec>)
+        };
+    }
+
+    match data_type {
+        DataType::Boolean => Ok(Box::new(BooleanCodec::new(opts)) as Box<dyn ColumnCodec>),
+
+        DataType::Int8 => primitive!(Int8Type),
+        DataType::Int16 => primitive!(Int16Type),
+        DataType::Int32 => primitive!(Int32Type),
+        DataType::Int64 => primitive!(Int64Type),
+        DataType::UInt8 => primitive!(UInt8Type),
+        DataType::UInt16 => primitive!(UInt16Type),
+        DataType::UInt32 => primitive!(UInt32Type),
+        DataType::UInt64 => primitive!(UInt64Type),
+        DataType::Float32 => primitive!(Float32Type),
+        DataType::Float64 => primitive!(Float64Type),
+
+        DataType::Date32 => primitive!(Date32Type),
+        DataType::Date64 => primitive!(Date64Type),
+        DataType::Time32(TimeUnit::Second) => primitive!(Time32SecondType),
+        DataType::Time32(TimeUnit::Millisecond) => primitive!(Time32MillisecondType),
+        DataType::Time64(TimeUnit::Microsecond) => primitive!(Time64MicrosecondType),
+        DataType::Time64(TimeUnit::Nanosecond) => primitive!(Time64NanosecondType),
+        DataType::Timestamp(TimeUnit::Second, _) => primitive!(TimestampSecondType),
+        DataType::Timestamp(TimeUnit::Millisecond, _) => primitive!(TimestampMillisecondType),
+        DataType::Timestamp(TimeUnit::Microsecond, _) => primitive!(TimestampMicrosecondType),
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => primitive!(TimestampNanosecondType),
+
+        DataType::Decimal128(_, _) => primitive!(Decimal128Type),
+        DataType::Decimal256(_, _) => primitive!(Decimal256Type),
+
+        DataType::Binary => variable!(VarKind::Binary),
+        DataType::LargeBinary => variable!(VarKind::LargeBinary),
+        DataType::Utf8 => variable!(VarKind::Utf8),
+        DataType::LargeUtf8 => variable!(VarKind::LargeUtf8),
+        DataType::BinaryView => variable!(VarKind::BinaryView),
+        DataType::Utf8View => variable!(VarKind::Utf8View),
+
+        other => Err(ArrowError::NotYetImplemented(format!(
+            "cayenne row_converter: unsupported primary key type: {other}"
+        ))),
+    }
+}

--- a/crates/cayenne/src/row_converter/v1/variable.rs
+++ b/crates/cayenne/src/row_converter/v1/variable.rs
@@ -109,7 +109,7 @@ impl ColumnCodec for VariableCodec {
             VarKind::Binary => {
                 let mut builder = BinaryBuilder::new();
                 for row in rows.iter_mut() {
-                    match decode_one(row, opts) {
+                    match decode_one(row, opts)? {
                         Some(value) => builder.append_value(&value),
                         None => builder.append_null(),
                     }
@@ -119,7 +119,7 @@ impl ColumnCodec for VariableCodec {
             VarKind::LargeBinary => {
                 let mut builder = LargeBinaryBuilder::new();
                 for row in rows.iter_mut() {
-                    match decode_one(row, opts) {
+                    match decode_one(row, opts)? {
                         Some(value) => builder.append_value(&value),
                         None => builder.append_null(),
                     }
@@ -129,7 +129,7 @@ impl ColumnCodec for VariableCodec {
             VarKind::Utf8 => {
                 let mut builder = StringBuilder::new();
                 for row in rows.iter_mut() {
-                    match decode_one(row, opts) {
+                    match decode_one(row, opts)? {
                         Some(value) => builder.append_value(bytes_to_str(value)?),
                         None => builder.append_null(),
                     }
@@ -139,7 +139,7 @@ impl ColumnCodec for VariableCodec {
             VarKind::LargeUtf8 => {
                 let mut builder = LargeStringBuilder::new();
                 for row in rows.iter_mut() {
-                    match decode_one(row, opts) {
+                    match decode_one(row, opts)? {
                         Some(value) => builder.append_value(bytes_to_str(value)?),
                         None => builder.append_null(),
                     }
@@ -149,7 +149,7 @@ impl ColumnCodec for VariableCodec {
             VarKind::BinaryView => {
                 let mut builder = BinaryViewBuilder::new();
                 for row in rows.iter_mut() {
-                    match decode_one(row, opts) {
+                    match decode_one(row, opts)? {
                         Some(value) => builder.append_value(&value),
                         None => builder.append_null(),
                     }
@@ -159,7 +159,7 @@ impl ColumnCodec for VariableCodec {
             VarKind::Utf8View => {
                 let mut builder = StringViewBuilder::new();
                 for row in rows.iter_mut() {
-                    match decode_one(row, opts) {
+                    match decode_one(row, opts)? {
                         Some(value) => builder.append_value(bytes_to_str(value)?),
                         None => builder.append_null(),
                     }
@@ -355,18 +355,31 @@ fn block_length_byte(len: usize) -> u8 {
     len as u8
 }
 
+/// Error for a row that ends before a complete value could be decoded.
+fn truncated() -> ArrowError {
+    ArrowError::InvalidArgumentError("row_converter: truncated or malformed row bytes".to_string())
+}
+
 /// Decodes the blocks of a single encoded value, calling `f` with each decoded chunk. Returns
-/// the number of bytes consumed.
-fn decode_blocks(row: &[u8], options: SortOptions, mut f: impl FnMut(&[u8])) -> usize {
+/// the number of bytes consumed, or an error if the row is truncated/malformed. Every index into
+/// `row` is bounds-checked so malformed input yields an `ArrowError` rather than a panic.
+fn decode_blocks(
+    row: &[u8],
+    options: SortOptions,
+    mut f: impl FnMut(&[u8]),
+) -> Result<usize, ArrowError> {
     let (non_empty_sentinel, continuation) = if options.descending {
         (!NON_EMPTY_SENTINEL, !BLOCK_CONTINUATION)
     } else {
         (NON_EMPTY_SENTINEL, BLOCK_CONTINUATION)
     };
 
-    if row[0] != non_empty_sentinel {
+    let Some(&first) = row.first() else {
+        return Err(truncated());
+    };
+    if first != non_empty_sentinel {
         // Empty or null value
-        return 1;
+        return Ok(1);
     }
 
     let block_len = |sentinel: u8| {
@@ -379,41 +392,61 @@ fn decode_blocks(row: &[u8], options: SortOptions, mut f: impl FnMut(&[u8])) -> 
 
     let mut idx = 1;
     for _ in 0..MINI_BLOCK_COUNT {
-        let sentinel = row[idx + MINI_BLOCK_SIZE];
-        if sentinel != continuation {
-            f(&row[idx..idx + block_len(sentinel)]);
-            return idx + MINI_BLOCK_SIZE + 1;
+        let sentinel_idx = idx + MINI_BLOCK_SIZE;
+        if sentinel_idx >= row.len() {
+            return Err(truncated());
         }
-        f(&row[idx..idx + MINI_BLOCK_SIZE]);
-        idx += MINI_BLOCK_SIZE + 1;
+        let sentinel = row[sentinel_idx];
+        if sentinel != continuation {
+            let end = idx + block_len(sentinel);
+            if end > row.len() {
+                return Err(truncated());
+            }
+            f(&row[idx..end]);
+            return Ok(sentinel_idx + 1);
+        }
+        f(&row[idx..sentinel_idx]);
+        idx = sentinel_idx + 1;
     }
 
     loop {
-        let sentinel = row[idx + BLOCK_SIZE];
-        if sentinel != continuation {
-            f(&row[idx..idx + block_len(sentinel)]);
-            return idx + BLOCK_SIZE + 1;
+        let sentinel_idx = idx + BLOCK_SIZE;
+        if sentinel_idx >= row.len() {
+            return Err(truncated());
         }
-        f(&row[idx..idx + BLOCK_SIZE]);
-        idx += BLOCK_SIZE + 1;
+        let sentinel = row[sentinel_idx];
+        if sentinel != continuation {
+            let end = idx + block_len(sentinel);
+            if end > row.len() {
+                return Err(truncated());
+            }
+            f(&row[idx..end]);
+            return Ok(sentinel_idx + 1);
+        }
+        f(&row[idx..sentinel_idx]);
+        idx = sentinel_idx + 1;
     }
 }
 
-/// Decodes one value from `row`, advancing it past the bytes consumed. `None` is a null.
-fn decode_one(row: &mut &[u8], options: SortOptions) -> Option<Vec<u8>> {
+/// Decodes one value from `row`, advancing it past the bytes consumed. `Ok(None)` is a null;
+/// an error is returned for truncated/malformed input.
+fn decode_one(row: &mut &[u8], options: SortOptions) -> Result<Option<Vec<u8>>, ArrowError> {
     let slice: &[u8] = row;
-    let is_null = slice[0] == null_sentinel(options);
+    let Some(&first) = slice.first() else {
+        return Err(truncated());
+    };
+    let is_null = first == null_sentinel(options);
     let mut buf = Vec::new();
-    let consumed = decode_blocks(slice, options, |b| buf.extend_from_slice(b));
+    let consumed = decode_blocks(slice, options, |b| buf.extend_from_slice(b))?;
     *row = &slice[consumed..];
     if is_null {
-        None
+        Ok(None)
     } else {
         if options.descending {
             for b in &mut buf {
                 *b = !*b;
             }
         }
-        Some(buf)
+        Ok(Some(buf))
     }
 }

--- a/crates/cayenne/src/row_converter/v1/variable.rs
+++ b/crates/cayenne/src/row_converter/v1/variable.rs
@@ -1,0 +1,419 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! V1 variable-length codec for the byte/string family (`Binary`, `LargeBinary`, `Utf8`,
+//! `LargeUtf8`, `BinaryView`, `Utf8View`).
+//!
+//! The byte layout is copied from Apache Arrow's `arrow-row` crate (Apache-2.0): a null is a
+//! single sentinel byte, an empty value is a single `1` byte, and a non-empty value is a `2`
+//! byte followed by 0-padded fixed-width blocks each terminated by a continuation byte (`0xFF`)
+//! or the block's unpadded length. Descending order inverts all bytes.
+
+use std::sync::Arc;
+
+use arrow::array::builder::{
+    BinaryBuilder, BinaryViewBuilder, LargeBinaryBuilder, LargeStringBuilder, StringBuilder,
+    StringViewBuilder,
+};
+use arrow::array::types::{ByteArrayType, ByteViewType};
+use arrow::array::{Array, ArrayRef, AsArray, GenericByteArray, GenericByteViewArray};
+use arrow::datatypes::ArrowNativeType;
+use arrow_schema::{ArrowError, SortOptions};
+
+use crate::row_converter::codec::{ColumnCodec, LengthTracker, null_sentinel};
+
+/// The block size of the variable length encoding.
+const BLOCK_SIZE: usize = 32;
+/// The first block is split into this many mini-blocks to reduce amplification for short values.
+const MINI_BLOCK_COUNT: usize = 4;
+/// The mini block size.
+const MINI_BLOCK_SIZE: usize = BLOCK_SIZE / MINI_BLOCK_COUNT;
+/// The continuation token.
+const BLOCK_CONTINUATION: u8 = 0xFF;
+/// Indicates an empty value.
+const EMPTY_SENTINEL: u8 = 1;
+/// Indicates a non-empty value.
+const NON_EMPTY_SENTINEL: u8 = 2;
+
+/// The byte/string variant this codec handles.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum VarKind {
+    Binary,
+    LargeBinary,
+    Utf8,
+    LargeUtf8,
+    BinaryView,
+    Utf8View,
+}
+
+/// Codec for the variable-length byte/string family.
+#[derive(Debug)]
+pub(crate) struct VariableCodec {
+    kind: VarKind,
+    options: SortOptions,
+}
+
+impl VariableCodec {
+    pub(crate) fn new(kind: VarKind, options: SortOptions) -> Self {
+        Self { kind, options }
+    }
+}
+
+impl ColumnCodec for VariableCodec {
+    fn append_lengths(&self, array: &dyn Array, tracker: &mut LengthTracker) {
+        match self.kind {
+            VarKind::Binary => push_byte_array_lengths(tracker, array.as_binary::<i32>()),
+            VarKind::LargeBinary => push_byte_array_lengths(tracker, array.as_binary::<i64>()),
+            VarKind::Utf8 => push_byte_array_lengths(tracker, array.as_string::<i32>()),
+            VarKind::LargeUtf8 => push_byte_array_lengths(tracker, array.as_string::<i64>()),
+            VarKind::BinaryView => push_byte_view_lengths(tracker, array.as_binary_view()),
+            VarKind::Utf8View => push_byte_view_lengths(tracker, array.as_string_view()),
+        }
+    }
+
+    fn encode(&self, data: &mut [u8], offsets: &mut [usize], array: &dyn Array) {
+        let opts = self.options;
+        match self.kind {
+            VarKind::Binary => encode_byte_array(data, offsets, array.as_binary::<i32>(), opts),
+            VarKind::LargeBinary => {
+                encode_byte_array(data, offsets, array.as_binary::<i64>(), opts);
+            }
+            VarKind::Utf8 => encode_byte_array(data, offsets, array.as_string::<i32>(), opts),
+            VarKind::LargeUtf8 => encode_byte_array(data, offsets, array.as_string::<i64>(), opts),
+            VarKind::BinaryView => encode(data, offsets, array.as_binary_view().iter(), opts),
+            VarKind::Utf8View => encode(
+                data,
+                offsets,
+                array.as_string_view().iter().map(|x| x.map(str::as_bytes)),
+                opts,
+            ),
+        }
+    }
+
+    fn decode(&self, rows: &mut [&[u8]], _validate_utf8: bool) -> Result<ArrayRef, ArrowError> {
+        let opts = self.options;
+        let array: ArrayRef = match self.kind {
+            VarKind::Binary => {
+                let mut builder = BinaryBuilder::new();
+                for row in rows.iter_mut() {
+                    match decode_one(row, opts) {
+                        Some(value) => builder.append_value(&value),
+                        None => builder.append_null(),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            VarKind::LargeBinary => {
+                let mut builder = LargeBinaryBuilder::new();
+                for row in rows.iter_mut() {
+                    match decode_one(row, opts) {
+                        Some(value) => builder.append_value(&value),
+                        None => builder.append_null(),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            VarKind::Utf8 => {
+                let mut builder = StringBuilder::new();
+                for row in rows.iter_mut() {
+                    match decode_one(row, opts) {
+                        Some(value) => builder.append_value(bytes_to_str(value)?),
+                        None => builder.append_null(),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            VarKind::LargeUtf8 => {
+                let mut builder = LargeStringBuilder::new();
+                for row in rows.iter_mut() {
+                    match decode_one(row, opts) {
+                        Some(value) => builder.append_value(bytes_to_str(value)?),
+                        None => builder.append_null(),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            VarKind::BinaryView => {
+                let mut builder = BinaryViewBuilder::new();
+                for row in rows.iter_mut() {
+                    match decode_one(row, opts) {
+                        Some(value) => builder.append_value(&value),
+                        None => builder.append_null(),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            VarKind::Utf8View => {
+                let mut builder = StringViewBuilder::new();
+                for row in rows.iter_mut() {
+                    match decode_one(row, opts) {
+                        Some(value) => builder.append_value(bytes_to_str(value)?),
+                        None => builder.append_null(),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+        };
+        Ok(array)
+    }
+}
+
+fn bytes_to_str(bytes: Vec<u8>) -> Result<String, ArrowError> {
+    String::from_utf8(bytes)
+        .map_err(|e| ArrowError::InvalidArgumentError(format!("invalid UTF-8 in decoded row: {e}")))
+}
+
+/// Returns the padded encoded length of a value of `len` bytes (1 for null).
+#[inline]
+fn padded_length(a: Option<usize>) -> usize {
+    match a {
+        Some(a) => non_null_padded_length(a),
+        None => 1,
+    }
+}
+
+/// Returns the padded encoded length of a non-null value of `len` bytes.
+#[inline]
+fn non_null_padded_length(len: usize) -> usize {
+    if len <= BLOCK_SIZE {
+        1 + ceil(len, MINI_BLOCK_SIZE) * (MINI_BLOCK_SIZE + 1)
+    } else {
+        MINI_BLOCK_COUNT + ceil(len, BLOCK_SIZE) * (BLOCK_SIZE + 1)
+    }
+}
+
+#[inline]
+fn ceil(value: usize, divisor: usize) -> usize {
+    value.div_ceil(divisor)
+}
+
+fn push_byte_array_lengths<T: ByteArrayType>(
+    tracker: &mut LengthTracker,
+    array: &GenericByteArray<T>,
+) {
+    if let Some(nulls) = array.nulls().filter(|n| n.null_count() > 0) {
+        tracker.push_variable(
+            array
+                .offsets()
+                .lengths()
+                .zip(nulls.iter())
+                .map(|(length, is_valid)| if is_valid { Some(length) } else { None })
+                .map(padded_length),
+        );
+    } else {
+        tracker.push_variable(array.offsets().lengths().map(non_null_padded_length));
+    }
+}
+
+fn push_byte_view_lengths<T: ByteViewType>(
+    tracker: &mut LengthTracker,
+    array: &GenericByteViewArray<T>,
+) {
+    if let Some(nulls) = array.nulls().filter(|n| n.null_count() > 0) {
+        tracker.push_variable(
+            array
+                .lengths()
+                .zip(nulls.iter())
+                .map(|(length, is_valid)| {
+                    if is_valid {
+                        Some(length as usize)
+                    } else {
+                        None
+                    }
+                })
+                .map(padded_length),
+        );
+    } else {
+        tracker.push_variable(array.lengths().map(|len| padded_length(Some(len as usize))));
+    }
+}
+
+/// Variable length values are encoded as a null/empty sentinel, or `2` followed by blocks.
+fn encode<'a, I: Iterator<Item = Option<&'a [u8]>>>(
+    data: &mut [u8],
+    offsets: &mut [usize],
+    i: I,
+    opts: SortOptions,
+) {
+    for (offset, maybe_val) in offsets.iter_mut().skip(1).zip(i) {
+        *offset += encode_one(&mut data[*offset..], maybe_val, opts);
+    }
+}
+
+/// [`encode`] specialized for a contiguous byte array.
+fn encode_byte_array<T: ByteArrayType>(
+    data: &mut [u8],
+    offsets: &mut [usize],
+    input_array: &GenericByteArray<T>,
+    opts: SortOptions,
+) {
+    let input_offsets = input_array.value_offsets();
+    let bytes = input_array.values().as_slice();
+
+    if let Some(null_buffer) = input_array.nulls().filter(|x| x.null_count() > 0) {
+        let input_iter =
+            input_offsets
+                .windows(2)
+                .zip(null_buffer.iter())
+                .map(|(start_end, is_valid)| {
+                    if is_valid {
+                        let item_range = start_end[0].as_usize()..start_end[1].as_usize();
+                        Some(&bytes[item_range])
+                    } else {
+                        None
+                    }
+                });
+        encode(data, offsets, input_iter, opts);
+    } else {
+        let input_iter = input_offsets.windows(2).map(|start_end| {
+            let item_range = start_end[0].as_usize()..start_end[1].as_usize();
+            Some(&bytes[item_range])
+        });
+        encode(data, offsets, input_iter, opts);
+    }
+}
+
+#[inline]
+fn encode_one(out: &mut [u8], val: Option<&[u8]>, opts: SortOptions) -> usize {
+    match val {
+        None => {
+            out[0] = null_sentinel(opts);
+            1
+        }
+        Some([]) => {
+            out[0] = if opts.descending {
+                !EMPTY_SENTINEL
+            } else {
+                EMPTY_SENTINEL
+            };
+            1
+        }
+        Some(val) => {
+            out[0] = NON_EMPTY_SENTINEL;
+            let len = if val.len() <= BLOCK_SIZE {
+                1 + encode_blocks::<MINI_BLOCK_SIZE>(&mut out[1..], val)
+            } else {
+                let (initial, rem) = val.split_at(BLOCK_SIZE);
+                let offset = encode_blocks::<MINI_BLOCK_SIZE>(&mut out[1..], initial);
+                out[offset] = BLOCK_CONTINUATION;
+                1 + offset + encode_blocks::<BLOCK_SIZE>(&mut out[1 + offset..], rem)
+            };
+            if opts.descending {
+                out[..len].iter_mut().for_each(|v| *v = !*v);
+            }
+            len
+        }
+    }
+}
+
+/// Writes `val` in `SIZE` blocks with the appropriate continuation tokens.
+#[inline]
+fn encode_blocks<const SIZE: usize>(out: &mut [u8], val: &[u8]) -> usize {
+    let block_count = ceil(val.len(), SIZE);
+    let end_offset = block_count * (SIZE + 1);
+    let to_write = &mut out[..end_offset];
+
+    let chunks = val.chunks_exact(SIZE);
+    let remainder = chunks.remainder();
+    for (input, output) in chunks.clone().zip(to_write.chunks_exact_mut(SIZE + 1)) {
+        output[..SIZE].copy_from_slice(input);
+        output[SIZE] = BLOCK_CONTINUATION;
+    }
+
+    let last = to_write.len() - 1;
+    if remainder.is_empty() {
+        to_write[last] = block_length_byte(SIZE);
+    } else {
+        let start_offset = (block_count - 1) * (SIZE + 1);
+        to_write[start_offset..start_offset + remainder.len()].copy_from_slice(remainder);
+        to_write[last] = block_length_byte(remainder.len());
+    }
+    end_offset
+}
+
+/// The trailing length byte for a block. `len` is always `<= BLOCK_SIZE`, so the truncation is
+/// impossible in practice.
+#[inline]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "block length is bounded by BLOCK_SIZE (32), well within u8"
+)]
+fn block_length_byte(len: usize) -> u8 {
+    len as u8
+}
+
+/// Decodes the blocks of a single encoded value, calling `f` with each decoded chunk. Returns
+/// the number of bytes consumed.
+fn decode_blocks(row: &[u8], options: SortOptions, mut f: impl FnMut(&[u8])) -> usize {
+    let (non_empty_sentinel, continuation) = if options.descending {
+        (!NON_EMPTY_SENTINEL, !BLOCK_CONTINUATION)
+    } else {
+        (NON_EMPTY_SENTINEL, BLOCK_CONTINUATION)
+    };
+
+    if row[0] != non_empty_sentinel {
+        // Empty or null value
+        return 1;
+    }
+
+    let block_len = |sentinel: u8| {
+        if options.descending {
+            !sentinel as usize
+        } else {
+            sentinel as usize
+        }
+    };
+
+    let mut idx = 1;
+    for _ in 0..MINI_BLOCK_COUNT {
+        let sentinel = row[idx + MINI_BLOCK_SIZE];
+        if sentinel != continuation {
+            f(&row[idx..idx + block_len(sentinel)]);
+            return idx + MINI_BLOCK_SIZE + 1;
+        }
+        f(&row[idx..idx + MINI_BLOCK_SIZE]);
+        idx += MINI_BLOCK_SIZE + 1;
+    }
+
+    loop {
+        let sentinel = row[idx + BLOCK_SIZE];
+        if sentinel != continuation {
+            f(&row[idx..idx + block_len(sentinel)]);
+            return idx + BLOCK_SIZE + 1;
+        }
+        f(&row[idx..idx + BLOCK_SIZE]);
+        idx += BLOCK_SIZE + 1;
+    }
+}
+
+/// Decodes one value from `row`, advancing it past the bytes consumed. `None` is a null.
+fn decode_one(row: &mut &[u8], options: SortOptions) -> Option<Vec<u8>> {
+    let slice: &[u8] = row;
+    let is_null = slice[0] == null_sentinel(options);
+    let mut buf = Vec::new();
+    let consumed = decode_blocks(slice, options, |b| buf.extend_from_slice(b));
+    *row = &slice[consumed..];
+    if is_null {
+        None
+    } else {
+        if options.descending {
+            for b in &mut buf {
+                *b = !*b;
+            }
+        }
+        Some(buf)
+    }
+}


### PR DESCRIPTION
## Why

Cayenne's `RowConverterBased` primary-key strategy encodes composite / non-`Int64` PKs with
Arrow's `arrow_row::RowConverter` and **persists those bytes durably** — as the `row_key` column
of deletion-vector files, as `cayenne_insert_record.pk_bytes` in the metastore, and inside
inlined-delete blobs. On read (after a restart or compaction) Cayenne re-encodes fresh keys and
byte-compares them against the stored bytes.

`arrow-row` explicitly documents that *"the encoding of the row format may change from release to
release"* — it is a transient sort/compare representation, not a storage format. A future arrow-rs
bump could silently change the bytes Cayenne persists, resurrecting deleted rows or hiding
reinserts on composite-PK tables.

## What

Vendors the exact pieces of the row format Cayenne uses into a Cayenne-owned, **versioned** module
at `crates/cayenne/src/row_converter/`:

- `RowConverter` is an enum whose variant is the wire-format version (`Version1`). `Version1` is
  **byte-identical to `arrow-row` 58.3.0**, so all previously-persisted data reads unchanged
  (it is implicitly version 1). Older data stays readable by construction as new versions are added.
- Version-agnostic framing (`RowCodec`: offsets, null sentinels, column concatenation) is separated
  from per-column encoding behind a `ColumnCodec` trait. A future version that optimizes one data
  type's encoding adds one small codec and routes that type to it — it never re-implements the rest.
- Only the Arrow types reachable as a Cayenne primary key are supported (all integer/float
  primitives, `Boolean`, the byte/string family including views, dates, times, microsecond
  timestamps, and decimals). Unsupported types return `NotYetImplemented`.

Cayenne's runtime no longer depends on `arrow-row`'s unstable row format — the crate is moved to
`[dev-dependencies]`, kept only for the byte-identity test. The ~13 call sites are a mechanical
drop-in swap (identical signatures).

## Validation

- **Byte-identity (the core guarantee):** a golden test encodes a battery of arrays — every
  supported type, composite keys, nulls, empty and multi-block strings, and all sort options — with
  both the vendored converter and `arrow_row`, and asserts the row bytes are identical.
- Round-trip decode tests and `OwnedRow` hash/eq semantics.
- All existing cayenne delete / PK / on-conflict tests pass unchanged.

## Also

Fixes a pre-existing `redundant_clone` clippy failure in a `mem_tier` test (introduced by #11649,
whose own Rust Lint never completed before merge) that currently breaks `make lint-rust` on trunk.
