### PR TITLE
fix(ci): use GraphQL API to check isLatest in spiced_docker workflow

### DIFF
--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -180,7 +180,20 @@ jobs:
 
           if [ "$tag_latest_input" = "auto" ]; then
             # Query GitHub for whether this tag is currently the 'latest' release.
-            is_latest=$(gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" --json isLatest -q .isLatest 2>/dev/null || echo "false")
+            # Use GraphQL because `gh release view --json isLatest` can return stale
+            # data when a newer release was published after the REST API cached it.
+            gh_owner="${GITHUB_REPOSITORY%%/*}"
+            gh_repo="${GITHUB_REPOSITORY##*/}"
+            is_latest=$(gh api graphql \
+              -f owner="${gh_owner}" \
+              -f repo="${gh_repo}" \
+              -f tag="${release_tag}" \
+              -f query='query($owner: String!, $repo: String!, $tag: String!) {
+                repository(owner: $owner, name: $repo) {
+                  release(tagName: $tag) { isLatest }
+                }
+              }' \
+              --jq '.data.repository.release.isLatest // false' 2>/dev/null || echo "false")
             if [ "$is_latest" = "true" ]; then
               should_tag_latest="true"
               echo "Release ${release_tag} is marked as 'latest' on GitHub, will tag as 'latest'"


### PR DESCRIPTION
## Summary
Issue in [spiced_docker.yaml](https://github.com/spiceai/spiceai/blob/trunk/.github/workflows/spiced_docker.yml#L183C1-L184C1) results in `is_latest` always being false (Likely change in `gh` CLI interface).
```yaml
# Query GitHub for whether this tag is currently the 'latest' release.
is_latest=$(gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" --json isLatest -q .isLatest 2>/dev/null || echo "false")
```

```shell
>>> gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" --json isLatest -q .isLatest
Unknown JSON field: "isLatest"
Available fields:
  apiUrl
  assets
  author
  body
  createdAt
  id
  isDraft
  isPrerelease
  name
  publishedAt
  tagName
  tarballUrl
  targetCommitish
  uploadUrl
  url
  zipballUrl
```
Replace with equivalent `gh api graphql`