### PR TITLE
cherry-pick: release notes v2.1.0 + datafusion ORDER BY alias unparser fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "regex",
  "toml 1.1.2+spec-1.1.0",
  "windows-registry",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -218,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "ansi_colors"
-version = "2.1.0"
+version = "2.1.0-unstable"
 
 [[package]]
 name = "anstream"
@@ -314,7 +323,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -325,7 +334,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -395,7 +404,7 @@ checksum = "fca387cdc0a1f9c7a7c26556d584aa2d07fc529843082e4861003cde4ab914ed"
 
 [[package]]
 name = "app"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "serde",
  "snafu",
@@ -738,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_sql_gen"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -752,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_tools"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -1519,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cognitoidentityprovider"
-version = "1.122.0"
+version = "1.123.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e39cb12d93f1c19f2dac01828e560cfe2730fb3b999574888d20279cb79ec1"
+checksum = "b5ad7e92dd962febc85a12e88571bdb23d8f5ad52d8b481c368d1e844c62262d"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1544,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-credential-bridge"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1623,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.233.0"
+version = "1.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3652743d6ceefbe1aaa48b2d438e8fb9023efca7d9c616bc0243bcda092a9a89"
+checksum = "28ed92717d884f32913e3fc2960f58cf6cd970fc99a08925f1313c2e00708844"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1649,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-glue"
-version = "1.152.0"
+version = "1.153.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267d3459c708985a1c1472bb2eb8def3b8673abbcdb3e8057d73e40fa5a7f5b4"
+checksum = "48b33661f9c0b02b6c23d42646f43ea9eab6db37fdcbd80f85fabe72a70b9d8e"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -2388,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0a99d7c0a44488a202b893d0e53ada35ba96a9a6#0a99d7c0a44488a202b893d0e53ada35ba96a9a6"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f#ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2425,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0a99d7c0a44488a202b893d0e53ada35ba96a9a6#0a99d7c0a44488a202b893d0e53ada35ba96a9a6"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f#ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2456,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=0a99d7c0a44488a202b893d0e53ada35ba96a9a6#0a99d7c0a44488a202b893d0e53ada35ba96a9a6"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f#ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2844,6 +2853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3481,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "cayenne"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "aegis",
  "arc-swap",
