### PR TITLE
perf(pgwire-replication): incremental zero-copy framing (FrameReader) + bounded message size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ lint: lint-rust
 lint-rust:
 	cargo fmt --all -- --check
 	## All except metal, cuda, nfs (nfs requires system libnfs library)
-	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --keep-going --lib --bins --features adbc,aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,snapshots,elasticsearch,http-functions,wasm-functions,rate-control,spicebench --workspace --exclude libnfs --exclude lopdf --exclude ttf-parser --exclude pdf-extract --exclude pgwire-replication -- \
+	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --keep-going --lib --bins --features adbc,aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,snapshots,elasticsearch,http-functions,wasm-functions,rate-control,spicebench --workspace --exclude libnfs --exclude lopdf --exclude ttf-parser --exclude pdf-extract -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \
@@ -122,7 +122,7 @@ lint-rust:
 		-Dclippy::todo \
 		-Dclippy::assertions_on_result_states \
 		-Dclippy::allow_attributes
-	cargo clippy $(CARGO_PROFILE) --keep-going --tests --features adbc,aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,snapshots,elasticsearch,http-functions,wasm-functions,rate-control,spicebench --workspace --exclude libnfs --exclude lopdf --exclude ttf-parser --exclude pdf-extract --exclude pgwire-replication -- \
+	cargo clippy $(CARGO_PROFILE) --keep-going --tests --features adbc,aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,snapshots,elasticsearch,http-functions,wasm-functions,rate-control,spicebench --workspace --exclude libnfs --exclude lopdf --exclude ttf-parser --exclude pdf-extract -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \
@@ -150,7 +150,7 @@ _LINT_PKG_FLAGS := $(foreach p,$(PACKAGES),-p $(p))
 _LINT_WORKSPACE_FLAGS := $(_LINT_PKG_FLAGS)
 _FMT_FLAGS := $(_LINT_PKG_FLAGS)
 else
-_LINT_WORKSPACE_FLAGS := --workspace --exclude libnfs --exclude lopdf --exclude ttf-parser --exclude pdf-extract --exclude pgwire-replication
+_LINT_WORKSPACE_FLAGS := --workspace --exclude libnfs --exclude lopdf --exclude ttf-parser --exclude pdf-extract
 _FMT_FLAGS := --all
 endif
 # Apply FEATURES if provided, otherwise default to hardcoded features only for workspace-wide linting

--- a/crates/data_components/src/postgres_replication/client.rs
+++ b/crates/data_components/src/postgres_replication/client.rs
@@ -134,6 +134,9 @@ pub(crate) fn build_replication_config(
         status_interval: params.status_interval,
         idle_wakeup_interval: Duration::from_secs(1),
         buffer_events: 1024,
+        // Keep the crate default (~1 GiB) so large TOAST-row changes are never
+        // rejected; the reader allocates incrementally regardless of this cap.
+        ..Default::default()
     }
 }
 

--- a/crates/runtime/tests/postgres/replication.rs
+++ b/crates/runtime/tests/postgres/replication.rs
@@ -50,6 +50,13 @@ fn dataset_schema() -> SchemaRef {
     ]))
 }
 
+fn big_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("blob", DataType::Utf8, true),
+    ]))
+}
+
 fn params_for(port: u16, slot_name: &str, publication_name: &str) -> ReplicationParams {
     ReplicationParams {
         host: "localhost".into(),
@@ -89,6 +96,28 @@ async fn setup_source_table(port: u16) -> Result<tokio_postgres::Client, anyhow:
     client.simple_query("TRUNCATE public.repl_users").await?;
     client
         .simple_query("INSERT INTO public.repl_users VALUES (1, 'Alice'), (2, 'Bob')")
+        .await?;
+    Ok(client)
+}
+
+async fn setup_big_table(port: u16) -> Result<tokio_postgres::Client, anyhow::Error> {
+    let mut cfg = tokio_postgres::Config::new();
+    cfg.host("localhost")
+        .port(port)
+        .user("postgres")
+        .password(common::PG_PASSWORD)
+        .dbname("postgres");
+    let (client, connection) = cfg.connect(NoTls).await?;
+    tokio::spawn(async move {
+        let _: Result<(), tokio_postgres::Error> = connection.await;
+    });
+    client
+        .simple_query("CREATE TABLE IF NOT EXISTS public.repl_big (id int PRIMARY KEY, blob text)")
+        .await?;
+    client.simple_query("TRUNCATE public.repl_big").await?;
+    // Seed one small row so the bootstrap has content and marks the dataset ready.
+    client
+        .simple_query("INSERT INTO public.repl_big VALUES (0, 'seed')")
         .await?;
     Ok(client)
 }
@@ -227,6 +256,133 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
     );
     assert!(is_ready, "forced resume snapshot must mark dataset ready");
     committer.commit().await?;
+
+    Ok(())
+}
+
+/// End-to-end regression for the incremental zero-copy `FrameReader` read path
+/// (the streaming reader in the vendored `pgwire-replication` fork), driven
+/// against a real Postgres:
+///
+/// 1. **Large value** — a single ~4 MiB row produces one WAL `XLogData` message
+///    far larger than a socket read / TCP segment, so `FrameReader` must
+///    assemble the frame across many `read_buf` calls (its incremental,
+///    geometrically-growing buffer path). We assert the value round-trips with
+///    exact length and content — a framing off-by-one would corrupt it.
+/// 2. **Burst** — 1000 rows in a single transaction arrive as many frames
+///    buffered together, exercising the tight drain loop
+///    (`has_buffered_frame` + `next`). We assert every row id arrives exactly
+///    once.
+#[tokio::test(flavor = "multi_thread")]
+async fn large_value_and_burst_replicate_intact() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port_u16 = u16::try_from(port).expect("port fits in u16");
+    let source = setup_big_table(port_u16).await?;
+
+    let params = params_for(port_u16, "spice_itest_slot_big", "spice_itest_pub_big");
+    let input = ReplicationStreamInput {
+        dataset_name: "repl_big".into(),
+        params,
+        schema: big_schema(),
+        primary_keys: vec!["id".into()],
+        schema_name: "public".into(),
+        table_name: "repl_big".into(),
+        metrics: ReplicationMetricsCollector::new(),
+    };
+    let mut stream = start_replication_stream(input);
+
+    // Bootstrap: the seed row marks the dataset ready.
+    let envelope = tokio::time::timeout(Duration::from_secs(30), stream.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("bootstrap envelope missing"))??;
+    let (committer, change_batch, is_ready) = envelope.into_parts();
+    assert_eq!(change_batch.record.num_rows(), 1);
+    assert!(is_ready, "bootstrap must mark dataset ready");
+    committer.commit().await?;
+
+    // --- 1. Large value (~4 MiB): spans many socket reads, so the FrameReader
+    // assembles one frame incrementally instead of in a single read. ---
+    const BIG_LEN: usize = 4 * 1024 * 1024;
+    source
+        .simple_query(&format!(
+            "INSERT INTO public.repl_big VALUES (1, repeat('A', {BIG_LEN}))"
+        ))
+        .await?;
+
+    let envelope = tokio::time::timeout(Duration::from_secs(30), stream.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("large-value envelope missing"))??;
+    let (committer, change_batch, _) = envelope.into_parts();
+    assert_eq!(change_batch.record.num_rows(), 1);
+    let data_struct = change_batch
+        .record
+        .column_by_name("data")
+        .expect("data")
+        .as_struct();
+    let blob_col = data_struct
+        .column_by_name("blob")
+        .expect("blob")
+        .as_string::<i32>();
+    let received = blob_col.value(0);
+    assert_eq!(
+        received.len(),
+        BIG_LEN,
+        "large value must round-trip with exact length"
+    );
+    assert!(
+        received.bytes().all(|b| b == b'A'),
+        "large value content must be intact"
+    );
+    committer.commit().await?;
+
+    // --- 2. Burst: 1000 rows in one transaction => many frames buffered
+    // together, exercising the tight drain loop. ---
+    const BURST: i32 = 1000;
+    const BURST_START: i32 = 1000;
+    source
+        .simple_query(&format!(
+            "INSERT INTO public.repl_big SELECT g, 'x' FROM generate_series({BURST_START}, {}) g",
+            BURST_START + BURST - 1
+        ))
+        .await?;
+
+    let mut seen = std::collections::BTreeSet::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while (seen.len() as i32) < BURST {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .ok_or_else(|| {
+                anyhow::anyhow!("timed out collecting burst; got {} of {BURST}", seen.len())
+            })?;
+        let envelope = tokio::time::timeout(remaining, stream.next())
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("burst stream ended early; got {} of {BURST}", seen.len())
+            })??;
+        let (committer, change_batch, _) = envelope.into_parts();
+        let data_struct = change_batch
+            .record
+            .column_by_name("data")
+            .expect("data")
+            .as_struct();
+        let ids = data_struct
+            .column_by_name("id")
+            .expect("id")
+            .as_primitive::<arrow::datatypes::Int32Type>();
+        for i in 0..change_batch.record.num_rows() {
+            seen.insert(ids.value(i));
+        }
+        committer.commit().await?;
+    }
+    assert_eq!(seen.len() as i32, BURST, "all burst rows must arrive");
+    assert_eq!(*seen.iter().next().expect("min id"), BURST_START);
+    assert_eq!(
+        *seen.iter().next_back().expect("max id"),
+        BURST_START + BURST - 1
+    );
 
     Ok(())
 }

