### PR TITLE
feat(datafusion-flightsql): back with QueryEngine + add do_exchange

### DIFF
--- a/crates/datafusion-flightsql/Cargo.toml
+++ b/crates/datafusion-flightsql/Cargo.toml
@@ -13,8 +13,10 @@ arrow-ipc = { workspace = true }
 arrow-schema = { workspace = true }
 arrow_tools = { path = "../arrow_tools" }
 async-stream = { workspace = true }
+async-trait = { workspace = true }
 bytes = { workspace = true }
 datafusion = { workspace = true }
+runtime-query-engine = { path = "../runtime-query-engine" }
 futures = { workspace = true }
 http = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
@@ -22,6 +24,7 @@ postcard = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 snafu = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/crates/datafusion-flightsql/examples/serve_and_query.rs
+++ b/crates/datafusion-flightsql/examples/serve_and_query.rs
@@ -115,7 +115,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Flight SQL server listening on {addr}  (press Ctrl-C to stop)");
 
     Server::builder()
-        .add_service(FlightSqlService::new(ctx).into_server())
+        .add_service(FlightSqlService::from_session_context(ctx).into_server())
         .serve_with_shutdown(addr, shutdown_signal())
         .await?;
 

--- a/crates/datafusion-flightsql/src/actions.rs
+++ b/crates/datafusion-flightsql/src/actions.rs
@@ -27,15 +27,15 @@ use arrow_flight::{
     flight_service_server::FlightService,
     sql::{self, Any, ProstMessageExt},
 };
