### PR TITLE
fix(postgres_replication): size CDC change-batch builders to the transaction row count

### DIFF
--- a/crates/data_components/src/postgres_replication/bootstrap.rs
+++ b/crates/data_components/src/postgres_replication/bootstrap.rs
@@ -413,7 +413,12 @@ impl BootstrapBuilder {
                 *scale,
             ),
             DataType::List(_) | DataType::Dictionary(_, _) => {
-                Self::TextCast(super::changes::FieldBuilder::new(data_type)?)
+                // Bootstrap builders accumulate up to `bootstrap_batch_size`
+                // rows before finishing; start at Arrow's default capacity (1024)
+                // and let amortized growth cover the rest.
+                Self::TextCast(super::changes::FieldBuilder::with_capacity(
+                    data_type, 1024,
+                )?)
             }
             DataType::LargeList(_) | DataType::FixedSizeList(_, _) => {
                 return PgOutputDecodeSnafu {

--- a/crates/data_components/src/postgres_replication/changes.rs
+++ b/crates/data_components/src/postgres_replication/changes.rs
@@ -217,11 +217,14 @@ pub fn build_change_batch(
     pk_offsets.push(0);
     let mut pk_values: Vec<&str> = Vec::with_capacity(num_rows.saturating_mul(primary_keys.len()));
 
-    // One builder per output field, typed from dataset schema.
+    // One builder per output field, typed from dataset schema. Sized to the
+    // transaction's row count: default-capacity builders reserve 1024 elements
+    // per column, which turns a 1-row change on a wide table into a ~64 KB
+    // allocation and inflates every byte-based CDC accounting downstream.
     let mut data_builders: Vec<FieldBuilder> = dataset_schema
         .fields()
         .iter()
-        .map(|f| FieldBuilder::new(f.data_type()))
+        .map(|f| FieldBuilder::with_capacity(f.data_type(), num_rows))
         .collect::<Result<Vec<_>>>()?;
 
     // Precompute dataset_field_idx → relation_column_idx once per batch so the
@@ -416,31 +419,43 @@ pub(super) enum FieldBuilder {
 }
 
 impl FieldBuilder {
-    pub(super) fn new(data_type: &DataType) -> Result<Self> {
+    /// Create a builder pre-sized for `capacity` values. Arrow's default
+    /// builder constructors reserve 1024 elements per column, so an unsized
+    /// builder makes small CDC batches (often a single row) allocate and
+    /// report orders of magnitude more memory than the payload. String-like
+    /// builders get a modest per-value byte estimate; under-estimates grow
+    /// amortized, so a low guess is cheap.
+    pub(super) fn with_capacity(data_type: &DataType, capacity: usize) -> Result<Self> {
+        // Starting guess for variable-width data buffers (bytes per value).
+        let data_capacity = capacity.saturating_mul(8);
         Ok(match data_type {
-            DataType::Utf8 => Self::Utf8(StringBuilder::new()),
-            DataType::LargeUtf8 => Self::LargeUtf8(LargeStringBuilder::new()),
-            DataType::Binary => Self::Binary(BinaryBuilder::new()),
-            DataType::Boolean => Self::Bool(BooleanBuilder::new()),
-            DataType::Int8 => Self::Int8(Int8Builder::new()),
-            DataType::Int16 => Self::Int16(Int16Builder::new()),
-            DataType::Int32 => Self::Int32(Int32Builder::new()),
-            DataType::Int64 => Self::Int64(Int64Builder::new()),
-            DataType::UInt32 => Self::UInt32(UInt32Builder::new()),
-            DataType::Float32 => Self::Float32(Float32Builder::new()),
-            DataType::Float64 => Self::Float64(Float64Builder::new()),
-            DataType::Date32 => Self::Date32(Date32Builder::new()),
+            DataType::Utf8 => Self::Utf8(StringBuilder::with_capacity(capacity, data_capacity)),
+            DataType::LargeUtf8 => {
+                Self::LargeUtf8(LargeStringBuilder::with_capacity(capacity, data_capacity))
+            }
+            DataType::Binary => Self::Binary(BinaryBuilder::with_capacity(capacity, data_capacity)),
+            DataType::Boolean => Self::Bool(BooleanBuilder::with_capacity(capacity)),
+            DataType::Int8 => Self::Int8(Int8Builder::with_capacity(capacity)),
+            DataType::Int16 => Self::Int16(Int16Builder::with_capacity(capacity)),
+            DataType::Int32 => Self::Int32(Int32Builder::with_capacity(capacity)),
+            DataType::Int64 => Self::Int64(Int64Builder::with_capacity(capacity)),
+            DataType::UInt32 => Self::UInt32(UInt32Builder::with_capacity(capacity)),
+            DataType::Float32 => Self::Float32(Float32Builder::with_capacity(capacity)),
+            DataType::Float64 => Self::Float64(Float64Builder::with_capacity(capacity)),
+            DataType::Date32 => Self::Date32(Date32Builder::with_capacity(capacity)),
             DataType::Time64(TimeUnit::Nanosecond) => {
-                Self::Time64Nanos(Time64NanosecondBuilder::new())
+                Self::Time64Nanos(Time64NanosecondBuilder::with_capacity(capacity))
             }
-            DataType::Timestamp(TimeUnit::Microsecond, tz) => {
-                Self::TimestampMicros(TimestampMicrosecondBuilder::new(), tz.clone())
-            }
-            DataType::Timestamp(TimeUnit::Nanosecond, tz) => {
-                Self::TimestampNanos(TimestampNanosecondBuilder::new(), tz.clone())
-            }
+            DataType::Timestamp(TimeUnit::Microsecond, tz) => Self::TimestampMicros(
+                TimestampMicrosecondBuilder::with_capacity(capacity),
+                tz.clone(),
+            ),
+            DataType::Timestamp(TimeUnit::Nanosecond, tz) => Self::TimestampNanos(
+                TimestampNanosecondBuilder::with_capacity(capacity),
+                tz.clone(),
+            ),
             DataType::Decimal128(precision, scale) => Self::Decimal128(
-                Decimal128Builder::new().with_data_type(data_type.clone()),
+                Decimal128Builder::with_capacity(capacity).with_data_type(data_type.clone()),
                 *precision,
                 *scale,
             ),
@@ -458,11 +473,15 @@ impl FieldBuilder {
                     }
                     .fail();
                 }
+                let mut offsets = Vec::with_capacity(capacity.saturating_add(1));
+                offsets.push(0);
                 Self::List {
                     item_field: Arc::clone(item_field),
-                    inner: Box::new(Self::new(item_field.data_type())?),
-                    offsets: vec![0],
-                    validity: Vec::new(),
+                    // Element count per list is unknown; one element per row
+                    // is a floor the inner builder grows past as needed.
+                    inner: Box::new(Self::with_capacity(item_field.data_type(), capacity)?),
+                    offsets,
+                    validity: Vec::with_capacity(capacity),
                 }
             }
             DataType::LargeList(_) | DataType::FixedSizeList(_, _) => {
@@ -476,10 +495,18 @@ impl FieldBuilder {
                 .fail();
             }
             // The Postgres provider maps ENUM columns to Dictionary(Int8, Utf8).
+            // Keys are sized to the row count; the values side holds only the
+            // distinct ENUM labels, which are few — start small and grow.
             DataType::Dictionary(key, value) if **value == DataType::Utf8 => match **key {
-                DataType::Int8 => Self::DictUtf8Int8(StringDictionaryBuilder::new()),
-                DataType::Int16 => Self::DictUtf8Int16(StringDictionaryBuilder::new()),
-                DataType::Int32 => Self::DictUtf8Int32(StringDictionaryBuilder::new()),
+                DataType::Int8 => {
+                    Self::DictUtf8Int8(StringDictionaryBuilder::with_capacity(capacity, 8, 128))
+                }
+                DataType::Int16 => {
+                    Self::DictUtf8Int16(StringDictionaryBuilder::with_capacity(capacity, 8, 128))
+                }
+                DataType::Int32 => {
+                    Self::DictUtf8Int32(StringDictionaryBuilder::with_capacity(capacity, 8, 128))
+                }
                 ref other => {
                     return PgOutputDecodeSnafu {
                         message: format!(
@@ -1207,6 +1234,60 @@ mod tests {
         assert!(name_col.is_null(1));
     }
 
+    #[test]
+    fn build_change_batch_memory_sized_to_row_count() {
+        // Regression guard: the data-struct builders must be sized to the
+        // transaction's row count. Default-capacity Arrow builders reserve
+        // 1024 elements per column, so a 1-row change on a wide schema both
+        // allocated and reported ~100 KB from `get_array_memory_size()`,
+        // inflating the CDC coalescer's byte budget and the Cayenne mem-tier
+        // accounting by orders of magnitude.
+        let mut fields = vec![Field::new("id", DataType::Int32, false)];
+        let mut columns = vec![PgColumn {
+            is_key: true,
+            name: "id".into(),
+            type_oid: 23,
+            type_modifier: -1,
+        }];
+        for i in 0..12 {
+            let name = format!("v{i}");
+            fields.push(Field::new(&name, DataType::Int64, true));
+            columns.push(PgColumn {
+                is_key: false,
+                name,
+                type_oid: 20,
+                type_modifier: -1,
+            });
+        }
+        let schema: SchemaRef = Arc::new(Schema::new(fields));
+        let relation = Relation {
+            relation_id: 1,
+            namespace: "public".to_string(),
+            name: "wide".to_string(),
+            replica_identity: b'd',
+            columns,
+        };
+        let row = TupleData {
+            columns: (0..13)
+                .map(|i| Some(PgValue::Text(i.to_string())))
+                .collect(),
+        };
+        let changes = vec![DecodedChange {
+            op: ChangeOp::Create,
+            row,
+        }];
+
+        let batch = build_change_batch(&schema, &relation, &changes).expect("build batch");
+        assert_eq!(batch.record.num_rows(), 1);
+        let size = batch.record.get_array_memory_size();
+        assert!(
+            size < 16 * 1024,
+            "1-row change batch reports {size} bytes; data builders are likely \
+             no longer sized to num_rows (default-capacity Arrow builders \
+             reserve 1024 elements per column)"
+        );
+    }
+
     #[tokio::test]
     async fn lsn_committer_advances_monotonically() {
         let lsn = Arc::new(AtomicU64::new(0));
@@ -1694,7 +1775,7 @@ mod tests {
             DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
             true,
         )));
-        let Err(err) = FieldBuilder::new(&nested) else {
+        let Err(err) = FieldBuilder::with_capacity(&nested, 1) else {
             panic!("expected nested-List rejection");
         };
         let msg = err.to_string();
@@ -1863,9 +1944,10 @@ mod tests {
 
     #[test]
     fn fieldbuilder_rejects_interval() {
-        let Err(err) = FieldBuilder::new(&DataType::Interval(
-            arrow::datatypes::IntervalUnit::MonthDayNano,
-        )) else {
+        let Err(err) = FieldBuilder::with_capacity(
+            &DataType::Interval(arrow::datatypes::IntervalUnit::MonthDayNano),
+            1,
+        ) else {
             panic!("expected Interval rejection");
         };
         assert!(err.to_string().contains("INTERVAL"));


### PR DESCRIPTION
## Summary

`build_change_batch` created the `data`-struct Arrow builders with default capacity (1024 elements per column), so a single-row CDC envelope on a wide table allocated — and reported via `get_array_memory_size()` — ~64–100 KB. Under small-transaction OLTP load this inflated the CDC coalescer's byte budget and the Cayenne mem-tier byte accounting.

- `FieldBuilder::new(data_type)` → `FieldBuilder::with_capacity(data_type, capacity)`; `build_change_batch` passes the transaction's row count. Bootstrap keeps its previous behavior (explicit 1024 starting capacity).
- Adds a regression test: a 1-row change batch on a 13-column schema must report < 16 KiB (was ~100 KB).

Note:
 - envelope is per transaction so in most cases we have single-to-few rows envelops, for eg  `envelopes=7724 rows=7724 ` (from our traces)

## Testing

- `cargo test -p data_components --features postgres --lib postgres_replication` — 96 passed
- clippy (repo pedantic flags) and rustfmt clean