### PR TITLE
perf(cdc): cache per-dataset metric labels to avoid per-event string copies

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -427,9 +427,12 @@ impl RefreshTaskBuilder {
                 .with_sink_indexes(federated_indexes),
         ));
 
+        let dataset_metric_labels = DatasetMetricLabels::new(&self.dataset_name);
+
         RefreshTask {
             runtime_status: self.runtime_status,
             dataset_name: self.dataset_name,
+            dataset_metric_labels,
             federated: self.federated,
             federated_source: self.federated_source,
             accelerator: self.accelerator,
@@ -460,9 +463,49 @@ impl RefreshTaskBuilder {
     }
 }
 
+/// Prebuilt metric labels for one dataset. The `dataset` label value is held as
+/// an `Arc<str>` inside a `KeyValue`, so cloning it is a refcount bump rather
+/// than a fresh `dataset_name.to_string()` heap copy. This lets the CDC apply
+/// loop (and the refresh ingestion loop) record their per-event / per-batch
+/// metrics without re-allocating the label on every call. Built once per
+/// dataset task; the emitted metric output is byte-identical to constructing the
+/// label inline.
+#[derive(Debug, Clone)]
+pub(crate) struct DatasetMetricLabels {
+    /// A single-element array holding `KeyValue { "dataset": Arc<str> }` so
+    /// dataset-only record sites can pass `&self.dataset_only` — no allocation,
+    /// no clone.
+    dataset_only: [KeyValue; 1],
+}
+
+impl DatasetMetricLabels {
+    pub(crate) fn new(dataset_name: &TableReference) -> Self {
+        let name: Arc<str> = Arc::from(dataset_name.to_string());
+        Self {
+            dataset_only: [KeyValue::new("dataset", name)],
+        }
+    }
+
+    /// The dataset-only label set — a zero-allocation slice reuse.
+    pub(crate) fn dataset(&self) -> &[KeyValue] {
+        &self.dataset_only
+    }
+
+    /// The dataset label plus one additional static-valued label. Cloning the
+    /// cached dataset `KeyValue` is an `Arc` refcount bump and the static second
+    /// label allocates nothing, so only the two-element stack array is produced —
+    /// no string copy.
+    pub(crate) fn tagged(&self, key: &'static str, value: &'static str) -> [KeyValue; 2] {
+        [self.dataset_only[0].clone(), KeyValue::new(key, value)]
+    }
+}
+
 pub struct RefreshTask {
     runtime_status: Arc<status::RuntimeStatus>,
     dataset_name: TableReference,
+    /// Prebuilt per-dataset metric labels (see [`DatasetMetricLabels`]), reused
+    /// by the hot metric-record sites instead of re-allocating the label.
+    dataset_metric_labels: DatasetMetricLabels,
     federated: Arc<FederatedTable>,
     federated_source: Option<String>,
     accelerator: Arc<dyn TableProvider>,
@@ -902,6 +945,7 @@ impl RefreshTask {
                     data_update.data,
                     RefreshStat::default(),
                     dataset_name.to_string(),
+                    self.dataset_metric_labels.clone(),
                     notify_written_data_stat_available,
                     DataLoadTracing::new(&self.dataset_name),
                     resource_monitor,
@@ -910,6 +954,7 @@ impl RefreshTask {
                     mut stream,
                     mut stat,
                     ds_name,
+                    metric_labels,
                     notify_refresh_stat_available,
                     mut tracing,
                     resource_monitor,
@@ -922,10 +967,12 @@ impl RefreshTask {
                                 stat.memory_size += batch.get_array_memory_size();
 
                                 // Record incremental ingestion counters per batch.
-                                let labels = [KeyValue::new("dataset", ds_name.clone())];
-                                metrics::REFRESH_ROWS_WRITTEN.add(batch.num_rows() as u64, &labels);
+                                // Reuse the prebuilt dataset label (no per-batch
+                                // `dataset` string copy) — see `DatasetMetricLabels`.
+                                let labels = metric_labels.dataset();
+                                metrics::REFRESH_ROWS_WRITTEN.add(batch.num_rows() as u64, labels);
                                 metrics::REFRESH_BYTES_WRITTEN
-                                    .add(batch.get_array_memory_size() as u64, &labels);
+                                    .add(batch.get_array_memory_size() as u64, labels);
 
                                 // Check memory usage after processing each batch
                                 if let Some(ref monitor) = resource_monitor {
@@ -938,6 +985,7 @@ impl RefreshTask {
                                         stream,
                                         stat,
                                         ds_name,
+                                        metric_labels,
                                         notify_refresh_stat_available,
                                         tracing,
                                         resource_monitor,
@@ -950,6 +998,7 @@ impl RefreshTask {
                                     stream,
                                     stat,
                                     ds_name,
+                                    metric_labels,
                                     notify_refresh_stat_available,
                                     tracing,
                                     resource_monitor,

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+use super::DatasetMetricLabels;
 use super::RefreshTask;
 use crate::accelerated_table::refresh::Refresh;
 use crate::accelerated_table::refresh_task::deletion::build_batch_delete_expr_from_change_batch;
@@ -303,6 +304,9 @@ impl CdcInsertPlanCache {
 struct ApplyContext<'a> {
     refresh_sql: Option<&'a str>,
     dataset_name: &'a TableReference,
+    /// Prebuilt per-dataset metric labels reused by the apply-loop record sites
+    /// (see [`DatasetMetricLabels`]). Always `&self.dataset_metric_labels`.
+    metric_labels: &'a DatasetMetricLabels,
     caching: Option<&'a Weak<Caching>>,
     ready_sender: Option<&'a Arc<Notify>>,
     initial_load_completed: &'a Arc<AtomicBool>,
@@ -1009,6 +1013,10 @@ impl RefreshTask {
         initial_load_completed: Arc<AtomicBool>,
     ) -> crate::accelerated_table::Result<()> {
         let dataset_name = self.dataset_name.clone();
+        // Prebuilt dataset metric labels reused by this stream's hot record sites
+        // (reader send-wait, apply cycle, coalesce flush, burst, fixed-cost
+        // phases). Clone is an `Arc` refcount bump — see `DatasetMetricLabels`.
+        let metric_labels = self.dataset_metric_labels.clone();
         let sql = refresh.read().await.display_sql();
 
         self.set_refresh_status(sql.as_deref(), status::ComponentStatus::Refreshing)
@@ -1034,9 +1042,10 @@ impl RefreshTask {
         let tx_probe = tx.downgrade();
 
         let reader_dataset = dataset_name.clone();
+        let reader_metric_labels = metric_labels.clone();
         let reader_handle = tokio::spawn(async move {
             let mut stream = changes_stream;
-            let send_labels = [KeyValue::new("dataset", reader_dataset.to_string())];
+            let send_labels = reader_metric_labels.dataset();
             // `select!` on `tx.closed()` lets the reader exit promptly even
             // when it is parked in `stream.next()`. This matters at shutdown:
             // when the parent task is aborted, its locals (including `rx`)
@@ -1060,7 +1069,7 @@ impl RefreshTask {
                         // full and the apply loop can't drain fast enough (apply-bound).
                         let send_start = Instant::now();
                         let send_res = tx.send(item).await;
-                        metrics::CDC_READER_SEND_WAIT_MS.record(elapsed_ms(send_start), &send_labels);
+                        metrics::CDC_READER_SEND_WAIT_MS.record(elapsed_ms(send_start), send_labels);
                         if send_res.is_err() {
                             tracing::debug!(
                                 "CDC consumer for {reader_dataset} dropped; reader exiting"
@@ -1097,7 +1106,7 @@ impl RefreshTask {
         let mut last_cycle_start = Instant::now();
         let write_ctx = SessionContext::new();
         let write_session_state = write_ctx.state();
-        let recv_wait_labels = [KeyValue::new("dataset", dataset_name.to_string())];
+        let recv_wait_labels = metric_labels.dataset();
 
         // In-memory CDC durability (`cdc_durability: memory`): if this stream's
         // Cayenne provider is memory-capable, set up the deferred-commit queue.
@@ -1130,7 +1139,7 @@ impl RefreshTask {
             // Apply cadence: period between successive burst recv-starts (ground-truths
             // the per-stage attribution, which overstates the cycle where phases overlap).
             if let Some(prev) = prev_recv_start {
-                metrics::CDC_APPLY_CYCLE_MS.record(elapsed_ms(prev), &recv_wait_labels);
+                metrics::CDC_APPLY_CYCLE_MS.record(elapsed_ms(prev), recv_wait_labels);
             }
             prev_recv_start = Some(recv_start);
             let from_carried = carried_item.is_some();
@@ -1181,6 +1190,7 @@ impl RefreshTask {
                             let mut context = ApplyContext {
                                 refresh_sql: sql.as_deref(),
                                 dataset_name: &dataset_name,
+                                metric_labels: &metric_labels,
                                 caching: caching.as_ref(),
                                 ready_sender: ready_sender.as_ref(),
                                 initial_load_completed: &initial_load_completed,
@@ -1209,15 +1219,15 @@ impl RefreshTask {
                     }
                 },
             };
-            metrics::CDC_SOURCE_RECV_WAIT_MS.record(elapsed_ms(recv_start), &recv_wait_labels);
+            metrics::CDC_SOURCE_RECV_WAIT_MS.record(elapsed_ms(recv_start), recv_wait_labels);
             // Sample prefetch-channel occupancy at the moment the apply loop wakes
             // (the just-received `first` is out of the buffer; whatever remains is
             // the backlog the reader has queued ahead). Near capacity => apply-bound.
             if let Some(tx) = tx_probe.upgrade() {
                 let capacity = tx.max_capacity() as u64;
                 let occupancy = capacity.saturating_sub(tx.capacity() as u64);
-                metrics::CDC_PREFETCH_BUFFER_OCCUPANCY.record(occupancy, &recv_wait_labels);
-                metrics::CDC_PREFETCH_BUFFER_CAPACITY.record(capacity, &recv_wait_labels);
+                metrics::CDC_PREFETCH_BUFFER_OCCUPANCY.record(occupancy, recv_wait_labels);
+                metrics::CDC_PREFETCH_BUFFER_CAPACITY.record(capacity, recv_wait_labels);
             }
             let Some(first) = next_item else {
                 break;
@@ -1256,7 +1266,7 @@ impl RefreshTask {
                         reason = "arrival lag in ms as f64 for the histogram; sub-ms precision is irrelevant at second/minute-scale backlogs"
                     )]
                     let arrival_lag_ms = now_ms.saturating_sub(commit_ts_ms).max(0) as f64;
-                    metrics::CDC_SOURCE_ARRIVAL_LAG_MS.record(arrival_lag_ms, &recv_wait_labels);
+                    metrics::CDC_SOURCE_ARRIVAL_LAG_MS.record(arrival_lag_ms, recv_wait_labels);
                 }
             }
             // First envelope of this burst is now in hand; time from here until the
@@ -1374,7 +1384,7 @@ impl RefreshTask {
                         }
                     }
                 }
-                metrics::CDC_LINGER_WAIT_MS.record(elapsed_ms(linger_start), &recv_wait_labels);
+                metrics::CDC_LINGER_WAIT_MS.record(elapsed_ms(linger_start), recv_wait_labels);
             }
 
             // Attribute what ended coalescing and how long the head-of-batch
@@ -1396,14 +1406,8 @@ impl RefreshTask {
                 "buffer_drained"
             };
             metrics::CDC_COALESCE_BATCH_AGE_MS
-                .record(elapsed_ms(batch_first_received), &recv_wait_labels);
-            metrics::CDC_COALESCE_FLUSH_TOTAL.add(
-                1,
-                &[
-                    KeyValue::new("dataset", dataset_name.to_string()),
-                    KeyValue::new("reason", flush_reason),
-                ],
-            );
+                .record(elapsed_ms(batch_first_received), recv_wait_labels);
+            metrics::CDC_COALESCE_FLUSH_TOTAL.add(1, &metric_labels.tagged("reason", flush_reason));
 
             // Mark the start of this burst's processing cycle: the next burst's
             // linger deadline is measured from here, so the apply below counts as
@@ -1413,6 +1417,7 @@ impl RefreshTask {
             let mut apply_context = ApplyContext {
                 refresh_sql: sql.as_deref(),
                 dataset_name: &dataset_name,
+                metric_labels: &metric_labels,
                 caching: caching.as_ref(),
                 ready_sender: ready_sender.as_ref(),
                 initial_load_completed: &initial_load_completed,
@@ -1470,6 +1475,7 @@ impl RefreshTask {
                 let mut context = ApplyContext {
                     refresh_sql: sql.as_deref(),
                     dataset_name: &dataset_name,
+                    metric_labels: &metric_labels,
                     caching: caching.as_ref(),
                     ready_sender: ready_sender.as_ref(),
                     initial_load_completed: &initial_load_completed,
@@ -1574,11 +1580,11 @@ impl RefreshTask {
             .filter_map(|item| item.as_ref().ok())
             .map(|env| env.change_batch.record.num_rows() as u64)
             .fold(0_u64, u64::saturating_add);
-        let labels = [KeyValue::new("dataset", context.dataset_name.to_string())];
-        metrics::CDC_APPLY_BURST_ENVELOPES.record(burst_envelopes, &labels);
+        let labels = context.metric_labels.dataset();
+        metrics::CDC_APPLY_BURST_ENVELOPES.record(burst_envelopes, labels);
         metrics::CDC_APPLY_BURST_BYTES
-            .record(u64::try_from(burst_bytes).unwrap_or(u64::MAX), &labels);
-        metrics::CDC_APPLY_BURST_ROWS_TOTAL.add(burst_rows, &labels);
+            .record(u64::try_from(burst_bytes).unwrap_or(u64::MAX), labels);
+        metrics::CDC_APPLY_BURST_ROWS_TOTAL.add(burst_rows, labels);
 
         // Freshest upstream commit timestamp in this burst, for the CDC
         // replication-lag gauge. Computed here (before the burst is consumed by the
@@ -1598,7 +1604,7 @@ impl RefreshTask {
             .filter_map(|env| env.change_batch.source_commit_ts_ms())
             .max();
         if let Some(ts) = max_commit_ts_ms {
-            metrics::CDC_RECEIVED_COMMIT_UNIX_TIME_MS.record(ts, &labels);
+            metrics::CDC_RECEIVED_COMMIT_UNIX_TIME_MS.record(ts, labels);
         }
 
         // Walk the burst preserving arrival order, processing contiguous
@@ -1619,7 +1625,7 @@ impl RefreshTask {
 
                     if !self.apply_envelope_run(context, envelopes).await {
                         metrics::CDC_APPLY_BURST_DURATION_MS
-                            .record(elapsed_ms(burst_start), &labels);
+                            .record(elapsed_ms(burst_start), labels);
                         return false;
                     }
                 }
@@ -1650,7 +1656,7 @@ impl RefreshTask {
             apply_ms = elapsed_ms(burst_start),
             "Applied coalesced CDC change burst"
         );
-        metrics::CDC_APPLY_BURST_DURATION_MS.record(elapsed_ms(burst_start), &labels);
+        metrics::CDC_APPLY_BURST_DURATION_MS.record(elapsed_ms(burst_start), labels);
 
         // Record CDC progress only now that the burst's Ok runs have applied (the
         // early `return false` above skips it, so a failed apply never reports fresh
@@ -1659,10 +1665,10 @@ impl RefreshTask {
         // wall clock (skipped on pre-epoch / overflow rather than reporting a
         // misleading 0ms).
         if let Some(max_commit_ts_ms) = max_commit_ts_ms {
-            metrics::CDC_APPLIED_COMMIT_UNIX_TIME_MS.record(max_commit_ts_ms, &labels);
+            metrics::CDC_APPLIED_COMMIT_UNIX_TIME_MS.record(max_commit_ts_ms, labels);
             if let Some(now_ms) = util::time::system_time_to_unix_ms(std::time::SystemTime::now()) {
                 metrics::CDC_REPLICATION_LAG_MS
-                    .record(now_ms.saturating_sub(max_commit_ts_ms).max(0), &labels);
+                    .record(now_ms.saturating_sub(max_commit_ts_ms).max(0), labels);
             }
         }
         true
@@ -1745,7 +1751,7 @@ impl RefreshTask {
                     .await;
                     return false;
                 }
-                record_cdc_fixed_cost(context.dataset_name, "commit_wait", commit_wait_start);
+                record_cdc_fixed_cost(context.metric_labels, "commit_wait", commit_wait_start);
             }
 
             *context.pending_commit = Some(spawn_ordered_commit_task(
@@ -1854,7 +1860,7 @@ impl RefreshTask {
                 }
             }
         };
-        record_cdc_fixed_cost(context.dataset_name, "coalesce", coalesce_start);
+        record_cdc_fixed_cost(context.metric_labels, "coalesce", coalesce_start);
 
         #[cfg(not(windows))]
         let can_defer_current_burst = committers_all_support_deferral(&committers);
@@ -1915,7 +1921,7 @@ impl RefreshTask {
             .await
         {
             Ok(write_outcome) => {
-                record_cdc_fixed_cost(context.dataset_name, "write", write_start);
+                record_cdc_fixed_cost(context.metric_labels, "write", write_start);
 
                 if let Some(previous_pending) = context.pending_finalize.take() {
                     let finalize_start = Instant::now();
@@ -1933,7 +1939,7 @@ impl RefreshTask {
                         .await;
                         return CoalescedRunOutcome::Stop;
                     }
-                    record_cdc_fixed_cost(context.dataset_name, "finalize_wait", finalize_start);
+                    record_cdc_fixed_cost(context.metric_labels, "finalize_wait", finalize_start);
 
                     if !self
                         .run_finalize_side_effects(
@@ -2001,7 +2007,7 @@ impl RefreshTask {
                             return CoalescedRunOutcome::Stop;
                         }
                         record_cdc_fixed_cost(
-                            context.dataset_name,
+                            context.metric_labels,
                             "commit_wait",
                             commit_wait_start,
                         );
@@ -2254,13 +2260,13 @@ impl RefreshTask {
                 // A pending finalize is the durable Stage-B path — never memory
                 // mode (an in-memory-staged write has nothing to finalize), so no
                 // epoch to defer here.
-                record_cdc_apply_path(&self.dataset_name, "durable_append");
+                record_cdc_apply_path(&self.dataset_metric_labels, "durable_append");
                 return Ok(UpsertOutcome {
                     pending_finalize: Some(spawn_cayenne_finalize(cayenne_write)),
                     in_memory_epoch: None,
                 });
             }
-            record_cdc_apply_path(&self.dataset_name, "inmem_append");
+            record_cdc_apply_path(&self.dataset_metric_labels, "inmem_append");
 
             cayenne_write
                 .finish()
@@ -2613,7 +2619,7 @@ impl RefreshTask {
             .count();
         metrics::CDC_KEYS_PER_DELETE_BURST.record(
             u64::try_from(keyed_count).unwrap_or(u64::MAX),
-            &[KeyValue::new("dataset", dataset_name.to_string())],
+            self.dataset_metric_labels.dataset(),
         );
 
         // In-memory absorption: when the burst-level gate kept this burst on
@@ -2655,7 +2661,7 @@ impl RefreshTask {
                     epoch,
                     "Delete sub-batch absorbed into the in-memory CDC tier"
                 );
-                record_cdc_apply_path(dataset_name, "inmem_delete");
+                record_cdc_apply_path(&self.dataset_metric_labels, "inmem_delete");
                 self.update_last_updated_at();
                 return Ok(Some(epoch));
             }
@@ -2673,10 +2679,9 @@ impl RefreshTask {
 
         metrics::CDC_DELETE_ABSORB_FALLTHROUGH.add(
             1,
-            &[
-                KeyValue::new("dataset", dataset_name.to_string()),
-                KeyValue::new("reason", fallthrough_reason),
-            ],
+            &self
+                .dataset_metric_labels
+                .tagged("reason", fallthrough_reason),
         );
 
         // Durable delete fallback (in-memory absorb declined, e.g. deletes cleared
@@ -2685,7 +2690,7 @@ impl RefreshTask {
         // and, before these sub-phases, was invisible in the write-phase breakdown
         // (it is not a cayenne write_phase). Decompose it so a table pinned here
         // (new_order) shows WHERE its apply time goes.
-        record_cdc_apply_path(dataset_name, "durable_delete");
+        record_cdc_apply_path(&self.dataset_metric_labels, "durable_delete");
         let (keyless_rows, keyed_rows): (Vec<_>, Vec<_>) = row_indices
             .iter()
             .copied()
@@ -2696,7 +2701,11 @@ impl RefreshTask {
         // acquire alone can dominate a delete burst.
         let lock_start = Instant::now();
         let _lock_guard = self.accelerator_write_mutex.lock().await;
-        record_cdc_fixed_cost(dataset_name, "durable_delete_lock_wait", lock_start);
+        record_cdc_fixed_cost(
+            &self.dataset_metric_labels,
+            "durable_delete_lock_wait",
+            lock_start,
+        );
         let apply_start = Instant::now();
 
         if !keyless_rows.is_empty() {
@@ -2771,14 +2780,22 @@ impl RefreshTask {
                 wrote = true;
             }
         }
-        record_cdc_fixed_cost(dataset_name, "durable_delete_apply", apply_start);
+        record_cdc_fixed_cost(
+            &self.dataset_metric_labels,
+            "durable_delete_apply",
+            apply_start,
+        );
 
         if wrote {
             // Whole-burst maintenance (compaction trigger) runs synchronously here —
             // a prime contributor to a long durable-delete burst; time it separately.
             let maint_start = Instant::now();
             perform_change_write_maintenance(&self.accelerator).await?;
-            record_cdc_fixed_cost(dataset_name, "durable_delete_maintenance", maint_start);
+            record_cdc_fixed_cost(
+                &self.dataset_metric_labels,
+                "durable_delete_maintenance",
+                maint_start,
+            );
             self.update_last_updated_at();
         }
 
@@ -2863,12 +2880,8 @@ fn elapsed_ms(start: Instant) -> f64 {
     start.elapsed().as_secs_f64() * 1000.0
 }
 
-fn record_cdc_fixed_cost(dataset_name: &TableReference, phase: &'static str, start: Instant) {
-    let labels = [
-        KeyValue::new("dataset", dataset_name.to_string()),
-        KeyValue::new("phase", phase),
-    ];
-    metrics::CDC_APPLY_FIXED_COST_MS.record(elapsed_ms(start), &labels);
+fn record_cdc_fixed_cost(labels: &DatasetMetricLabels, phase: &'static str, start: Instant) {
+    metrics::CDC_APPLY_FIXED_COST_MS.record(elapsed_ms(start), &labels.tagged("phase", phase));
 }
 
 /// Count which apply path a change sub-batch took. `inmem_append` / `inmem_delete`
@@ -2877,12 +2890,8 @@ fn record_cdc_fixed_cost(dataset_name: &TableReference, phase: &'static str, sta
 /// expensive path a table is forced onto when a burst can't defer (e.g. deletes
 /// clear the slot-advancer). Reveals WHY a table's apply time is high, which the
 /// phase-coverage gap can only hint at.
-fn record_cdc_apply_path(dataset_name: &TableReference, path: &'static str) {
-    let labels = [
-        KeyValue::new("dataset", dataset_name.to_string()),
-        KeyValue::new("path", path),
-    ];
-    metrics::CDC_APPLY_PATH_TOTAL.add(1, &labels);
+fn record_cdc_apply_path(labels: &DatasetMetricLabels, path: &'static str) {
+    metrics::CDC_APPLY_PATH_TOTAL.add(1, &labels.tagged("path", path));
 }
 
 fn select_rows(
@@ -5785,6 +5794,7 @@ mod tests {
         let task = make_refresh_task(provider as Arc<dyn TableProvider>);
         let log = CommitLog::new();
         let dataset_name = TableReference::bare("test");
+        let metric_labels = DatasetMetricLabels::new(&dataset_name);
         let initial_load_completed = Arc::new(AtomicBool::new(false));
         let mut pending_finalize = None;
         let mut pending_commit = None;
@@ -5793,6 +5803,7 @@ mod tests {
         let mut context = ApplyContext {
             refresh_sql: None,
             dataset_name: &dataset_name,
+            metric_labels: &metric_labels,
             caching: None,
             ready_sender: None,
             initial_load_completed: &initial_load_completed,
@@ -6018,6 +6029,7 @@ mod tests {
     #[tokio::test]
     async fn test_apply_envelope_run_mixed_schemas_applies_per_group_under_policy() {
         let dataset_name = TableReference::bare("schema_evo_mixed_groups");
+        let metric_labels = DatasetMetricLabels::new(&dataset_name);
         install_cdc_schema_evolution(
             &dataset_name,
             CdcSchemaEvolution {
@@ -6039,6 +6051,7 @@ mod tests {
         let mut context = ApplyContext {
             refresh_sql: None,
             dataset_name: &dataset_name,
+            metric_labels: &metric_labels,
             caching: None,
             ready_sender: None,
             initial_load_completed: &initial_load_completed,
@@ -6083,6 +6096,7 @@ mod tests {
     #[tokio::test]
     async fn test_apply_envelope_run_mixed_schemas_without_policy_keeps_error_skip() {
         let dataset_name = TableReference::bare("schema_evo_mixed_block");
+        let metric_labels = DatasetMetricLabels::new(&dataset_name);
         let task = make_refresh_task_named(
             "schema_evo_mixed_block",
             make_mem_table() as Arc<dyn TableProvider>,
@@ -6096,6 +6110,7 @@ mod tests {
         let mut context = ApplyContext {
             refresh_sql: None,
             dataset_name: &dataset_name,
+            metric_labels: &metric_labels,
             caching: None,
             ready_sender: None,
             initial_load_completed: &initial_load_completed,

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -304,8 +304,8 @@ impl CdcInsertPlanCache {
 struct ApplyContext<'a> {
     refresh_sql: Option<&'a str>,
     dataset_name: &'a TableReference,
-    /// Prebuilt per-dataset metric labels reused by the apply-loop record sites
-    /// (see [`DatasetMetricLabels`]). Always `&self.dataset_metric_labels`.
+    /// Prebuilt per-dataset metric labels reused by hot record sites in the apply loop
+    /// (see [`DatasetMetricLabels`]).
     metric_labels: &'a DatasetMetricLabels,
     caching: Option<&'a Weak<Caching>>,
     ready_sender: Option<&'a Arc<Notify>>,


### PR DESCRIPTION
## What

The CDC apply-path counters and fixed-cost timers added in the recent observability work (#11610, #11673) rebuilt `KeyValue::new("dataset", dataset_name.to_string())` on **every** call — per flush, per sub-batch, per burst — at full ingress rates, heap-allocating the `dataset` label each time.

This builds the dataset label **once per dataset task** and reuses it, matching the pattern the CDC reader loop already used for `send_labels`/`recv_wait_labels`.

## How

- Add `DatasetMetricLabels`, holding the `dataset` label as a `KeyValue` backed by an `Arc<str>`:
  - `dataset()` → `&[KeyValue]` — zero-allocation slice reuse for single-label sites.
  - `tagged(key, value)` → `[KeyValue; 2]` — clones the cached label (an `Arc` refcount bump, no string copy) and appends a `&'static` second label (no allocation); only a two-element stack array is produced.
- Store it on `RefreshTask`, built once in the builder; thread it through `ApplyContext` and the `record_cdc_fixed_cost` / `record_cdc_apply_path` helpers (now taking `&DatasetMetricLabels` instead of `&TableReference`).
- Convert every hot CDC apply-loop record site (`CDC_APPLY_*`, `CDC_COALESCE_*`, `CDC_KEYS_PER_DELETE_BURST`, `CDC_DELETE_ABSORB_FALLTHROUGH`, the fixed-cost phase timers, the apply-path counters) plus the per-batch refresh-ingestion counters (`REFRESH_ROWS_WRITTEN`/`REFRESH_BYTES_WRITTEN`, which cloned a `String` per batch).

## Scope / correctness

- **Source-agnostic:** the converted sites live in the shared apply loop, so every CDC connector (Postgres shared/dedicated slot, MySQL, Kafka, MongoDB, DynamoDB) benefits.
- **Metric output is byte-identical:** label key order is unchanged, and an `Arc<str>`-backed `KeyValue` value renders identically to the previous owned string (opentelemetry `OtelString::RefCounted` vs. `Owned`).
- Deliberately left the cold/rare sites alone (per-refresh-completion counters, `SCHEMA_EVOLUTION_FAILED` error paths, and the multi-dataset-name loops where a single cached label would be incorrect) — none are hot loops.

## Testing

- `cargo check -p runtime` — green.
- `cargo test -p runtime --lib accelerated_table::refresh_task::changes` — 66 passed, 0 failed.
- `make lint-rust-fix PACKAGES="runtime"` — clippy gate.