### PR TITLE
fix(cayenne): validate acceleration directory early; clearer errors on invalid paths

### DIFF
--- a/crates/cayenne/src/provider/partitioned_wal.rs
+++ b/crates/cayenne/src/provider/partitioned_wal.rs
@@ -139,11 +139,13 @@ impl PartitionedWal {
         // distinction below drives whether we fsync the parent. If the table
         // root itself is missing (e.g. the very first write, before any
         // partition directory has been materialized), fall back to a recursive
-        // create rather than failing with a bare ENOENT — then fsync the parent
-        // exactly as the fresh-create path does.
-        let created = match tokio::fs::create_dir(wal_dir).await {
-            Ok(()) => true,
-            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => false,
+        // create rather than failing with a bare ENOENT.
+        let table_root_created = match tokio::fs::create_dir(wal_dir).await {
+            Ok(()) => false,
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Already exists: nothing was created, so no fsync is owed.
+                return Ok(());
+            }
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
                 tokio::fs::create_dir_all(wal_dir)
                     .await
@@ -153,21 +155,37 @@ impl PartitionedWal {
             Err(source) => return Err(Error::IoError { source }),
         };
 
-        if created {
-            let parent = table_root.to_path_buf(); // the table root
-            let table = table_root.display().to_string();
+        // Sync the table root so the newly created `_partitioned_wal/` entry is
+        // written through (directory ordering tier: plain fsync on macOS, full
+        // fsync elsewhere — see `provider/fsync_tier.rs`).
+        Self::ordering_sync_dir(table_root).await?;
 
-            // Sync the table root so the _partitioned_wal/ subdir entry is
-            // written through (directory ordering tier: plain fsync on
-            // macOS, full fsync elsewhere — see `provider/fsync_tier.rs`).
-            tokio::task::spawn_blocking(move || {
-                let dir = std::fs::File::open(&parent)?;
-                crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
-            })
-            .await
-            .map_err(|source| Error::TaskPanicked { table, source })??;
+        // In the fallback path `table_root` itself was just created by
+        // `create_dir_all`, so its own directory entry is not yet durable.
+        // Sync its parent too — otherwise a crash could make `table_root` (and
+        // the `_partitioned_wal/` dir inside it) "disappear" even though the
+        // catalog was committed to point at it. This mirrors the parent-sync
+        // requirement documented in `Table::ensure_snapshot_dir_exists`.
+        if table_root_created
+            && let Some(grandparent) = table_root.parent()
+        {
+            Self::ordering_sync_dir(grandparent).await?;
         }
 
+        Ok(())
+    }
+
+    /// Open `dir` and fsync it at the directory ordering tier, so a child entry
+    /// created inside it is persisted through to the device.
+    async fn ordering_sync_dir(dir: &Path) -> Result<()> {
+        let path = dir.to_path_buf();
+        let table = dir.display().to_string();
+        tokio::task::spawn_blocking(move || {
+            let dir = std::fs::File::open(&path)?;
+            crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+        })
+        .await
+        .map_err(|source| Error::TaskPanicked { table, source })??;
         Ok(())
     }
 
@@ -471,6 +489,40 @@ mod tests {
                 },
             ],
         )
+    }
+
+    #[tokio::test]
+    async fn write_to_creates_missing_table_root() {
+        // The coordination dir uses a non-recursive `create_dir`, which assumes
+        // `table_root` already exists. If it does not (e.g. the very first write
+        // before any partition directory has been materialized), the write must
+        // still succeed by recursively creating the tree — not fail with a bare
+        // ENOENT. Uses a nested-missing `table_root` where only the temp dir
+        // exists.
+        let tmp = TempDir::new().expect("tempdir");
+        let table_root = tmp.path().join("schema").join("table");
+        assert!(
+            !table_root.exists(),
+            "precondition: nested table_root should not exist yet"
+        );
+
+        let wal = sample_wal();
+        let path = wal
+            .write_to(&table_root)
+            .await
+            .expect("write should create the missing table root");
+
+        assert!(path.exists(), "WAL file should exist after write");
+        assert!(
+            table_root.join(PARTITIONED_WAL_DIR).is_dir(),
+            "coordination dir should have been created under the new table root"
+        );
+
+        let all = PartitionedWal::read_all_in(&table_root)
+            .await
+            .expect("read");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, wal);
     }
 
     #[tokio::test]

