### PR TITLE
feat(spidapter): support cluster_name for private nodegroup targeting

### DIFF
--- a/.github/workflows/testoperator_run_cluster_bench.yml
+++ b/.github/workflows/testoperator_run_cluster_bench.yml
@@ -107,6 +107,14 @@ on:
         required: false
         default: ''
         type: string
+      cluster_name:
+        description: |
+          Spice Cloud nodegroup name passed to spidapter as SPIDAPTER_CLUSTER_NAME
+          (from GET /v1/clusters). Empty keeps the default regional shared stamp;
+          set e.g. `spicehq-ballista` to pin apps onto that private nodegroup.
+        required: false
+        default: ''
+        type: string
       scale_factor:
         description: 'Scale factor for the benchmark'
         required: false
@@ -172,6 +180,7 @@ env:
   CB_EPHEMERAL_STORAGE_LIMIT: ${{ github.event.inputs.ephemeral_storage_limit || '' }}
   CB_CAYENNE_FILE_PATH: ${{ github.event.inputs.cayenne_file_path || '' }}
   CB_CAYENNE_METADATA_DIR: ${{ github.event.inputs.cayenne_metadata_dir || '' }}
+  CB_CLUSTER_NAME: ${{ github.event.inputs.cluster_name || '' }}
   CB_SCALE_FACTOR: ${{ github.event.inputs.scale_factor || '1' }}
   CB_VALIDATE_RESULTS: ${{ github.event.inputs.validate_results || 'false' }}
   CB_UPDATE_SNAPSHOTS: ${{ github.event.inputs.update_snapshots || 'default' }}
@@ -293,6 +302,7 @@ jobs:
           EPHEMERAL_STORAGE_LIMIT: ${{ env.CB_EPHEMERAL_STORAGE_LIMIT }}
           CAYENNE_FILE_PATH: ${{ env.CB_CAYENNE_FILE_PATH }}
           CAYENNE_METADATA_DIR: ${{ env.CB_CAYENNE_METADATA_DIR }}
+          CLUSTER_NAME: ${{ env.CB_CLUSTER_NAME }}
           QUERY_SET: ${{ env.CB_QUERY_SET }}
           QUERY_TRANSPORT: ${{ env.CB_QUERY_TRANSPORT }}
           SCALE_FACTOR: ${{ env.CB_SCALE_FACTOR }}
@@ -350,6 +360,7 @@ jobs:
           export_spidapter_env_if_set SPIDAPTER_EPHEMERAL_STORAGE_LIMIT_GB "${EPHEMERAL_STORAGE_LIMIT}"
           export_spidapter_env_if_set SPIDAPTER_CAYENNE_FILE_PATH "${CAYENNE_FILE_PATH}"
           export_spidapter_env_if_set SPIDAPTER_CAYENNE_METADATA_DIR "${CAYENNE_METADATA_DIR}"
