### PR TITLE
fix(bucket): guard against ahash AES-path re-bucketing of partition data (fixes #11277)

### DIFF
--- a/crates/runtime-datafusion-udfs/src/bucket.rs
+++ b/crates/runtime-datafusion-udfs/src/bucket.rs
@@ -657,7 +657,7 @@ mod tests {
     /// output from the same seed, so an AES build would silently re-bucket
     /// persisted partitioned datasets relative to the shipped fallback-hashed
     /// builds (#11277). `vendored_hash.rs` has a `compile_error!` that fails any
-    /// x86/x86_64 build with `target_feature = "aes"` active, so on such a build
+    /// `x86/x86_64` build with `target_feature = "aes"` active, so on such a build
     /// this crate does not compile and this test never runs. Where it *does* run,
     /// assert the invariant explicitly and re-lock one fallback golden to prove
     /// the active hasher is in fact the portable fallback.

--- a/crates/runtime-datafusion-udfs/src/bucket.rs
+++ b/crates/runtime-datafusion-udfs/src/bucket.rs
@@ -652,6 +652,44 @@ mod tests {
         );
     }
 
+    /// The `bucket()` partition hash must never come from ahash's AES-accelerated
+    /// hasher: `aes_hash::AHasher` and `fallback_hash::AHasher` produce different
+    /// output from the same seed, so an AES build would silently re-bucket
+    /// persisted partitioned datasets relative to the shipped fallback-hashed
+    /// builds (#11277). `vendored_hash.rs` has a `compile_error!` that fails any
+    /// x86/x86_64 build with `target_feature = "aes"` active, so on such a build
+    /// this crate does not compile and this test never runs. Where it *does* run,
+    /// assert the invariant explicitly and re-lock one fallback golden to prove
+    /// the active hasher is in fact the portable fallback.
+    #[test]
+    fn test_bucket_uses_portable_fallback_hash_not_aes() {
+        let aes_hasher_active = cfg!(all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            target_feature = "aes",
+            not(miri)
+        ));
+        assert!(
+            !aes_hasher_active,
+            "the compile_error! guard in vendored_hash.rs should have prevented \
+             compiling this crate with ahash's AES hasher active (see #11277)"
+        );
+
+        // Same input/golden as `test_bucket_hash_stability_golden_values` (Utf8
+        // "user_42"): proves the hasher actually driving bucket() in this build
+        // is the portable fallback, not an output-incompatible variant.
+        let bucket = compute_bucket(
+            &ScalarValue::Utf8(Some("user_42".to_string())),
+            MAX_NUM_BUCKETS,
+            &DataType::Int64,
+        )
+        .expect("compute_bucket should succeed for Utf8");
+        assert_eq!(
+            bucket,
+            ScalarValue::Int64(Some(594_815)),
+            "bucket() must use the frozen portable fallback hash (#11277)"
+        );
+    }
+
     #[test]
     fn test_first_arg_wrong_scalar_type_error_message() {
         // Test error message when first argument is a scalar but wrong type

--- a/crates/runtime-datafusion-udfs/src/vendored_hash.rs
+++ b/crates/runtime-datafusion-udfs/src/vendored_hash.rs
@@ -35,14 +35,44 @@
 //! Caveat: this module freezes the *seed and the hashing loop*, but still
 //! delegates the actual byte hashing to the external `ahash` crate (pinned only
 //! as `^0.8`). ahash gives **no** cross-version output guarantee, so a routine
-//! `cargo update` — or a build that enables ahash's AES path — could still
-//! silently change these hashes (#11277). `bucket::tests::
-//! test_bucket_hash_stability_golden_values` pins the current output for every
-//! supported type so any such drift fails CI loudly instead of silently
-//! re-bucketing persisted data. Keep that guard passing; only regenerate its
-//! goldens as part of a deliberate, format-versioned migration.
+//! `cargo update` could still silently change these hashes (#11277).
+//! `bucket::tests::test_bucket_hash_stability_golden_values` pins the current
+//! output for every supported type so any such version drift fails CI loudly
+//! instead of silently re-bucketing persisted data. Keep that guard passing;
+//! only regenerate its goldens as part of a deliberate, format-versioned
+//! migration.
+//!
+//! The other half of #11277 — a build that enables ahash's AES path — is closed
+//! by the `compile_error!` guard below. ahash's `aes_hash::AHasher` and
+//! `fallback_hash::AHasher` produce **different** `hash_one` output from the
+//! same `RandomState` seed, so a build compiled for x86/x86_64 with
+//! `target_feature = "aes"` (e.g. `-C target-cpu=native`) would re-bucket every
+//! persisted partitioned dataset relative to the shipped fallback-hashed builds.
+//! CI never sets `+aes`, so the golden test alone cannot catch it — the guard
+//! turns that silent corruption into a loud build failure instead.
 
 #![allow(clippy::pedantic)]
+
+// Mirror the exact cfg ahash uses to switch `RandomState`/`AHasher` to its
+// AES-accelerated (and thus output-incompatible) implementation on x86 — see
+// `ahash::AHasher` selection in ahash's `lib.rs`. The arm AES paths additionally
+// require ahash's `nightly-arm-aes` feature, which this workspace never enables,
+// so only the x86 condition can activate through our dependency graph.
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "aes",
+    not(miri)
+))]
+compile_error!(
+    "runtime-datafusion-udfs is being compiled with ahash's AES hasher active \
+     (x86/x86_64 + target_feature=\"aes\", e.g. `-C target-cpu=native`). ahash's \
+     AES and fallback hashers produce different output, so this would silently \
+     re-bucket the bucket() partition transform relative to shipped builds and \
+     mis-prune persisted partitioned datasets (#11277). Build this crate without \
+     the `aes` target-feature (drop `target-cpu=native` or add `-C \
+     target-feature=-aes`), or make the bucket() hash version-independent as a \
+     deliberate, format-versioned migration."
+);
 
 pub use ahash::RandomState;
 use arrow::array::types::{IntervalDayTime, IntervalMonthDayNano};


