### PR TITLE
fix(cache): cache empty (zero-row) SQL result sets

### DIFF
--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -209,12 +209,22 @@ pub fn to_cached_record_batch_stream(
         // so that compressed results that fit in the cache are not prematurely rejected.
         if records_size < cache_max_size || has_encoder {
             match batches_to_cache(&records) {
-                None if !records.is_empty() => {
+                // `batches_to_cache` only returns `None` when transient HTTP
+                // error responses (5xx/429) are present, which requires a
+                // non-empty result set — skip the write to avoid caching a
+                // partial result.
+                None => {
                     tracing::debug!(
                         "Transient HTTP error responses were present, skipping cache storage"
                     );
                 }
-                Some(records_to_cache) if !records_to_cache.is_empty() => {
+                // Cache the result, including genuinely empty (0-row / 0-batch)
+                // result sets. The schema is stored separately in
+                // `CachedQueryResult`, so an empty result round-trips with the
+                // correct schema, and caching it lets repeat queries that
+                // legitimately return no rows be served from cache instead of
+                // re-executing on every request.
+                Some(records_to_cache) => {
                     let cached_at = std::time::Instant::now();
                     let encoder = cache_provider.encoder();
 
@@ -245,7 +255,6 @@ pub fn to_cached_record_batch_stream(
                         }
                     }
                 }
-                _ => {}
             }
         }
     };
@@ -963,6 +972,123 @@ pub(crate) mod tests {
             .expect("cached result should decode");
         assert_eq!(cached_batches.len(), 1);
         assert_eq!(cached_batches[0].num_rows(), n);
+    }
+
+    /// Regression test: a query that returns an empty result set by yielding
+    /// **zero batches** (e.g. `DataFusion`'s `EmptyExec` for `WHERE 1=0`) must
+    /// still be cached, so repeat queries that legitimately return no rows are
+    /// served from cache instead of re-executing on every request.
+    #[tokio::test]
+    async fn test_empty_result_zero_batches_is_cached() {
+        use datafusion::error::DataFusionError;
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::TryStreamExt;
+        use spicepod::component::caching::SQLResultsCacheConfig;
+
+        let cache_provider = Arc::new(
+            crate::QueryResultsCacheProvider::try_new(
+                &SQLResultsCacheConfig {
+                    item_ttl: Some("10m".to_string()),
+                    ..Default::default()
+                },
+                Box::new([]),
+            )
+            .expect("valid cache provider"),
+        );
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+        // A stream that yields no batches at all (0 batches, 0 rows).
+        let raw_cache_key = crate::key::CacheKey::Query("empty-zero-batches", None)
+            .as_raw_key(cache_provider.hasher());
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(Vec::<Result<RecordBatch, DataFusionError>>::new()),
+        ));
+
+        let cached_stream = to_cached_record_batch_stream(
+            Arc::clone(&cache_provider),
+            stream,
+            raw_cache_key,
+            Arc::new(HashSet::from(["local_table".into()])),
+        );
+
+        let output_batches = cached_stream
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("stream should be collected successfully");
+        assert!(output_batches.is_empty());
+
+        let cached = cache_provider
+            .get_raw_key(&raw_cache_key)
+            .await
+            .expect("cache lookup should succeed")
+            .expect("empty result sets (zero batches) should be cached");
+
+        let cached_batches = cached.records().await.expect("cached result should decode");
+        assert!(
+            cached_batches.iter().all(|b| b.num_rows() == 0),
+            "cached empty result should contain no rows"
+        );
+        assert_eq!(
+            cached.schema.fields().len(),
+            1,
+            "cached empty result should preserve the query schema"
+        );
+    }
+
+    /// A query that returns an empty result set by yielding a single schema-only
+    /// batch (0 rows) must also be cached. This is the sibling case to
+    /// [`test_empty_result_zero_batches_is_cached`] — both represent zero rows
+    /// and must be cached consistently.
+    #[tokio::test]
+    async fn test_empty_result_zero_row_batch_is_cached() {
+        use datafusion::error::DataFusionError;
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::TryStreamExt;
+        use spicepod::component::caching::SQLResultsCacheConfig;
+
+        let cache_provider = Arc::new(
+            crate::QueryResultsCacheProvider::try_new(
+                &SQLResultsCacheConfig {
+                    item_ttl: Some("10m".to_string()),
+                    ..Default::default()
+                },
+                Box::new([]),
+            )
+            .expect("valid cache provider"),
+        );
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let empty_batch = RecordBatch::new_empty(Arc::clone(&schema));
+
+        let raw_cache_key = crate::key::CacheKey::Query("empty-zero-row-batch", None)
+            .as_raw_key(cache_provider.hasher());
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![Ok::<RecordBatch, DataFusionError>(empty_batch)]),
+        ));
+
+        let cached_stream = to_cached_record_batch_stream(
+            Arc::clone(&cache_provider),
+            stream,
+            raw_cache_key,
+            Arc::new(HashSet::from(["local_table".into()])),
+        );
+
+        let _output = cached_stream
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("stream should be collected successfully");
+
+        let cached = cache_provider
+            .get_raw_key(&raw_cache_key)
+            .await
+            .expect("cache lookup should succeed")
+            .expect("empty result sets (zero-row batch) should be cached");
+
+        let cached_batches = cached.records().await.expect("cached result should decode");
+        assert!(cached_batches.iter().all(|b| b.num_rows() == 0));
     }
 
     /// Verify that when there is no encoder and the result exceeds the cache

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -515,10 +515,10 @@ impl Query {
                 return;
             };
 