--- a/crates/runtime/tests/postgres/replication.rs
+++ b/crates/runtime/tests/postgres/replication.rs
@@ -275,6 +275,12 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
 ///    once.
 #[tokio::test(flavor = "multi_thread")]
 async fn large_value_and_burst_replicate_intact() -> Result<(), anyhow::Error> {
+    // Declared before any statements to satisfy clippy::items_after_statements.
+    const BIG_LEN: usize = 4 * 1024 * 1024;
+    const FIRST_ID: i32 = 1000;
+    const LAST_ID: i32 = 1999;
+    const BURST_ROWS: usize = 1000; // LAST_ID - FIRST_ID + 1
+
     let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
 
     let port = common::get_random_port()?;
@@ -305,7 +311,6 @@ async fn large_value_and_burst_replicate_intact() -> Result<(), anyhow::Error> {
 
     // --- 1. Large value (~4 MiB): spans many socket reads, so the FrameReader
     // assembles one frame incrementally instead of in a single read. ---
-    const BIG_LEN: usize = 4 * 1024 * 1024;
     source
         .simple_query(&format!(
             "INSERT INTO public.repl_big VALUES (1, repeat('A', {BIG_LEN}))"
@@ -340,27 +345,30 @@ async fn large_value_and_burst_replicate_intact() -> Result<(), anyhow::Error> {
 
     // --- 2. Burst: 1000 rows in one transaction => many frames buffered
     // together, exercising the tight drain loop. ---
-    const BURST: i32 = 1000;
-    const BURST_START: i32 = 1000;
     source
         .simple_query(&format!(
-            "INSERT INTO public.repl_big SELECT g, 'x' FROM generate_series({BURST_START}, {}) g",
-            BURST_START + BURST - 1
+            "INSERT INTO public.repl_big SELECT g, 'x' FROM generate_series({FIRST_ID}, {LAST_ID}) g"
         ))
         .await?;
 
     let mut seen = std::collections::BTreeSet::new();
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    while (seen.len() as i32) < BURST {
+    while seen.len() < BURST_ROWS {
         let remaining = deadline
             .checked_duration_since(std::time::Instant::now())
             .ok_or_else(|| {
-                anyhow::anyhow!("timed out collecting burst; got {} of {BURST}", seen.len())
+                anyhow::anyhow!(
+                    "timed out collecting burst; got {} of {BURST_ROWS}",
+                    seen.len()
+                )
             })?;
         let envelope = tokio::time::timeout(remaining, stream.next())
             .await?
             .ok_or_else(|| {
-                anyhow::anyhow!("burst stream ended early; got {} of {BURST}", seen.len())
+                anyhow::anyhow!(
+                    "burst stream ended early; got {} of {BURST_ROWS}",
+                    seen.len()
+                )
             })??;
         let (committer, change_batch, _) = envelope.into_parts();
         let data_struct = change_batch
@@ -377,12 +385,9 @@ async fn large_value_and_burst_replicate_intact() -> Result<(), anyhow::Error> {
         }
         committer.commit().await?;
     }
-    assert_eq!(seen.len() as i32, BURST, "all burst rows must arrive");
-    assert_eq!(*seen.iter().next().expect("min id"), BURST_START);
-    assert_eq!(
-        *seen.iter().next_back().expect("max id"),
-        BURST_START + BURST - 1
-    );
+    assert_eq!(seen.len(), BURST_ROWS, "all burst rows must arrive");
+    assert_eq!(*seen.iter().next().expect("min id"), FIRST_ID);
+    assert_eq!(*seen.iter().next_back().expect("max id"), LAST_ID);
 
     Ok(())
 }

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -51,6 +51,11 @@ use crate::postgres::common;
 const SLOT: &str = "spice_itest_shared_slot";
 const PUBLICATION: &str = "spice_itest_shared_slot_pub";
 
+// A second, *independent* slot used by `shared_and_independent_slots_coexist` to
+// run a non-shared dataset alongside the shared-slot group in one process.
+const INDEP_SLOT: &str = "spice_itest_mix_indep_slot";
+const INDEP_PUBLICATION: &str = "spice_itest_mix_indep_pub";
+
 fn dataset_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int32, false),
@@ -80,6 +85,24 @@ fn shared_params(port: u16) -> ReplicationParams {
 
 fn input_for(port: u16, table: &str) -> ReplicationStreamInput {
     input_with_schema(port, table, dataset_schema())
+}
+
+/// A non-shared dataset on its own slot/publication (`shared: false`), for the
+/// mixed-mode coexistence test.
+fn independent_input(port: u16, table: &str) -> ReplicationStreamInput {
+    let mut params = shared_params(port);
+    params.slot_name = INDEP_SLOT.into();
+    params.publication_name = INDEP_PUBLICATION.into();
+    params.shared = false;
+    ReplicationStreamInput {
+        dataset_name: table.to_string(),
+        params,
+        schema: dataset_schema(),
+        primary_keys: vec!["id".into()],
+        schema_name: "public".into(),
+        table_name: table.to_string(),
+        metrics: ReplicationMetricsCollector::new(),
+    }
 }
 
 fn input_with_schema(port: u16, table: &str, schema: SchemaRef) -> ReplicationStreamInput {
@@ -771,6 +794,93 @@ async fn shared_slot_partitioned_source_table_streams_changes() -> Result<(), an
     drop_replication_slot_when_inactive(&source, SLOT).await?;
     source
         .simple_query(&format!("DROP PUBLICATION IF EXISTS {PUBLICATION}"))
+        .await?;
+    Ok(())
+}
+
+/// Mixed deployment: a **shared-slot group** (two member datasets multiplexed
+/// onto one slot) and an **independent-slot dataset** (its own slot) run in the
+/// **same process against the same Postgres at the same time**. This is the gap
+/// the per-mode tests leave open — each of those provisions its own database and
+/// exercises a single mode. Here we prove the two modes coexist: distinct slots
+/// and walsenders, no publication/slot-name interference, and each per-worker
+/// `FrameReader` decoding its own stream correctly under concurrent load.
+#[tokio::test(flavor = "multi_thread")]
+async fn shared_and_independent_slots_coexist() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port = u16::try_from(port).expect("port fits in u16");
+    let source = pg_client(port).await?;
+
+    create_table(&source, "mix_shared_a", &[(1, "a1")]).await?;
+    create_table(&source, "mix_shared_b", &[(1, "b1")]).await?;
+    create_table(&source, "mix_indep", &[(1, "i1")]).await?;
+
+    // Shared-slot group: two members on ONE slot. Independent dataset: its OWN
+    // slot — all three streaming in this one process against this one Postgres.
+    let mut shared_a = start_replication_stream(input_for(port, "mix_shared_a"));
+    let boot_a = next_envelope(&mut shared_a, "bootstrap shared_a").await?;
+    assert_eq!(boot_a.change_batch.record.num_rows(), 1);
+    boot_a.commit().await?;
+
+    let mut shared_b = start_replication_stream(input_for(port, "mix_shared_b"));
+    let boot_b = next_envelope(&mut shared_b, "bootstrap shared_b").await?;
+    assert_eq!(boot_b.change_batch.record.num_rows(), 1);
+    boot_b.commit().await?;
+
+    let mut indep = start_replication_stream(independent_input(port, "mix_indep"));
+    let boot_i = next_envelope(&mut indep, "bootstrap indep").await?;
+    assert_eq!(boot_i.change_batch.record.num_rows(), 1);
+    boot_i.commit().await?;
+
+    // Both slots exist side by side: one shared, one independent.
+    let shared_slots: i64 = source
+        .query_one(
+            "SELECT count(*) FROM pg_replication_slots WHERE slot_name = $1",
+            &[&SLOT],
+        )
+        .await?
+        .get(0);
+    let indep_slots: i64 = source
+        .query_one(
+            "SELECT count(*) FROM pg_replication_slots WHERE slot_name = $1",
+            &[&INDEP_SLOT],
+        )
+        .await?
+        .get(0);
+    assert_eq!(shared_slots, 1, "shared slot must be present");
+    assert_eq!(indep_slots, 1, "independent slot must be present");
+
+    // Concurrent live changes to all three tables must route to the right
+    // stream — the shared pump demultiplexes A vs B by relation, and the
+    // independent slot delivers only its own table.
+    source
+        .simple_query("INSERT INTO public.mix_shared_a VALUES (2, 'a2')")
+        .await?;
+    source
+        .simple_query("INSERT INTO public.mix_shared_b VALUES (2, 'b2')")
+        .await?;
+    source
+        .simple_query("INSERT INTO public.mix_indep VALUES (2, 'i2')")
+        .await?;
+
+    expect_single_change(&mut shared_a, "shared_a live insert", "c", 2).await?;
+    expect_single_change(&mut shared_b, "shared_b live insert", "c", 2).await?;
+    expect_single_change(&mut indep, "indep live insert", "c", 2).await?;
+
+    // --- Cleanup ---
+    drop(shared_a);
+    drop(shared_b);
+    drop(indep);
+    drop_replication_slot_when_inactive(&source, SLOT).await?;
+    drop_replication_slot_when_inactive(&source, INDEP_SLOT).await?;
+    source
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {PUBLICATION}"))
+        .await?;
+    source
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {INDEP_PUBLICATION}"))
         .await?;
     Ok(())
 }

--- a/crates/vendor/pgwire-replication/Cargo.toml
+++ b/crates/vendor/pgwire-replication/Cargo.toml
@@ -37,7 +37,20 @@ md5 = ["dep:md5"]
 # dropped. `testcontainers 0.27` pins `bollard-stubs =1.52.0-rc`, which is
 # incompatible with the `=1.47.1-rc` pin from `testoperator`'s `bollard 0.18`.
 # The upstream `tests/integration_postgres.rs` (its only consumer) is likewise
-# not vendored. Library source is otherwise unmodified from crates.io 0.3.2.
+# not vendored.
+#
+# Local patches on top of crates.io 0.3.2 (candidates to upstream):
+#   * Streaming read path rewritten around an incremental, zero-copy
+#     `FrameReader` (src/protocol/framing.rs): reads straight into a single
+#     growable buffer via `read_buf` (no per-message zero-fill), slices frames
+#     with `split_to` (no intermediate `BufReader` copy), and grows capacity
+#     from bytes actually received (bounds oversized-length amplification).
+#   * The streaming loop (src/client/worker.rs) now splits the stream after the
+#     handshake and sends standby-status feedback independently of the consume
+#     path, so a slow consumer can no longer starve keepalives and trip the
+#     server's `wal_sender_timeout`.
+#   * `ReplicationConfig::max_message_size` (src/config.rs) makes the accepted
+#     backend-message size a configurable, pre-allocation-checked bound.
 
 [dependencies]
 bytes = "1"

--- a/crates/vendor/pgwire-replication/benches/protocol_bench.rs
+++ b/crates/vendor/pgwire-replication/benches/protocol_bench.rs
@@ -7,7 +7,7 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use std::io::Cursor;
 
 use pgwire_replication::lsn::Lsn;
-use pgwire_replication::protocol::framing::{read_backend_message_into, MessageReader};
+use pgwire_replication::protocol::framing::{read_backend_message_into, FrameReader, MessageReader};
 use pgwire_replication::protocol::messages::{parse_error_response, ErrorFields};
 use pgwire_replication::protocol::replication::{encode_standby_status_update, parse_copy_data};
 
@@ -144,7 +144,7 @@ fn bench_read_backend_message(c: &mut Criterion) {
             },
         );
 
-        // New cancellation-safe path used by the streaming loop.
+        // Prior cancellation-safe path (per-message zero-filled buffer).
         group.bench_with_input(
             BenchmarkId::new("MessageReader", size),
             &stream,
@@ -158,6 +158,26 @@ fn bench_read_backend_message(c: &mut Criterion) {
                         let mut reader = MessageReader::new();
                         for _ in 0..COUNT {
                             let _msg = reader.read(&mut cur).await.unwrap();
+                        }
+                    });
+                });
+            },
+        );
+
+        // Current streaming path: incremental, zero-copy, no per-message memset.
+        group.bench_with_input(
+            BenchmarkId::new("FrameReader", size),
+            &stream,
+            |b, stream| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap();
+                b.iter(|| {
+                    rt.block_on(async {
+                        let mut cur = Cursor::new(black_box(stream.as_slice()));
+                        let mut reader = FrameReader::new(1024 * 1024 * 1024);
+                        for _ in 0..COUNT {
+                            let _msg = reader.next(&mut cur).await.unwrap();
                         }
                     });
                 });

--- a/crates/vendor/pgwire-replication/benches/protocol_bench.rs
+++ b/crates/vendor/pgwire-replication/benches/protocol_bench.rs
@@ -7,7 +7,9 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use std::io::Cursor;
 
 use pgwire_replication::lsn::Lsn;
-use pgwire_replication::protocol::framing::{read_backend_message_into, FrameReader, MessageReader};
+use pgwire_replication::protocol::framing::{
+    read_backend_message_into, FrameReader, MessageReader,
+};
 use pgwire_replication::protocol::messages::{parse_error_response, ErrorFields};
 use pgwire_replication::protocol::replication::{encode_standby_status_update, parse_copy_data};
 

--- a/crates/vendor/pgwire-replication/examples/basic.rs
+++ b/crates/vendor/pgwire-replication/examples/basic.rs
@@ -40,6 +40,7 @@ pub async fn main() -> anyhow::Result<()> {
         status_interval: std::time::Duration::from_secs(1),
         idle_wakeup_interval: std::time::Duration::from_secs(30),
         buffer_events: 8192,
+        ..Default::default()
     };
 
     let mut repl = ReplicationClient::connect(cfg).await?;

--- a/crates/vendor/pgwire-replication/examples/bounded_replay.rs
+++ b/crates/vendor/pgwire-replication/examples/bounded_replay.rs
@@ -52,6 +52,7 @@ pub async fn main() -> anyhow::Result<()> {
         status_interval: std::time::Duration::from_secs(1),
         idle_wakeup_interval: std::time::Duration::from_secs(30),
         buffer_events: 8192,
+        ..Default::default()
     };
 
     let mut repl = ReplicationClient::connect(cfg).await?;

--- a/crates/vendor/pgwire-replication/examples/checkpointed.rs
+++ b/crates/vendor/pgwire-replication/examples/checkpointed.rs
@@ -42,6 +42,7 @@ async fn main() -> anyhow::Result<()> {
         status_interval: std::time::Duration::from_secs(1),
         idle_wakeup_interval: std::time::Duration::from_secs(30),
         buffer_events: 8192,
+        ..Default::default()
     };
 
     let mut repl = ReplicationClient::connect(cfg).await?;

--- a/crates/vendor/pgwire-replication/examples/control_and_stream.rs
+++ b/crates/vendor/pgwire-replication/examples/control_and_stream.rs
@@ -100,6 +100,7 @@ pub async fn main() -> anyhow::Result<()> {
         status_interval: std::time::Duration::from_secs(1),
         idle_wakeup_interval: std::time::Duration::from_secs(30),
         buffer_events: 8192,
+        ..Default::default()
     };
 
     let mut repl = ReplicationClient::connect(cfg).await?;

--- a/crates/vendor/pgwire-replication/examples/with_mtls.rs
+++ b/crates/vendor/pgwire-replication/examples/with_mtls.rs
@@ -74,6 +74,7 @@ pub async fn main() -> anyhow::Result<()> {
         status_interval: std::time::Duration::from_secs(1),
         idle_wakeup_interval: std::time::Duration::from_secs(30),
         buffer_events: 8192,
+        ..Default::default()
     };
 
     let mut repl = ReplicationClient::connect(cfg).await?;

--- a/crates/vendor/pgwire-replication/examples/with_tls.rs
+++ b/crates/vendor/pgwire-replication/examples/with_tls.rs
@@ -58,6 +58,7 @@ pub async fn main() -> anyhow::Result<()> {
         status_interval: std::time::Duration::from_secs(1),
         idle_wakeup_interval: std::time::Duration::from_secs(30),
         buffer_events: 8192,
+        ..Default::default()
     };
 
     let mut repl = ReplicationClient::connect(cfg).await?;

--- a/crates/vendor/pgwire-replication/src/auth/mod.rs
+++ b/crates/vendor/pgwire-replication/src/auth/mod.rs
@@ -1,9 +1,9 @@
-//! Authentication mechanisms for PostgreSQL connections.
+//! Authentication mechanisms for `PostgreSQL` connections.
 //!
-//! This module provides implementations for PostgreSQL authentication methods:
+//! This module provides implementations for `PostgreSQL` authentication methods:
 //!
 //! - **SCRAM-SHA-256** (feature: `scram`): Modern, secure password authentication
-//!   recommended for PostgreSQL 10+. Provides mutual authentication and doesn't
+//!   recommended for `PostgreSQL` 10+. Provides mutual authentication and doesn't
 //!   transmit the password.
 //!
 //! # Feature Flags

--- a/crates/vendor/pgwire-replication/src/auth/scram.rs
+++ b/crates/vendor/pgwire-replication/src/auth/scram.rs
@@ -1,7 +1,7 @@
 //! SCRAM-SHA-256 authentication implementation.
 //!
 //! This module implements the SCRAM-SHA-256 authentication mechanism as specified
-//! in RFC 5802 and RFC 7677, used by PostgreSQL for secure password authentication.
+//! in RFC 5802 and RFC 7677, used by `PostgreSQL` for secure password authentication.
 //!
 //! # Protocol Overview
 //!
@@ -65,7 +65,8 @@ impl ScramClient {
     /// Create a new SCRAM client with a random nonce.
     ///
     /// # Arguments
-    /// * `username` - PostgreSQL username (will be SASL-escaped)
+    /// * `username` - `PostgreSQL` username (will be SASL-escaped)
+    #[must_use]
     pub fn new(username: &str) -> ScramClient {
         let mut nonce = [0u8; 18];
         rand::rng().fill_bytes(&mut nonce);
@@ -243,7 +244,7 @@ fn sasl_escape_username(u: &str) -> String {
     u.replace('=', "=3D").replace(',', "=2C")
 }
 
-/// Hi() function from RFC 5802 - essentially PBKDF2-HMAC-SHA256.
+/// `Hi()` function from RFC 5802 - essentially PBKDF2-HMAC-SHA256.
 ///
 /// Derives a key from password and salt using the specified iteration count.
 #[cfg(feature = "scram")]
@@ -269,6 +270,10 @@ fn hi_sha256(password: &[u8], salt: &[u8], iters: u32) -> Vec<u8> {
 
 /// Compute HMAC-SHA-256.
 #[cfg(feature = "scram")]
+#[expect(
+    clippy::expect_used,
+    reason = "HMAC accepts a key of any length, so new_from_slice never returns Err here"
+)]
 fn hmac_sha256(key: &[u8], msg: &[u8]) -> Vec<u8> {
     let mut mac = HmacSha256::new_from_slice(key).expect("HMAC key length is always valid");
     mac.update(msg);
@@ -334,7 +339,8 @@ mod tests {
 
     #[test]
     fn parse_server_first_valid() {
-        let (r, s, i) = ScramClient::parse_server_first("r=abc123,s=c2FsdA==,i=4096").unwrap();
+        let (r, s, i) =
+            ScramClient::parse_server_first("r=abc123,s=c2FsdA==,i=4096").expect("should succeed");
         assert_eq!(r, "abc123");
         assert_eq!(s, "c2FsdA==");
         assert_eq!(i, 4096);
@@ -343,7 +349,8 @@ mod tests {
     #[test]
     fn parse_server_first_different_order() {
         // Fields can appear in any order
-        let (r, s, i) = ScramClient::parse_server_first("i=1000,s=Zm9v,r=xyz").unwrap();
+        let (r, s, i) =
+            ScramClient::parse_server_first("i=1000,s=Zm9v,r=xyz").expect("should succeed");
         assert_eq!(r, "xyz");
         assert_eq!(s, "Zm9v");
         assert_eq!(i, 1000);
@@ -352,8 +359,8 @@ mod tests {
     #[test]
     fn parse_server_first_with_extensions() {
         // Should ignore unknown extensions
-        let (r, s, i) =
-            ScramClient::parse_server_first("r=nonce,s=c2FsdA==,i=4096,x=unknown").unwrap();
+        let (r, s, i) = ScramClient::parse_server_first("r=nonce,s=c2FsdA==,i=4096,x=unknown")
+            .expect("should succeed");
         assert_eq!(r, "nonce");
         assert_eq!(i, 4096);
         let _ = s; // unused but parsed
@@ -361,25 +368,26 @@ mod tests {
 
     #[test]
     fn parse_server_first_missing_nonce() {
-        let err = ScramClient::parse_server_first("s=c2FsdA==,i=4096").unwrap_err();
+        let err = ScramClient::parse_server_first("s=c2FsdA==,i=4096").expect_err("should error");
         assert!(err.to_string().contains("nonce"));
     }
 
     #[test]
     fn parse_server_first_missing_salt() {
-        let err = ScramClient::parse_server_first("r=abc,i=4096").unwrap_err();
+        let err = ScramClient::parse_server_first("r=abc,i=4096").expect_err("should error");
         assert!(err.to_string().contains("salt"));
     }
 
     #[test]
     fn parse_server_first_missing_iterations() {
-        let err = ScramClient::parse_server_first("r=abc,s=c2FsdA==").unwrap_err();
+        let err = ScramClient::parse_server_first("r=abc,s=c2FsdA==").expect_err("should error");
         assert!(err.to_string().contains("iteration"));
     }
 
     #[test]
     fn parse_server_first_invalid_iterations() {
-        let err = ScramClient::parse_server_first("r=abc,s=c2FsdA==,i=notanumber").unwrap_err();
+        let err = ScramClient::parse_server_first("r=abc,s=c2FsdA==,i=notanumber")
+            .expect_err("should error");
         assert!(err.to_string().contains("iteration"));
     }
 
@@ -392,8 +400,9 @@ mod tests {
 
         let server_first = "r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096";
 
-        let (client_final, auth_message, salted_password) =
-            client.client_final("pencil", server_first).unwrap();
+        let (client_final, auth_message, salted_password) = client
+            .client_final("pencil", server_first)
+            .expect("should succeed");
 
         // Verify structure
         assert!(client_final.starts_with("c=biws,r="));
@@ -414,7 +423,9 @@ mod tests {
         // Server returns nonce that doesn't start with client nonce
         let server_first = "r=differentnonce,s=c2FsdA==,i=4096";
 
-        let err = client.client_final("password", server_first).unwrap_err();
+        let err = client
+            .client_final("password", server_first)
+            .expect_err("should error");
         assert!(err.to_string().contains("nonce mismatch"));
     }
 
@@ -424,7 +435,9 @@ mod tests {
 
         let server_first = "r=abcdef,s=!!!invalid!!!,i=4096";
 
-        let err = client.client_final("password", server_first).unwrap_err();
+        let err = client
+            .client_final("password", server_first)
+            .expect_err("should error");
         assert!(err.to_string().contains("base64"));
     }
 
@@ -437,8 +450,9 @@ mod tests {
 
         let server_first = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096";
 
-        let (_, auth_message, salted_password) =
-            client.client_final("pencil", server_first).unwrap();
+        let (_, auth_message, salted_password) = client
+            .client_final("pencil", server_first)
+            .expect("should succeed");
 
         // Compute expected server signature manually
         let server_key = hmac_sha256(&salted_password, b"Server Key");
@@ -446,7 +460,8 @@ mod tests {
         let server_final = format!("v={}", B64.encode(&server_sig));
 
         // Should succeed
-        ScramClient::verify_server_final(&server_final, &salted_password, &auth_message).unwrap();
+        ScramClient::verify_server_final(&server_final, &salted_password, &auth_message)
+            .expect("should succeed");
     }
 
     #[test]
@@ -456,26 +471,28 @@ mod tests {
         let server_final = "v=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; // wrong
 
         let err = ScramClient::verify_server_final(server_final, &salted_password, auth_message)
-            .unwrap_err();
+            .expect_err("should error");
         assert!(err.to_string().contains("signature mismatch"));
     }
 
     #[test]
     fn verify_server_final_rejects_missing_signature() {
-        let err = ScramClient::verify_server_final("", &[], "").unwrap_err();
+        let err = ScramClient::verify_server_final("", &[], "").expect_err("should error");
         assert!(err.to_string().contains("missing signature"));
     }
 
     #[test]
     fn verify_server_final_handles_server_error() {
-        let err = ScramClient::verify_server_final("e=invalid-proof", &[], "").unwrap_err();
+        let err =
+            ScramClient::verify_server_final("e=invalid-proof", &[], "").expect_err("should error");
         assert!(err.to_string().contains("server error"));
         assert!(err.to_string().contains("invalid-proof"));
     }
 
     #[test]
     fn verify_server_final_rejects_invalid_base64() {
-        let err = ScramClient::verify_server_final("v=!!!invalid!!!", &[], "").unwrap_err();
+        let err =
+            ScramClient::verify_server_final("v=!!!invalid!!!", &[], "").expect_err("should error");
         assert!(err.to_string().contains("base64"));
     }
 

--- a/crates/vendor/pgwire-replication/src/client/mod.rs
+++ b/crates/vendor/pgwire-replication/src/client/mod.rs
@@ -1,11 +1,11 @@
-//! PostgreSQL logical replication client.
+//! `PostgreSQL` logical replication client.
 //!
 //! This module provides the main interface for consuming logical replication
-//! events from PostgreSQL.
+//! events from `PostgreSQL`.
 //!
 //! # Overview
 //!
-//! The client establishes a replication connection to PostgreSQL and streams
+//! The client establishes a replication connection to `PostgreSQL` and streams
 //! change events (inserts, updates, deletes) from the configured publication.
 //!
 //! # Architecture

--- a/crates/vendor/pgwire-replication/src/client/tokio_client.rs
+++ b/crates/vendor/pgwire-replication/src/client/tokio_client.rs
@@ -16,7 +16,7 @@ use crate::config::SslMode;
 
 use super::worker::{ReplicationEvent, ReplicationEventReceiver, SharedProgress, WorkerState};
 
-/// PostgreSQL logical replication client.
+/// `PostgreSQL` logical replication client.
 ///
 /// This client spawns a background worker task that maintains the replication
 /// connection and streams events to the consumer via a bounded channel.
@@ -70,7 +70,7 @@ pub struct ReplicationClient {
 }
 
 impl ReplicationClient {
-    /// Connect to PostgreSQL and start streaming replication events.
+    /// Connect to `PostgreSQL` and start streaming replication events.
     ///
     /// This establishes a TCP connection (optionally upgrading to TLS),
     /// authenticates, and starts the replication stream. Events are buffered
@@ -86,6 +86,10 @@ impl ReplicationClient {
     /// - Publication doesn't exist
     /// - Unix socket does not exist (when host starts with `/`)
     /// - TLS requested with Unix socket connection
+    #[expect(
+        clippy::unused_async,
+        reason = "public async constructor: callers await it, and it spawns the worker task"
+    )]
     pub async fn connect(cfg: ReplicationConfig) -> Result<Self> {
         let (tx, rx) = mpsc::channel(cfg.buffer_events);
 
@@ -117,8 +121,12 @@ impl ReplicationClient {
     /// Receive the next replication event.
     ///
     /// - `Ok(Some(event))` => received an event
-    /// - `Ok(None)`        => replication ended normally (stop requested or stop_at_lsn reached)
+    /// - `Ok(None)`        => replication ended normally (stop requested or `stop_at_lsn` reached)
     /// - `Err(e)`          => replication ended abnormally
+    ///
+    /// # Errors
+    /// Returns the worker's terminating error if the replication stream failed
+    /// (I/O, protocol, auth, or a worker panic surfaced as [`PgWireError::Task`]).
     pub async fn recv(&mut self) -> Result<Option<ReplicationEvent>> {
         match self.rx.recv().await {
             Some(Ok(ev)) => Ok(Some(ev)),
@@ -157,24 +165,26 @@ impl ReplicationClient {
     /// After calling this, [`recv()`](Self::recv) will return remaining buffered
     /// events, then `Ok(None)` once the worker exits cleanly.
     ///
-    /// This sends a CopyDone message to the server to cleanly terminate
+    /// This sends a `CopyDone` message to the server to cleanly terminate
     /// the replication stream.
     #[inline]
     pub fn stop(&self) {
         let _ = self.stop_tx.send(true);
     }
 
+    #[must_use]
     pub fn is_running(&self) -> bool {
-        self.join
-            .as_ref()
-            .map(|j| !j.is_finished())
-            .unwrap_or(false)
+        self.join.as_ref().is_some_and(|j| !j.is_finished())
     }
 
     /// Wait for the worker task to complete and return its result.
     ///
     /// This consumes the client. Use this for diagnostics or to ensure
     /// clean shutdown after calling [`stop()`](Self::stop).
+    ///
+    /// # Errors
+    /// Returns the worker's terminating error, or [`PgWireError::Task`] if the
+    /// worker was already joined or panicked.
     pub async fn join(mut self) -> Result<()> {
         let join = self
             .join
@@ -189,7 +199,7 @@ impl ReplicationClient {
 
     /// Abort the worker task immediately.
     ///
-    /// This is a hard cancel and does not send CopyDone.
+    /// This is a hard cancel and does not send `CopyDone`.
     /// Prefer `stop()`/`shutdown()` for graceful termination.
     pub fn abort(&mut self) {
         if let Some(join) = self.join.take() {
@@ -198,6 +208,10 @@ impl ReplicationClient {
     }
 
     /// Request a graceful stop and wait for the worker to exit.
+    ///
+    /// # Errors
+    /// Returns the worker's terminating error if it ended abnormally, or
+    /// [`PgWireError::Task`] if the worker was already joined or panicked.
     pub async fn shutdown(&mut self) -> Result<()> {
         self.stop();
 
@@ -233,20 +247,17 @@ impl Drop for ReplicationClient {
         // We cannot .await here. Prefer to detach a join in the background
         // so the worker can exit cleanly without being aborted.
         if let Some(join) = self.join.take() {
-            match tokio::runtime::Handle::try_current() {
-                Ok(handle) => {
-                    handle.spawn(async move {
-                        let _ = join.await;
-                    });
-                }
-                Err(_) => {
-                    // No Tokio runtime available (dropping outside async context).
-                    // Fall back to abort to avoid a potentially unbounded leaked task.
-                    tracing::debug!(
-                        "dropping ReplicationClient outside a Tokio runtime; aborting worker task"
-                    );
-                    join.abort();
-                }
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = join.await;
+                });
+            } else {
+                // No Tokio runtime available (dropping outside async context).
+                // Fall back to abort to avoid a potentially unbounded leaked task.
+                tracing::debug!(
+                    "dropping ReplicationClient outside a Tokio runtime; aborting worker task"
+                );
+                join.abort();
             }
         }
     }

--- a/crates/vendor/pgwire-replication/src/client/tokio_client.rs
+++ b/crates/vendor/pgwire-replication/src/client/tokio_client.rs
@@ -262,14 +262,16 @@ async fn run_worker(worker: &mut WorkerState, cfg: &ReplicationConfig) -> Result
         }
 
         let path = cfg.unix_socket_path();
-        let mut stream = UnixStream::connect(&path).await.map_err(|e| {
+        let stream = UnixStream::connect(&path).await.map_err(|e| {
             PgWireError::Io(std::sync::Arc::new(std::io::Error::new(
                 e.kind(),
                 format!("failed to connect to Unix socket {}: {e}", path.display()),
             )))
         })?;
 
-        return worker.run_on_stream(&mut stream).await;
+        // Owned stream: `run_on_stream` splits it into read/write halves after
+        // the handshake so feedback is decoupled from the consume path.
+        return worker.run_on_stream(stream).await;
     }
 
     let tcp = TcpStream::connect((cfg.host.as_str(), cfg.port)).await?;
@@ -277,12 +279,11 @@ async fn run_worker(worker: &mut WorkerState, cfg: &ReplicationConfig) -> Result
 
     #[cfg(feature = "tls-rustls")]
     {
-        use crate::tls::rustls::{maybe_upgrade_to_tls, MaybeTlsStream};
+        use crate::tls::rustls::maybe_upgrade_to_tls;
+        // `MaybeTlsStream` is `AsyncRead + AsyncWrite`, so hand the unified
+        // stream (plain or TLS) to the worker by value and let it split.
         let upgraded = maybe_upgrade_to_tls(tcp, &cfg.tls, &cfg.host).await?;
-        match upgraded {
-            MaybeTlsStream::Plain(mut s) => worker.run_on_stream(&mut s).await,
-            MaybeTlsStream::Tls(mut s) => worker.run_on_stream(s.as_mut()).await,
-        }
+        worker.run_on_stream(upgraded).await
     }
 
     #[cfg(not(feature = "tls-rustls"))]
@@ -290,7 +291,6 @@ async fn run_worker(worker: &mut WorkerState, cfg: &ReplicationConfig) -> Result
         if !matches!(cfg.tls.mode, SslMode::Disable) {
             return Err(PgWireError::Tls("tls-rustls feature not enabled".into()));
         }
-        let mut s = tcp;
-        worker.run_on_stream(&mut s).await
+        worker.run_on_stream(tcp).await
     }
 }

--- a/crates/vendor/pgwire-replication/src/client/worker.rs
+++ b/crates/vendor/pgwire-replication/src/client/worker.rs
@@ -1,16 +1,17 @@
 use bytes::Bytes;
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::io::{AsyncRead, AsyncWrite, BufReader};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, watch};
-use tokio::time::Instant;
+use tokio::time::MissedTickBehavior;
 
 use crate::config::ReplicationConfig;
 use crate::error::{PgWireError, Result};
 use crate::lsn::Lsn;
 use crate::protocol::framing::{
     read_backend_message, write_copy_data, write_copy_done, write_password_message, write_query,
-    write_startup_message, MessageReader,
+    write_startup_message, BackendMessage, FrameReader,
 };
 use crate::protocol::messages::{parse_auth_request, parse_error_response};
 use crate::protocol::replication::{
@@ -149,18 +150,25 @@ impl WorkerState {
     }
 
     /// Run the replication protocol on the given stream.
-    pub async fn run_on_stream<S: AsyncRead + AsyncWrite + Unpin>(
+    ///
+    /// Takes the stream by value so that, once the request/response handshake is
+    /// complete, it can be split into independent read and write halves: the
+    /// streaming loop reads WAL on one half while feedback (standby status
+    /// updates) is written on the other, so a slow consumer applying
+    /// backpressure to the event channel can never starve the keepalive path
+    /// (which would otherwise trip the server's `wal_sender_timeout` and drop
+    /// the slot). The handshake reads are exact (never over-read past a message
+    /// boundary), so no buffered bytes are lost across the split.
+    pub async fn run_on_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
         &mut self,
-        stream: &mut S,
+        mut stream: S,
     ) -> Result<()> {
-        // Wrap in a 128KB read buffer to batch multiple WAL messages into fewer
-        // recv() syscalls. BufReader delegates AsyncWrite to the inner stream,
-        // so writes (standby status replies, etc.) are unaffected.
-        let mut stream = BufReader::with_capacity(128 * 1024, stream);
         self.startup(&mut stream).await?;
         self.authenticate(&mut stream).await?;
         self.start_replication(&mut stream).await?;
-        self.stream_loop(&mut stream).await
+
+        let (read_half, write_half) = tokio::io::split(stream);
+        self.stream_loop(read_half, write_half).await
     }
 
     /// Send startup message with replication parameters.
@@ -203,158 +211,162 @@ impl WorkerState {
 
     /// Main replication streaming loop.
     ///
-    /// Uses a two-phase approach for throughput:
-    /// 1. **Drain phase**: while the BufReader has buffered data, read messages
-    ///    in a tight loop without `select!` or timeout overhead.
-    /// 2. **Wait phase**: when the buffer is empty, fall back to `select!` with
-    ///    timeout + stop signal to handle idle keepalives and graceful shutdown.
+    /// Runs on the split stream: `r` (read half) feeds a [`FrameReader`] that
+    /// slices WAL messages zero-copy, while `w` (write half) carries feedback.
+    /// One `select!` interleaves three concerns so none starves the others:
     ///
-    /// Reads use [`MessageReader`], which preserves partial-read state across
-    /// dropped futures so the wait-phase `select!` is cancellation-safe.
-    async fn stream_loop<S: AsyncRead + AsyncWrite + Unpin>(
-        &mut self,
-        stream: &mut BufReader<S>,
-    ) -> Result<()> {
-        let mut last_status_sent = Instant::now() - self.cfg.status_interval;
-        let mut last_applied = self.progress.load_applied();
-        // Cancellation-safe message reader, partial reads survive dropped futures.
-        let mut reader = MessageReader::new();
-        // How many messages to process in the tight loop before checking
-        // stop signal and sending periodic status feedback.
+    /// 1. **Consume** — decode frames and hand [`ReplicationEvent`]s to the
+    ///    consumer over the bounded channel. Frames already buffered are drained
+    ///    in a tight loop (no per-message `select!`/timer overhead).
+    /// 2. **Feedback** — send a standby status update every `status_interval`,
+    ///    *and* while the event channel is full and we wait for capacity. This
+    ///    is the key resilience property: a stalled consumer cannot stop
+    ///    keepalives, so the server never trips `wal_sender_timeout` and drops
+    ///    the slot. Feedback reports only the durably-applied LSN, so keeping the
+    ///    connection alive never advances the server's confirmed position past
+    ///    what the consumer has persisted.
+    /// 3. **Shutdown** — a graceful stop (or the consumer dropping) sends
+    ///    `CopyDone` and returns.
+    ///
+    /// [`FrameReader::next`] is cancellation-safe, so `select!` dropping the read
+    /// future mid-message loses no bytes.
+    async fn stream_loop<R, W>(&mut self, mut r: R, mut w: W) -> Result<()>
+    where
+        R: AsyncRead + Unpin,
+        W: AsyncWrite + Unpin,
+    {
+        let mut reader = FrameReader::new(self.cfg.max_message_size);
+        // Events decoded but not yet accepted by the consumer. Usually holds 0
+        // or 1; the bounded-replay stop path can enqueue 2 (final data + Stop).
+        let mut pending: VecDeque<ReplicationEvent> = VecDeque::new();
+        // Feedback cadence: honor both the periodic `status_interval` and the
+        // (historically idle-only) `idle_wakeup_interval` by ticking at the
+        // tighter of the two, so neither config field is silently ignored and
+        // the server hears from us — releasing WAL — at least that often even
+        // while the consumer is quiet. Clamp to >= 1ms since `interval` panics
+        // on a zero period.
+        let feedback_interval = self
+            .cfg
+            .status_interval
+            .min(self.cfg.idle_wakeup_interval)
+            .max(std::time::Duration::from_millis(1));
+        // `interval` fires its first tick immediately, sending an initial status
+        // update (matches the previous behavior).
+        let mut status = tokio::time::interval(feedback_interval);
+        status.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // Bound the tight drain so feedback/stop get a turn under a firehose.
         const DRAIN_BATCH: usize = 256;
 
         loop {
-            // Update applied LSN from client
-            let current_applied = self.progress.load_applied();
-            if current_applied != last_applied {
-                last_applied = current_applied;
-            }
-
-            // Send periodic status feedback
-            if last_status_sent.elapsed() >= self.cfg.status_interval {
-                self.send_feedback(stream, last_applied, false).await?;
-                last_status_sent = Instant::now();
-            }
-
-            // ── Drain phase: tight loop while BufReader has buffered data ──
-            // The BufReader has a 128KB internal buffer. When the kernel delivers
-            // a large TCP segment, many WAL messages are available without syscalls.
-            // Read them in a tight loop to avoid select!/timeout overhead per message.
-            let mut drained = 0usize;
-            while stream.buffer().len() >= 5 && drained < DRAIN_BATCH {
-                let msg = reader.read(stream).await?;
-                drained += 1;
-                if msg.tag == b'E' {
-                    return Err(PgWireError::Server(parse_error_response(&msg.payload)));
-                }
-                if msg.tag == b'd'
-                    && self
-                        .handle_copy_data(
-                            stream,
-                            msg.payload,
-                            &mut last_applied,
-                            &mut last_status_sent,
-                        )
-                        .await?
-                {
-                    return Ok(());
-                }
-            }
-
-            // If we drained messages, loop back to check stop/status before
-            // potentially blocking on the next read.
-            if drained > 0 {
-                // Check stop signal without blocking
-                if self.stop_rx.has_changed().unwrap_or(false) && *self.stop_rx.borrow() {
-                    let _ = write_copy_done(stream).await;
-                    return Ok(());
-                }
-                continue;
-            }
-
-            // ── Wait phase: buffer empty, need to wait for socket data ──
-            //
-            // Both `stop_rx.changed()` and the timeout can drop the read future
-            // mid-message. `MessageReader::read` is cancellation-safe — partial
-            // header/payload state lives on `reader` and is preserved across the
-            // drop, so the next iteration resumes the read without losing bytes.
-            let msg = tokio::select! {
-                biased;
-
-                _ = self.stop_rx.changed() => {
-                    if *self.stop_rx.borrow() {
-                        let _ = write_copy_done(stream).await;
+            // ── Flush decoded events to the consumer. ──
+            // Fast path is a non-blocking `try_send`. When the channel is full
+            // (slow consumer), fall back to a `select!` that keeps sending
+            // feedback while awaiting capacity, so backpressure never starves
+            // keepalives.
+            while let Some(ev) = pending.pop_front() {
+                match self.out.try_send(Ok(ev)) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        tracing::debug!("event channel closed, client may have disconnected");
                         return Ok(());
                     }
-                    continue;
+                    Err(mpsc::error::TrySendError::Full(item)) => 'wait: loop {
+                        tokio::select! {
+                            biased;
+
+                            res = self.stop_rx.changed() => {
+                                if res.is_err() || *self.stop_rx.borrow() {
+                                    let _ = write_copy_done(&mut w).await;
+                                    return Ok(());
+                                }
+                            }
+
+                            permit = self.out.reserve() => {
+                                match permit {
+                                    Ok(p) => { p.send(item); break 'wait; }
+                                    Err(_) => return Ok(()), // channel closed
+                                }
+                            }
+
+                            _ = status.tick() => {
+                                self.send_feedback(&mut w, self.progress.load_applied(), false)
+                                    .await?;
+                            }
+                        }
+                    },
+                }
+            }
+
+            // ── Wait for the next frame, a feedback tick, or a stop signal. ──
+            tokio::select! {
+                biased;
+
+                res = self.stop_rx.changed() => {
+                    if res.is_err() || *self.stop_rx.borrow() {
+                        let _ = write_copy_done(&mut w).await;
+                        return Ok(());
+                    }
                 }
 
-                msg_result = tokio::time::timeout(
-                    self.cfg.idle_wakeup_interval,
-                    reader.read(stream),
-                ) => {
-                    match msg_result {
-                        Ok(res) => res?,
-                        Err(_) => {
-                            let applied = self.progress.load_applied();
-                            last_applied = applied;
-                            self.send_feedback(stream, applied, false).await?;
-                            last_status_sent = Instant::now();
-                            continue;
+                _ = status.tick() => {
+                    self.send_feedback(&mut w, self.progress.load_applied(), false).await?;
+                }
+
+                msg = reader.next(&mut r) => {
+                    let msg = msg?;
+                    if self.handle_message(msg, &mut pending, &mut w).await? {
+                        return Ok(());
+                    }
+                    // Drain frames already buffered without awaiting the socket.
+                    let mut drained = 0usize;
+                    while drained < DRAIN_BATCH && reader.has_buffered_frame() {
+                        let msg = reader.next(&mut r).await?;
+                        drained += 1;
+                        if self.handle_message(msg, &mut pending, &mut w).await? {
+                            return Ok(());
                         }
                     }
                 }
-            };
-
-            if msg.tag == b'E' {
-                return Err(PgWireError::Server(parse_error_response(&msg.payload)));
-            }
-            if msg.tag == b'd'
-                && self
-                    .handle_copy_data(
-                        stream,
-                        msg.payload,
-                        &mut last_applied,
-                        &mut last_status_sent,
-                    )
-                    .await?
-            {
-                return Ok(());
             }
         }
     }
 
-    /// Handle a CopyData message. Returns true if we should stop.
-    async fn handle_copy_data<S: AsyncRead + AsyncWrite + Unpin>(
-        &mut self,
-        stream: &mut BufReader<S>,
-        payload: Bytes,
-        last_applied: &mut Lsn,
-        last_status_sent: &mut Instant,
-    ) -> Result<bool> {
-        let cd = parse_copy_data(payload)?;
+    /// Decode one backend message and enqueue any resulting events into
+    /// `pending`. Sends an immediate feedback reply for solicited keepalives.
+    /// Returns `Ok(true)` when a configured `stop_at_lsn` has been reached and
+    /// the stream should terminate.
+    async fn handle_message<W>(
+        &self,
+        msg: BackendMessage,
+        pending: &mut VecDeque<ReplicationEvent>,
+        w: &mut W,
+    ) -> Result<bool>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        match msg.tag {
+            b'E' => return Err(PgWireError::Server(parse_error_response(&msg.payload))),
+            b'd' => {}
+            // ParameterStatus / NoticeResponse / etc. mid-stream: ignore.
+            _ => return Ok(false),
+        }
 
-        match cd {
+        match parse_copy_data(msg.payload)? {
             ReplicationCopyData::KeepAlive {
                 wal_end,
                 server_time_micros,
                 reply_requested,
             } => {
-                // Respond immediately if server requests it
+                // Respond immediately if the server requests it.
                 if reply_requested {
-                    let applied = self.progress.load_applied();
-                    *last_applied = applied;
-                    self.send_feedback(stream, applied, true).await?;
-                    *last_status_sent = Instant::now();
+                    self.send_feedback(w, self.progress.load_applied(), true)
+                        .await?;
                 }
-
-                self.send_event(Ok(ReplicationEvent::KeepAlive {
+                pending.push_back(ReplicationEvent::KeepAlive {
                     wal_end,
                     reply_requested,
                     server_time_micros,
-                }))
-                .await;
-
+                });
                 Ok(false)
             }
             ReplicationCopyData::XLogData {
@@ -363,7 +375,8 @@ impl WorkerState {
                 server_time_micros,
                 data,
             } => {
-                // If the payload is a pgoutput Begin/Commit message, emit only the boundary event.
+                // Begin/Commit/Message boundaries surface as their own typed
+                // events; other payloads pass through as raw XLogData.
                 if let Some(boundary_ev) = parse_pgoutput_boundary(&data)? {
                     let reached_lsn = match boundary_ev {
                         ReplicationEvent::Begin { final_lsn, .. } => final_lsn,
@@ -371,63 +384,44 @@ impl WorkerState {
                         _ => wal_end, // should never happen if parser only returns Begin/Commit
                     };
 
-                    self.send_event(Ok(boundary_ev)).await;
+                    pending.push_back(boundary_ev);
 
-                    // Stop condition (prefer boundary LSN semantics when available)
+                    // Stop condition (prefer boundary LSN semantics when available).
                     if let Some(stop_lsn) = self.cfg.stop_at_lsn {
                         if reached_lsn >= stop_lsn {
-                            self.send_event(Ok(ReplicationEvent::StoppedAt {
+                            pending.push_back(ReplicationEvent::StoppedAt {
                                 reached: reached_lsn,
-                            }))
-                            .await;
-                            let _ = write_copy_done(stream).await;
-                            return Ok(true); // should stop.
+                            });
+                            let _ = write_copy_done(w).await;
+                            return Ok(true);
                         }
                     }
 
                     return Ok(false);
                 }
-                // Otherwise, emit raw payload
-                // Check stop condition
+
                 if let Some(stop_lsn) = self.cfg.stop_at_lsn {
                     if wal_end >= stop_lsn {
-                        // Send final event, then stop signal
-                        self.send_event(Ok(ReplicationEvent::XLogData {
+                        pending.push_back(ReplicationEvent::XLogData {
                             wal_start,
                             wal_end,
                             server_time_micros,
                             data,
-                        }))
-                        .await;
-
-                        self.send_event(Ok(ReplicationEvent::StoppedAt { reached: wal_end }))
-                            .await;
-
-                        let _ = write_copy_done(stream).await;
+                        });
+                        pending.push_back(ReplicationEvent::StoppedAt { reached: wal_end });
+                        let _ = write_copy_done(w).await;
                         return Ok(true);
                     }
                 }
 
-                self.send_event(Ok(ReplicationEvent::XLogData {
+                pending.push_back(ReplicationEvent::XLogData {
                     wal_start,
                     wal_end,
                     server_time_micros,
                     data,
-                }))
-                .await;
-
+                });
                 Ok(false)
             }
-        }
-    }
-
-    /// Send an event to the client channel.
-    ///
-    /// If the channel is full or closed, we log and continue - the client
-    /// may have stopped listening but we don't want to crash the worker.
-    async fn send_event(&self, event: std::result::Result<ReplicationEvent, PgWireError>) {
-        if self.out.send(event).await.is_err() {
-            tracing::debug!("event channel closed, client may have disconnected");
         }
     }
 
@@ -725,6 +719,8 @@ fn postgres_md5(password: &str, user: &str, salt: &[u8; 4]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+    use tokio::io::AsyncWriteExt;
 
     #[test]
     fn parse_sasl_mechanisms_single() {
@@ -761,5 +757,201 @@ mod tests {
         // Any time after 2000-01-01 should be positive
         let ts = current_pg_timestamp();
         assert!(ts > 0);
+    }
+
+    // ==================== streaming loop tests ====================
+
+    /// Wrap a backend message: tag + i32 length (counts itself + payload) + payload.
+    fn backend_frame(tag: u8, payload: &[u8]) -> Vec<u8> {
+        let len = (4 + payload.len()) as i32;
+        let mut v = Vec::with_capacity(5 + payload.len());
+        v.push(tag);
+        v.extend_from_slice(&len.to_be_bytes());
+        v.extend_from_slice(payload);
+        v
+    }
+
+    /// A CopyData ('d') wrapping an XLogData ('w') record carrying `data`.
+    fn xlog_copydata(wal_start: u64, wal_end: u64, data: &[u8]) -> Vec<u8> {
+        let mut inner = vec![b'w'];
+        inner.extend_from_slice(&(wal_start as i64).to_be_bytes());
+        inner.extend_from_slice(&(wal_end as i64).to_be_bytes());
+        inner.extend_from_slice(&0i64.to_be_bytes()); // server_time
+        inner.extend_from_slice(data);
+        backend_frame(b'd', &inner)
+    }
+
+    /// A CopyData ('d') wrapping a KeepAlive ('k') record.
+    fn keepalive_copydata(wal_end: u64, reply_requested: bool) -> Vec<u8> {
+        let mut inner = vec![b'k'];
+        inner.extend_from_slice(&(wal_end as i64).to_be_bytes());
+        inner.extend_from_slice(&0i64.to_be_bytes()); // server_time
+        inner.push(u8::from(reply_requested));
+        backend_frame(b'd', &inner)
+    }
+
+    /// Returns true if `msg` is a standby status update ('d' CopyData starting 'r').
+    fn is_feedback(msg: &BackendMessage) -> bool {
+        msg.tag == b'd' && msg.payload.first() == Some(&b'r')
+    }
+
+    fn spawn_worker<R, W>(
+        cfg: ReplicationConfig,
+        r: R,
+        w: W,
+    ) -> (
+        Arc<SharedProgress>,
+        watch::Sender<bool>,
+        mpsc::Receiver<std::result::Result<ReplicationEvent, PgWireError>>,
+        tokio::task::JoinHandle<Result<()>>,
+    )
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+        W: AsyncWrite + Unpin + Send + 'static,
+    {
+        let (out, rx) = mpsc::channel(cfg.buffer_events.max(1));
+        let progress = Arc::new(SharedProgress::new(Lsn(0)));
+        let (stop_tx, stop_rx) = watch::channel(false);
+        let mut worker = WorkerState::new(cfg, Arc::clone(&progress), stop_rx, out);
+        let handle = tokio::spawn(async move { worker.stream_loop(r, w).await });
+        (progress, stop_tx, rx, handle)
+    }
+
+    /// The key resilience property (top-cluster #1): a consumer that never
+    /// drains the event channel must NOT stop standby-status feedback. Without
+    /// the read/feedback split a stalled consumer would block the single task
+    /// and the server would eventually trip `wal_sender_timeout`.
+    #[tokio::test]
+    async fn feedback_survives_consumer_backpressure() {
+        let cfg = ReplicationConfig::default()
+            .with_status_interval(Duration::from_millis(20))
+            .with_buffer_size(1); // fill after one event
+
+        let (worker_io, server_io) = tokio::io::duplex(64 * 1024);
+        let (wr, ww) = tokio::io::split(worker_io);
+        let (mut sr, mut sw) = tokio::io::split(server_io);
+
+        let (_progress, stop_tx, _rx, handle) = spawn_worker(cfg, wr, ww);
+
+        // Fire several changes; the consumer (`_rx`) is intentionally never
+        // drained, so the channel is full after the first event.
+        for i in 0..5u64 {
+            sw.write_all(&xlog_copydata(i, i + 1, &[b'I', 1, 2, 3]))
+                .await
+                .unwrap();
+        }
+        sw.flush().await.unwrap();
+
+        // We must keep receiving feedback despite the stalled consumer.
+        let got = tokio::time::timeout(Duration::from_secs(2), async {
+            let mut feedbacks = 0;
+            loop {
+                let msg = read_backend_message(&mut sr).await.expect("read feedback");
+                if is_feedback(&msg) {
+                    feedbacks += 1;
+                    if feedbacks >= 3 {
+                        return feedbacks;
+                    }
+                }
+            }
+        })
+        .await;
+        assert!(
+            got.is_ok(),
+            "feedback was starved under consumer backpressure"
+        );
+
+        // Cleanup: stop and drain writes until the worker drops its half.
+        let _ = stop_tx.send(true);
+        let _ = tokio::time::timeout(Duration::from_secs(1), async {
+            while read_backend_message(&mut sr).await.is_ok() {}
+        })
+        .await;
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+    }
+
+    /// A keepalive with `reply_requested` must be answered immediately, well
+    /// before the (here: very long) periodic interval, and still surface a
+    /// `KeepAlive` event to the consumer.
+    #[tokio::test]
+    async fn keepalive_reply_requested_triggers_immediate_feedback() {
+        let cfg = ReplicationConfig::default().with_status_interval(Duration::from_secs(3600));
+
+        let (worker_io, server_io) = tokio::io::duplex(64 * 1024);
+        let (wr, ww) = tokio::io::split(worker_io);
+        let (mut sr, mut sw) = tokio::io::split(server_io);
+
+        let (_progress, stop_tx, mut rx, handle) = spawn_worker(cfg, wr, ww);
+
+        // Drain the immediate initial feedback (interval's first tick).
+        let first = read_backend_message(&mut sr).await.unwrap();
+        assert!(is_feedback(&first), "expected an initial status update");
+
+        sw.write_all(&keepalive_copydata(42, true)).await.unwrap();
+        sw.flush().await.unwrap();
+
+        let fb = tokio::time::timeout(Duration::from_secs(1), read_backend_message(&mut sr))
+            .await
+            .expect("no feedback within timeout")
+            .unwrap();
+        assert!(is_feedback(&fb), "keepalive reply must be a status update");
+
+        let ev = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("no event")
+            .expect("channel closed")
+            .expect("worker error");
+        assert!(
+            matches!(ev, ReplicationEvent::KeepAlive { wal_end, reply_requested: true, .. } if wal_end == Lsn(42)),
+            "expected KeepAlive event, got {ev:?}"
+        );
+
+        let _ = stop_tx.send(true);
+        let _ = tokio::time::timeout(Duration::from_secs(1), async {
+            while read_backend_message(&mut sr).await.is_ok() {}
+        })
+        .await;
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+    }
+
+    /// Events are delivered to the consumer in wire order.
+    #[tokio::test]
+    async fn events_flow_in_order_when_drained() {
+        let cfg = ReplicationConfig::default().with_status_interval(Duration::from_secs(3600));
+
+        let (worker_io, server_io) = tokio::io::duplex(64 * 1024);
+        let (wr, ww) = tokio::io::split(worker_io);
+        let (mut sr, mut sw) = tokio::io::split(server_io);
+
+        let (_progress, stop_tx, mut rx, handle) = spawn_worker(cfg, wr, ww);
+
+        for i in 1..=4u64 {
+            sw.write_all(&xlog_copydata(i, i, &[b'I', i as u8]))
+                .await
+                .unwrap();
+        }
+        sw.flush().await.unwrap();
+
+        for i in 1..=4u64 {
+            let ev = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .expect("timed out awaiting event")
+                .expect("channel closed")
+                .expect("worker error");
+            match ev {
+                ReplicationEvent::XLogData { wal_end, data, .. } => {
+                    assert_eq!(wal_end, Lsn(i));
+                    assert_eq!(&data[..], &[b'I', i as u8]);
+                }
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
+
+        let _ = stop_tx.send(true);
+        let _ = tokio::time::timeout(Duration::from_secs(1), async {
+            while read_backend_message(&mut sr).await.is_ok() {}
+        })
+        .await;
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
     }
 }

--- a/crates/vendor/pgwire-replication/src/client/worker.rs
+++ b/crates/vendor/pgwire-replication/src/client/worker.rs
@@ -19,7 +19,7 @@ use crate::protocol::replication::{
 
 /// Shared replication progress updated by the consumer and read by the worker.
 ///
-/// Stored as an AtomicU64 so progress updates are cheap and monotonic
+/// Stored as an `AtomicU64` so progress updates are cheap and monotonic
 /// without async backpressure.
 pub struct SharedProgress {
     applied: AtomicU64,
@@ -173,7 +173,7 @@ impl WorkerState {
             ("client_encoding", "UTF8"),
             ("application_name", "pgwire-replication"),
         ];
-        write_startup_message(stream, 196608, &params).await
+        write_startup_message(stream, 196_608, &params).await
     }
 
     /// Start the logical replication stream.
@@ -196,8 +196,8 @@ impl WorkerState {
             match msg.tag {
                 b'W' => return Ok(()), // CopyBothResponse - ready to stream
                 b'E' => return Err(PgWireError::Server(parse_error_response(&msg.payload))),
-                b'N' | b'S' | b'K' => continue, // Notice, ParameterStatus, BackendKeyData
-                _ => continue,
+                // Notice / ParameterStatus / BackendKeyData / anything else: keep waiting.
+                _ => {}
             }
         }
     }
@@ -221,13 +221,14 @@ impl WorkerState {
         &mut self,
         stream: &mut S,
     ) -> Result<()> {
+        // How many messages to process in the tight loop before checking
+        // stop signal and sending periodic status feedback.
+        const DRAIN_BATCH: usize = 256;
+
         let mut last_status_sent = Instant::now() - self.cfg.status_interval;
         let mut last_applied = self.progress.load_applied();
         // Incremental, zero-copy, cancellation-safe reader.
         let mut reader = FrameReader::new(self.cfg.max_message_size);
-        // How many messages to process in the tight loop before checking
-        // stop signal and sending periodic status feedback.
-        const DRAIN_BATCH: usize = 256;
 
         loop {
             // Update applied LSN from client
@@ -299,15 +300,12 @@ impl WorkerState {
                     self.cfg.idle_wakeup_interval,
                     reader.next(stream),
                 ) => {
-                    match msg_result {
-                        Ok(res) => res?,
-                        Err(_) => {
-                            let applied = self.progress.load_applied();
-                            last_applied = applied;
-                            self.send_feedback(stream, applied, false).await?;
-                            last_status_sent = Instant::now();
-                            continue;
-                        }
+                    if let Ok(res) = msg_result { res? } else {
+                        let applied = self.progress.load_applied();
+                        last_applied = applied;
+                        self.send_feedback(stream, applied, false).await?;
+                        last_status_sent = Instant::now();
+                        continue;
                     }
                 }
             };
@@ -330,7 +328,7 @@ impl WorkerState {
         }
     }
 
-    /// Handle a CopyData message. Returns true if we should stop.
+    /// Handle a `CopyData` message. Returns true if we should stop.
     async fn handle_copy_data<S: AsyncRead + AsyncWrite + Unpin>(
         &mut self,
         stream: &mut S,
@@ -453,7 +451,7 @@ impl WorkerState {
     ///
     /// A plain `out.send().await` on a full events channel parks the entire
     /// worker until the consumer drains — and while parked, the worker sends no
-    /// standby status updates and services no keepalives. PostgreSQL then sees
+    /// standby status updates and services no keepalives. `PostgreSQL` then sees
     /// no feedback for `> wal_sender_timeout` and terminates the walsender
     /// (connection reset), forcing a reconnect and WAL replay. This is the
     /// coupling this method breaks.
@@ -538,7 +536,7 @@ impl WorkerState {
         }
     }
 
-    /// Handle PostgreSQL authentication exchange.
+    /// Handle `PostgreSQL` authentication exchange.
     async fn authenticate<S: AsyncRead + AsyncWrite + Unpin>(
         &mut self,
         stream: &mut S,
@@ -551,8 +549,8 @@ impl WorkerState {
                     self.handle_auth_request(stream, code, rest).await?;
                 }
                 b'E' => return Err(PgWireError::Server(parse_error_response(&msg.payload))),
-                b'S' | b'K' => {}      // ParameterStatus, BackendKeyData - ignore
                 b'Z' => return Ok(()), // ReadyForQuery - auth complete
+                // ParameterStatus / BackendKeyData / anything else - ignore
                 _ => {}
             }
         }
@@ -588,7 +586,7 @@ impl WorkerState {
                 let mut salt = [0u8; 4];
                 salt.copy_from_slice(&data[..4]);
 
-                let hash = postgres_md5(&self.cfg.password, &self.cfg.user, &salt);
+                let hash = postgres_md5(&self.cfg.password, &self.cfg.user, salt);
                 let mut payload = hash.into_bytes();
                 payload.push(0);
                 write_password_message(stream, &payload).await
@@ -628,7 +626,13 @@ impl WorkerState {
             // Send SASLInitialResponse
             let mut init = Vec::new();
             init.extend_from_slice(b"SCRAM-SHA-256\0");
-            init.extend_from_slice(&(scram.client_first.len() as i32).to_be_bytes());
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_possible_wrap,
+                reason = "SASL client-first length (nonce + username) is far below i32::MAX"
+            )]
+            let client_first_len = scram.client_first.len() as i32;
+            init.extend_from_slice(&client_first_len.to_be_bytes());
             init.extend_from_slice(scram.client_first.as_bytes());
             write_password_message(stream, &init).await?;
 
@@ -683,14 +687,16 @@ fn parse_sasl_mechanisms(data: &[u8]) -> Vec<String> {
     mechanisms
 }
 
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "pgoutput LSNs, xid, and content length are unsigned values carried as \
+              signed integers on the wire; these casts are bit-preserving"
+)]
 fn parse_pgoutput_boundary(data: &Bytes) -> Result<Option<ReplicationEvent>> {
-    if data.is_empty() {
-        return Ok(None);
-    }
-
-    let tag = data[0];
-    let mut p = &data[1..];
-
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "a pgoutput flags byte is a signed i8 on the wire"
+    )]
     fn take_i8(p: &mut &[u8]) -> Result<i8> {
         if p.is_empty() {
             return Err(PgWireError::Protocol("pgoutput: truncated i8".into()));
@@ -706,7 +712,9 @@ fn parse_pgoutput_boundary(data: &Bytes) -> Result<Option<ReplicationEvent>> {
         }
         let (head, tail) = p.split_at(4);
         *p = tail;
-        Ok(i32::from_be_bytes(head.try_into().unwrap()))
+        let mut b = [0u8; 4];
+        b.copy_from_slice(head);
+        Ok(i32::from_be_bytes(b))
     }
 
     fn take_i64(p: &mut &[u8]) -> Result<i64> {
@@ -715,8 +723,17 @@ fn parse_pgoutput_boundary(data: &Bytes) -> Result<Option<ReplicationEvent>> {
         }
         let (head, tail) = p.split_at(8);
         *p = tail;
-        Ok(i64::from_be_bytes(head.try_into().unwrap()))
+        let mut b = [0u8; 8];
+        b.copy_from_slice(head);
+        Ok(i64::from_be_bytes(b))
     }
+
+    if data.is_empty() {
+        return Ok(None);
+    }
+
+    let tag = data[0];
+    let mut p = &data[1..];
 
     match tag {
         b'B' => {
@@ -800,7 +817,11 @@ async fn read_auth_data<S: AsyncRead + AsyncWrite + Unpin>(
     }
 }
 
-/// Get current time as PostgreSQL timestamp (microseconds since 2000-01-01).
+/// Get current time as `PostgreSQL` timestamp (microseconds since 2000-01-01).
+#[expect(
+    clippy::cast_possible_wrap,
+    reason = "seconds since the UNIX epoch fit in i64 for the next ~292 billion years"
+)]
 fn current_pg_timestamp() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -808,13 +829,13 @@ fn current_pg_timestamp() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default();
 
-    let unix_micros = (now.as_secs() as i64) * 1_000_000 + (now.subsec_micros() as i64);
+    let unix_micros = (now.as_secs() as i64) * 1_000_000 + i64::from(now.subsec_micros());
     unix_micros - PG_EPOCH_MICROS
 }
 
-/// Compute PostgreSQL MD5 password hash.
+/// Compute `PostgreSQL` MD5 password hash.
 #[cfg(feature = "md5")]
-fn postgres_md5(password: &str, user: &str, salt: &[u8; 4]) -> String {
+fn postgres_md5(password: &str, user: &str, salt: [u8; 4]) -> String {
     fn md5_hex(data: &[u8]) -> String {
         format!("{:x}", md5::compute(data))
     }
@@ -824,7 +845,7 @@ fn postgres_md5(password: &str, user: &str, salt: &[u8; 4]) -> String {
 
     // Second hash: md5(inner_hash + salt)
     let mut outer_input = inner.into_bytes();
-    outer_input.extend_from_slice(salt);
+    outer_input.extend_from_slice(&salt);
 
     format!("md5{}", md5_hex(&outer_input))
 }
@@ -858,7 +879,7 @@ mod tests {
     fn postgres_md5_known_value() {
         // Test vector: user="md5_user", password="md5_pass", salt=[0x01, 0x02, 0x03, 0x04]
         // Can verify with: SELECT 'md5' || md5(md5('md5_passmd5_user') || E'\\x01020304');
-        let hash = postgres_md5("md5_pass", "md5_user", &[0x01, 0x02, 0x03, 0x04]);
+        let hash = postgres_md5("md5_pass", "md5_user", [0x01, 0x02, 0x03, 0x04]);
         assert!(hash.starts_with("md5"));
         assert_eq!(hash.len(), 35); // "md5" + 32 hex chars
     }

--- a/crates/vendor/pgwire-replication/src/config.rs
+++ b/crates/vendor/pgwire-replication/src/config.rs
@@ -313,6 +313,20 @@ pub struct ReplicationConfig {
     ///
     /// Default: 8192 events
     pub buffer_events: usize,
+
+    /// Maximum accepted size (bytes) of a single backend message payload during
+    /// streaming. A frame whose declared length exceeds this is rejected as a
+    /// protocol error before any buffer is allocated for it, bounding the memory
+    /// a malformed or malicious length field can request.
+    ///
+    /// The default is PostgreSQL's ~1 GiB field-size ceiling, so legitimate
+    /// large-row (TOAST) changes are never rejected. Lower it only if you know
+    /// the replicated relations have no large values — the reader already grows
+    /// its buffer incrementally from bytes actually received, so a high cap does
+    /// not by itself cause a large allocation.
+    ///
+    /// Default: 1 GiB
+    pub max_message_size: usize,
 }
 
 impl Default for ReplicationConfig {
@@ -331,6 +345,7 @@ impl Default for ReplicationConfig {
             status_interval: Duration::from_secs(10),
             idle_wakeup_interval: Duration::from_secs(10),
             buffer_events: 8192,
+            max_message_size: crate::protocol::framing::MAX_MESSAGE_SIZE,
         }
     }
 }
@@ -479,6 +494,14 @@ impl ReplicationConfig {
     /// Set the event buffer size.
     pub fn with_buffer_size(mut self, size: usize) -> Self {
         self.buffer_events = size;
+        self
+    }
+
+    /// Set the maximum accepted backend-message payload size (bytes).
+    ///
+    /// See [`max_message_size`](Self::max_message_size). Defaults to ~1 GiB.
+    pub fn with_max_message_size(mut self, size: usize) -> Self {
+        self.max_message_size = size;
         self
     }
 

--- a/crates/vendor/pgwire-replication/src/config.rs
+++ b/crates/vendor/pgwire-replication/src/config.rs
@@ -1,7 +1,7 @@
-//! Configuration types for PostgreSQL replication connections.
+//! Configuration types for `PostgreSQL` replication connections.
 //!
 //! This module provides configuration structures for establishing replication
-//! connections to PostgreSQL, including TLS settings and replication parameters.
+//! connections to `PostgreSQL`, including TLS settings and replication parameters.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -10,7 +10,7 @@ use crate::lsn::Lsn;
 
 /// SSL/TLS connection mode.
 ///
-/// These modes match PostgreSQL's `sslmode` connection parameter.
+/// These modes match `PostgreSQL`'s `sslmode` connection parameter.
 /// See [PostgreSQL SSL Support](https://www.postgresql.org/docs/current/libpq-ssl.html)
 /// for detailed documentation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -43,24 +43,27 @@ pub enum SslMode {
 impl SslMode {
     /// Returns `true` if this mode requires TLS (won't fall back to plain).
     #[inline]
+    #[must_use]
     pub fn requires_tls(&self) -> bool {
         !matches!(self, SslMode::Disable | SslMode::Prefer)
     }
 
     /// Returns `true` if this mode verifies the certificate chain.
     #[inline]
+    #[must_use]
     pub fn verifies_certificate(&self) -> bool {
         matches!(self, SslMode::VerifyCa | SslMode::VerifyFull)
     }
 
     /// Returns `true` if this mode verifies the server hostname.
     #[inline]
+    #[must_use]
     pub fn verifies_hostname(&self) -> bool {
         matches!(self, SslMode::VerifyFull)
     }
 }
 
-/// TLS/SSL configuration for PostgreSQL connections.
+/// TLS/SSL configuration for `PostgreSQL` connections.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TlsConfig {
     /// SSL mode controlling connection security level.
@@ -105,6 +108,7 @@ impl TlsConfig {
     /// let tls = TlsConfig::disabled();
     /// assert!(!tls.mode.requires_tls());
     /// ```
+    #[must_use]
     pub fn disabled() -> Self {
         Self::default()
     }
@@ -122,6 +126,7 @@ impl TlsConfig {
     /// assert!(tls.mode.requires_tls());
     /// assert!(!tls.mode.verifies_certificate());
     /// ```
+    #[must_use]
     pub fn require() -> Self {
         Self {
             mode: SslMode::Require,
@@ -144,6 +149,7 @@ impl TlsConfig {
     /// // Using custom CA
     /// let tls = TlsConfig::verify_ca(Some("/path/to/ca.pem".into()));
     /// ```
+    #[must_use]
     pub fn verify_ca(ca_path: Option<PathBuf>) -> Self {
         Self {
             mode: SslMode::VerifyCa,
@@ -166,6 +172,7 @@ impl TlsConfig {
     /// let tls = TlsConfig::verify_full(Some("/etc/ssl/certs/ca.pem".into()));
     /// assert!(tls.mode.verifies_hostname());
     /// ```
+    #[must_use]
     pub fn verify_full(ca_path: Option<PathBuf>) -> Self {
         Self {
             mode: SslMode::VerifyFull,
@@ -183,6 +190,7 @@ impl TlsConfig {
     /// let tls = TlsConfig::verify_full(None)
     ///     .with_sni_hostname("db.example.com");
     /// ```
+    #[must_use]
     pub fn with_sni_hostname(mut self, hostname: impl Into<String>) -> Self {
         self.sni_hostname = Some(hostname.into());
         self
@@ -197,6 +205,7 @@ impl TlsConfig {
     /// let tls = TlsConfig::verify_full(Some("/ca.pem".into()))
     ///     .with_client_cert("/client.pem", "/client.key");
     /// ```
+    #[must_use]
     pub fn with_client_cert(
         mut self,
         cert_path: impl Into<PathBuf>,
@@ -209,12 +218,13 @@ impl TlsConfig {
 
     /// Returns `true` if mutual TLS (client certificate) is configured.
     #[inline]
+    #[must_use]
     pub fn is_mtls(&self) -> bool {
         self.client_cert_pem_path.is_some() && self.client_key_pem_path.is_some()
     }
 }
 
-/// Configuration for PostgreSQL logical replication connections.
+/// Configuration for `PostgreSQL` logical replication connections.
 ///
 /// # Example
 ///
@@ -238,13 +248,13 @@ impl TlsConfig {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReplicationConfig {
-    /// PostgreSQL server hostname or IP address.
+    /// `PostgreSQL` server hostname or IP address.
     pub host: String,
 
-    /// PostgreSQL server port (default: 5432).
+    /// `PostgreSQL` server port (default: 5432).
     pub port: u16,
 
-    /// PostgreSQL username with replication privileges.
+    /// `PostgreSQL` username with replication privileges.
     ///
     /// The user must have the `REPLICATION` attribute or be a superuser.
     pub user: String,
@@ -272,7 +282,7 @@ pub struct ReplicationConfig {
     /// LSN position to start replication from.
     ///
     /// - `Lsn(0)`: Start from slot's `confirmed_flush_lsn`
-    /// - Specific LSN: Resume from that position (must be >= slot's restart_lsn)
+    /// - Specific LSN: Resume from that position (must be >= slot's `restart_lsn`)
     pub start_lsn: Lsn,
 
     /// Optional LSN to stop replication at.
@@ -287,7 +297,7 @@ pub struct ReplicationConfig {
 
     /// Interval for sending standby status updates to the server.
     ///
-    /// Status updates inform PostgreSQL of the client's replay position,
+    /// Status updates inform `PostgreSQL` of the client's replay position,
     /// allowing the server to release WAL segments. Too infrequent updates
     /// may cause WAL accumulation; too frequent updates add overhead.
     ///
@@ -325,7 +335,7 @@ pub struct ReplicationConfig {
     ///
     /// When `true` (default), a full event channel no longer parks the worker:
     /// it keeps emitting standby status updates on [`Self::status_interval`]
-    /// while it waits for the consumer to drain, so PostgreSQL never sees a
+    /// while it waits for the consumer to drain, so `PostgreSQL` never sees a
     /// feedback gap longer than `status_interval` and will not terminate the
     /// walsender on `wal_sender_timeout`.
     ///
@@ -339,7 +349,7 @@ pub struct ReplicationConfig {
     /// protocol error before any buffer is allocated for it, bounding the memory
     /// a malformed or malicious length field can request.
     ///
-    /// The default is PostgreSQL's ~1 GiB field-size ceiling, so legitimate
+    /// The default is `PostgreSQL`'s ~1 GiB field-size ceiling, so legitimate
     /// large-row (TOAST) changes are never rejected. Lower it only if you know
     /// the replicated relations have no large values — the reader already grows
     /// its buffer incrementally from bytes actually received, so a high cap does
@@ -411,8 +421,9 @@ impl ReplicationConfig {
     /// Returns `true` if `host` refers to a Unix domain socket directory.
     ///
     /// Following libpq convention, a host starting with `/` is treated as
-    /// the directory containing the PostgreSQL Unix socket file.
+    /// the directory containing the `PostgreSQL` Unix socket file.
     #[inline]
+    #[must_use]
     pub fn is_unix_socket(&self) -> bool {
         self.host.starts_with('/')
     }
@@ -422,6 +433,7 @@ impl ReplicationConfig {
     /// # Panics
     ///
     /// Panics if `host` does not start with `/` (i.e. `is_unix_socket()` is false).
+    #[must_use]
     pub fn unix_socket_path(&self) -> std::path::PathBuf {
         assert!(
             self.is_unix_socket(),
@@ -433,7 +445,7 @@ impl ReplicationConfig {
 
     /// Create a configuration for connecting via Unix domain socket.
     ///
-    /// `socket_dir` is the directory containing the PostgreSQL socket file
+    /// `socket_dir` is the directory containing the `PostgreSQL` socket file
     /// (e.g. `/var/run/postgresql`). The actual socket path will be
     /// `{socket_dir}/.s.PGSQL.{port}`.
     ///
@@ -477,42 +489,49 @@ impl ReplicationConfig {
     }
 
     /// Set the server port.
+    #[must_use]
     pub fn with_port(mut self, port: u16) -> Self {
         self.port = port;
         self
     }
 
     /// Set TLS configuration.
+    #[must_use]
     pub fn with_tls(mut self, tls: TlsConfig) -> Self {
         self.tls = tls;
         self
     }
 
     /// Set the starting LSN.
+    #[must_use]
     pub fn with_start_lsn(mut self, lsn: Lsn) -> Self {
         self.start_lsn = lsn;
         self
     }
 
     /// Set an optional stop LSN for bounded replay.
+    #[must_use]
     pub fn with_stop_lsn(mut self, lsn: Lsn) -> Self {
         self.stop_at_lsn = Some(lsn);
         self
     }
 
     /// Set the status update interval.
+    #[must_use]
     pub fn with_status_interval(mut self, interval: Duration) -> Self {
         self.status_interval = interval;
         self
     }
 
     /// Set the idle wakeup interval.
+    #[must_use]
     pub fn with_wakeup_interval(mut self, timeout: Duration) -> Self {
         self.idle_wakeup_interval = timeout;
         self
     }
 
     /// Set the event buffer size.
+    #[must_use]
     pub fn with_buffer_size(mut self, size: usize) -> Self {
         self.buffer_events = size;
         self
@@ -520,6 +539,7 @@ impl ReplicationConfig {
 
     /// Set whether standby status feedback keeps flowing while the consumer is
     /// backpressured. See [`Self::feedback_while_backpressured`].
+    #[must_use]
     pub fn with_feedback_while_backpressured(mut self, enabled: bool) -> Self {
         self.feedback_while_backpressured = enabled;
         self
@@ -528,6 +548,7 @@ impl ReplicationConfig {
     /// Set the maximum accepted backend-message payload size (bytes).
     ///
     /// See [`max_message_size`](Self::max_message_size). Defaults to ~1 GiB.
+    #[must_use]
     pub fn with_max_message_size(mut self, size: usize) -> Self {
         self.max_message_size = size;
         self
@@ -536,6 +557,7 @@ impl ReplicationConfig {
     /// Returns the connection string for display (password masked).
     ///
     /// Useful for logging without exposing credentials.
+    #[must_use]
     pub fn display_connection(&self) -> String {
         if self.is_unix_socket() {
             format!(

--- a/crates/vendor/pgwire-replication/src/error.rs
+++ b/crates/vendor/pgwire-replication/src/error.rs
@@ -3,7 +3,7 @@
 //! All errors in this crate are represented by [`PgWireError`], which covers:
 //! - I/O errors (network, file system)
 //! - Protocol errors (malformed messages, unexpected responses)
-//! - Server errors (PostgreSQL error responses)
+//! - Server errors (`PostgreSQL` error responses)
 //! - Authentication errors (wrong password, unsupported method)
 //! - TLS errors (handshake failure, certificate issues)
 //! - Task errors (worker panics, unexpected termination)
@@ -25,7 +25,7 @@ pub enum PgWireError {
     #[error("protocol error: {0}")]
     Protocol(String),
 
-    /// Server error - PostgreSQL returned an error response.
+    /// Server error - `PostgreSQL` returned an error response.
     ///
     /// The message typically includes SQLSTATE code.
     #[error("server error: {0}")]
@@ -51,24 +51,28 @@ pub enum PgWireError {
 impl PgWireError {
     /// Returns `true` if this is an I/O error.
     #[inline]
+    #[must_use]
     pub fn is_io(&self) -> bool {
         matches!(self, PgWireError::Io(_))
     }
 
     /// Returns `true` if this is a server error.
     #[inline]
+    #[must_use]
     pub fn is_server(&self) -> bool {
         matches!(self, PgWireError::Server(_))
     }
 
     /// Returns `true` if this is an authentication error.
     #[inline]
+    #[must_use]
     pub fn is_auth(&self) -> bool {
         matches!(self, PgWireError::Auth(_))
     }
 
     /// Returns `true` if this is a TLS error.
     #[inline]
+    #[must_use]
     pub fn is_tls(&self) -> bool {
         matches!(self, PgWireError::Tls(_))
     }
@@ -77,6 +81,7 @@ impl PgWireError {
     ///
     /// Transient errors include I/O errors and task errors. Non-transient
     /// errors (auth, server, protocol) typically require configuration changes.
+    #[must_use]
     pub fn is_transient(&self) -> bool {
         matches!(self, PgWireError::Io(_) | PgWireError::Task(_))
     }

--- a/crates/vendor/pgwire-replication/src/lib.rs
+++ b/crates/vendor/pgwire-replication/src/lib.rs
@@ -1,6 +1,6 @@
 //! # pgwire-replication
 //!
-//! A Tokio-based PostgreSQL logical replication client implementing the pgoutput protocol.
+//! A Tokio-based `PostgreSQL` logical replication client implementing the pgoutput protocol.
 //!
 //! ## Features
 //!
@@ -60,31 +60,11 @@
 //! - `scram` (default) - SCRAM-SHA-256 authentication
 //! - `md5` - MD5 authentication (legacy)
 
-// spiceai vendoring: this is third-party code excluded from the workspace lint
-// policy (see `--exclude pgwire-replication` in the Makefile). It is still
-// compiled as a path dependency of `data_components`, and path deps are linted
-// (not `--cap-lints`-suppressed), so the workspace's forced `-D` clippy flags
-// would otherwise fire on unmodified upstream code. We suppress them here
-// rather than editing upstream sources — mirroring the other vendored crates
-// (lopdf/ttf-parser/pdf-extract). Upstream's own `#![warn(clippy::cargo, ...)]`
-// is intentionally dropped: under the workspace `-Dwarnings` it escalated
-// `clippy::cargo` to deny and reported `cargo_common_metadata` for every other
-// workspace crate.
-#![allow(
-    clippy::all,
-    clippy::pedantic,
-    clippy::nursery,
-    clippy::cargo,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::clone_on_ref_ptr,
-    clippy::todo,
-    clippy::assertions_on_result_states,
-    clippy::equatable_if_let,
-    clippy::needless_collect,
-    clippy::redundant_clone,
-    clippy::allow_attributes
-)]
+// spiceai vendoring: originally imported from crates.io 0.3.2 (see Cargo.toml),
+// now maintained as a local fork. Unlike the other vendored crates it carries no
+// blanket `#![allow]` and is NOT excluded from `make lint-rust` — it is held to
+// the same clippy bar (pedantic + the workspace's denied lints) as first-class
+// workspace crates.
 
 pub mod auth;
 pub mod client;

--- a/crates/vendor/pgwire-replication/src/lsn.rs
+++ b/crates/vendor/pgwire-replication/src/lsn.rs
@@ -1,6 +1,6 @@
-//! PostgreSQL Log Sequence Number (LSN) type.
+//! `PostgreSQL` Log Sequence Number (LSN) type.
 //!
-//! PostgreSQL displays LSNs as `X/Y` (uppercase hex), where:
+//! `PostgreSQL` displays LSNs as `X/Y` (uppercase hex), where:
 //! - `X` is the high 32 bits
 //! - `Y` is the low 32 bits
 //!
@@ -21,14 +21,14 @@ impl fmt::Display for ParseLsnError {
 
 impl std::error::Error for ParseLsnError {}
 
-/// PostgreSQL Log Sequence Number.
+/// `PostgreSQL` Log Sequence Number.
 ///
 /// Represents a position in the write-ahead log (WAL). LSNs are used to
 /// track replication progress and identify specific points in the WAL stream.
 ///
 /// # Format
 ///
-/// PostgreSQL displays LSNs as `XXXXXXXX/YYYYYYYY` where:
+/// `PostgreSQL` displays LSNs as `XXXXXXXX/YYYYYYYY` where:
 /// - `XXXXXXXX` is the high 32 bits (segment file number)
 /// - `YYYYYYYY` is the low 32 bits (offset within segment)
 ///
@@ -50,7 +50,7 @@ impl Lsn {
     /// The zero LSN, representing "start from the beginning" or "no position".
     pub const ZERO: Lsn = Lsn(0);
 
-    /// Parse an LSN from PostgreSQL's `XXXXXXXX/YYYYYYYY` format.
+    /// Parse an LSN from `PostgreSQL`'s `XXXXXXXX/YYYYYYYY` format.
     ///
     /// # Errors
     ///
@@ -69,26 +69,30 @@ impl Lsn {
         Ok(Lsn((hi << 32) | lo))
     }
 
-    /// Format as PostgreSQL's `XXXXXXXX/YYYYYYYY` string.
+    /// Format as `PostgreSQL`'s `XXXXXXXX/YYYYYYYY` string.
     #[inline]
+    #[must_use]
     pub fn to_pg_string(self) -> String {
         self.to_string()
     }
 
     /// Returns `true` if this is the zero LSN.
     #[inline]
+    #[must_use]
     pub fn is_zero(self) -> bool {
         self.0 == 0
     }
 
     /// Returns the raw 64-bit value.
     #[inline]
+    #[must_use]
     pub fn as_u64(self) -> u64 {
         self.0
     }
 
     /// Create an LSN from a raw 64-bit value.
     #[inline]
+    #[must_use]
     pub fn from_u64(value: u64) -> Self {
         Lsn(value)
     }
@@ -99,7 +103,7 @@ impl fmt::Display for Lsn {
         let v: u64 = self.as_u64();
         let hi = (v >> 32) as u32;
         let lo = (v & 0xFFFF_FFFF) as u32;
-        write!(f, "{:X}/{:X}", hi, lo)
+        write!(f, "{hi:X}/{lo:X}")
     }
 }
 

--- a/crates/vendor/pgwire-replication/src/protocol/framing.rs
+++ b/crates/vendor/pgwire-replication/src/protocol/framing.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::io;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -165,6 +165,171 @@ impl MessageReader {
 impl Default for MessageReader {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Incremental, cancellation-safe, zero-copy backend-message reader.
+///
+/// This is the reader used by the streaming replication loop. Unlike
+/// [`MessageReader`] — which reads each message into a freshly zero-filled
+/// buffer (`resize(len, 0)`) via per-byte-range `read` calls — `FrameReader`
+/// keeps a single growable buffer that it fills with
+/// [`read_buf`](tokio::io::AsyncReadExt::read_buf), reading directly into
+/// **uninitialized** spare capacity (no `memset`), and slices complete frames
+/// out of it with `split_to` (zero-copy: each returned payload shares the
+/// buffer's allocation via refcount). Compared with the previous
+/// `BufReader` + `MessageReader` combination this removes both the
+/// per-message zero-fill and the extra copy the intermediate `BufReader`
+/// added (bytes went kernel → `BufReader` → per-message `BytesMut`; now they
+/// go kernel → one `BytesMut`, and frames are views into it).
+///
+/// # Cancellation safety
+///
+/// [`next`](Self::next) only ever awaits a single `read_buf` call, which
+/// resolves atomically with the buffer advance — a dropped future loses no
+/// bytes. Any partially-buffered frame stays in `buf` and the next call
+/// resumes. This makes it safe to drive from `tokio::select!` /
+/// `tokio::time::timeout`.
+///
+/// # Memory safety under adversarial input
+///
+/// Buffer growth is driven by bytes **actually read**, not by the declared
+/// frame length: capacity is only grown once existing spare is exhausted, and
+/// each grow at most doubles (bounded below by [`READ_CHUNK`], above by the
+/// remaining bytes of the in-flight frame). A frame whose declared length
+/// exceeds `max_message_size` is rejected before any allocation. Together these
+/// bound the amplification of a bogus/oversized length field to ~2× the bytes
+/// the peer actually sent, instead of the eager `resize(declared_len, 0)` the
+/// old reader performed.
+pub struct FrameReader {
+    buf: BytesMut,
+    max_message_size: usize,
+}
+
+/// Minimum spare capacity ensured before each socket read, and the floor for
+/// geometric buffer growth. Larger than a typical TCP segment so many small
+/// WAL messages arrive per syscall.
+const READ_CHUNK: usize = 128 * 1024;
+
+impl FrameReader {
+    /// Create a reader that rejects frames whose payload exceeds
+    /// `max_message_size` bytes.
+    pub fn new(max_message_size: usize) -> Self {
+        Self::with_capacity(READ_CHUNK, max_message_size)
+    }
+
+    pub fn with_capacity(capacity: usize, max_message_size: usize) -> Self {
+        Self {
+            buf: BytesMut::with_capacity(capacity),
+            max_message_size,
+        }
+    }
+
+    /// Bytes currently buffered but not yet consumed.
+    #[inline]
+    pub fn buffered(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Current allocated capacity of the read buffer. Exposed for diagnostics
+    /// and to assert the anti-amplification bound in tests.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.buf.capacity()
+    }
+
+    /// Returns `true` if a complete frame is already buffered, so
+    /// [`next`](Self::next) will return it without awaiting a socket read.
+    /// Used by the streaming loop to drain buffered frames in a tight loop.
+    ///
+    /// Returns `false` on a header that is not yet fully buffered *or* that is
+    /// malformed — a malformed header surfaces as an error from `next`.
+    #[inline]
+    pub fn has_buffered_frame(&self) -> bool {
+        matches!(self.frame_len(), Ok(Some(frame_len)) if self.buf.len() >= frame_len)
+    }
+
+    /// Total wire length (tag + length field + payload) of the frame at the
+    /// front of the buffer, if its 5-byte header is fully buffered. `Ok(None)`
+    /// if the header is not yet complete; `Err` if the length is invalid or
+    /// exceeds `max_message_size`.
+    #[inline]
+    fn frame_len(&self) -> Result<Option<usize>> {
+        if self.buf.len() < 5 {
+            return Ok(None);
+        }
+        let len = i32::from_be_bytes([self.buf[1], self.buf[2], self.buf[3], self.buf[4]]);
+        if len < 4 {
+            return Err(PgWireError::Protocol(format!(
+                "invalid backend message length: {len}"
+            )));
+        }
+        let payload_len = (len - 4) as usize;
+        if payload_len > self.max_message_size {
+            return Err(PgWireError::Protocol(format!(
+                "backend message too large: {payload_len} bytes (max {})",
+                self.max_message_size
+            )));
+        }
+        // Wire framing: 1 tag byte + `len`, where `len` already counts the
+        // 4-byte length field plus the payload.
+        Ok(Some(1 + len as usize))
+    }
+
+    /// Slice one complete frame out of the buffer without reading, if present.
+    fn try_decode(&mut self) -> Result<Option<BackendMessage>> {
+        let Some(frame_len) = self.frame_len()? else {
+            return Ok(None);
+        };
+        if self.buf.len() < frame_len {
+            return Ok(None);
+        }
+        let mut frame = self.buf.split_to(frame_len);
+        let tag = frame[0];
+        frame.advance(5); // drop tag + 4-byte length field
+        Ok(Some(BackendMessage {
+            tag,
+            payload: frame.freeze(),
+        }))
+    }
+
+    /// Ensure there is spare capacity to read into, growing geometrically so
+    /// accumulating a large frame stays amortized O(n). Growth is driven by
+    /// actual fill (called only when spare is low), never by the declared
+    /// length, and is capped at the in-flight frame's remaining bytes so we
+    /// never over-allocate beyond the message being assembled.
+    fn ensure_read_capacity(&mut self) {
+        let spare = self.buf.capacity() - self.buf.len();
+        if spare >= READ_CHUNK {
+            return;
+        }
+        // At least READ_CHUNK, at most a doubling of current capacity.
+        let mut additional = READ_CHUNK.max(self.buf.capacity());
+        if let Ok(Some(frame_len)) = self.frame_len() {
+            let needed = frame_len.saturating_sub(self.buf.len());
+            additional = additional.min(needed.max(READ_CHUNK));
+        }
+        self.buf.reserve(additional);
+    }
+
+    /// Read the next complete backend message.
+    ///
+    /// Cancellation-safe — see the type-level docs. Returns an `UnexpectedEof`
+    /// I/O error if the peer closes the stream mid-message.
+    pub async fn next<R: AsyncRead + Unpin>(&mut self, rd: &mut R) -> Result<BackendMessage> {
+        loop {
+            if let Some(msg) = self.try_decode()? {
+                return Ok(msg);
+            }
+            self.ensure_read_capacity();
+            let n = rd.read_buf(&mut self.buf).await?;
+            if n == 0 {
+                return Err(PgWireError::Io(std::sync::Arc::new(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "EOF while reading backend message",
+                ))));
+            }
+        }
     }
 }
 
@@ -543,6 +708,157 @@ mod tests {
         assert_eq!(buf[0], b'c');
         // Length = 4 (just the length field itself, no payload)
         assert_eq!(&buf[1..5], &4i32.to_be_bytes());
+    }
+
+    // ==================== FrameReader tests ====================
+
+    const TEST_MAX: usize = 1024 * 1024 * 1024;
+
+    /// Build one wire frame: tag + i32 length (len counts itself + payload) + payload.
+    fn wire_frame(tag: u8, payload: &[u8]) -> Vec<u8> {
+        let len = (4 + payload.len()) as i32;
+        let mut v = Vec::with_capacity(5 + payload.len());
+        v.push(tag);
+        v.extend_from_slice(&len.to_be_bytes());
+        v.extend_from_slice(payload);
+        v
+    }
+
+    #[tokio::test]
+    async fn frame_reader_reads_complete_message() {
+        let data = [b'Z', 0, 0, 0, 5, b'I'];
+        let mut cursor = Cursor::new(&data[..]);
+        let mut reader = FrameReader::new(TEST_MAX);
+        let msg = reader.next(&mut cursor).await.unwrap();
+        assert_eq!(msg.tag, b'Z');
+        assert_eq!(&msg.payload[..], b"I");
+    }
+
+    #[tokio::test]
+    async fn frame_reader_reads_back_to_back_messages() {
+        let mut data = wire_frame(b'Z', b"I");
+        data.extend_from_slice(&wire_frame(b'N', b""));
+        data.extend_from_slice(&wire_frame(b'd', b"copydata"));
+        let mut cursor = Cursor::new(data.as_slice());
+        let mut reader = FrameReader::new(TEST_MAX);
+
+        let m1 = reader.next(&mut cursor).await.unwrap();
+        assert_eq!(m1.tag, b'Z');
+        assert_eq!(&m1.payload[..], b"I");
+        // With a single buffered read, the following frames must already be
+        // available without another socket read.
+        assert!(reader.has_buffered_frame());
+
+        let m2 = reader.next(&mut cursor).await.unwrap();
+        assert_eq!(m2.tag, b'N');
+        assert!(m2.payload.is_empty());
+
+        let m3 = reader.next(&mut cursor).await.unwrap();
+        assert_eq!(m3.tag, b'd');
+        assert_eq!(&m3.payload[..], b"copydata");
+    }
+
+    /// Cancellation-safety: dropping the read future mid-header must not lose
+    /// the bytes already buffered.
+    #[tokio::test]
+    async fn frame_reader_resumes_after_cancellation_mid_header() {
+        let (mut writer, mut rd) = tokio::io::duplex(64);
+        let mut reader = FrameReader::new(TEST_MAX);
+
+        let frame = wire_frame(b'd', b"abcd");
+        writer.write_all(&frame[..3]).await.unwrap();
+
+        let timed_out =
+            tokio::time::timeout(std::time::Duration::from_millis(20), reader.next(&mut rd)).await;
+        assert!(timed_out.is_err(), "must time out awaiting remaining header");
+
+        writer.write_all(&frame[3..]).await.unwrap();
+        let msg = reader.next(&mut rd).await.unwrap();
+        assert_eq!(msg.tag, b'd');
+        assert_eq!(&msg.payload[..], b"abcd");
+    }
+
+    /// Cancellation-safety: dropping the read future mid-payload must resume.
+    #[tokio::test]
+    async fn frame_reader_resumes_after_cancellation_mid_payload() {
+        let (mut writer, mut rd) = tokio::io::duplex(64);
+        let mut reader = FrameReader::new(TEST_MAX);
+
+        let payload: [u8; 16] = std::array::from_fn(|i| i as u8);
+        let frame = wire_frame(b'd', &payload);
+        writer.write_all(&frame[..9]).await.unwrap(); // header + 4 payload bytes
+
+        let timed_out =
+            tokio::time::timeout(std::time::Duration::from_millis(20), reader.next(&mut rd)).await;
+        assert!(timed_out.is_err(), "must time out awaiting remaining payload");
+
+        writer.write_all(&frame[9..]).await.unwrap();
+        let msg = reader.next(&mut rd).await.unwrap();
+        assert_eq!(msg.tag, b'd');
+        assert_eq!(&msg.payload[..], &payload[..]);
+    }
+
+    #[tokio::test]
+    async fn frame_reader_rejects_invalid_length() {
+        let data = [b'Z', 0, 0, 0, 3]; // len < 4
+        let mut cursor = Cursor::new(&data[..]);
+        let mut reader = FrameReader::new(TEST_MAX);
+        let err = reader.next(&mut cursor).await.unwrap_err();
+        assert!(err.to_string().contains("invalid backend message length"));
+    }
+
+    #[tokio::test]
+    async fn frame_reader_rejects_oversized_message() {
+        // Declared payload of 1000 bytes with a 100-byte cap.
+        let header = wire_frame(b'd', &vec![0u8; 1000]);
+        let mut cursor = Cursor::new(header.as_slice());
+        let mut reader = FrameReader::new(100);
+        let err = reader.next(&mut cursor).await.unwrap_err();
+        assert!(err.to_string().contains("too large"));
+    }
+
+    /// A large-but-valid frame must reassemble byte-for-byte across many reads.
+    #[tokio::test]
+    async fn frame_reader_assembles_large_message_incrementally() {
+        let payload: Vec<u8> = (0..(2 * 1024 * 1024)).map(|i| (i % 251) as u8).collect();
+        let frame = wire_frame(b'd', &payload);
+        // Cursor hands out at most `spare` bytes per read_buf, so this drives
+        // many reads + geometric growth for one message.
+        let mut cursor = Cursor::new(frame.as_slice());
+        let mut reader = FrameReader::new(TEST_MAX);
+        let msg = reader.next(&mut cursor).await.unwrap();
+        assert_eq!(msg.tag, b'd');
+        assert_eq!(msg.payload.len(), payload.len());
+        assert_eq!(&msg.payload[..], &payload[..]);
+    }
+
+    /// Anti-amplification: a header claiming a huge (but under-cap) payload,
+    /// followed by only a handful of bytes, must NOT pre-allocate the declared
+    /// size. Buffer growth is driven by bytes actually received.
+    #[tokio::test]
+    async fn frame_reader_bogus_length_does_not_preallocate() {
+        let (mut writer, mut rd) = tokio::io::duplex(64);
+        let mut reader = FrameReader::new(TEST_MAX);
+
+        // Claim ~900 MiB of payload but send only the header + 8 bytes.
+        let claimed = 900 * 1024 * 1024i32;
+        let len = 4 + claimed;
+        let mut header = Vec::new();
+        header.push(b'd');
+        header.extend_from_slice(&len.to_be_bytes());
+        header.extend_from_slice(&[0u8; 8]);
+        writer.write_all(&header).await.unwrap();
+
+        // The frame never completes, so `next` stays pending.
+        let timed_out =
+            tokio::time::timeout(std::time::Duration::from_millis(50), reader.next(&mut rd)).await;
+        assert!(timed_out.is_err(), "incomplete frame must not resolve");
+
+        assert!(
+            reader.capacity() < 4 * 1024 * 1024,
+            "must not pre-allocate the declared 900 MiB; capacity was {}",
+            reader.capacity()
+        );
     }
 
     #[test]

--- a/crates/vendor/pgwire-replication/src/protocol/framing.rs
+++ b/crates/vendor/pgwire-replication/src/protocol/framing.rs
@@ -770,7 +770,10 @@ mod tests {
 
         let timed_out =
             tokio::time::timeout(std::time::Duration::from_millis(20), reader.next(&mut rd)).await;
-        assert!(timed_out.is_err(), "must time out awaiting remaining header");
+        assert!(
+            timed_out.is_err(),
+            "must time out awaiting remaining header"
+        );
 
         writer.write_all(&frame[3..]).await.unwrap();
         let msg = reader.next(&mut rd).await.unwrap();
@@ -790,7 +793,10 @@ mod tests {
 
         let timed_out =
             tokio::time::timeout(std::time::Duration::from_millis(20), reader.next(&mut rd)).await;
-        assert!(timed_out.is_err(), "must time out awaiting remaining payload");
+        assert!(
+            timed_out.is_err(),
+            "must time out awaiting remaining payload"
+        );
 
         writer.write_all(&frame[9..]).await.unwrap();
         let msg = reader.next(&mut rd).await.unwrap();

--- a/crates/vendor/pgwire-replication/src/protocol/framing.rs
+++ b/crates/vendor/pgwire-replication/src/protocol/framing.rs
@@ -15,37 +15,42 @@ pub struct BackendMessage {
 }
 
 impl BackendMessage {
-    /// Returns true if this is an ErrorResponse ('E')
+    /// Returns true if this is an `ErrorResponse` ('E')
     #[inline]
     pub fn is_error(&self) -> bool {
         self.tag == b'E'
     }
 
-    /// Returns true if this is a ReadyForQuery ('Z')
+    /// Returns true if this is a `ReadyForQuery` ('Z')
     #[inline]
     pub fn is_ready_for_query(&self) -> bool {
         self.tag == b'Z'
     }
 
-    /// Returns true if this is CopyBothResponse ('W')
+    /// Returns true if this is `CopyBothResponse` ('W')
     #[inline]
     pub fn is_copy_both_response(&self) -> bool {
         self.tag == b'W'
     }
 
-    /// Returns true if this is CopyData ('d')
+    /// Returns true if this is `CopyData` ('d')
     #[inline]
     pub fn is_copy_data(&self) -> bool {
         self.tag == b'd'
     }
 
-    /// Returns true if this is AuthenticationRequest ('R')
+    /// Returns true if this is `AuthenticationRequest` ('R')
     #[inline]
     pub fn is_auth_request(&self) -> bool {
         self.tag == b'R'
     }
 }
 
+/// Read a single complete backend message from `rd`.
+///
+/// # Errors
+/// Returns [`PgWireError::Io`] on a read failure or EOF, or
+/// [`PgWireError::Protocol`] if the framed length is invalid or oversized.
 pub async fn read_backend_message<R: AsyncRead + Unpin>(rd: &mut R) -> Result<BackendMessage> {
     let mut reader = MessageReader::new();
     reader.read(rd).await
@@ -53,7 +58,7 @@ pub async fn read_backend_message<R: AsyncRead + Unpin>(rd: &mut R) -> Result<Ba
 
 /// Cancellation-safe backend message reader.
 ///
-/// PostgreSQL backend messages span multiple `read` operations (5-byte header,
+/// `PostgreSQL` backend messages span multiple `read` operations (5-byte header,
 /// then a variable payload). A naive implementation using `read_exact` is
 /// **not** cancellation-safe: if the future is dropped between reads (e.g. by
 /// `tokio::select!` or `tokio::time::timeout`), bytes already pulled from the
@@ -76,10 +81,12 @@ pub struct MessageReader {
 }
 
 impl MessageReader {
+    #[must_use]
     pub fn new() -> Self {
         Self::with_capacity(4096)
     }
 
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             hdr: [0u8; 5],
@@ -95,6 +102,10 @@ impl MessageReader {
     ///
     /// Cancellation-safe: dropping the returned future preserves all progress
     /// so far on `self`. Re-call to resume.
+    ///
+    /// # Errors
+    /// Returns [`PgWireError::Io`] on a read failure or EOF, or
+    /// [`PgWireError::Protocol`] if the framed length is invalid or oversized.
     pub async fn read<R: AsyncRead + Unpin>(&mut self, rd: &mut R) -> Result<BackendMessage> {
         // Phase 1: fill the 5-byte header
         while self.hdr_filled < 5 {
@@ -121,6 +132,10 @@ impl MessageReader {
                 )));
             }
 
+            #[expect(
+                clippy::cast_sign_loss,
+                reason = "len is checked >= 4 above, so len - 4 is non-negative"
+            )]
             let payload_len = (len - 4) as usize;
 
             if payload_len > MAX_MESSAGE_SIZE {
@@ -137,7 +152,13 @@ impl MessageReader {
             self.payload_len = Some(payload_len);
         }
 
-        let payload_len = self.payload_len.unwrap();
+        // Set either just above (fresh header) or on a prior call resumed after
+        // a dropped future; a typed error keeps this non-panicking.
+        let Some(payload_len) = self.payload_len else {
+            return Err(PgWireError::Internal(
+                "MessageReader: payload length unset after header parse".into(),
+            ));
+        };
 
         // Phase 3: fill the payload
         while self.payload_filled < payload_len {
@@ -214,10 +235,12 @@ const READ_CHUNK: usize = 128 * 1024;
 impl FrameReader {
     /// Create a reader that rejects frames whose payload exceeds
     /// `max_message_size` bytes.
+    #[must_use]
     pub fn new(max_message_size: usize) -> Self {
         Self::with_capacity(READ_CHUNK, max_message_size)
     }
 
+    #[must_use]
     pub fn with_capacity(capacity: usize, max_message_size: usize) -> Self {
         Self {
             buf: BytesMut::with_capacity(capacity),
@@ -227,6 +250,7 @@ impl FrameReader {
 
     /// Bytes currently buffered but not yet consumed.
     #[inline]
+    #[must_use]
     pub fn buffered(&self) -> usize {
         self.buf.len()
     }
@@ -234,6 +258,7 @@ impl FrameReader {
     /// Current allocated capacity of the read buffer. Exposed for diagnostics
     /// and to assert the anti-amplification bound in tests.
     #[inline]
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.buf.capacity()
     }
@@ -245,6 +270,7 @@ impl FrameReader {
     /// Returns `false` on a header that is not yet fully buffered *or* that is
     /// malformed — a malformed header surfaces as an error from `next`.
     #[inline]
+    #[must_use]
     pub fn has_buffered_frame(&self) -> bool {
         matches!(self.frame_len(), Ok(Some(frame_len)) if self.buf.len() >= frame_len)
     }
@@ -254,6 +280,10 @@ impl FrameReader {
     /// if the header is not yet complete; `Err` if the length is invalid or
     /// exceeds `max_message_size`.
     #[inline]
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "len is checked >= 4 before the usize casts, so both are non-negative"
+    )]
     fn frame_len(&self) -> Result<Option<usize>> {
         if self.buf.len() < 5 {
             return Ok(None);
@@ -314,8 +344,12 @@ impl FrameReader {
 
     /// Read the next complete backend message.
     ///
-    /// Cancellation-safe — see the type-level docs. Returns an `UnexpectedEof`
-    /// I/O error if the peer closes the stream mid-message.
+    /// Cancellation-safe — see the type-level docs.
+    ///
+    /// # Errors
+    /// Returns [`PgWireError::Io`] (`UnexpectedEof`) if the peer closes the
+    /// stream mid-message, or [`PgWireError::Protocol`] if a framed length is
+    /// invalid or exceeds `max_message_size`.
     pub async fn next<R: AsyncRead + Unpin>(&mut self, rd: &mut R) -> Result<BackendMessage> {
         loop {
             if let Some(msg) = self.try_decode()? {
@@ -337,6 +371,14 @@ impl FrameReader {
 ///
 /// **Not** cancellation-safe — see [`MessageReader`] for a cancel-safe
 /// alternative used in the streaming loop.
+///
+/// # Errors
+/// Returns [`PgWireError::Io`] on a read failure or EOF, or
+/// [`PgWireError::Protocol`] if the framed length is invalid or oversized.
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "len is checked >= 4 above, so len - 4 is non-negative"
+)]
 pub async fn read_backend_message_into<R: AsyncRead + Unpin>(
     rd: &mut R,
     buf: &mut BytesMut,
@@ -369,15 +411,28 @@ pub async fn read_backend_message_into<R: AsyncRead + Unpin>(
     })
 }
 
+/// Send an `SSLRequest` packet.
+///
+/// # Errors
+/// Returns [`PgWireError::Io`] if the write or flush fails.
 pub async fn write_ssl_request<W: AsyncWrite + Unpin>(wr: &mut W) -> Result<()> {
     let mut buf = [0u8; 8];
     buf[0..4].copy_from_slice(&(8i32).to_be_bytes());
-    buf[4..8].copy_from_slice(&(80877103i32).to_be_bytes());
+    buf[4..8].copy_from_slice(&(80_877_103i32).to_be_bytes());
     wr.write_all(&buf).await?;
     wr.flush().await?;
     Ok(())
 }
 
+/// Send a `StartupMessage` with the given protocol version and parameters.
+///
+/// # Errors
+/// Returns [`PgWireError::Io`] if the write or flush fails.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    reason = "startup message length is bounded well below i32::MAX"
+)]
 pub async fn write_startup_message<W: AsyncWrite + Unpin>(
     wr: &mut W,
     protocol_version: i32,
@@ -403,6 +458,15 @@ pub async fn write_startup_message<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
+/// Send a simple Query message.
+///
+/// # Errors
+/// Returns [`PgWireError::Io`] if the write or flush fails.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    reason = "query message length is bounded well below i32::MAX"
+)]
 pub async fn write_query<W: AsyncWrite + Unpin>(wr: &mut W, sql: &str) -> Result<()> {
     let mut buf = BytesMut::with_capacity(sql.len() + 64);
     buf.put_u8(b'Q');
@@ -418,6 +482,15 @@ pub async fn write_query<W: AsyncWrite + Unpin>(wr: &mut W, sql: &str) -> Result
     Ok(())
 }
 
+/// Send a `PasswordMessage` (or SASL response) carrying `payload`.
+///
+/// # Errors
+/// Returns [`PgWireError::Io`] if the write or flush fails.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    reason = "password/SASL message length is bounded well below i32::MAX"
+)]
 pub async fn write_password_message<W: AsyncWrite + Unpin>(
     wr: &mut W,
     payload: &[u8],
@@ -435,6 +508,15 @@ pub async fn write_password_message<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
+/// Send a `CopyData` message carrying `payload` (e.g. a standby status update).
+///
+/// # Errors
+/// Returns [`PgWireError::Io`] if the write or flush fails.
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    reason = "CopyData message length is bounded well below i32::MAX"
+)]
 pub async fn write_copy_data<W: AsyncWrite + Unpin>(wr: &mut W, payload: &[u8]) -> Result<()> {
     let mut buf = BytesMut::with_capacity(payload.len() + 16);
     buf.put_u8(b'd');
@@ -449,6 +531,10 @@ pub async fn write_copy_data<W: AsyncWrite + Unpin>(wr: &mut W, payload: &[u8]) 
     Ok(())
 }
 
+/// Send a `CopyDone` message.
+///
+/// # Errors
+/// Returns [`PgWireError::Io`] if the write or flush fails.
 pub async fn write_copy_done<W: AsyncWrite + Unpin>(wr: &mut W) -> Result<()> {
     let mut buf = BytesMut::with_capacity(5);
     buf.put_u8(b'c'); // CopyDone
@@ -459,6 +545,13 @@ pub async fn write_copy_done<W: AsyncWrite + Unpin>(wr: &mut W) -> Result<()> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::unreadable_literal,
+    reason = "test wire-frame builders use small, known constants and hex byte vectors"
+)]
 mod tests {
     use super::*;
     use std::io::Cursor;
@@ -470,7 +563,9 @@ mod tests {
         let data = [b'Z', 0, 0, 0, 5, b'I'];
         let mut cursor = Cursor::new(&data[..]);
 
-        let msg = read_backend_message(&mut cursor).await.unwrap();
+        let msg = read_backend_message(&mut cursor)
+            .await
+            .expect("should succeed");
         assert_eq!(msg.tag, b'Z');
         assert_eq!(&msg.payload[..], b"I");
         assert!(msg.is_ready_for_query());
@@ -482,7 +577,9 @@ mod tests {
         let data = [b'N', 0, 0, 0, 4];
         let mut cursor = Cursor::new(&data[..]);
 
-        let msg = read_backend_message(&mut cursor).await.unwrap();
+        let msg = read_backend_message(&mut cursor)
+            .await
+            .expect("should succeed");
         assert_eq!(msg.tag, b'N');
         assert!(msg.payload.is_empty());
     }
@@ -493,7 +590,9 @@ mod tests {
         let data = [b'Z', 0, 0, 0, 3];
         let mut cursor = Cursor::new(&data[..]);
 
-        let err = read_backend_message(&mut cursor).await.unwrap_err();
+        let err = read_backend_message(&mut cursor)
+            .await
+            .expect_err("should error");
         assert!(err.to_string().contains("invalid backend message length"));
     }
 
@@ -504,7 +603,7 @@ mod tests {
         let mut cursor = Cursor::new(&data[..]);
 
         let mut reader = MessageReader::new();
-        let msg = reader.read(&mut cursor).await.unwrap();
+        let msg = reader.read(&mut cursor).await.expect("should succeed");
         assert_eq!(msg.tag, b'Z');
         assert_eq!(&msg.payload[..], b"I");
     }
@@ -517,11 +616,11 @@ mod tests {
 
         let mut reader = MessageReader::new();
 
-        let m1 = reader.read(&mut cursor).await.unwrap();
+        let m1 = reader.read(&mut cursor).await.expect("should succeed");
         assert_eq!(m1.tag, b'Z');
         assert_eq!(&m1.payload[..], b"I");
 
-        let m2 = reader.read(&mut cursor).await.unwrap();
+        let m2 = reader.read(&mut cursor).await.expect("should succeed");
         assert_eq!(m2.tag, b'N');
         assert!(m2.payload.is_empty());
     }
@@ -544,7 +643,10 @@ mod tests {
         let payload = b"abcd";
 
         // Deliver only the first 3 header bytes, then cancel.
-        writer.write_all(&header[..3]).await.unwrap();
+        writer
+            .write_all(&header[..3])
+            .await
+            .expect("should succeed");
 
         let timed_out =
             tokio::time::timeout(std::time::Duration::from_millis(20), reader.read(&mut rd)).await;
@@ -555,10 +657,13 @@ mod tests {
 
         // Deliver the remaining bytes. A correct cancel-safe reader resumes
         // and returns the original message intact.
-        writer.write_all(&header[3..]).await.unwrap();
-        writer.write_all(payload).await.unwrap();
+        writer
+            .write_all(&header[3..])
+            .await
+            .expect("should succeed");
+        writer.write_all(payload).await.expect("should succeed");
 
-        let msg = reader.read(&mut rd).await.unwrap();
+        let msg = reader.read(&mut rd).await.expect("should succeed");
         assert_eq!(msg.tag, b'd');
         assert_eq!(&msg.payload[..], payload);
     }
@@ -581,8 +686,11 @@ mod tests {
         ];
 
         // Full header + first 5 bytes of payload, then cancel.
-        writer.write_all(&header).await.unwrap();
-        writer.write_all(&payload[..5]).await.unwrap();
+        writer.write_all(&header).await.expect("should succeed");
+        writer
+            .write_all(&payload[..5])
+            .await
+            .expect("should succeed");
 
         let timed_out =
             tokio::time::timeout(std::time::Duration::from_millis(20), reader.read(&mut rd)).await;
@@ -592,9 +700,12 @@ mod tests {
         );
 
         // Deliver the rest.
-        writer.write_all(&payload[5..]).await.unwrap();
+        writer
+            .write_all(&payload[5..])
+            .await
+            .expect("should succeed");
 
-        let msg = reader.read(&mut rd).await.unwrap();
+        let msg = reader.read(&mut rd).await.expect("should succeed");
         assert_eq!(msg.tag, b'd');
         assert_eq!(&msg.payload[..], &payload[..]);
     }
@@ -605,7 +716,7 @@ mod tests {
         let mut cursor = Cursor::new(&data[..]);
 
         let mut reader = MessageReader::new();
-        let err = reader.read(&mut cursor).await.unwrap_err();
+        let err = reader.read(&mut cursor).await.expect_err("should error");
         assert!(err.to_string().contains("invalid backend message length"));
     }
 
@@ -622,14 +733,16 @@ mod tests {
         ];
         let mut cursor = Cursor::new(&data[..]);
 
-        let err = read_backend_message(&mut cursor).await.unwrap_err();
+        let err = read_backend_message(&mut cursor)
+            .await
+            .expect_err("should error");
         assert!(err.to_string().contains("too large"));
     }
 
     #[tokio::test]
     async fn write_ssl_request_produces_valid_bytes() {
         let mut buf = Vec::new();
-        write_ssl_request(&mut buf).await.unwrap();
+        write_ssl_request(&mut buf).await.expect("should succeed");
 
         assert_eq!(buf.len(), 8);
         // length = 8
@@ -644,7 +757,7 @@ mod tests {
         let params = [("user", "postgres"), ("database", "test")];
         write_startup_message(&mut buf, 196608, &params)
             .await
-            .unwrap();
+            .expect("should succeed");
 
         // Should contain the parameter strings
         let s = String::from_utf8_lossy(&buf);
@@ -661,7 +774,9 @@ mod tests {
     #[tokio::test]
     async fn write_query_produces_valid_message() {
         let mut buf = Vec::new();
-        write_query(&mut buf, "SELECT 1").await.unwrap();
+        write_query(&mut buf, "SELECT 1")
+            .await
+            .expect("should succeed");
 
         // Should start with 'Q'
         assert_eq!(buf[0], b'Q');
@@ -680,7 +795,9 @@ mod tests {
     #[tokio::test]
     async fn write_password_message_produces_valid_message() {
         let mut buf = Vec::new();
-        write_password_message(&mut buf, b"secret").await.unwrap();
+        write_password_message(&mut buf, b"secret")
+            .await
+            .expect("should succeed");
 
         assert_eq!(buf[0], b'p');
         let len = i32::from_be_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
@@ -691,7 +808,9 @@ mod tests {
     #[tokio::test]
     async fn write_copy_data_produces_valid_message() {
         let mut buf = Vec::new();
-        write_copy_data(&mut buf, b"payload").await.unwrap();
+        write_copy_data(&mut buf, b"payload")
+            .await
+            .expect("should succeed");
 
         assert_eq!(buf[0], b'd');
         let len = i32::from_be_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
@@ -702,7 +821,7 @@ mod tests {
     #[tokio::test]
     async fn write_copy_done_produces_valid_message() {
         let mut buf = Vec::new();
-        write_copy_done(&mut buf).await.unwrap();
+        write_copy_done(&mut buf).await.expect("should succeed");
 
         assert_eq!(buf.len(), 5);
         assert_eq!(buf[0], b'c');
@@ -729,7 +848,7 @@ mod tests {
         let data = [b'Z', 0, 0, 0, 5, b'I'];
         let mut cursor = Cursor::new(&data[..]);
         let mut reader = FrameReader::new(TEST_MAX);
-        let msg = reader.next(&mut cursor).await.unwrap();
+        let msg = reader.next(&mut cursor).await.expect("should succeed");
         assert_eq!(msg.tag, b'Z');
         assert_eq!(&msg.payload[..], b"I");
     }
@@ -742,18 +861,18 @@ mod tests {
         let mut cursor = Cursor::new(data.as_slice());
         let mut reader = FrameReader::new(TEST_MAX);
 
-        let m1 = reader.next(&mut cursor).await.unwrap();
+        let m1 = reader.next(&mut cursor).await.expect("should succeed");
         assert_eq!(m1.tag, b'Z');
         assert_eq!(&m1.payload[..], b"I");
         // With a single buffered read, the following frames must already be
         // available without another socket read.
         assert!(reader.has_buffered_frame());
 
-        let m2 = reader.next(&mut cursor).await.unwrap();
+        let m2 = reader.next(&mut cursor).await.expect("should succeed");
         assert_eq!(m2.tag, b'N');
         assert!(m2.payload.is_empty());
 
-        let m3 = reader.next(&mut cursor).await.unwrap();
+        let m3 = reader.next(&mut cursor).await.expect("should succeed");
         assert_eq!(m3.tag, b'd');
         assert_eq!(&m3.payload[..], b"copydata");
     }
@@ -766,7 +885,7 @@ mod tests {
         let mut reader = FrameReader::new(TEST_MAX);
 
         let frame = wire_frame(b'd', b"abcd");
-        writer.write_all(&frame[..3]).await.unwrap();
+        writer.write_all(&frame[..3]).await.expect("should succeed");
 
         let timed_out =
             tokio::time::timeout(std::time::Duration::from_millis(20), reader.next(&mut rd)).await;
@@ -775,8 +894,8 @@ mod tests {
             "must time out awaiting remaining header"
         );
 
-        writer.write_all(&frame[3..]).await.unwrap();
-        let msg = reader.next(&mut rd).await.unwrap();
+        writer.write_all(&frame[3..]).await.expect("should succeed");
+        let msg = reader.next(&mut rd).await.expect("should succeed");
         assert_eq!(msg.tag, b'd');
         assert_eq!(&msg.payload[..], b"abcd");
     }
@@ -789,7 +908,7 @@ mod tests {
 
         let payload: [u8; 16] = std::array::from_fn(|i| i as u8);
         let frame = wire_frame(b'd', &payload);
-        writer.write_all(&frame[..9]).await.unwrap(); // header + 4 payload bytes
+        writer.write_all(&frame[..9]).await.expect("should succeed"); // header + 4 payload bytes
 
         let timed_out =
             tokio::time::timeout(std::time::Duration::from_millis(20), reader.next(&mut rd)).await;
@@ -798,8 +917,8 @@ mod tests {
             "must time out awaiting remaining payload"
         );
 
-        writer.write_all(&frame[9..]).await.unwrap();
-        let msg = reader.next(&mut rd).await.unwrap();
+        writer.write_all(&frame[9..]).await.expect("should succeed");
+        let msg = reader.next(&mut rd).await.expect("should succeed");
         assert_eq!(msg.tag, b'd');
         assert_eq!(&msg.payload[..], &payload[..]);
     }
@@ -809,7 +928,7 @@ mod tests {
         let data = [b'Z', 0, 0, 0, 3]; // len < 4
         let mut cursor = Cursor::new(&data[..]);
         let mut reader = FrameReader::new(TEST_MAX);
-        let err = reader.next(&mut cursor).await.unwrap_err();
+        let err = reader.next(&mut cursor).await.expect_err("should error");
         assert!(err.to_string().contains("invalid backend message length"));
     }
 
@@ -819,7 +938,7 @@ mod tests {
         let header = wire_frame(b'd', &vec![0u8; 1000]);
         let mut cursor = Cursor::new(header.as_slice());
         let mut reader = FrameReader::new(100);
-        let err = reader.next(&mut cursor).await.unwrap_err();
+        let err = reader.next(&mut cursor).await.expect_err("should error");
         assert!(err.to_string().contains("too large"));
     }
 
@@ -832,7 +951,7 @@ mod tests {
         // many reads + geometric growth for one message.
         let mut cursor = Cursor::new(frame.as_slice());
         let mut reader = FrameReader::new(TEST_MAX);
-        let msg = reader.next(&mut cursor).await.unwrap();
+        let msg = reader.next(&mut cursor).await.expect("should succeed");
         assert_eq!(msg.tag, b'd');
         assert_eq!(msg.payload.len(), payload.len());
         assert_eq!(&msg.payload[..], &payload[..]);
@@ -853,7 +972,7 @@ mod tests {
         header.push(b'd');
         header.extend_from_slice(&len.to_be_bytes());
         header.extend_from_slice(&[0u8; 8]);
-        writer.write_all(&header).await.unwrap();
+        writer.write_all(&header).await.expect("should succeed");
 
         // The frame never completes, so `next` stays pending.
         let timed_out =

--- a/crates/vendor/pgwire-replication/src/protocol/messages.rs
+++ b/crates/vendor/pgwire-replication/src/protocol/messages.rs
@@ -2,7 +2,7 @@ use bytes::Buf;
 
 use crate::error::{PgWireError, Result};
 
-/// Parsed PostgreSQL error/notice response fields
+/// Parsed `PostgreSQL` error/notice response fields
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ErrorFields {
     pub severity: Option<String>,
@@ -24,6 +24,7 @@ pub struct ErrorFields {
 
 impl ErrorFields {
     /// Parse error fields from payload bytes
+    #[must_use]
     pub fn parse(payload: &[u8]) -> Self {
         let mut fields = ErrorFields::default();
         let mut b = payload;
@@ -64,6 +65,7 @@ impl ErrorFields {
     }
 
     /// Format as a human-readable error string
+    #[must_use]
     pub fn to_error_string(&self) -> String {
         match (&self.message, &self.code) {
             (Some(m), Some(c)) => format!("{m} (SQLSTATE {c})"),
@@ -74,23 +76,28 @@ impl ErrorFields {
     }
 }
 
-/// Parse an ErrorResponse payload into a human-readable string.
+/// Parse an `ErrorResponse` payload into a human-readable string.
 ///
 /// For more detailed error information, use `ErrorFields::parse()` instead.
+#[must_use]
 pub fn parse_error_response(payload: &[u8]) -> String {
     ErrorFields::parse(payload).to_error_string()
 }
 
-/// Parse an AuthenticationRequest payload.
+/// Parse an `AuthenticationRequest` payload.
 ///
-/// Returns (auth_type, remaining_data).
+/// Returns (`auth_type`, `remaining_data`).
 /// Auth types:
-/// - 0 = AuthenticationOk
-/// - 3 = AuthenticationCleartextPassword
-/// - 5 = AuthenticationMD5Password (data contains 4-byte salt)
-/// - 10 = AuthenticationSASL (data contains mechanism names)
-/// - 11 = AuthenticationSASLContinue
-/// - 12 = AuthenticationSASLFinal
+/// - 0 = `AuthenticationOk`
+/// - 3 = `AuthenticationCleartextPassword`
+/// - 5 = `AuthenticationMD5Password` (data contains 4-byte salt)
+/// - 10 = `AuthenticationSASL` (data contains mechanism names)
+/// - 11 = `AuthenticationSASLContinue`
+/// - 12 = `AuthenticationSASLFinal`
+///
+/// # Errors
+/// Returns [`PgWireError::Protocol`] if the payload is shorter than the 4-byte
+/// authentication type field.
 pub fn parse_auth_request(payload: &[u8]) -> Result<(i32, &[u8])> {
     if payload.len() < 4 {
         return Err(PgWireError::Protocol("auth request too short".into()));
@@ -206,7 +213,7 @@ mod tests {
     #[test]
     fn parse_auth_request_ok() {
         let payload = [0, 0, 0, 0]; // auth type 0 = OK
-        let (code, rest) = parse_auth_request(&payload).unwrap();
+        let (code, rest) = parse_auth_request(&payload).expect("should succeed");
         assert_eq!(code, auth::OK);
         assert!(rest.is_empty());
     }
@@ -217,7 +224,7 @@ mod tests {
         payload.extend_from_slice(&5i32.to_be_bytes()); // MD5
         payload.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]); // salt
 
-        let (code, salt) = parse_auth_request(&payload).unwrap();
+        let (code, salt) = parse_auth_request(&payload).expect("should succeed");
         assert_eq!(code, auth::MD5_PASSWORD);
         assert_eq!(salt, &[0xDE, 0xAD, 0xBE, 0xEF]);
     }
@@ -230,7 +237,7 @@ mod tests {
         payload.extend_from_slice(b"SCRAM-SHA-256-PLUS\0");
         payload.push(0); // terminator
 
-        let (code, mechanisms) = parse_auth_request(&payload).unwrap();
+        let (code, mechanisms) = parse_auth_request(&payload).expect("should succeed");
         assert_eq!(code, auth::SASL);
         assert!(mechanisms.starts_with(b"SCRAM-SHA-256"));
     }
@@ -238,7 +245,7 @@ mod tests {
     #[test]
     fn parse_auth_request_rejects_short_payload() {
         let payload = [0, 0, 0]; // only 3 bytes
-        let err = parse_auth_request(&payload).unwrap_err();
+        let err = parse_auth_request(&payload).expect_err("should error");
         assert!(err.to_string().contains("too short"));
     }
 

--- a/crates/vendor/pgwire-replication/src/protocol/mod.rs
+++ b/crates/vendor/pgwire-replication/src/protocol/mod.rs
@@ -1,13 +1,13 @@
-//! PostgreSQL wire protocol implementation.
+//! `PostgreSQL` wire protocol implementation.
 //!
 //! This module provides low-level primitives for:
-//! - Reading and writing PostgreSQL frontend/backend messages ([`framing`])
+//! - Reading and writing `PostgreSQL` frontend/backend messages ([`framing`])
 //! - Parsing authentication and error responses ([`messages`])
 //! - Handling streaming replication protocol messages ([`replication`])
 //!
 //! # Wire Protocol Overview
 //!
-//! PostgreSQL uses a message-based protocol where each message consists of:
+//! `PostgreSQL` uses a message-based protocol where each message consists of:
 //! - 1 byte: message type tag
 //! - 4 bytes: message length (including these 4 bytes)
 //! - N bytes: message payload
@@ -16,7 +16,7 @@
 //!
 //! # Replication Protocol
 //!
-//! During logical replication, the server sends CopyData messages containing
+//! During logical replication, the server sends `CopyData` messages containing
 //! either `XLogData` (WAL changes) or `KeepAlive` (heartbeats). The client
 //! responds with `StandbyStatusUpdate` messages to report replay progress.
 

--- a/crates/vendor/pgwire-replication/src/protocol/replication.rs
+++ b/crates/vendor/pgwire-replication/src/protocol/replication.rs
@@ -3,9 +3,9 @@ use bytes::{Buf, Bytes};
 use crate::error::{PgWireError, Result};
 use crate::lsn::Lsn;
 
-/// Replication protocol CopyData message types.
+/// Replication protocol `CopyData` message types.
 ///
-/// During logical replication streaming, PostgreSQL sends data wrapped in CopyData
+/// During logical replication streaming, `PostgreSQL` sends data wrapped in `CopyData`
 /// messages. This enum represents the two primary message types:
 /// - `XLogData`: Contains actual WAL data (transaction changes)
 /// - `KeepAlive`: Server heartbeat, optionally requesting client response
@@ -28,25 +28,25 @@ pub enum ReplicationCopyData {
         wal_end: Lsn,
         /// Server timestamp in microseconds since 2000-01-01
         server_time_micros: i64,
-        /// If true, server expects StandbyStatusUpdate reply
+        /// If true, server expects `StandbyStatusUpdate` reply
         reply_requested: bool,
     },
 }
 
 impl ReplicationCopyData {
-    /// Returns true if this is an XLogData message
+    /// Returns true if this is an `XLogData` message
     #[inline]
     pub fn is_xlog_data(&self) -> bool {
         matches!(self, ReplicationCopyData::XLogData { .. })
     }
 
-    /// Returns true if this is a KeepAlive message
+    /// Returns true if this is a `KeepAlive` message
     #[inline]
     pub fn is_keepalive(&self) -> bool {
         matches!(self, ReplicationCopyData::KeepAlive { .. })
     }
 
-    /// Returns true if this is a KeepAlive that requests a reply
+    /// Returns true if this is a `KeepAlive` that requests a reply
     #[inline]
     pub fn requires_reply(&self) -> bool {
         matches!(
@@ -59,10 +59,18 @@ impl ReplicationCopyData {
     }
 }
 
-/// Parse a CopyData payload into a replication message.
+/// Parse a `CopyData` payload into a replication message.
 ///
-/// The payload should be the CopyData content (after stripping the 'd' tag and length).
+/// The payload should be the `CopyData` content (after stripping the 'd' tag and length).
 /// Returns either `XLogData` or `KeepAlive` depending on the first byte.
+///
+/// # Errors
+/// Returns [`PgWireError::Protocol`] if the payload is empty, too short for its
+/// kind, or has an unrecognized `CopyData` kind byte.
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "an LSN is a u64 carried as i64 on the wire; the cast is bit-preserving"
+)]
 pub fn parse_copy_data(payload: Bytes) -> Result<ReplicationCopyData> {
     if payload.is_empty() {
         return Err(PgWireError::Protocol("empty CopyData payload".into()));
@@ -117,7 +125,7 @@ pub fn parse_copy_data(payload: Bytes) -> Result<ReplicationCopyData> {
     }
 }
 
-/// Encode a StandbyStatusUpdate message.
+/// Encode a `StandbyStatusUpdate` message.
 ///
 /// This message reports the client's replay position to the server.
 /// All three LSN fields (write, flush, apply) are set to the same value.
@@ -128,7 +136,12 @@ pub fn parse_copy_data(payload: Bytes) -> Result<ReplicationCopyData> {
 /// * `reply_requested` - If true, server should send a reply (usually false)
 ///
 /// # Returns
-/// Raw bytes suitable for sending via CopyData
+/// Raw bytes suitable for sending via `CopyData`
+#[must_use]
+#[expect(
+    clippy::cast_possible_wrap,
+    reason = "an LSN is a u64 sent as i64 on the wire; the cast is bit-preserving"
+)]
 pub fn encode_standby_status_update(
     applied: Lsn,
     client_time_micros: i64,
@@ -147,27 +160,35 @@ pub fn encode_standby_status_update(
     // Client system clock
     out.extend_from_slice(&client_time_micros.to_be_bytes());
     // Reply requested
-    out.push(if reply_requested { 1 } else { 0 });
+    out.push(u8::from(reply_requested));
 
     out
 }
 
-/// PostgreSQL epoch (2000-01-01) in microseconds since Unix epoch.
+/// `PostgreSQL` epoch (2000-01-01) in microseconds since Unix epoch.
 pub const PG_EPOCH_MICROS: i64 = 946_684_800_000_000;
 
-/// Convert Unix timestamp (micros) to PostgreSQL timestamp (micros since 2000-01-01).
+/// Convert Unix timestamp (micros) to `PostgreSQL` timestamp (micros since 2000-01-01).
 #[inline]
+#[must_use]
 pub fn unix_to_pg_timestamp(unix_micros: i64) -> i64 {
     unix_micros - PG_EPOCH_MICROS
 }
 
-/// Convert PostgreSQL timestamp to Unix timestamp (micros).
+/// Convert `PostgreSQL` timestamp to Unix timestamp (micros).
 #[inline]
+#[must_use]
 pub fn pg_to_unix_timestamp(pg_micros: i64) -> i64 {
     pg_micros + PG_EPOCH_MICROS
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::unreadable_literal,
+    clippy::match_wildcard_for_single_variants,
+    reason = "test vectors use hex byte constants; the wildcard arms are panics on the \
+              other CopyData variant, exhaustive by test construction"
+)]
 mod tests {
     use super::*;
 
@@ -182,7 +203,7 @@ mod tests {
         v.extend_from_slice(&3i64.to_be_bytes()); // server_time
                                                   // no data payload
 
-        let msg = parse_copy_data(Bytes::from(v)).unwrap();
+        let msg = parse_copy_data(Bytes::from(v)).expect("should succeed");
         match msg {
             ReplicationCopyData::XLogData {
                 wal_start,
@@ -208,7 +229,7 @@ mod tests {
         v.extend_from_slice(&(-12345i64).to_be_bytes());
         v.extend_from_slice(b"hello world pgoutput data");
 
-        let msg = parse_copy_data(Bytes::from(v)).unwrap();
+        let msg = parse_copy_data(Bytes::from(v)).expect("should succeed");
         match msg {
             ReplicationCopyData::XLogData {
                 wal_start,
@@ -231,7 +252,7 @@ mod tests {
         v.push(b'w');
         v.extend_from_slice(&[0u8; 23]); // only 23 bytes, need 24
 
-        let err = parse_copy_data(Bytes::from(v)).unwrap_err();
+        let err = parse_copy_data(Bytes::from(v)).expect_err("should error");
         assert!(err.to_string().contains("XLogData"));
         assert!(err.to_string().contains("too short"));
     }
@@ -246,7 +267,7 @@ mod tests {
         v.extend_from_slice(&200i64.to_be_bytes()); // server_time
         v.push(1); // reply_requested = true
 
-        let msg = parse_copy_data(Bytes::from(v)).unwrap();
+        let msg = parse_copy_data(Bytes::from(v)).expect("should succeed");
         match msg {
             ReplicationCopyData::KeepAlive {
                 wal_end,
@@ -269,7 +290,7 @@ mod tests {
         v.extend_from_slice(&888i64.to_be_bytes());
         v.push(0); // reply_requested = false
 
-        let msg = parse_copy_data(Bytes::from(v)).unwrap();
+        let msg = parse_copy_data(Bytes::from(v)).expect("should succeed");
         match msg {
             ReplicationCopyData::KeepAlive {
                 reply_requested, ..
@@ -289,7 +310,7 @@ mod tests {
         v.extend_from_slice(&0i64.to_be_bytes());
         v.push(42); // non-zero = true
 
-        let msg = parse_copy_data(Bytes::from(v)).unwrap();
+        let msg = parse_copy_data(Bytes::from(v)).expect("should succeed");
         assert!(matches!(
             msg,
             ReplicationCopyData::KeepAlive {
@@ -305,7 +326,7 @@ mod tests {
         v.push(b'k');
         v.extend_from_slice(&[0u8; 16]); // only 16 bytes, need 17
 
-        let err = parse_copy_data(Bytes::from(v)).unwrap_err();
+        let err = parse_copy_data(Bytes::from(v)).expect_err("should error");
         assert!(err.to_string().contains("KeepAlive"));
         assert!(err.to_string().contains("too short"));
     }
@@ -314,14 +335,14 @@ mod tests {
 
     #[test]
     fn parse_empty_payload() {
-        let err = parse_copy_data(Bytes::new()).unwrap_err();
+        let err = parse_copy_data(Bytes::new()).expect_err("should error");
         assert!(err.to_string().contains("empty"));
     }
 
     #[test]
     fn parse_unknown_kind() {
         let v = vec![b'X', 0, 0, 0]; // unknown kind 'X'
-        let err = parse_copy_data(Bytes::from(v)).unwrap_err();
+        let err = parse_copy_data(Bytes::from(v)).expect_err("should error");
         assert!(err.to_string().contains("unknown CopyData kind"));
         assert!(err.to_string().contains("0x58")); // 'X' in hex
     }

--- a/crates/vendor/pgwire-replication/src/tls/rustls.rs
+++ b/crates/vendor/pgwire-replication/src/tls/rustls.rs
@@ -1,9 +1,9 @@
 //! TLS support using rustls.
 //!
-//! This module provides TLS/SSL connection upgrade for PostgreSQL connections
+//! This module provides TLS/SSL connection upgrade for `PostgreSQL` connections
 //! using the rustls library. It supports:
 //!
-//! - All PostgreSQL SSL modes (disable, prefer, require, verify-ca, verify-full)
+//! - All `PostgreSQL` SSL modes (disable, prefer, require, verify-ca, verify-full)
 //! - Custom CA certificates
 //! - Client certificate authentication (mTLS)
 //! - SNI hostname override
@@ -54,7 +54,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use rustls::{ClientConfig, RootCertStore};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 use tokio_rustls::{client::TlsStream, TlsConnector};
 
@@ -140,8 +140,8 @@ impl AsyncWrite for MaybeTlsStream {
 
 /// Attempt to upgrade a TCP connection to TLS based on configuration.
 ///
-/// This function implements PostgreSQL's SSL negotiation protocol:
-/// 1. Send SSLRequest message
+/// This function implements `PostgreSQL`'s SSL negotiation protocol:
+/// 1. Send `SSLRequest` message
 /// 2. Read single-byte response ('S' = proceed, 'N' = rejected)
 /// 3. If proceeding, perform TLS handshake
 ///
@@ -176,7 +176,6 @@ pub async fn maybe_upgrade_to_tls(
     write_ssl_request(&mut tcp).await?;
 
     let mut resp = [0u8; 1];
-    use tokio::io::AsyncReadExt;
     tcp.read_exact(&mut resp).await?;
 
     if resp[0] != b'S' {
@@ -209,7 +208,7 @@ pub async fn maybe_upgrade_to_tls(
     Ok(MaybeTlsStream::Tls(Box::new(tls_stream)))
 }
 
-/// Build rustls ClientConfig based on TLS settings.
+/// Build rustls `ClientConfig` based on TLS settings.
 fn build_rustls_config(
     tls: &TlsConfig,
     verify_chain: bool,
@@ -243,10 +242,12 @@ fn build_rustls_config(
     let builder = ClientConfig::builder().with_root_certificates(roots);
 
     // ---- Client authentication (mTLS) ----
-    let mut cfg: ClientConfig = if has_cert {
-        let cert_path = tls.client_cert_pem_path.as_ref().unwrap();
-        let key_path = tls.client_key_pem_path.as_ref().unwrap();
-
+    // The XOR check above guarantees cert and key are both set or both unset,
+    // so matching both `Some` is equivalent to the earlier `has_cert` test.
+    let mut cfg: ClientConfig = if let (Some(cert_path), Some(key_path)) = (
+        tls.client_cert_pem_path.as_ref(),
+        tls.client_key_pem_path.as_ref(),
+    ) {
         let cert_chain = load_cert_chain(cert_path)?;
         let key = load_private_key(key_path)?;
 
@@ -497,7 +498,7 @@ mod tests {
             client_key_pem_path: None,
             ..Default::default()
         };
-        let err = build_rustls_config(&tls, false, false, "localhost").unwrap_err();
+        let err = build_rustls_config(&tls, false, false, "localhost").expect_err("should error");
         assert!(err.to_string().contains("mTLS requires both"));
 
         // Key without cert
@@ -506,7 +507,7 @@ mod tests {
             client_key_pem_path: Some("/path/to/key.pem".into()),
             ..Default::default()
         };
-        let err = build_rustls_config(&tls, false, false, "localhost").unwrap_err();
+        let err = build_rustls_config(&tls, false, false, "localhost").expect_err("should error");
         assert!(err.to_string().contains("mTLS requires both"));
     }
 
@@ -521,7 +522,7 @@ mod tests {
         };
 
         // Should fail early: IP address can't match certificate hostname
-        let err = build_rustls_config(&tls, true, true, "192.168.1.1").unwrap_err();
+        let err = build_rustls_config(&tls, true, true, "192.168.1.1").expect_err("should error");
         assert!(err.to_string().contains("IP address"));
     }
 
@@ -538,38 +539,45 @@ mod tests {
             ..Default::default()
         };
 
-        let err = build_root_store(&tls).unwrap_err().to_string();
+        let err = build_root_store(&tls)
+            .expect_err("should error")
+            .to_string();
         assert!(err.contains("failed to open"));
         assert!(err.contains("ca.pem"));
     }
 
     #[test]
     fn empty_ca_file_gives_clear_error() {
-        let f = NamedTempFile::new().unwrap();
+        let f = NamedTempFile::new().expect("should succeed");
         let tls = TlsConfig {
             ca_pem_path: Some(f.path().to_path_buf()),
             ..Default::default()
         };
 
-        let err = build_root_store(&tls).unwrap_err().to_string();
+        let err = build_root_store(&tls)
+            .expect_err("should error")
+            .to_string();
         assert!(err.contains("no valid CA certificates"));
     }
 
     #[test]
     fn empty_key_file_gives_clear_error() {
-        let f = NamedTempFile::new().unwrap();
+        let f = NamedTempFile::new().expect("should succeed");
 
-        let err = load_private_key(f.path()).unwrap_err().to_string();
+        let err = load_private_key(f.path())
+            .expect_err("should error")
+            .to_string();
         assert!(err.contains("failed to load private key"));
     }
 
     #[test]
     fn invalid_pem_gives_clear_error() {
-        let mut f = NamedTempFile::new().unwrap();
-        f.write_all(b"this is not a valid PEM file").unwrap();
+        let mut f = NamedTempFile::new().expect("should succeed");
+        f.write_all(b"this is not a valid PEM file")
+            .expect("should succeed");
 
         // Should fail gracefully, not panic
-        assert!(load_private_key(f.path()).is_err());
-        assert!(load_cert_chain(f.path()).is_err());
+        load_private_key(f.path()).expect_err("should error");
+        load_cert_chain(f.path()).expect_err("should error");
     }
 }


### PR DESCRIPTION
## What

Improves the vendored `pgwire-replication` crate — the Postgres logical-replication (pgoutput) client on the **Cayenne CDC ingest hot path** — with an incremental, zero-copy read path and a bounded message-size guard.

> **Composes with #11653.** That PR (merged) decoupled keepalive/feedback from consumer backpressure via a non-blocking `send_event`. This PR is the orthogonal read-path/efficiency + hardening work it did not touch; it's rebased on top and keeps #11653's `send_event`, `feedback_while_backpressured`, and 5s `status_interval` intact. (An earlier version of this branch also implemented backpressure-safe feedback via a stream split; that was dropped in favor of #11653's merged design.)

### 1. Incremental, zero-copy `FrameReader` (throughput / efficiency)

The streaming loop previously wrapped the socket in a 128 KiB `BufReader` and read each backend message into a freshly **zero-filled** buffer (`BytesMut::resize(len, 0)`). Every WAL byte was copied **twice** in userspace (kernel → `BufReader` → per-message `BytesMut`) and the per-message buffer was `memset` immediately before the socket overwrote it.

`FrameReader` keeps a single growable buffer, fills it with `read_buf` (reads into *uninitialized* spare capacity — **no memset**), and slices complete frames with `split_to` (zero-copy, refcounted views into the shared allocation). It is cancellation-safe by construction (only ever awaits one `read_buf`; a dropped future loses no bytes), so it drops straight into #11653's two-phase drain/wait loop in place of `MessageReader` + `BufReader` — the `stop_rx`/`timeout`/`send_event` structure is unchanged.

Buffer growth is driven by bytes **actually received** (geometric, floored at 128 KiB, capped at the in-flight frame's remaining bytes), so an oversized/bogus length field can no longer force an eager giant allocation.

**Framing microbench** (`benches/protocol_bench.rs`, 256-message batches, `--measurement-time 3`):

| payload size | `MessageReader` (old) | `FrameReader` (new) | speedup |
|---:|---:|---:|---:|
| 64 B  | 4.55 µs | 3.48 µs | **1.31×** |
| 256 B | 5.79 µs | 5.10 µs | **1.14×** |
| 1024 B | 11.11 µs | 7.30 µs | **1.52×** |
| 4096 B | 37.40 µs | 17.64 µs | **2.12×** |

The win grows with message size, where the eliminated `memset` + redundant copy dominate.

### 2. Configurable `max_message_size` (resilience)

`ReplicationConfig::max_message_size` makes the accepted backend-message payload a pre-allocation-checked bound. Defaults to the existing ~1 GiB ceiling so legitimate large-TOAST-row changes are **never rejected** (correctness first); operators can tighten it. The real amplification defense is the incremental growth in (1), not the cap value.

## Tests

New `FrameReader` unit tests (all green; 95 in-crate incl. #11653's backpressure test):
- complete / back-to-back reads, cancellation mid-header & mid-payload, invalid & oversized length rejection, **incremental reassembly of a 2 MiB frame**, and **anti-amplification** (a 900 MiB declared length with only a few bytes sent must not pre-allocate — buffer stays < 4 MiB).

The framing bench adds a `FrameReader` arm alongside the existing `MessageReader` / `read_backend_message_into` comparison.

**Real-Postgres e2e** (`crates/runtime/tests/postgres/`, self-provisioned `wal_level=logical` container, run by `integration.yml` with `--features postgres`) — the WAL→Arrow path runs through `FrameReader`:
- `replication.rs::large_value_and_burst_replicate_intact` — a ~4 MiB row (one WAL frame far larger than a socket read → `FrameReader`'s incremental, geometrically-growing assembly, asserted byte-exact) and a 1000-row single-transaction burst (many frames buffered → the tight drain loop).
- `replication_shared.rs::shared_and_independent_slots_coexist` — a shared-slot group (two members on one slot) **and** an independent-slot dataset streaming in one process against one Postgres simultaneously, asserting both slots coexist and each change routes to the correct stream under concurrent load.

## Notes

- Local patches on top of vendored crates.io 0.3.2 (recorded in `Cargo.toml`); candidates to upstream.
- **The crate is now held to the workspace clippy bar** — its blanket `#![allow(clippy::all, ...)]` and the `--exclude pgwire-replication` from `make lint-rust`/`lint-rust-fix` are removed, and every resulting finding is fixed under the workspace flags (pedantic + `unwrap_used`/`expect_used`/`clone_on_ref_ptr`/… denied). No behavior change: intentional wire-protocol casts are `#[expect(clippy::cast_*, reason=…)]`, lib `unwrap`/`expect` restructured away, test `unwrap`→`expect`; all 95 unit + 16 doc tests pass and clippy is green under the exact CI flags.
- Public API change is limited to the additive `ReplicationConfig::max_message_size` field + `with_max_message_size` builder; `data_components` and the examples keep the default via `..Default::default()`.
- No change to the pgoutput decode boundary — `XLogData` payloads still reach the consumer's `Decoder` as zero-copy `Bytes`.

Follow-ups from the original audit (not in this PR): structured SQLSTATE on `PgWireError::Server` (so retry classification stops string-grepping), handshake/connect timeouts, and TCP keepalive.
