### PR TITLE
fix(cayenne): harden Vortex compaction writes

### DIFF
--- a/crates/cayenne/src/lib.rs
+++ b/crates/cayenne/src/lib.rs
@@ -101,11 +101,12 @@ pub use provider::{
     CayenneCdcWrite, CayenneContext, CayenneStagedAppend, CayenneTableProvider,
     CayenneTableProviderBuilder, EncodeBudgetSnapshot, PARTITIONED_WAL_DIR, PartitionedWal,
     PartitionedWalEntry, PreparedOverwrite, PreparedStagedAppend, QueryObservations, SlotAdvancer,
-    TimeRetentionFilterBuilder, cap_global_encode_concurrency, deregister_query_observations,
-    encode_budget_snapshot, global_mem_tier_total, global_mem_tier_used, global_qph,
+    TimeRetentionFilterBuilder, begin_compaction_shutdown, cap_global_encode_concurrency,
+    deregister_query_observations, drain_compaction_tasks, encode_budget_snapshot,
+    global_mem_tier_total, global_mem_tier_used, global_qph, in_flight_compaction_tasks,
     record_global_query, record_query_latency, register_query_observations,
-    set_compaction_runtime_env, set_compaction_runtime_handle, set_cpu_burstable,
-    set_global_encode_concurrency, set_global_mem_tier_bytes, set_global_memory_budget,
-    set_query_admission_governor, update_global_mem_tier_total,
+    reset_compaction_shutdown, set_compaction_runtime_env, set_compaction_runtime_handle,
+    set_cpu_burstable, set_global_encode_concurrency, set_global_mem_tier_bytes,
+    set_global_memory_budget, set_query_admission_governor, update_global_mem_tier_total,
 };
 pub use schema::transform_schema_for_vortex;

--- a/crates/cayenne/src/provider/compaction.rs
+++ b/crates/cayenne/src/provider/compaction.rs
@@ -36,6 +36,7 @@ limitations under the License.
 //! tables can't overwhelm the writer pool.
 
 use std::future::Future;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -62,11 +63,113 @@ use tokio::task::JoinHandle;
 /// `dedicated_thread_pool=disabled` — compaction falls back to [`tokio::spawn`]
 /// on the ambient runtime, preserving prior behavior.
 static COMPACTION_RUNTIME: LazyLock<RwLock<Option<Handle>>> = LazyLock::new(|| RwLock::new(None));
