### PR TITLE
observability(chbench): limit CH-BenCHmark logs to info and above

### DIFF
--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -231,7 +231,6 @@ jobs:
           [ -n "$DIAG_PIDS" ] && kill $DIAG_PIDS 2>/dev/null || true
           exit $testop_exit
         env:
-          SPICED_LOG: "runtime::accelerated_table::refresh_task::changes=debug,cayenne::mem_tier=debug,info"
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           # Dedicated in-cluster PG pod on xlarge; per-run docker container (loopback) elsewhere.

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -18406,7 +18406,10 @@ impl CayenneTableProvider {
             "mem_tier_checkpoint",
             checkpoint_start,
         );
-        tracing::debug!(
+        // Fires on every mem-tier checkpoint flush — per-snapshot happy-path
+        // diagnostic (spammy under sustained ingest, e.g. a snapshot storm), so
+        // keep it at trace so it is omitted even at debug verbosity.
+        tracing::trace!(
             target: "cayenne::mem_tier",
             table = self.table_metadata.table_name.as_str(),
             flushed_rows = flushed_mem_rows,


### PR DESCRIPTION
## Problem

The scheduled CH-BenCHmark (HTAP) runs were emitting **debug** logs. This was introduced yesterday in #11645 (`3f42919ce`), which added a `SPICED_LOG` env var to the HTAP workflow as diagnostic instrumentation for the mem-tier snapshot-storm fix:

```yaml
SPICED_LOG: "runtime::accelerated_table::refresh_task::changes=debug,cayenne::mem_tier=debug,info"
```

This regressed benchmark log volume on two axes:
1. Two targets were forced to `debug`.
2. Setting `SPICED_LOG` at all flips spiced from `LogVerbosity::Default` to `Specific` (see `bin/spiced/src/tracing.rs`), which raises the **global floor from WARN to info for every crate** — noisier than the pre-#11645 baseline. The other benchmark workflows (`run_bench`, `run_cluster_bench`, `run_streaming_bench`) set no `SPICED_LOG`.

## Changes

- **Remove `SPICED_LOG`** from `testoperator_run_htap.yml`, restoring the `Default` verbosity (internal components at INFO, everything else WARN, no debug) — consistent with the other benchmark workflows.
- **Demote `debug!` → `trace!`** for the *"Mem-tier checkpoint flushed a durable snapshot"* log in `crates/cayenne/src/provider/table.rs` (the one log #11645 added). It fires on **every** mem-tier checkpoint flush — the exact per-snapshot spam a storm produces — so it now stays off even at `debug` (`-v`); `-vv`/trace is required to see it.

Other `debug!` sites were intentionally left alone: the `refresh_task::changes` ones are rare shutdown/retry/cancel lifecycle events, and the mem-tier "critical memory pressure" log is a meaningful low-frequency signal — none are per-operation floods.

## Testing

Mechanical `debug!`→`trace!` swap (identical macro args) plus a workflow env-var removal; no behavior change beyond log level. CI lint/build covers compilation.