### PR TITLE
ci(chbench): run scheduled SF1000-adaptive HTAP bench every 6h instead of 3h

### DIFF
--- a/.github/workflows/testoperator_dispatch_htap.yml
+++ b/.github/workflows/testoperator_dispatch_htap.yml
@@ -2,9 +2,9 @@ name: testoperator dispatch htap
 
 on:
   schedule:
-    # htap-sf1000-adaptive, every 3 hours (0000, 0300, …, 2100) — the high-value SF1000 adaptive
+    # htap-sf1000-adaptive, every 6 hours (0000, 0600, 1200, 1800) — the high-value SF1000 adaptive
     # config for frequent adaptive trend data (spiceai-dev-xlarge-runners).
-    - cron: '0 */3 * * *'
+    - cron: '0 */6 * * *'
     # htap-sf1000 (other configs), once daily (0100) — the remaining SF1000 configs
     # (adaptive-turso, duckdb baseline) on the xlarge pool.
     - cron: '0 1 * * *'
@@ -106,7 +106,7 @@ jobs:
           SF="${{ github.event.inputs.scale_factor }}"
           if [ -z "$SF" ]; then
             case "${{ github.event.schedule }}" in
-              '0 */3 * * *')                  SF=sf1000-adaptive ;;
+              '0 */6 * * *')                  SF=sf1000-adaptive ;;
               '0 1 * * *')                    SF=sf1000 ;;
               '0 6,18 * * *')                 SF=sf1 ;;
               '0 8 * * *')                    SF=sf1000-cold ;;


### PR DESCRIPTION
## What

Halves the cadence of the scheduled **SF1000-adaptive** HTAP CH-benCHmark dispatcher from **every 3 hours** to **every 6 hours** in `.github/workflows/testoperator_dispatch_htap.yml`.

- Cron trigger: `'0 */3 * * *'` → `'0 */6 * * *'` (now fires 0000, 0600, 1200, 1800)
- Updated the accompanying schedule comment
- Updated the matching `github.event.schedule` `case` label in the *Resolve scale factor* step so it still maps to `sf1000-adaptive`

## Why

Reduce recurring `spiceai-dev-xlarge-runners` load from the most frequent SF1000 dispatcher while retaining regular adaptive tuned-vs-baseline trend coverage.

## Notes

- The other three schedules are untouched: `sf1000` daily @0100, `sf1` @0600/1800, `sf1000-cold` @0800.
- `*/6` overlaps the `sf1` cron (`0 6,18 * * *`) at 0600/1800 — exactly as the old `*/3` already did. GitHub delivers a separate workflow run per matching cron entry, each keyed by its own `github.event.schedule` string, and the per-schedule `concurrency.group` keeps them from blocking each other, so the two resolve independently and safely.
- Workflow-file-only change; scheduled workflows run from the default branch, so it takes effect once merged to `trunk`.