### PR TITLE
fix(flightsql): advertise analyzed query schemas

### DIFF
--- a/crates/cayenne/src/provider/mem_tier.rs
+++ b/crates/cayenne/src/provider/mem_tier.rs
@@ -1283,7 +1283,7 @@ mod tests {
             0,
         ));
         let before_hash =
-            ShardedMemTier::version_hash_of(&[Arc::new(tier.clone()), Arc::clone(&other_shard)]);
+            ShardedMemTier::version_hash_of(&[Arc::new(tier), Arc::clone(&other_shard)]);
         let after_hash =
             ShardedMemTier::version_hash_of(&[Arc::new(sealed.clone()), Arc::clone(&other_shard)]);
         assert_eq!(

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1479,8 +1479,27 @@ impl Query {
             self.handle_schema_error(&request_context, &e);
             return Err(e);
         }
-        let dataset_schema = plan.schema().as_arrow().clone();
-        let parameter_schema = parameter_schema_for_plan(&plan)?;
+
+        // Advertise the schema after the analyzer has applied type coercion,
+        // but before logical optimizer rules run. Execution also analyzes the
+        // plan before planning, so using the raw logical schema here can make
+        // FlightSQL GetFlightInfo disagree with DoGet for expressions such as
+        // `CASE WHEN ... THEN decimal_col ELSE 0 END`.
+        let analyzed_plan = match session.analyzer().execute_and_check(
+            (*plan).clone(),
+            session.config_options(),
+            |_, _| {},
+        ) {
+            Ok(plan) => plan,
+            Err(e) => {
+                let e = find_datafusion_root(e);
+                self.handle_schema_error(&request_context, &e);
+                return Err(e);
+            }
+        };
+
+        let dataset_schema = analyzed_plan.schema().as_arrow().clone();
+        let parameter_schema = parameter_schema_for_plan(&analyzed_plan)?;
 
         Ok((dataset_schema, parameter_schema))
     }
@@ -2624,6 +2643,59 @@ mod tests {
         }
 
         assert_eq!(query.cache_status, CacheStatus::CacheMiss);
