### PR TITLE
fix: bump DataFusion for eager decimal SUM schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5805,7 +5805,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5857,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5881,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5905,7 +5905,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5930,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "futures",
  "log",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6000,7 +6000,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6022,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6093,12 +6093,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6119,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6141,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6193,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6244,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6268,7 +6268,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6292,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6307,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6323,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6332,7 +6332,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6342,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "chrono",
@@ -6393,7 +6393,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "chrono",
@@ -6444,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6496,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "chrono",
@@ -6525,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6537,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6552,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6565,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6593,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6611,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=43dcd07b56d4b1a7ca6f09189f4e1d657b121004#43dcd07b56d4b1a7ca6f09189f4e1d657b121004"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,41 +395,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" } # branch: jeadie/fix-parallelize-sorts-collect-left-coalesce
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" } # branch: spiceai-54 (spiceai/datafusion#185)
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "43dcd07b56d4b1a7ca6f09189f4e1d657b121004" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/crates/cayenne/src/provider/mem_tier.rs
+++ b/crates/cayenne/src/provider/mem_tier.rs
@@ -1283,7 +1283,7 @@ mod tests {
             0,
         ));
         let before_hash =
-            ShardedMemTier::version_hash_of(&[Arc::new(tier.clone()), Arc::clone(&other_shard)]);
+            ShardedMemTier::version_hash_of(&[Arc::new(tier), Arc::clone(&other_shard)]);
         let after_hash =
             ShardedMemTier::version_hash_of(&[Arc::new(sealed.clone()), Arc::clone(&other_shard)]);
         assert_eq!(


### PR DESCRIPTION
## Summary

Bump the Spice DataFusion fork to include spiceai/datafusion#185, which fixes eager aggregation changing the SQL-visible schema for decimal `SUM`.

The DataFusion fix preserves the original aggregate return field when eager aggregation rewrites self-merging aggregates around joins, preventing decimal `SUM` from widening twice:

```text
SUM(Decimal128(6,2)) -> Decimal128(16,2)  // expected
SUM(SUM(Decimal128(6,2))) -> Decimal128(26,2)  // prior eager-aggregation physical schema
```

This resolves the CH-benCH Q18 FlightSQL mismatch where `GetFlightInfo` advertised `amount_sum: decimal128(16, 2)` but `DoGet` streamed `decimal128(26, 2)`.

Also fixes the current trunk clippy failure in the Cayenne mem-tier test by removing a redundant clone.

## Changes

- Bump all DataFusion fork patches to merged DataFusion commit `43dcd07b` (`spiceai/datafusion#185`).
- Update `Cargo.lock` for the new DataFusion revision.
- Fix `clippy::redundant-clone` in `crates/cayenne/src/provider/mem_tier.rs`.

## Validation

```bash
cargo check -p datafusion-optimizer-rules
cargo clippy -p cayenne --lib --tests -- -D clippy::redundant-clone
```

Earlier end-to-end validation against the DataFusion fix:

```bash
cd ~/code/spicepod_test/260706-chbench-q8-q18-decimal-repro
./scripts/use_cayenne.sh
./scripts/start_spiced.sh ~/code/spiceai/four/target/debug/spiced
./scripts/run_queries.sh --query q18
./scripts/stop_spiced.sh
```

Result: Q18 passed with both advertised and streamed schemas showing:

```text
amount_sum: decimal128(16, 2)
```