-use datafusion::prelude::SessionContext;
 use futures::stream::BoxStream;
 use prost::Message;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status};
 
 use crate::{FlightSqlService, flightsql::prepared_statement_query, to_tonic_err};
 
 pub(crate) async fn do_action(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     request: Request<Action>,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoActionStream>, Status> {
     let action = request.into_inner();
@@ -46,7 +46,7 @@ pub(crate) async fn do_action(
     match sql::Command::try_from(msg).map_err(to_tonic_err)? {
         sql::Command::ActionCreatePreparedStatementRequest(stmt) => {
             let result =
-                prepared_statement_query::do_action_create_prepared_statement(ctx, stmt).await?;
+                prepared_statement_query::do_action_create_prepared_statement(engine, stmt).await?;
             let output = futures::stream::iter(vec![Ok(arrow_flight::Result {
                 body: result.as_any().encode_to_vec().into(),
             })]);

--- a/crates/datafusion-flightsql/src/change_source.rs
+++ b/crates/datafusion-flightsql/src/change_source.rs
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Abstraction over a live feed of data changes used to serve `do_exchange`
+//! (CDC-style) subscriptions.
+
+use datafusion::sql::TableReference;
+use futures::stream::BoxStream;
+use runtime_query_engine::query_engine::DataUpdate;
+use tonic::Status;
+
+/// A source of live change updates for a table.
+///
+/// Implementations bridge whatever change-propagation mechanism the host uses
+/// (e.g. a broadcast channel) into a simple stream of [`DataUpdate`]s.
+#[async_trait::async_trait]
+pub trait ChangeSource: Send + Sync {
+    /// Subscribe to change updates for `table`.
+    ///
+    /// Yields [`DataUpdate`]s until the source ends. A terminal `None` on the
+    /// returned stream is treated as the source closing.
+    async fn subscribe(
+        &self,
+        table: &TableReference,
+    ) -> BoxStream<'static, Result<DataUpdate, Status>>;
+}

--- a/crates/datafusion-flightsql/src/do_exchange.rs
+++ b/crates/datafusion-flightsql/src/do_exchange.rs
@@ -1,0 +1,483 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `DoExchange` handler serving CDC-style subscriptions.
+//!
+//! On subscription this streams an initial snapshot of the requested table
+//! (converted into "change" batches with an `op = "r"` operation), then
+//! interleaves live updates supplied by a [`ChangeSource`]. Ported from the
+//! Spice runtime's `do_exchange` implementation, decoupled from runtime
+//! infrastructure: `DataUpdate`/`UpdateType` come from `runtime-query-engine`,
+//! the initial snapshot is read via the [`QueryEngine`]'s `SessionContext`, and
+//! the live feed is a generic [`BoxStream`] rather than a broadcast receiver.
+
+use std::{collections::VecDeque, sync::Arc};
+
+use arrow::array::{ListArray, StringArray, StructArray};
+use arrow::array::{ListBuilder, RecordBatch, StringBuilder, new_null_array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow_flight::{
+    FlightData, SchemaAsIpc, flight_service_server::FlightService,
+};
+use arrow_ipc::writer::{self, CompressionContext, DictionaryTracker, IpcDataGenerator};
+use async_stream::try_stream;
+use datafusion::common::{Constraint, Constraints};
+use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::sql::TableReference;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use runtime_query_engine::query_engine::{DataUpdate, QueryEngine, UpdateType};
+use tonic::{Request, Response, Status, Streaming};
+
+use crate::{ChangeSource, FlightSqlService};
+
+const MAX_PENDING_INITIAL_SNAPSHOT_UPDATES: usize = 1_024;
+const MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_BATCHES: usize = 128;
+const MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_ROWS: usize = 1_000_000;
+const MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_BYTES: usize = 128 * 1024 * 1024;
+
+/// The Arrow schema that represents a change event.
+///
+/// Inlined from `data_components::cdc::changes_schema` to avoid depending on
+/// the heavy `data_components` crate.
+fn changes_schema(table_schema: &Schema) -> Schema {
+    Schema::new(vec![
+        Field::new("op", DataType::Utf8, false),
+        Field::new(
+            "primary_keys",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, false))),
+            true,
+        ),
+        Field::new(
+            "data",
+            DataType::Struct(table_schema.fields().clone()),
+            true,
+        ),
+    ])
+}
+
+#[derive(Default)]
+struct PendingInitialSnapshotUpdates {
+    updates: VecDeque<DataUpdate>,
+    batches: usize,
+    rows: usize,
+    bytes: usize,
+}
+
+impl PendingInitialSnapshotUpdates {
+    fn push_back(&mut self, update: DataUpdate) -> bool {
+        let (update_batches, update_rows, update_bytes) = update_stats(&update);
+        let next_updates = self.updates.len().saturating_add(1);
+        let next_batches = self.batches.saturating_add(update_batches);
+        let next_rows = self.rows.saturating_add(update_rows);
+        let next_bytes = self.bytes.saturating_add(update_bytes);
+
+        if next_updates > MAX_PENDING_INITIAL_SNAPSHOT_UPDATES
+            || next_batches > MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_BATCHES
+            || next_rows > MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_ROWS
+            || next_bytes > MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_BYTES
+        {
+            self.clear();
+            return false;
+        }
+
+        self.batches = next_batches;
+        self.rows = next_rows;
+        self.bytes = next_bytes;
+        self.updates.push_back(update);
+        true
+    }
+
+    fn pop_front(&mut self) -> Option<DataUpdate> {
+        let update = self.updates.pop_front()?;
+        let (update_batches, update_rows, update_bytes) = update_stats(&update);
+        self.batches = self.batches.saturating_sub(update_batches);
+        self.rows = self.rows.saturating_sub(update_rows);
+        self.bytes = self.bytes.saturating_sub(update_bytes);
+        Some(update)
+    }
+
+    fn clear(&mut self) {
+        self.updates.clear();
+        self.batches = 0;
+        self.rows = 0;
+        self.bytes = 0;
+    }
+}
+
+fn update_stats(update: &DataUpdate) -> (usize, usize, usize) {
+    update.data.iter().fold(
+        (0usize, 0usize, 0usize),
+        |(batch_count, row_count, byte_count), batch| {
+            (
+                batch_count.saturating_add(1),
+                row_count.saturating_add(batch.num_rows()),
+                byte_count.saturating_add(batch.get_array_memory_size()),
+            )
+        },
+    )
+}
+
+struct ChangeFlightEncoder {
+    encoder: IpcDataGenerator,
+    tracker: DictionaryTracker,
+    compression_context: CompressionContext,
+    write_options: writer::IpcWriteOptions,
+    schema: Option<SchemaRef>,
+}
+
+impl Default for ChangeFlightEncoder {
+    fn default() -> Self {
+        Self {
+            encoder: IpcDataGenerator::default(),
+            tracker: DictionaryTracker::new(false),
+            compression_context: CompressionContext::default(),
+            write_options: writer::IpcWriteOptions::default(),
+            schema: None,
+        }
+    }
+}
+
+impl ChangeFlightEncoder {
+    fn encode(&mut self, record_batch: &RecordBatch) -> Result<Vec<FlightData>, Status> {
+        let mut flights = Vec::new();
+        let schema_changed = self
+            .schema
+            .as_ref()
+            .is_none_or(|schema| schema.as_ref() != record_batch.schema().as_ref());
+
+        if schema_changed {
+            flights.push(FlightData::from(SchemaAsIpc::new(
+                record_batch.schema().as_ref(),
+                &self.write_options,
+            )));
+            self.schema = Some(record_batch.schema());
+            self.tracker = DictionaryTracker::new(false);
+        }
+
+        let (flight_dictionaries, flight_batch) = self
+            .encoder
+            .encode(
+                record_batch,
+                &mut self.tracker,
+                &self.write_options,
+                &mut self.compression_context,
+            )
+            .map_err(|source| Status::internal(format!("Unable to encode batch: {source}")))?;
+
+        flights.extend(flight_dictionaries.into_iter().map(Into::into));
+        flights.push(flight_batch.into());
+
+        Ok(flights)
+    }
+}
+
+pub(crate) async fn handle(
+    engine: Arc<dyn QueryEngine>,
+    change_source: Option<Arc<dyn ChangeSource>>,
+    request: Request<Streaming<FlightData>>,
+) -> Result<Response<<FlightSqlService as FlightService>::DoExchangeStream>, Status> {
+    let mut streaming_request = request.into_inner();
+    let req = streaming_request.next().await;
+    let Some(subscription_request) = req else {
+        return Err(Status::invalid_argument(
+            "Need to send a FlightData message with a FlightDescriptor to subscribe to",
+        ));
+    };
+
+    let subscription_request = match subscription_request {
+        Ok(subscription_request) => subscription_request,
+        Err(e) => {
+            return Err(Status::invalid_argument(format!(
+                "Unable to read subscription request: {e}",
+            )));
+        }
+    };
+
+    // TODO: Support multiple flight descriptors to subscribe to multiple data sources
+    let Some(flight_descriptor) = subscription_request.flight_descriptor else {
+        return Err(Status::invalid_argument(
+            "Flight descriptor required to indicate which data to subscribe to",
+        ));
+    };
+
+    if flight_descriptor.path.is_empty() {
+        return Err(Status::invalid_argument(
+            "Flight descriptor needs to specify a path to indicate which data to subscribe to",
+        ));
+    }
+
+    let data_path = TableReference::parse_str(&flight_descriptor.path.join("."));
+
+    let Some(table_provider) = engine.get_table(&data_path).await else {
+        return Err(Status::invalid_argument(format!(
+            r#"Unknown dataset: "{data_path}""#,
+        )));
+    };
+
+    let Some(change_source) = change_source else {
+        return Err(Status::unimplemented(
+            "do_exchange requires a configured ChangeSource",
+        ));
+    };
+
+    let update_stream = change_source.subscribe(&data_path).await;
+
+    Ok(Response::new(do_exchange_response_stream(
+        update_stream,
+        table_provider,
+        engine,
+        data_path,
+    )))
+}
+
+fn do_exchange_response_stream(
+    mut update_stream: BoxStream<'static, Result<DataUpdate, Status>>,
+    table_provider_stream: Arc<dyn TableProvider>,
+    engine_stream: Arc<dyn QueryEngine>,
+    data_path_stream: TableReference,
+) -> BoxStream<'static, Result<FlightData, Status>> {
+    // The stream interleaves a fallible initial snapshot, live updates, and IPC encoding without materializing the response.
+    let response_stream = try_stream! {
+        let mut encoder = ChangeFlightEncoder::default();
+        enum InitialSnapshotEvent {
+            DataUpdate(Option<Result<DataUpdate, Status>>),
+            SnapshotBatch(Option<Result<RecordBatch, DataFusionError>>),
+        }
+
+        let mut initial_snapshot_stream = initial_snapshot_stream(
+            &engine_stream,
+            Arc::clone(&table_provider_stream),
+        )
+        .await?;
+        let snapshot_schema = initial_snapshot_stream.schema();
+
+        let truncate_batch = truncate_change_batch(&snapshot_schema)?;
+        let flights = encoder.encode(&truncate_batch)?;
+        for flight in flights {
+            yield flight;
+        }
+
+        let mut pending_updates = PendingInitialSnapshotUpdates::default();
+
+        loop {
+            let event = tokio::select! {
+                update = update_stream.next() => InitialSnapshotEvent::DataUpdate(update),
+                batch = initial_snapshot_stream.next() => InitialSnapshotEvent::SnapshotBatch(batch),
+            };
+
+            match event {
+                InitialSnapshotEvent::DataUpdate(Some(Ok(data_update))) => {
+                    if !pending_updates.push_back(data_update) {
+                        tracing::warn!(
+                            dataset = %data_path_stream,
+                            max_pending_updates = MAX_PENDING_INITIAL_SNAPSHOT_UPDATES,
+                            max_pending_batches = MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_BATCHES,
+                            max_pending_rows = MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_ROWS,
+                            max_pending_bytes = MAX_PENDING_INITIAL_SNAPSHOT_UPDATE_BYTES,
+                            "DoExchange subscriber received too much buffered update data while streaming initial snapshot"
+                        );
+                        Err(Status::data_loss(format!(
+                            "DoExchange subscriber missed data updates while receiving the initial snapshot for dataset {data_path_stream}; resubscribe and reconcile state"
+                        )))?;
+                    }
+                }
+                InitialSnapshotEvent::DataUpdate(Some(Err(status))) => {
+                    Err(status)?;
+                }
+                InitialSnapshotEvent::DataUpdate(None) => {
+                    Err(Status::data_loss(format!(
+                        "DoExchange subscriber update stream closed while receiving the initial snapshot for dataset {data_path_stream}; resubscribe and reconcile state"
+                    )))?;
+                }
+                InitialSnapshotEvent::SnapshotBatch(Some(batch)) => {
+                    let batch = batch.map_err(|source| Status::internal(format!(
+                        "Unable to stream initial snapshot: {source}"
+                    )))?;
+                    let change_batch = record_batch_to_change_batch(
+                        &table_provider_stream,
+                        &batch,
+                    )?;
+                    let flights = encoder.encode(&change_batch)?;
+                    for flight in flights {
+                        yield flight;
+                    }
+                }
+                InitialSnapshotEvent::SnapshotBatch(None) => break,
+            }
+        }
+
+        while let Some(data_update) = pending_updates.pop_front() {
+            if data_update.update_type == UpdateType::Overwrite {
+                let truncate_batch = truncate_change_batch(&data_update.schema)?;
+                let flights = encoder.encode(&truncate_batch)?;
+                for flight in flights {
+                    yield flight;
+                }
+            }
+
+            for batch in &data_update.data {
+                let change_batch = record_batch_to_change_batch(&table_provider_stream, batch)?;
+                let flights = encoder.encode(&change_batch)?;
+                for flight in flights {
+                    yield flight;
+                }
+            }
+        }
+
+        loop {
+            let data_update = match update_stream.next().await {
+                Some(Ok(data_update)) => data_update,
+                Some(Err(status)) => {
+                    Err(status)?
+                }
+                None => {
+                    Err(Status::data_loss(format!(
+                        "DoExchange subscriber update stream closed for dataset {data_path_stream}; resubscribe and reconcile state"
+                    )))?
+                }
+            };
+
+            if data_update.update_type == UpdateType::Overwrite {
+                let truncate_batch = truncate_change_batch(&data_update.schema)?;
+                let flights = encoder.encode(&truncate_batch)?;
+                for flight in flights {
+                    yield flight;
+                }
+            }
+
+            for batch in &data_update.data {
+                let change_batch = record_batch_to_change_batch(&table_provider_stream, batch)?;
+                let flights = encoder.encode(&change_batch)?;
+                for flight in flights {
+                    yield flight;
+                }
+            }
+        }
+    };
+
+    response_stream.boxed()
+}
+
+async fn initial_snapshot_stream(
+    engine: &Arc<dyn QueryEngine>,
+    table_provider: Arc<dyn TableProvider>,
+) -> Result<SendableRecordBatchStream, Status> {
+    let df = engine
+        .session_context()
+        .read_table(table_provider)
+        .map_err(|source| Status::internal(format!("Unable to read initial snapshot: {source}")))?;
+
+    df.execute_stream().await.map_err(|source| {
+        Status::internal(format!(
+            "Unable to execute initial snapshot stream: {source}"
+        ))
+    })
+}
+
+fn record_batch_to_change_batch(
+    table_provider: &Arc<dyn TableProvider>,
+    batch: &RecordBatch,
+) -> Result<RecordBatch, Status> {
+    let schema = batch.schema();
+    let row_count = batch.num_rows();
+    let op_array = StringArray::from(vec!["r"; row_count]);
+    let primary_keys = get_primary_keys_from_constraints(&schema, table_provider.constraints())?;
+    let primary_keys_array = match primary_keys.as_ref() {
+        Some(primary_keys) => get_primary_keys_array(primary_keys, row_count),
+        None => ListArray::new_null(
+            Arc::new(Field::new("item", DataType::Utf8, false)),
+            row_count,
+        ),
+    };
+    let data_array = StructArray::from(batch.clone());
+    let change_schema = Arc::new(changes_schema(schema.as_ref()));
+
+    RecordBatch::try_new(
+        change_schema,
+        vec![
+            Arc::new(op_array),
+            Arc::new(primary_keys_array),
+            Arc::new(data_array),
+        ],
+    )
+    .map_err(|source| {
+        Status::internal(format!(
+            "Unable to convert record batch into change event: {source}"
+        ))
+    })
+}
+
+fn truncate_change_batch(schema: &SchemaRef) -> Result<RecordBatch, Status> {
+    let change_schema = Arc::new(changes_schema(schema.as_ref()));
+    let op_array = StringArray::from(vec!["t"]);
+    let primary_keys_array =
+        ListArray::new_null(Arc::new(Field::new("item", DataType::Utf8, false)), 1);
+    let data_array = new_null_array(&DataType::Struct(schema.fields().clone()), 1);
+
+    RecordBatch::try_new(
+        change_schema,
+        vec![Arc::new(op_array), Arc::new(primary_keys_array), data_array],
+    )
+    .map_err(|source| {
+        Status::internal(format!(
+            "Unable to create initial snapshot truncate event: {source}"
+        ))
+    })
+}
+
+fn get_primary_keys_from_constraints<'a>(
+    schema: &'a SchemaRef,
+    constraints: Option<&Constraints>,
+) -> Result<Option<Vec<&'a str>>, Status> {
+    let Some(primary_key_indices) = constraints.and_then(|constraints| {
+        constraints.iter().find_map(|constraint| match constraint {
+            Constraint::PrimaryKey(primary_key_indices) => Some(primary_key_indices.as_slice()),
+            Constraint::Unique(_) => None,
+        })
+    }) else {
+        return Ok(None);
+    };
+
+    let mut primary_keys = Vec::with_capacity(primary_key_indices.len());
+    for primary_key_index in primary_key_indices {
+        let Some(field) = schema.fields().get(*primary_key_index) else {
+            return Err(Status::internal(format!(
+                "Primary key index {primary_key_index} is not present in schema"
+            )));
+        };
+        primary_keys.push(field.name().as_str());
+    }
+
+    Ok(Some(primary_keys))
+}
+
+fn get_primary_keys_array(primary_keys: &[&str], row_count: usize) -> ListArray {
+    let mut list_builder = ListBuilder::new(StringBuilder::new()).with_field(Arc::new(Field::new(
+        "item",
+        DataType::Utf8,
+        false,
+    )));
+    for _ in 0..row_count {
+        for key in primary_keys {
+            list_builder.values().append_value(key);
+        }
+        list_builder.append(true);
+    }
+    list_builder.finish()
+}

