### PR TITLE
fix(cdc): memory-mode changes stream no longer fatally stops on a transient deferred-commit queue (fixes #11644)

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1352,6 +1352,22 @@ pub struct CayenneTableProvider {
     /// (the single shard keeps `MemTier::epoch` as the slot-ack currency, so the
     /// N=1 path is byte-identical). Shared across writer clones.
     mem_tier_apply_epoch: Arc<std::sync::atomic::AtomicU64>,
+    /// The highest durable epoch any real checkpoint has reported to the slot
+    /// advancer, encoded as `epoch + 1` so `0` means "no checkpoint has fired
+    /// yet" (epoch `0` is itself a valid N>1 `apply_epoch`). Updated in
+    /// [`Self::fire_slot_advancer`] via `fetch_max`, so it is monotone
+    /// non-decreasing. Read by the `nothing_to_flush` path of
+    /// [`Self::checkpoint_mem_tier`] to RE-fire the advancer on an empty tier:
+    /// the runtime enqueues a batch's source committer AFTER the write returns
+    /// its epoch, so a background checkpoint can flush that batch and fire the
+    /// advancer in the gap BEFORE the committer is queued. The next durable-path
+    /// apply then checkpoints the (now-empty) tier to release the late committer
+    /// — an empty tier means every appended epoch is already durable, so the
+    /// re-fire is always safe and releases exactly the committers at or below
+    /// this watermark. Without it the runtime declares the deferred-commit queue
+    /// permanently stuck and fatally stops the changes stream (#11644). Shared
+    /// across writer clones.
+    last_fired_durable_epoch: Arc<std::sync::atomic::AtomicU64>,
     /// Cross-layer handle the runtime installs in memory mode so
     /// `checkpoint_mem_tier` can advance the source slot AFTER the durable fence
     /// (the slot-deferral correctness seam). `None` in file mode (and for
@@ -4403,6 +4419,7 @@ impl CayenneTableProvider {
                 .collect::<Vec<_>>()
                 .into(),
             mem_tier_apply_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            last_fired_durable_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             slot_advancer: Arc::new(ParkingMutex::new(None)),
             mem_tier_max_age_ms,
             mem_tier_shadow_present: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -5299,6 +5316,7 @@ impl CayenneTableProvider {
             // lock (the seq-ordering invariant requires a single lock per table).
             mem_tier_publish_locks: Arc::clone(&self.mem_tier_publish_locks),
             mem_tier_apply_epoch: Arc::clone(&self.mem_tier_apply_epoch),
+            last_fired_durable_epoch: Arc::clone(&self.last_fired_durable_epoch),
             slot_advancer: Arc::clone(&self.slot_advancer),
             mem_tier_max_age_ms: self.mem_tier_max_age_ms,
             mem_tier_shadow_present: Arc::clone(&self.mem_tier_shadow_present),
@@ -17773,6 +17791,19 @@ impl CayenneTableProvider {
             shard_snapshots.iter().all(|s| s.is_empty())
         };
         if nothing_to_flush {
+            // The tier is fully empty — every epoch ever appended has already
+            // been flushed durable by a prior checkpoint (a real flush always
+            // fires the advancer for its epoch). But the runtime enqueues a
+            // batch's source committer AFTER `write_change` returns its epoch, so
+            // a committer can be queued LATE, after the flush that drained its
+            // epoch already fired. Re-fire the advancer with the last durable
+            // watermark so that late committer is released; otherwise the runtime
+            // finds a non-empty deferred-commit queue after this "successful"
+            // checkpoint and fatally (permanently) stops the changes stream
+            // (#11644). Safe because an empty tier carries no un-durable RAM
+            // batch, and idempotent because the advancer only drains committers
+            // still queued at or below the watermark.
+            self.refire_last_durable_slot_advancer().await;
             return Ok(0);
         }
         // At N==1 the slot-ack currency stays the single shard's `MemTier::epoch`
@@ -18557,6 +18588,14 @@ impl CayenneTableProvider {
     /// up (memory mode). A no-op in file mode / when the runtime did not install
     /// a handle.
     async fn fire_slot_advancer(&self, durable_epoch: u64) {
+        // Record the durable high-watermark (encoded `epoch + 1`, monotone via
+        // `fetch_max`) so the `nothing_to_flush` path can RE-fire the advancer for
+        // a source committer queued after this flush already drained its epoch —
+        // the late-enqueue race that otherwise fatally stops the stream (#11644).
+        self.last_fired_durable_epoch.fetch_max(
+            durable_epoch.saturating_add(1),
+            std::sync::atomic::Ordering::SeqCst,
+        );
         // Reset the freshness clock: the slot just advanced (via a seal or a bake),
         // so the next seal is due one `seal_age` from now. Read by `seal_due`.
         *self.last_slot_advance_at.lock() = Instant::now();
@@ -18573,6 +18612,32 @@ impl CayenneTableProvider {
                 self.table_metadata.table_name.clone(),
             )],
         );
+        let advancer = self.slot_advancer.lock().clone();
+        if let Some(advancer) = advancer {
+            advancer.on_checkpoint_durable(durable_epoch).await;
+        }
+    }
+
+    /// Re-fire the installed slot advancer with the last durable epoch a real
+    /// checkpoint reported, WITHOUT touching the freshness clock or the epoch
+    /// telemetry (this is not a new durable advance — it releases committers a
+    /// prior flush already made durable). Used by the `nothing_to_flush` path of
+    /// [`Self::checkpoint_mem_tier`]: an empty tier means every appended epoch is
+    /// already durable, so a source committer the runtime queued LATE — after the
+    /// flush that drained its epoch fired — must still be released. The advancer
+    /// drains only committers still queued at or below the watermark, so a no-op
+    /// (empty queue, or nothing new) is harmless and this is idempotent across
+    /// repeated empty checkpoints. See [`Self::last_fired_durable_epoch`] and
+    /// issue #11644.
+    async fn refire_last_durable_slot_advancer(&self) {
+        let encoded = self
+            .last_fired_durable_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
+        // `0` means no checkpoint has ever fired: nothing is durable yet, so
+        // there is nothing to release.
+        let Some(durable_epoch) = encoded.checked_sub(1) else {
+            return;
+        };
         let advancer = self.slot_advancer.lock().clone();
         if let Some(advancer) = advancer {
             advancer.on_checkpoint_durable(durable_epoch).await;
@@ -25481,6 +25546,71 @@ mod tests {
             tier.sealed_segments,
             tier.segments.len(),
             "every segment is now the immutable (sealed) piece"
+        );
+    }
+
+    /// Repro for #11644 (root cause of the fatal changes-stream stop). In
+    /// `cdc_durability: memory` the runtime enqueues a batch's source committer
+    /// tagged with its mem-tier epoch AFTER `write_change` returns the epoch. A
+    /// background mem-tier checkpoint can flush that batch and fire the slot
+    /// advancer in the gap BEFORE the committer is queued (see
+    /// `test_slot_advancer_delays_committers_pushed_after_checkpoint` in the
+    /// runtime). The next durable-path apply then calls `checkpoint_mem_tier` to
+    /// release the now-late-queued committer — but the tier is ALREADY EMPTY, so
+    /// the `nothing_to_flush` early return must STILL re-fire the slot advancer
+    /// with the last durable epoch. Without it the advancer never runs for the
+    /// late committer, the runtime's deferred-commit queue stays non-empty, and
+    /// the gate declares "deferred source commits remain after durable
+    /// checkpoint" — fatally (and permanently) stopping the stream.
+    #[tokio::test]
+    async fn mem_tier_empty_checkpoint_refires_slot_advancer() {
+        use std::sync::atomic::Ordering::SeqCst;
+        // A checkpoint on an empty tier never legitimately advances to this
+        // sentinel epoch, so any observed value below it proves a real re-fire.
+        const SENTINEL: u64 = u64::MAX;
+
+        let runtime_env = SessionContext::new().runtime_env();
+        let (provider, _catalog, _tmp) =
+            create_memory_mode_upsert_table("empty_ckpt_refire", Arc::clone(&runtime_env)).await;
+        let durable = Arc::new(std::sync::atomic::AtomicU64::new(SENTINEL));
+        provider.install_slot_advancer(Arc::new(EpochRecorder(Arc::clone(&durable))));
+
+        // Append a batch and checkpoint it durable: this is the "background
+        // checkpoint" of the race — it fires the advancer for the batch's epoch
+        // and drains the tier.
+        let no_deletions = OnConflictDeletions::default();
+        let batch = int64_id_batch(&[1, 2, 3]);
+        let bytes = batch.get_array_memory_size() as u64;
+        let epoch = provider
+            .append_to_mem_tier(vec![batch], &no_deletions, bytes, 0)
+            .await
+            .expect("append");
+        provider
+            .checkpoint_mem_tier()
+            .await
+            .expect("flush checkpoint");
+        assert_eq!(
+            durable.load(SeqCst),
+            epoch,
+            "the flushing checkpoint fires the advancer for the batch's epoch"
+        );
+        assert!(provider.mem_tier.tier().load().is_empty(), "tier drained");
+
+        // Now the runtime queues the batch's committer (LATE — after the flush
+        // already fired). The gate runs `checkpoint_mem_tier` on the now-empty
+        // tier to release it. Reset the recorder so only a genuine re-fire is
+        // observable, then run the empty-tier checkpoint.
+        durable.store(SENTINEL, SeqCst);
+        provider
+            .checkpoint_mem_tier()
+            .await
+            .expect("empty-tier gate checkpoint");
+        assert_eq!(
+            durable.load(SeqCst),
+            epoch,
+            "an empty-tier checkpoint must re-fire the slot advancer with the last \
+             durable epoch so a late-queued committer is released (issue #11644); \
+             without this the deferred-commit queue is declared permanently stuck"
         );
     }
 

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -368,6 +368,19 @@ const METRICS: &[MetricSpec] = &[
          pump. Only reported for datasets on a shared (explicitly-named) slot.",
     )
     .auto_register(),
+    MetricSpec::new(
+        "replication_member_attached",
+        MetricType::ObservableGaugeU64,
+    )
+    .description(
+        "1 while this dataset is an attached member of its shared replication slot, \
+         0 once it has detached. A detached member freezes its ack floor and pins WAL \
+         retention for the WHOLE shared slot until it rejoins or spiced restarts, so a \
+         value of 0 is the unambiguous signal for which dataset stalled the slot (the \
+         lag metric grows on the surviving slot-mates instead). Only reported for \
+         datasets on a shared (explicitly-named) slot; a dedicated slot reports no series.",
+    )
+    .auto_register(),
 ];
 
 #[derive(Debug, Clone)]
@@ -489,6 +502,16 @@ impl MetricsProvider for PostgresMetricsProvider {
             "replication_member_send_stalled_seconds_total" => {
                 Some(ObserveMetricCallback::U64(Box::new(move |instrument| {
                     instrument.observe(m.member_send_stalled_seconds_total(), &attributes);
+                })))
+            }
+            "replication_member_attached" => {
+                Some(ObserveMetricCallback::U64(Box::new(move |instrument| {
+                    // Observe only for shared-slot members (`Some`); a dedicated slot
+                    // has no member-detach concept, so its series stays absent rather
+                    // than a misleading constant `0`.
+                    if let Some(v) = m.member_attached() {
+                        instrument.observe(v, &attributes);
+                    }
                 })))
             }
             _ => None,

--- a/crates/data_components/src/postgres_replication/metrics.rs
+++ b/crates/data_components/src/postgres_replication/metrics.rs
@@ -74,6 +74,17 @@ pub struct MetricsCollector {
     /// stays alive throughout. Only ever set for shared-slot datasets.
     member_send_stalled_seconds_total: AtomicU64,
 
+    // Shared-slot membership liveness. `member_attached` is `1` while this
+    // dataset is an attached member of its shared replication slot and `0` once
+    // it has detached — a detached member freezes its ack floor and pins WAL
+    // retention for the WHOLE shared slot until it rejoins or spiced restarts
+    // (#11644). `member_attached_known` gates observation to shared-slot datasets
+    // only: it stays `false` for a dedicated (non-shared) slot, whose single
+    // consumer has no member-detach concept, so the metric reports no series
+    // there rather than a misleading constant `0`/`1`.
+    member_attached: AtomicU64,
+    member_attached_known: AtomicBool,
+
     // Watermark: commit time of the most-recent transaction we've ingested.
     // Used to compute `replication_lag_ms = now - watermark`.
     last_commit_seen_at: RwLock<Option<SystemTime>>,
@@ -209,6 +220,25 @@ impl MetricsCollector {
     pub fn inc_reconnect(&self) {
         self.replication_reconnects_total
             .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Mark this dataset as an attached member of its shared replication slot
+    /// (fresh join or in-process rejoin). Also flips the "known" flag so the
+    /// metric begins reporting — a dataset on a dedicated (non-shared) slot never
+    /// calls this, so its series stays absent rather than a misleading `0`.
+    pub fn mark_member_attached(&self) {
+        self.member_attached.store(1, Ordering::Relaxed);
+        // Release pairs with the Acquire load in `member_attached()` so a reader
+        // that observes `known == true` also sees the value store above.
+        self.member_attached_known.store(true, Ordering::Release);
+    }
+
+    /// Mark this dataset as DETACHED from its shared replication slot: its ack
+    /// floor is now frozen and pins WAL retention for the whole slot until it
+    /// rejoins or spiced restarts (#11644).
+    pub fn mark_member_detached(&self) {
+        self.member_attached.store(0, Ordering::Relaxed);
+        self.member_attached_known.store(true, Ordering::Release);
     }
 }
 
@@ -346,6 +376,22 @@ impl Metrics {
             .member_send_stalled_seconds_total
             .load(Ordering::Relaxed)
     }
+
+    /// Shared-slot membership liveness: `Some(1)` while attached, `Some(0)` once
+    /// detached (ack floor frozen, WAL pinned for the whole slot — #11644), or
+    /// `None` for a dedicated (non-shared) slot, which has no member-detach
+    /// concept and reports no series. Callers observe only on `Some` so an absent
+    /// series means "not applicable", never a misleading `0`.
+    #[must_use]
+    pub fn member_attached(&self) -> Option<u64> {
+        // Acquire pairs with the Release store in `mark_member_{attached,detached}`
+        // so the value load never observes a stale default once `known` is true.
+        if self.collector.member_attached_known.load(Ordering::Acquire) {
+            Some(self.collector.member_attached.load(Ordering::Relaxed))
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]
@@ -397,6 +443,24 @@ mod tests {
         c.set_bootstrap_rows_expected(0);
         assert_eq!(m.bootstrap_rows_expected(), Some(0));
         assert_eq!(m.bootstrap_progress_percent(), Some(100));
+    }
+
+    #[test]
+    fn member_attached_reports_only_for_shared_slot_members() {
+        let c = MetricsCollector::new();
+        let m = Metrics::new(Arc::clone(&c));
+        // A dedicated (non-shared) slot never marks membership: no series, so an
+        // absent value means "not applicable" — never a misleading `0`.
+        assert_eq!(m.member_attached(), None);
+
+        // A shared-slot member: attached on join, 0 on detach (ack floor frozen /
+        // WAL pinned), back to 1 on rejoin.
+        c.mark_member_attached();
+        assert_eq!(m.member_attached(), Some(1));
+        c.mark_member_detached();
+        assert_eq!(m.member_attached(), Some(0));
+        c.mark_member_attached();
+        assert_eq!(m.member_attached(), Some(1));
     }
 
     #[test]

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -63,9 +63,13 @@ limitations under the License.
 //! with no traffic are credited forward on keepalives/commits whenever they
 //! have no in-flight envelopes. A stalled or failed member therefore pins WAL
 //! retention for the whole slot **by design** — acking past it would lose its
-//! changes permanently. The pinning is observable via the existing
-//! `dataset_postgres_replication_lag_bytes` metric and a WARN log on detach;
-//! restarting spiced (or the member rejoining) heals it by replaying from the
+//! changes permanently. The detached state is observable directly via the
+//! `dataset_postgres_replication_member_attached` gauge (1 attached / 0 detached)
+//! and an ERROR log on a stalling detach; the resulting WAL growth also shows on
+//! `dataset_postgres_replication_lag_bytes` (which, on a shared slot, grows for
+//! the *surviving* members whose ack floor is pinned by the detached one — the
+//! member gauge is the unambiguous signal for *which* dataset stalled).
+//! Restarting spiced (or the member rejoining) heals it by replaying from the
 //! held LSN, which every member applies idempotently.
 //!
 //! # Backpressure vs. server liveness
@@ -456,21 +460,44 @@ impl SharedSource {
     /// its table is (best-effort) removed from the publication — any rejoin,
     /// in-process or after a restart, then re-adds the table and takes a fresh
     /// snapshot.
-    fn detach_member(&self, key: &MemberKey, reason: &str) {
+    /// Detach a member from the shared slot. `stalls_slot` distinguishes a
+    /// genuine, unhealed stall (the member's changes stream died and its ack
+    /// floor now pins WAL for every slot-mate until it rejoins or spiced
+    /// restarts — a page-worthy, ERROR-level condition) from a self-healing
+    /// supersede (an already-closed member being replaced by an incoming
+    /// re-subscription, which re-attaches immediately — only WARN).
+    fn detach_member(&self, key: &MemberKey, reason: &str, stalls_slot: bool) {
         let removed = lock(&self.members).remove(key);
         let was_snapshotting = self.ack.detach(key);
         lock(&self.detached).insert(key.clone());
         if let Some(member) = removed {
-            tracing::warn!(
-                dataset = %member.dataset_name,
-                table = %format_member(key),
-                slot = %self.key.slot_name,
-                reason,
-                was_snapshotting,
-                "shared replication member detached; its last applied LSN now pins WAL \
-                 retention for the shared slot until the dataset rejoins or spiced restarts \
-                 (watch dataset_postgres_replication_lag_bytes)"
-            );
+            // Flip the membership-liveness gauge to detached (0) so the state is
+            // observable, not only logged (#11644). A superseding re-subscription
+            // re-attaches (back to 1) via `mark_member_attached` on rejoin.
+            member.metrics.mark_member_detached();
+            if stalls_slot {
+                tracing::error!(
+                    dataset = %member.dataset_name,
+                    table = %format_member(key),
+                    slot = %self.key.slot_name,
+                    reason,
+                    was_snapshotting,
+                    "shared replication member detached; its last applied LSN now pins WAL \
+                     retention for the shared slot until the dataset rejoins or spiced restarts \
+                     (watch dataset_postgres_replication_member_attached and \
+                     dataset_postgres_replication_lag_bytes)"
+                );
+            } else {
+                tracing::warn!(
+                    dataset = %member.dataset_name,
+                    table = %format_member(key),
+                    slot = %self.key.slot_name,
+                    reason,
+                    was_snapshotting,
+                    "shared replication member detached and is being replaced by a new \
+                     subscription (rejoin in progress)"
+                );
+            }
         }
         if was_snapshotting {
             let params = self.params.clone();
@@ -500,7 +527,7 @@ impl SharedSource {
             .map(|(k, _)| k.clone())
             .collect();
         for key in closed {
-            self.detach_member(&key, "changes stream receiver dropped");
+            self.detach_member(&key, "changes stream receiver dropped", true);
         }
     }
 }
@@ -602,7 +629,7 @@ async fn attach_member(
             // The previous subscription's receiver is gone (dataset reload,
             // failed sink) but the pump hasn't reaped it yet — detach it now
             // so this is a rejoin, not a duplicate.
-            source.detach_member(&member_key, "superseded by a new subscription");
+            source.detach_member(&member_key, "superseded by a new subscription", false);
         } else {
             return Err(Error::SharedTableAlreadySubscribed {
                 schema: schema_name,
@@ -651,6 +678,11 @@ async fn attach_member(
             metrics: Arc::clone(&metrics),
         }),
     );
+    // Membership liveness is now observable (`dataset_postgres_replication_member_attached`):
+    // this dataset is an attached member of the shared slot. Covers both a fresh
+    // join and an in-process rejoin (both reach here); the paired `mark_member_detached`
+    // in `detach_member` flips it to 0 when the member leaves (#11644).
+    metrics.mark_member_attached();
 
     tracing::info!(
         dataset = %dataset_name,
@@ -793,7 +825,7 @@ async fn member_fatal(source: &Arc<SharedSource>, key: &MemberKey, message: Stri
             .send(Err(StreamError::External(message)))
             .await;
     }
-    source.detach_member(key, "fatal member error");
+    source.detach_member(key, "fatal member error", true);
 }
 
 /// Mark the source dead and drop it from the registry (only if the registry
@@ -1271,7 +1303,7 @@ async fn deliver_commit(
             {
                 Ok(()) => break,
                 Err(mpsc::error::SendTimeoutError::Closed(_)) => {
-                    source.detach_member(member_key, "changes stream receiver dropped");
+                    source.detach_member(member_key, "changes stream receiver dropped", true);
                     break;
                 }
                 Err(mpsc::error::SendTimeoutError::Timeout(returned)) => {

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -201,42 +201,66 @@ async fn checkpoint_pending_memory_cdc_commits(
     dataset_name: &TableReference,
     runtime_status: &status::RuntimeStatus,
 ) -> Option<String> {
+    // Bounded checkpoint retries before a still-non-empty queue is declared
+    // fatal (declared before the first statement to satisfy pedantic
+    // `items_after_statements`).
+    const MAX_CHECKPOINT_ATTEMPTS: usize = 3;
+
     if deferred_commit_queue_is_empty(queue).await {
         return None;
     }
 
-    match cayenne.checkpoint_mem_tier().await {
-        Ok(_) => {
-            if deferred_commit_queue_is_empty(queue).await {
-                None
-            } else if runtime_status.is_shutdown() {
-                tracing::debug!(
-                    "Deferred CDC commits remain for {dataset_name} during shutdown after mem-tier checkpoint"
-                );
-                None
-            } else {
-                let error_message = format!(
-                    "Failed to checkpoint in-memory CDC tier for {dataset_name}: deferred source commits remain after durable checkpoint"
-                );
-                tracing::error!("{error_message}");
-                Some(error_message)
+    // A queue still non-empty AFTER a successful checkpoint is, in practice,
+    // transient rather than a real invariant violation: the apply loop enqueues a
+    // batch's committer only AFTER `write_change` returns its epoch, so the
+    // covering checkpoint can fire (and drain nothing) before the committer is
+    // queued — the late-enqueue race. `checkpoint_mem_tier` re-fires the slot
+    // advancer for the last durable epoch even on an empty tier (Cayenne #11644
+    // fix), which releases such a committer; but a concurrent background
+    // checkpoint or a straggler epoch can still need one more checkpoint to seal.
+    // Retry a bounded number of times before declaring failure — the only
+    // correctness requirement is that the source slot must NOT advance past a
+    // still-un-durable RAM batch, and waiting (re-checkpointing) preserves that
+    // trivially. Only a queue that survives every attempt is fatal (#11644).
+    for attempt in 1..=MAX_CHECKPOINT_ATTEMPTS {
+        match cayenne.checkpoint_mem_tier().await {
+            Ok(_) => {
+                if deferred_commit_queue_is_empty(queue).await {
+                    return None;
+                }
+                if runtime_status.is_shutdown() {
+                    tracing::debug!(
+                        "Deferred CDC commits remain for {dataset_name} during shutdown after mem-tier checkpoint"
+                    );
+                    return None;
+                }
+                if attempt < MAX_CHECKPOINT_ATTEMPTS {
+                    tracing::debug!(
+                        "Deferred CDC commits still queued for {dataset_name} after checkpoint attempt {attempt}/{MAX_CHECKPOINT_ATTEMPTS}; re-checkpointing to seal the straggler epoch"
+                    );
+                }
             }
-        }
-        Err(e) => {
-            if runtime_status.is_shutdown() {
-                tracing::debug!(
-                    "Failed to checkpoint in-memory CDC tier for {dataset_name} during shutdown: {e}"
-                );
-                None
-            } else {
+            Err(e) => {
+                if runtime_status.is_shutdown() {
+                    tracing::debug!(
+                        "Failed to checkpoint in-memory CDC tier for {dataset_name} during shutdown: {e}"
+                    );
+                    return None;
+                }
                 let error_message = format!(
                     "Failed to checkpoint in-memory CDC tier for {dataset_name} before advancing source commit: {e}"
                 );
                 tracing::error!("{error_message}");
-                Some(error_message)
+                return Some(error_message);
             }
         }
     }
+
+    let error_message = format!(
+        "Failed to checkpoint in-memory CDC tier for {dataset_name}: deferred source commits remain after {MAX_CHECKPOINT_ATTEMPTS} durable checkpoints"
+    );
+    tracing::error!("{error_message}");
+    Some(error_message)
 }
 
 pub(super) struct CdcInsertPlanCache {


### PR DESCRIPTION
Fixes #11644.

## Problem & impact

Under `cdc_durability: memory`, a Postgres CDC changes stream could **permanently stop** mid-run with:

```
ERROR ... Failed to checkpoint in-memory CDC tier for <dataset>: deferred source commits remain after durable checkpoint
WARN  ... shared replication member detached; its last applied LSN now pins WAL retention for the shared slot ...
```

**Impact of the stop:** once the apply loop returns, the dataset's changes-stream receiver closes and its shared-slot member detaches. That freezes the member's ack floor, so **that table's CDC progresses at 0.0x realtime for the rest of the process lifetime** (no restart short of bouncing `spiced`). On a shared slot the frozen floor pins WAL retention for the *whole* slot, so every slot-mate's `replication_lag_bytes` climbs even though they keep applying fine — the dead table is the one that stalled, but the lag shows up on its neighbours.

Observed 2-for-2 on SF-1000 CH-benCHmark HTAP runs on a grouped multi-slot topology; timing-dependent.

## Root cause (the spurious fatal)

In memory mode the runtime enqueues a batch's source committer **after** the write returns its mem-tier epoch. A background checkpoint can flush that batch and fire the slot advancer in the gap **before** the committer is queued. The next durable-path apply calls `checkpoint_mem_tier` to release the now-late-queued committer — but the tier is already empty, and the `nothing_to_flush` early return returned `Ok(0)` **without firing the advancer**. The committer was never drained, so the gate declared the deferred-commit queue permanently stuck.

## Fixes

**Correctness**
- **cayenne** — the provider tracks `last_fired_durable_epoch` (monotone `fetch_max` watermark). The empty-tier checkpoint path now **re-fires** the slot advancer with that watermark (`refire_last_durable_slot_advancer`). An empty tier means every appended epoch is already durable, so releasing a late-queued committer at or below the watermark is always safe and idempotent.
- **runtime** — `checkpoint_pending_memory_cdc_commits` retries the checkpoint a bounded number of times before treating a still-non-empty queue as fatal. The only correctness requirement is that the source slot must not advance past an un-durable RAM batch; waiting / re-checkpointing preserves that trivially.

**Visibility (so a genuine stall is never silent)**
- New `dataset_postgres_replication_member_attached` gauge (1 attached / 0 detached; absent for dedicated slots, which have no member-detach concept). A value of **0 is the unambiguous signal for which dataset stalled the slot** — the lag metric misleads here because it grows on the surviving slot-mates.
- The detach log is promoted **WARN → ERROR** for a genuine, unhealed stall (receiver dropped / fatal member error), and kept at WARN for a self-healing supersede (an already-closed member replaced by an incoming re-subscription).

## Deliberately *not* included

We are **not** adding a general-purpose changes-stream restart/rejoin loop. With the two correctness fixes above, the stream no longer stops for this trigger, and as a rule things should **not** crash — a supervised auto-restart would paper over genuine errors rather than surface them. The new gauge + ERROR log make any *future* genuine stall immediately observable (and page-worthy) instead of silent, which is the piece that had been missing.

## Relationship to #11642

Independent. #11642 reroutes durable CDC *deletes* onto a count-skipping fast path (freshness regression #11633); it does not touch the checkpoint gate, epoch tagging, the slot advancer, or the empty-checkpoint path.

## Tests

- `cayenne::…::mem_tier_empty_checkpoint_refires_slot_advancer` — reproduces the exact late-enqueue race: **fails before the fix** (an empty checkpoint does not re-fire the advancer), passes after.
- `data_components::…::member_attached_reports_only_for_shared_slot_members` — the new gauge (Some(1)/Some(0)/None semantics).

Verified green: cayenne `mem_tier` suite (67), runtime `refresh_task::changes` (65), data_components `postgres_replication` metrics (with `postgres` feature), and the full **pedantic** clippy pass (`-Dclippy::pedantic`, `CLIPPY_CONF_DIR=.ci`) with zero warnings in the touched files.
