### PR TITLE
fix(spicepod): reject unknown fields on columns[] config (fixes #10972)

### DIFF
--- a/crates/spicepod/src/semantic.rs
+++ b/crates/spicepod/src/semantic.rs
@@ -30,6 +30,7 @@ use crate::{
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Column {
     pub name: String,
 
@@ -148,6 +149,7 @@ impl From<&str> for Column {
 ///
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct ColumnLevelEmbeddingConfig {
     #[serde(rename = "from", default)]
     pub model: String,
@@ -270,6 +272,7 @@ where
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct FullTextSearchConfig {
     pub enabled: bool,
 
@@ -470,5 +473,77 @@ mod tests {
         let parsed: ColumnLevelEmbeddingConfig =
             yaml::from_str(yaml).expect("Failed to parse ColumnLevelEmbeddingConfig");
         assert_eq!(parsed.row_ids, None);
+    }
+
+    // Regression tests for #10972 — column-level configuration silently accepted
+    // typo'd/unknown fields. `Column`, `ColumnLevelEmbeddingConfig`, and
+    // `FullTextSearchConfig` now carry `#[serde(deny_unknown_fields)]`, matching
+    // their parent `Dataset` and the rest of the spicepod component structs.
+
+    #[test]
+    fn test_column_valid_fields_parse() {
+        let yaml = r"
+name: id
+type: bigint
+nullable: false
+description: primary key
+";
+        let column: Column = yaml::from_str(yaml).expect("Failed to parse Column");
+        assert_eq!(column.name, "id");
+        assert_eq!(column.r#type.as_deref(), Some("bigint"));
+        assert_eq!(column.nullable, Some(false));
+    }
+
+    #[test]
+    fn test_column_data_type_alias_still_parses() {
+        // `data_type` is an accepted alias for `type`; deny_unknown_fields must
+        // not reject aliased fields.
+        let yaml = r"
+name: id
+data_type: bigint
+";
+        let column: Column = yaml::from_str(yaml).expect("Failed to parse Column");
+        assert_eq!(column.r#type.as_deref(), Some("bigint"));
+    }
+
+    #[test]
+    fn test_column_unknown_field_rejected() {
+        // Issue #10972 case A: `typee`/`nulleble` were silently discarded.
+        let yaml = r"
+name: id
+typee: bigint
+nulleble: false
+";
+        let result: Result<Column, _> = yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "unknown fields on columns[] should be rejected due to deny_unknown_fields"
+        );
+    }
+
+    #[test]
+    fn test_column_embedding_config_unknown_field_rejected() {
+        let yaml = r"
+from: model_name
+vector_sizee: 384
+";
+        let result: Result<ColumnLevelEmbeddingConfig, _> = yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "unknown fields on columns[].embeddings[] should be rejected due to deny_unknown_fields"
+        );
+    }
+
+    #[test]
+    fn test_full_text_search_config_unknown_field_rejected() {
+        let yaml = r"
+enabled: true
+index_storee: memory
+";
+        let result: Result<FullTextSearchConfig, _> = yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "unknown fields on columns[].full_text_search should be rejected due to deny_unknown_fields"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Spicepod dataset column configuration silently accepted unknown/typo'd fields. A column defined with `typee: bigint` or `nulleble: false` parsed cleanly — `spice validate` reported `OK` and the runtime started — while the misspelled fields were discarded and the intended schema declaration never took effect (issue #10972, case A).

**Root cause:** the three column-level config structs — `Column`, `ColumnLevelEmbeddingConfig`, and `FullTextSearchConfig` (`crates/spicepod/src/semantic.rs`) — lacked `#[serde(deny_unknown_fields)]`. Their parent `Dataset` and ~30 sibling component structs across the crate already deny unknown fields, so a typo at the dataset level (`datasets[].nam`) errored, while the same class of typo one level down under `columns[]` passed silently. That is an inconsistency, not a deliberate leniency policy.

## Changes

- Add `#[serde(deny_unknown_fields)]` to `Column`, `ColumnLevelEmbeddingConfig`, and `FullTextSearchConfig`, bringing them in line with `Dataset` and the rest of the crate. serde now rejects unrecognized keys, naming the field it did not expect.
- None of the three structs use `#[serde(flatten)]` — their `params`/`metadata` are explicit keys — so open connector/engine params and column metadata are unaffected.
- Add regression tests: valid fields (incl. the `data_type` alias) still parse; unknown fields on each of the three structs are now rejected.

## Scope

Fixes issue case **A** (column field-name typos). Deliberately out of scope:
- Cases **C**/**D** — `runtime.params` key/value typos — are a free-form `HashMap` and are tracked separately in #10970.
- Case **B** — garbage *values* for `columns[].type` — depends on the Phase 2 type-parsing work noted in #10661 (the field is currently forwarded without runtime effect).

## Test plan

- `make lint`
- `make test`

## Checklist

- [x] Regression test fails on old code, passes on new
- [x] Existing spicepod fixtures (`test_all_v1_fixtures_load`, `test_all_v2_fixtures_load`) still load
- [x] `schemars` feature still compiles (deny_unknown_fields sets `additionalProperties: false` in the generated schema)
- [x] No behavior change to open `params`/`metadata` maps

Fixes #10972