@@ -3555,7 +3573,7 @@ dependencies = [
 
 [[package]]
 name = "cayenne-flightsql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "cayenne",
@@ -3580,6 +3598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -3670,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "chbench-driver"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3769,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "chunking"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "criterion 0.7.0",
  "snafu",
@@ -3991,6 +4018,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4064,8 +4100,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 
 [[package]]
+name = "connector-abfs"
+version = "2.1.0-unstable"
+dependencies = [
+ "object_store 0.13.2",
+ "runtime",
+ "secrecy",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "connector-adbc"
+version = "2.1.0-unstable"
+dependencies = [
+ "adbc_core",
+ "adbc_driver_manager",
+ "app",
+ "arrow",
+ "async-trait",
+ "blake3",
+ "data_components",
+ "datafusion",
+ "datafusion-table-providers",
+ "futures",
+ "parking_lot",
+ "runtime",
+ "secrecy",
+ "sha2 0.10.9",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "connector-clickhouse"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "clickhouse-rs",
@@ -4083,8 +4155,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "connector-cosmosdb"
+version = "2.1.0-unstable"
+dependencies = [
+ "async-trait",
+ "data_components",
+ "datafusion",
+ "datafusion-table-providers",
+ "opentelemetry",
+ "runtime",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "connector-databricks"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "async-trait",
@@ -4109,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "connector-delta-lake"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "aws-sdk-credential-bridge",
@@ -4127,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "connector-dremio"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4145,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "connector-duckdb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4159,8 +4246,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "connector-ducklake"
+version = "2.1.0-unstable"
+dependencies = [
+ "async-trait",
+ "data_components",
+ "datafusion",
+ "datafusion-table-providers",
+ "duckdb",
+ "runtime",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "connector-elasticsearch"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4176,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "connector-flightsql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4192,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "connector-ftp"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "linkme",
  "paste",
@@ -4203,8 +4305,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "connector-gcs"
+version = "2.1.0-unstable"
+dependencies = [
+ "object_store 0.13.2",
+ "runtime",
+ "snafu",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "connector-git"
+version = "2.1.0-unstable"
+dependencies = [
+ "async-trait",
+ "data_components",
+ "datafusion",
+ "globset",
+ "opentelemetry",
+ "reqwest 0.13.4",
+ "runtime",
+ "secrecy",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "connector-github"
+version = "2.1.0-unstable"
+dependencies = [
+ "app",
+ "arrow",
+ "arrow-schema",
+ "arrow_tools",
+ "async-trait",
+ "chrono",
+ "data_components",
+ "datafusion",
+ "futures",
+ "globset",
+ "governor",
+ "graphql-parser",
+ "http 1.4.1",
+ "reqwest 0.13.4",
+ "runtime",
+ "runtime-rate-control",
+ "runtime-secrets",
+ "secrecy",
+ "serde_json",
+ "snafu",
+ "spicepod",
+ "token_provider",
+ "tokio",
+ "tracing",
+ "url",
+ "util",
+]
+
+[[package]]
+name = "connector-glue"
+version = "2.1.0-unstable"
+dependencies = [
+ "runtime",
+]
+
+[[package]]
 name = "connector-graphql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "async-trait",
@@ -4222,7 +4391,7 @@ dependencies = [
 
 [[package]]
 name = "connector-imap"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4237,8 +4406,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "connector-kafka"
+version = "2.1.0-unstable"
+dependencies = [
+ "arrow-schema",
+ "async-stream",
+ "async-trait",
+ "data_components",
+ "dataformat-json",
+ "datafusion",
+ "fundu",
+ "futures",
+ "opentelemetry",
+ "runtime",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "connector-mongodb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4261,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "connector-mssql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4275,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "connector-mysql"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4306,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "connector-odbc"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4321,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "connector-oracle"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4337,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "connector-postgres"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4357,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "connector-scylladb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4375,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "connector-sftp"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "linkme",
  "paste",
@@ -4387,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "connector-sharepoint"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4407,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "connector-smb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "linkme",
  "paste",
@@ -4419,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "connector-snowflake"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4435,8 +4627,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "connector-snowflake-native"
+version = "2.1.0-unstable"
+dependencies = [
+ "async-trait",
+ "data_components",
+ "datafusion",
+ "datafusion-table-providers",
+ "db_connection_pool",
+ "runtime",
+ "snafu",
+ "snowflake-api",
+]
+
+[[package]]
 name = "connector-spark"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "data_components",
@@ -4446,6 +4652,13 @@ dependencies = [
  "runtime",
  "runtime-parameters",
  "snafu",
+]
+
+[[package]]
+name = "connector-spiceai"
+version = "2.1.0-unstable"
+dependencies = [
+ "runtime",
 ]
 
 [[package]]
@@ -4587,6 +4800,15 @@ name = "core_detect"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "cpp_demangle"
@@ -4882,6 +5104,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.8.2",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4896,6 +5143,16 @@ name = "criterion-plot"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -5414,8 +5671,10 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data_components"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
+ "adbc_core",
+ "adbc_driver_manager",
  "ahash 0.8.12",
  "arrow",
  "arrow-array",
@@ -5528,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "dataformat-json"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5546,7 +5805,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5598,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5622,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5646,7 +5905,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5671,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "futures",
  "log",
@@ -5681,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5718,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5741,7 +6000,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5763,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5785,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5814,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ddl"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5824,7 +6083,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-dml"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5834,12 +6093,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5860,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5882,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5934,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5965,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5985,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6009,7 +6268,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6033,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6048,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6064,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6073,7 +6332,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6083,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "chrono",
@@ -6101,7 +6360,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer-rules"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -6134,7 +6393,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6155,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6169,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "chrono",
@@ -6185,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6205,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6237,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "chrono",
@@ -6266,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6278,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6293,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6306,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6334,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6352,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=00544972330059292e030240a5e66c500d6827c5#00544972330059292e030240a5e66c500d6827c5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6436,7 +6695,7 @@ checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "db_connection_pool"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-odbc",
@@ -6809,7 +7068,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6873,7 +7132,7 @@ checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document_parse"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "bytes",
  "calamine",
@@ -7001,7 +7260,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duration-parse"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "snafu",
 ]
@@ -7036,7 +7295,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamodb-streams"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
@@ -7053,11 +7312,11 @@ dependencies = [
 
 [[package]]
 name = "ecb"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
 dependencies = [
- "cipher 0.4.4",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -7115,7 +7374,7 @@ dependencies = [
 
 [[package]]
 name = "elasticsearch"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7256,6 +7515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -7273,6 +7533,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
+ "jiff",
  "log",
 ]
 
@@ -7320,7 +7581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7376,7 +7637,7 @@ dependencies = [
 
 [[package]]
 name = "event_stream"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "futures",
  "snafu",
@@ -7668,7 +7929,7 @@ dependencies = [
 
 [[package]]
 name = "flight-cookie-server"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow-array",
  "arrow-flight",
@@ -7686,7 +7947,7 @@ dependencies = [
 
 [[package]]
 name = "flight_client"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7707,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "flightpublisher"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7720,7 +7981,7 @@ dependencies = [
 
 [[package]]
 name = "flightsubscriber"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow-flight",
  "clap",
@@ -8301,8 +8562,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -8417,7 +8678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -8427,7 +8688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -8501,7 +8762,7 @@ dependencies = [
 
 [[package]]
 name = "google-genai"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "bytes",
  "futures",
@@ -8762,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "hash-index"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -9406,7 +9667,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9912,7 +10173,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -9922,6 +10183,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -10048,7 +10310,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10820,7 +11082,7 @@ dependencies = [
 
 [[package]]
 name = "llms"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -10951,29 +11213,41 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
+version = "0.43.0"
 dependencies = [
- "aes 0.8.4",
+ "aes 0.9.1",
  "bitflags 2.13.0",
- "cbc",
+ "cbc 0.2.1",
+ "chrono",
+ "clap",
+ "criterion 0.8.2",
  "ecb",
  "encoding_rs",
+ "env_logger",
  "flate2",
  "getrandom 0.4.2",
+ "image 0.25.10",
  "indexmap 2.14.0",
  "itoa",
+ "jiff",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "nom 8.0.0",
  "rand 0.10.1",
  "rangemap",
- "sha2 0.10.9",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "shellexpand",
  "stringprep",
+ "tempfile",
  "thiserror 2.0.18",
+ "time",
+ "tokio",
  "ttf-parser",
- "weezl",
+ "wasm-bindgen-test",
+ "weezl 0.2.1",
 ]
 
 [[package]]
@@ -11273,6 +11547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "mea"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11406,6 +11686,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
 ]
 
 [[package]]
@@ -11712,7 +12002,7 @@ dependencies = [
 
 [[package]]
 name = "model_components"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "arrow",
@@ -12232,7 +12522,7 @@ dependencies = [
 
 [[package]]
 name = "ns_lookup"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "hickory-resolver",
  "snafu",
@@ -12256,7 +12546,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13435,7 +13725,7 @@ dependencies = [
 
 [[package]]
 name = "otel-arrow"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -13447,7 +13737,7 @@ dependencies = [
 
 [[package]]
 name = "otelpublisher"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "clap",
  "opentelemetry-proto",
@@ -13535,7 +13825,7 @@ dependencies = [
 
 [[package]]
 name = "package"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "bytes",
  "futures",
@@ -13555,6 +13845,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69e0a534dd2e6aefce319af62a0aa0066a76bdfcec0201dfe02df226bc9ec70"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -13633,7 +13933,7 @@ dependencies = [
 
 [[package]]
 name = "parsley"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "bytes",
  "chunking",
@@ -13758,8 +14058,6 @@ dependencies = [
 [[package]]
 name = "pdf-extract"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
 dependencies = [
  "adobe-cmap-parser",
  "cff-parser",
@@ -13768,8 +14066,11 @@ dependencies = [
  "log",
  "lopdf",
  "postscript",
+ "simple_logger",
+ "test-log",
  "type1-encoding-parser",
  "unicode-normalization",
+ "ureq",
 ]
 
 [[package]]
@@ -13855,18 +14156,20 @@ dependencies = [
 [[package]]
 name = "pgwire-replication"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec6334b2466a0163bd91c29e06a25b391c155231934aee80381b99560e240e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bytes",
+ "criterion 0.5.1",
  "hmac 0.12.1",
+ "md5",
  "rand 0.9.4",
  "rustls",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-postgres",
  "tokio-rustls",
  "tokio-util",
  "tracing",
@@ -13983,6 +14286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14021,7 +14330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.5.0",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -14055,7 +14364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
  "aes 0.8.4",
- "cbc",
+ "cbc 0.1.2",
  "der",
  "des",
  "pbkdf2 0.12.2",
@@ -14256,9 +14565,12 @@ dependencies = [
 
 [[package]]
 name = "postscript"
-version = "0.14.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
+checksum = "9a2238e788cf2c9b6edc23b83cf8ccdd4a6380cc9bf0598cc220fac42a55def6"
+dependencies = [
+ "typeface",
+]
 
 [[package]]
 name = "potential_utf"
@@ -14292,7 +14604,7 @@ dependencies = [
 
 [[package]]
 name = "pr-builds"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "clap",
@@ -14492,7 +14804,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14855,7 +15167,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14893,7 +15205,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -15495,7 +15807,7 @@ dependencies = [
 
 [[package]]
 name = "repl"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ansi_colors",
  "arrow",
@@ -16037,7 +16349,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -16083,15 +16395,24 @@ dependencies = [
  "chrono",
  "chunking",
  "clap",
+ "connector-abfs",
+ "connector-adbc",
  "connector-clickhouse",
+ "connector-cosmosdb",
  "connector-databricks",
  "connector-delta-lake",
  "connector-dremio",
  "connector-duckdb",
+ "connector-ducklake",
  "connector-flightsql",
  "connector-ftp",
+ "connector-gcs",
+ "connector-git",
+ "connector-github",
+ "connector-glue",
  "connector-graphql",
  "connector-imap",
+ "connector-kafka",
  "connector-mongodb",
  "connector-mssql",
  "connector-mysql",
@@ -16103,6 +16424,7 @@ dependencies = [
  "connector-smb",
  "connector-snowflake",
  "connector-spark",
+ "connector-spiceai",
  "criterion 0.7.0",
  "csv",
  "dashmap",
@@ -16266,7 +16588,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-acceleration"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "arrow",
@@ -16306,7 +16628,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-api-types"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "serde",
  "serde_json",
@@ -16315,7 +16637,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-async"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "futures",
  "libc",
@@ -16328,7 +16650,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-auth"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "axum",
@@ -16345,7 +16667,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-cluster"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "arrow",
@@ -16389,7 +16711,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-datafusion"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -16431,7 +16753,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-datafusion-index"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow_tools",
  "async-trait",
@@ -16445,7 +16767,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-datafusion-udfs"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -16487,7 +16809,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-object-store"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -16517,11 +16839,11 @@ dependencies = [
 
 [[package]]
 name = "runtime-parameter-spec"
-version = "2.1.0"
+version = "2.1.0-unstable"
 
 [[package]]
 name = "runtime-parameters"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "itertools 0.14.0",
  "runtime-parameter-spec",
@@ -16535,7 +16857,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-proto"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "datafusion",
  "datafusion-common",
@@ -16550,7 +16872,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-query-engine"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -16562,7 +16884,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-rate-control"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "futures",
  "governor",
@@ -16578,7 +16900,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-request-context"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "async-trait",
@@ -16600,7 +16922,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-search"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "arrow",
@@ -16643,7 +16965,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-secrets"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -16676,7 +16998,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-table-partition"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -16700,7 +17022,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tools"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "arrow",
@@ -16918,7 +17240,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16995,7 +17317,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17064,7 +17386,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3_vectors"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -17077,7 +17399,7 @@ dependencies = [
 
 [[package]]
 name = "s3_vectors_metadata_filter"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "aws-smithy-types",
  "datafusion",
@@ -17201,7 +17523,7 @@ dependencies = [
 
 [[package]]
 name = "scheduler"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17403,7 +17725,7 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "search"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -17569,7 +17891,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -17854,6 +18176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17989,6 +18320,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_logger"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7038d0e96661bf9ce647e1a6f6ef6d6f3663f66d9bf741abf14ba4876071c17"
+dependencies = [
+ "colored",
+ "log",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "simsimd"
 version = "6.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18055,7 +18397,7 @@ checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
 name = "smb"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "aes 0.8.4",
  "bytes",
@@ -18110,7 +18452,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -18201,7 +18543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -18264,7 +18606,7 @@ dependencies = [
 
 [[package]]
 name = "spice"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "ansi_colors",
  "arrow",
@@ -18318,7 +18660,7 @@ dependencies = [
 
 [[package]]
 name = "spice-cloud"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -18333,7 +18675,7 @@ dependencies = [
 
 [[package]]
 name = "spice-cloud-client"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "reqwest 0.13.4",
  "serde",
@@ -18374,20 +18716,29 @@ dependencies = [
 
 [[package]]
 name = "spiced"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "clap",
+ "connector-abfs",
+ "connector-adbc",
  "connector-clickhouse",
+ "connector-cosmosdb",
  "connector-databricks",
  "connector-delta-lake",
  "connector-dremio",
  "connector-duckdb",
+ "connector-ducklake",
  "connector-elasticsearch",
  "connector-flightsql",
  "connector-ftp",
+ "connector-gcs",
+ "connector-git",
+ "connector-github",
+ "connector-glue",
  "connector-graphql",
  "connector-imap",
+ "connector-kafka",
  "connector-mongodb",
  "connector-mssql",
  "connector-mysql",
@@ -18401,6 +18752,7 @@ dependencies = [
  "connector-smb",
  "connector-snowflake",
  "connector-spark",
+ "connector-spiceai",
  "event_stream",
  "futures",
  "mimalloc",
@@ -18436,7 +18788,7 @@ dependencies = [
 
 [[package]]
 name = "spicepod"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "aws-sdk-credential-bridge",
@@ -18460,7 +18812,7 @@ dependencies = [
 
 [[package]]
 name = "spicepod-validator"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "app",
  "clap",
@@ -18470,7 +18822,7 @@ dependencies = [
 
 [[package]]
 name = "spicepodschema"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "connector-clickhouse",
  "connector-delta-lake",
@@ -18502,7 +18854,7 @@ dependencies = [
 
 [[package]]
 name = "spiceschema"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "clap",
  "runtime",
@@ -18512,7 +18864,7 @@ dependencies = [
 
 [[package]]
 name = "spidapter"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "arrow",
@@ -18522,6 +18874,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-ec2",
  "base64 0.22.1",
+ "chrono",
  "clap",
  "dirs",
  "mongodb",
@@ -18665,7 +19018,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -18706,6 +19059,12 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "string-interner"
@@ -19363,7 +19722,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "telemetry"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -19392,7 +19751,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19454,7 +19813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19471,7 +19830,7 @@ checksum = "d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9"
 
 [[package]]
 name = "test-framework"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "app",
@@ -19555,7 +19914,7 @@ dependencies = [
 
 [[package]]
 name = "testoperator"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -19662,7 +20021,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",
@@ -19769,7 +20128,7 @@ checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
 dependencies = [
  "flate2",
  "jpeg-decoder",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -19782,7 +20141,7 @@ dependencies = [
  "flate2",
  "half",
  "quick-error 2.0.1",
- "weezl",
+ "weezl 0.1.12",
  "zune-jpeg",
 ]
 
@@ -19881,6 +20240,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19917,13 +20287,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token_provider"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
+ "chrono",
+ "jsonwebtoken 10.4.0",
+ "reqwest 0.13.4",
  "secrecy",
+ "serde",
  "sha2 0.10.9",
  "snafu",
  "tokio",
  "tracing",
+ "util",
 ]
 
 [[package]]
@@ -20349,7 +20724,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "rmcp",
@@ -20430,7 +20805,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tpc-extension"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-trait",
  "duckdb",
@@ -20736,8 +21111,13 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "base64 0.22.1",
+ "core_maths",
+ "pico-args",
+ "tiny-skia-path",
+ "xmlwriter",
+]
 
 [[package]]
 name = "tungstenite"
@@ -20788,7 +21168,7 @@ dependencies = [
 
 [[package]]
 name = "turso-shared"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "rand 0.10.1",
 ]
@@ -21026,6 +21406,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeface"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f6b49e025f4dc953a29b83e4f5a905089117d09fa53491015d7678951b8be1"
 
 [[package]]
 name = "typeid"
@@ -21407,7 +21793,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "util"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -21744,7 +22130,7 @@ dependencies = [
 
 [[package]]
 name = "vortex-datafusion"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "anyhow",
  "arrow-schema",
@@ -22295,6 +22681,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22677,6 +23102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "weezl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ca08e5ef825b65b056d9efbd95c8750683f0a6d0466d02e96dc2e4e360f3d2"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22751,7 +23182,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -23409,7 +23840,7 @@ dependencies = [
 
 [[package]]
 name = "workers"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -23533,6 +23964,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23540,7 +23977,7 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yaml"
-version = "2.1.0"
+version = "2.1.0-unstable"
 dependencies = [
  "indexmap 2.14.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5209,9 +5209,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,41 +389,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" } # branch: spiceai-54 (spiceai/datafusion#182)
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "00544972330059292e030240a5e66c500d6827c5" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,7 @@ ignore = [
   # `document_parse` pulls `ttf-parser` through `pdf-extract`/`lopdf`; the author
   # marked it unmaintained and there is no safe upgrade (the suggested `skrifa`
   # alternative is not wired through `lopdf`/`pdf-extract`). Owner: document_parse.
+  "RUSTSEC-2026-0192",
   # `quick-xml` quadratic duplicate-attribute check on start tags (DoS). Pulled
   # transitively in several versions (via vortex, AWS-XML, and serialization
   # dependencies); no single safe upgrade across all pins yet. Owner: data components/runtime.

--- a/deny.toml
+++ b/deny.toml
@@ -30,23 +30,11 @@ ignore = [
   "RUSTSEC-2023-0071",
   # TLS dependencies pull `rustls-pemfile`; no safe upgrade is available yet. Owner: data components/runtime.
   "RUSTSEC-2025-0134",
-  # Legacy `rustls` 0.21 dependencies pull `rustls-webpki` 0.101.x; newer 0.103.x is updated in Cargo.lock. Owner: AWS/MSSQL integrations.
-  "RUSTSEC-2026-0098",
-  # Legacy `rustls` 0.21 dependencies pull `rustls-webpki` 0.101.x; newer 0.103.x is updated in Cargo.lock. Owner: AWS/MSSQL integrations.
-  "RUSTSEC-2026-0099",
-  # Legacy `rustls` 0.21 dependencies pull `rustls-webpki` 0.101.x; newer 0.103.x is updated in Cargo.lock. Owner: AWS/MSSQL integrations.
-  "RUSTSEC-2026-0104",
   # Azure storage dependencies pull `http-types` through `azure_core` 0.21; no safe upgrade is available yet. Owner: data connectors/runtime.
   "RUSTSEC-2026-0174",
-  # `rand` 0.7.3 (unsound) is pulled by `http-types` through Azure `azure_core` 0.21
-  # — the same legacy chain as RUSTSEC-2026-0174; no safe upgrade is available yet,
-  # and the unsoundness (custom-logger `rand::rng()`) is not exercised by this
-  # transitive use. Owner: data connectors/runtime.
-  "RUSTSEC-2026-0097",
   # `document_parse` pulls `ttf-parser` through `pdf-extract`/`lopdf`; the author
   # marked it unmaintained and there is no safe upgrade (the suggested `skrifa`
   # alternative is not wired through `lopdf`/`pdf-extract`). Owner: document_parse.
-  "RUSTSEC-2026-0192",
   # `quick-xml` quadratic duplicate-attribute check on start tags (DoS). Pulled
   # transitively in several versions (via vortex, AWS-XML, and serialization
   # dependencies); no single safe upgrade across all pins yet. Owner: data components/runtime.
@@ -132,4 +120,3 @@ name = "cfg_block"
 version = "0.1.1"
 expression = "Apache-2.0"
 license-files = []
-

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,55 +15,44 @@ To propose features or report issues, please [file an issue](https://github.com/
 
 ## Release Timeline
 
-### [v2.1](https://github.com/spiceai/spiceai/milestone/95) (July 2026)
+### [v2.2](https://github.com/spiceai/spiceai/milestone/99) (July 2026)
 
-**Focus:** Schema Management and Distributed Search.
-
-**DataFusion:** v53
-
-- **Schema Registry (Initial)**: Versioning and backward compatibility checks.
-- **Schema Evolution**: Safe, non-breaking schema changes for accelerated datasets (add/drop/rename columns, type widening) with automatic migration.
-- **Cayenne Improvements**: Non-distributed Cayenne catalog, multi-version metadata schema support, and orphaned deletion-vector cleanup during retention.
-- **Distributed Acceleration Hardening**: Continued planner and runtime improvements for distributed acceleration, including partitioning, readiness signaling, and filter/TopK pushdown.
-- **Ballista / Distributed Query**: Shared job state across schedulers and faster partition reassignment on executor failure.
-- **Write-Back Acceleration**: Eventually-consistent write-back, with full DML (UPDATE/DELETE) and `spice refresh`/`refresh_check_interval` on write-through accelerated tables.
-
-### [v2.2](https://github.com/spiceai/spiceai/milestone/99) (September 2026)
-
-**Focus:** Reactive Actions & Event Processing.
-
-**DataFusion:** v54
-
-- **Distributed Search (Alpha)**: Federated vector and full-text search across multiple nodes, with FTS indexes available in distributed query mode.
-- **Webhooks & Event Notifications**: Push-based data change alerts for downstream consumers.
-- **Actions (Drasi-based)**: Reactive event-driven actions triggered by data changes.
-
-### [v2.3](https://github.com/spiceai/spiceai/milestone/100) (October 2026)
-
-**Focus:** Enterprise Security, Compliance, & Governance.
+**Focus:** Schema Registry, Distributed Search & Event Processing.
 
 **DataFusion:** v55
 
+- **Schema Registry (Initial)**: Versioning and backward compatibility checks.
+- **Distributed Search (Alpha)**: Federated vector and full-text search across multiple nodes, with FTS indexes available in distributed query mode.
+- **Webhooks & Event Notifications**: Push-based data change alerts for downstream consumers.
+- **Write-Back Acceleration**: Eventually-consistent write-back, with full DML (UPDATE/DELETE) and `spice refresh`/`refresh_check_interval` on write-through accelerated tables.
+
+### [v2.3](https://github.com/spiceai/spiceai/milestone/100) (September 2026)
+
+**Focus:** Enterprise Security, Compliance, & Governance.
+
+**DataFusion:** v56
+
 - **Audit Logging**: Persistent, immutable query and access logs for compliance.
 - **Resource Quotas**: Per-user/tenant query limits and throttling.
+- **Actions (Drasi-based)**: Reactive event-driven actions triggered by data changes.
 - **Distributed Cayenne Catalog**: Cayenne catalog with full distributed query and acceleration support.
 - **Distributed Search Scale-Out**: Search query partitioning and relative score fusion across distributed nodes.
 
-### [v2.4](https://github.com/spiceai/spiceai/milestone/101) (December 2026)
+### [v2.4](https://github.com/spiceai/spiceai/milestone/101) (October 2026)
 
 **Focus:** Extensibility & Plugin Architecture.
 
-**DataFusion:** v56
+**DataFusion:** v57
 
 - **Extensible Middleware**: Pluggable extensions for dynamic customization.
 - **Search at 100B+ Row Scale**: Vector and full-text search benchmarked and tuned for hundred-billion-row deployments, including S3 Vectors throughput improvements.
 - **Unified Connector Rate Control**: Extend the runtime-wide rate-control surface from HTTP connectors to database and file/object-store connectors for consistent per-origin concurrency and request-rate limits.
 
-### [v2.5](https://github.com/spiceai/spiceai/milestone/102) (January 2027)
+### [v2.5](https://github.com/spiceai/spiceai/milestone/102) (November 2026)
 
 **Focus:** Encryption.
 
-**DataFusion:** v57
+**DataFusion:** v58
 
 - **Customer-Managed Keys (BYOK)**: Encryption key management for sensitive workloads.
 - **Data-at-Rest Encryption**: Encrypted storage for accelerated datasets.

--- a/docs/release_notes/v2.1.0.md
+++ b/docs/release_notes/v2.1.0.md
@@ -1,0 +1,507 @@
+# Spice v2.1.0 (June 29, 2026)
+
+Spice v2.1.0 is the next minor release of Spice, headlined by **high-throughput Cayenne CDC**, scaling and resilience improvements to **PostgreSQL logical replication**, expanded **distributed query** with Iceberg catalog scans and broadcast joins, and the upgrade to **DataFusion v54** (including v53), Arrow v58.3, and Vortex v0.74. The release also adds experimental adaptive self-tuning for the Cayenne accelerator, distributed GLM inference, and a range of security, search, and connector improvements.
+
+Highlights in v2.1.0 include:
+
+- **[High-Throughput Cayenne CDC](#high-throughput-cayenne-cdc)** — in-memory CDC tier, dedicated compaction runtime, and write-path optimizations that cut replication lag on high-volume CDC workloads
+- **[PostgreSQL Replication at Scale](#change-data-capture--htap)** — multiple `changes`-mode datasets share a single replication slot, unchanged-TOAST recovery, and resilient reconnects across rolling deploys
+- **[Distributed Query](#distributed-query)** — distributed Ballista scans of Iceberg catalog tables, broadcast joins for small dimension tables, and shared scheduler job state with failover
+- **[DataFusion v54](#performance--query-engine)** — upgrade to DataFusion v54 (folding in v53), Arrow v58.3, and Vortex v0.74, bringing faster joins, scans, and planning
+- **[Adaptive Self-Tuning (Experimental)](#adaptive-self-tuning-experimental)** — opt-in closed-loop tuning and maintained aggregates that adapt Cayenne to hardware, schema, and live workload
+
+## What's New in v2.1.0
+
+### High-Throughput Cayenne CDC
+
+A major focus of v2.1 is [Spice Cayenne](https://spiceai.org/docs/components/data-accelerators/cayenne) write-path throughput for change-data-capture (HTAP) workloads:
+
+- **In-Memory CDC Tier**: A new in-memory CDC tier and follow-ups cut replication lag on hot upsert tables, with bounded mem-tier checkpointing and O(1) per-scan deletion views, plus a two-phase off-fence checkpoint on the ingest path.
+- **Dedicated Compaction Runtime**: A dedicated compaction runtime with CDC pipelining and protected snapshots isolates compaction from query and ingest paths, with parallelized deletion-vector writes, per-batch directory-barrier coalescing, and size-aware parallel encode for protected-snapshot compaction.
+- **Incremental Protected Snapshot Compaction**: Incremental compaction of protected snapshots (used in Cayenne's merge-on-read deletion index) reduces disk usage and improves query performance.
+- **Smaller WAL & Metadata-Only Publish**: `cayenne_insert_record` table IDs are stored as 16-byte raw-UUID BLOBs, cutting CDC WAL volume ~34%; upsert commits publish metadata-only, dropping per-key insert records; transient staged CDC deltas are light-encoded.
+- **Delta-Write Encoding Levels**: A new `cayenne_delta_encoding` setting (default `auto`) selects delta-write encoding, and `cayenne_compression_strategy: zstd` is now fully wired.
+- **In-Memory CDC Sharding**: PK-hash intra-apply sharding parallelizes in-memory CDC apply.
+- **Scan Safety Under Write**: In-flight scans are ref-counted so snapshot GC can't delete Vortex files mid-read; in-RAM scan parallelism, query admission control, and sound scan output ordering improve read behavior under sustained CDC.
+
+Delta-write encoding effort and Vortex compression are tunable per accelerator. `cayenne_delta_encoding: auto` (the default) size-gates fresh CDC/append writes — small deltas use a light scheme and are re-encoded during compaction — or pin an explicit level `0..10` (`7` is the full default cascade); `cayenne_compression_strategy` selects the Vortex compression:
+
+```yaml
+acceleration:
+  engine: cayenne
+  refresh_mode: changes
+  params:
+    cayenne_delta_encoding: auto # 'auto' (default), or pin a level 0..10 (7 = full cascade)
+    cayenne_compression_strategy: zstd # 'btrblocks' (default) or 'zstd'
+```
+
+### Change Data Capture & HTAP
+
+PostgreSQL logical replication (CDC, `refresh_mode: changes`, [introduced in v2.0](https://spiceai.org/docs/components/data-connectors/postgres)) gets significant scaling and resilience work in v2.1:
+
+- **Shared Replication Slot**: Multiple `refresh_mode: changes` [PostgreSQL](https://spiceai.org/docs/components/data-connectors/postgres) datasets on the same connection can name the same `pg_replication_slot` to share a single replication slot, walsender decoder, and publication, with decoded changes multiplexed by `(schema, table)` to each dataset. This collapses the slot count from one-per-dataset to one — staying well under Postgres's default `max_replication_slots = 10`.
+
+```yaml
+datasets:
+  - from: postgres:public.orders
+    name: orders
+    params:
+      pg_db: mydb
+      pg_replication_slot: spice_cdc # shared slot name
+    acceleration:
+      refresh_mode: changes
+  - from: postgres:public.customers
+    name: customers
+    params:
+      pg_db: mydb
+      pg_replication_slot: spice_cdc # same name -> one slot, walsender & publication
+    acceleration:
+      refresh_mode: changes
+```
+
+- **Unchanged-TOAST Recovery**: Under `REPLICA IDENTITY FULL`, when an `UPDATE` leaves a large TOASTed column unchanged, pgoutput sends an "unchanged" marker; Spice now fills that value from the old tuple — its old value is its current value — so updates no longer error or drop columns. Without an old tuple, the error persists with a hint to enable `REPLICA IDENTITY FULL`.
+- **Transient Walsender Contention**: Slot-contention errors during rolling deploys — `SQLSTATE 55006` ("replication slot is active for PID") and `53300` ("requested standby connections exceeds max_wal_senders") — are now classified as transient and retried with backoff instead of fatally terminating the stream. Replication connections are also released at shutdown start (not process exit), freeing walsender seats for replacement instances.
+- **Strict CDC Param Validation**: PostgreSQL CDC parameters are strictly validated rather than silently defaulted.
+- **Debezium Schema Evolution**: Fixes for Debezium schema-evolution support, including tombstone-message handling and sign-extension of minimal-width base64 decimals.
+
+### Distributed Query
+
+[Distributed Query](https://spiceai.org/docs/features/distributed-query) gains:
+
+- **Distributed Iceberg Catalog Scans**: Ballista distributes scans of Iceberg catalog tables across executors.
+- **Broadcast Joins**: Small dimension tables are broadcast to executors for distributed joins.
+- **Shared Scheduler Job State with Failover**: Ballista job state is shared so the scheduler can fail over without losing in-flight work.
+
+### Performance & Query Engine
+
+[Apache DataFusion](https://datafusion.apache.org/) is upgraded to **v54**, folding in v53, alongside **Arrow v58.3** and **Vortex v0.74** (with a pin bump adding intra-file decode split and a per-execution kernel cache). Two DataFusion releases land in this upgrade:
+
+- **DataFusion v54** ([release notes](https://datafusion.apache.org/blog/2026/06/12/datafusion-54.0.0/)): adds `LATERAL` joins, SQL lambda functions (`x -> expr` with `array_transform`/`array_filter`/`array_any_match`), spilling nested-loop joins, and a faster `arrow-avro` reader. Performance work includes morsel-driven Parquet scans (up to ~2x faster for skewed scans), 20-50x faster sort-merge semi/anti/mark joins, redundant-sort-key pruning, NDV-based cardinality estimation, and `inner_product`/`cosine_distance` functions.
+- **DataFusion v53** ([release notes](https://datafusion.apache.org/blog/2026/04/02/datafusion-53.0.0/)): adds `LIMIT`-aware Parquet row-group pruning, broader filter pushdown through joins and `UNION`, nested-field pushdown (`get_field` into the scan), faster query planning (some plans dropping from ~4-5ms to ~100us), and 42 faster built-in functions.
+
+Federation deny-list enforcement and catalog DDL are restored after the DataFusion upgrades, and a cost-based left-deep join reordering rule is added for Cayenne acceleration.
+
+### AI & LLM
+
+- **Native GLM Support with Distributed Inference**: Native GLM model support with surfaced `reasoning_content`, including tensor-parallel GLM inference. Load a GLM model with `model_type: glm4` (`glm4moe` and `glm4moelite` are also supported):
+
+```yaml
+models:
+  - name: glm
+    from: huggingface:huggingface.co/THUDM/glm-4-9b-chat
+    params:
+      model_type: glm4
+```
+
+For large models, GLM inference can be distributed across nodes (tensor parallelism) via the mistral.rs pure-TCP `ring` all-reduce backend — no NCCL/system dependency. This is a [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise) feature requiring the `distributed` build. Run the same model on each node, changing only `node_rank`:
+
+```yaml
+models:
+  - name: glm
+    from: huggingface:huggingface.co/THUDM/glm-4-9b-chat
+    params:
+      model_type: glm4
+      distributed_backend: ring
+      nodes: 10.0.4.21,10.0.4.22 # ordered host/IP per rank; the ring backend currently requires exactly 2
+      node_rank: 0 # rank of THIS node in [0, world_size); rank 0 serves the API. Set node_rank: 1 on 10.0.4.22
+```
+
+- **NSQL Context Endpoint**: A new `GET /v1/nsql/context` endpoint returns the SQL dialect, dataset schemas (with optional sample rows), and registered functions that Spice injects into natural-language-to-SQL (`POST /v1/nsql`) requests — useful for inspecting or caching exactly what the model sees:
+
+```bash
+# Inspect the context injected into /v1/nsql requests (examples_limit default 3, max 100)
+curl "http://localhost:8090/v1/nsql/context?include_examples=true&examples_limit=3"
+```
+
+Returns the dialect, per-dataset schema (keys, indexes, searchable columns), the registered function inventory, and sample rows (abbreviated):
+
+```json
+{
+  "context": "# Spice.ai NSQL Context",
+  "instructions": [
+    "Write SQL for the Spice runtime, which uses Apache DataFusion with the SQL parser configured for the PostgreSQL dialect.",
+    "Use table and column descriptions, primary keys, foreign keys, unique constraints, and indexes when choosing joins and filters."
+  ],
+  "sql": {
+    "engine": "Apache DataFusion",
+    "version": "54.0.0",
+    "dialect": "PostgreSQL",
+    "parser": "DataFusion SQL parser configured with PostgreSQL dialect"
+  },
+  "datasets": [
+    {
+      "name": "sales.orders",
+      "table": "orders",
+      "description": "Customer orders",
+      "columns": [
+        { "name": "order_id", "data_type": "Int64", "nullable": false, "primary_key": true, "indexed": true },
+        { "name": "customer_id", "data_type": "Utf8", "nullable": false, "vector_search": true, "full_text_search": true }
+      ],
+      "primary_key": ["order_id"],
+      "foreign_keys": [
+        { "columns": ["customer_id"], "foreign_table": "spice.sales.customers", "foreign_columns": ["id"] }
+      ]
+    }
+  ],
+  "functions": {
+    "summary": "Spice SQL runs on Apache DataFusion ... Run SELECT * FROM list_udfs() to inspect the full registered function inventory",
+    "search": [
+      { "name": "vector_search", "syntax": "vector_search(dataset, 'query text'[, column])" },
+      { "name": "text_search", "syntax": "text_search(dataset, 'query text'[, column])" }
+    ]
+  },
+  "samples": [
+    { "title": "Example rows for `sales.orders`", "content": "| order_id | customer_id |\n| --- | --- |\n| 42 | CUST-1 |" }
+  ]
+}
+```
+
+### Search & Vectors
+
+- **S3 Vectors Pagination**: `QueryVectors` paginates for top-K up to 10,000.
+- **Elasticsearch kNN Candidate Pool**: The default kNN candidate pool is raised from 10 to 1000 for better recall.
+
+### SQL & Query Engine
+
+- **FlightSQL Substrait Plans**: `CommandStatementSubstraitPlan` support.
+- **Large Result Streaming**: Flight streaming is optimized for large result sets.
+- **Write Authorization**: The SQL tool allows writes for ReadWrite API keys.
+- **Schema Evolution Policies**: `on_schema_change` supports widening-only evolution and a `drop_and_recreate` policy.
+
+### Security & Connectors
+
+- **Kafka mTLS**: Mutual TLS configuration is surfaced in the Kafka data connector.
+- **Secret Resolution at Startup**: Secret references are checked and reported at startup.
+- **DuckDB HNSW**: Upgrade to DuckDB v1.5.3 with the statically linked VSS (HNSW) vector extension.
+
+### Adaptive Self-Tuning (Experimental)
+
+The Spice Cayenne accelerator gains experimental opt-in self-tuning. `cayenne_tuning: auto` derives configuration from the detected hardware and inferred schema, while `adaptive` additionally runs a per-table closed-feedback controller that adapts flush caps, the in-memory CDC tier, compaction cadence, and write concurrency toward operator SLOs (replication lag, freshness, query latency, queries-per-hour). Cayenne can also maintain aggregates incrementally — with predicate-aware delta serving and incremental retraction — and fold whole-table `SUM`/`AVG`/`COUNT`/`MIN`/`MAX` from statistics. These features are experimental and disabled by default.
+
+```yaml
+datasets:
+  - from: postgres:public.orders
+    name: orders
+    acceleration:
+      engine: cayenne
+      refresh_mode: changes
+      params:
+        cayenne_tuning: adaptive # 'auto' (static, env- + schema-derived) or 'adaptive' (closed-loop)
+```
+
+### Observability
+
+- **Per-Dataset Query Attribution**: The `query_executions` metric gains a `datasets` dimension.
+- **HTAP Diagnostics**: Improved HTAP replication diagnostics on non-convergence.
+- **Cayenne Write Observability**: Write-phase observability for the in-memory CDC tier.
+
+### Notable Bug Fixes
+
+- **Cayenne Utf8View**: The Utf8View read schema avoids a hash-join offset overflow.
+- **Cayenne metastore**: `cayenne_metastore: turso` is honored for partitioned tables and the dataset checkpoint.
+- **Dual-write detection**: Dual-write accelerated tables are detected behind the metadata-enrichment wrapper.
+- **`digest_many` collisions**: Values are length-prefixed so column boundaries can't collide.
+- **Turso WAL checkpoint**: WAL checkpoints route through the native Turso connection.
+- **TLS status probe**: The status check probes the metrics endpoint over HTTPS when TLS is enabled.
+- **Search snippet offsets**: Character chunk offsets persist so search snippets aren't shifted or garbled.
+- **Async query chunk offsets**: `/v1/queries` chunk `row_offset` uses the cumulative offset rather than `chunk_index * chunk_size`.
+
+### Dependency Updates
+
+| Dependency / Component | Version |
+| ---------------------- | ------- |
+| **DataFusion**         | v54     |
+| **Arrow (arrow-rs)**   | v58.3   |
+| **Vortex**             | v0.74   |
+| **iceberg-rust**       | v0.9.1  |
+| **DuckDB**             | v1.5.3  |
+| **Rust toolchain**     | v1.95.0 |
+
+## Contributors
+
+- [@bjchambers](https://github.com/bjchambers)
+- [@ewgenius](https://github.com/ewgenius)
+- [@Jeadie](https://github.com/Jeadie)
+- [@krinart](https://github.com/krinart)
+- [@lukekim](https://github.com/lukekim)
+- [@melks](https://github.com/melks)
+- [@mvanhorn](https://github.com/mvanhorn)
+- [@Oxygen56](https://github.com/Oxygen56)
+- [@peasee](https://github.com/peasee)
+- [@phillipleblanc](https://github.com/phillipleblanc)
+- [@sgrebnov](https://github.com/sgrebnov)
+- [@v1gnesh](https://github.com/v1gnesh)
+
+## Breaking Changes
+
+No breaking changes.
+
+## Cookbook Updates
+
+No new cookbook recipes.
+
+The [Spice Cookbook](https://spiceai.org/cookbook) includes more than 100 recipes to help you get started with Spice quickly and easily.
+
+## Upgrading
+
+To upgrade to v2.1.0, use one of the following methods:
+
+**CLI**:
+
+```console
+spice upgrade
+```
+
+**Homebrew**:
+
+```console
+brew upgrade spiceai/spiceai/spice
+```
+
+**Docker**:
+
+Pull the `spiceai/spiceai:2.1.0` image:
+
+```console
+docker pull spiceai/spiceai:2.1.0
+```
+
+For available tags, see [DockerHub](https://hub.docker.com/r/spiceai/spiceai/tags).
+
+**Helm**:
+
+```console
+helm repo update
+helm upgrade spiceai spiceai/spiceai --version 2.1.0
+```
+
+**AWS Marketplace**:
+
+Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-jmf6jskjvnq7i).
+
+## What's Changed
+
+### Changelog
+
+- Make DuckDB schema cast logic more robust by [@sgrebnov](https://github.com/sgrebnov) in [#10991](https://github.com/spiceai/spiceai/pull/10991)
+- perf(cayenne): reduce allocation overheads in hot paths by [@lukekim](https://github.com/lukekim) in [#10950](https://github.com/spiceai/spiceai/pull/10950)
+- improve error message for 'params.spiceai_region' by [@Jeadie](https://github.com/Jeadie) in [#10954](https://github.com/spiceai/spiceai/pull/10954)
+- fix(acceleration): rename WriteMode variants to fix #10960 by [@phillipleblanc](https://github.com/phillipleblanc) in [#10974](https://github.com/spiceai/spiceai/pull/10974)
+- add Scylla, bigquery and turso to throughput benchmarking by [@Jeadie](https://github.com/Jeadie) in [#11006](https://github.com/spiceai/spiceai/pull/11006)
+- deps(ballista): pull in shuffle-on-object-store correctness fixes (datafusion-ballista PRs #42 + #43) by [@phillipleblanc](https://github.com/phillipleblanc) in [#10919](https://github.com/spiceai/spiceai/pull/10919)
+- fix(kafka): seek to sidecar offsets via post_rebalance callback on restart by [@ewgenius](https://github.com/ewgenius) in [#11007](https://github.com/spiceai/spiceai/pull/11007)
+- Propagate source comments into schema metadata by [@lukekim](https://github.com/lukekim) in [#10944](https://github.com/spiceai/spiceai/pull/10944)
+- feat(chbench-driver): better alignment to BenchBase by [@sgrebnov](https://github.com/sgrebnov) in [#11012](https://github.com/spiceai/spiceai/pull/11012)
+- fix: handle EXISTS/NOT EXISTS subqueries in federation analyzer by [@sgrebnov](https://github.com/sgrebnov) in [#10996](https://github.com/spiceai/spiceai/pull/10996)
+- Enable filter pushdown in spicepod defined UDTFs by [@Jeadie](https://github.com/Jeadie) in [#11004](https://github.com/spiceai/spiceai/pull/11004)
+- Refactor spice dataset configuration command by [@Jeadie](https://github.com/Jeadie) in [#10999](https://github.com/spiceai/spiceai/pull/10999)
+- fix: ensure HashJoinExec partition counts match when join input is statically empty by [@phillipleblanc](https://github.com/phillipleblanc) in [#11025](https://github.com/spiceai/spiceai/pull/11025)
+- feat(chbench): Improve OLTP throughput and reduce PostgreSQL CDC overhead by [@sgrebnov](https://github.com/sgrebnov) in [#11018](https://github.com/spiceai/spiceai/pull/11018)
+- feat(cluster): add distributed query observability metrics by [@phillipleblanc](https://github.com/phillipleblanc) in [#10990](https://github.com/spiceai/spiceai/pull/10990)
+- fix: delegate truncate in PolyTableProvider to inner write provider by [@claudespice](https://github.com/claudespice) in [#11036](https://github.com/spiceai/spiceai/pull/11036)
+- Remove default runtime features - enable explicitly in spiced by [@phillipleblanc](https://github.com/phillipleblanc) in [#11037](https://github.com/spiceai/spiceai/pull/11037)
+- fix: preserve field and schema metadata in Vortex physical schema calculation by [@claudespice](https://github.com/claudespice) in [#11013](https://github.com/spiceai/spiceai/pull/11013)
+- Expose metadata descriptions via PostgreSQL UDFs by [@lukekim](https://github.com/lukekim) in [#11032](https://github.com/spiceai/spiceai/pull/11032)
+- fix: route Turso WAL checkpoint through native turso connection (fixes #10657) by [@claudespice](https://github.com/claudespice) in [#11048](https://github.com/spiceai/spiceai/pull/11048)
+- fix: add missing truncate delegation and guards for wrapper TableProviders by [@claudespice](https://github.com/claudespice) in [#11014](https://github.com/spiceai/spiceai/pull/11014)
+- Update DataConnector statuses by [@krinart](https://github.com/krinart) in [#11052](https://github.com/spiceai/spiceai/pull/11052)
+- docs: refresh public roadmap for May 2026 by [@lukekim](https://github.com/lukekim) in [#11053](https://github.com/spiceai/spiceai/pull/11053)
+- remove redundant readonly checks by [@Jeadie](https://github.com/Jeadie) in [#10975](https://github.com/spiceai/spiceai/pull/10975)
+- Fix Unity Catalog connector compatibility with OSS Unity Catalog by [@ewgenius](https://github.com/ewgenius) in [#11026](https://github.com/spiceai/spiceai/pull/11026)
+- refactor(cdc): reduce CDC sub-batch splits for interleaved upsert/delete workloads by [@sgrebnov](https://github.com/sgrebnov) in [#11051](https://github.com/spiceai/spiceai/pull/11051)
+- feat(cayenne): allow inline writes with pending deletions (deletes/upserts) by [@sgrebnov](https://github.com/sgrebnov) in [#11031](https://github.com/spiceai/spiceai/pull/11031)
+- fix(sql-tool): defer read-only gate to caller's API key role by [@phillipleblanc](https://github.com/phillipleblanc) in [#11040](https://github.com/spiceai/spiceai/pull/11040)
+- fix: map Gemini Recitation finish reason to ContentFilter by [@claudespice](https://github.com/claudespice) in [#11046](https://github.com/spiceai/spiceai/pull/11046)
+- feat(cayenne): fast-path CDC deletes by extracting PK values from filters by [@sgrebnov](https://github.com/sgrebnov) in [#11049](https://github.com/spiceai/spiceai/pull/11049)
+- docs(cayenne): rewrite internal README for accuracy and add techniques section by [@lukekim](https://github.com/lukekim) in [#11034](https://github.com/spiceai/spiceai/pull/11034)
+- fix(cluster): gate scheduler readiness on executor partition loads by [@phillipleblanc](https://github.com/phillipleblanc) in [#10992](https://github.com/spiceai/spiceai/pull/10992)
+- fix(snowflake): enforce function deny-list in federation pushdown by [@claudespice](https://github.com/claudespice) in [#11057](https://github.com/spiceai/spiceai/pull/11057)
+- perf(cdc): Last-write-wins dedup in `group_into_sub_batches` to reduce sub-batch splits by [@sgrebnov](https://github.com/sgrebnov) in [#11059](https://github.com/spiceai/spiceai/pull/11059)
+- [Bug] Timing between reconnect and AllocateInitialPartitions leaves connection without flight_sql_client by [@Jeadie](https://github.com/Jeadie) in [#10805](https://github.com/spiceai/spiceai/pull/10805)
+- Define 'trait QueryEngine' to refactor runtime crate by [@Jeadie](https://github.com/Jeadie) in [#11028](https://github.com/spiceai/spiceai/pull/11028)
+- fix(snowflake): apply Spice function deny-list in extracted connector crate by [@claudespice](https://github.com/claudespice) in [#11071](https://github.com/spiceai/spiceai/pull/11071)
+- perf(cayenne): keep CDC upsert PK keysets resident to avoid per-batch full-table rebuilds by [@lukekim](https://github.com/lukekim) in [#11074](https://github.com/spiceai/spiceai/pull/11074)
+- fix(postgres-replication): emit recovery log + reduce reconnect-warn volume by [@claudespice](https://github.com/claudespice) in [#11084](https://github.com/spiceai/spiceai/pull/11084)
+- fix metadata on search indexing by [@Jeadie](https://github.com/Jeadie) in [#11080](https://github.com/spiceai/spiceai/pull/11080)
+- perf(cayenne): scale CDC inline flush caps with memory + storage class by [@lukekim](https://github.com/lukekim) in [#11087](https://github.com/spiceai/spiceai/pull/11087)
+- feat(cayenne): merge-on-read position deletes for PK upsert tables + memory-pool accounting by [@lukekim](https://github.com/lukekim) in [#11085](https://github.com/spiceai/spiceai/pull/11085)
+- Support tuple-IN composite PK extraction in Cayenne delete fast-path by [@sgrebnov](https://github.com/sgrebnov) in [#11093](https://github.com/spiceai/spiceai/pull/11093)
+- feat(cluster): report per-executor table statistics so distributed JoinSelection can size joins by [@phillipleblanc](https://github.com/phillipleblanc) in [#11089](https://github.com/spiceai/spiceai/pull/11089)
+- feat(cluster): NDV-aware executor stats so CDC q18 join swap fires by [@phillipleblanc](https://github.com/phillipleblanc) in [#11098](https://github.com/spiceai/spiceai/pull/11098)
+- Improve HTAP replication diagnostics on non-convergence by [@sgrebnov](https://github.com/sgrebnov) in [#11100](https://github.com/spiceai/spiceai/pull/11100)
+- Normalize `DataType::Null` to `Int32` in acceleration schema for duckdb by [@krinart](https://github.com/krinart) in [#11062](https://github.com/spiceai/spiceai/pull/11062)
+- Fix debezium schema evolution support by [@ewgenius](https://github.com/ewgenius) in [#11095](https://github.com/spiceai/spiceai/pull/11095)
+- feat(cayenne): incremental write-path executor statistics for distributed join sizing by [@phillipleblanc](https://github.com/phillipleblanc) in [#11104](https://github.com/spiceai/spiceai/pull/11104)
+- fix(cache): periodic moka maintenance to drain invalidation predicates (#11077) by [@phillipleblanc](https://github.com/phillipleblanc) in [#11106](https://github.com/spiceai/spiceai/pull/11106)
+- fix: validate Snowflake account identifiers and auth config by [@Jeadie](https://github.com/Jeadie) in [#11024](https://github.com/spiceai/spiceai/pull/11024)
+- fix: trace external mcp server tool calls by [@ewgenius](https://github.com/ewgenius) in [#11058](https://github.com/spiceai/spiceai/pull/11058)
+- Remove unwrap from test code; drop clippy::unwrap_used suppressions by [@phillipleblanc](https://github.com/phillipleblanc) in [#11108](https://github.com/spiceai/spiceai/pull/11108)
+- Upgrade to DuckDB 1.5.3 + statically link the VSS (HNSW) extension by [@sgrebnov](https://github.com/sgrebnov) in [#11107](https://github.com/spiceai/spiceai/pull/11107)
+- Fix fetched_at for HTTP connector by [@Jeadie](https://github.com/Jeadie) in [#11116](https://github.com/spiceai/spiceai/pull/11116)
+- fix(search): propagate LIMIT to base TableScan in VectorScanTableProvider (fixes #8368) by [@claudespice](https://github.com/claudespice) in [#11124](https://github.com/spiceai/spiceai/pull/11124)
+- feat(runtime): add spicebench feature to register the Cayenne catalog connector by [@phillipleblanc](https://github.com/phillipleblanc) in [#11122](https://github.com/spiceai/spiceai/pull/11122)
+- fix(cayenne): tombstone inline-checkpointed rows on upsert to prevent duplicate PKs by [@sgrebnov](https://github.com/sgrebnov) in [#11129](https://github.com/spiceai/spiceai/pull/11129)
+- Remove possibility of a deadlock in `RuntimeStatus` by [@krinart](https://github.com/krinart) in [#11114](https://github.com/spiceai/spiceai/pull/11114)
+- Fix Windows build: vendored-vss duckdb-rs + adapt to table-providers mongodb API by [@phillipleblanc](https://github.com/phillipleblanc) in [#11140](https://github.com/spiceai/spiceai/pull/11140)
+- localpod: synchronize child refreshes when parent uses in-memory (arrow) accelerator by [@phillipleblanc](https://github.com/phillipleblanc) in [#11139](https://github.com/spiceai/spiceai/pull/11139)
+- Add `datasets` dimension to the `query_executions` metric by [@phillipleblanc](https://github.com/phillipleblanc) in [#11138](https://github.com/spiceai/spiceai/pull/11138)
+- fix(spiceai): keep correlated subqueries out of JOIN ON for Spice Cloud federation by [@phillipleblanc](https://github.com/phillipleblanc) in [#11143](https://github.com/spiceai/spiceai/pull/11143)
+- fix(duckdb): normalize timestamp columns to microsecond precision (fixes #10627) by [@claudespice](https://github.com/claudespice) in [#11145](https://github.com/spiceai/spiceai/pull/11145)
+- feat(cayenne): sharded parallel Vortex encode with key/time clustering by [@lukekim](https://github.com/lukekim) in [#11144](https://github.com/spiceai/spiceai/pull/11144)
+- fix(cluster): prevent DoPut write pipeline self-deadlock under ingest backpressure by [@phillipleblanc](https://github.com/phillipleblanc) in [#11160](https://github.com/spiceai/spiceai/pull/11160)
+- feat(chbench): configurable HTAP concurrency, DuckDB query overrides, and OLTP rate control by [@sgrebnov](https://github.com/sgrebnov) in [#11162](https://github.com/spiceai/spiceai/pull/11162)
+- fix(http): preserve non-JSON response rows instead of crashing nested decomposition (fixes #11155) by [@claudespice](https://github.com/claudespice) in [#11161](https://github.com/spiceai/spiceai/pull/11161)
+- Use declared schema in DynamoDB/MongoDB/Debezium by [@krinart](https://github.com/krinart) in [#11066](https://github.com/spiceai/spiceai/pull/11066)
+- fix(cluster): prevent partitioned datasets from staying Refreshing by [@phillipleblanc](https://github.com/phillipleblanc) in [#11157](https://github.com/spiceai/spiceai/pull/11157)
+- fix(runtime): don't list `postgres` as a valid accelerator engine when `postgres-accel` is disabled by [@sgrebnov](https://github.com/sgrebnov) in [#11169](https://github.com/spiceai/spiceai/pull/11169)
+- fix(spark): recover stale or broken Spark Connect sessions on failure by [@lukekim](https://github.com/lukekim) in [#11171](https://github.com/spiceai/spiceai/pull/11171)
+- fix(secrets): don't abort secret lookup precedence walk on a failing store by [@phillipleblanc](https://github.com/phillipleblanc) in [#11175](https://github.com/spiceai/spiceai/pull/11175)
+- feat(cayenne): bound aggregate write concurrency, conservative defaults, and write/read observability by [@lukekim](https://github.com/lukekim) in [#11170](https://github.com/spiceai/spiceai/pull/11170)
+- feat(unity_catalog): support Unity Catalog credential vending for Delta Lake tables by [@phillipleblanc](https://github.com/phillipleblanc) in [#11180](https://github.com/spiceai/spiceai/pull/11180)
+- fix(secrets): keep failed secret stores registered so lookups report the init root cause by [@phillipleblanc](https://github.com/phillipleblanc) in [#11181](https://github.com/spiceai/spiceai/pull/11181)
+- fix(debezium): sign-extend minimal-width base64 decimals instead of zero-padding by [@claudespice](https://github.com/claudespice) in [#11184](https://github.com/spiceai/spiceai/pull/11184)
+- fix(deps): update hickory-resolver to 0.26 (evicts hickory-proto 0.25.x) by [@phillipleblanc](https://github.com/phillipleblanc) in [#11183](https://github.com/spiceai/spiceai/pull/11183)
+- refactor(secrets): derive secret store metadata from a single registry table by [@phillipleblanc](https://github.com/phillipleblanc) in [#11188](https://github.com/spiceai/spiceai/pull/11188)
+- perf(cayenne): cut CDC replication lag on hot upsert tables by [@lukekim](https://github.com/lukekim) in [#11191](https://github.com/spiceai/spiceai/pull/11191)
+- feat(cayenne): async inline-fallback (per-tombstone published flag) + 64c/256GB tuning by [@lukekim](https://github.com/lukekim) in [#11194](https://github.com/spiceai/spiceai/pull/11194)
+- Add HTTP connector mTLS support by [@lukekim](https://github.com/lukekim) in [#11127](https://github.com/spiceai/spiceai/pull/11127)
+- feat(snowflake): push AT TIME ZONE as CONVERT_TIMEZONE and pin session to UTC by [@lukekim](https://github.com/lukekim) in [#11190](https://github.com/spiceai/spiceai/pull/11190)
+- feat(cdc): make cdc_max_coalesce_age_ms a real apply-loop linger by [@sgrebnov](https://github.com/sgrebnov) in [#11196](https://github.com/spiceai/spiceai/pull/11196)
+- feat(cayenne): delta-write encoding levels (cayenne_delta_encoding, default auto) + make compression_strategy=zstd real by [@lukekim](https://github.com/lukekim) in [#11199](https://github.com/spiceai/spiceai/pull/11199)
+- Add NSQL context endpoint by [@lukekim](https://github.com/lukekim) in [#11075](https://github.com/spiceai/spiceai/pull/11075)
+- fix(federation): respect the Spice function deny-list across all SQL connectors; dialect-aware DuckDB pushdown by [@claudespice](https://github.com/claudespice) in [#11186](https://github.com/spiceai/spiceai/pull/11186)
+- fix: surface unknown/applied cayenne_* runtime.params at startup (fixes #10970) by [@claudespice](https://github.com/claudespice) in [#11133](https://github.com/spiceai/spiceai/pull/11133)
+- perf(cayenne): plain-fsync ordering tier on the staged-commit hot path by [@lukekim](https://github.com/lukekim) in [#11198](https://github.com/spiceai/spiceai/pull/11198)
+- fix(kafka): decode JSON payloads to Arrow directly — fixes lossy Decimal128 + removes double-parse (#11192) by [@claudespice](https://github.com/claudespice) in [#11207](https://github.com/spiceai/spiceai/pull/11207)
+- feat(cayenne): self-tuning accelerator — hardware + schema + closed-loop adaptive (auto/adaptive modes) by [@lukekim](https://github.com/lukekim) in [#11213](https://github.com/spiceai/spiceai/pull/11213)
+- perf(cayenne): CDC throughput — SF-100 @10K txn/s toward <5s lag + 5K QPH by [@lukekim](https://github.com/lukekim) in [#11206](https://github.com/spiceai/spiceai/pull/11206)
+- fix(cluster): distribute accelerated tables wrapped by metadata/index providers by [@phillipleblanc](https://github.com/phillipleblanc) in [#11226](https://github.com/spiceai/spiceai/pull/11226)
+- Improve Cayenne adaptive tuning and schema safety by [@lukekim](https://github.com/lukekim) in [#11237](https://github.com/spiceai/spiceai/pull/11237)
+- feat: Add cayenne_file_pruning param by [@peasee](https://github.com/peasee) in [#11239](https://github.com/spiceai/spiceai/pull/11239)
+- Debezium connector - handle tombstone messages in kafka topic, with schema evolution enabled by [@ewgenius](https://github.com/ewgenius) in [#11197](https://github.com/spiceai/spiceai/pull/11197)
+- feat(cayenne): broadcast small-dimension joins to executors by [@phillipleblanc](https://github.com/phillipleblanc) in [#11245](https://github.com/spiceai/spiceai/pull/11245)
+- fix: scope request context across the managed query runtime by [@phillipleblanc](https://github.com/phillipleblanc) in [#11253](https://github.com/spiceai/spiceai/pull/11253)
+- fix: Strip inference columns from table schema on query by [@peasee](https://github.com/peasee) in [#11251](https://github.com/spiceai/spiceai/pull/11251)
+- fix(flightsql): don't drop un-pushed FilterExec predicates in distributed pushdown rules by [@claudespice](https://github.com/claudespice) in [#11256](https://github.com/spiceai/spiceai/pull/11256)
+- feat(postgres): share one replication slot across multiple changes-mode datasets by [@phillipleblanc](https://github.com/phillipleblanc) in [#11255](https://github.com/spiceai/spiceai/pull/11255)
+- feat: Update roadmap with new features and adjustments for v2.1 and v2.2 by [@lukekim](https://github.com/lukekim) in [#11258](https://github.com/spiceai/spiceai/pull/11258)
+- Upgrade to DataFusion v53.1, Arrow v58.3, Vortex v0.74, and dependencies by [@lukekim](https://github.com/lukekim) in [#11118](https://github.com/spiceai/spiceai/pull/11118)
+- feat(connectors): support file_format: vortex everywhere parquet is supported by [@lukekim](https://github.com/lukekim) in [#11282](https://github.com/spiceai/spiceai/pull/11282)
+- perf(cayenne): metadata-only publish — drop per-key insert records on upsert commit by [@lukekim](https://github.com/lukekim) in [#11260](https://github.com/spiceai/spiceai/pull/11260)
+- fix(kafka): harden fetch_latest_message for multi-partition topics by [@ewgenius](https://github.com/ewgenius) in [#11285](https://github.com/spiceai/spiceai/pull/11285)
+- perf(cayenne): bound mem-tier checkpoint churn + O(1) per-scan deletion view by [@lukekim](https://github.com/lukekim) in [#11249](https://github.com/spiceai/spiceai/pull/11249)
+- fix(udfs): length-prefix digest_many values so column boundaries can't collide (fixes #11272) by [@claudespice](https://github.com/claudespice) in [#11288](https://github.com/spiceai/spiceai/pull/11288)
+- fix: restore federation deny-list enforcement regressed by the DataFusion 53 upgrade by [@claudespice](https://github.com/claudespice) in [#11294](https://github.com/spiceai/spiceai/pull/11294)
+- fix(postgres): recover unchanged-TOAST columns from the old tuple; classify walsender contention as transient by [@phillipleblanc](https://github.com/phillipleblanc) in [#11293](https://github.com/spiceai/spiceai/pull/11293)
+- feat: deepen extended schema inference and wire it into cayenne compaction sharding/sorting by [@lukekim](https://github.com/lukekim) in [#11284](https://github.com/spiceai/spiceai/pull/11284)
+- perf(cayenne): in-memory CDC tier follow-ups + write-phase observability by [@lukekim](https://github.com/lukekim) in [#11278](https://github.com/spiceai/spiceai/pull/11278)
+- Support per-dataset CDC tunable overrides by [@sgrebnov](https://github.com/sgrebnov) in [#11295](https://github.com/spiceai/spiceai/pull/11295)
+- feat(cayenne): harden adaptive auto-tuner (controller hygiene, mem-tier actuator, delete/burst signals, single opt-in) by [@lukekim](https://github.com/lukekim) in [#11302](https://github.com/spiceai/spiceai/pull/11302)
+- fix(cayenne): scan inlined-view capture starvation under sustained CDC (analytical QPH) by [@lukekim](https://github.com/lukekim) in [#11299](https://github.com/spiceai/spiceai/pull/11299)
+- fix(vortex): don't row-evaluate hash-join dynamic filters in the scan by [@sgrebnov](https://github.com/sgrebnov) in [#11307](https://github.com/spiceai/spiceai/pull/11307)
+- fix(deps): bump rust-postgres crates (RUSTSEC-2026-0178/0179) by [@lukekim](https://github.com/lukekim) in [#11313](https://github.com/spiceai/spiceai/pull/11313)
+- fix: strict validation of Postgres CDC params instead of silent defaults (fixes #11274) by [@claudespice](https://github.com/claudespice) in [#11304](https://github.com/spiceai/spiceai/pull/11304)
+- fix(duckdb): always quote on-refresh sort columns so reserved-word names don't break refresh by [@claudespice](https://github.com/claudespice) in [#11305](https://github.com/spiceai/spiceai/pull/11305)
+- feat(flightsql): fall back to original connection when endpoint location is unreachable by [@melks](https://github.com/melks) in [#11287](https://github.com/spiceai/spiceai/pull/11287)
+- perf(cayenne): light-encode transient staged CDC deltas by [@lukekim](https://github.com/lukekim) in [#11311](https://github.com/spiceai/spiceai/pull/11311)
+- feat(acceleration): widening-only schema evolution via on_schema_change by [@lukekim](https://github.com/lukekim) in [#11261](https://github.com/spiceai/spiceai/pull/11261)
+- deps(vortex): bump pin to spiceai-53 HEAD — intra-file decode split + per-execution kernel cache by [@lukekim](https://github.com/lukekim) in [#11314](https://github.com/spiceai/spiceai/pull/11314)
+- feat(github): enhance GitHub component validation and error handling by [@lukekim](https://github.com/lukekim) in [#11259](https://github.com/spiceai/spiceai/pull/11259)
+- feat(cayenne): goal-driven adaptive tuning toward operator SLOs (lag, freshness, query latency, QPH) by [@lukekim](https://github.com/lukekim) in [#11310](https://github.com/spiceai/spiceai/pull/11310)
+- fix(cayenne): broadcast-join rewrite must bail on ambiguous columns, NULL-equal joins, and residual filters by [@claudespice](https://github.com/claudespice) in [#11252](https://github.com/spiceai/spiceai/pull/11252)
+- Add Cayenne maintained aggregates by [@lukekim](https://github.com/lukekim) in [#11235](https://github.com/spiceai/spiceai/pull/11235)
+- perf(cayenne): single-hash composite deletion filter via KeyDeletionIndex::get_batch by [@phillipleblanc](https://github.com/phillipleblanc) in [#11325](https://github.com/spiceai/spiceai/pull/11325)
+- fix(Vortex): decline only the `InList` membership conjunct of hash-join dynamic filters by [@sgrebnov](https://github.com/sgrebnov) in [#11335](https://github.com/spiceai/spiceai/pull/11335)
+- fix: scope SQL UDF arg inlining to args-table columns (fixes #11273) by [@claudespice](https://github.com/claudespice) in [#11337](https://github.com/spiceai/spiceai/pull/11337)
+- fix(refresh): restore S3 ETag/Version refresh-skip behind provider wrappers by [@phillipleblanc](https://github.com/phillipleblanc) in [#11339](https://github.com/spiceai/spiceai/pull/11339)
+- fix(cayenne): ref-count in-flight scans so GC can't delete Vortex files mid-read by [@phillipleblanc](https://github.com/phillipleblanc) in [#11321](https://github.com/spiceai/spiceai/pull/11321)
+- fix(runtime): retry object-store dataset load when source files are not yet available by [@phillipleblanc](https://github.com/phillipleblanc) in [#11342](https://github.com/spiceai/spiceai/pull/11342)
+- feat(s3): default to path-style for dotted bucket names on standard AWS by [@phillipleblanc](https://github.com/phillipleblanc) in [#11347](https://github.com/spiceai/spiceai/pull/11347)
+- fix(runtime): resolve accelerated table through metadata-enrichment wrapper by [@phillipleblanc](https://github.com/phillipleblanc) in [#11345](https://github.com/spiceai/spiceai/pull/11345)
+- fix: detect dual-write accelerated tables behind the metadata-enrichment wrapper by [@claudespice](https://github.com/claudespice) in [#11351](https://github.com/spiceai/spiceai/pull/11351)
+- feat(cayenne): incremental seq-prefix bake — shrink the merge-on-read deletion index by [@lukekim](https://github.com/lukekim) in [#11326](https://github.com/spiceai/spiceai/pull/11326)
+- fix(adbc): prevent Spice-specific UDFs from being pushed down to ADBC sources by [@krinart](https://github.com/krinart) in [#11297](https://github.com/spiceai/spiceai/pull/11297)
+- fix: Query Redshift schema details from svv_redshift tables by [@peasee](https://github.com/peasee) in [#11362](https://github.com/spiceai/spiceai/pull/11362)
+- perf(cayenne): tune Turso connection PRAGMAs + jitter metastore retries by [@lukekim](https://github.com/lukekim) in [#11359](https://github.com/spiceai/spiceai/pull/11359)
+- Upgrade to DataFusion 54 by [@sgrebnov](https://github.com/sgrebnov) in [#11360](https://github.com/spiceai/spiceai/pull/11360)
+- feat(runtime): dedicated CDC-apply tokio runtime + per-runtime tokio metrics by [@lukekim](https://github.com/lukekim) in [#11370](https://github.com/spiceai/spiceai/pull/11370)
+- fix(cayenne): spill oversized hash joins via sort-merge to avoid OOM by [@lukekim](https://github.com/lukekim) in [#11371](https://github.com/spiceai/spiceai/pull/11371)
+- fix(cayenne): honor cayenne_metastore: turso for partitioned tables and the dataset checkpoint by [@phillipleblanc](https://github.com/phillipleblanc) in [#11365](https://github.com/spiceai/spiceai/pull/11365)
+- perf(cayenne): in-RAM scan parallelism, query admission control, skip no-op deletion encode, sound scan output_ordering by [@lukekim](https://github.com/lukekim) in [#11332](https://github.com/spiceai/spiceai/pull/11332)
+- fix(catalog): restore DDL after DataFusion 54 broke transparent catalog-provider downcasts by [@phillipleblanc](https://github.com/phillipleblanc) in [#11375](https://github.com/spiceai/spiceai/pull/11375)
+- feat(flightsql): infer schema via SELECT * LIMIT 1 when GetTables is unimplemented by [@melks](https://github.com/melks) in [#11286](https://github.com/spiceai/spiceai/pull/11286)
+- fix(cayenne): Utf8View read schema avoids hash-join offset overflow by [@lukekim](https://github.com/lukekim) in [#11379](https://github.com/spiceai/spiceai/pull/11379)
+- feat(cluster): support distributed (Ballista) scans of Iceberg tables by [@phillipleblanc](https://github.com/phillipleblanc) in [#11378](https://github.com/spiceai/spiceai/pull/11378)
+- feat(optimizer): cost-based left-deep join reordering for Cayenne acceleration by [@sgrebnov](https://github.com/sgrebnov) in [#11377](https://github.com/spiceai/spiceai/pull/11377)
+- cli - fix service-account auth in `spice cloud *` commands by [@ewgenius](https://github.com/ewgenius) in [#11316](https://github.com/spiceai/spiceai/pull/11316)
+- fix: Support external Redshift table schema inference and Hive external type parsing by [@peasee](https://github.com/peasee) in [#11399](https://github.com/spiceai/spiceai/pull/11399)
+- feat(llms): native GLM support — opt-in flash-attn + surface reasoning_content by [@lukekim](https://github.com/lukekim) in [#11400](https://github.com/spiceai/spiceai/pull/11400)
+- feat(s3_vectors): paginate QueryVectors for topK up to 10,000 by [@bjchambers](https://github.com/bjchambers) in [#11405](https://github.com/spiceai/spiceai/pull/11405)
+- fix: surface .env parse errors with line numbers instead of silently skipping by [@Oxygen56](https://github.com/Oxygen56) in [#11306](https://github.com/spiceai/spiceai/pull/11306)
+- fix(status): probe metrics endpoint over https when TLS is enabled by [@phillipleblanc](https://github.com/phillipleblanc) in [#11393](https://github.com/spiceai/spiceai/pull/11393)
+- fix(mcp): record task_history spans for tool calls proxied through /v1/mcp by [@phillipleblanc](https://github.com/phillipleblanc) in [#11397](https://github.com/spiceai/spiceai/pull/11397)
+- Properly handle date_trunc in BigQueryDialect by [@krinart](https://github.com/krinart) in [#11416](https://github.com/spiceai/spiceai/pull/11416)
+- fix(snowflake): honor column scale in Int64 timestamp arm and cast TIME by [@claudespice](https://github.com/claudespice) in [#11418](https://github.com/spiceai/spiceai/pull/11418)
+- fix: /v1/queries chunk row_offset uses cumulative offset, not chunk_index * chunk_size (fixes #11271) by [@claudespice](https://github.com/claudespice) in [#11398](https://github.com/spiceai/spiceai/pull/11398)
+- feat(cayenne): incremental retraction for maintained aggregates + anchor bench by [@lukekim](https://github.com/lukekim) in [#11389](https://github.com/spiceai/spiceai/pull/11389)
+- feat(cluster): support distributed (Ballista) scans of Iceberg catalog tables by [@phillipleblanc](https://github.com/phillipleblanc) in [#11419](https://github.com/spiceai/spiceai/pull/11419)
+- Simplify chat/responses models by [@Jeadie](https://github.com/Jeadie) in [#10997](https://github.com/spiceai/spiceai/pull/10997)
+- feat(llms): distributed tensor-parallel GLM inference via mistral.rs ring backend by [@lukekim](https://github.com/lukekim) in [#11406](https://github.com/spiceai/spiceai/pull/11406)
+- Optimize Flight streaming for large result sets by [@lukekim](https://github.com/lukekim) in [#11420](https://github.com/spiceai/spiceai/pull/11420)
+- fix(deps): evict rustls 0.21 / rustls-webpki 0.101.7 (GHSA-82j2-j2ch-gfr8) by [@phillipleblanc](https://github.com/phillipleblanc) in [#11428](https://github.com/spiceai/spiceai/pull/11428)
+- feat(cayenne): in-memory CDC intra-apply sharding (PK-hash shards) by [@lukekim](https://github.com/lukekim) in [#11421](https://github.com/spiceai/spiceai/pull/11421)
+- fix(cayenne): shard CDC upserts with pending deletions so the N>1 slot-ack advances by [@lukekim](https://github.com/lukekim) in [#11445](https://github.com/spiceai/spiceai/pull/11445)
+- fix(cluster): keep built-in avg over Spark avg (distributed aggregate state schema mismatch) by [@phillipleblanc](https://github.com/phillipleblanc) in [#11434](https://github.com/spiceai/spiceai/pull/11434)
+- feat(views): support params.file_format for embedding chunking by [@Jeadie](https://github.com/Jeadie) in [#11424](https://github.com/spiceai/spiceai/pull/11424)
+- fix: offload blocking sync calls off the primary async runtime by [@phillipleblanc](https://github.com/phillipleblanc) in [#11435](https://github.com/spiceai/spiceai/pull/11435)
+- fix(udfs): rebind dot_product alias to Spice's inner_product on DataFusion 54 by [@lukekim](https://github.com/lukekim) in [#11443](https://github.com/spiceai/spiceai/pull/11443)
+- feat(secrets): add full-fidelity reference iteration and a resolution-status API by [@phillipleblanc](https://github.com/phillipleblanc) in [#11195](https://github.com/spiceai/spiceai/pull/11195)
+- fix: Deny unsupported array functions for Postgres pushdown by [@peasee](https://github.com/peasee) in [#11450](https://github.com/spiceai/spiceai/pull/11450)
+- fix(cli): spice query honors --http-endpoint instead of failing on a Flight connect by [@phillipleblanc](https://github.com/phillipleblanc) in [#11452](https://github.com/spiceai/spiceai/pull/11452)
+- fix(cayenne): coordinate query-pool + in-memory CDC tier budgets to prevent adaptive OOM by [@lukekim](https://github.com/lukekim) in [#11449](https://github.com/spiceai/spiceai/pull/11449)
+- Surface mTLS config in Kafka data connector by [@v1gnesh](https://github.com/v1gnesh) in [#11372](https://github.com/spiceai/spiceai/pull/11372)
+- feat(secrets): check and report secret references at startup by [@phillipleblanc](https://github.com/phillipleblanc) in [#11457](https://github.com/spiceai/spiceai/pull/11457)
+- Default cayenne_force_view_types to false by [@sgrebnov](https://github.com/sgrebnov) in [#11459](https://github.com/spiceai/spiceai/pull/11459)
+- fix: resolve table-reference qualification in results-cache invalidation (fixes #11266) by [@claudespice](https://github.com/claudespice) in [#11460](https://github.com/spiceai/spiceai/pull/11460)
+- feat(cayenne): metadata aggregate pushdown — fold whole-table SUM/AVG/COUNT/MIN/MAX from statistics by [@bjchambers](https://github.com/bjchambers) in [#11414](https://github.com/spiceai/spiceai/pull/11414)
+- fix(search): restore numeric trunc and fix SortPreservingMergeExec planning error (DF54) by [@Jeadie](https://github.com/Jeadie) in [#11415](https://github.com/spiceai/spiceai/pull/11415)
+- fix(cluster): route Ballista shuffle/temp to the data PVC by [@phillipleblanc](https://github.com/phillipleblanc) in [#11454](https://github.com/spiceai/spiceai/pull/11454)
+- fix(search): default Elasticsearch kNN candidate pool to 1000 instead of 10 (fixes #11264) by [@claudespice](https://github.com/claudespice) in [#11467](https://github.com/spiceai/spiceai/pull/11467)
+- feat(acceleration): add on_schema_change drop_and_recreate policy by [@lukekim](https://github.com/lukekim) in [#11462](https://github.com/spiceai/spiceai/pull/11462)
+- feat(cayenne): predicate-aware maintained aggregates serve filtered analytical queries from the CDC delta by [@lukekim](https://github.com/lukekim) in [#11458](https://github.com/spiceai/spiceai/pull/11458)
+- feat(cluster): shared Ballista job state with scheduler failover by [@phillipleblanc](https://github.com/phillipleblanc) in [#11436](https://github.com/spiceai/spiceai/pull/11436)
+- feat(cayenne): extend HLL NDV sketching to string and date columns by [@bjchambers](https://github.com/bjchambers) in [#11468](https://github.com/spiceai/spiceai/pull/11468)
+- fix(search): persist character chunk offsets so search snippets aren't shifted/garbled (fixes #11269) by [@claudespice](https://github.com/claudespice) in [#11479](https://github.com/spiceai/spiceai/pull/11479)
+- feat(cayenne): storage-aware adaptive CDC tuning — calibration probe, IMDS, I/O-cliff fast path, infeasible-SLO feedback by [@lukekim](https://github.com/lukekim) in [#11463](https://github.com/spiceai/spiceai/pull/11463)
+- fix(cayenne): LIMIT N under-delivers on key-deletion tables by [@lukekim](https://github.com/lukekim) in [#11490](https://github.com/spiceai/spiceai/pull/11490)
+- fix(cayenne): live/tier-accurate join build-side stats (merge-on-read deletes + never-shrink NDV) by [@lukekim](https://github.com/lukekim) in [#11496](https://github.com/spiceai/spiceai/pull/11496)
+- perf(cayenne): kernel-space I/O hygiene — compaction fadvise + staged-commit barrier reduction by [@lukekim](https://github.com/lukekim) in [#11495](https://github.com/spiceai/spiceai/pull/11495)
+- feat(cayenne): feed maintained-aggregate IVM from the staged-disk CDC path by [@lukekim](https://github.com/lukekim) in [#11491](https://github.com/spiceai/spiceai/pull/11491)
+- feat(cayenne): global adaptive-tuning SLOs with per-dataset overrides; QPH global-only by [@lukekim](https://github.com/lukekim) in [#11497](https://github.com/spiceai/spiceai/pull/11497)
+- Update search snapshots by [@sgrebnov](https://github.com/sgrebnov) in [#11473](https://github.com/spiceai/spiceai/pull/11473)
+- fix: Support reading column types longer than 128 chars in Redshift by [@peasee](https://github.com/peasee) in [#11500](https://github.com/spiceai/spiceai/pull/11500)
+- fix(cluster): distributed (Ballista) query-execution config + scheduled SF10 bench by [@phillipleblanc](https://github.com/phillipleblanc) in [#11478](https://github.com/spiceai/spiceai/pull/11478)
+- fix(http): retry transient response-body read failures; de-flake backoff test by [@claudespice](https://github.com/claudespice) in [#11482](https://github.com/spiceai/spiceai/pull/11482)
+- Re-land orphaned deletion-vector cleanup during retention deletes by [@lukekim](https://github.com/lukekim) in [#11501](https://github.com/spiceai/spiceai/pull/11501)
+- fix(cayenne): re-upsert over a pending delete tombstone records an insert-record (overwrite resurrection) by [@bjchambers](https://github.com/bjchambers) in [#11469](https://github.com/spiceai/spiceai/pull/11469)
+- fix: Flight DoPut silently dropped client batches on early sink completion by [@claudespice](https://github.com/claudespice) in [#11507](https://github.com/spiceai/spiceai/pull/11507)
+- Upgrade OpenTelemetry to 0.32 and reqwest to 0.13 by [@phillipleblanc](https://github.com/phillipleblanc) in [#11506](https://github.com/spiceai/spiceai/pull/11506)
+- fix(queries): run async /v1/queries jobs under the submitting request context by [@phillipleblanc](https://github.com/phillipleblanc) in [#11505](https://github.com/spiceai/spiceai/pull/11505)
+- chore(ci): remove HTAP SF100 from scheduled runs by [@sgrebnov](https://github.com/sgrebnov) in [#11512](https://github.com/spiceai/spiceai/pull/11512)
+- Bump anyhow by [@bjchambers](https://github.com/bjchambers) in [#11513](https://github.com/spiceai/spiceai/pull/11513)
+- fix(cayenne): restore append-only current-snapshot compaction by [@Jeadie](https://github.com/Jeadie) in [#11439](https://github.com/spiceai/spiceai/pull/11439)
+- perf(cayenne): orphaned deletion-vector cleanup off the write path, behind a knob by [@bjchambers](https://github.com/bjchambers) in [#11517](https://github.com/spiceai/spiceai/pull/11517)
+- fix(datafusion): accurate projected scan byte size so hash joins build the smaller side by [@sgrebnov](https://github.com/sgrebnov) in [#11503](https://github.com/spiceai/spiceai/pull/11503)
+- fix(cayenne): user-visible DELETE WHERE pk IN (...) reports the real row count by [@lukekim](https://github.com/lukekim) in [#11514](https://github.com/spiceai/spiceai/pull/11514)
+- fix(cayenne): seed persisted `num_rows` for hash-join sizing by [@sgrebnov](https://github.com/sgrebnov) in [#11515](https://github.com/spiceai/spiceai/pull/11515)
+- fix(cayenne): correctness & memory_limit fixes from perf audit (2 P0, 3 P1) by [@lukekim](https://github.com/lukekim) in [#11516](https://github.com/spiceai/spiceai/pull/11516)
+- feat(cayenne): wire orphaned-DV cleanup knob to spicepod params + doc sync by [@bjchambers](https://github.com/bjchambers) in [#11523](https://github.com/spiceai/spiceai/pull/11523)
+- Fix s3 vectors API by [@krinart](https://github.com/krinart) in [#11536](https://github.com/spiceai/spiceai/pull/11536)
+- fix: Placeholder table initialization lock swap by [@peasee](https://github.com/peasee) in [#11540](https://github.com/spiceai/spiceai/pull/11540)
+- chore(cluster): bump ballista pin for the null-aware anti-join fix by [@phillipleblanc](https://github.com/phillipleblanc) in [#11544](https://github.com/spiceai/spiceai/pull/11544)
+- fix(runtime-tools): fix memory table identifier validation rejecting valid names by [@Jeadie](https://github.com/Jeadie) in [#11546](https://github.com/spiceai/spiceai/pull/11546)
+- Bump datafusion to include spiceai/datafusion#181 by [@Jeadie](https://github.com/Jeadie) in [#11563](https://github.com/spiceai/spiceai/pull/11563)
+- Update deny.toml by [@krinart](https://github.com/krinart) in [#11571](https://github.com/spiceai/spiceai/pull/11571)
+- Bump datafusion (spiceai/datafusion#182) and datafusion-table-providers (#27): fix q16 CollectLeft planning error and SQLite q6 wrong revenue by [@Jeadie](https://github.com/Jeadie) in [#11598](https://github.com/spiceai/spiceai/pull/11598)
+
+**Full Changelog**: <https://github.com/spiceai/spiceai/compare/v2.0.0...v2.1.0>


### PR DESCRIPTION
## Summary

Cherry-picks two commits onto `release/2.1`:

- `1d0f4eb` Release notes for v2.1.0 (#11429)
- `b64a945` deps: bump spiceai/datafusion to pick up ORDER BY alias unparser fix (#11655)

The datafusion bump points to `spiceai/datafusion` at `3c74952f1` (spiceai-54 head), picking up:
- Keep bare output-column alias as top-level ORDER BY key (fixes TPC-DS q12/q20/q98 on federated remotes)
- Preserve eager aggregation decimal sum type

The `Cargo.toml` conflict was resolved by taking the newer rev (`3c74952f1`) over the `release/2.1` base rev (`00544972`).