### PR TITLE
feat(postgres): pgoutput binary-format CDC decoding + zero-copy decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5764,6 +5764,7 @@ dependencies = [
  "percent-encoding",
  "pgwire-replication",
  "postgres-native-tls",
+ "postgres-protocol",
  "rand 0.10.1",
  "rdkafka",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,6 +280,9 @@ pem = "3.0.4"
 percent-encoding = "2.3.1"
 pgwire-replication = { path = "crates/vendor/pgwire-replication", default-features = false, features = ["tls-rustls", "scram"] }
 postgres-native-tls = "0.5"
+# Low-level Postgres binary wire-format `*_from_sql` primitives for pgoutput
+# binary CDC decoding. Matches tokio-postgres 0.7.x's transitive pin.
+postgres-protocol = "0.6"
 native-tls = "0.2"
 pin-project = "1.1"
 pingora-lru = "0.7"

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -29,8 +29,7 @@ use async_stream::try_stream;
 use data_components::cdc::{ChangesStream, StreamError};
 use data_components::postgres_replication::{
     PgOutputFormat, ReplicationMetrics, ReplicationMetricsCollector, ReplicationParams,
-    ReplicationStreamInput,
-    SchemaEvolutionPolicy, config, start_replication_stream_with_policy,
+    ReplicationStreamInput, SchemaEvolutionPolicy, config, start_replication_stream_with_policy,
 };
 use datafusion::sql::TableReference;
 use futures::StreamExt;

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -28,7 +28,8 @@ use std::time::Duration;
 use async_stream::try_stream;
 use data_components::cdc::{ChangesStream, StreamError};
 use data_components::postgres_replication::{
-    ReplicationMetrics, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput,
+    PgOutputFormat, ReplicationMetrics, ReplicationMetricsCollector, ReplicationParams,
+    ReplicationStreamInput,
     SchemaEvolutionPolicy, config, start_replication_stream_with_policy,
 };
 use datafusion::sql::TableReference;
@@ -605,6 +606,10 @@ fn replication_params_from_connector_params(
         status_interval,
         bootstrap_batch_size,
         shared,
+        // Binary pgoutput on every stream — faster decode, no source-side text
+        // formatting. Not a user-facing parameter; the per-column text fallback
+        // still handles types Postgres emits as text.
+        pg_output_format: PgOutputFormat::Binary,
     })
 }
 

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -85,6 +85,7 @@ native-tls = { workspace = true, optional = true }
 percent-encoding.workspace = true
 pgwire-replication = { workspace = true, optional = true }
 postgres-native-tls = { workspace = true, optional = true }
+postgres-protocol = { workspace = true, optional = true }
 rand.workspace = true
 rdkafka = { workspace = true, features = ["ssl-vendored"], optional = true }
 regex.workspace = true