-            if batches_to_cache.is_empty() {
-                return;
-            }
-
+            // Empty (0-row) revalidation results are cached too. The schema is
+            // preserved separately in `CachedQueryResult`, so an empty result
+            // refreshes the entry correctly rather than leaving the previous
+            // (now stale) value in place.
             let cached_at = std::time::Instant::now();
             let encoder = cache_provider.encoder();
 
@@ -1170,6 +1170,67 @@ mod tests {
                 // Since cache-control is set, an invalid key with repeated query will fall back
                 // to the default plan-key behavior and result in a cache hit
                 assert_eq!(result.cache_status, CacheStatus::CacheHit);
+            })
+            .await;
+    }
+
+    /// Regression test for empty (0-row) result sets not being cached.
+    ///
+    /// `SELECT 1 WHERE 1=0` is optimized to an `EmptyRelation`/`EmptyExec`,
+    /// which yields **zero** record batches. Such a result must still be cached
+    /// so the second identical request is served from cache instead of being
+    /// re-executed against the source.
+    #[tokio::test]
+    async fn test_empty_result_set_is_cached() {
+        let df = prepare_runtime(Some(SQLResultsCacheConfig {
+            item_ttl: Some("10m".to_string()),
+            cache_key_type: spicepod::component::caching::CacheKeyType::Sql,
+            ..Default::default()
+        }))
+        .await;
+
+        let request_context =
+            create_test_request_context(CacheControl::Cache(CacheKeyType::Raw), None);
+
+        // First request: cache miss, populates the cache when drained.
+        let query = QueryBuilder::new("SELECT 1 WHERE 1=0", Arc::clone(&df)).build();
+        Arc::clone(&request_context)
+            .scope(async move {
+                let result = query.run().await.expect("query should succeed");
+                assert_eq!(result.cache_status, CacheStatus::CacheMiss);
+                let records = result
+                    .data
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .expect("should collect");
+                let total_rows: usize = records
+                    .iter()
+                    .map(arrow::array::RecordBatch::num_rows)
+                    .sum();
+                assert_eq!(total_rows, 0, "result set should be empty");
+            })
+            .await;
+
+        // Second request: must be a cache hit for the empty result set.
+        let query = QueryBuilder::new("SELECT 1 WHERE 1=0", Arc::clone(&df)).build();
+        Arc::clone(&request_context)
+            .scope(async move {
+                let result = query.run().await.expect("query should succeed");
+                assert_eq!(
+                    result.cache_status,
+                    CacheStatus::CacheHit,
+                    "empty result sets should be served from cache on repeat requests"
+                );
+                let records = result
+                    .data
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .expect("should collect");
+                let total_rows: usize = records
+                    .iter()
+                    .map(arrow::array::RecordBatch::num_rows)
+                    .sum();
+                assert_eq!(total_rows, 0, "cached empty result should still be empty");
             })
             .await;
     }

--- a/crates/runtime/tests/http/mod.rs
+++ b/crates/runtime/tests/http/mod.rs
@@ -138,6 +138,19 @@ WHERE request_path = '/edge'
 ORDER BY id
 ";
 