+static COMPACTION_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
+static IN_FLIGHT_COMPACTION_PASSES: LazyLock<CompactionPassTracker> =
+    LazyLock::new(CompactionPassTracker::default);
+
+#[derive(Default)]
+struct CompactionPassTracker {
+    count: AtomicUsize,
+    notify: Notify,
+}
+
+impl CompactionPassTracker {
+    fn start(&self) -> CompactionPassGuard<'_> {
+        self.count.fetch_add(1, Ordering::AcqRel);
+        CompactionPassGuard { tracker: self }
+    }
+
+    fn finish(&self) {
+        if self.count.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.notify.notify_waiters();
+        }
+    }
+
+    fn in_flight(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+
+    async fn drain(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.in_flight() == 0 {
+                return true;
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return self.in_flight() == 0;
+            }
+
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            // Register before the second count check so a pass that finishes
+            // after the first check cannot notify between `in_flight()` and the
+            // await setup, which would otherwise sleep until the timeout.
+            notified.as_mut().enable();
+            if self.in_flight() == 0 {
+                return true;
+            }
+
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                return self.in_flight() == 0;
+            }
+        }
+    }
+}
+
+/// RAII marker for one active Cayenne maintenance pass that may be inside a
+/// Vortex read/write pipeline on the compaction runtime.
+pub(crate) struct CompactionPassGuard<'a> {
+    tracker: &'a CompactionPassTracker,
+}
+
+impl Drop for CompactionPassGuard<'_> {
+    fn drop(&mut self) {
+        self.tracker.finish();
+    }
+}
+
+/// Mark a Vortex-producing Cayenne maintenance pass as active unless compaction
+/// shutdown has already begun.
+///
+/// The background schedulers themselves are long-lived sleep loops; tracking
+/// those tasks would make shutdown wait forever. Track only the bounded pass
+/// bodies (subset/full compaction, mem-tier checkpoint, cold promotion) so
+/// runtime shutdown can avoid dropping Vortex CPU tasks while they are still
+/// being awaited.
+pub(crate) fn try_track_compaction_pass() -> Option<CompactionPassGuard<'static>> {
+    let guard = IN_FLIGHT_COMPACTION_PASSES.start();
+    if COMPACTION_SHUTTING_DOWN.load(Ordering::Acquire) {
+        drop(guard);
+        None
+    } else {
+        Some(guard)
+    }
+}
+
+/// Prevent new Cayenne compaction-runtime maintenance passes from starting.
+/// Existing pass guards remain counted and can be drained via
+/// [`drain_compaction_tasks`].
+pub fn begin_compaction_shutdown() {
+    COMPACTION_SHUTTING_DOWN.store(true, Ordering::Release);
+}
+
+/// Allow Cayenne compaction-runtime maintenance passes to start again.
+///
+/// Runtime construction calls this so tests or embedded runtimes that create a
+/// fresh runtime after shutting down a prior one do not inherit stale global
+/// shutdown state. Normal `spiced` startup also resets via
+/// [`set_compaction_runtime_handle`].
+pub fn reset_compaction_shutdown() {
+    COMPACTION_SHUTTING_DOWN.store(false, Ordering::Release);
+}
 
 /// Inject the dedicated compaction runtime handle. Called once at process
 /// startup. Later calls replace the previous handle so tests that create a new
 /// runtime after dropping an old one do not retain stale global state.
 pub fn set_compaction_runtime_handle(handle: Handle) {
+    reset_compaction_shutdown();
     let mut guard = COMPACTION_RUNTIME.write();
     if guard.is_some() {
         tracing::debug!(
@@ -91,6 +194,22 @@ where
 {
     let handle = COMPACTION_RUNTIME.read().clone();
     spawn_on(handle.as_ref(), future)
+}
+
+/// Wait for active Vortex-producing Cayenne maintenance passes to finish.
+///
+/// Runtime shutdown uses this before the dedicated compaction Tokio runtime is
+/// dropped. That gives in-flight Vortex writes a bounded chance to drain
+/// naturally; otherwise Tokio can drop the runtime underneath pending Vortex
+/// `Task`s, which can panic in `vortex-io`.
+pub async fn drain_compaction_tasks(timeout: Duration) -> bool {
+    IN_FLIGHT_COMPACTION_PASSES.drain(timeout).await
+}
+
+/// Number of Vortex-producing Cayenne maintenance passes currently in flight.
+#[must_use]
+pub fn in_flight_compaction_tasks() -> usize {
+    IN_FLIGHT_COMPACTION_PASSES.in_flight()
 }
 
 /// Spawn `future` on `handle` if provided, otherwise on the ambient runtime via
@@ -501,18 +620,17 @@ impl BackgroundCompactor {
 /// How long the detached drain thread lets an in-flight compaction finish its
 /// current Vortex write before force-aborting. Bounded so shutdown can never hang.
 ///
-/// Sized to outlast a realistic compaction pass: a pass rewrites the whole
-/// current snapshot (see `run_one_compaction_pass` / `rewrite_current_snapshot_for_compaction`),
-/// so its duration scales with table size. At large scale factors that rewrite
-/// can take well over the original 5s, so the abort fired mid-write and vortex-io
-/// panicked ("Runtime dropped task without completing it"). 30s covers a realistic
-/// large-table pass and coincides with the runtime's connection-drain window.
+/// Sized to outlast the large seq-prefix/subset passes seen during SF100
+/// CH-benCH: individual passes can legitimately run for 60-90s while the
+/// benchmark is still applying CDC. Aborting those writes mid-flight can leave
+/// Vortex layout tasks awaiting CPU jobs that Tokio has cancelled, which panics
+/// in `vortex-io` ("Runtime dropped task without completing it").
 ///
-/// This is a mitigation, not a cure: a pass that still exceeds the window aborts
-/// mid-write and panics on shutdown. The durable fix is incremental (tiered) merge
-/// of the picked candidate files instead of a full-snapshot rewrite, which keeps a
-/// pass short enough to always drain — see the picker's `CompactionCandidate`.
-const COMPACTOR_SHUTDOWN_DRAIN: Duration = Duration::from_secs(30);
+/// This is still a mitigation: a pass that exceeds the window may be aborted.
+/// The durable performance fix is to keep each pass shorter (incremental merge
+/// width / bake sizing) so shutdown and provider replacement rarely need this
+/// backstop.
+const COMPACTOR_SHUTDOWN_DRAIN: Duration = Duration::from_mins(2);
 
 fn drain_and_abort_compactor(handle: &JoinHandle<()>) {
     // Let an in-flight compaction finish its current write before the
@@ -663,6 +781,9 @@ impl BackgroundMemTierCheckpointer {
                 // One checkpoint per tick. The tick itself is a no-op on an empty
                 // or unarmed tier and takes the per-table lock only when there is
                 // something to flush, so an idle table costs one cheap wake.
+                let Some(_pass) = try_track_compaction_pass() else {
+                    break;
+                };
                 runner.run_mem_tier_checkpoint_tick().await;
             }
         });
@@ -790,6 +911,9 @@ impl BackgroundColdTierPromoter {
                     "Periodic cold-tier promotion wake",
                 );
 
+                let Some(_pass) = try_track_compaction_pass() else {
+                    break;
+                };
                 runner.run_cold_tier_promotion_tick().await;
             }
         });
