### PR TITLE
fix: MySQL connector returns graceful error for unsupported column types (fixes #8363)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,7 +4023,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6643,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=451a6371132e1518891d24d06657af1f83063a18#451a6371132e1518891d24d06657af1f83063a18"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=12321c06d7919b04acf6ce05b969536b2e7ccbbb#12321c06d7919b04acf6ce05b969536b2e7ccbbb"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -8575,8 +8575,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -9715,7 +9715,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -14817,7 +14817,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.10.5",
  "log",
  "multimap",
@@ -18476,7 +18476,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -20045,7 +20045,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",
@@ -23216,7 +23216,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ datafusion-proto-common = "54.0.0"
 datafusion-pruning = "54.0.0"
 datafusion-spark = "54.0.0"
 datafusion-substrait = "54.0.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "451a6371132e1518891d24d06657af1f83063a18" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "12321c06d7919b04acf6ce05b969536b2e7ccbbb" } # spiceai-54
 
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",


### PR DESCRIPTION
## Summary

The MySQL data connector panicked via `unimplemented!()` in the row-to-Arrow converter (`map_column_to_data_type` / `rows_to_arrow`) whenever it encountered an unsupported column type such as `GEOMETRY` or `VECTOR`. This crashed the tokio runtime worker at dataset-load time instead of surfacing a graceful, actionable error (issue #8363).

Root cause and fix live in the `datafusion-table-providers` fork (spiceai/datafusion-table-providers#29): `map_column_to_data_type` now returns `None` for unsupported column types so schema inference surfaces a normal "Unsupported data type" error, and `rows_to_arrow` returns a typed `UnsupportedColumnType` error instead of panicking. The fork PR carries the regression tests.

This PR is the corresponding rev bump in the main repo.

## Changes

- Bump `datafusion-table-providers` `451a6371` → `12321c06` (`spiceai-54` branch HEAD) in `Cargo.toml` + `Cargo.lock`.

## Stacking

This is **stacked on #11691** (MySQL unsigned-integer fix, which bumps the pin to the parent commit `451a6371`). Base is set to `fix/8364-mysql-unsigned-int`, so the diff here is the single incremental fork bump `451a6371` → `12321c06`. Once #11691 merges to `trunk`, GitHub retargets this PR to `trunk` and the diff remains the clean one-commit bump. Both fixes together close out the MySQL type-conversion crash class.

## Test plan

- `make lint`
- `make test`
- Scoped compile verified locally: `cargo check -p data_components --features mysql` (green with the new fork rev).
- Regression coverage for the graceful-error behavior lives in the fork (spiceai/datafusion-table-providers#29): unsupported column types map to `None`; supported types keep their existing Arrow mappings.

## Checklist

- [x] Fork fix merged (spiceai/datafusion-table-providers#29) into `spiceai-54`
- [x] Pin bumped to fork HEAD, `Cargo.lock` regenerated by cargo
- [x] Compiles with `mysql` feature
- [ ] CI green

Fixes #8363