### PR TITLE
fix(cayenne): drop redundant tier.clone() in mem-tier seal-hash test (unblocks Rust Lint on trunk)

### DIFF
--- a/crates/cayenne/src/provider/mem_tier.rs
+++ b/crates/cayenne/src/provider/mem_tier.rs
@@ -1283,7 +1283,7 @@ mod tests {
             0,
         ));
         let before_hash =
-            ShardedMemTier::version_hash_of(&[Arc::new(tier.clone()), Arc::clone(&other_shard)]);
+            ShardedMemTier::version_hash_of(&[Arc::new(tier), Arc::clone(&other_shard)]);
         let after_hash =
             ShardedMemTier::version_hash_of(&[Arc::new(sealed.clone()), Arc::clone(&other_shard)]);
         assert_eq!(


### PR DESCRIPTION
## Problem

The most recent trunk commit (#11649) added a seal-transparency assertion to the `MemTier` seal test that clones `tier` into `ShardedMemTier::version_hash_of`:

```rust
let before_hash =
    ShardedMemTier::version_hash_of(&[Arc::new(tier.clone()), Arc::clone(&other_shard)]);
```

`tier` is never used after this line, so the `.clone()` is dead. The `--tests` pass of **Rust Lint** runs `-Dclippy::redundant_clone`, which rejects it:

```
error: redundant clone
  --> crates/cayenne/src/provider/mem_tier.rs:1286:60
note: this value is dropped without further use
```

This reddens the Rust Lint job on trunk and on **every open PR's merge-ref** (each merge-ref includes current trunk's tests), so it blocks the whole queue — e.g. #11651's Rust Lint fails solely because its merge-ref pulls in this trunk test.

## Fix

Move `tier` into the `Arc` instead of cloning it. `sealed.clone()` on the next line is left as-is, because `sealed` is reused by the later `append_segment` call and is therefore not a redundant clone (clippy flagged only `tier`). Moving vs. cloning produces the same `MemTier` content, so `version_hash_of` returns the same value and the `after_hash == before_hash` assertion is unchanged.

## Test plan
- [x] `CLIPPY_CONF_DIR=.ci cargo clippy -p cayenne --profile lint --tests -- -Dclippy::redundant_clone -Dclippy::unwrap_used -Dclippy::clone_on_ref_ptr` — clears (this is the exact CI lint that was failing); cayenne test target compiles.
- [x] `cargo test -p cayenne --lib mark_sealed_through_advances_split_monotone_and_clamped` — passes.
- [x] `cargo fmt -p cayenne` — clean.

Note: the diff is a single-line, test-only change confined to `crates/cayenne`, so the scoped clippy above (run with the CI deny-flags) is a complete lint check for it. Workspace `cargo fmt --all` / full `make lint` could not be run locally from this git worktree due to a `cargo metadata` "believes it's in a workspace when it's not" quirk for nested-worktree paths; the full-workspace Rust Lint job runs it on CI.

Fixes the trunk Rust Lint breakage introduced by #11649.