@@ -1024,6 +1148,32 @@ mod tests {
         // max_files_per_pick=0 should be clamped to 2 as well.
         let cfg = CompactionPickerConfig::new(8, 0, 128 * 1024 * 1024);
         assert!(cfg.max_files_per_pick >= 2);
+    }
+
+    // ------------------------------------------------------------------
+    // Active compaction pass tracker tests
+    // ------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn compaction_pass_tracker_drains_when_guard_drops() {
+        let tracker = Arc::new(CompactionPassTracker::default());
+        let guard = tracker.start();
+        assert_eq!(tracker.in_flight(), 1);
+
+        let drain_tracker = Arc::clone(&tracker);
+        let drain = tokio::spawn(async move { drain_tracker.drain(Duration::from_secs(5)).await });
+
+        // Give the drain task a chance to observe the active pass and register
+        // for notification, then finish the pass.
+        tokio::task::yield_now().await;
+        drop(guard);
+
+        let drained = tokio::time::timeout(Duration::from_secs(1), drain)
+            .await
+            .expect("drain should not wait for its full timeout")
+            .expect("drain task should not panic");
+        assert!(drained);
+        assert_eq!(tracker.in_flight(), 0);
     }
 
     // ------------------------------------------------------------------

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -110,7 +110,10 @@ pub(crate) mod write_budget;
 pub(crate) mod zorder;
 
 // Re-export the main type at the module level for convenience