@@ -175,6 +176,7 @@ postgres = [
     "dep:pgwire-replication",
     "dep:native-tls",
     "dep:postgres-native-tls",
+    "dep:postgres-protocol",
     "federation",
     "datafusion-table-providers/postgres",
     "datafusion-table-providers/postgres-federation",
@@ -238,3 +240,8 @@ required-features = ["mongodb"]
 harness = false
 name = "kafka_decode"
 required-features = ["bench", "kafka"]
+
+[[bench]]
+harness = false
+name = "pgoutput_decode"
+required-features = ["postgres"]

--- a/crates/data_components/benches/pgoutput_decode.rs
+++ b/crates/data_components/benches/pgoutput_decode.rs
@@ -1,0 +1,297 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Decode microbench for the Postgres pgoutput CDC path, over a change stream
+//! shaped like a TPC-H `orders` table (mixed int / numeric / date / string
+//! columns). Measures the full hot path: `Decoder::decode` over a synthesized
+//! Relation + N Insert messages, then `build_change_batch` into Arrow.
+//!
+//! The `text` and `binary` variants encode the *same logical rows* two ways, so
+//! the numbers are directly comparable. Payload `Bytes` are built once, outside
+//! the timed loop; the per-message `Bytes::clone` inside the loop is an O(1)
+//! refcount bump — the same handoff the replication frame reader performs.
+//!
+//! Run:
+//!   cargo bench -p data_components --features postgres --bench pgoutput_decode
+//! Compare against the pre-refactor text baseline:
+//!   cargo bench -p data_components --features postgres --bench pgoutput_decode \
+//!     -- --baseline text-before
+
+#![allow(clippy::expect_used, clippy::cast_possible_truncation)]
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use data_components::postgres_replication::changes::{ChangeOp, DecodedChange, build_change_batch};
+use data_components::postgres_replication::pgoutput::{DecodedMessage, Decoder, Relation};
+
+const REL_ID: u32 = 16_384;
+
+/// Postgres type OIDs used by the `orders` fixture.
+mod oid {
+    pub const INT8: u32 = 20;
+    pub const INT4: u32 = 23;
+    pub const BPCHAR: u32 = 1042;
+    pub const VARCHAR: u32 = 1043;
+    pub const NUMERIC: u32 = 1700;
+    pub const DATE: u32 = 1082;
+}
+
+/// numeric typmod packs `((precision << 16) | scale) + VARHDRSZ(4)`.
+fn numeric_typmod(precision: i32, scale: i32) -> i32 {
+    ((precision << 16) | scale) + 4
+}
+
+/// (name, oid, typmod, is_key) for each `orders` column, in table order.
+fn orders_columns() -> Vec<(&'static str, u32, i32, bool)> {
+    vec![
+        ("o_orderkey", oid::INT8, -1, true),
+        ("o_custkey", oid::INT8, -1, false),
+        ("o_orderstatus", oid::BPCHAR, -1, false),
+        ("o_totalprice", oid::NUMERIC, numeric_typmod(15, 2), false),
+        ("o_orderdate", oid::DATE, -1, false),
+        ("o_orderpriority", oid::VARCHAR, -1, false),
+        ("o_clerk", oid::VARCHAR, -1, false),
+        ("o_shippriority", oid::INT4, -1, false),
+        ("o_comment", oid::VARCHAR, -1, false),
+    ]
+}
+
+/// Dataset Arrow schema matching what the Postgres provider exposes for
+/// `orders`.
+fn orders_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("o_orderkey", DataType::Int64, false),
+        Field::new("o_custkey", DataType::Int64, false),
+        Field::new("o_orderstatus", DataType::Utf8, false),
+        Field::new("o_totalprice", DataType::Decimal128(15, 2), false),
+        Field::new("o_orderdate", DataType::Date32, false),
+        Field::new("o_orderpriority", DataType::Utf8, false),
+        Field::new("o_clerk", DataType::Utf8, false),
+        Field::new("o_shippriority", DataType::Int32, false),
+        Field::new("o_comment", DataType::Utf8, false),
+    ]))
+}
+
+// ---- shared per-row logical values --------------------------------------
+
+/// Deterministic logical values for row `i`, kept as native types so the text
+/// and binary encoders can render the *same* row two ways.
+struct OrderRow {
+    orderkey: i64,
+    custkey: i64,
+    status: &'static str,
+    dollars: u64,
+    cents: u16,
+    day: u32, // day-of-month in 1996-01
+    priority: &'static str,
+    clerk: String,
+    shippriority: i32,
+    comment: String,
+}
+
+fn order_row(i: usize) -> OrderRow {
+    OrderRow {
+        orderkey: i as i64 + 1,
+        custkey: (i % 150_000) as i64 + 1,
+        status: ["O", "F", "P"][i % 3],
+        dollars: 10_000 + (i % 300_000) as u64,
+        cents: (i % 100) as u16,
+        day: 1 + (i % 27) as u32,
+        priority: ["1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED", "5-LOW"][i % 5],
+        clerk: format!("Clerk#{:09}", (i % 1000) + 1),
+        shippriority: 0,
+        comment: format!(
+            "carefully regular deposits for order {} nag across the express requests",
+            i + 1
+        ),
+    }
+}
+
+// ---- pgoutput Relation encoder ------------------------------------------
+
+fn put_cstr(out: &mut Vec<u8>, s: &str) {
+    out.extend_from_slice(s.as_bytes());
+    out.push(0);
+}
+
+fn encode_relation() -> Bytes {
+    let mut out = vec![b'R'];
+    out.extend_from_slice(&REL_ID.to_be_bytes());
+    put_cstr(&mut out, "public");
+    put_cstr(&mut out, "orders");
+    out.push(b'd'); // replica identity DEFAULT
+    let cols = orders_columns();
+    out.extend_from_slice(&(cols.len() as u16).to_be_bytes());
+    for (name, type_oid, typmod, is_key) in cols {
+        out.push(u8::from(is_key)); // flags: 0x01 => key
+        put_cstr(&mut out, name);
+        out.extend_from_slice(&type_oid.to_be_bytes());
+        out.extend_from_slice(&typmod.to_be_bytes());
+    }
+    Bytes::from(out)
+}
+
+// ---- text-format Insert encoder (pgoutput tuple tag `t`) -----------------
+
+fn row_text(r: &OrderRow) -> Vec<String> {
+    vec![
+        r.orderkey.to_string(),
+        r.custkey.to_string(),
+        r.status.to_string(),
+        format!("{}.{:02}", r.dollars, r.cents),
+        format!("1996-01-{:02}", r.day),
+        r.priority.to_string(),
+        r.clerk.clone(),
+        r.shippriority.to_string(),
+        r.comment.clone(),
+    ]
+}
+
+fn encode_insert_text(values: &[String]) -> Bytes {
+    let mut out = vec![b'I'];
+    out.extend_from_slice(&REL_ID.to_be_bytes());
+    out.push(b'N');
+    out.extend_from_slice(&(values.len() as u16).to_be_bytes());
+    for v in values {
+        out.push(b't');
+        out.extend_from_slice(&(v.len() as u32).to_be_bytes());
+        out.extend_from_slice(v.as_bytes());
+    }
+    Bytes::from(out)
+}
+
+// ---- binary-format Insert encoder (pgoutput tuple tag `b`) ---------------
+
+/// Encode a Postgres binary `numeric` for `dollars.cents` at scale 2. Groups
+/// are base-10000, most-significant first; the fractional group is `cents*100`.
+fn enc_numeric_dollars_cents(dollars: u64, cents: u16) -> Vec<u8> {
+    let mut int_groups: Vec<u16> = Vec::new();
+    let mut n = dollars;
+    while n > 0 {
+        int_groups.push((n % 10_000) as u16);
+        n /= 10_000;
+    }
+    int_groups.reverse();
+    let g = int_groups.len();
+    let mut digits = int_groups;
+    digits.push(cents * 100);
+    let weight: i16 = if g == 0 { -1 } else { g as i16 - 1 };
+
+    let mut o = Vec::new();
+    o.extend_from_slice(&(digits.len() as u16).to_be_bytes());
+    o.extend_from_slice(&weight.to_be_bytes());
+    o.extend_from_slice(&0u16.to_be_bytes()); // sign = positive
+    o.extend_from_slice(&2u16.to_be_bytes()); // dscale
+    for d in &digits {
+        o.extend_from_slice(&d.to_be_bytes());
+    }
+    o
+}
+
+/// Days from the Postgres epoch (2000-01-01) to 1996-01-`day`.
+fn pg_days_1996(day: u32) -> i32 {
+    -1461 + (day as i32 - 1)
+}
+
+fn row_binary(r: &OrderRow) -> Vec<Vec<u8>> {
+    vec![
+        r.orderkey.to_be_bytes().to_vec(),
+        r.custkey.to_be_bytes().to_vec(),
+        r.status.as_bytes().to_vec(),
+        enc_numeric_dollars_cents(r.dollars, r.cents),
+        pg_days_1996(r.day).to_be_bytes().to_vec(),
+        r.priority.as_bytes().to_vec(),
+        r.clerk.as_bytes().to_vec(),
+        r.shippriority.to_be_bytes().to_vec(),
+        r.comment.as_bytes().to_vec(),
+    ]
+}
+
+fn encode_insert_binary(values: &[Vec<u8>]) -> Bytes {
+    let mut out = vec![b'I'];
+    out.extend_from_slice(&REL_ID.to_be_bytes());
+    out.push(b'N');
+    out.extend_from_slice(&(values.len() as u16).to_be_bytes());
+    for v in values {
+        out.push(b'b');
+        out.extend_from_slice(&(v.len() as u32).to_be_bytes());
+        out.extend_from_slice(v);
+    }
+    Bytes::from(out)
+}
+
+// ---- measured work -------------------------------------------------------
+
+fn decode_and_build(schema: &SchemaRef, relation: &Bytes, inserts: &[Bytes]) {
+    let mut decoder = Decoder::new();
+    let rel: Relation = match decoder.decode(relation.clone()).expect("decode relation") {
+        DecodedMessage::Relation(r) => r,
+        other => panic!("expected Relation, got {other:?}"),
+    };
+    let mut changes: Vec<DecodedChange> = Vec::with_capacity(inserts.len());
+    for msg in inserts {
+        match decoder.decode(msg.clone()).expect("decode insert") {
+            DecodedMessage::Insert { tuple, .. } => changes.push(DecodedChange {
+                op: ChangeOp::Create,
+                row: tuple,
+            }),
+            other => panic!("expected Insert, got {other:?}"),
+        }
+    }
+    let batch = build_change_batch(schema, &rel, &changes).expect("build batch");
+    black_box(batch);
+}
+
+fn bench_decode(c: &mut Criterion) {
+    let schema = orders_schema();
+    let mut group = c.benchmark_group("pgoutput_orders_decode");
+    for &n in &[100usize, 1_000, 10_000] {
+        let rows: Vec<OrderRow> = (0..n).map(order_row).collect();
+        let relation = encode_relation();
+        let text: Vec<Bytes> = rows
+            .iter()
+            .map(|r| encode_insert_text(&row_text(r)))
+            .collect();
+        let binary: Vec<Bytes> = rows
+            .iter()
+            .map(|r| encode_insert_binary(&row_binary(r)))
+            .collect();
+
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(
+            BenchmarkId::new("text", n),
+            &(&relation, &text),
+            |b, (r, ins)| {
+                b.iter(|| decode_and_build(black_box(&schema), black_box(r), black_box(ins)));
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("binary", n),
+            &(&relation, &binary),
+            |b, (r, ins)| {
+                b.iter(|| decode_and_build(black_box(&schema), black_box(r), black_box(ins)));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_decode);
+criterion_main!(benches);

--- a/crates/data_components/src/postgres_replication/bootstrap.rs
+++ b/crates/data_components/src/postgres_replication/bootstrap.rs
@@ -658,9 +658,13 @@ impl BootstrapBuilder {
                         message: format!("bootstrap read column (as text): {e}"),
                     })?;
                 match v {
+                    // Bootstrap fetches these columns as `::text`, so the value
+                    // is always text — the `type_oid` is irrelevant here (only
+                    // the binary branch consults it), hence `0` (unknown).
                     Some(s) => fb.append(
-                        Some(&super::pgoutput::Value::Text(s)),
+                        Some(&super::pgoutput::Value::Text(bytes::Bytes::from(s))),
                         super::changes::ChangeOp::Create,
+                        0,
                     )?,
                     None => fb.append_null(),
                 }

--- a/crates/data_components/src/postgres_replication/changes.rs
+++ b/crates/data_components/src/postgres_replication/changes.rs
@@ -18,6 +18,7 @@ limitations under the License.
 //! [`crate::cdc::ChangeBatch`]es that the existing refresh loop knows how to
 //! apply.
 
+use std::borrow::Cow;
 use std::sync::{Arc, atomic::AtomicU64};
 
 use arrow::{
@@ -777,11 +778,16 @@ impl FieldBuilder {
             Self::Float64(b) => {
                 b.append_value(pg::float8_from_sql(raw).map_err(decode_err("float8"))?);
             }
-            Self::Utf8(b) => b.append_value(pg::text_from_sql(raw).map_err(decode_err("text"))?),
-            Self::LargeUtf8(b) => {
-                b.append_value(pg::text_from_sql(raw).map_err(decode_err("text"))?);
-            }
-            // bytea `send` form is the raw bytes — identity.
+            // A column mapped to Arrow Utf8 can be a genuine text type (whose
+            // binary send form IS UTF-8 text) or a non-text type Postgres still
+            // maps to a string (uuid/inet/cidr/macaddr). `decode_binary_text`
+            // dispatches on the OID and yields the canonical Postgres text —
+            // identical to what the `::text` bootstrap path produces, so the
+            // snapshot and WAL agree.
+            Self::Utf8(b) => b.append_value(decode_binary_text(raw, type_oid)?.as_ref()),
+            Self::LargeUtf8(b) => b.append_value(decode_binary_text(raw, type_oid)?.as_ref()),
+            // bytea `send` form is the raw payload verbatim; append it directly
+            // (the one copy into the Arrow buffer is unavoidable).
             Self::Binary(b) => b.append_value(raw),
             Self::Date32(b) => {
                 let pg_days = pg::date_from_sql(raw).map_err(decode_err("date"))?;
@@ -1285,10 +1291,13 @@ fn decode_binary_array(raw: &[u8]) -> Result<(u32, Vec<Option<&[u8]>>)> {
         })?;
     }
 
+    // Fallibly reserve so a corrupt/oversized `count` from the WAL surfaces as a
+    // structured error instead of aborting the process on a huge allocation.
     let mut out = Vec::new();
-    out.try_reserve_exact(count).map_err(|e| super::Error::PgOutputDecode {
-        message: format!("postgres_replication: array too large (len {count}): {e}"),
-    })?;
+    out.try_reserve_exact(count)
+        .map_err(|e| super::Error::PgOutputDecode {
+            message: format!("postgres_replication: array too large (len {count}): {e}"),
+        })?;
     for _ in 0..count {
         ensure!(
             b.remaining() >= 4,
@@ -1315,6 +1324,108 @@ fn decode_binary_array(raw: &[u8]) -> Result<(u32, Vec<Option<&[u8]>>)> {
         }
     }
     Ok((elem_oid, out))
+}
+
+/// Decode a binary value destined for an Arrow `Utf8`/`LargeUtf8` column into
+/// its canonical Postgres text, dispatched by the source type OID.
+///
+/// Most Arrow-`Utf8` sources (`text`, `varchar`, `bpchar`, `name`, `json`,
+/// `xml`) have a binary send form that already *is* UTF-8 text. A few
+/// Postgres types map to Arrow strings but send non-text binary — `uuid`,
+/// `inet`, `cidr`, `macaddr` — so we format those to the exact text the
+/// `::text` bootstrap path (and SQL queries) produce, keeping snapshot and WAL
+/// in agreement. Any other OID targeting a text column is an explicit error
+/// rather than a silent mis-decode.
+fn decode_binary_text(raw: &[u8], type_oid: u32) -> Result<Cow<'_, str>> {
+    use postgres_protocol::types as pg;
+
+    let decode_err =
+        move |e: Box<dyn std::error::Error + Sync + Send>| super::Error::PgOutputDecode {
+            message: format!(
+                "postgres_replication: binary text decode failed (type oid {type_oid}): {e}"
+            ),
+        };
+
+    match type_oid {
+        // text, varchar, bpchar, name, json, xml — binary send is UTF-8 text.
+        25 | 1043 | 1042 | 19 | 114 | 142 => {
+            Ok(Cow::Borrowed(pg::text_from_sql(raw).map_err(decode_err)?))
+        }
+        // uuid → canonical lowercase hyphenated form.
+        2950 => Ok(Cow::Owned(format_uuid(
+            &pg::uuid_from_sql(raw).map_err(decode_err)?,
+        ))),
+        // macaddr → lowercase colon-separated form.
+        829 => Ok(Cow::Owned(format_macaddr(
+            pg::macaddr_from_sql(raw).map_err(decode_err)?,
+        ))),
+        // inet / cidr → `addr` or `addr/bits` (matches inet_out / cidr_out).
+        869 | 650 => Ok(Cow::Owned(format_inet(raw)?)),
+        other => PgOutputDecodeSnafu {
+            message: format!(
+                "postgres_replication: binary decoding into a text column is not supported for \
+                 Postgres type OID {other}. Exclude the column from the dataset schema, or \
+                 request text replication output for this dataset."
+            ),
+        }
+        .fail(),
+    }
+}
+
+const HEX_LOWER: &[u8; 16] = b"0123456789abcdef";
+
+fn push_hex_byte(s: &mut String, byte: u8) {
+    s.push(HEX_LOWER[(byte >> 4) as usize] as char);
+    s.push(HEX_LOWER[(byte & 0x0f) as usize] as char);
+}
+
+/// Format 16 UUID bytes as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` (lowercase),
+/// matching Postgres `uuid_out`.
+fn format_uuid(bytes: &[u8; 16]) -> String {
+    let mut s = String::with_capacity(36);
+    for (i, byte) in bytes.iter().enumerate() {
+        if matches!(i, 4 | 6 | 8 | 10) {
+            s.push('-');
+        }
+        push_hex_byte(&mut s, *byte);
+    }
+    s
+}
+
+/// Format 6 MAC bytes as `xx:xx:xx:xx:xx:xx` (lowercase), matching Postgres
+/// `macaddr_out`.
+fn format_macaddr(bytes: [u8; 6]) -> String {
+    let mut s = String::with_capacity(17);
+    for (i, byte) in bytes.iter().enumerate() {
+        if i != 0 {
+            s.push(':');
+        }
+        push_hex_byte(&mut s, *byte);
+    }
+    s
+}
+
+/// Format a binary `inet`/`cidr` as Postgres would: `addr/bits` always for
+/// `cidr`, and for `inet` only when `bits` is not the address width (matching
+/// `inet_out`/`cidr_out`). IP address text uses the standard canonical form
+/// (RFC 5952 for IPv6).
+fn format_inet(raw: &[u8]) -> Result<String> {
+    use postgres_protocol::types as pg;
+
+    let inet = pg::inet_from_sql(raw).map_err(|e| super::Error::PgOutputDecode {
+        message: format!("postgres_replication: binary inet decode failed: {e}"),
+    })?;
+    // Byte 2 of the wire format is the `is_cidr` flag, which `Inet` discards but
+    // which decides whether a full-width prefix is printed.
+    let is_cidr = raw.get(2).is_some_and(|b| *b != 0);
+    let addr = inet.addr();
+    let bits = inet.netmask();
+    let max_bits = if addr.is_ipv4() { 32 } else { 128 };
+    Ok(if is_cidr || bits != max_bits {
+        format!("{addr}/{bits}")
+    } else {
+        format!("{addr}")
+    })
 }
 
 fn parse_pg_numeric_to_i128(s: &str, precision: u8, scale: i8) -> Result<i128> {
@@ -2679,6 +2790,86 @@ mod tests {
         assert_eq!(ints.value(0), 1);
         assert!(ints.is_null(1));
         assert_eq!(ints.value(2), 3);
+    }
+
+    #[test]
+    fn binary_uuid_and_macaddr_decode_to_canonical_text() {
+        // uuid → lowercase hyphenated (matches `uuid_out`).
+        let uuid = [
+            0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44,
+            0x00, 0x00,
+        ];
+        assert_eq!(
+            bin_one(&DataType::Utf8, 2950, &uuid)
+                .as_string::<i32>()
+                .value(0),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        // macaddr → lowercase colon-separated (matches `macaddr_out`).
+        assert_eq!(
+            bin_one(&DataType::Utf8, 829, &[0x08, 0x00, 0x2b, 0x01, 0x02, 0x03])
+                .as_string::<i32>()
+                .value(0),
+            "08:00:2b:01:02:03"
+        );
+    }
+
+    /// Encode a binary `inet`/`cidr` value.
+    fn enc_inet(family: u8, bits: u8, is_cidr: u8, addr: &[u8]) -> Vec<u8> {
+        let mut o = vec![
+            family,
+            bits,
+            is_cidr,
+            u8::try_from(addr.len()).expect("addr len fits u8"),
+        ];
+        o.extend_from_slice(addr);
+        o
+    }
+
+    #[test]
+    fn binary_inet_cidr_decode_to_canonical_text() {
+        // inet host: full-width prefix omitted (matches `inet_out`).
+        assert_eq!(
+            bin_one(&DataType::Utf8, 869, &enc_inet(2, 32, 0, &[10, 0, 0, 1]))
+                .as_string::<i32>()
+                .value(0),
+            "10.0.0.1"
+        );
+        // inet with a network prefix keeps it.
+        assert_eq!(
+            bin_one(&DataType::Utf8, 869, &enc_inet(2, 24, 0, &[10, 0, 0, 0]))
+                .as_string::<i32>()
+                .value(0),
+            "10.0.0.0/24"
+        );
+        // cidr always prints the prefix, even at full width (matches `cidr_out`).
+        assert_eq!(
+            bin_one(&DataType::Utf8, 650, &enc_inet(2, 32, 1, &[10, 0, 0, 0]))
+                .as_string::<i32>()
+                .value(0),
+            "10.0.0.0/32"
+        );
+        // IPv6 canonical (RFC 5952) compressed form.
+        let mut v6 = [0u8; 16];
+        v6[0] = 0x20;
+        v6[1] = 0x01;
+        v6[2] = 0x0d;
+        v6[3] = 0xb8;
+        v6[15] = 0x01;
+        assert_eq!(
+            bin_one(&DataType::Utf8, 869, &enc_inet(3, 128, 0, &v6))
+                .as_string::<i32>()
+                .value(0),
+            "2001:db8::1"
+        );
+    }
+
+    #[test]
+    fn binary_text_column_rejects_unsupported_oid() {
+        // An OID with no supported text/binary mapping targeting a Utf8 column
+        // must error loudly (here: jsonb, whose binary carries a version byte),
+        // never silently mis-decode into a wrong string.
+        decode_binary_text(&[0x01, b'{', b'}'], 3802).expect_err("unsupported oid must error");
     }
 
     #[test]

--- a/crates/data_components/src/postgres_replication/changes.rs
+++ b/crates/data_components/src/postgres_replication/changes.rs
@@ -32,10 +32,20 @@ use arrow::{
     datatypes::{DataType, Field, Int8Type, Int16Type, Int32Type, Schema, SchemaRef, TimeUnit},
 };
 use async_trait::async_trait;
+use snafu::ensure;
 
 use super::pgoutput::{Relation, TupleData, Value};
 use super::{PgOutputDecodeSnafu, Result};
 use crate::cdc::{ChangeBatch, ChangeEnvelope, CommitChange, CommitError, changes_schema};
+
+/// Microseconds between the Unix epoch (1970-01-01) and the Postgres epoch
+/// (2000-01-01). Binary `timestamp`/`timestamptz` are relative to the Postgres
+/// epoch; Arrow timestamps are relative to the Unix epoch.
+const PG_EPOCH_MICROS: i64 = 946_684_800_000_000;
+
+/// Days between the Unix epoch and the Postgres epoch. Binary `date` is days
+/// since the Postgres epoch; Arrow `Date32` is days since the Unix epoch.
+const PG_EPOCH_DAYS: i32 = 10_957;
 
 /// One logical change derived from a pgoutput message.
 #[derive(Debug, Clone)]
@@ -258,7 +268,10 @@ pub fn build_change_batch(
             match source_idx {
                 Some(source_idx) => {
                     let value = change.row.columns.get(*source_idx).and_then(Option::as_ref);
-                    data_builders[col_idx].append(value, change.op)?;
+                    // The source column's Postgres type OID drives binary-format
+                    // decoding; the text path ignores it.
+                    let type_oid = relation.columns[*source_idx].type_oid;
+                    data_builders[col_idx].append(value, change.op, type_oid)?;
                 }
                 None => data_builders[col_idx].append_null(),
             }
@@ -536,13 +549,33 @@ impl FieldBuilder {
         })
     }
 
-    pub(super) fn append(&mut self, value: Option<&Value>, op: ChangeOp) -> Result<()> {
+    /// Append one pgoutput column value into the typed Arrow builder.
+    ///
+    /// `type_oid` is the source column's Postgres type OID (from the pgoutput
+    /// `Relation` message). It is consulted only for binary-format values
+    /// ([`Value::Binary`]); the text path is self-describing and ignores it.
+    ///
+    /// Under the binary output protocol Postgres tags each column `t` or `b`
+    /// per-value, so *both* paths must remain live regardless of the requested
+    /// format — a type without a binary send function still arrives as text.
+    pub(super) fn append(
+        &mut self,
+        value: Option<&Value>,
+        op: ChangeOp,
+        type_oid: u32,
+    ) -> Result<()> {
         let Some(v) = value else {
             self.append_null();
             return Ok(());
         };
         let s = match v {
-            Value::Text(s) => s,
+            Value::Text(bytes) => {
+                // UTF-8 validation is deferred to here (the decoder keeps raw
+                // bytes) so it happens exactly once, on the way into the builder.
+                std::str::from_utf8(bytes).map_err(|e| super::Error::PgOutputDecode {
+                    message: format!("invalid utf8 in text value: {e}"),
+                })?
+            }
             Value::Unchanged => {
                 // For UPDATE with a TOASTed column that wasn't changed, pgoutput
                 // omits the value. Silently coercing to NULL would overwrite the
@@ -560,21 +593,9 @@ impl FieldBuilder {
                 .fail();
             }
             Value::Binary(bytes) => {
-                // pgoutput delivers bytea in binary format when the publication
-                // uses the binary encoding. We only accept this for BinaryBuilder;
-                // for other builders it's an error (silent coerce to NULL would
-                // be wrong).
-                if let Self::Binary(b) = self {
-                    b.append_value(bytes);
-                    return Ok(());
-                }
-                return PgOutputDecodeSnafu {
-                    message: "postgres_replication: binary-format pgoutput value received \
-                              for non-binary column. Configure the publication to use the \
-                              text output format."
-                        .to_string(),
-                }
-                .fail();
+                // Binary output protocol: decode the type's `send` wire form
+                // straight into the typed builder (no text round-trip).
+                return self.append_binary(bytes, type_oid);
             }
         };
         match self {
@@ -598,7 +619,7 @@ impl FieldBuilder {
                 })?;
                 b.append_value(bytes);
             }
-            Self::Bool(b) => b.append_value(matches!(s.as_str(), "t" | "true" | "TRUE")),
+            Self::Bool(b) => b.append_value(matches!(s, "t" | "true" | "TRUE")),
             Self::Int8(b) => {
                 b.append_value(s.parse::<i8>().map_err(|e| super::Error::PgOutputDecode {
                     message: format!("int8 parse '{s}': {e}"),
@@ -687,10 +708,13 @@ impl FieldBuilder {
                 for element in &elements {
                     match element {
                         Some(text) => {
-                            let value = Value::Text(text.clone());
-                            inner.append(Some(&value), op)?;
+                            // Text array literal: each element is itself text,
+                            // so the inner builder's text path handles it and
+                            // the element `type_oid` is irrelevant (`0`).
+                            let value = Value::Text(bytes::Bytes::from(text.clone()));
+                            inner.append(Some(&value), op, 0)?;
                         }
-                        None if item_field.is_nullable() => inner.append(None, op)?,
+                        None if item_field.is_nullable() => inner.append(None, op, 0)?,
                         None => {
                             return PgOutputDecodeSnafu {
                                 message: format!(
@@ -705,6 +729,153 @@ impl FieldBuilder {
                 }
                 let end = offsets.last().copied().unwrap_or(0)
                     + i32::try_from(elements.len()).map_err(|e| super::Error::PgOutputDecode {
+                        message: format!("array too large: {e}"),
+                    })?;
+                offsets.push(end);
+                validity.push(true);
+            }
+        }
+        Ok(())
+    }
+
+    /// Decode a binary (`send`-format) pgoutput value directly into the typed
+    /// builder. Reached when Postgres tags the column `b` under the binary
+    /// output protocol. `type_oid` names the source type for diagnostics.
+    fn append_binary(&mut self, raw: &[u8], type_oid: u32) -> Result<()> {
+        use postgres_protocol::types as pg;
+
+        // Map a postgres-protocol binary-decode error into our decode error,
+        // naming the failing logical type and OID for actionable diagnostics.
+        // `kind` is always a string literal, so `'static` lets the returned
+        // closure capture it without a borrow that would outlive the call.
+        let decode_err = |kind: &'static str| {
+            move |e: Box<dyn std::error::Error + Sync + Send>| super::Error::PgOutputDecode {
+                message: format!(
+                    "postgres_replication: binary {kind} decode failed (type oid {type_oid}): {e}"
+                ),
+            }
+        };
+        let range_err = |kind: &str, detail: String| super::Error::PgOutputDecode {
+            message: format!(
+                "postgres_replication: binary {kind} value out of range (type oid {type_oid}): \
+                 {detail}"
+            ),
+        };
+
+        match self {
+            Self::Bool(b) => b.append_value(pg::bool_from_sql(raw).map_err(decode_err("bool"))?),
+            Self::Int8(b) => {
+                b.append_value(pg::char_from_sql(raw).map_err(decode_err("\"char\""))?);
+            }
+            Self::Int16(b) => b.append_value(pg::int2_from_sql(raw).map_err(decode_err("int2"))?),
+            Self::Int32(b) => b.append_value(pg::int4_from_sql(raw).map_err(decode_err("int4"))?),
+            Self::Int64(b) => b.append_value(pg::int8_from_sql(raw).map_err(decode_err("int8"))?),
+            Self::UInt32(b) => b.append_value(pg::oid_from_sql(raw).map_err(decode_err("oid"))?),
+            Self::Float32(b) => {
+                b.append_value(pg::float4_from_sql(raw).map_err(decode_err("float4"))?);
+            }
+            Self::Float64(b) => {
+                b.append_value(pg::float8_from_sql(raw).map_err(decode_err("float8"))?);
+            }
+            Self::Utf8(b) => b.append_value(pg::text_from_sql(raw).map_err(decode_err("text"))?),
+            Self::LargeUtf8(b) => {
+                b.append_value(pg::text_from_sql(raw).map_err(decode_err("text"))?);
+            }
+            // bytea `send` form is the raw bytes — identity.
+            Self::Binary(b) => b.append_value(pg::bytea_from_sql(raw)),
+            Self::Date32(b) => {
+                let pg_days = pg::date_from_sql(raw).map_err(decode_err("date"))?;
+                let days = pg_days
+                    .checked_add(PG_EPOCH_DAYS)
+                    .ok_or_else(|| range_err("date", format!("pg days {pg_days}")))?;
+                b.append_value(days);
+            }
+            Self::Time64Nanos(b) => {
+                let micros = pg::time_from_sql(raw).map_err(decode_err("time"))?;
+                let nanos = micros
+                    .checked_mul(1_000)
+                    .ok_or_else(|| range_err("time", format!("micros {micros}")))?;
+                b.append_value(nanos);
+            }
+            Self::TimestampMicros(b, _tz) => {
+                let pg_micros = pg::timestamp_from_sql(raw).map_err(decode_err("timestamp"))?;
+                let micros = pg_micros
+                    .checked_add(PG_EPOCH_MICROS)
+                    .ok_or_else(|| range_err("timestamp", format!("pg micros {pg_micros}")))?;
+                b.append_value(micros);
+            }
+            Self::TimestampNanos(b, _tz) => {
+                let pg_micros = pg::timestamp_from_sql(raw).map_err(decode_err("timestamp"))?;
+                let micros = pg_micros
+                    .checked_add(PG_EPOCH_MICROS)
+                    .ok_or_else(|| range_err("timestamp", format!("pg micros {pg_micros}")))?;
+                let nanos = micros
+                    .checked_mul(1_000)
+                    .ok_or_else(|| range_err("timestamp", format!("micros {micros}")))?;
+                b.append_value(nanos);
+            }
+            Self::Decimal128(b, precision, scale) => {
+                let v = numeric_from_binary(raw, *precision, *scale)?;
+                b.append_value(v);
+            }
+            Self::DictUtf8Int8(b) => {
+                b.append(pg::text_from_sql(raw).map_err(decode_err("enum"))?)
+                    .map_err(|e| super::Error::PgOutputDecode {
+                        message: format!("dictionary append: {e}"),
+                    })?;
+            }
+            Self::DictUtf8Int16(b) => {
+                b.append(pg::text_from_sql(raw).map_err(decode_err("enum"))?)
+                    .map_err(|e| super::Error::PgOutputDecode {
+                        message: format!("dictionary append: {e}"),
+                    })?;
+            }
+            Self::DictUtf8Int32(b) => {
+                b.append(pg::text_from_sql(raw).map_err(decode_err("enum"))?)
+                    .map_err(|e| super::Error::PgOutputDecode {
+                        message: format!("dictionary append: {e}"),
+                    })?;
+            }
+            Self::List {
+                item_field,
+                inner,
+                offsets,
+                validity,
+            } => {
+                if matches!(
+                    item_field.data_type(),
+                    DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _)
+                ) {
+                    return PgOutputDecodeSnafu {
+                        message:
+                            "postgres_replication: multidimensional arrays are not supported. \
+                                  Cast the column to a scalar type on the source, or exclude the \
+                                  column from the dataset schema."
+                                .to_string(),
+                    }
+                    .fail();
+                }
+                let (elem_oid, elements) = decode_binary_array(raw)?;
+                let count = elements.len();
+                for element in elements {
+                    match element {
+                        // Recurse into the inner builder's binary path with the
+                        // element slice directly — no per-element allocation.
+                        Some(elem) => inner.append_binary(elem, elem_oid)?,
+                        None if item_field.is_nullable() => inner.append_null(),
+                        None => {
+                            return PgOutputDecodeSnafu {
+                                message: format!(
+                                    "NULL array element for non-nullable list item field `{}`",
+                                    item_field.name()
+                                ),
+                            }
+                            .fail();
+                        }
+                    }
+                }
+                let end = offsets.last().copied().unwrap_or(0)
+                    + i32::try_from(count).map_err(|e| super::Error::PgOutputDecode {
                         message: format!("array too large: {e}"),
                     })?;
                 offsets.push(end);
@@ -930,6 +1101,187 @@ fn parse_pg_timestamp_nanos(s: &str) -> Result<i64> {
 /// implementation.
 pub(super) fn parse_pg_numeric_public(s: &str, scale: i8) -> Result<i128> {
     parse_pg_numeric_to_i128(s, 38, scale)
+}
+
+/// Decode a Postgres binary `numeric` (`send` wire form) into an `i128` scaled
+/// to the dataset's declared Arrow scale.
+///
+/// Wire format: `i16 ndigits, i16 weight, u16 sign, u16 dscale`, then `ndigits`
+/// base-10000 groups (`i16` each, most-significant first). The value is
+/// `sign · Σ digit[i]·10000^(weight−i)`. We fold the groups into a base-10000
+/// integer `m` and rescale by `10^(4·(weight−(ndigits−1)) + scale)`; a negative
+/// exponent that does not divide `m` evenly means the value carries more
+/// fractional precision than the declared scale — an error, never a silent
+/// round (mirrors the text path's scale check). `NaN`/`±Infinity` sign words
+/// are rejected: `Decimal128` cannot represent them.
+fn numeric_from_binary(raw: &[u8], _precision: u8, scale: i8) -> Result<i128> {
+    use bytes::Buf;
+
+    const NUMERIC_POS: u16 = 0x0000;
+    const NUMERIC_NEG: u16 = 0x4000;
+
+    let mut b = raw;
+    ensure!(
+        b.remaining() >= 8,
+        PgOutputDecodeSnafu {
+            message: "short binary numeric header".to_string()
+        }
+    );
+    let ndigits = b.get_u16();
+    let weight = b.get_i16();
+    let sign = b.get_u16();
+    let _dscale = b.get_u16();
+
+    let negative = match sign {
+        NUMERIC_POS => false,
+        NUMERIC_NEG => true,
+        other => {
+            return PgOutputDecodeSnafu {
+                message: format!(
+                    "postgres_replication: numeric special value (sign 0x{other:04x}, \
+                     NaN/Infinity) is not representable as Decimal128"
+                ),
+            }
+            .fail();
+        }
+    };
+
+    ensure!(
+        b.remaining() >= usize::from(ndigits) * 2,
+        PgOutputDecodeSnafu {
+            message: "short binary numeric digits".to_string()
+        }
+    );
+
+    let overflow = || super::Error::PgOutputDecode {
+        message: "postgres_replication: numeric magnitude exceeds Decimal128 range".to_string(),
+    };
+
+    let mut m: i128 = 0;
+    for _ in 0..ndigits {
+        let d = b.get_u16();
+        ensure!(
+            d < 10_000,
+            PgOutputDecodeSnafu {
+                message: format!("postgres_replication: invalid base-10000 numeric digit {d}")
+            }
+        );
+        m = m
+            .checked_mul(10_000)
+            .and_then(|m| m.checked_add(i128::from(d)))
+            .ok_or_else(overflow)?;
+    }
+
+    // result = m · 10^p, where p rescales the least-significant base-10000 group
+    // (exponent weight−(ndigits−1), i.e. ×10^(4·that)) to the declared scale.
+    let e_min = i64::from(weight) - (i64::from(ndigits) - 1);
+    let p = 4 * e_min + i64::from(scale);
+
+    let result = if p >= 0 {
+        let exp = u32::try_from(p).map_err(|_| overflow())?;
+        m.checked_mul(pow10_i128(exp)?).ok_or_else(overflow)?
+    } else {
+        let exp = u32::try_from(-p).map_err(|_| overflow())?;
+        let pow = pow10_i128(exp)?;
+        ensure!(
+            m % pow == 0,
+            PgOutputDecodeSnafu {
+                message: format!(
+                    "postgres_replication: numeric value carries more fractional precision \
+                     than the dataset's declared scale {scale}"
+                )
+            }
+        );
+        m / pow
+    };
+
+    Ok(if negative { -result } else { result })
+}
+
+/// `10^exp` as `i128`, erroring if it overflows `Decimal128`'s range.
+fn pow10_i128(exp: u32) -> Result<i128> {
+    let mut v: i128 = 1;
+    for _ in 0..exp {
+        v = v
+            .checked_mul(10)
+            .ok_or_else(|| super::Error::PgOutputDecode {
+                message: format!(
+                    "postgres_replication: numeric magnitude 10^{exp} exceeds Decimal128 range"
+                ),
+            })?;
+    }
+    Ok(v)
+}
+
+/// Parse a Postgres binary array (`send` wire form) into its element OID and a
+/// row-major list of element payloads (`None` = SQL NULL). Only 0- and
+/// 1-dimensional arrays are supported — matching the text path, which rejects
+/// multidimensional arrays. Element slices borrow from `raw`.
+fn decode_binary_array(raw: &[u8]) -> Result<(u32, Vec<Option<&[u8]>>)> {
+    use bytes::Buf;
+
+    let mut b = raw;
+    ensure!(
+        b.remaining() >= 12,
+        PgOutputDecodeSnafu {
+            message: "short binary array header".to_string()
+        }
+    );
+    let ndim = b.get_i32();
+    let _flags = b.get_i32();
+    let elem_oid = b.get_u32();
+    ensure!(
+        (0..=1).contains(&ndim),
+        PgOutputDecodeSnafu {
+            message: format!(
+                "postgres_replication: unsupported array dimensionality {ndim} \
+                 (only scalar 1-D arrays are supported). Cast the column to a scalar type."
+            )
+        }
+    );
+
+    let mut count: usize = 0;
+    if ndim == 1 {
+        ensure!(
+            b.remaining() >= 8,
+            PgOutputDecodeSnafu {
+                message: "short binary array dimension".to_string()
+            }
+        );
+        let len = b.get_i32();
+        let _lower_bound = b.get_i32();
+        count = usize::try_from(len).map_err(|_| super::Error::PgOutputDecode {
+            message: format!("postgres_replication: negative array dimension {len}"),
+        })?;
+    }
+
+    let mut out = Vec::with_capacity(count);
+    for _ in 0..count {
+        ensure!(
+            b.remaining() >= 4,
+            PgOutputDecodeSnafu {
+                message: "short binary array element length".to_string()
+            }
+        );
+        let raw_len = b.get_i32();
+        if raw_len < 0 {
+            out.push(None);
+        } else {
+            let elem_len = usize::try_from(raw_len).map_err(|e| super::Error::PgOutputDecode {
+                message: format!("invalid array element length: {e}"),
+            })?;
+            ensure!(
+                b.remaining() >= elem_len,
+                PgOutputDecodeSnafu {
+                    message: "short binary array element body".to_string()
+                }
+            );
+            let (elem, rest) = b.split_at(elem_len);
+            b = rest;
+            out.push(Some(elem));
+        }
+    }
+    Ok((elem_oid, out))
 }
 
 fn parse_pg_numeric_to_i128(s: &str, precision: u8, scale: i8) -> Result<i128> {
@@ -1172,8 +1524,8 @@ mod tests {
     fn tuple_for(id: &str, name: Option<&str>) -> TupleData {
         TupleData {
             columns: vec![
-                Some(PgValue::Text(id.to_string())),
-                name.map(|n| PgValue::Text(n.to_string())),
+                Some(PgValue::Text(bytes::Bytes::from(id.to_string()))),
+                name.map(|n| PgValue::Text(bytes::Bytes::from(n.to_string()))),
             ],
         }
     }
@@ -1269,7 +1621,7 @@ mod tests {
         };
         let row = TupleData {
             columns: (0..13)
-                .map(|i| Some(PgValue::Text(i.to_string())))
+                .map(|i| Some(PgValue::Text(bytes::Bytes::from(i.to_string()))))
                 .collect(),
         };
         let changes = vec![DecodedChange {
@@ -1635,7 +1987,7 @@ mod tests {
         DecodedChange {
             op,
             row: TupleData {
-                columns: vec![Some(PgValue::Text(text.to_string()))],
+                columns: vec![Some(PgValue::Text(bytes::Bytes::from(text.to_string())))],
             },
         }
     }
@@ -2065,5 +2417,287 @@ mod tests {
         decode_hex("abc").expect_err("odd length should fail");
         // Invalid digit → error.
         decode_hex("zz").expect_err("invalid digit should fail");
+    }
+
+    // ---- binary-format (pgoutput `b` tag) decode tests ----------------------
+
+    use arrow::datatypes::{
+        Date32Type, Decimal128Type, Float32Type, Float64Type, Int64Type, Time64NanosecondType,
+        TimestampNanosecondType, UInt32Type,
+    };
+    use bytes::Bytes;
+
+    /// Append one binary (`send`-format) value into a fresh builder for `dt`
+    /// and finish it into a single-element array.
+    fn bin_one(dt: &DataType, type_oid: u32, raw: &[u8]) -> ArrayRef {
+        let mut fb = FieldBuilder::with_capacity(dt, 1).expect("builder");
+        fb.append(
+            Some(&PgValue::Binary(Bytes::copy_from_slice(raw))),
+            ChangeOp::Create,
+            type_oid,
+        )
+        .expect("append binary value");
+        fb.finish()
+    }
+
+    /// Encode a Postgres binary `numeric` from its base-10000 digit groups.
+    fn enc_numeric(digits: &[u16], weight: i16, negative: bool, dscale: u16) -> Vec<u8> {
+        let mut o = Vec::new();
+        o.extend_from_slice(&(u16::try_from(digits.len()).expect("ndigits")).to_be_bytes());
+        o.extend_from_slice(&weight.to_be_bytes());
+        o.extend_from_slice(&(if negative { 0x4000u16 } else { 0 }).to_be_bytes());
+        o.extend_from_slice(&dscale.to_be_bytes());
+        for d in digits {
+            o.extend_from_slice(&d.to_be_bytes());
+        }
+        o
+    }
+
+    #[test]
+    fn binary_scalar_types_decode() {
+        assert!(bin_one(&DataType::Boolean, 16, &[1]).as_boolean().value(0));
+        assert!(!bin_one(&DataType::Boolean, 16, &[0]).as_boolean().value(0));
+        assert_eq!(
+            bin_one(&DataType::Int16, 21, &1234i16.to_be_bytes())
+                .as_primitive::<Int16Type>()
+                .value(0),
+            1234
+        );
+        assert_eq!(
+            bin_one(&DataType::Int32, 23, &(-42i32).to_be_bytes())
+                .as_primitive::<Int32Type>()
+                .value(0),
+            -42
+        );
+        assert_eq!(
+            bin_one(&DataType::Int64, 20, &9_000_000_000i64.to_be_bytes())
+                .as_primitive::<Int64Type>()
+                .value(0),
+            9_000_000_000
+        );
+        // "char" (oid 18) -> Int8; 0xFF is -1.
+        assert_eq!(
+            bin_one(&DataType::Int8, 18, &[0xFF])
+                .as_primitive::<Int8Type>()
+                .value(0),
+            -1
+        );
+        assert_eq!(
+            bin_one(&DataType::UInt32, 26, &4_000_000_000u32.to_be_bytes())
+                .as_primitive::<UInt32Type>()
+                .value(0),
+            4_000_000_000
+        );
+        assert!(
+            (bin_one(&DataType::Float32, 700, &1.5f32.to_be_bytes())
+                .as_primitive::<Float32Type>()
+                .value(0)
+                - 1.5)
+                .abs()
+                < f32::EPSILON
+        );
+        assert!(
+            (bin_one(&DataType::Float64, 701, &2.25f64.to_be_bytes())
+                .as_primitive::<Float64Type>()
+                .value(0)
+                - 2.25)
+                .abs()
+                < f64::EPSILON
+        );
+        assert_eq!(
+            bin_one(&DataType::Utf8, 25, b"hello")
+                .as_string::<i32>()
+                .value(0),
+            "hello"
+        );
+        // bytea `send` form is identity.
+        assert_eq!(
+            bin_one(&DataType::Binary, 17, &[0xde, 0xad])
+                .as_binary::<i32>()
+                .value(0),
+            &[0xde, 0xad]
+        );
+    }
+
+    #[test]
+    fn binary_temporal_decode() {
+        // date: pg day 0 (2000-01-01) -> Arrow Date32 10957.
+        assert_eq!(
+            bin_one(&DataType::Date32, 1082, &0i32.to_be_bytes())
+                .as_primitive::<Date32Type>()
+                .value(0),
+            10_957
+        );
+        // timestamp: pg micros 0 (2000-01-01) -> Arrow nanos since Unix epoch.
+        let ts = DataType::Timestamp(TimeUnit::Nanosecond, None);
+        assert_eq!(
+            bin_one(&ts, 1114, &0i64.to_be_bytes())
+                .as_primitive::<TimestampNanosecondType>()
+                .value(0),
+            946_684_800_000_000_000
+        );
+        // time: 1_000_000 micros since midnight (00:00:01) -> 1e9 nanos.
+        let t = DataType::Time64(TimeUnit::Nanosecond);
+        assert_eq!(
+            bin_one(&t, 1083, &1_000_000i64.to_be_bytes())
+                .as_primitive::<Time64NanosecondType>()
+                .value(0),
+            1_000_000_000
+        );
+    }
+
+    #[test]
+    fn binary_numeric_decode_matches_expected() {
+        // 172799.49 @ scale 2 -> 17279949 (digits [17,2799,4900], weight 1).
+        assert_eq!(
+            numeric_from_binary(&enc_numeric(&[17, 2799, 4900], 1, false, 2), 15, 2)
+                .expect("172799.49"),
+            17_279_949
+        );
+        // 0.01 @ scale 2 -> 1.
+        assert_eq!(
+            numeric_from_binary(&enc_numeric(&[100], -1, false, 2), 15, 2).expect("0.01"),
+            1
+        );
+        // 100 @ scale 2 -> 10000.
+        assert_eq!(
+            numeric_from_binary(&enc_numeric(&[100], 0, false, 2), 15, 2).expect("100.00"),
+            10_000
+        );
+        // -5 @ scale 0 -> -5.
+        assert_eq!(
+            numeric_from_binary(&enc_numeric(&[5], 0, true, 0), 15, 0).expect("-5"),
+            -5
+        );
+        // Zero (ndigits 0) -> 0.
+        assert_eq!(
+            numeric_from_binary(&enc_numeric(&[], 0, false, 0), 15, 2).expect("0"),
+            0
+        );
+        // Same value through the Decimal128 builder arm of `append_binary`.
+        assert_eq!(
+            bin_one(
+                &DataType::Decimal128(15, 2),
+                1700,
+                &enc_numeric(&[17, 2799, 4900], 1, false, 2)
+            )
+            .as_primitive::<Decimal128Type>()
+            .value(0),
+            17_279_949
+        );
+    }
+
+    #[test]
+    fn binary_numeric_rejects_overscale_and_special() {
+        // 1.234 @ scale 2: more fractional precision than declared -> error, not
+        // a silent round.
+        numeric_from_binary(&enc_numeric(&[1, 2340], 0, false, 3), 15, 2)
+            .expect_err("overscale must error");
+        // NaN sign word 0xC000 is not representable as Decimal128.
+        let mut nan = Vec::new();
+        nan.extend_from_slice(&0u16.to_be_bytes()); // ndigits
+        nan.extend_from_slice(&0i16.to_be_bytes()); // weight
+        nan.extend_from_slice(&0xC000u16.to_be_bytes()); // sign = NaN
+        nan.extend_from_slice(&0u16.to_be_bytes()); // dscale
+        numeric_from_binary(&nan, 15, 2).expect_err("NaN must error");
+    }
+
+    /// Encode a 1-D binary `int4[]` array (`send` wire form).
+    fn enc_binary_int4_array(elems: &[Option<i32>]) -> Vec<u8> {
+        let mut o = Vec::new();
+        o.extend_from_slice(&1i32.to_be_bytes()); // ndim
+        o.extend_from_slice(&1i32.to_be_bytes()); // flags (has nulls)
+        o.extend_from_slice(&23u32.to_be_bytes()); // element oid = int4
+        o.extend_from_slice(&(i32::try_from(elems.len()).expect("len")).to_be_bytes()); // dim len
+        o.extend_from_slice(&1i32.to_be_bytes()); // lower bound
+        for e in elems {
+            match e {
+                Some(v) => {
+                    o.extend_from_slice(&4i32.to_be_bytes());
+                    o.extend_from_slice(&v.to_be_bytes());
+                }
+                None => o.extend_from_slice(&(-1i32).to_be_bytes()),
+            }
+        }
+        o
+    }
+
+    #[test]
+    fn binary_array_int4_decode() {
+        let dt = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+        let arr = bin_one(&dt, 1007, &enc_binary_int4_array(&[Some(1), None, Some(3)]));
+        let list = arr.as_list::<i32>();
+        assert_eq!(list.len(), 1);
+        let values = list.value(0);
+        let ints = values.as_primitive::<Int32Type>();
+        assert_eq!(ints.len(), 3);
+        assert_eq!(ints.value(0), 1);
+        assert!(ints.is_null(1));
+        assert_eq!(ints.value(2), 3);
+    }
+
+    #[test]
+    fn build_change_batch_decodes_binary_tuple() {
+        // A row with binary-encoded columns flows through the same batch builder
+        // as text, driven by the relation's per-column type OIDs.
+        let relation = Relation {
+            relation_id: 1,
+            namespace: "public".to_string(),
+            name: "orders".to_string(),
+            replica_identity: b'd',
+            columns: vec![
+                PgColumn {
+                    is_key: true,
+                    name: "id".to_string(),
+                    type_oid: 20,
+                    type_modifier: -1,
+                },
+                PgColumn {
+                    is_key: false,
+                    name: "amount".to_string(),
+                    type_oid: 1700,
+                    type_modifier: -1,
+                },
+            ],
+        };
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("amount", DataType::Decimal128(15, 2), false),
+        ]));
+        let change = DecodedChange {
+            op: ChangeOp::Create,
+            row: TupleData {
+                columns: vec![
+                    Some(PgValue::Binary(Bytes::from(7i64.to_be_bytes().to_vec()))),
+                    Some(PgValue::Binary(Bytes::from(enc_numeric(
+                        &[17, 2799, 4900],
+                        1,
+                        false,
+                        2,
+                    )))),
+                ],
+            },
+        };
+        let batch = build_change_batch(&schema, &relation, &[change]).expect("build batch");
+        assert_eq!(batch.record.num_rows(), 1);
+        let data = batch
+            .record
+            .column_by_name("data")
+            .expect("data column")
+            .as_struct();
+        assert_eq!(
+            data.column_by_name("id")
+                .expect("id")
+                .as_primitive::<Int64Type>()
+                .value(0),
+            7
+        );
+        assert_eq!(
+            data.column_by_name("amount")
+                .expect("amount")
+                .as_primitive::<Decimal128Type>()
+                .value(0),
+            17_279_949
+        );
     }
 }

--- a/crates/data_components/src/postgres_replication/changes.rs
+++ b/crates/data_components/src/postgres_replication/changes.rs
@@ -1114,7 +1114,7 @@ pub(super) fn parse_pg_numeric_public(s: &str, scale: i8) -> Result<i128> {
 /// fractional precision than the declared scale — an error, never a silent
 /// round (mirrors the text path's scale check). `NaN`/`±Infinity` sign words
 /// are rejected: `Decimal128` cannot represent them.
-fn numeric_from_binary(raw: &[u8], _precision: u8, scale: i8) -> Result<i128> {
+fn numeric_from_binary(raw: &[u8], precision: u8, scale: i8) -> Result<i128> {
     use bytes::Buf;
 
     const NUMERIC_POS: u16 = 0x0000;
@@ -1195,7 +1195,36 @@ fn numeric_from_binary(raw: &[u8], _precision: u8, scale: i8) -> Result<i128> {
         m / pow
     };
 
-    Ok(if negative { -result } else { result })
+    let signed = if negative { -result } else { result };
+    ensure_decimal_precision(signed, precision)?;
+    Ok(signed)
+}
+
+/// Ensure a decoded unscaled `Decimal128` value fits the column's declared
+/// precision (`abs(value) < 10^precision`).
+///
+/// Postgres enforces precision on the source column, so a violation means the
+/// dataset schema declares a narrower precision than the source — surface it as
+/// a structured error rather than storing a value Arrow would treat as out of
+/// range for the declared type. Shared by the text and binary numeric decoders
+/// so both agree on what's representable.
+fn ensure_decimal_precision(value: i128, precision: u8) -> Result<()> {
+    // Saturates for precision >= 39; that's fine — `i128`'s magnitude never
+    // reaches `u128::MAX`, and Arrow caps `Decimal128` precision at 38 anyway.
+    let mut bound: u128 = 1;
+    for _ in 0..precision {
+        bound = bound.saturating_mul(10);
+    }
+    ensure!(
+        value.unsigned_abs() < bound,
+        PgOutputDecodeSnafu {
+            message: format!(
+                "postgres_replication: numeric value exceeds the dataset's declared \
+                 Decimal128 precision {precision}"
+            )
+        }
+    );
+    Ok(())
 }
 
 /// `10^exp` as `i128`, erroring if it overflows `Decimal128`'s range.
@@ -1235,7 +1264,8 @@ fn decode_binary_array(raw: &[u8]) -> Result<(u32, Vec<Option<&[u8]>>)> {
         PgOutputDecodeSnafu {
             message: format!(
                 "postgres_replication: unsupported array dimensionality {ndim} \
-                 (only scalar 1-D arrays are supported). Cast the column to a scalar type."
+                 (only empty or 1-dimensional arrays of scalars are supported). \
+                 Cast the column to a scalar type."
             )
         }
     );
@@ -1332,9 +1362,9 @@ fn parse_pg_numeric_to_i128(s: &str, precision: u8, scale: i8) -> Result<i128> {
     })?;
     let value = sign * magnitude;
 
-    // Sanity-check against declared precision — Arrow will enforce this on
-    // `append_value` anyway, but a friendlier error helps ops.
-    let _ = precision;
+    // Enforce the declared precision here (with a friendly error) rather than
+    // relying on Arrow, and to stay consistent with the binary decoder.
+    ensure_decimal_precision(value, precision)?;
     Ok(value)
 }
 
@@ -2600,6 +2630,18 @@ mod tests {
         nan.extend_from_slice(&0xC000u16.to_be_bytes()); // sign = NaN
         nan.extend_from_slice(&0u16.to_be_bytes()); // dscale
         numeric_from_binary(&nan, 15, 2).expect_err("NaN must error");
+
+        // 10^15 exceeds precision 15 (max unscaled magnitude 10^15 - 1) —
+        // reject rather than store an out-of-precision Decimal128 value.
+        // 10^15 = 1000 * 10000^3 → digits [1000], weight 3, scale 0.
+        numeric_from_binary(&enc_numeric(&[1000], 3, false, 0), 15, 0)
+            .expect_err("value exceeding declared precision must error");
+        // One less (10^15 - 1) fits precision 15.
+        assert_eq!(
+            numeric_from_binary(&enc_numeric(&[999, 9999, 9999, 9999], 3, false, 0), 15, 0)
+                .expect("10^15 - 1 fits precision 15"),
+            999_999_999_999_999
+        );
     }
 
     /// Encode a 1-D binary `int4[]` array (`send` wire form).

--- a/crates/data_components/src/postgres_replication/changes.rs
+++ b/crates/data_components/src/postgres_replication/changes.rs
@@ -782,7 +782,7 @@ impl FieldBuilder {
                 b.append_value(pg::text_from_sql(raw).map_err(decode_err("text"))?);
             }
             // bytea `send` form is the raw bytes — identity.
-            Self::Binary(b) => b.append_value(pg::bytea_from_sql(raw)),
+            Self::Binary(b) => b.append_value(raw),
             Self::Date32(b) => {
                 let pg_days = pg::date_from_sql(raw).map_err(decode_err("date"))?;
                 let days = pg_days
@@ -1285,7 +1285,10 @@ fn decode_binary_array(raw: &[u8]) -> Result<(u32, Vec<Option<&[u8]>>)> {
         })?;
     }
 
-    let mut out = Vec::with_capacity(count);
+    let mut out = Vec::new();
+    out.try_reserve_exact(count).map_err(|e| super::Error::PgOutputDecode {
+        message: format!("postgres_replication: array too large (len {count}): {e}"),
+    })?;
     for _ in 0..count {
         ensure!(
             b.remaining() >= 4,

--- a/crates/data_components/src/postgres_replication/client.rs
+++ b/crates/data_components/src/postgres_replication/client.rs
@@ -139,6 +139,14 @@ pub(crate) fn build_replication_config(
         // status updates long enough for Postgres to hit `wal_sender_timeout`
         // and reset the walsender. See `pgwire_replication` worker `send_event`.
         feedback_while_backpressured: true,
+        // pgoutput column output format. The connector always sets Binary (see
+        // `ReplicationParams::pg_output_format`); tests may force Text to exercise
+        // the fallback. Postgres still tags each column text/binary per-value, so
+        // types without a binary send function (and the fixed Begin/Commit
+        // framing) arrive as text and are decoded by the text fallback — but the
+        // common int/float/date/timestamp/numeric columns arrive binary, skipping
+        // text formatting + reparsing on both ends. The decoder handles either tag.
+        format: params.pg_output_format,
         // Keep the crate default (~1 GiB) max_message_size so large TOAST-row
         // changes are never rejected; the reader allocates incrementally
         // regardless of this cap.
@@ -299,7 +307,7 @@ fn wal_stream(
                 }
                 ReplicationEvent::XLogData { data, wal_end, .. } => {
                     metrics.set_server_wal_end(wal_end.0);
-                    let msg = match decoder.decode(&data) {
+                    let msg = match decoder.decode(data) {
                         Ok(m) => m,
                         Err(e) => {
                             metrics.inc_decode_error();

--- a/crates/data_components/src/postgres_replication/config.rs
+++ b/crates/data_components/src/postgres_replication/config.rs
@@ -19,6 +19,7 @@ limitations under the License.
 use std::path::PathBuf;
 use std::time::Duration;
 
+use pgwire_replication::PgOutputFormat;
 use secrecy::{ExposeSecret, SecretString};
 
 /// Parameters for a single dataset's replication stream.
@@ -68,6 +69,15 @@ pub struct ReplicationParams {
     /// (per-dataset generated) slot names keep the dedicated per-dataset
     /// stream.
     pub shared: bool,
+
+    /// pgoutput column output format to request on the WAL stream. Internal —
+    /// not a spicepod parameter: the connector always sets [`PgOutputFormat::Binary`]
+    /// (binary decodes faster and avoids source-side text formatting). Exposed
+    /// as a field only so tests can force [`PgOutputFormat::Text`] to exercise
+    /// the text fallback and assert binary/text parity. Per-column the server
+    /// still emits text for types lacking a binary send function, so the text
+    /// decode path stays live regardless of this setting.
+    pub pg_output_format: PgOutputFormat,
 }
 
 impl std::fmt::Debug for ReplicationParams {
@@ -87,6 +97,7 @@ impl std::fmt::Debug for ReplicationParams {
             .field("status_interval", &self.status_interval)
             .field("bootstrap_batch_size", &self.bootstrap_batch_size)
             .field("shared", &self.shared)
+            .field("pg_output_format", &self.pg_output_format)
             .finish_non_exhaustive()
     }
 }

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -43,6 +43,7 @@ use snafu::Snafu;
 use crate::cdc::{ChangesStream, StreamError};
 
 pub use config::{ReplicationParams, SchemaEvolutionPolicy};
+pub use pgwire_replication::PgOutputFormat;
 pub use metrics::{Metrics as ReplicationMetrics, MetricsCollector as ReplicationMetricsCollector};
 pub use slot::{SlotInfo, SlotSetupOutcome};
 

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -43,8 +43,8 @@ use snafu::Snafu;
 use crate::cdc::{ChangesStream, StreamError};
 
 pub use config::{ReplicationParams, SchemaEvolutionPolicy};
-pub use pgwire_replication::PgOutputFormat;
 pub use metrics::{Metrics as ReplicationMetrics, MetricsCollector as ReplicationMetricsCollector};
+pub use pgwire_replication::PgOutputFormat;
 pub use slot::{SlotInfo, SlotSetupOutcome};
 
 /// Extracts a human-readable message from a `tokio_postgres::Error`.

--- a/crates/data_components/src/postgres_replication/pgoutput.rs
+++ b/crates/data_components/src/postgres_replication/pgoutput.rs
@@ -23,7 +23,7 @@ limitations under the License.
 
 use std::collections::HashMap;
 
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 use snafu::ensure;
 
 use super::{PgOutputDecodeSnafu, Result};
@@ -93,13 +93,25 @@ pub struct TupleData {
     pub columns: Vec<Option<Value>>,
 }
 
+/// A single column value, carried as a zero-copy [`Bytes`] slice of the
+/// originating `XLogData` frame.
+///
+/// The decoder does not copy or validate value payloads: text values keep
+/// their raw (unvalidated) bytes and binary values keep their `send`-format
+/// bytes. Interpretation (UTF-8 validation, integer/temporal/numeric parsing,
+/// binary `FromSql` decoding) happens once, downstream, when a value is
+/// appended into its typed Arrow builder. Because `Bytes` is refcounted, a
+/// whole transaction's worth of buffered tuples holds only slices of the
+/// underlying frame buffers alive — no per-column heap allocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {
-    /// Text-format representation (pgoutput emits text for most types).
-    Text(String),
-    /// Binary-format payload for columns with `TYPE_OID` emitting binary.
-    Binary(Vec<u8>),
-    /// TOAST column that was not changed in the UPDATE.
+    /// Text-format payload (pgoutput tuple tag `t`). Raw, not yet UTF-8
+    /// validated.
+    Text(Bytes),
+    /// Binary-format payload (pgoutput tuple tag `b`) — the type's `send`
+    /// wire form. Also used for `bytea` under the text protocol.
+    Binary(Bytes),
+    /// TOAST column that was not changed in the UPDATE (tuple tag `u`).
     Unchanged,
 }
 
@@ -145,7 +157,10 @@ impl Decoder {
     /// Decode a single pgoutput message. If it's a `Relation`, the decoder
     /// caches it internally so later Insert/Update/Delete messages can refer
     /// to it.
-    pub fn decode(&mut self, mut buf: &[u8]) -> Result<DecodedMessage> {
+    ///
+    /// Takes the `XLogData` payload as an owned [`Bytes`]; tuple values are
+    /// peeled out as zero-copy sub-slices of it (see [`Value`]).
+    pub fn decode(&mut self, mut buf: Bytes) -> Result<DecodedMessage> {
         ensure!(
             buf.remaining() >= 1,
             PgOutputDecodeSnafu {
@@ -177,7 +192,7 @@ impl Decoder {
     }
 }
 
-fn decode_begin(buf: &mut &[u8]) -> Result<DecodedMessage> {
+fn decode_begin(buf: &mut Bytes) -> Result<DecodedMessage> {
     ensure!(
         buf.remaining() >= 8 + 8 + 4,
         PgOutputDecodeSnafu {
@@ -194,7 +209,7 @@ fn decode_begin(buf: &mut &[u8]) -> Result<DecodedMessage> {
     })
 }
 
-fn decode_commit(buf: &mut &[u8]) -> Result<DecodedMessage> {
+fn decode_commit(buf: &mut Bytes) -> Result<DecodedMessage> {
     ensure!(
         buf.remaining() >= 1 + 8 + 8 + 8,
         PgOutputDecodeSnafu {
@@ -212,7 +227,7 @@ fn decode_commit(buf: &mut &[u8]) -> Result<DecodedMessage> {
     })
 }
 
-fn decode_relation(buf: &mut &[u8]) -> Result<Relation> {
+fn decode_relation(buf: &mut Bytes) -> Result<Relation> {
     ensure!(
         buf.remaining() >= 4,
         PgOutputDecodeSnafu {
@@ -264,7 +279,7 @@ fn decode_relation(buf: &mut &[u8]) -> Result<Relation> {
     })
 }
 
-fn decode_insert(buf: &mut &[u8]) -> Result<DecodedMessage> {
+fn decode_insert(buf: &mut Bytes) -> Result<DecodedMessage> {
     ensure!(
         buf.remaining() > 4,
         PgOutputDecodeSnafu {
@@ -283,7 +298,7 @@ fn decode_insert(buf: &mut &[u8]) -> Result<DecodedMessage> {
     Ok(DecodedMessage::Insert { relation_id, tuple })
 }
 
-fn decode_update(buf: &mut &[u8]) -> Result<DecodedMessage> {
+fn decode_update(buf: &mut Bytes) -> Result<DecodedMessage> {
     ensure!(
         buf.remaining() > 4,
         PgOutputDecodeSnafu {
@@ -322,7 +337,7 @@ fn decode_update(buf: &mut &[u8]) -> Result<DecodedMessage> {
     }
 }
 
-fn decode_delete(buf: &mut &[u8]) -> Result<DecodedMessage> {
+fn decode_delete(buf: &mut Bytes) -> Result<DecodedMessage> {
     ensure!(
         buf.remaining() > 4,
         PgOutputDecodeSnafu {
@@ -341,7 +356,7 @@ fn decode_delete(buf: &mut &[u8]) -> Result<DecodedMessage> {
     Ok(DecodedMessage::Delete { relation_id, old })
 }
 
-fn decode_truncate(buf: &mut &[u8]) -> Result<DecodedMessage> {
+fn decode_truncate(buf: &mut Bytes) -> Result<DecodedMessage> {
     ensure!(
         buf.remaining() > 4,
         PgOutputDecodeSnafu {
@@ -366,7 +381,7 @@ fn decode_truncate(buf: &mut &[u8]) -> Result<DecodedMessage> {
     Ok(DecodedMessage::Truncate { relation_ids })
 }
 
-fn read_tuple(buf: &mut &[u8]) -> Result<TupleData> {
+fn read_tuple(buf: &mut Bytes) -> Result<TupleData> {
     ensure!(
         buf.remaining() >= 2,
         PgOutputDecodeSnafu {
@@ -386,46 +401,30 @@ fn read_tuple(buf: &mut &[u8]) -> Result<TupleData> {
         match tag {
             b'n' => columns.push(None),
             b'u' => columns.push(Some(Value::Unchanged)),
-            b't' => {
+            // `t` (text) and `b` (binary) differ only in how the downstream
+            // Arrow builder interprets the payload. Both peel a length-prefixed
+            // slice off `buf` with zero copy: `<Bytes as Buf>::copy_to_bytes`
+            // is a refcount bump + range advance, no allocation or UTF-8 check.
+            b't' | b'b' => {
                 ensure!(
                     buf.remaining() >= 4,
                     PgOutputDecodeSnafu {
-                        message: "short Tuple text length".to_string()
+                        message: "short Tuple value length".to_string()
                     }
                 );
                 let len = buf.get_u32() as usize;
                 ensure!(
                     buf.remaining() >= len,
                     PgOutputDecodeSnafu {
-                        message: "short Tuple text body".to_string()
+                        message: "short Tuple value body".to_string()
                     }
                 );
-                let bytes = &buf[..len];
-                let s = std::str::from_utf8(bytes)
-                    .map_err(|e| super::Error::PgOutputDecode {
-                        message: format!("invalid utf8: {e}"),
-                    })?
-                    .to_string();
-                buf.advance(len);
-                columns.push(Some(Value::Text(s)));
-            }
-            b'b' => {
-                ensure!(
-                    buf.remaining() >= 4,
-                    PgOutputDecodeSnafu {
-                        message: "short Tuple binary length".to_string()
-                    }
-                );
-                let len = buf.get_u32() as usize;
-                ensure!(
-                    buf.remaining() >= len,
-                    PgOutputDecodeSnafu {
-                        message: "short Tuple binary body".to_string()
-                    }
-                );
-                let bytes = buf[..len].to_vec();
-                buf.advance(len);
-                columns.push(Some(Value::Binary(bytes)));
+                let bytes = buf.copy_to_bytes(len);
+                columns.push(Some(if tag == b't' {
+                    Value::Text(bytes)
+                } else {
+                    Value::Binary(bytes)
+                }));
             }
             other => {
                 return PgOutputDecodeSnafu {
@@ -438,14 +437,16 @@ fn read_tuple(buf: &mut &[u8]) -> Result<TupleData> {
     Ok(TupleData { columns })
 }
 
-fn read_cstring(buf: &mut &[u8]) -> Result<String> {
-    let nul = buf
-        .iter()
-        .position(|b| *b == 0)
-        .ok_or_else(|| super::Error::PgOutputDecode {
-            message: "unterminated cstring".to_string(),
-        })?;
-    let s = std::str::from_utf8(&buf[..nul])
+fn read_cstring(buf: &mut Bytes) -> Result<String> {
+    // `Bytes` is contiguous, so `chunk()` exposes the whole remaining slice.
+    let nul =
+        buf.chunk()
+            .iter()
+            .position(|b| *b == 0)
+            .ok_or_else(|| super::Error::PgOutputDecode {
+                message: "unterminated cstring".to_string(),
+            })?;
+    let s = std::str::from_utf8(&buf.chunk()[..nul])
         .map_err(|e| super::Error::PgOutputDecode {
             message: format!("invalid utf8 in cstring: {e}"),
         })?
@@ -502,7 +503,7 @@ mod tests {
         begin.extend_from_slice(&0x1234u64.to_be_bytes());
         begin.extend_from_slice(&7i64.to_be_bytes());
         begin.extend_from_slice(&11u32.to_be_bytes());
-        match decoder.decode(&begin).expect("decode begin") {
+        match decoder.decode(Bytes::from(begin)).expect("decode begin") {
             DecodedMessage::Begin {
                 final_lsn,
                 commit_ts,
@@ -520,7 +521,7 @@ mod tests {
     fn decode_relation_inserts_into_cache() {
         let mut decoder = Decoder::new();
         let buf = build_relation_fixture();
-        let rel = match decoder.decode(&buf).expect("decode relation") {
+        let rel = match decoder.decode(Bytes::from(buf)).expect("decode relation") {
             DecodedMessage::Relation(r) => r,
             other => panic!("unexpected: {other:?}"),
         };
@@ -539,7 +540,7 @@ mod tests {
     fn decode_insert_basic() {
         let mut decoder = Decoder::new();
         let buf = build_insert_fixture();
-        let msg = decoder.decode(&buf).expect("decode insert");
+        let msg = decoder.decode(Bytes::from(buf)).expect("decode insert");
         let DecodedMessage::Insert { relation_id, tuple } = msg else {
             panic!("expected Insert")
         };
@@ -562,7 +563,8 @@ mod tests {
         buf.push(b'7');
         // col 1: null
         buf.push(b'n');
-        let DecodedMessage::Delete { relation_id, old } = decoder.decode(&buf).expect("decode")
+        let DecodedMessage::Delete { relation_id, old } =
+            decoder.decode(Bytes::from(buf)).expect("decode")
         else {
             panic!("expected Delete")
         };
@@ -586,7 +588,7 @@ mod tests {
             relation_id,
             old,
             new,
-        } = decoder.decode(&buf).expect("decode")
+        } = decoder.decode(Bytes::from(buf)).expect("decode")
         else {
             panic!("expected Update")
         };
@@ -613,7 +615,9 @@ mod tests {
         buf.push(b't');
         buf.extend_from_slice(&1u32.to_be_bytes());
         buf.push(b'9');
-        let DecodedMessage::Update { old, new, .. } = decoder.decode(&buf).expect("decode") else {
+        let DecodedMessage::Update { old, new, .. } =
+            decoder.decode(Bytes::from(buf)).expect("decode")
+        else {
             panic!("expected Update")
         };
         let old = old.expect("old tuple should be present");
@@ -629,7 +633,8 @@ mod tests {
         buf.push(0x00);
         buf.extend_from_slice(&42u32.to_be_bytes());
         buf.extend_from_slice(&43u32.to_be_bytes());
-        let DecodedMessage::Truncate { relation_ids } = decoder.decode(&buf).expect("decode")
+        let DecodedMessage::Truncate { relation_ids } =
+            decoder.decode(Bytes::from(buf)).expect("decode")
         else {
             panic!("expected Truncate")
         };
@@ -648,7 +653,7 @@ mod tests {
         buf.push(0x00); // flags
         buf.extend_from_slice(&42u32.to_be_bytes()); // only one relation id actually present
         decoder
-            .decode(&buf)
+            .decode(Bytes::from(buf))
             .expect_err("oversized truncate nrel should error, not over-allocate");
     }
 
@@ -656,6 +661,8 @@ mod tests {
     fn decode_unknown_message_type_errors() {
         let mut decoder = Decoder::new();
         let buf = [b'Z', 0, 0, 0];
-        decoder.decode(&buf).expect_err("unknown message type");
+        decoder
+            .decode(Bytes::copy_from_slice(&buf))
+            .expect_err("unknown message type");
     }
 }

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -1011,7 +1011,7 @@ async fn run_pump(source: Arc<SharedSource>) {
                 }
                 ReplicationEvent::XLogData { data, wal_end, .. } => {
                     source.for_each_member_metrics(|m| m.set_server_wal_end(wal_end.0));
-                    let msg = match decoder.decode(&data) {
+                    let msg = match decoder.decode(data) {
                         Ok(m) => m,
                         Err(e) => {
                             source.for_each_member_metrics(

--- a/crates/runtime/tests/postgres/replication.rs
+++ b/crates/runtime/tests/postgres/replication.rs
@@ -491,7 +491,11 @@ fn wide_schema() -> SchemaRef {
         Field::new("v_f8", DataType::Float64, true),
         Field::new("v_num", DataType::Decimal128(15, 2), true),
         Field::new("v_date", DataType::Date32, true),
-        Field::new("v_ts", DataType::Timestamp(TimeUnit::Nanosecond, None), true),
+        Field::new(
+            "v_ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        ),
         Field::new("v_text", DataType::Utf8, true),
     ]))
 }
@@ -576,7 +580,10 @@ async fn run_wide_types_scenario(
         .await?
         .ok_or_else(|| anyhow::anyhow!("ready envelope missing ({tag})"))??;
     let (_committer, ready_batch, is_ready) = ready.into_parts();
-    assert!(is_ready, "skip-bootstrap ready envelope must mark ready ({tag})");
+    assert!(
+        is_ready,
+        "skip-bootstrap ready envelope must mark ready ({tag})"
+    );
     assert_eq!(
         ready_batch.record.num_rows(),
         0,

--- a/crates/runtime/tests/postgres/replication.rs
+++ b/crates/runtime/tests/postgres/replication.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 use arrow::array::AsArray;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use data_components::postgres_replication::{
-    ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput, config,
+    PgOutputFormat, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput, config,
     start_replication_stream,
 };
 use futures::StreamExt;
@@ -74,6 +74,7 @@ fn params_for(port: u16, slot_name: &str, publication_name: &str) -> Replication
         status_interval: Duration::from_secs(1),
         bootstrap_batch_size: 8192,
         shared: false,
+        pg_output_format: PgOutputFormat::Binary,
     }
 }
 
@@ -474,6 +475,307 @@ async fn two_replicas_have_independent_slots() -> Result<(), anyhow::Error> {
     for slot in &["spice_itest_slot_r1", "spice_itest_slot_r2"] {
         drop_replication_slot_when_inactive(&source, slot).await?;
     }
+    Ok(())
+}
+
+/// Arrow schema covering every column type that has a distinct binary decoder,
+/// used by [`wide_column_types_binary_matches_text`].
+fn wide_schema() -> SchemaRef {
+    use arrow::datatypes::TimeUnit;
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("v_bool", DataType::Boolean, true),
+        Field::new("v_i2", DataType::Int16, true),
+        Field::new("v_i8", DataType::Int64, true),
+        Field::new("v_f4", DataType::Float32, true),
+        Field::new("v_f8", DataType::Float64, true),
+        Field::new("v_num", DataType::Decimal128(15, 2), true),
+        Field::new("v_date", DataType::Date32, true),
+        Field::new("v_ts", DataType::Timestamp(TimeUnit::Nanosecond, None), true),
+        Field::new("v_text", DataType::Utf8, true),
+    ]))
+}
+
+/// Every column type Postgres emits in pgoutput's *binary* format must decode to
+/// exactly the same Arrow value as its text form. The runtime now requests
+/// binary output by default, so this drives a wide-typed table end-to-end under
+/// BOTH [`PgOutputFormat::Binary`] and [`PgOutputFormat::Text`] and asserts the
+/// same decoded values for each — proving the binary decoders (including the
+/// hand-written numeric/date/timestamp paths) match the text fallback, and
+/// keeping the text path exercised now that binary is the default.
+#[tokio::test(flavor = "multi_thread")]
+async fn wide_column_types_binary_matches_text() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port = u16::try_from(port).expect("port fits in u16");
+
+    // Same scenario, both wire formats. Distinct table/slot/publication per run
+    // keeps them fully isolated.
+    run_wide_types_scenario(port, PgOutputFormat::Binary, "bin").await?;
+    run_wide_types_scenario(port, PgOutputFormat::Text, "txt").await?;
+    Ok(())
+}
+
+async fn run_wide_types_scenario(
+    port: u16,
+    format: PgOutputFormat,
+    tag: &str,
+) -> Result<(), anyhow::Error> {
+    use arrow::datatypes::{
+        Date32Type, Decimal128Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type,
+        TimestampNanosecondType,
+    };
+
+    let table = format!("repl_wide_{tag}");
+    let slot = format!("spice_wide_slot_{tag}");
+    let publication = format!("spice_wide_pub_{tag}");
+
+    // Fresh, empty source table — we drive the live binary WAL decode path with
+    // INSERT/UPDATE/DELETE (bootstrap is skipped below), not the snapshot path.
+    let mut cfg = tokio_postgres::Config::new();
+    cfg.host("localhost")
+        .port(port)
+        .user("postgres")
+        .password(common::PG_PASSWORD)
+        .dbname("postgres");
+    let (source, connection) = cfg.connect(NoTls).await?;
+    tokio::spawn(async move {
+        let _: Result<(), tokio_postgres::Error> = connection.await;
+    });
+    source
+        .simple_query(&format!(
+            "CREATE TABLE IF NOT EXISTS public.{table} (\
+               id int4 PRIMARY KEY, v_bool boolean, v_i2 int2, v_i8 int8, v_f4 float4, \
+               v_f8 float8, v_num numeric(15,2), v_date date, v_ts timestamp, v_text text)"
+        ))
+        .await?;
+    source
+        .simple_query(&format!("TRUNCATE public.{table}"))
+        .await?;
+
+    let mut params = params_for(port, &slot, &publication);
+    // Skip bootstrap so the row arrives via the pgoutput WAL path (the decoder
+    // under test), not the snapshot reader.
+    params.initial_snapshot = false;
+    params.pg_output_format = format;
+    let input = ReplicationStreamInput {
+        dataset_name: table.clone(),
+        params,
+        schema: wide_schema(),
+        primary_keys: vec!["id".into()],
+        schema_name: "public".into(),
+        table_name: table.clone(),
+        metrics: ReplicationMetricsCollector::new(),
+    };
+    let mut stream = start_replication_stream(input);
+
+    // `initial_snapshot: false` emits an immediate empty ready envelope; the
+    // slot exists by the time we receive it, so the INSERT below is captured.
+    let ready = tokio::time::timeout(Duration::from_secs(30), stream.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("ready envelope missing ({tag})"))??;
+    let (_committer, ready_batch, is_ready) = ready.into_parts();
+    assert!(is_ready, "skip-bootstrap ready envelope must mark ready ({tag})");
+    assert_eq!(
+        ready_batch.record.num_rows(),
+        0,
+        "ready envelope must be empty ({tag})"
+    );
+
+    // --- INSERT: one row exercising every binary type decoder ---
+    source
+        .simple_query(&format!(
+            "INSERT INTO public.{table} VALUES \
+             (1, true, 12345, 9000000000, 1.5, 2.5, 172799.49, '2000-01-01', \
+              '2000-01-01 00:00:00', 'hello world')"
+        ))
+        .await?;
+    let env = tokio::time::timeout(Duration::from_secs(15), stream.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("insert envelope missing ({tag})"))??;
+    let (committer, batch, _) = env.into_parts();
+    assert_eq!(
+        batch
+            .record
+            .column_by_name("op")
+            .expect("op")
+            .as_string::<i32>()
+            .value(0),
+        "c",
+        "insert op ({tag})"
+    );
+    let data = batch.record.column_by_name("data").expect("data");
+    let data = data.as_struct();
+    assert_eq!(
+        data.column_by_name("id")
+            .expect("id")
+            .as_primitive::<Int32Type>()
+            .value(0),
+        1,
+        "id ({tag})"
+    );
+    assert!(
+        data.column_by_name("v_bool")
+            .expect("v_bool")
+            .as_boolean()
+            .value(0),
+        "v_bool ({tag})"
+    );
+    assert_eq!(
+        data.column_by_name("v_i2")
+            .expect("v_i2")
+            .as_primitive::<Int16Type>()
+            .value(0),
+        12345,
+        "v_i2 ({tag})"
+    );
+    assert_eq!(
+        data.column_by_name("v_i8")
+            .expect("v_i8")
+            .as_primitive::<Int64Type>()
+            .value(0),
+        9_000_000_000,
+        "v_i8 ({tag})"
+    );
+    assert!(
+        (data
+            .column_by_name("v_f4")
+            .expect("v_f4")
+            .as_primitive::<Float32Type>()
+            .value(0)
+            - 1.5)
+            .abs()
+            < f32::EPSILON,
+        "v_f4 ({tag})"
+    );
+    assert!(
+        (data
+            .column_by_name("v_f8")
+            .expect("v_f8")
+            .as_primitive::<Float64Type>()
+            .value(0)
+            - 2.5)
+            .abs()
+            < f64::EPSILON,
+        "v_f8 ({tag})"
+    );
+    // numeric(15,2) 172799.49 -> i128 scaled by 2.
+    assert_eq!(
+        data.column_by_name("v_num")
+            .expect("v_num")
+            .as_primitive::<Decimal128Type>()
+            .value(0),
+        17_279_949,
+        "v_num ({tag})"
+    );
+    // date 2000-01-01 == the Postgres epoch: 10957 days after the Unix epoch.
+    assert_eq!(
+        data.column_by_name("v_date")
+            .expect("v_date")
+            .as_primitive::<Date32Type>()
+            .value(0),
+        10_957,
+        "v_date ({tag})"
+    );
+    // timestamp 2000-01-01 00:00:00 in nanoseconds since the Unix epoch.
+    assert_eq!(
+        data.column_by_name("v_ts")
+            .expect("v_ts")
+            .as_primitive::<TimestampNanosecondType>()
+            .value(0),
+        946_684_800_000_000_000,
+        "v_ts ({tag})"
+    );
+    assert_eq!(
+        data.column_by_name("v_text")
+            .expect("v_text")
+            .as_string::<i32>()
+            .value(0),
+        "hello world",
+        "v_text ({tag})"
+    );
+    committer.commit().await?;
+
+    // --- UPDATE: change numeric / bool / text / int8 ---
+    source
+        .simple_query(&format!(
+            "UPDATE public.{table} SET v_num = 1.00, v_bool = false, \
+             v_text = 'updated', v_i8 = -1 WHERE id = 1"
+        ))
+        .await?;
+    let env = tokio::time::timeout(Duration::from_secs(15), stream.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("update envelope missing ({tag})"))??;
+    let (committer, batch, _) = env.into_parts();
+    assert_eq!(
+        batch
+            .record
+            .column_by_name("op")
+            .expect("op")
+            .as_string::<i32>()
+            .value(0),
+        "u",
+        "update op ({tag})"
+    );
+    let data = batch.record.column_by_name("data").expect("data");
+    let data = data.as_struct();
+    assert_eq!(
+        data.column_by_name("v_num")
+            .expect("v_num")
+            .as_primitive::<Decimal128Type>()
+            .value(0),
+        100,
+        "updated v_num ({tag})"
+    );
+    assert!(
+        !data
+            .column_by_name("v_bool")
+            .expect("v_bool")
+            .as_boolean()
+            .value(0),
+        "updated v_bool ({tag})"
+    );
+    assert_eq!(
+        data.column_by_name("v_text")
+            .expect("v_text")
+            .as_string::<i32>()
+            .value(0),
+        "updated",
+        "updated v_text ({tag})"
+    );
+    assert_eq!(
+        data.column_by_name("v_i8")
+            .expect("v_i8")
+            .as_primitive::<Int64Type>()
+            .value(0),
+        -1,
+        "updated v_i8 ({tag})"
+    );
+    committer.commit().await?;
+
+    // --- DELETE ---
+    source
+        .simple_query(&format!("DELETE FROM public.{table} WHERE id = 1"))
+        .await?;
+    let env = tokio::time::timeout(Duration::from_secs(15), stream.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("delete envelope missing ({tag})"))??;
+    let (committer, batch, _) = env.into_parts();
+    assert_eq!(
+        batch
+            .record
+            .column_by_name("op")
+            .expect("op")
+            .as_string::<i32>()
+            .value(0),
+        "d",
+        "delete op ({tag})"
+    );
+    committer.commit().await?;
+
+    drop(stream);
+    drop_replication_slot_when_inactive(&source, &slot).await?;
     Ok(())
 }
 

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -38,7 +38,7 @@ use arrow::array::{Array, AsArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use data_components::cdc::{ChangeEnvelope, ChangesStream};
 use data_components::postgres_replication::{
-    ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput, config,
+    PgOutputFormat, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput, config,
     start_replication_stream,
 };
 use futures::StreamExt;
@@ -80,6 +80,7 @@ fn shared_params(port: u16) -> ReplicationParams {
         status_interval: Duration::from_secs(1),
         bootstrap_batch_size: 8192,
         shared: true,
+        pg_output_format: PgOutputFormat::Binary,
     }
 }
 

--- a/crates/vendor/pgwire-replication/src/client/worker.rs
+++ b/crates/vendor/pgwire-replication/src/client/worker.rs
@@ -183,10 +183,19 @@ impl WorkerState {
     ) -> Result<()> {
         // Escape single quotes in publication name
         let publication = self.cfg.publication.replace('\'', "''");
+        // pgoutput options. `binary 'true'` is only appended when requested;
+        // omitting it preserves the historical text-format wire and keeps the
+        // query identical to prior versions for text consumers.
+        let mut options = format!(
+            "proto_version '{}', publication_names '{}', messages 'true'",
+            self.cfg.proto_version, publication,
+        );
+        if matches!(self.cfg.format, crate::config::PgOutputFormat::Binary) {
+            options.push_str(", binary 'true'");
+        }
         let sql = format!(
-            "START_REPLICATION SLOT {} LOGICAL {} \
-            (proto_version '1', publication_names '{}', messages 'true')",
-            self.cfg.slot, self.cfg.start_lsn, publication,
+            "START_REPLICATION SLOT {} LOGICAL {} ({options})",
+            self.cfg.slot, self.cfg.start_lsn,
         );
         write_query(stream, &sql).await?;
 

--- a/crates/vendor/pgwire-replication/src/config.rs
+++ b/crates/vendor/pgwire-replication/src/config.rs
@@ -40,6 +40,26 @@ pub enum SslMode {
     VerifyFull,
 }
 
+/// Column output format requested from pgoutput via `START_REPLICATION`.
+///
+/// pgoutput encodes each column with a per-column tag, so `Binary` is a
+/// *request*: the server still emits text for any type lacking a binary send
+/// function (and always uses the binary form for the fixed Begin/Commit
+/// framing). A consumer must therefore be prepared to decode either form per
+/// column regardless of this setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PgOutputFormat {
+    /// Request text output (`START_REPLICATION` without the `binary` option).
+    /// pgoutput's historical default and the widest-compatibility choice.
+    #[default]
+    Text,
+
+    /// Request binary output (`binary 'true'`). Values for types with a binary
+    /// send function arrive in their `send`/`recv` wire form; the rest still
+    /// arrive as text.
+    Binary,
+}
+
 impl SslMode {
     /// Returns `true` if this mode requires TLS (won't fall back to plain).
     #[inline]
@@ -357,6 +377,23 @@ pub struct ReplicationConfig {
     ///
     /// Default: 1 GiB
     pub max_message_size: usize,
+
+    /// pgoutput logical decoding protocol version requested in
+    /// `START_REPLICATION` (`proto_version '<n>'`).
+    ///
+    /// `1` is the baseline every supported server speaks. Higher versions add
+    /// features (2: in-progress transaction streaming; 3: two-phase commit;
+    /// 4: parallel-apply streaming) whose extra message types the consumer
+    /// must be prepared to handle — leave at `1` unless the consumer decodes
+    /// them.
+    ///
+    /// Default: 1
+    pub proto_version: u8,
+
+    /// Column output format requested from pgoutput. See [`PgOutputFormat`].
+    ///
+    /// Default: [`PgOutputFormat::Text`]
+    pub format: PgOutputFormat,
 }
 
 impl Default for ReplicationConfig {
@@ -377,6 +414,8 @@ impl Default for ReplicationConfig {
             buffer_events: 8192,
             feedback_while_backpressured: true,
             max_message_size: crate::protocol::framing::MAX_MESSAGE_SIZE,
+            proto_version: 1,
+            format: PgOutputFormat::Text,
         }
     }
 }
@@ -551,6 +590,20 @@ impl ReplicationConfig {
     #[must_use]
     pub fn with_max_message_size(mut self, size: usize) -> Self {
         self.max_message_size = size;
+        self
+    }
+
+    /// Set the pgoutput protocol version. See [`proto_version`](Self::proto_version).
+    #[must_use]
+    pub fn with_proto_version(mut self, version: u8) -> Self {
+        self.proto_version = version;
+        self
+    }
+
+    /// Set the requested pgoutput column output format. See [`PgOutputFormat`].
+    #[must_use]
+    pub fn with_format(mut self, format: PgOutputFormat) -> Self {
+        self.format = format;
         self
     }
 

--- a/crates/vendor/pgwire-replication/src/lib.rs
+++ b/crates/vendor/pgwire-replication/src/lib.rs
@@ -75,6 +75,6 @@ pub mod protocol;
 pub mod tls;
 
 pub use client::{ReplicationClient, ReplicationEvent, ReplicationEventReceiver};
-pub use config::{ReplicationConfig, SslMode, TlsConfig};
+pub use config::{PgOutputFormat, ReplicationConfig, SslMode, TlsConfig};
 pub use error::{PgWireError, Result};
 pub use lsn::Lsn;


### PR DESCRIPTION
## What

Adds support for the **PostgreSQL pgoutput binary output format** to the CDC path (vendored `pgwire-replication` + `cayenne` `postgres_replication`), and reworks the decoder to be **zero-copy**. Binary is requested on every replication stream by default; PostgreSQL still tags each column text/binary per-value, so the text path remains a live per-column fallback for types without a binary send function.

## Why

The `refresh_mode: changes` WAL path decoded pgoutput **text** tuples: every value was copied out of the frame into a `String`/`Vec<u8>`, then re-parsed (`str::parse`, chrono, numeric) into Arrow. Two heap allocations + two copies per column value, plus source-side text formatting. Binary values decode with fixed-width reads and no reparse, and the zero-copy refactor removes the decoder-side allocation entirely.

## Changes

**Vendored `pgwire-replication`**
- New `PgOutputFormat { Text, Binary }` enum + configurable `proto_version` (default 1), wired into `START_REPLICATION` (`binary 'true'` only when requested). `proto_version` is the forward-compat seam for a future proto v2; no v2 state machine is built here.

**Zero-copy decoder (`pgoutput.rs`)**
- `Value::Text`/`Value::Binary` now hold refcounted `Bytes` sliced from the `XLogData` frame (`copy_to_bytes` = O(1) refcount). UTF-8 validation is deferred to append (done once, into the builder). A whole transaction's buffered tuples hold only slices of the frame buffers — no per-column heap allocation.

**Binary → Arrow (`changes.rs`)**
- `FieldBuilder::append` dispatches on the column's Postgres `type_oid` for binary values, using `postgres-protocol` primitives (`int*/float*/bool/text/bytea/date/time/timestamp`), a **hand-written binary `numeric` decoder** (`postgres-protocol` has none), and a hand-parsed binary array path. Temporals are rebased from the Postgres epoch (2000-01-01) to the Unix epoch. Unsupported/malformed values return a structured error — never a silent NULL or wrong value.

**Config**
- `build_replication_config` requests binary via a new internal `ReplicationParams.pg_output_format` field (defaults to `Binary`; not a spicepod parameter — exposed only so tests can force `Text`). `postgres-protocol` added as an optional dep under the `postgres` feature.

## Performance

Microbench (`benches/pgoutput_decode.rs`) over a TPC-H `orders`-shaped change stream (decode + `build_change_batch` into Arrow), median:

| rows | text (before) | text (zero-copy) | binary |
|-----:|--------------:|-----------------:|-------:|
| 100    | 46.1 µs | 34.2 µs (−26%) | 19.2 µs (−58%) |
| 1,000  | 397 µs  | 307 µs (−23%)  | 155 µs (−61%) |
| 10,000 | 3.99 ms | 3.10 ms (−22%) | 1.50 ms (−62%) |

Throughput rises ~2.5 → 3.2 Melem/s (zero-copy text) → ~6.6 Melem/s (binary). The text-only gain is the zero-copy refactor alone; binary adds the parse-free win on top.

## Testing

- **Unit** (`data_components`): per-type binary decode, binary `numeric` vs the text numeric routine (parity + scale-overflow/NaN rejection), binary array, and a `build_change_batch` binary tuple — all green; full `postgres_replication` suite passes.
- **Integration** (`crates/runtime/tests/postgres/replication.rs`, `make test-integration`): new `wide_column_types_binary_matches_text` drives a 10-column table (bool/int2/int8/float4/float8/numeric/date/timestamp/text) through INSERT/UPDATE/DELETE under **both** `Binary` and `Text`, asserting identical decoded Arrow values — the binary-vs-text parity guard against a live walsender. Because binary is now the default, the rest of the existing replication suite already exercises the binary path.
- `make lint-rust` clean (pedantic) for both crates.
