### PR TITLE
deps: bump spiceai/datafusion to pick up ORDER BY alias unparser fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5805,7 +5805,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5857,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5881,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5905,7 +5905,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5930,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "futures",
  "log",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6000,7 +6000,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6022,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6093,12 +6093,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6119,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6141,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6193,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6244,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6268,7 +6268,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6292,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6307,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6323,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6332,7 +6332,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6342,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "chrono",
@@ -6393,7 +6393,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "chrono",
@@ -6444,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6496,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "chrono",
@@ -6525,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6537,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6552,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6565,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6593,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6611,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,7 +395,7 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" } # branch: jeadie/unparser-keep-top-level-order-by-alias (spiceai/datafusion#184)
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" } # branch: spiceai-54
 datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
 datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
 datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,41 +395,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" } # branch: spiceai-54 (spiceai/datafusion#185)
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" } # branch: jeadie/unparser-keep-top-level-order-by-alias (spiceai/datafusion#184)
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).


### PR DESCRIPTION
## 📝 Summary

Points the `datafusion` patch pins (Cargo.toml + Cargo.lock) at spiceai/datafusion#184, which fixes the unparser to keep a bare output-column alias as a top-level ORDER BY key (`ORDER BY "revenueratio"`) instead of inlining the full aliased expression.

Fixes TPC-DS **q12 / q20 / q98** on `spicecloud-federated`: the inlined window expression in ORDER BY caused the remote engine to leak DataFusion's internal window schema name as a quoted identifier when re-unparsing for its backend:

```
Binder Error: Referenced column "sum(sum(tpcds.web_sales.ws_ext_sales_price)) PARTITION BY [tpcds.item.i_class] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING" not found in FROM clause!
```

Also picks up spiceai/datafusion e5aa73306 (unparser: emit `SELECT 1` for empty Projection nodes), which the previous pin predated.

## 🔗 Related

- spiceai/datafusion#184

## 👀 Notes for Reviewers

The `spicecloud-federated` explain snapshots for q12/q20/q98 should return to `ORDER BY ... "revenueratio" ASC NULLS LAST` with this pin.