-pub use compaction::{set_compaction_runtime_env, set_compaction_runtime_handle};
+pub use compaction::{
+    begin_compaction_shutdown, drain_compaction_tasks, in_flight_compaction_tasks,
+    reset_compaction_shutdown, set_compaction_runtime_env, set_compaction_runtime_handle,
+};
 pub use context::CayenneContext;
 pub use mem_tier::SlotAdvancer;
 pub use mem_tier_budget::{

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4841,6 +4841,7 @@ impl CayenneTableProvider {
 
         let tracked_schema = self.table_schema();
         let tracked_stream = {
+            let target_schema = Arc::clone(&tracked_schema);
             let total_bytes_written = Arc::clone(&total_bytes_written);
             let total_rows_written = Arc::clone(&total_rows_written);
             let last_progress_ms = Arc::clone(&last_progress_ms);
@@ -4849,36 +4850,57 @@ impl CayenneTableProvider {
             let start = start_time;
 
             stream.map(move |batch_result| {
-                if let Ok(batch) = &batch_result {
-                    total_bytes_written.fetch_add(batch.get_array_memory_size(), Ordering::Relaxed);
-                    total_rows_written.fetch_add(batch.num_rows() as u64, Ordering::Relaxed);
-                    stats_acc.update(batch);
+                let batch = batch_result?;
+                // Internal compaction reads can come from the query scan path,
+                // whose output schema may intentionally differ from the stored
+                // write schema (for example Utf8View when
+                // `cayenne_force_view_types` is enabled). Normalize every writer
+                // input batch to the snapshot writer schema before Vortex derives
+                // its dtype; otherwise the Vortex stream adapter can panic on a
+                // read-schema/write-schema dtype mismatch in the background
+                // compactor.
+                let batch = arrow_tools::record_batch::try_cast_to(
+                    batch,
+                    Arc::clone(&target_schema),
+                )
+                .map_err(|e| {
+                    DataFusionError::Context(
+                        format!(
+                            "Failed to cast writer input batch to Cayenne table schema for table {table_name}"
+                        ),
+                        Box::new(DataFusionError::from(e)),
+                    )
+                })?;
 
-                    if is_s3_storage {
-                        let elapsed = start.elapsed();
-                        let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
-                        let last_logged = last_progress_ms.load(Ordering::Relaxed);
-                        if elapsed_ms.saturating_sub(last_logged) >= 10_000 {
-                            let bytes_so_far = total_bytes_written.load(Ordering::Relaxed);
-                            let throughput = if elapsed.as_secs_f64() > 0.0 {
-                                #[expect(clippy::cast_precision_loss)]
-                                let bytes_per_sec = bytes_so_far as f64 / elapsed.as_secs_f64();
-                                format_bytes_per_sec(bytes_per_sec)
-                            } else {
-                                "calculating...".to_string()
-                            };
-                            tracing::info!(
-                                "S3 upload for {}: streamed {} in {:.1}s, {}",
-                                table_name,
-                                format_bytes(bytes_so_far),
-                                elapsed.as_secs_f64(),
-                                throughput
-                            );
-                            last_progress_ms.store(elapsed_ms, Ordering::Relaxed);
-                        }
+                total_bytes_written.fetch_add(batch.get_array_memory_size(), Ordering::Relaxed);
+                total_rows_written.fetch_add(batch.num_rows() as u64, Ordering::Relaxed);
+                stats_acc.update(&batch);
+
+                if is_s3_storage {
+                    let elapsed = start.elapsed();
+                    let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+                    let last_logged = last_progress_ms.load(Ordering::Relaxed);
+                    if elapsed_ms.saturating_sub(last_logged) >= 10_000 {
+                        let bytes_so_far = total_bytes_written.load(Ordering::Relaxed);
+                        let throughput = if elapsed.as_secs_f64() > 0.0 {
+                            #[expect(clippy::cast_precision_loss)]
+                            let bytes_per_sec = bytes_so_far as f64 / elapsed.as_secs_f64();
+                            format_bytes_per_sec(bytes_per_sec)
+                        } else {
+                            "calculating...".to_string()
+                        };
+                        tracing::info!(
+                            "S3 upload for {}: streamed {} in {:.1}s, {}",
+                            table_name,
+                            format_bytes(bytes_so_far),
+                            elapsed.as_secs_f64(),
+                            throughput
+                        );
+                        last_progress_ms.store(elapsed_ms, Ordering::Relaxed);
                     }
                 }
-                batch_result
+
+                Ok(batch)
             })
         };
 
@@ -23051,6 +23073,9 @@ fn format_bytes_per_sec(bytes_per_sec: f64) -> String {
 #[async_trait::async_trait]
 impl super::compaction::CompactionRunner for CayenneTableProvider {
     async fn run_compaction_trigger(&self) -> std::result::Result<bool, String> {
+        let Some(_pass) = super::compaction::try_track_compaction_pass() else {
+            return Ok(false);
+        };
         // Routes to the fast protected-snapshot subset compaction, which only
         // rewrites immutable protected snapshots and CAS-swaps them in the
         // catalog. Key-delete tables can run concurrently with appends because
@@ -23735,6 +23760,112 @@ mod tests {
                     .downcast_ref::<StringViewArray>()
                     .is_some(),
                 "scan must emit StringViewArray under force_view_read_schema"
+            );
+        }
+    }
+
+    /// Regression guard for the current-snapshot compactor's read-schema/write-schema
+    /// boundary. The rewrite input is built with `TableProvider::scan()`, which
+    /// emits the query read schema (`Utf8View` here), but Vortex file writes must
+    /// use the stored table schema (`Utf8`). `write_to_snapshot` must normalize
+    /// the scanned batches before Vortex derives/checks its dtype; otherwise the
+    /// background current-snapshot compactor can panic on a dtype mismatch.
+    #[tokio::test]
+    async fn current_snapshot_compaction_casts_force_view_scan_to_write_schema() {
+        use arrow::array::{Int64Array, StringArray, StringViewArray};
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        let ctx = SessionContext::new();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let metadata_dir = format!("{}/metadata", temp_dir.path().to_str().expect("path"));
+        let data_dir = format!("{}/data", temp_dir.path().to_str().expect("path"));
+        std::fs::create_dir_all(&metadata_dir).expect("metadata dir");
+        let connection_string = format!("sqlite://{metadata_dir}/cayenne.db");
+        let catalog = Arc::new(CayenneCatalog::new(connection_string).expect("catalog"))
+            as Arc<dyn MetadataCatalog>;
+        catalog.init().await.expect("catalog init");
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let vortex_config = VortexConfig {
+            force_view_read_schema: true,
+            ..VortexConfig::default()
+        };
+        let table_name = "view_compaction";
+        let context = CayenneContext::new(&vortex_config, ctx.runtime_env(), table_name);
+        let options = CreateTableOptions {
+            table_name: table_name.to_string(),
+            schema: Arc::clone(&schema),
+            primary_key: vec!["id".to_string()],
+            on_conflict: Some(OnConflict::Upsert(
+                datafusion_table_providers::util::column_reference::ColumnReference::new(vec![
+                    "id".to_string(),
+                ]),
+            )),
+            base_path: data_dir,
+            partition_column: None,
+            vortex_config,
+        };
+        let provider = CayenneTableProviderBuilder::new(Arc::clone(&catalog), ctx.runtime_env())
+            .with_context(context)
+            .create(options)
+            .await
+            .expect("table created");
+
+        assert_eq!(
+            provider
+                .schema()
+                .field_with_name("name")
+                .expect("name field")
+                .data_type(),
+            &DataType::Utf8View,
+        );
+        assert_eq!(
+            provider
+                .table_schema()
+                .field_with_name("name")
+                .expect("name field")
+                .data_type(),
+            &DataType::Utf8,
+        );
+
+        insert_batch(
+            &provider,
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from(vec![1_i64, 2])),
+                    Arc::new(StringArray::from(vec!["alice", "bob"])),
+                ],
+            )
+            .expect("batch"),
+        )
+        .await;
+        assert!(provider.cached_inlined_row_count() > 0, "rows land inline");
+
+        assert!(
+            provider
+                .rewrite_current_snapshot_for_compaction()
+                .await
+                .expect("current-snapshot rewrite succeeds"),
+            "rewrite should commit a compacted current snapshot"
+        );
+
+        let batches = read_all(&ctx, &provider, table_name).await;
+        let total: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total, 2, "rows survive compaction");
+        for batch in &batches {
+            let idx = batch.schema().index_of("name").expect("name col");
+            assert_eq!(batch.schema().field(idx).data_type(), &DataType::Utf8View);
+            assert!(
+                batch
+                    .column(idx)
+                    .as_any()
+                    .downcast_ref::<StringViewArray>()
+                    .is_some(),
+                "query scan remains view-typed after compaction"
             );
         }
     }

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -325,6 +325,12 @@ impl RuntimeBuilder {
             );
         }
 
+        // Cayenne compaction shutdown state is process-global. Reset it when a
+        // fresh Runtime is built so embedded/test runtimes created after a prior
+        // shutdown can start maintenance passes again, including when dedicated
+        // thread pools are disabled and no compaction runtime handle is injected.
+        cayenne::reset_compaction_shutdown();
+
         self.accelerator_engine_registry.register_all().await;
         dataconnector::register_all().await;
         catalogconnector::register_all().await;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -516,6 +516,7 @@ const CACHE_MAINTENANCE_INTERVAL: std::time::Duration = std::time::Duration::fro
 
 // Allow 30 seconds for tasks for graceful shutdown
 const RUNTIME_DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+const CAYENNE_COMPACTION_SHUTDOWN_TIMEOUT: Duration = Duration::from_mins(2);
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -1771,6 +1772,11 @@ impl Runtime {
             "Shutdown initiated; waiting up to {shutdown_timeout:?} for connections to drain"
         );
 
+        // Stop new Cayenne compaction-runtime passes as soon as shutdown begins.
+        // In-flight passes remain counted and are drained below before the
+        // dedicated compaction runtime itself can be dropped.
+        cayenne::begin_compaction_shutdown();
+
         let start_time = Instant::now();
 
         // Shutdown running components in phases so request-serving tasks drain
@@ -1807,6 +1813,24 @@ impl Runtime {
 
         // Clean up DataFusion first as there could be datasets loading and accessing registries below.
         self.df.shutdown().await;
+
+        let in_flight = cayenne::in_flight_compaction_tasks();
+        if in_flight > 0 {
+            let compaction_timeout = CAYENNE_COMPACTION_SHUTDOWN_TIMEOUT;
+            tracing::debug!(
+                in_flight,
+                ?compaction_timeout,
+                "Waiting for in-flight Cayenne compaction passes before dropping compaction runtime"
+            );
+            if !cayenne::drain_compaction_tasks(compaction_timeout).await {
+                tracing::warn!(
+                    remaining = cayenne::in_flight_compaction_tasks(),
+                    ?compaction_timeout,
+                    "Timed out waiting for Cayenne compaction passes during shutdown"
+                );
+            }
+        }
+
         dataconnector::unregister_all().await;
         catalogconnector::unregister_all().await;
         self.accelerator_engine_registry.unregister_all().await;


### PR DESCRIPTION
## Summary

Draft PR for review while we continue validating the exact customer failure.

This has two related Cayenne/Vortex compaction hardening changes:

1. **Shutdown / teardown hardening**
   - Track only active Vortex-producing Cayenne maintenance pass bodies, not the long-lived background scheduler loops.
   - Stop new compaction-runtime passes when runtime shutdown begins.
   - Drain active compaction passes before the dedicated compaction runtime is dropped.
   - Increase the bounded compactor drain window to 120s, matching observed CH-benCH SF100 compaction durations.

2. **Compaction write-boundary schema normalization**
   - Normalize batches entering `CayenneTableProvider::write_to_snapshot()` to the stored table schema before Vortex derives/checks its writer dtype.
   - This covers the restored current-snapshot background compactor path, which builds rewrite input through `TableProvider::scan()` and can therefore emit the query read schema (for example `Utf8View`) while the Vortex writer schema is the stored schema (`Utf8`).

## Why

Refs #11683.

The CI/local reproduced failure is an active Cayenne/Vortex compaction pass interrupted during shutdown/runtime teardown, producing:

```text
Runtime dropped task without completing it, likely it panicked
```

Separately, the customer-reported issue is a background-compactor panic. The schema-normalization change is a hardening fix for a concrete read-schema/write-schema seam in the current-snapshot compactor, but the customer root cause is **not yet proven**.

## Customer-shaped CDC repro status

A local repro using the same source mechanism as the customer — Postgres CDC (`refresh_mode: changes`) into a Cayenne file accelerator — was added and run:

```text
~/code/spicepod_test/260707-cayenne-vortex-compaction-race/postgres-cdc-upsert-protected-compaction-repro.sh
```

Latest PASS artifact:

```text
~/code/spicepod_test/260707-cayenne-vortex-compaction-race/postgres-cdc-upsert-protected-compaction-203303_41339/summary.txt
```

Result:

- Postgres CDC + `on_conflict: { id: upsert }` ingested 48 rows.
- Protected-snapshot subset compaction ran and completed 11 times.
- No `Runtime dropped task`, `panicked at`, Vortex dtype assertion, or abort markers.

Important caveat: valid Cayenne/Postgres `refresh_mode: changes` requires an `on_conflict` upsert config, so this customer-shaped CDC path writes protected snapshots and did **not** exercise the append-only/current-snapshot compactor. Postgres `text`/`varchar` columns also surfaced as `LargeUtf8`, not the `Utf8`/`Utf8View` seam from the targeted unit regression.

So this PR should be read as hardening + candidate fix, not as confirmed closure of the customer issue without the exact customer panic/backtrace/config.

## Validation

Passed locally:

```text
cargo fmt --all -- --check
cargo test -p cayenne compaction_pass_tracker_drains_when_guard_drops --lib
cargo test -p cayenne background_compactor_drains_in_flight_compaction_on_drop --lib
cargo test -p cayenne background_compactor_ticks_at_interval_and_stops_on_shutdown --lib
cargo test -p cayenne current_snapshot_compaction_casts_force_view_scan_to_write_schema --lib
cargo test -p cayenne current_snapshot_compaction_casts_force_view_scan_to_write_schema --lib --release
cargo test -p cayenne force_view_read_schema_scan_emits_utf8view --lib
cargo test -p cayenne --test small_files_compaction_test sqlite -- --nocapture
cargo check -p cayenne -p runtime
cargo build -p spiced --release --features models
cargo deny check licenses
cargo deny check advisories
make lint-rust
```

CI/review follow-up:

- Rebased onto latest `trunk` (`2370a819`).
- Added required PR metadata (`area/cayenne`, assignee).
- Addressed Copilot's shutdown-timeout review by using a fixed 2-minute compaction drain window instead of `max(remaining_timeout, drain_timeout)`.

Existing unrelated warning remains:

```text
warning: fields `catalog` and `table_identifier` are never read
--> crates/runtime/src/dataconnector/iceberg.rs:110:5
```

Manual/local artifacts:

- Failing shutdown repro before fix: `harness-sf100-101519.log`
- Fixed shutdown repros: `harness-sf100-120245.log`, `harness-sf10-125523.log`, `harness-sf10-141554.log`
- Bootstrap no-repro: `bootstrap-oorder-new-order-141337.log`
- Customer-shaped CDC protected-compaction pass: `postgres-cdc-upsert-protected-compaction-203303_41339/summary.txt`
- Schema mismatch side artifacts under `~/code/spicepod_test/260707-cayenne-vortex-compaction-race`

## Review notes

This remains draft because the exact customer root cause is not confirmed. The shutdown drain and write-boundary schema normalization are intentionally separate mechanisms; please review them independently.
