### PR TITLE
ci(chbench): FIFO-queue HTAP runs via concurrency queue: max; simplify dispatcher

### DIFF
--- a/.github/workflows/testoperator_dispatch_htap.yml
+++ b/.github/workflows/testoperator_dispatch_htap.yml
@@ -38,9 +38,11 @@ jobs:
   dispatch-htap:
     name: Dispatch HTAP - ${{ github.event.inputs.scale_factor || github.event.schedule }}
     runs-on: spiceai-dev-runners
-    # On schedule the dispatcher serializes the batch (--max-concurrent 1) and blocks for the sum of
-    # its run durations; an SF1000 batch can run several hours, so raise the cap above GitHub's 6h.
-    timeout-minutes: 720
+    # The dispatcher only fires the workflow_dispatch events (spaced ~80s apart) and exits; the runs
+    # themselves serialize via the htap workflow's queue: max concurrency group, not here. So this
+    # only needs to cover the build + dispatch loop (≤~10 min for the largest batch), not the sum of
+    # run durations.
+    timeout-minutes: 120
     # Per-cron group on schedule (so the SF1/SF100/SF1000 dispatchers don't block each other),
     # per-ref on manual dispatch.
     concurrency:
@@ -96,15 +98,13 @@ jobs:
           done
 
       # On manual dispatch the scale factor comes from the input. On schedule, derive it from the
-      # cron that fired. Scheduled batches also serialize (--max-concurrent 1) so each run finishes
-      # before the next is dispatched; --max-concurrent-wait-timeout-mins covers a full run's
-      # wall-clock so the slot wait doesn't give up early. Manual dispatch keeps the original
-      # fire-and-forget behaviour (no serialization flags).
+      # cron that fired. Both manual and scheduled dispatch are fire-and-forget: the runs serialize
+      # via the htap workflow's queue: max concurrency group (FIFO), so the dispatcher no longer
+      # feeds them one at a time with --max-concurrent.
       - name: Resolve scale factor
         id: resolve
         run: |
           SF="${{ github.event.inputs.scale_factor }}"
-          FLAGS=""
           if [ -z "$SF" ]; then
             case "${{ github.event.schedule }}" in
               '0 */3 * * *')                  SF=sf1000-tuned-adaptive ;;
@@ -113,17 +113,15 @@ jobs:
               '0 8 * * *')                    SF=sf1000-cold ;;
               *)                              SF= ;;   # unrecognized cron — dispatch nothing
             esac
-            FLAGS="--max-concurrent 1 --max-concurrent-wait-timeout-mins 180"
           fi
-          echo "Resolved scale factor: '$SF' (flags: '$FLAGS')"
+          echo "Resolved scale factor: '$SF'"
           echo "scale_factor=$SF" >> "$GITHUB_OUTPUT"
-          echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch Testoperator - HTAP - CH-BenCHmark - ${{ steps.resolve.outputs.scale_factor }}
         if: ${{ steps.resolve.outputs.scale_factor != '' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/chbench/${{ steps.resolve.outputs.scale_factor }} \
-            --workflow htap ${{ steps.resolve.outputs.flags }}
+            --workflow htap
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -69,12 +69,15 @@ on:
 # an in-flight benchmark is never killed mid-run. Other scale factors (e.g. manual SF1/SF10 runs)
 # get a unique group (github.run_id) and stay parallel.
 #
-# NOTE: GitHub keeps at most one in-progress + one pending run per group (a newer pending run
-# cancels the older pending one), so when a cron dispatches a batch faster than runs complete,
-# the intermediate dispatches are superseded rather than queued FIFO.
+# queue: max keeps up to 100 runs pending in the group, processed first-in-first-out by the time
+# each started waiting. So a batch dispatched faster than runs complete queues FIFO instead of the
+# newer pending run superseding (cancelling) the older one, which is the default (queue: single).
+# This is what lets the dispatcher fire a whole batch at once and let GitHub serialize it, rather
+# than blocking to feed runs one at a time; see testoperator_dispatch_htap.yml.
 concurrency:
   group: ${{ (github.event.inputs.scale_factor == '100' || github.event.inputs.scale_factor == '1000') && 'chbench-htap-sf100-sf1000' || github.run_id }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   run-htap:


### PR DESCRIPTION
## What

Let CH-BenCHmark (HTAP) runs **queue** in their shared concurrency group instead of superseding each other, and simplify the dispatcher accordingly.

- **`testoperator_run_htap.yml`**: keep the single shared `chbench-htap-sf100-sf1000` group (SF100/SF1000 still run one-at-a-time, preserving measurement isolation on the shared xlarge runner pool) and add **`queue: max`**. GitHub now keeps up to 100 runs `pending` per group, processed FIFO by wait-start time — so a batch dispatched faster than runs complete queues in order rather than the newer pending run cancelling the older one (the default `queue: single`).
- **`testoperator_dispatch_htap.yml`**: drop `--max-concurrent 1 --max-concurrent-wait-timeout-mins 180` (and the now-dead `FLAGS` plumbing), and lower `timeout-minutes` from `720` → `120`.

## Why

The run workflow's comment previously stated that GitHub allows only one in-progress + one pending run per group, so batched dispatches were "superseded rather than queued FIFO." GitHub has since shipped native FIFO queuing (`queue: max`), which makes that limitation obsolete.

With native queuing, serialization no longer needs to live in the dispatcher. Previously `--max-concurrent 1` made the dispatcher poll and **block until each run completed** before dispatching the next — holding a runner for the multi-hour sum of all run durations (hence `timeout-minutes: 720`). Now the dispatcher fires all `workflow_dispatch` events (spaced ~80s apart, unchanged in testoperator) and exits; GitHub serializes the runs via the concurrency queue. The dispatcher finishes in `N×80s` (≤~8 min for the largest, 6-config, batch), so `120m` is ample.

The 80s spacing gives each run a distinct, ordered wait-start time, so the batch queues **FIFO in dispatch order**.

## Caveats

1. **No priority.** Native concurrency is pure FIFO — a scheduled `trunk` batch **cannot** jump ahead of an already-queued manual run. This is acceptable in practice because cron only fires on the default branch and scheduled batches arrive at fixed times, so FIFO orders them naturally. If strict trunk-priority ever becomes a hard requirement, it needs custom orchestration (dispatcher-side logic) beyond native concurrency — a separate follow-up.

2. **`queue: max` and `cancel-in-progress: true` are mutually exclusive.** You cannot have both a FIFO queue and ref-conditioned preemption. We keep `cancel-in-progress: false` (an in-flight benchmark is never killed mid-run), which is compatible with `queue: max`.

3. **Queue depth is capped at 100 pending.** Far above any realistic batch, but if dispatches ever pile up faster than SF1000 runs drain for a very long stretch, the 101st pending run would supersede. Not a concern at current cadence.

4. **Isolation vs. the rejected alternative.** We deliberately did **not** split trunk vs. non-trunk into separate concurrency groups: that would let a trunk run and a manual run execute simultaneously and contend for the shared runner pool, skewing each other's freshness/QPH numbers. The single shared group + `queue: max` preserves one-heavy-run-at-a-time isolation while still queuing.

## Testing

- Both workflow YAMLs parse; no dangling `outputs.flags` references remain.
- No CI workflow linter in `.github/`, so the new `queue` key won't be rejected by a stale validator.
- No changes to testoperator Rust; `--max-concurrent` remains available for other dispatchers.
