### PR TITLE
feat(spidapter): date-prefix per-run MongoDB CDC databases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18874,6 +18874,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-ec2",
  "base64 0.22.1",
+ "chrono",
  "clap",
  "dirs",
  "mongodb",

--- a/tools/spidapter/Cargo.toml
+++ b/tools/spidapter/Cargo.toml
@@ -17,6 +17,7 @@ aws-config.workspace = true
 aws-sdk-dynamodb.workspace = true
 aws-sdk-ec2.workspace = true
 base64.workspace = true
+chrono.workspace = true
 clap.workspace = true
 dirs = "6"
 mongodb.workspace = true

--- a/tools/spidapter/src/stdio_server.rs
+++ b/tools/spidapter/src/stdio_server.rs
@@ -323,8 +323,9 @@ impl Drop for MongoDbGuard {
         // exit — must leave the database intact so a caller who asked to keep it
         // (or a crashed run) never loses data they may want to inspect.
         //
-        // The cost is that an abnormal exit leaks a throwaway `spidapter_<id>`
-        // database on the shared instance; those are safe to GC by name later.
+        // The cost is that an abnormal exit leaks a throwaway
+        // `spidapter_<YYYY_MM_DD>_<id>` database on the shared instance; those are
+        // safe to GC by name later (the date prefix makes stale ones identifiable).
         if let Some((_, database)) = self.target.take() {
             eprintln!(
                 "[stdio] MongoDbGuard: dropped without explicit teardown; \
@@ -1024,7 +1025,13 @@ impl Handler for SpidapterHandler {
                 // isolated and cleanup is a single drop. The database is created
                 // lazily on first write (by the spicebench sink) and dropped at
                 // teardown via the MongoDbGuard below.
-                let database = format!("spidapter_{short_id}");
+                //
+                // The `YYYY_MM_DD` prefix embeds the creation date in the name so
+                // leaked databases (abnormal exit — see MongoDbGuard) are visible at a
+                // glance and can be aged out by name without a per-database creation
+                // timestamp (MongoDB does not expose one).
+                let date = chrono::Utc::now().format("%Y_%m_%d");
+                let database = format!("spidapter_{date}_{short_id}");
                 let uri = with_mongodb_database(&mongo_conf.uri, &database);
                 eprintln!(
                     "[stdio] MongoDB connect: using per-run database '{database}' \


### PR DESCRIPTION
## What

Name connect-mode (shared Atlas) per-run MongoDB CDC databases `spidapter_<YYYY_MM_DD>_<id>` instead of `spidapter_<id>`.

## Why

Each connect-mode run routes to a throwaway per-run database that the adapter drops via the teardown RPC. That RPC only fires on a **clean** end of run — a cancelled / killed / crashed run leaks the database, because `MongoDbGuard` is intentionally fail-safe and never deletes on drop.

MongoDB exposes no per-database creation timestamp, so a leaked db was previously indistinguishable by age and could only be GC'd by a full manual sweep. Embedding the creation date in the name makes leaked databases:

- **visible at a glance** (a startup step reports the `spidapter_*` count; dates show which are old), and
- **safe to age out by name** — a companion spicebench workflow sweep drops any dated `>= 2` calendar days ago (guaranteed `>24h`, safely past the 10h max run).

## Notes

- Behavior is otherwise unchanged; the date comes from `chrono::Utc::now()` at setup.
- Adds `chrono` (already a workspace dependency) to the `spidapter` crate.
- Takes effect for CI once a new `ghcr.io/spiceai/spidapter:latest` is built and pushed. The companion spicebench workflow sweep tolerates both the old undated and new dated name formats.
- `cargo check -p spidapter` is green.