### PR TITLE
feat(testoperator): TPC-DS SF100 federated cluster-bench spicepod + default spicehq nodegroup

### DIFF
--- a/.github/workflows/testoperator_run_cluster_bench.yml
+++ b/.github/workflows/testoperator_run_cluster_bench.yml
@@ -48,6 +48,11 @@ on:
         required: true
         default: '4'
         type: string
+      organization_tag:
+        description: 'Organization tag applied to the spidapter app; selects the target nodegroup (empty = shared default nodegroup)'
+        required: false
+        default: 'spicehq'
+        type: string
       channel:
         description: 'Spice runtime image channel passed to spidapter (ignored when custom_image_tag is set)'
         required: true
@@ -163,6 +168,7 @@ env:
   CB_SCENARIO_QUERY_FILE: ${{ github.event.inputs.scenario_query_file || '' }}
   CB_QUERY_TRANSPORT: ${{ github.event.inputs.query_transport || 'v1-queries' }}
   CB_EXECUTOR_REPLICAS: ${{ github.event.inputs.executor_replicas || '3' }}
+  CB_ORGANIZATION_TAG: ${{ github.event.inputs.organization_tag || 'spicehq' }}
   CB_CHANNEL: ${{ github.event.inputs.channel || 'nightly' }}
   CB_CUSTOM_IMAGE_TAG: ${{ github.event.inputs.custom_image_tag || '' }}
   CB_SHUFFLE_LOCATION: ${{ github.event.inputs.shuffle_location || '' }}
@@ -281,6 +287,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ICEBERG_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
           AWS_DEFAULT_REGION: us-east-1
+          # Select the nodegroup for the spidapter cluster app via tags.organization.
+          # Defaults to the dedicated spicehq nodegroup; without it the app lands on
+          # the shared default nodegroup.
+          SPIDAPTER_ORGANIZATION_TAG: ${{ env.CB_ORGANIZATION_TAG }}
           SCHEDULER_STATE_LOCATION: 's3://spiceai-testing-cluster-state/testoperator-cluster-bench-${{ github.run_id }}/'
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           EXECUTOR_REPLICAS: ${{ env.CB_EXECUTOR_REPLICAS }}

--- a/test/spicepods/tpcds/sf100/federated/s3-public[parquet].yaml
+++ b/test/spicepods/tpcds/sf100/federated/s3-public[parquet].yaml
@@ -1,0 +1,80 @@
+version: v1
+kind: Spicepod
+name: s3-public[parquet]-federated
+
+datasets:
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/call_center.parquet
+    name: call_center
+    params: &s3_params
+      file_format: parquet
+      s3_auth: public
+      s3_region: us-west-2
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/catalog_page.parquet
+    name: catalog_page
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/catalog_returns.parquet
+    name: catalog_returns
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/catalog_sales.parquet
+    name: catalog_sales
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/customer.parquet
+    name: customer
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/customer_address.parquet
+    name: customer_address
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/customer_demographics.parquet
+    name: customer_demographics
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/date_dim.parquet
+    name: date_dim
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/household_demographics.parquet
+    name: household_demographics
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/income_band.parquet
+    name: income_band
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/inventory.parquet
+    name: inventory
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/item.parquet
+    name: item
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/promotion.parquet
+    name: promotion
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/reason.parquet
+    name: reason
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/ship_mode.parquet
+    name: ship_mode
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/store.parquet
+    name: store
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/store_returns.parquet
+    name: store_returns
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/store_sales.parquet
+    name: store_sales
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/time_dim.parquet
+    name: time_dim
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/warehouse.parquet
+    name: warehouse
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/web_page.parquet
+    name: web_page
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/web_returns.parquet
+    name: web_returns
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/web_sales.parquet
+    name: web_sales
+    params: *s3_params
+  - from: s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100/web_site.parquet
+    name: web_site
+    params: *s3_params


### PR DESCRIPTION
## What

Two additions to the distributed (Ballista) cluster-bench harness:

1. **TPC-DS SF100 federated public-S3 spicepod** — `test/spicepods/tpcds/sf100/federated/s3-public[parquet].yaml`. Mirrors the existing TPC-H `federated/s3-public[parquet].yaml`: all 24 TPC-DS tables read directly from public AWS S3 (`s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100`, `s3_auth: public`, us-west-2), no acceleration — the federated distributed-query path over TPC-DS at SF100.

2. **`organization_tag` wiring (defaults to `spicehq`)** in `testoperator_run_cluster_bench.yml`. The spidapter cluster app only gets a `tags.organization` label when `SPIDAPTER_ORGANIZATION_TAG` is set, and nothing set it — so cluster-bench apps scheduled on the shared default nodegroup instead of the dedicated `spicehq` nodegroup. This adds an `organization_tag` input (default `spicehq`) → `CB_ORGANIZATION_TAG` → `SPIDAPTER_ORGANIZATION_TAG`, so runs land on the right nodegroup by default (pass an empty value to use the shared nodegroup).

## Intentionally omitted

No `dispatch_cluster/tpcds/**` spec is added — **this must not run automatically.** The SF100 data is staged in the public bucket, so the spicepod is exercised on demand via `workflow_dispatch`:
`spicepod_path=federated/s3-public[parquet].yaml`, `query_set=tpcds`, `scale_factor=100`, `query_transport=v1-queries`.

## Notes

- SF100 data generated with `tpcgen-cli` (tpchgen-rs) and uploaded to `s3://spiceai-sandbox-tpch-us-west-2/tpcds_sf100` (public-readable, single file per table).
- Harness-only change: no runtime code touched.
