### PR TITLE
Update integration_models.yml

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -2,42 +2,42 @@
 name: integration tests (models)
 
 on:
-  push:
-    branches:
-      - trunk
-      - release/*
-  pull_request:
-    branches:
-      - trunk
-      - release-*
-      - release/*
-      - feature-*
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'README.md'
-      - 'Makefile'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'LICENSE'
-      - '.github/**'
-      - 'version.txt'
-      - '.schema/**'
-      - '.vscode/**'
-      - 'deploy/**'
-      - 'install/**'
-      - 'media/**'
-      - 'monitoring/**'
-      - 'acknowledgements.md'
-      - 'Dockerfile*'
-      - 'bin/spice/**'
+  # push:
+  #   branches:
+  #     - trunk
+  #     - release/*
+  # pull_request:
+  #   branches:
+  #     - trunk
+  #     - release-*
+  #     - release/*
+  #     - feature-*
+  #   paths-ignore:
+  #     - '**/*.md'
+  #     - 'docs/**'
+  #     - 'README.md'
+  #     - 'Makefile'
+  #     - 'CONTRIBUTING.md'
+  #     - 'SECURITY.md'
+  #     - 'LICENSE'
+  #     - '.github/**'
+  #     - 'version.txt'
+  #     - '.schema/**'
+  #     - '.vscode/**'
+  #     - 'deploy/**'
+  #     - 'install/**'
+  #     - 'media/**'
+  #     - 'monitoring/**'
+  #     - 'acknowledgements.md'
+  #     - 'Dockerfile*'
+  #     - 'bin/spice/**'
 
-  merge_group:
-    branches:
-      - trunk
-      - release-*
-      - release/*
-      - feature-*
+  # merge_group:
+  #   branches:
+  #     - trunk
+  #     - release-*
+  #     - release/*
+  #     - feature-*
 
   schedule:
     - cron: '0 0 * * *' # Daily at midnight UTC

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -2,43 +2,6 @@
 name: integration tests (models)
 
 on:
-  # push:
-  #   branches:
-  #     - trunk
-  #     - release/*
-  # pull_request:
-  #   branches:
-  #     - trunk
-  #     - release-*
-  #     - release/*
-  #     - feature-*
-  #   paths-ignore:
-  #     - '**/*.md'
-  #     - 'docs/**'
-  #     - 'README.md'
-  #     - 'Makefile'
-  #     - 'CONTRIBUTING.md'
-  #     - 'SECURITY.md'
-  #     - 'LICENSE'
-  #     - '.github/**'
-  #     - 'version.txt'
-  #     - '.schema/**'
-  #     - '.vscode/**'
-  #     - 'deploy/**'
-  #     - 'install/**'
-  #     - 'media/**'
-  #     - 'monitoring/**'
-  #     - 'acknowledgements.md'
-  #     - 'Dockerfile*'
-  #     - 'bin/spice/**'
-
-  # merge_group:
-  #   branches:
-  #     - trunk
-  #     - release-*
-  #     - release/*
-  #     - feature-*
-
   schedule:
     - cron: '0 0 * * *' # Daily at midnight UTC
 


### PR DESCRIPTION
Do not run on PRs or merge groups.

`integration_models.yml` was manually disabled, likely due to flaky tests. We should still allow manual runs, and run on schedule for testing/auditing purposes.
