### PR TITLE
chore: release finalization for v2.2.0

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         branch:
           - 'trunk'
-          - 'release/2.0'
+          - 'release/2.1'
     concurrency:
       group: testoperator-dispatch-scheduled-${{ matrix.branch }}-${{ github.event.schedule || github.event.ref }}
       cancel-in-progress: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ license-file = "LICENSE"
 publish = false
 repository = "https://github.com/spiceai/spiceai"
 rust-version = "1.95.0"
-version = "2.1.0-unstable"
+version = "2.2.0-unstable"
 
 [workspace.dependencies]
 adbc_core = "0.23"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,21 +2,23 @@
 
 ## Supported Versions
 
-Spice.ai has released 2.0-stable 🎉
+Spice.ai has released 2.1.0 🎉
 
 In the latest major version, the last 2 minor version series are supported for security updates.
 
 | Version | Supported          |
 |---------|--------------------|
+| 2.1.1   | :white_check_mark: |
+| 2.1.0   | :white_check_mark: |
 | 2.0.1   | :white_check_mark: |
 | 2.0.0   | :white_check_mark: |
-| 1.11.6  | :white_check_mark: |
-| 1.11.5  | :white_check_mark: |
-| 1.11.4  | :white_check_mark: |
-| 1.11.3  | :white_check_mark: |
-| 1.11.2  | :white_check_mark: |
-| 1.11.1  | :white_check_mark: |
-| 1.11.0  | :white_check_mark: |
+| 1.11.6  | :x:                |
+| 1.11.5  | :x:                |
+| 1.11.4  | :x:                |
+| 1.11.3  | :x:                |
+| 1.11.2  | :x:                |
+| 1.11.1  | :x:                |
+| 1.11.0  | :x:                |
 | 1.10.4  | :x:                |
 | 1.10.3  | :x:                |
 | 1.10.2  | :x:                |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,6 +13,19 @@ To propose features or report issues, please [file an issue](https://github.com/
 
 ---
 
+## Released Versions
+
+### [v2.1.0](https://github.com/spiceai/spiceai/releases/tag/v2.1.0) (June 29, 2026) ✅
+
+**Focus:** High-Throughput CDC, Distributed Query, and PostgreSQL Replication at Scale.
+
+- **Cayenne CDC at Scale**: Optimized CDC-fed acceleration for high-throughput streaming data.
+- **PostgreSQL Replication at Scale**: Enhanced PostgreSQL connector with improved replication performance.
+- **Distributed Query (Iceberg & Broadcast Joins)**: Federated queries with efficient broadcast join execution.
+- Full SDK support across all language bindings (Go, Java, Rust, Python, .NET).
+
+---
+
 ## Release Timeline
 
 ### [v2.2](https://github.com/spiceai/spiceai/milestone/99) (July 2026)

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-2.1.0-unstable
+2.2.0-unstable


### PR DESCRIPTION
## Summary

Post-release housekeeping for v2.1.0 endgame (#11422):

- Bump version to 2.2.0-unstable
- Update testoperator scheduled benchmark job to track `release/2.1` branch (instead of `release/2.0`)
- Add v2.1.0 to ROADMAP as released version with focus areas
- Update SECURITY.md to support 2.1.x and deprecate 1.11.x series (last 2 minor versions per policy)

## Related Issue
Closes #11422 (Release Finalization)