### PR DESCRIPTION
## Summary

`bucket(n, value)` is the partition transform behind `runtime-table-partition`, and its hash is part of the on-disk format: a value must map to the same bucket for the lifetime of a persisted dataset, or an equality-filter prune silently skips the partition holding the matching rows (missing-row data loss).

`vendored_hash.rs` freezes the seed and hashing loop but still delegates the actual byte hashing to the external `ahash` crate. ahash selects between two output-**incompatible** hashers at compile time: `fallback_hash::AHasher` (used by every shipped Spice build) and `aes_hash::AHasher`, which activates on x86/x86_64 when `target_feature = "aes"` is set — e.g. a from-source build with `-C target-cpu=native` on any modern AES-capable CPU. The two produce different `hash_one` output from the same `RandomState` seed, so an AES build re-buckets every persisted partitioned dataset relative to shipped builds and mis-prunes it.

The golden-values test added in #11623 guards against ahash **version** drift, but it runs only on CI's architecture (no `+aes`), so it cannot catch the AES-path divergence — that failure mode was silent.

Root cause: the AES half of #11277 had no guard.

## Changes

- **`crates/runtime-datafusion-udfs/src/vendored_hash.rs`**: added a `compile_error!` that mirrors ahash's exact x86 AES-selection cfg (`any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", not(miri)`). Any build that would activate ahash's AES hasher now fails to compile with an actionable message pointing at #11277, instead of silently producing incompatible buckets. Updated the module caveat doc accordingly.
  - This is a **non-migrating** fix: every shipped build already uses the fallback hasher (x86_64 CI sets no `+aes`; the aarch64 `.cargo/config.toml` enables only `neon/fp16/fhm`, and ahash's arm AES paths additionally require its `nightly-arm-aes` feature, which this workspace never enables). Bucket output is unchanged, so no on-disk format migration is needed. Verified empirically: the #11623 goldens were generated on x86_64 CI and `test_bucket_hash_stability_golden_values` passes unchanged on aarch64, confirming x86↔arm fallback stability.
- **`crates/runtime-datafusion-udfs/src/bucket.rs`**: added `test_bucket_uses_portable_fallback_hash_not_aes`, which asserts the guard cfg is inactive in the build under test and re-locks a fallback golden to prove the active hasher is the portable fallback.

This closes the AES half of #11277; together with the golden test (version drift) both silent-drift vectors are now loud. Swapping `bucket()` to a fully ahash-independent, version-pinned hash remains a deliberate, format-versioned migration (maintainer decision) — intentionally out of scope here because it changes on-disk bucket values.

## Performance impact

None. The guard is compile-time only; the hashing code path and its output are unchanged.

## Test plan

- `make lint`
- `make test`
- `cargo build --all-targets`

## Checklist

- [x] Guard mirrors ahash's exact AES cfg (no false positives on safe arm/`+crypto` builds)
- [x] No change to bucket output for shipped builds — no format migration
- [x] Golden stability test still passes (x86 and arm)
- [x] New regression test added

Fixes #11277
