### PR TITLE
perf(vortex): push boolean NOT filters into the Vortex scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22206,6 +22206,7 @@ dependencies = [
  "anyhow",
  "arrow-schema",
  "async-trait",
+ "criterion 0.7.0",
  "datafusion",
  "datafusion-catalog",
  "datafusion-common",

--- a/crates/vortex/Cargo.toml
+++ b/crates/vortex/Cargo.toml
@@ -39,9 +39,15 @@ vortex-utils = { workspace = true, features = ["dashmap"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 datafusion = { workspace = true }
+datafusion-common = { workspace = true }
 insta = { workspace = true }
 rstest = "0.26.1"
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "rt-multi-thread", "fs"] }
 url = { workspace = true }
+
+[[bench]]
+harness = false
+name = "filter_pushdown_not"

--- a/crates/vortex/Cargo.toml
+++ b/crates/vortex/Cargo.toml
@@ -41,7 +41,6 @@ vortex-utils = { workspace = true, features = ["dashmap"] }
 anyhow = { workspace = true }
 criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 datafusion = { workspace = true }
-datafusion-common = { workspace = true }
 insta = { workspace = true }
 rstest = "0.26.1"
 tempfile = { workspace = true }

--- a/crates/vortex/benches/filter_pushdown_not.rs
+++ b/crates/vortex/benches/filter_pushdown_not.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! End-to-end benchmark for boolean `NOT` filter pushdown.
+//!
+//! A selective `WHERE NOT flag` over a wide table is the target: when the
+//! predicate pushes into the Vortex scan, the scan evaluates the boolean
+//! during the scan and only materializes the wide payload columns for the
+//! surviving rows (late materialization) instead of decoding every column for
+//! every row and re-filtering in a `FilterExec` above the scan.
+//!
+//! `not_flag_boolean` is the query the pushdown fixes. `eq_zero_int_reference`
+//! is the same selectivity expressed as an integer equality that always pushed
+//! down — it is the floor `not_flag_boolean` should reach once the boolean
+//! `NOT` also pushes.
+
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use datafusion::datasource::provider::DefaultTableFactory;
+use datafusion::execution::SessionStateBuilder;
+use datafusion::prelude::SessionContext;
+use datafusion_common::GetExt;
+use object_store::memory::InMemory;
+use tokio::runtime::Runtime;
+use vortex::VortexSessionDefault;
+use vortex::io::session::RuntimeSessionExt;
+use vortex::session::VortexSession;
+use vortex_datafusion::{VortexFormatFactory, VortexTableOptions};
+
+/// Rows in the benched table. Wide enough that per-row decode dominates and
+/// small enough that the bench completes quickly.
+const ROW_COUNT: usize = 262_144;
+/// One row in every `SELECTIVITY_DIVISOR` has `flag = false`, so `NOT flag`
+/// (and the integer reference) keep ~6% of rows — selective enough that late
+/// materialization of the payload columns is the dominant cost.
+const SELECTIVITY_DIVISOR: usize = 16;
+
+/// Vortex's write path resolves its executor from the ambient Tokio runtime
+/// unless the session is explicitly configured with one; a current-thread
+/// runtime satisfies that (a multi-thread `Runtime::new()` does not).
+fn build_runtime() -> Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread tokio runtime")
+}
+
+fn build_context(rt: &Runtime) -> SessionContext {
+    rt.block_on(async {
+        // Configure the Vortex session with the current Tokio runtime so the
+        // write sink can resolve its executor (see `build_runtime`); `with_tokio`
+        // captures `Handle::current()`, so it must run inside `block_on`.
+        let session = VortexSession::default().with_tokio();
+        let factory = Arc::new(VortexFormatFactory::new_with_options(
+            session,
+            VortexTableOptions::default(),
+        ));
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_table_factory(
+                factory.get_ext().to_uppercase(),
+                Arc::new(DefaultTableFactory::new()),
+            )
+            .with_file_formats(vec![factory])
+            .build();
+        let ctx = SessionContext::new_with_state(state).enable_url_table();
+
+        let store = Arc::new(InMemory::new());
+        ctx.register_object_store(
+            &url::Url::try_from("file://").expect("file:// should parse as a URL"),
+            store,
+        );
+
+        ctx.sql(
+            "CREATE EXTERNAL TABLE wide (\
+                id BIGINT NOT NULL, \
+                flag BOOLEAN NOT NULL, \
+                flag_int BIGINT NOT NULL, \
+                p0 BIGINT NOT NULL, p1 BIGINT NOT NULL, p2 BIGINT NOT NULL, \
+                p3 BIGINT NOT NULL, p4 BIGINT NOT NULL, p5 BIGINT NOT NULL) \
+            STORED AS vortex LOCATION '/wide/'",
+        )
+        .await
+        .expect("create table");
+
+        // `flag` is true for all but every SELECTIVITY_DIVISOR-th row; `flag_int`
+        // is 0 exactly when `flag` is false, so the two filters select the same
+        // rows. The payload columns give the scan real per-row decode work.
+        ctx.sql(&format!(
+            "INSERT INTO wide \
+             SELECT v AS id, \
+                    (v % {div} <> 0) AS flag, \
+                    CASE WHEN v % {div} = 0 THEN 0 ELSE 1 END AS flag_int, \
+                    v * 2 AS p0, v * 3 AS p1, v * 5 AS p2, \
+                    v * 7 AS p3, v * 11 AS p4, v * 13 AS p5 \
+             FROM generate_series(1, {rows}) AS t(v)",
+            div = SELECTIVITY_DIVISOR,
+            rows = ROW_COUNT,
+        ))
+        .await
+        .expect("insert plan")
+        .collect()
+        .await
+        .expect("insert exec");
+
+        ctx
+    })
+}
+
+fn run_query(rt: &Runtime, ctx: &SessionContext, sql: &str) -> usize {
+    rt.block_on(async {
+        let batches = ctx
+            .sql(sql)
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("exec");
+        batches.iter().map(|b| b.num_rows()).sum()
+    })
+}
+
+fn bench_not_pushdown(c: &mut Criterion) {
+    let rt = build_runtime();
+    let ctx = build_context(&rt);
+
+    // Materialize all payload columns so late materialization of the wide side
+    // is the cost under test, not just the filter column.
+    let projection = "id, p0, p1, p2, p3, p4, p5";
+    let not_flag = format!("SELECT {projection} FROM wide WHERE NOT flag");
+    let eq_zero = format!("SELECT {projection} FROM wide WHERE flag_int = 0");
+
+    // Sanity-check both filters select the same (selective) row set before timing.
+    let not_rows = run_query(&rt, &ctx, &not_flag);
+    let eq_rows = run_query(&rt, &ctx, &eq_zero);
+    assert_eq!(
+        not_rows, eq_rows,
+        "NOT flag and flag_int = 0 must select the same rows"
+    );
+    assert!(
+        not_rows > 0 && not_rows < ROW_COUNT / 4,
+        "filter should be selective, kept {not_rows} of {ROW_COUNT}"
+    );
+
+    let mut group = c.benchmark_group("filter_pushdown_not");
+    group.bench_function("not_flag_boolean", |b| {
+        b.iter(|| run_query(&rt, &ctx, &not_flag));
+    });
+    group.bench_function("eq_zero_int_reference", |b| {
+        b.iter(|| run_query(&rt, &ctx, &eq_zero));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_not_pushdown);
+criterion_main!(benches);

--- a/crates/vortex/src/convert/exprs.rs
+++ b/crates/vortex/src/convert/exprs.rs
@@ -248,6 +248,18 @@ impl ExpressionConvertor for DefaultExpressionConvertor {
             return Ok(is_not_null(arg));
         }
 
+        if let Some(not_expr) = df.downcast_ref::<df_expr::NotExpr>() {
+            // Boolean NOT. Vortex's `not` inverts the value bits while preserving
+            // the validity buffer (NOT NULL = NULL), matching SQL three-valued
+            // logic and DataFusion's `FilterExec`. DataFusion normalizes
+            // `col = false`, `col != true`, and `NOT (a AND b)` fragments to a
+            // `NotExpr` over a boolean operand, so this arm is what lets those
+            // common boolean-flag filters push into the Vortex scan instead of
+            // being row-evaluated above it.
+            let arg = self.convert(not_expr.arg().as_ref())?;
+            return Ok(not(arg));
+        }
+
         if let Some(in_list) = df.downcast_ref::<df_expr::InListExpr>() {
             let value = self.convert(in_list.expr().as_ref())?;
             let list_elements: Vec<_> = in_list
@@ -460,6 +472,8 @@ fn can_be_pushed_down_impl(df_expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> 
         can_be_pushed_down_impl(is_null.arg(), schema)
     } else if let Some(is_not_null) = expr.downcast_ref::<df_expr::IsNotNullExpr>() {
         can_be_pushed_down_impl(is_not_null.arg(), schema)
+    } else if let Some(not_expr) = expr.downcast_ref::<df_expr::NotExpr>() {
+        can_be_pushed_down_impl(not_expr.arg(), schema)
     } else if let Some(in_list) = expr.downcast_ref::<df_expr::InListExpr>() {
         can_be_pushed_down_impl(in_list.expr(), schema)
             && in_list
@@ -500,6 +514,9 @@ fn is_convertible_expr(df_expr: &Arc<dyn PhysicalExpr>) -> bool {
             .is_some_and(|e| is_convertible_expr(e.expr()))
         || expr.downcast_ref::<df_expr::IsNullExpr>().is_some()
         || expr.downcast_ref::<df_expr::IsNotNullExpr>().is_some()
+        || expr
+            .downcast_ref::<df_expr::NotExpr>()
+            .is_some_and(|n| is_convertible_expr(n.arg()))
         || expr.downcast_ref::<df_expr::InListExpr>().is_some()
         || expr
             .downcast_ref::<ScalarFunctionExpr>()
@@ -874,6 +891,46 @@ mod tests {
                 case_insensitive
             }
         );
+    }
+
+    #[test]
+    fn test_expr_from_df_not() {
+        // `NOT (id = 42)` must convert to a Vortex `not` over the pushed comparison.
+        let left = Arc::new(df_expr::Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+        let right =
+            Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(42)))) as Arc<dyn PhysicalExpr>;
+        let binary = Arc::new(df_expr::BinaryExpr::new(left, DFOperator::Eq, right));
+        let not_expr = df_expr::NotExpr::new(binary);
+
+        let result = DefaultExpressionConvertor::default()
+            .convert(&not_expr)
+            .expect("NOT expression should convert");
+
+        let display = result.display_tree().to_string();
+        assert!(
+            display.contains("vortex.not"),
+            "converted NOT must emit a vortex.not node: {display}"
+        );
+    }
+
+    #[rstest]
+    fn test_can_be_pushed_down_not_over_boolean_column(test_schema: Schema) {
+        // `NOT active` where `active` is a supported boolean column pushes down.
+        let active = Arc::new(df_expr::Column::new("active", 3)) as Arc<dyn PhysicalExpr>;
+        let not_expr = Arc::new(df_expr::NotExpr::new(active)) as Arc<dyn PhysicalExpr>;
+
+        assert!(can_be_pushed_down_impl(&not_expr, &test_schema));
+    }
+
+    #[rstest]
+    fn test_can_be_pushed_down_not_unsupported_operand(test_schema: Schema) {
+        // `NOT` over an unsupported-typed column must not push (the convertor
+        // must never promise DataFusion a pushdown the scan can't honor).
+        let list_col =
+            Arc::new(df_expr::Column::new("unsupported_list", 5)) as Arc<dyn PhysicalExpr>;
+        let not_expr = Arc::new(df_expr::NotExpr::new(list_col)) as Arc<dyn PhysicalExpr>;
+
+        assert!(!can_be_pushed_down_impl(&not_expr, &test_schema));
     }
 
     #[test]

--- a/crates/vortex/src/persistent/mod.rs
+++ b/crates/vortex/src/persistent/mod.rs
@@ -182,6 +182,83 @@ mod tests {
         Ok(())
     }
 
+    /// Boolean `NOT` filters (including `col = false`, which `DataFusion`
+    /// normalizes to `NOT col`) must push into the Vortex scan and must honor SQL
+    /// three-valued logic — a `NULL` operand yields `NULL`, which `WHERE` treats
+    /// as "not kept".
+    #[tokio::test]
+    async fn test_not_boolean_filter_pushes_down_and_handles_nulls() -> anyhow::Result<()> {
+        let ctx = TestSessionContext::default();
+
+        ctx.session
+            .sql(
+                "CREATE EXTERNAL TABLE flags (id INT NOT NULL, active BOOLEAN) \
+                STORED AS vortex LOCATION '/flags/'",
+            )
+            .await?;
+
+        ctx.session
+            .sql(
+                "INSERT INTO flags VALUES \
+                    (1, true), (2, false), (3, NULL), (4, false), (5, true)",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        // The predicate must be pushed into the Vortex `DataSourceExec` (shown as
+        // `predicate:` on the scan) and there must be no `FilterExec` re-applying it
+        // above the scan — that is the whole point of the pushdown.
+        let df = ctx
+            .session
+            .sql("SELECT id FROM flags WHERE NOT active")
+            .await?;
+        let plan = ctx
+            .session
+            .state()
+            .create_physical_plan(df.logical_plan())
+            .await?;
+        let plan_display = DisplayableExecutionPlan::new(plan.as_ref())
+            .indent(true)
+            .to_string();
+        assert!(
+            plan_display.contains("predicate:") && plan_display.contains("vortex"),
+            "NOT filter should push into the Vortex scan, got plan:\n{plan_display}"
+        );
+        assert!(
+            !plan_display.contains("FilterExec"),
+            "NOT filter should not leave a FilterExec above the scan, got plan:\n{plan_display}"
+        );
+
+        // Correctness across three-valued logic: true → dropped, false → kept,
+        // NULL → dropped. Rows 2 and 4 (active = false) are the only matches.
+        let result = ctx
+            .session
+            .sql("SELECT id FROM flags WHERE NOT active ORDER BY id")
+            .await?
+            .collect()
+            .await?;
+        let result_fmt = pretty_format_batches(&result)?.to_string();
+        assert_snapshot!("not_boolean_filter_result", result_fmt);
+
+        // `active = false` is simplified by DataFusion to `NOT active`; it must
+        // return the identical set, proving the pushdown covers the common
+        // boolean-equals-false shape too.
+        let eq_false = ctx
+            .session
+            .sql("SELECT id FROM flags WHERE active = false ORDER BY id")
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(
+            result_fmt,
+            pretty_format_batches(&eq_false)?.to_string(),
+            "`active = false` must match `NOT active`"
+        );
+
+        Ok(())
+    }
+
     /// Doc example: demonstrates creating, writing, reading, and filtering a Vortex table.
     #[tokio::test]
     async fn doc_example() -> anyhow::Result<()> {

--- a/crates/vortex/src/persistent/snapshots/vortex_datafusion__persistent__tests__not_boolean_filter_result.snap
+++ b/crates/vortex/src/persistent/snapshots/vortex_datafusion__persistent__tests__not_boolean_filter_result.snap
@@ -1,0 +1,10 @@
+---
+source: crates/vortex/src/persistent/mod.rs
+expression: result_fmt
+---
++----+
+| id |
++----+
+| 2  |
+| 4  |
++----+


### PR DESCRIPTION
## What

Push boolean `NOT` filters into the Vortex scan. The DataFusion→Vortex expression convertor (`crates/vortex/src/convert/exprs.rs`) had no arm for `df_expr::NotExpr`, so any predicate that reduces to a boolean `NOT` at the physical level failed conversion, was reported `PushedDown::No` by `VortexSource::try_pushdown_filters`, and stayed in a `FilterExec` **above** the scan — forcing the scan to decode every projected column for every row before the filter runs.

## Why it matters

DataFusion normalizes several of the most common analytics filter shapes to a `NotExpr` over a boolean operand, and **none of them pushed into the scan** before this change (verified on the real physical plan):

| Query | Baseline plan |
|---|---|
| `WHERE NOT active` | `FilterExec: NOT active@1` above the scan |
| `WHERE active = false` | simplifier rewrites → `NOT active` → same un-pushed `FilterExec` |
| `WHERE NOT (active AND id > 1)` | → `NOT active OR id <= 1`; the un-convertible `NOT active` fragment blocks the whole `OR` from pushing |

These are bread-and-butter filters — soft-delete flags (`NOT deleted`), status booleans (`is_active = false`), and negated conjunctions. Leaving them above the scan means no zone pruning and no late materialization: the wide side is fully decoded, then thrown away.

## The fix

Add `NotExpr` to the three places every other expression class is handled — `convert` (→ vortex `not`), `can_be_pushed_down_impl`, and `is_convertible_expr` — mirroring the existing `IsNull`/`IsNotNull` arms.

**Correctness (SQL three-valued logic):** vortex `not` inverts the value bits while **preserving the validity buffer**, so `NOT NULL = NULL` — identical to DataFusion's `FilterExec`. A `NULL` boolean operand yields `NULL`, which `WHERE` treats as "not kept". The `PushedDown::Yes ⟹ scan evaluates it` invariant is preserved: `can_be_pushed_down(NOT x) = can_be_pushed_down(x)` and `convert(NOT x) = not(convert(x))`, so acceptance and conversion always agree.

## Benchmark

New `filter_pushdown_not` criterion bench — selective `WHERE NOT flag` over a 262k-row wide table, end-to-end via `SessionContext` (Apple Silicon):

| Query | Before | After | Speedup |
|---|---|---|---|
| `WHERE NOT flag` (boolean) | 1.528 ms | **0.842 ms** | **1.81×** |
| `WHERE flag_int = 0` (control, always pushed) | 0.970 ms | 0.958 ms | ~1.0× |

After the change `NOT flag` is at/below the already-pushable integer-equality floor — confirming it now pushes like a native comparison. The control is unchanged, confirming the change is isolated to the `NOT` path and doesn't regress other pushdowns. ("Before" measured by reverting only `exprs.rs` to `trunk`.)

## Tests

- 3 convertor unit tests (`convert`, `can_be_pushed_down` supported/unsupported operand).
- Integration test asserting **both** that `WHERE NOT active` pushes into the scan (no `FilterExec` above it) **and** SQL three-valued NULL correctness (`true`→dropped, `false`→kept, `NULL`→dropped), plus `active = false ≡ NOT active`.
- `cargo test -p vortex-datafusion`: 249 passed. `clippy` (pedantic + full CI deny-set on `--lib --tests`): clean. `cargo fmt`: clean.

## Scope

Localized to the internal `vortex-datafusion` integration crate; the upstream `spiceai/vortex` fork is untouched. Ruled out this pass: stats propagation (already complete via `infer_stats`), scalar-function pushdown (`lower`/`substr`/… — larger follow-up), and a theoretical `Scalar::list` mixed-dtype hardening (not reachable given DataFusion's IN-list coercion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