--- a/crates/cayenne/src/provider/partitioned_wal.rs
+++ b/crates/cayenne/src/provider/partitioned_wal.rs
@@ -135,23 +135,37 @@ impl PartitionedWal {
         table_root: &Path,
         wal_dir: &Path,
     ) -> Result<()> {
-        match tokio::fs::create_dir(wal_dir).await {
-            Ok(()) => {
-                let parent = table_root.to_path_buf(); // the table root
-                let table = table_root.display().to_string();
-
-                // Sync the table root so the _partitioned_wal/ subdir entry is
-                // written through (directory ordering tier: plain fsync on
-                // macOS, full fsync elsewhere — see `provider/fsync_tier.rs`).
-                tokio::task::spawn_blocking(move || {
-                    let dir = std::fs::File::open(&parent)?;
-                    crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
-                })
-                .await
-                .map_err(|source| Error::TaskPanicked { table, source })??;
+        // `create_dir` (not `create_dir_all`) so the fresh-vs-existing
+        // distinction below drives whether we fsync the parent. If the table
+        // root itself is missing (e.g. the very first write, before any
+        // partition directory has been materialized), fall back to a recursive
+        // create rather than failing with a bare ENOENT — then fsync the parent
+        // exactly as the fresh-create path does.
+        let created = match tokio::fs::create_dir(wal_dir).await {
+            Ok(()) => true,
+            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => false,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                tokio::fs::create_dir_all(wal_dir)
+                    .await
+                    .map_err(|source| Error::IoError { source })?;
+                true
             }
-            Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {}
             Err(source) => return Err(Error::IoError { source }),
+        };
+
+        if created {
+            let parent = table_root.to_path_buf(); // the table root
+            let table = table_root.display().to_string();
+
+            // Sync the table root so the _partitioned_wal/ subdir entry is
+            // written through (directory ordering tier: plain fsync on
+            // macOS, full fsync elsewhere — see `provider/fsync_tier.rs`).
+            tokio::task::spawn_blocking(move || {
+                let dir = std::fs::File::open(&parent)?;
+                crate::provider::fsync_tier::ordering_sync_dir_std(&dir)
+            })
+            .await
+            .map_err(|source| Error::TaskPanicked { table, source })??;
         }
 
         Ok(())

--- a/crates/cayenne/src/provider/partitioned_wal.rs
+++ b/crates/cayenne/src/provider/partitioned_wal.rs
@@ -166,9 +166,7 @@ impl PartitionedWal {
         // the `_partitioned_wal/` dir inside it) "disappear" even though the
         // catalog was committed to point at it. This mirrors the parent-sync
         // requirement documented in `Table::ensure_snapshot_dir_exists`.
-        if table_root_created
-            && let Some(grandparent) = table_root.parent()
-        {
+        if table_root_created && let Some(grandparent) = table_root.parent() {
             Self::ordering_sync_dir(grandparent).await?;
         }
 

--- a/crates/cayenne/src/provider/partitioned_wal.rs
+++ b/crates/cayenne/src/provider/partitioned_wal.rs
@@ -155,10 +155,16 @@ impl PartitionedWal {
             Err(source) => return Err(Error::IoError { source }),
         };
 
+        // Error context uses `table_root` for every sync below (including the
+        // grandparent one), so a spawn-blocking join failure is attributed to
+        // this table rather than to whatever ancestor directory we happened to
+        // fsync.
+        let table = table_root.display().to_string();
+
         // Sync the table root so the newly created `_partitioned_wal/` entry is
         // written through (directory ordering tier: plain fsync on macOS, full
         // fsync elsewhere — see `provider/fsync_tier.rs`).
-        Self::ordering_sync_dir(table_root).await?;
+        Self::ordering_sync_dir(table_root, &table).await?;
 
         // In the fallback path `table_root` itself was just created by
         // `create_dir_all`, so its own directory entry is not yet durable.
@@ -167,17 +173,19 @@ impl PartitionedWal {
         // catalog was committed to point at it. This mirrors the parent-sync
         // requirement documented in `Table::ensure_snapshot_dir_exists`.
         if table_root_created && let Some(grandparent) = table_root.parent() {
-            Self::ordering_sync_dir(grandparent).await?;
+            Self::ordering_sync_dir(grandparent, &table).await?;
         }
 
         Ok(())
     }
 
     /// Open `dir` and fsync it at the directory ordering tier, so a child entry
-    /// created inside it is persisted through to the device.
-    async fn ordering_sync_dir(dir: &Path) -> Result<()> {
+    /// created inside it is persisted through to the device. `table` labels the
+    /// owning table for error context (it may differ from `dir`, e.g. when
+    /// syncing `dir`'s parent on behalf of the table root).
+    async fn ordering_sync_dir(dir: &Path, table: &str) -> Result<()> {
         let path = dir.to_path_buf();
-        let table = dir.display().to_string();
+        let table = table.to_string();
         tokio::task::spawn_blocking(move || {
             let dir = std::fs::File::open(&path)?;
             crate::provider::fsync_tier::ordering_sync_dir_std(&dir)

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -2738,6 +2738,57 @@ mod tests {
     }
 
     #[test]
+    fn missing_data_file_during_collect_is_classified_transient() {
+        // A source read that fails mid-stream (e.g. a data file that is
+        // transiently missing) surfaces from `collect()` in the write sink as a
+        // bare `External(io error)`. Routing it through
+        // `check_and_mark_retriable_error` before `retry_from_df_error` (as
+        // `TableSink::insert_into` now does) must classify it transient so the
+        // refresh retries, rather than failing permanently.
+        let io_err = std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "No such file or directory (os error 2)",
+        );
+        let df_err = DataFusionError::External(Box::new(io_err));
+
+        let classified = retry_from_df_error(check_and_mark_retriable_error(df_err));
+
+        match classified {
+            RetryError::Transient { err, .. } => {
+                assert!(
+                    matches!(err, super::super::Error::UnableToGetDataFromConnector { .. }),
+                    "transient refresh error should be UnableToGetDataFromConnector, got: {err}"
+                );
+            }
+            RetryError::Permanent(err) => {
+                panic!("missing-file read error should be transient, got permanent: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_query_error_during_collect_stays_permanent() {
+        // Invalid-query errors (plan/schema/SQL) must remain permanent even
+        // after the new `check_and_mark_retriable_error` pass — retrying them
+        // would loop pointlessly.
+        let df_err = DataFusionError::Plan("invalid projection".to_string());
+
+        let classified = retry_from_df_error(check_and_mark_retriable_error(df_err));
+
+        match classified {
+            RetryError::Permanent(err) => {
+                assert!(
+                    matches!(err, super::super::Error::FailedToRefreshDataset { .. }),
+                    "permanent refresh error should be FailedToRefreshDataset, got: {err}"
+                );
+            }
+            RetryError::Transient { err, .. } => {
+                panic!("invalid-query error should be permanent, got transient: {err}");
+            }
+        }
+    }
+
+    #[test]
     fn table_provider_with_existing_metadata_preserves_indexed_provider() {
         let schema = Arc::new(Schema::new_with_metadata(
             vec![

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -2756,7 +2756,10 @@ mod tests {
         match classified {
             RetryError::Transient { err, .. } => {
                 assert!(
-                    matches!(err, super::super::Error::UnableToGetDataFromConnector { .. }),
+                    matches!(
+                        err,
+                        super::super::Error::UnableToGetDataFromConnector { .. }
+                    ),
                     "transient refresh error should be UnableToGetDataFromConnector, got: {err}"
                 );
             }

--- a/crates/runtime/src/accelerated_table/sink/table.rs
+++ b/crates/runtime/src/accelerated_table/sink/table.rs
@@ -29,6 +29,8 @@ use runtime_datafusion_index::{Index, IndexedTableProvider};
 use runtime_table_partition::provider::PartitionTableProvider;
 use util::RetryError;
 
+use datafusion_table_providers::util::retriable_error::check_and_mark_retriable_error;
+
 use crate::{
     accelerated_table::refresh_task::retry_from_df_error, datafusion::error::find_datafusion_root,
     dataupdate::StreamingDataUpdateExecutionPlan, schema_evolution::SCHEMA_EVOLUTION_DETECTED,
@@ -217,7 +219,15 @@ impl TableSink {
                 collect_start.elapsed().as_secs_f64()
             );
             run_on_write_failed(&providers_before_write, &self.sink_indexes).await;
-            return Err(retry_from_df_error(e));
+            // Mirror the read path (`RefreshTask::get_data_update`): the source
+            // is read while this insertion plan is collected, so a mid-stream
+            // read failure (e.g. a data file that is transiently missing during
+            // source-side maintenance) surfaces here. Route it through
+            // `check_and_mark_retriable_error` so such failures are classified
+            // transient and retried, instead of falling straight through to a
+            // permanent refresh failure. Invalid-query errors (SQL/plan/schema)
+            // are left permanent by that helper.
+            return Err(retry_from_df_error(check_and_mark_retriable_error(e)));
         }
 
         // Perform post-write index maintenance (e.g., rebuild hash indexes) if the table supports it.

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -1668,17 +1668,15 @@ impl CayenneAccelerator {
         }
 
         // Strip any `file://` scheme so the on-disk operations receive a real
-        // filesystem path. Materialize the `Arc<str>` once for reuse in both
-        // error contexts below.
+        // filesystem path. `fs_path` stays a `&str`: the SNAFU context selectors
+        // below only convert it to the error's `Arc<str>` when `into_error` runs
+        // on the `Err` branch, so the success path allocates nothing.
         let fs_path = fs_probe_path(dir_path);
-        let path: Arc<str> = Arc::from(fs_path);
 
         // 1. mkdir -p: create the full directory tree.
         tokio::fs::create_dir_all(fs_path)
             .await
-            .context(AccelerationDirectoryUnavailableSnafu {
-                path: Arc::clone(&path),
-            })?;
+            .context(AccelerationDirectoryUnavailableSnafu { path: fs_path })?;
 
         // 2. Writability probe: write then remove a marker file. The probe file
         //    name is unique per directory prep so concurrent dataset loads
@@ -1687,7 +1685,7 @@ impl CayenneAccelerator {
             .join(format!(".spice-cayenne-write-probe-{}", uuid::Uuid::now_v7()));
         tokio::fs::write(&probe_path, b"spice")
             .await
-            .context(AccelerationDirectoryUnavailableSnafu { path })?;
+            .context(AccelerationDirectoryUnavailableSnafu { path: fs_path })?;
         // Best-effort cleanup; a leftover probe file is harmless.
         let _ = tokio::fs::remove_file(&probe_path).await;
 

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -112,8 +112,8 @@ pub enum Error {
 
     #[snafu(display(
         "Failed to prepare the Cayenne acceleration directory {path}: {source}. \
-        Ensure 'cayenne_file_path' resolves to a location Spice can create and write to \
-        (its parent directory must exist and be writable). \
+        Ensure 'cayenne_file_path' resolves to a local path Spice has permission to \
+        create and write to. \
         See: https://spiceai.org/docs/components/data-accelerators/cayenne#params"
     ))]
     AccelerationDirectoryUnavailable {
@@ -1668,13 +1668,17 @@ impl CayenneAccelerator {
         }
 
         // Strip any `file://` scheme so the on-disk operations receive a real
-        // filesystem path.
+        // filesystem path. Materialize the `Arc<str>` once for reuse in both
+        // error contexts below.
         let fs_path = fs_probe_path(dir_path);
+        let path: Arc<str> = Arc::from(fs_path);
 
         // 1. mkdir -p: create the full directory tree.
         tokio::fs::create_dir_all(fs_path)
             .await
-            .context(AccelerationDirectoryUnavailableSnafu { path: fs_path })?;
+            .context(AccelerationDirectoryUnavailableSnafu {
+                path: Arc::clone(&path),
+            })?;
 
         // 2. Writability probe: write then remove a marker file. The probe file
         //    name is unique per directory prep so concurrent dataset loads
@@ -1683,7 +1687,7 @@ impl CayenneAccelerator {
             .join(format!(".spice-cayenne-write-probe-{}", uuid::Uuid::now_v7()));
         tokio::fs::write(&probe_path, b"spice")
             .await
-            .context(AccelerationDirectoryUnavailableSnafu { path: fs_path })?;
+            .context(AccelerationDirectoryUnavailableSnafu { path })?;
         // Best-effort cleanup; a leftover probe file is harmless.
         let _ = tokio::fs::remove_file(&probe_path).await;
 
@@ -2240,16 +2244,20 @@ impl DataAccelerator for CayenneAccelerator {
         let dir_path = self.file_path(source)?;
         let is_s3_express = s3::is_s3_express_data_path(source);
 
-        // For local storage, validate and prepare both the data and metadata
-        // directories up front. A misconfigured `cayenne_file_path` (missing
-        // parent, or an existing-but-unwritable directory) fails here with an
-        // actionable, path-naming error instead of surfacing later as a bare
+        // Validate and prepare the acceleration directories up front. A
+        // misconfigured local path (missing intermediate directory, or an
+        // existing-but-unwritable directory) fails here with an actionable,
+        // path-naming error instead of surfacing later as a bare
         // `No such file or directory (os error 2)` from the write path.
-        if !is_s3_express {
-            Self::prepare_local_acceleration_dir(&dir_path).await?;
-            let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
-            Self::prepare_local_acceleration_dir(&metadata_dir).await?;
-        }
+        //
+        // `prepare_local_acceleration_dir` no-ops for object-store (`s3://`)
+        // paths, so this correctly covers every layout: fully-local setups
+        // (both dirs local), and S3 Express (the data dir on S3 is skipped, but
+        // the metadata dir is always local and must still be validated — the
+        // `is_s3_express` data-path flag says nothing about the metadata dir).
+        Self::prepare_local_acceleration_dir(&dir_path).await?;
+        let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
+        Self::prepare_local_acceleration_dir(&metadata_dir).await?;
 
         // Handle S3 Express One Zone configuration
         if is_s3_express {
@@ -3444,6 +3452,17 @@ mod tests {
             .await
             .expect("set readonly perms");
 
+        // Confirm the environment actually enforces the write ban before
+        // asserting on it. Running as root (or on a mount that ignores
+        // permission bits) can write to a 0o555 directory anyway, which would
+        // make the probe legitimately succeed; in that case there is nothing to
+        // regress against, so skip rather than assert vacuously.
+        let sentinel = readonly.join("permission-enforced-probe");
+        let write_is_blocked = tokio::fs::write(&sentinel, b"x").await.is_err();
+        if !write_is_blocked {
+            let _ = tokio::fs::remove_file(&sentinel).await;
+        }
+
         let dir = readonly.to_string_lossy().to_string();
         let result = CayenneAccelerator::prepare_local_acceleration_dir(&dir).await;
 
@@ -3452,12 +3471,22 @@ mod tests {
         restore.set_mode(0o755);
         let _ = tokio::fs::set_permissions(&readonly, restore).await;
 
-        // Running as root bypasses permission bits, so only assert the failure
-        // (and the actionable error) when the probe could actually be blocked.
-        if let Err(err) = result {
-            assert!(
-                matches!(err, Error::AccelerationDirectoryUnavailable { .. }),
-                "expected AccelerationDirectoryUnavailable, got: {err}"
+        if write_is_blocked {
+            // The directory is genuinely unwritable, so the probe MUST fail with
+            // the actionable error — this is the behavior under test.
+            match result {
+                Err(Error::AccelerationDirectoryUnavailable { .. }) => {}
+                Err(other) => {
+                    panic!("expected AccelerationDirectoryUnavailable, got: {other}")
+                }
+                Ok(()) => panic!(
+                    "write+delete probe did not catch an unwritable directory (returned Ok)"
+                ),
+            }
+        } else {
+            eprintln!(
+                "skipping writability assertion: environment does not enforce the read-only bit \
+                 (likely running as root)"
             );
         }
     }

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -2259,6 +2259,20 @@ impl DataAccelerator for CayenneAccelerator {
         // `is_s3_express` data-path flag says nothing about the metadata dir).
         Self::prepare_local_acceleration_dir(&dir_path).await?;
         let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
+        // The Cayenne metastore (SQLite/Turso catalog) is always stored on local
+        // disk, so the metadata directory must be local. Reject a non-local
+        // `cayenne_metadata_dir` (e.g. an `s3://` URL) up front — otherwise
+        // `prepare_local_acceleration_dir` would no-op on it and later local
+        // filesystem operations would fail obscurely on the URL string.
+        if !is_local_path(&metadata_dir) {
+            return Err(Box::new(Error::InvalidConfiguration {
+                detail: Arc::from(format!(
+                    "Cayenne metadata directory must be a local path, but it resolved to '{metadata_dir}'. \
+                    The Cayenne metastore (SQLite/Turso catalog) is stored on local disk; \
+                    set 'cayenne_metadata_dir' to a local path or a 'file://' URL."
+                )),
+            }) as Box<dyn std::error::Error + Send + Sync>);
+        }
         Self::prepare_local_acceleration_dir(&metadata_dir).await?;
 
         // Handle S3 Express One Zone configuration
@@ -3812,6 +3826,56 @@ mod tests {
             .collect();
         assert!(dims.contains(&256));
         assert!(dims.contains(&1536));
+    }
+
+    #[tokio::test]
+    async fn init_rejects_non_local_metadata_dir() {
+        // The Cayenne metastore is always local, so a non-local
+        // `cayenne_metadata_dir` (e.g. an s3:// URL) must be rejected up front
+        // with an actionable error — not silently skipped by the local-dir
+        // preparation and left to fail obscurely later.
+        let app = AppBuilder::new("test").build();
+        let rt = crate::Runtime::builder().build().await;
+        let temp = tempfile::TempDir::new().expect("create temp dir");
+
+        let mut dataset = DatasetBuilder::try_new(
+            "cayenne_bad_metadata_dir".to_string(),
+            "cayenne_bad_metadata_dir",
+        )
+        .expect("Failed to create builder")
+        .with_app(Arc::new(app))
+        .with_runtime(Arc::new(rt))
+        .build()
+        .expect("Failed to build dataset");
+
+        dataset.acceleration = Some(Acceleration {
+            engine: Engine::Cayenne,
+            mode: Mode::File,
+            params: [
+                (
+                    "cayenne_file_path".to_string(),
+                    temp.path().to_string_lossy().to_string(),
+                ),
+                (
+                    "cayenne_metadata_dir".to_string(),
+                    "s3://example-bucket/cayenne-metadata".to_string(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        });
+
+        let accelerator = CayenneAccelerator::new();
+        let err = accelerator
+            .init(&dataset)
+            .await
+            .expect_err("init should reject a non-local metadata directory");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("metadata directory must be a local path"),
+            "error should explain the metadata dir must be local, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -109,6 +109,17 @@ pub enum Error {
 
     #[snafu(display("RuntimeEnv is required for Cayenne accelerator but was not provided"))]
     RuntimeEnvRequired,
+
+    #[snafu(display(
+        "Failed to prepare the Cayenne acceleration directory {path}: {source}. \
+        Ensure 'cayenne_file_path' resolves to a location Spice can create and write to \
+        (its parent directory must exist and be writable). \
+        See: https://spiceai.org/docs/components/data-accelerators/cayenne#params"
+    ))]
+    AccelerationDirectoryUnavailable {
+        path: Arc<str>,
+        source: std::io::Error,
+    },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -1631,6 +1642,54 @@ impl CayenneAccelerator {
         Ok(path_buf)
     }
 
+    /// Validate and prepare a *local* Cayenne acceleration directory before any
+    /// table data is written.
+    ///
+    /// This fails fast, at load time, with an actionable error naming the
+    /// directory — rather than letting a misconfigured `cayenne_file_path`
+    /// surface later as a bare `No such file or directory (os error 2)` from
+    /// deep in the write path during the first refresh (the write path's
+    /// `IoError` is `#[snafu(transparent)]`, so it carries no path or context).
+    ///
+    /// Two checks, in order:
+    /// 1. `create_dir_all` (mkdir -p): recursively materialize every missing
+    ///    component, so a nested path such as `/data/a/b` where only `/data`
+    ///    exists is created rather than failing on the missing intermediate.
+    /// 2. A write+delete probe: prove the directory is actually writable. This
+    ///    catches read-only mounts and permission problems that step 1 cannot
+    ///    reveal (the directory can already exist yet be unwritable).
+    ///
+    /// No-op for object-store (`s3://`) locations; their existence and
+    /// permissions are validated by the S3 bootstrap path.
+    async fn prepare_local_acceleration_dir(dir_path: &str) -> Result<()> {
+        // Object-store URLs (e.g. S3 Express One Zone) are validated elsewhere.
+        if dir_path.contains("://") && !dir_path.starts_with("file://") {
+            return Ok(());
+        }
+
+        // Strip any `file://` scheme so the on-disk operations receive a real
+        // filesystem path.
+        let fs_path = fs_probe_path(dir_path);
+
+        // 1. mkdir -p: create the full directory tree.
+        tokio::fs::create_dir_all(fs_path)
+            .await
+            .context(AccelerationDirectoryUnavailableSnafu { path: fs_path })?;
+
+        // 2. Writability probe: write then remove a marker file. The probe file
+        //    name is unique per directory prep so concurrent dataset loads
+        //    sharing a parent do not race on the same marker.
+        let probe_path = std::path::Path::new(fs_path)
+            .join(format!(".spice-cayenne-write-probe-{}", uuid::Uuid::now_v7()));
+        tokio::fs::write(&probe_path, b"spice")
+            .await
+            .context(AccelerationDirectoryUnavailableSnafu { path: fs_path })?;
+        // Best-effort cleanup; a leftover probe file is harmless.
+        let _ = tokio::fs::remove_file(&probe_path).await;
+
+        Ok(())
+    }
+
     async fn get_or_create_catalog(
         &self,
         metadata_dir: &str,
@@ -2180,6 +2239,17 @@ impl DataAccelerator for CayenneAccelerator {
 
         let dir_path = self.file_path(source)?;
         let is_s3_express = s3::is_s3_express_data_path(source);
+
+        // For local storage, validate and prepare both the data and metadata
+        // directories up front. A misconfigured `cayenne_file_path` (missing
+        // parent, or an existing-but-unwritable directory) fails here with an
+        // actionable, path-naming error instead of surfacing later as a bare
+        // `No such file or directory (os error 2)` from the write path.
+        if !is_s3_express {
+            Self::prepare_local_acceleration_dir(&dir_path).await?;
+            let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
+            Self::prepare_local_acceleration_dir(&metadata_dir).await?;
+        }
 
         // Handle S3 Express One Zone configuration
         if is_s3_express {
@@ -3289,6 +3359,108 @@ mod tests {
     use datafusion_table_providers::UnsupportedTypeAction;
     use search::index::{SearchIndex, VectorIndex};
     use std::sync::Arc;
+
+    #[tokio::test]
+    async fn prepare_local_acceleration_dir_creates_nested_missing_path() {
+        // A nested `cayenne_file_path` where only a shallow prefix exists must
+        // be created recursively (mkdir -p), not fail on the missing
+        // intermediate component (the reported `os error 2` scenario).
+        let temp = tempfile::TempDir::new().expect("create temp dir");
+        let nested = temp
+            .path()
+            .join("a")
+            .join("b")
+            .join("dataset")
+            .to_string_lossy()
+            .to_string();
+        assert!(
+            !std::path::Path::new(&nested).exists(),
+            "precondition: nested path should not exist yet"
+        );
+
+        CayenneAccelerator::prepare_local_acceleration_dir(&nested)
+            .await
+            .expect("nested directory should be created recursively");
+
+        assert!(
+            std::path::Path::new(&nested).is_dir(),
+            "nested directory should exist after preparation"
+        );
+        // The write probe must not leave any marker files behind.
+        let mut entries = tokio::fs::read_dir(&nested).await.expect("read_dir");
+        assert!(
+            entries.next_entry().await.expect("next_entry").is_none(),
+            "prepared directory should be empty (write probe cleaned up)"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_local_acceleration_dir_reports_path_when_uncreatable() {
+        // When a path component is a *file* (not a directory), `create_dir_all`
+        // cannot proceed. The error must name the offending directory and be an
+        // AccelerationDirectoryUnavailable, not a bare io error.
+        let temp = tempfile::TempDir::new().expect("create temp dir");
+        let file_path = temp.path().join("not-a-dir");
+        tokio::fs::write(&file_path, b"i am a file")
+            .await
+            .expect("write blocker file");
+
+        // Attempt to use a directory *underneath* the file.
+        let bad = file_path.join("dataset").to_string_lossy().to_string();
+
+        let err = CayenneAccelerator::prepare_local_acceleration_dir(&bad)
+            .await
+            .expect_err("preparation under a file should fail");
+
+        match err {
+            Error::AccelerationDirectoryUnavailable { path, .. } => {
+                assert!(
+                    bad.contains(path.as_ref()),
+                    "error should name the acceleration directory, got: {path}"
+                );
+            }
+            other => panic!("expected AccelerationDirectoryUnavailable, got: {other}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prepare_local_acceleration_dir_probes_writability() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // A directory that exists but is read-only passes `create_dir_all` yet
+        // is unusable; the write+delete probe must catch it up front.
+        let temp = tempfile::TempDir::new().expect("create temp dir");
+        let readonly = temp.path().join("readonly");
+        tokio::fs::create_dir_all(&readonly)
+            .await
+            .expect("create readonly dir");
+        let mut perms = tokio::fs::metadata(&readonly)
+            .await
+            .expect("metadata")
+            .permissions();
+        perms.set_mode(0o555); // r-xr-xr-x: no write
+        tokio::fs::set_permissions(&readonly, perms.clone())
+            .await
+            .expect("set readonly perms");
+
+        let dir = readonly.to_string_lossy().to_string();
+        let result = CayenneAccelerator::prepare_local_acceleration_dir(&dir).await;
+
+        // Restore write permission so the TempDir can clean itself up.
+        let mut restore = perms;
+        restore.set_mode(0o755);
+        let _ = tokio::fs::set_permissions(&readonly, restore).await;
+
+        // Running as root bypasses permission bits, so only assert the failure
+        // (and the actionable error) when the probe could actually be blocked.
+        if let Err(err) = result {
+            assert!(
+                matches!(err, Error::AccelerationDirectoryUnavailable { .. }),
+                "expected AccelerationDirectoryUnavailable, got: {err}"
+            );
+        }
+    }
 
     #[test]
     fn resolve_goal_raw_global_default_then_per_dataset_override() {

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -112,7 +112,8 @@ pub enum Error {
 
     #[snafu(display(
         "Failed to prepare the Cayenne acceleration directory {path}: {source}. \
-        Ensure 'cayenne_file_path' resolves to a local path Spice has permission to \
+        Ensure the configured Cayenne path ('cayenne_file_path', or 'cayenne_metadata_dir' \
+        for the metadata directory) resolves to a local path Spice has permission to \
         create and write to. \
         See: https://spiceai.org/docs/components/data-accelerators/cayenne#params"
     ))]
@@ -1663,7 +1664,8 @@ impl CayenneAccelerator {
     /// permissions are validated by the S3 bootstrap path.
     async fn prepare_local_acceleration_dir(dir_path: &str) -> Result<()> {
         // Object-store URLs (e.g. S3 Express One Zone) are validated elsewhere.
-        if dir_path.contains("://") && !dir_path.starts_with("file://") {
+        // Reuse `is_local_path` so the local/remote predicate stays in one place.
+        if !is_local_path(dir_path) {
             return Ok(());
         }
 
@@ -1681,8 +1683,10 @@ impl CayenneAccelerator {
         // 2. Writability probe: write then remove a marker file. The probe file
         //    name is unique per directory prep so concurrent dataset loads
         //    sharing a parent do not race on the same marker.
-        let probe_path = std::path::Path::new(fs_path)
-            .join(format!(".spice-cayenne-write-probe-{}", uuid::Uuid::now_v7()));
+        let probe_path = std::path::Path::new(fs_path).join(format!(
+            ".spice-cayenne-write-probe-{}",
+            uuid::Uuid::now_v7()
+        ));
         tokio::fs::write(&probe_path, b"spice")
             .await
             .context(AccelerationDirectoryUnavailableSnafu { path: fs_path })?;
@@ -3477,9 +3481,9 @@ mod tests {
                 Err(other) => {
                     panic!("expected AccelerationDirectoryUnavailable, got: {other}")
                 }
-                Ok(()) => panic!(
-                    "write+delete probe did not catch an unwritable directory (returned Ok)"
-                ),
+                Ok(()) => {
+                    panic!("write+delete probe did not catch an unwritable directory (returned Ok)")
+                }
             }
         } else {
             eprintln!(


### PR DESCRIPTION
## Problem

An accelerated dataset failed to refresh with an opaque error:

> Failed to refresh dataset ... Failed to refresh dataset from the data connector: External error: No such file or directory (os error 2). Verify the dataset configuration and data connector status, and try again.

The message named no file, didn't indicate what operation failed, and pointed at "data connector status" — when the actual cause was the **cayenne accelerator's local storage path**, not the source. Signals that pinned it down:

- The same source worked under duckdb acceleration but not cayenne.
- It failed at initial load (ruling out a compaction/GC race).
- `os error 2` (ENOENT) is a local-filesystem error; an object-store miss reports `NotFound`, not `os error 2`.

### Why the message was useless

`cayenne::provider::Error::IoError` is `#[snafu(transparent)]`, so every raw filesystem `?` surfaces as just the OS error with no path/table/operation. And the write path mixes recursive `create_dir_all` with a non-recursive `create_dir` (and `OpenOptions::create(true)`) that assume their parent directory already exists — so a `cayenne_file_path` whose parent tree isn't fully present produces a bare ENOENT deep in the write path.

## Changes

**Cayenne — fail fast with an actionable error**
- `prepare_local_acceleration_dir` runs in the accelerator's `init` for both the data and metadata directories (local paths only): recursive create + a write+delete probe to catch existing-but-unwritable directories and read-only mounts that a plain `create_dir_all` would pass.
- New `AccelerationDirectoryUnavailable { path, source }` error names the directory and gives an actionable fix + docs link.

**Cayenne — mkdir → mkdir -p safety**
- The partitioned-WAL coordination directory now falls back to recursive creation when the table root is missing, preserving the fresh-vs-existing distinction that drives the parent fsync (durability unchanged).

**Refresh — retriability**
- The `collect()` error in `TableSink::insert_into` is routed through `check_and_mark_retriable_error` (mirroring the read path), so a source read that fails mid-stream is classified transient and retried rather than failing the refresh permanently. Invalid-query errors (SQL/plan/schema) remain permanent.

## Testing

- New unit tests: nested-missing-path creation, uncreatable-path error names the path, writability probe (Unix), transient-vs-permanent classification of collect errors — all passing.
- Existing `partitioned_wal` tests pass.
- `cargo clippy` on `runtime` + `cayenne` (`--tests`) clean, no warnings in changed files.

## Follow-ups (not in this PR)
- Attaching the missing **data-file path** to iceberg *source* errors would require patching the `iceberg-rust` fork; the source wasn't the culprit here, so it's left out.
- Incrementally adding `{operation, path}` context to the remaining cayenne write-path io sites (broad refactor of the transparent `IoError`).