+/// Same source/path as [`HTTP_JSON_EDGE_QUERY`] (so the connector still fetches
+/// `/edge` exactly once), but an extra predicate filters out every row, leaving
+/// an empty (zero-row) result set. Used to verify empty results are cached.
+const HTTP_JSON_EDGE_EMPTY_QUERY: &str = r"
+SELECT
+    CAST(json_get(content, 'id') AS BIGINT) AS id,
+    CAST(json_get(content, 'name') AS VARCHAR) AS name
+FROM http_json_edges
+WHERE request_path = '/edge'
+  AND CAST(json_get(content, 'id') AS BIGINT) = 999
+ORDER BY id
+";
+
 fn expected_http_json_edge_rows() -> Value {
     json!([
         {
@@ -386,6 +399,30 @@ async fn run_http_json_edge_query(rt: &Runtime) -> Result<(CacheStatus, Vec<Reco
         .try_collect::<Vec<RecordBatch>>()
         .await
         .map_err(|e| format!("Failed to collect HTTP JSON edge query results: {e}"))?;
+
+    Ok((cache_status, batches))
+}
+
+/// Run an arbitrary SQL query against the HTTP JSON edge runtime, returning the
+/// cache status and collected batches.
+async fn run_http_json_query(
+    rt: &Runtime,
+    sql: &str,
+) -> Result<(CacheStatus, Vec<RecordBatch>), String> {
+    let query_result = rt
+        .datafusion()
+        .query_builder(sql)
+        .build()
+        .run()
+        .await
+        .map_err(|e| format!("Failed to run HTTP JSON query: {e}"))?;
+
+    let cache_status = query_result.cache_status;
+    let batches = query_result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(|e| format!("Failed to collect HTTP JSON query results: {e}"))?;
 
     Ok((cache_status, batches))
 }
@@ -1236,6 +1273,74 @@ async fn test_http_json_edge_cases_results_cache() -> Result<(), String> {
             assert_eq!(
                 second_http_cache_header.as_deref(),
                 Some("Hit from spiceai")
+            );
+
+            rt.shutdown().await;
+
+            tx.send(())
+                .map_err(|()| "Failed to send shutdown signal".to_string())?;
+            Ok(())
+        })
+        .await
+}
+
+/// Regression test: an empty (zero-row) result set from a live source must be
+/// cached, and the second identical request must be served from cache WITHOUT
+/// re-fetching the upstream source.
+///
+/// This is the strongest form of the empty-result caching regression test:
+/// `edge_request_count` proves the source was hit exactly once across both
+/// requests. Before the fix, the empty result was never cached, so the second
+/// request re-executed (cache miss) and re-fetched the source (count == 2).
+#[tokio::test]
+async fn test_http_json_edge_cases_empty_result_cache() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let (tx, addr, edge_request_count) = start_http_server().await?;
+            let rt = setup_http_json_edge_runtime(
+                "http_json_edge_cases_empty_result_cache",
+                &format!("http://{addr}/api"),
+                false,
+                Some(SQLResultsCacheConfig {
+                    item_ttl: Some("60s".to_string()),
+                    ..Default::default()
+                }),
+            )
+            .await?;
+
+            // First request: cache miss, empty result, source fetched once.
+            let (first_cache_status, first_batches) =
+                run_http_json_query(rt.as_ref(), HTTP_JSON_EDGE_EMPTY_QUERY).await?;
+            assert_eq!(first_cache_status, CacheStatus::CacheMiss);
+            assert_eq!(
+                first_batches
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                0,
+                "query should return zero rows"
+            );
+            assert_eq!(edge_request_count.load(Ordering::SeqCst), 1);
+
+            // Second request: cache hit, still empty, and NO second fetch.
+            let (second_cache_status, second_batches) =
+                run_http_json_query(rt.as_ref(), HTTP_JSON_EDGE_EMPTY_QUERY).await?;
+            assert_eq!(second_cache_status, CacheStatus::CacheHit);
+            assert_eq!(
+                second_batches
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                0,
+                "cached query should still return zero rows"
+            );
+            assert_eq!(
+                edge_request_count.load(Ordering::SeqCst),
+                1,
+                "results-cache hit on an empty result should avoid a second HTTP fetch"
             );
 
             rt.shutdown().await;

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -87,6 +87,72 @@ async fn results_cache_system_queries() -> Result<(), String> {
         .await
 }
 
+/// Empty result sets (queries that return zero rows) must be cached, so a
+/// repeat request is served from cache instead of being re-executed against the
+/// source.
+///
+/// This is a regression test for empty results not being cached. In
+/// `DataFusion`, a filter that matches nothing yields **zero** record batches
+/// (not a single zero-row batch) — the common shape for
+/// `SELECT ... WHERE <key> = <absent>`, `WHERE 1 = 0`, and `LIMIT 0`. The
+/// results cache previously keyed its "should I store this?" decision on the
+/// batch count, so these were never cached and re-executed on every request.
+#[tokio::test]
+async fn results_cache_empty_result_sets() -> Result<(), String> {
+    let _tracing = init_tracing(None);
+    register_test_connectors().await;
+
+    test_request_context()
+        .scope(async {
+            let sql_results_cache = SQLResultsCacheConfig {
+                item_ttl: Some("60s".to_string()),
+                ..Default::default()
+            };
+
+            let app = AppBuilder::new("cache_test")
+                .with_sql_cache(sql_results_cache)
+                .with_dataset(make_s3_tpch_dataset("customer"))
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+
+            let cloned_rt = Arc::new(rt.clone());
+            cloned_rt.load_components().await;
+
+            // Each query returns zero rows. Verify: first request misses, is
+            // empty; second request hits, is still empty (served from cache).
+            // `c_custkey = -1` covers the realistic "key not present" case; the
+            // other two cover the `WHERE 1 = 0` / `LIMIT 0` shapes.
+            for query in [
+                "SELECT * FROM customer WHERE c_custkey = -1",
+                "SELECT * FROM customer WHERE 1 = 0",
+                "SELECT * FROM customer LIMIT 0",
+            ] {
+                let miss = execute_query_and_check_cache_status(&rt, query, CacheStatus::CacheMiss)
+                    .await
+                    .expect("first request should run successfully");
+                assert_eq!(
+                    miss.iter().map(RecordBatch::num_rows).sum::<usize>(),
+                    0,
+                    "query should return zero rows: {query}"
+                );
+
+                let hit = execute_query_and_check_cache_status(&rt, query, CacheStatus::CacheHit)
+                    .await
+                    .expect("repeat request should run successfully");
+                assert_eq!(
+                    hit.iter().map(RecordBatch::num_rows).sum::<usize>(),
+                    0,
+                    "cached query should still return zero rows: {query}"
+                );
+            }
+
+            Ok(())
+        })
+        .await
+}
+
 async fn execute_query_and_check_cache_status(
     rt: &Runtime,
     query: &str,


### PR DESCRIPTION
# Cache empty (zero-row) SQL result sets

## Problem

The SQL results cache never stored empty result sets. Repeat queries that
legitimately return no rows were re-executed against the source on every
request, defeating the cache for a very common query shape.

The root cause is that the "should I store this result?" decision keyed on the
number of **record batches** collected from the result stream, not the number of
rows:

- `crates/cache/src/utils.rs` — `to_cached_record_batch_stream` skipped the
  write when `records_to_cache.is_empty()` (zero batches).
- `crates/runtime/src/datafusion/query/cache.rs` — the stale-while-revalidate
  background refresh skipped the write when `batches_to_cache.is_empty()`.

In DataFusion, a filter that matches nothing yields **zero** record batches
(DataFusion's `FilterExec` drops zero-row batches rather than forwarding them),
so the overwhelmingly common way to produce an empty result set was never
cached.

## How common is this? (measured)

Number of record batches actually emitted by the physical plan for various
empty-result queries (real `MemTable` with 3 rows):

| Query | Batches | Rows | Cached before this PR? |
|---|---|---|---|
| `SELECT * FROM t WHERE id = 999` (key absent) | **0** | 0 | ❌ no |
| `SELECT * FROM t WHERE 1=0` | **0** | 0 | ❌ no |
| `SELECT * FROM t LIMIT 0` | **0** | 0 | ❌ no |
| `SELECT id FROM t WHERE id = 999 ORDER BY id` | **0** | 0 | ❌ no |
| `SELECT * FROM t WHERE id = 999 GROUP BY id, v` | **0** | 0 | ❌ no |
| `SELECT 1 WHERE 1=0` | **0** | 0 | ❌ no |
| `SELECT sum(v) FROM t WHERE id = 999` (bare aggregate) | 1 | 1 | ✅ yes |

The only empty results that were being cached are bare aggregates with no
`GROUP BY` (`COUNT`/`SUM`/… with no matching rows), because those always emit
exactly one row. That is why the bug looked intermittent.

## Fix

Cache empty result sets. Both write paths now store the result regardless of
batch count; the transient-HTTP-error skip (5xx/429) is preserved. The schema is
already stored separately in `CachedQueryResult`, so an empty result round-trips
with the correct schema, and the cache read path already handles empty records.

## Why it is safe to cache empty results

- **Errors are not cached as empty:** an errored query yields an `Err` in the
  stream, which is never pushed into the cached buffer, and consumers stop on the
  first `Err`, so the store code at the end of the stream never runs.
- **Schema preserved:** `CachedQueryResult` stores the schema independently of
  the batches.
- **Correctness:** an empty result is a correct result and obeys the same
  TTL/eviction as any other. The previous behavior was the inconsistent one.

## Tests

- `crates/cache/src/utils.rs`: `test_empty_result_zero_batches_is_cached`
  (fails on `trunk`) and `test_empty_result_zero_row_batch_is_cached` (sibling
  consistency case).
- `crates/runtime/src/datafusion/query/cache.rs`:
  `test_empty_result_set_is_cached` — end-to-end miss → drain → hit on
  `SELECT 1 WHERE 1=0`.
- `crates/runtime/tests/results_cache/mod.rs`: `results_cache_empty_result_sets`
  — real S3 TPC-H `customer` table, runs `WHERE c_custkey = -1`, `WHERE 1 = 0`,
  and `LIMIT 0` twice each, asserting miss → hit and empty results.
- `crates/runtime/tests/http/mod.rs`:
  `test_http_json_edge_cases_empty_result_cache` — proves an empty result from a
  live source is served from cache on the second request **without re-fetching
  the upstream** (`edge_request_count` stays at 1).