--- a/crates/datafusion-flightsql/src/do_get.rs
+++ b/crates/datafusion-flightsql/src/do_get.rs
@@ -21,32 +21,32 @@ use arrow_flight::{
     flight_service_server::FlightService,
     sql::{Any, Command},
 };
-use datafusion::prelude::SessionContext;
 use prost::Message;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status};
 
 use crate::{FlightSqlService, flightsql, to_tonic_err};
 
 pub(crate) async fn handle(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     request: Request<Ticket>,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoGetStream>, Status> {
     let msg: Any = match Message::decode(&*request.get_ref().ticket) {
         Ok(msg) => msg,
-        Err(_) => return do_get_simple(ctx, request).await,
+        Err(_) => return do_get_simple(engine, request).await,
     };
 
     match Command::try_from(msg).map_err(to_tonic_err)? {
-        Command::CommandStatementQuery(cmd) => flightsql::statement_query::do_get(ctx, cmd).await,
+        Command::CommandStatementQuery(cmd) => flightsql::statement_query::do_get(engine, cmd).await,
         Command::CommandPreparedStatementQuery(cmd) => {
-            Box::pin(flightsql::prepared_statement_query::do_get(ctx, cmd)).await
+            Box::pin(flightsql::prepared_statement_query::do_get(engine, cmd)).await
         }
         Command::CommandPreparedStatementUpdate(cmd) => {
-            Box::pin(flightsql::prepared_statement_update::do_get(ctx, cmd)).await
+            Box::pin(flightsql::prepared_statement_update::do_get(engine, cmd)).await
         }
-        Command::CommandGetCatalogs(cmd) => flightsql::get_catalogs::do_get(&ctx, cmd),
-        Command::CommandGetDbSchemas(cmd) => flightsql::get_schemas::do_get(&ctx, cmd),
-        Command::CommandGetTables(cmd) => flightsql::get_tables::do_get(ctx, cmd).await,
+        Command::CommandGetCatalogs(cmd) => flightsql::get_catalogs::do_get(&engine, cmd),
+        Command::CommandGetDbSchemas(cmd) => flightsql::get_schemas::do_get(&engine, cmd),
+        Command::CommandGetTables(cmd) => flightsql::get_tables::do_get(engine, cmd).await,
         Command::CommandGetPrimaryKeys(cmd) => Ok(flightsql::get_primary_keys::do_get(&cmd)),
         Command::CommandGetTableTypes(cmd) => flightsql::get_table_types::do_get(cmd),
         Command::CommandGetSqlInfo(cmd) => flightsql::get_sql_info::do_get(cmd),
@@ -61,7 +61,7 @@ pub(crate) async fn handle(
 }
 
 async fn do_get_simple(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     request: Request<Ticket>,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoGetStream>, Status> {
     let ticket = request.into_inner();
@@ -70,7 +70,7 @@ async fn do_get_simple(
 
     tracing::trace!("do_get (plain SQL): {sql}");
 
-    let output = FlightSqlService::sql_to_flight_stream(ctx, sql, None).await?;
+    let output = FlightSqlService::sql_to_flight_stream(engine, sql, None).await?;
     Ok(Response::new(
         Box::pin(output) as <FlightSqlService as FlightService>::DoGetStream
     ))

--- a/crates/datafusion-flightsql/src/do_put.rs
+++ b/crates/datafusion-flightsql/src/do_put.rs
@@ -30,15 +30,15 @@ use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::physical_plan::collect;
-use datafusion::prelude::SessionContext;
 use prost::Message;
+use runtime_query_engine::query_engine::QueryEngine;
 use tokio_stream::adapters::Peekable;
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::{FlightSqlService, flightsql, handle_datafusion_error, to_tonic_err};
 
 pub(crate) async fn handle(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     request: Request<Streaming<FlightData>>,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoPutStream>, Status> {
     let mut streaming_flight: Peekable<Streaming<FlightData>> =
@@ -54,7 +54,7 @@ pub(crate) async fn handle(
     let descriptor_path = fd.path.clone();
 
     let Ok(message) = Any::decode(&*cmd) else {
-        return do_put_raw(ctx, streaming_flight, None).await;
+        return do_put_raw(engine, streaming_flight, None).await;
     };
 
     match Command::try_from(message).map_err(|e| Status::internal(format!("{e:?}")))? {
@@ -64,12 +64,14 @@ pub(crate) async fn handle(
         Command::CommandPreparedStatementUpdate(cmd) => {
             flightsql::prepared_statement_update::do_put_update(cmd, streaming_flight).await
         }
-        Command::CommandStatementUpdate(cmd) => flightsql::statement_update::do_put(ctx, cmd).await,
+        Command::CommandStatementUpdate(cmd) => {
+            flightsql::statement_update::do_put(engine, cmd).await
+        }
         Command::CommandStatementIngest(cmd) => {
             let path_override = ingest_command_path_override(&cmd, &descriptor_path);
-            do_put_raw(ctx, streaming_flight, path_override).await
+            do_put_raw(engine, streaming_flight, path_override).await
         }
-        _ => do_put_raw(ctx, streaming_flight, None).await,
+        _ => do_put_raw(engine, streaming_flight, None).await,
     }
 }
 
@@ -215,7 +217,7 @@ fn coerce_batches_to_schema(
 }
 
 async fn do_put_raw(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     mut streaming: Peekable<Streaming<FlightData>>,
     path_override: Option<Vec<String>>,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoPutStream>, Status> {
@@ -231,10 +233,12 @@ async fn do_put_raw(
         return Err(Status::invalid_argument("no path provided"));
     }
 
-    let table_provider = ctx
-        .table_provider(resolve_table_path(path))
-        .await
-        .map_err(handle_datafusion_error)?;
+    let table_ref = resolve_table_path(path);
+    let table_provider = engine.get_table(&table_ref).await.ok_or_else(|| {
+        handle_datafusion_error(datafusion::error::DataFusionError::Plan(format!(
+            "table '{table_ref}' not found"
+        )))
+    })?;
 
     let (schema, batches) = decode_flight_batches(streaming).await?;
 
@@ -246,14 +250,14 @@ async fn do_put_raw(
 
     let insert_plan = table_provider
         .insert_into(
-            &ctx.state(),
+            &engine.session_context().state(),
             MemorySourceConfig::try_new_exec(&[batches], schema, None)
                 .map_err(handle_datafusion_error)?,
             InsertOp::Append,
         )
         .await
         .map_err(handle_datafusion_error)?;
-    collect(insert_plan, ctx.task_ctx())
+    collect(insert_plan, engine.session_context().task_ctx())
         .await
         .map_err(handle_datafusion_error)?;
 

--- a/crates/datafusion-flightsql/src/flightsql/get_catalogs.rs
+++ b/crates/datafusion-flightsql/src/flightsql/get_catalogs.rs
@@ -21,8 +21,8 @@ use arrow_flight::{
     flight_service_server::FlightService,
     sql::{self, ProstMessageExt},
 };
-use datafusion::prelude::SessionContext;
 use prost::Message;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status};
 
 use crate::{FlightSqlService, record_batches_to_flight_stream, to_tonic_err};
@@ -43,11 +43,12 @@ pub(crate) fn get_flight_info(
 }
 
 pub(crate) fn do_get(
-    ctx: &Arc<SessionContext>,
+    engine: &Arc<dyn QueryEngine>,
     query: sql::CommandGetCatalogs,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoGetStream>, Status> {
     tracing::trace!("do_get get_catalogs: {query:?}");
 
+    let ctx = engine.session_context();
     let mut builder = query.into_builder();
     for catalog in ctx.catalog_names() {
         builder.append(catalog);

--- a/crates/datafusion-flightsql/src/flightsql/get_schemas.rs
+++ b/crates/datafusion-flightsql/src/flightsql/get_schemas.rs
@@ -21,7 +21,7 @@ use arrow_flight::{
     flight_service_server::FlightService,
     sql::{self},
 };
-use datafusion::prelude::SessionContext;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status};
 
 use crate::{FlightSqlService, record_batches_to_flight_stream, to_tonic_err};
@@ -42,11 +42,12 @@ pub(crate) fn get_flight_info(
 }
 
 pub(crate) fn do_get(
-    ctx: &Arc<SessionContext>,
+    engine: &Arc<dyn QueryEngine>,
     query: sql::CommandGetDbSchemas,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoGetStream>, Status> {
     tracing::trace!("do_get get_schemas: {query:?}");
 
+    let ctx = engine.session_context();
     let catalogs = match &query.catalog {
         Some(c) => vec![c.clone()],
         None => ctx.catalog_names(),

--- a/crates/datafusion-flightsql/src/flightsql/get_tables.rs
+++ b/crates/datafusion-flightsql/src/flightsql/get_tables.rs
@@ -24,7 +24,7 @@ use arrow_flight::{
 };
 use arrow_tools::schema::to_source_native_type_name;
 use datafusion::datasource::TableType;
-use datafusion::prelude::SessionContext;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status};
 
 use crate::{FlightSqlService, record_batches_to_flight_stream, to_tonic_err};
@@ -45,11 +45,12 @@ pub(crate) fn get_flight_info(
 }
 
 pub(crate) async fn do_get(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     query: sql::CommandGetTables,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoGetStream>, Status> {
     tracing::trace!("do_get get_tables: {query:?}");
 
+    let ctx = engine.session_context();
     let catalogs = match &query.catalog {
         Some(c) => vec![c.clone()],
         None => ctx.catalog_names(),

--- a/crates/datafusion-flightsql/src/flightsql/prepared_statement_query.rs
+++ b/crates/datafusion-flightsql/src/flightsql/prepared_statement_query.rs
@@ -35,7 +35,6 @@ use arrow_flight::{
 use arrow_schema::SchemaRef;
 use arrow_tools::record_batch::record_to_param_values;
 use datafusion::common::ParamValues;
-use datafusion::prelude::SessionContext;
 use datafusion::sql::sqlparser::{
     ast::{Expr, Statement, Value, VisitMut, VisitorMut},
     dialect::GenericDialect,
@@ -47,6 +46,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use tokio_stream::adapters::Peekable;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::{FlightSqlService, to_tonic_err};
@@ -209,7 +209,7 @@ pub(crate) struct PreparedStatement {
 // ── DoAction: CreatePreparedStatement ────────────────────────────────────────
 
 pub(crate) async fn do_action_create_prepared_statement(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     statement: sql::ActionCreatePreparedStatementRequest,
 ) -> Result<sql::ActionCreatePreparedStatementResult, Status> {
     tracing::trace!("do_action_create_prepared_statement: {:?}", statement.query);
@@ -220,7 +220,7 @@ pub(crate) async fn do_action_create_prepared_statement(
     // Attempt schema inference; fall back to empty schema if type inference
     // fails (e.g. for parameterised queries before parameters are bound).
     let (dataset_schema, parameter_schema) =
-        match FlightSqlService::get_arrow_schema(&ctx, &query).await {
+        match FlightSqlService::get_arrow_schema(&engine, &query).await {
             Ok(schema) => (schema, None),
             Err(e) => {
                 let msg = e.message();
@@ -261,14 +261,14 @@ pub(crate) async fn do_action_create_prepared_statement(
 // ── GetFlightInfo for prepared statement query ────────────────────────────────
 
 pub(crate) async fn get_flight_info(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     handle: sql::CommandPreparedStatementQuery,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<FlightInfo>, Status> {
     let PreparedStatement { query: sql, .. } =
         from_bytes(&handle.prepared_statement_handle).map_err(error_to_status)?;
 
-    let maybe_schema = match FlightSqlService::get_arrow_schema(&ctx, &sql).await {
+    let maybe_schema = match FlightSqlService::get_arrow_schema(&engine, &sql).await {
         Ok(schema) => Some(schema),
         Err(e) => {
             let msg = e.message();
@@ -303,7 +303,7 @@ pub(crate) async fn get_flight_info(
 // ── DoGet: execute prepared statement query ───────────────────────────────────
 
 pub(crate) async fn do_get(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     query: sql::CommandPreparedStatementQuery,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoGetStream>, Status> {
     tracing::trace!("do_get prepared_statement_query");
@@ -327,7 +327,8 @@ pub(crate) async fn do_get(
         Cow::Borrowed(sql.as_str())
     };
 
-    let output = FlightSqlService::sql_to_flight_stream(ctx, &sql_to_execute, param_values).await?;
+    let output =
+        FlightSqlService::sql_to_flight_stream(engine, &sql_to_execute, param_values).await?;
     Ok(Response::new(
         Box::pin(output) as <FlightSqlService as FlightService>::DoGetStream
     ))

--- a/crates/datafusion-flightsql/src/flightsql/prepared_statement_update.rs
+++ b/crates/datafusion-flightsql/src/flightsql/prepared_statement_update.rs
@@ -27,16 +27,16 @@ use arrow_flight::{
 };
 use arrow_ipc::writer::StreamWriter;
 use arrow_schema::SchemaRef;
-use datafusion::prelude::SessionContext;
 use futures::TryStreamExt;
 use postcard::{from_bytes, to_stdvec};
 use prost::Message;
+use runtime_query_engine::query_engine::{QueryEngine, QueryRequest};
 use std::sync::LazyLock;
 use tokio_stream::adapters::Peekable;
 use tonic::{Request, Response, Status, Streaming};
 
 use super::prepared_statement_query::{PreparedStatement, decode_param_values, error_to_status};
-use crate::{FlightSqlService, handle_datafusion_error, to_tonic_err};
+use crate::{FlightSqlService, query_engine_err_to_status, to_tonic_err};
 
 static AFFECTED_ROWS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(Schema::new(vec![Field::new(
@@ -63,7 +63,7 @@ pub(crate) fn get_flight_info(
 }
 
 pub(crate) async fn do_get(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     query: sql::CommandPreparedStatementUpdate,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoGetStream>, Status> {
     tracing::trace!("do_get prepared_statement_update");
@@ -76,14 +76,18 @@ pub(crate) async fn do_get(
 
     let param_values = decode_param_values(&parameters).map_err(error_to_status)?;
 
-    let df = ctx.sql(&sql).await.map_err(handle_datafusion_error)?;
-    let df = if let Some(params) = param_values {
-        df.with_param_values(params)
-            .map_err(handle_datafusion_error)?
-    } else {
-        df
-    };
-    let results: Vec<RecordBatch> = df.collect().await.map_err(handle_datafusion_error)?;
+    let mut request = QueryRequest::new(&sql);
+    if let Some(params) = param_values {
+        request = request.parameters(params);
+    }
+    let stream = engine
+        .execute_query(request)
+        .await
+        .map_err(query_engine_err_to_status)?;
+    let results: Vec<RecordBatch> = stream
+        .try_collect()
+        .await
+        .map_err(|e| Status::internal(e.to_string()))?;
     let affected_rows = extract_affected_rows(&results);
 
     let batch = RecordBatch::try_new(

--- a/crates/datafusion-flightsql/src/flightsql/statement_query.rs
+++ b/crates/datafusion-flightsql/src/flightsql/statement_query.rs
@@ -21,20 +21,20 @@ use arrow_flight::{
     flight_service_server::FlightService,
     sql::{self, ProstMessageExt},
 };
-use datafusion::prelude::SessionContext;
 use prost::Message;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status};
 
 use crate::{FlightSqlService, to_tonic_err};
 
 pub(crate) async fn get_flight_info(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     query: sql::CommandStatementQuery,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<FlightInfo>, Status> {
     tracing::trace!("get_flight_info statement_query: {:?}", query.query);
 
-    let arrow_schema = FlightSqlService::get_arrow_schema(&ctx, &query.query).await?;
+    let arrow_schema = FlightSqlService::get_arrow_schema(&engine, &query.query).await?;
     let fd = request.into_inner();
 
     let endpoint = FlightEndpoint::new().with_ticket(Ticket {
@@ -51,12 +51,12 @@ pub(crate) async fn get_flight_info(
 }
 
 pub(crate) async fn do_get(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     cmd: sql::CommandStatementQuery,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoGetStream>, Status> {
     tracing::trace!("do_get statement_query: {:?}", cmd.query);
 
-    let output = FlightSqlService::sql_to_flight_stream(ctx, &cmd.query, None).await?;
+    let output = FlightSqlService::sql_to_flight_stream(engine, &cmd.query, None).await?;
     Ok(Response::new(
         Box::pin(output) as <FlightSqlService as FlightService>::DoGetStream
     ))

--- a/crates/datafusion-flightsql/src/flightsql/statement_update.rs
+++ b/crates/datafusion-flightsql/src/flightsql/statement_update.rs
@@ -25,20 +25,27 @@ use arrow_flight::{
     flight_service_server::FlightService,
     sql::{CommandStatementUpdate, DoPutUpdateResult},
 };
-use datafusion::prelude::SessionContext;
+use futures::TryStreamExt;
 use prost::Message;
+use runtime_query_engine::query_engine::{QueryEngine, QueryRequest};
 use tonic::{Response, Status};
 
-use crate::{FlightSqlService, handle_datafusion_error};
+use crate::{FlightSqlService, query_engine_err_to_status};
 
 pub(crate) async fn do_put(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     cmd: CommandStatementUpdate,
 ) -> Result<Response<<FlightSqlService as FlightService>::DoPutStream>, Status> {
     tracing::trace!("do_put statement_update: {}", cmd.query);
 
-    let df = ctx.sql(&cmd.query).await.map_err(handle_datafusion_error)?;
-    let results: Vec<RecordBatch> = df.collect().await.map_err(handle_datafusion_error)?;
+    let stream = engine
+        .execute_query(QueryRequest::new(&cmd.query))
+        .await
+        .map_err(query_engine_err_to_status)?;
+    let results: Vec<RecordBatch> = stream
+        .try_collect()
+        .await
+        .map_err(|e| Status::internal(e.to_string()))?;
 
     let affected_rows = extract_affected_rows(&results);
 

--- a/crates/datafusion-flightsql/src/get_flight_info.rs
+++ b/crates/datafusion-flightsql/src/get_flight_info.rs
@@ -20,26 +20,26 @@ use arrow_flight::{
     FlightDescriptor, FlightEndpoint, FlightInfo, Ticket,
     sql::{Any, Command},
 };
-use datafusion::prelude::SessionContext;
 use prost::Message;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status};
 
 use crate::{FlightSqlService, flightsql, to_tonic_err};
 
 pub(crate) async fn handle(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<FlightInfo>, Status> {
     let Ok(message) = Any::decode(&*request.get_ref().cmd) else {
-        return get_flight_info_simple(ctx, request).await;
+        return get_flight_info_simple(engine, request).await;
     };
 
     match Command::try_from(message).map_err(to_tonic_err)? {
         Command::CommandStatementQuery(cmd) => {
-            flightsql::statement_query::get_flight_info(ctx, cmd, request).await
+            flightsql::statement_query::get_flight_info(engine, cmd, request).await
         }
         Command::CommandPreparedStatementQuery(handle) => {
-            flightsql::prepared_statement_query::get_flight_info(ctx, handle, request).await
+            flightsql::prepared_statement_query::get_flight_info(engine, handle, request).await
         }
         Command::CommandPreparedStatementUpdate(handle) => {
             flightsql::prepared_statement_update::get_flight_info(&handle, request)
@@ -73,13 +73,13 @@ pub(crate) async fn handle(
 }
 
 async fn get_flight_info_simple(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<FlightInfo>, Status> {
     let fd = request.into_inner();
     let sql = std::str::from_utf8(&fd.cmd).map_err(|e| Status::invalid_argument(e.to_string()))?;
 
-    let arrow_schema = FlightSqlService::get_arrow_schema(&ctx, sql).await?;
+    let arrow_schema = FlightSqlService::get_arrow_schema(&engine, sql).await?;
 
     let info = FlightInfo {
         flight_descriptor: Some(fd.clone()),

--- a/crates/datafusion-flightsql/src/get_schema.rs
+++ b/crates/datafusion-flightsql/src/get_schema.rs
@@ -20,14 +20,14 @@ use arrow_flight::{
     FlightDescriptor, IpcMessage, SchemaAsIpc, SchemaResult, flight_descriptor::DescriptorType,
 };
 use arrow_ipc::writer::IpcWriteOptions;
-use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
+use runtime_query_engine::query_engine::QueryEngine;
 use tonic::{Request, Response, Status};
 
 use crate::{FlightSqlService, handle_datafusion_error, to_tonic_err};
 
 pub(crate) async fn handle(
-    ctx: Arc<SessionContext>,
+    engine: Arc<dyn QueryEngine>,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<SchemaResult>, Status> {
     let fd = request.into_inner();
@@ -36,7 +36,7 @@ pub(crate) async fn handle(
         x if x == DescriptorType::Cmd as i32 => {
             let sql = std::str::from_utf8(&fd.cmd)
                 .map_err(|e| Status::invalid_argument(e.to_string()))?;
-            let schema = FlightSqlService::get_arrow_schema(&ctx, sql).await?;
+            let schema = FlightSqlService::get_arrow_schema(&engine, sql).await?;
 
             let options = IpcWriteOptions::default();
             let IpcMessage(schema_bytes) = SchemaAsIpc::new(&schema, &options)
@@ -48,10 +48,11 @@ pub(crate) async fn handle(
         }
         x if x == DescriptorType::Path as i32 => {
             let table_ref = TableReference::from(fd.path.join("."));
-            let table = ctx
-                .table_provider(table_ref)
-                .await
-                .map_err(handle_datafusion_error)?;
+            let table = engine.get_table(&table_ref).await.ok_or_else(|| {
+                handle_datafusion_error(datafusion::error::DataFusionError::Plan(format!(
+                    "table '{table_ref}' not found"
+                )))
+            })?;
             let schema = table.schema();
             let options = IpcWriteOptions::default();
             let IpcMessage(schema_bytes) = SchemaAsIpc::new(schema.as_ref(), &options)

--- a/crates/datafusion-flightsql/src/lib.rs
+++ b/crates/datafusion-flightsql/src/lib.rs
@@ -36,7 +36,7 @@ limitations under the License.
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let ctx = Arc::new(SessionContext::new());
-//!     let svc = FlightSqlService::new(ctx);
+//!     let svc = FlightSqlService::from_session_context(ctx);
 //!     Server::builder()
 //!         .add_service(FlightServiceServer::new(svc))
 //!         .serve("0.0.0.0:50051".parse()?)
@@ -62,9 +62,13 @@ use datafusion::common::ParamValues;
 use datafusion::prelude::SessionContext;
 use futures::StreamExt;
 use futures::stream::BoxStream;
+use runtime_query_engine::query_engine::{QueryEngine, QueryRequest};
+use runtime_query_engine::session::QuerySession;
 use tonic::{Request, Response, Status, Streaming};
 
 mod actions;
+mod change_source;
+mod do_exchange;
 mod do_get;
 mod do_put;
 pub(crate) mod flightsql;
@@ -75,29 +79,56 @@ mod session;
 pub mod session_auth;
 pub(crate) mod util;
 
+pub use change_source::ChangeSource;
 pub use session::SessionStore;
 pub(crate) use util::{handle_datafusion_error, record_batches_to_flight_stream, to_tonic_err};
+
+/// Convert a [`runtime_query_engine::query_engine::Error`] into a `tonic` [`Status`].
+pub(crate) fn query_engine_err_to_status(
+    err: runtime_query_engine::query_engine::Error,
+) -> Status {
+    Status::internal(err.to_string())
+}
 
 /// A `FlightSQL` service backed by an arbitrary `DataFusion` [`SessionContext`].
 ///
 /// Create with [`FlightSqlService::new`] and wrap in
 /// [`FlightServiceServer`] to serve over gRPC.
 pub struct FlightSqlService {
-    /// Base context used when no per-session context exists for a request.
-    ctx: Arc<SessionContext>,
+    /// Base query engine used when no per-session context exists for a request.
+    engine: Arc<dyn QueryEngine>,
     session_store: SessionStore,
+    /// Optional live-change feed used to serve `do_exchange` subscriptions.
+    change_source: Option<Arc<dyn ChangeSource>>,
 }
 
 impl FlightSqlService {
-    /// Create a new service using `ctx` as the default query context.
+    /// Create a new service using `engine` as the default query engine.
     ///
     /// Call [`FlightSqlService::into_server`] to wrap in a `FlightServiceServer`.
     #[must_use]
-    pub fn new(ctx: Arc<SessionContext>) -> Self {
+    pub fn new(engine: Arc<dyn QueryEngine>) -> Self {
         Self {
-            ctx,
+            engine,
             session_store: SessionStore::new(),
+            change_source: None,
         }
+    }
+
+    /// Create a new service backed by a bare [`SessionContext`].
+    ///
+    /// This wraps `ctx` in a [`QuerySession`] and preserves the ergonomics of
+    /// the pre-`QueryEngine` API.
+    #[must_use]
+    pub fn from_session_context(ctx: Arc<SessionContext>) -> Self {
+        Self::new(Arc::new(QuerySession::new(ctx)))
+    }
+
+    /// Attach a [`ChangeSource`] used to serve `do_exchange` subscriptions.
+    #[must_use]
+    pub fn with_change_source(mut self, src: Arc<dyn ChangeSource>) -> Self {
+        self.change_source = Some(src);
+        self
     }
 
     /// Returns a clone of the session store (useful for auth wrappers).
@@ -112,18 +143,19 @@ impl FlightSqlService {
         FlightServiceServer::new(self)
     }
 
-    /// Resolve the [`SessionContext`] for a request.
+    /// Resolve the [`QueryEngine`] for a request.
     ///
-    /// Returns the per-session context if the request carries a known session
-    /// ID (via `x-session-id` or `Authorization: Bearer <id>`), otherwise
-    /// falls back to the base context.
-    pub(crate) fn session_ctx(
+    /// Returns a per-session engine (wrapping the request's `SessionContext`)
+    /// if the request carries a known session ID (via `x-session-id` or
+    /// `Authorization: Bearer <id>`), otherwise falls back to the base engine.
+    pub(crate) fn session_engine(
         &self,
         metadata: &tonic::metadata::MetadataMap,
-    ) -> Arc<SessionContext> {
+    ) -> Arc<dyn QueryEngine> {
         self.session_store
             .get_session_from_metadata(metadata)
-            .unwrap_or_else(|| Arc::clone(&self.ctx))
+            .map(|ctx| Arc::new(QuerySession::new(ctx)) as Arc<dyn QueryEngine>)
+            .unwrap_or_else(|| Arc::clone(&self.engine))
     }
 }
 
@@ -143,7 +175,11 @@ impl FlightService for FlightSqlService {
         &self,
         request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
-        handshake::handle(request.metadata(), &self.ctx, &self.session_store)
+        handshake::handle(
+            request.metadata(),
+            self.engine.session_context(),
+            &self.session_store,
+        )
     }
 
     async fn list_flights(
@@ -157,8 +193,8 @@ impl FlightService for FlightSqlService {
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
-        let ctx = self.session_ctx(request.metadata());
-        Box::pin(get_flight_info::handle(ctx, request)).await
+        let engine = self.session_engine(request.metadata());
+        Box::pin(get_flight_info::handle(engine, request)).await
     }
 
     async fn poll_flight_info(
@@ -172,41 +208,40 @@ impl FlightService for FlightSqlService {
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<SchemaResult>, Status> {
-        let ctx = self.session_ctx(request.metadata());
-        get_schema::handle(ctx, request).await
+        let engine = self.session_engine(request.metadata());
+        get_schema::handle(engine, request).await
     }
 
     async fn do_get(
         &self,
         request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
-        let ctx = self.session_ctx(request.metadata());
-        Box::pin(do_get::handle(ctx, request)).await
+        let engine = self.session_engine(request.metadata());
+        Box::pin(do_get::handle(engine, request)).await
     }
 
     async fn do_put(
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
-        let ctx = self.session_ctx(request.metadata());
-        do_put::handle(ctx, request).await
+        let engine = self.session_engine(request.metadata());
+        do_put::handle(engine, request).await
     }
 
     async fn do_exchange(
         &self,
-        _request: Request<Streaming<FlightData>>,
+        request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
-        Err(Status::unimplemented(
-            "do_exchange is not supported by this service",
-        ))
+        let engine = self.session_engine(request.metadata());
+        do_exchange::handle(engine, self.change_source.clone(), request).await
     }
 
     async fn do_action(
         &self,
         request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
-        let ctx = self.session_ctx(request.metadata());
-        Box::pin(actions::do_action(ctx, request)).await
+        let engine = self.session_engine(request.metadata());
+        Box::pin(actions::do_action(engine, request)).await
     }
 
     async fn list_actions(
@@ -220,15 +255,25 @@ impl FlightService for FlightSqlService {
 // ── Query execution utilities ─────────────────────────────────────────────────
 
 impl FlightSqlService {
-    /// Plan `sql` against `ctx` and return the output Arrow schema.
+    /// Plan `sql` against `engine` and return the output Arrow schema.
     ///
     /// Applies `expand_views_schema` so that the advertised schema matches
     /// what `sql_to_flight_stream` will actually produce.
+    ///
+    /// There is no `QueryEngine` trait method for planning arbitrary SQL for
+    /// schema resolution, so this plans directly via the engine's
+    /// [`SessionContext`] (bypassing any richer `execute_query` semantics such
+    /// as caching, telemetry, or access-control). That is acceptable for
+    /// schema-only resolution.
     pub(crate) async fn get_arrow_schema(
-        ctx: &Arc<SessionContext>,
+        engine: &Arc<dyn QueryEngine>,
         sql: &str,
     ) -> Result<Schema, Status> {
-        let df = ctx.sql(sql).await.map_err(handle_datafusion_error)?;
+        let df = engine
+            .session_context()
+            .sql(sql)
+            .await
+            .map_err(handle_datafusion_error)?;
         let schema = df.schema().as_arrow().clone();
         Ok(arrow_tools::schema::expand_views_schema(&schema))
     }
@@ -241,26 +286,26 @@ impl FlightSqlService {
         Ok(message.0)
     }
 
-    /// Execute `sql` against `ctx` and encode the result as a Flight data stream.
+    /// Execute `sql` against `engine` and encode the result as a Flight data stream.
     pub(crate) async fn sql_to_flight_stream(
-        ctx: Arc<SessionContext>,
+        engine: Arc<dyn QueryEngine>,
         sql: &str,
         parameters: Option<ParamValues>,
     ) -> Result<BoxStream<'static, Result<FlightData, Status>>, Status> {
-        let df = ctx.sql(sql).await.map_err(handle_datafusion_error)?;
+        let mut request = QueryRequest::new(sql);
+        if let Some(params) = parameters {
+            request = request.parameters(params);
+        }
 
-        let df = if let Some(params) = parameters {
-            df.with_param_values(params)
-                .map_err(handle_datafusion_error)?
-        } else {
-            df
-        };
+        let data_stream = engine
+            .execute_query(request)
+            .await
+            .map_err(query_engine_err_to_status)?;
 
-        let raw_schema = std::sync::Arc::clone(df.schema().inner());
+        let raw_schema = data_stream.schema();
         // Expand view types (Utf8View → LargeUtf8, BinaryView → LargeBinary) so
         // that the advertised schema matches the cast batches we send below.
         let schema = Arc::new(arrow_tools::schema::expand_views_schema(&raw_schema));
-        let data_stream = df.execute_stream().await.map_err(handle_datafusion_error)?;
 
         // Pre-compute schema flight data once, matching the runtime's approach.
         let options = IpcWriteOptions::default();


### PR DESCRIPTION
Two changes to the standalone `datafusion-flightsql` crate 
 1. Use `QueryEngine` not `SessionContext` (can still provide a session context ``FlightSqlService::from_session_context(ctx)``).
 2. Add `QueryEngine::do_exchange` and use in `datafusion-flightsql` .