### PR TITLE
Fix cargo-deny crossbeam-epoch advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5209,9 +5209,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -30,23 +30,11 @@ ignore = [
   "RUSTSEC-2023-0071",
   # TLS dependencies pull `rustls-pemfile`; no safe upgrade is available yet. Owner: data components/runtime.
   "RUSTSEC-2025-0134",
-  # Legacy `rustls` 0.21 dependencies pull `rustls-webpki` 0.101.x; newer 0.103.x is updated in Cargo.lock. Owner: AWS/MSSQL integrations.
-  "RUSTSEC-2026-0098",
-  # Legacy `rustls` 0.21 dependencies pull `rustls-webpki` 0.101.x; newer 0.103.x is updated in Cargo.lock. Owner: AWS/MSSQL integrations.
-  "RUSTSEC-2026-0099",
-  # Legacy `rustls` 0.21 dependencies pull `rustls-webpki` 0.101.x; newer 0.103.x is updated in Cargo.lock. Owner: AWS/MSSQL integrations.
-  "RUSTSEC-2026-0104",
   # Azure storage dependencies pull `http-types` through `azure_core` 0.21; no safe upgrade is available yet. Owner: data connectors/runtime.
   "RUSTSEC-2026-0174",
-  # `rand` 0.7.3 (unsound) is pulled by `http-types` through Azure `azure_core` 0.21
-  # — the same legacy chain as RUSTSEC-2026-0174; no safe upgrade is available yet,
-  # and the unsoundness (custom-logger `rand::rng()`) is not exercised by this
-  # transitive use. Owner: data connectors/runtime.
-  "RUSTSEC-2026-0097",
   # `document_parse` pulls `ttf-parser` through `pdf-extract`/`lopdf`; the author
   # marked it unmaintained and there is no safe upgrade (the suggested `skrifa`
   # alternative is not wired through `lopdf`/`pdf-extract`). Owner: document_parse.
-  "RUSTSEC-2026-0192",
   # `quick-xml` quadratic duplicate-attribute check on start tags (DoS). Pulled
   # transitively in several versions (via vortex, AWS-XML, and serialization
   # dependencies); no single safe upgrade across all pins yet. Owner: data components/runtime.
@@ -132,4 +120,3 @@ name = "cfg_block"
 version = "0.1.1"
 expression = "Apache-2.0"
 license-files = []
-


### PR DESCRIPTION
## Summary
- update crossbeam-epoch in Cargo.lock from 0.9.18 to 0.9.20 to address RUSTSEC-2026-0204
- remove stale cargo-deny ignore entries that no longer match any dependency

## Testing
- cargo deny check advisories