+          export_spidapter_env_if_set SPIDAPTER_CLUSTER_NAME "${CLUSTER_NAME}"
 
           # When a custom image tag is provided (e.g. a `trunk-<sha>` image
           # freshly published by `spiced_docker_dev`), pin spidapter to that

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -532,6 +532,7 @@ fn build_create_app_request(
         // The Cloud create-app endpoint currently accepts the target deployment region
         // in the legacy `cname` request field; update-app uses the newer `region` field.
         cname: Some(region.to_string()),
+        cluster_name: None,
         tags,
         replicas,
         resources,

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -200,8 +200,14 @@ pub struct CreateAppRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub visibility: String,
+    /// Deprecated region source. Mutually exclusive with [`Self::cluster_name`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cname: Option<String>,
+    /// Dedicated-cluster / nodegroup assignment (from `GET /v1/clusters`).
+    /// Mutually exclusive with [`Self::cname`]; when set, cloud injects the
+    /// `organization` / `_cluster` scheduling tags from the nodegroup row.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cluster_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tools/spidapter/scenarios/cayenne.yaml
+++ b/tools/spidapter/scenarios/cayenne.yaml
@@ -4,6 +4,7 @@ compute:
     image_tag: ${SPIDAPTER_IMAGE_TAG:-}
     scheduler_state_location: ${SCHEDULER_STATE_LOCATION:-}
     organization_tag: ${SPIDAPTER_ORGANIZATION_TAG:-}
+    cluster_name: ${SPIDAPTER_CLUSTER_NAME:-}
     query_memory_limit: ${SPIDAPTER_QUERY_MEMORY_LIMIT:-}
     resources:
       app_memory: ${SPIDAPTER_APP_MEMORY_LIMIT:-62Gi}

--- a/tools/spidapter/scenarios/dynamodb-streams.yaml
+++ b/tools/spidapter/scenarios/dynamodb-streams.yaml
@@ -4,6 +4,7 @@ compute:
     image_tag: ${SPIDAPTER_IMAGE_TAG:-}
     scheduler_state_location: ${SCHEDULER_STATE_LOCATION:-}
     organization_tag: ${SPIDAPTER_ORGANIZATION_TAG:-}
+    cluster_name: ${SPIDAPTER_CLUSTER_NAME:-}
     resources:
       app_memory: ${SPIDAPTER_APP_MEMORY_LIMIT:-64Gi}
       ephemeral_storage_gb: ${SPIDAPTER_EPHEMERAL_STORAGE_LIMIT_GB:-}

--- a/tools/spidapter/scenarios/federated-direct.yaml
+++ b/tools/spidapter/scenarios/federated-direct.yaml
@@ -9,6 +9,7 @@ compute:
     image_tag: ${SPIDAPTER_IMAGE_TAG:-}
     scheduler_state_location: ${SCHEDULER_STATE_LOCATION:-}
     organization_tag: ${SPIDAPTER_ORGANIZATION_TAG:-}
+    cluster_name: ${SPIDAPTER_CLUSTER_NAME:-}
     query_memory_limit: ${SPIDAPTER_QUERY_MEMORY_LIMIT:-}
     resources:
       app_memory: ${SPIDAPTER_APP_MEMORY_LIMIT:-62Gi}

--- a/tools/spidapter/scenarios/mongodb-streams.yaml
+++ b/tools/spidapter/scenarios/mongodb-streams.yaml
@@ -4,6 +4,7 @@ compute:
     image_tag: ${SPIDAPTER_IMAGE_TAG:-}
     scheduler_state_location: ${SCHEDULER_STATE_LOCATION:-}
     organization_tag: ${SPIDAPTER_ORGANIZATION_TAG:-}
+    cluster_name: ${SPIDAPTER_CLUSTER_NAME:-}
     resources:
       app_memory: ${SPIDAPTER_APP_MEMORY_LIMIT:-64Gi}
       ephemeral_storage_gb: ${SPIDAPTER_EPHEMERAL_STORAGE_LIMIT_GB:-}

--- a/tools/spidapter/scenarios/postgres-wal.yaml
+++ b/tools/spidapter/scenarios/postgres-wal.yaml
@@ -4,6 +4,7 @@ compute:
     image_tag: ${SPIDAPTER_IMAGE_TAG:-}
     scheduler_state_location: ${SCHEDULER_STATE_LOCATION:-}
     organization_tag: ${SPIDAPTER_ORGANIZATION_TAG:-}
+    cluster_name: ${SPIDAPTER_CLUSTER_NAME:-}
     resources:
       app_memory: ${SPIDAPTER_APP_MEMORY_LIMIT:-64Gi}
       ephemeral_storage_gb: ${SPIDAPTER_EPHEMERAL_STORAGE_LIMIT_GB:-}

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -259,12 +259,11 @@ pub(crate) async fn ensure_spice_cloud_app(
                 .cluster_name
                 .as_ref()
                 .is_none_or(|name| name.trim().is_empty())
+                && let Some(org) = &config.organization_tag
             {
-                if let Some(org) = &config.organization_tag {
-                    let org = org.trim();
-                    if !org.is_empty() {
-                        tags.insert("organization".to_string(), org.to_string());
-                    }
+                let org = org.trim();
+                if !org.is_empty() {
+                    tags.insert("organization".to_string(), org.to_string());
                 }
             }
             Some(tags)

--- a/tools/spidapter/src/commands/mod.rs
+++ b/tools/spidapter/src/commands/mod.rs
@@ -44,6 +44,9 @@ pub(crate) struct AppCreateConfig {
     pub executor_storage_size_gb: Option<f64>,
     pub ephemeral_storage_limit_gb: Option<String>,
     pub organization_tag: Option<String>,
+    /// Dedicated-cluster / nodegroup name from `GET /v1/clusters`. When set,
+    /// cloud injects scheduling tags; mutually exclusive with sending `cname`.
+    pub cluster_name: Option<String>,
 }
 
 pub(crate) fn spice_cloud_base_url(api_url_override: Option<&str>) -> String {
@@ -197,7 +200,19 @@ pub(crate) async fn ensure_spice_cloud_app(
         return Ok(app.id);
     }
 
-    let cname = resolve_default_cname(cloud).await?;
+    // When assigning to a dedicated-cluster nodegroup, `cluster_name` is the
+    // region source and must not be combined with the deprecated `cname`.
+    // Otherwise keep today's regional `cname` path.
+    let (cname, cluster_name) = if let Some(cluster) = &config.cluster_name {
+        let cluster = cluster.trim();
+        if cluster.is_empty() {
+            (Some(resolve_default_cname(cloud).await?), None)
+        } else {
+            (None, Some(cluster.to_string()))
+        }
+    } else {
+        (Some(resolve_default_cname(cloud).await?), None)
+    };
 
     // App (scheduler) resources — start from defaults, then apply any overrides.
     let resources = resources_over(
@@ -231,14 +246,26 @@ pub(crate) async fn ensure_spice_cloud_app(
         name: app_name.to_string(),
         description: None,
         visibility: "private".to_string(),
-        cname: Some(cname),
+        cname,
+        cluster_name,
         tags: {
             let mut tags = BTreeMap::new();
             if matches!(deployment_mode, DeploymentMode::Cluster) {
                 tags.insert("kind".to_string(), "cluster".to_string());
             }
-            if let Some(org) = &config.organization_tag {
-                tags.insert("organization".to_string(), org.clone());
+            // Skip when `cluster_name` is set — cloud injects organization/_cluster
+            // from the nodegroup row; client-set `_cluster` is restricted.
+            if config
+                .cluster_name
+                .as_ref()
+                .is_none_or(|name| name.trim().is_empty())
+            {
+                if let Some(org) = &config.organization_tag {
+                    let org = org.trim();
+                    if !org.is_empty() {
+                        tags.insert("organization".to_string(), org.to_string());
+                    }
+                }
             }
             Some(tags)
         },

--- a/tools/spidapter/src/provision/spice_cloud.rs
+++ b/tools/spidapter/src/provision/spice_cloud.rs
@@ -73,6 +73,7 @@ pub(crate) async fn provision_scp_app(
         executor_storage_size_gb: res.executor_storage_size_gb,
         ephemeral_storage_limit_gb: res.ephemeral_storage_gb.clone(),
         organization_tag: scp.organization_tag.clone(),
+        cluster_name: scp.cluster_name.clone(),
     };
     eprintln!(
         "[stdio] App resource config: \

--- a/tools/spidapter/src/scenario.rs
+++ b/tools/spidapter/src/scenario.rs
@@ -60,6 +60,10 @@ pub(crate) struct ScpConfig {
     pub scheduler_state_location: Option<String>,
     /// Organization tag to apply to the created app.
     pub organization_tag: Option<String>,
+    /// Dedicated-cluster / nodegroup name (`GET /v1/clusters`). When set, cloud
+    /// injects scheduling tags from the nodegroup; do not also set
+    /// `organization_tag` for the same create.
+    pub cluster_name: Option<String>,
     /// Query memory limit (e.g. `150Gi`).
     pub query_memory_limit: Option<String>,
     /// Pod resource allocations.


### PR DESCRIPTION
## Summary
- Adds `cluster_name` to `CreateAppRequest` and plumbs it through spidapter scenarios via `SPIDAPTER_CLUSTER_NAME`.
- When set, create omits `cname` (mutually exclusive) and skips client `organization` tags so cloud injects `organization` / `_cluster` from the registered nodegroup.
- Adds optional `cluster_name` input on `testoperator_run_cluster_bench` (default empty) that exports `SPIDAPTER_CLUSTER_NAME` for the federated-direct scenario.
- Intended use with temporary shared-stamp NG `spicehq-ballista` (parent `spicehq-bench`): set workflow input `cluster_name=spicehq-ballista`.

## Test plan
- [x] `cargo check -p spice-cloud-client -p spidapter`
- [ ] Dispatch `cluster benchmark e2e tests` with `cluster_name` empty — behavior unchanged (regional stamp)
- [ ] Dispatch with `cluster_name=spicehq-ballista` after cloud rows + CDK NG exist — pods land on `organization=spicehq-ballista` nodes