+    }
+
+    #[tokio::test]
+    async fn get_schema_preserves_parameter_schema_for_unbound_parameters() {
+        let df = Arc::new(
+            DataFusionBuilder::new(
+                RuntimeStatus::new(),
+                Arc::new(AcceleratorEngineRegistry::new()),
+                Handle::current(),
+            )
+            .build(),
+        );
+
+        let (schema, parameter_schema) = QueryBuilder::new("SELECT $1 + 1 AS x", df)
+            .build()
+            .get_schema()
+            .await
+            .expect("schema should be available");
+
+        assert_eq!(
+            schema.field_with_name("x").expect("x field").data_type(),
+            &DataType::Int64
+        );
+        let parameter_schema = parameter_schema.expect("parameter schema");
+        assert_eq!(parameter_schema.fields().len(), 1);
+        assert_eq!(parameter_schema.field(0).name(), "$1");
+    }
+
+    #[tokio::test]
+    async fn get_schema_uses_analyzed_plan_for_decimal_case_coercion() {
+        let df = Arc::new(
+            DataFusionBuilder::new(
+                RuntimeStatus::new(),
+                Arc::new(AcceleratorEngineRegistry::new()),
+                Handle::current(),
+            )
+            .build(),
+        );
+
+        // Mirrors the CH-benCH Q8 pattern: a decimal branch plus an untyped
+        // integer literal branch. DataFusion's analyzer coerces Int64(0) to
+        // Decimal128(20,0), making the CASE output Decimal128(22,2).
+        let sql = "SELECT CASE WHEN TRUE THEN CAST(1.23 AS DECIMAL(6,2)) ELSE 0 END AS x";
+
+        let (schema, parameter_schema) = QueryBuilder::new(sql, df)
+            .build()
+            .get_schema()
+            .await
+            .expect("schema should be available");
+
+        assert!(parameter_schema.is_none());
+        let field = schema.field_with_name("x").expect("x field");
+        assert_eq!(field.data_type(), &DataType::Decimal128(22, 2));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1485,18 +1485,18 @@ impl Query {
         // plan before planning, so using the raw logical schema here can make
         // FlightSQL GetFlightInfo disagree with DoGet for expressions such as
         // `CASE WHEN ... THEN decimal_col ELSE 0 END`.
-        let analyzed_plan = match session.analyzer().execute_and_check(
-            (*plan).clone(),
-            session.config_options(),
-            |_, _| {},
-        ) {
-            Ok(plan) => plan,
-            Err(e) => {
-                let e = find_datafusion_root(e);
-                self.handle_schema_error(&request_context, &e);
-                return Err(e);
-            }
-        };
+        let analyzed_plan =
+            match session
+                .analyzer()
+                .execute_and_check(*plan, session.config_options(), |_, _| {})
+            {
+                Ok(plan) => plan,
+                Err(e) => {
+                    let e = find_datafusion_root(e);
+                    self.handle_schema_error(&request_context, &e);
+                    return Err(e);
+                }
+            };
 
         let dataset_schema = analyzed_plan.schema().as_arrow().clone();
         let parameter_schema = parameter_schema_for_plan(&analyzed_plan)?;
@@ -2662,9 +2662,10 @@ mod tests {
             .await
             .expect("schema should be available");
 
-        assert_eq!(
-            schema.field_with_name("x").expect("x field").data_type(),
-            &DataType::Int64
+        let output_type = schema.field_with_name("x").expect("x field").data_type();
+        assert!(
+            output_type == &DataType::Int64 || output_type == &DataType::UInt64,
+            "expected Int64 or UInt64 output type, got {output_type:?}"
         );
         let parameter_schema = parameter_schema.expect("parameter schema");
         assert_eq!(parameter_schema.fields().len(), 1);


### PR DESCRIPTION
## Summary

- Run DataFusion analyzer rules in `Query::get_schema` before returning the advertised schema.
- Keep schema discovery before logical optimizer rules, while still applying analyzer/type-coercion changes used by execution.
- Add regression coverage for decimal `CASE ... ELSE 0` coercion and unbound parameter schema discovery.
- Fix a pre-existing Cayenne test lint issue (`clippy::redundant_clone`) that blocks `make lint-rust`.

## Why

CH-benCH Q8 failed through FlightSQL because `GetFlightInfo` advertised the raw logical schema, while `DoGet` executed an analyzed plan with decimal type coercion applied. For expressions like:

```sql
CASE WHEN ... THEN decimal_col ELSE 0 END
```

DataFusion coerces the expression to a wider decimal type during analysis. Advertising the raw schema caused FlightSQL schema mismatches.

This PR only fixes the Q8/GetFlightInfo analyzed-schema path. Q18's eager-aggregation decimal `SUM` schema widening is separate and intentionally not addressed here.

## Validation

- `cargo fmt --check`
- `cargo test -p runtime --lib get_schema_preserves_parameter_schema_for_unbound_parameters -- --nocapture`
- `cargo test -p runtime --lib get_schema_uses_analyzed_plan_for_decimal_case_coercion -- --nocapture`
- `cargo test -p runtime --lib parameter_schema -- --nocapture`
- `cargo test -p runtime --lib parameterized_query -- --nocapture`
- `cargo build -p spiced`
- `make lint-rust`

Manual Q8 repro:

```bash
cd ~/code/spicepod_test/260706-chbench-q8-q18-decimal-repro
./scripts/use_cayenne.sh
./scripts/start_spiced.sh ~/code/spiceai/two/target/debug/spiced
./scripts/run_queries.sh --query q8
```

Result:

```text
q8: PASS
FlightSQL advertised: mkt_share: decimal128(38, 6)
streamed schema:      mkt_share: decimal128(38, 6)
```
