### PR TITLE
refactor(runtime): parameterize table-provider unwrapping by inner-fn set

### DIFF
--- a/crates/runtime-datafusion-index/src/lib.rs
+++ b/crates/runtime-datafusion-index/src/lib.rs
@@ -23,7 +23,9 @@ use snafu::prelude::*;
 
 pub mod analyzer;
 mod provider;
+pub mod util;
 pub use provider::*;
+pub use util::{INDEXED_INNER, InnerProviderFn, find_concrete_table_provider_with};
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime-datafusion-index/src/util.rs
+++ b/crates/runtime-datafusion-index/src/util.rs
@@ -1,0 +1,58 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use datafusion::datasource::TableProvider;
+
+use crate::IndexedTableProvider;
+
+/// Returns a borrow of the inner provider of a single known wrapper layer of a
+/// [`TableProvider`], or `None` if this accessor does not apply.
+///
+/// The borrow is tied to the input reference (`for<'a>`), so a chain of these
+/// can be followed without cloning any `Arc`.
+pub type InnerProviderFn = for<'a> fn(&'a dyn TableProvider) -> Option<&'a Arc<dyn TableProvider>>;
+
+/// Inner-provider accessor for [`IndexedTableProvider`].
+pub const INDEXED_INNER: InnerProviderFn = |tbl| {
+    tbl.downcast_ref::<IndexedTableProvider>()
+        .map(IndexedTableProvider::get_underlying_ref)
+};
+
+/// Attempt to return a concrete [`TableProvider`] type from a given
+/// [`impl TableProvider`], peeling only the wrapper layers in `inner_fns`.
+///
+/// At each step the current provider is checked against `T`; if it does not
+/// match, the first applicable accessor is followed to the inner provider.
+/// When no accessor applies, the search ends. Callers can therefore restrict
+/// the search to a specific set of layers by passing a narrower slice.
+pub fn find_concrete_table_provider_with<'a, T: TableProvider + 'static>(
+    tbl: &'a Arc<dyn TableProvider>,
+    inner_fns: &[InnerProviderFn],
+) -> Option<&'a T> {
+    let mut current_tbl = tbl;
+
+    loop {
+        if let Some(found_table) = current_tbl.downcast_ref::<T>() {
+            return Some(found_table);
+        }
+
+        current_tbl = inner_fns
+            .iter()
+            .find_map(|inner| inner(current_tbl.as_ref()))?;
+    }
+}

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -54,7 +54,9 @@ use datafusion::{execution::context::SessionContext, physical_plan::collect};
 use futures::{StreamExt, stream};
 use opentelemetry::KeyValue;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
-use runtime_datafusion_index::IndexedTableProvider;
+use runtime_datafusion_index::{
+    INDEXED_INNER, IndexedTableProvider, InnerProviderFn, find_concrete_table_provider_with,
+};
 use runtime_metrics::acceleration as metrics;
 use runtime_search::embeddings::table::EmbeddingTable;
 use runtime_table_partition::provider::PartitionTableProvider;
@@ -2478,35 +2480,31 @@ impl RefreshTask {
     /// `CayenneTableProvider` misses through any of these, so without peeling the
     /// CDC apply silently falls back to the synchronous `insert_into` path and
     /// loses pipelined finalization (backgrounded publish, no blocking
-    /// `apply_on_conflict_deletions`). Mirrors the wrapper-peeling done by
-    /// `search::util::find_concrete_table_provider`.
+    /// `apply_on_conflict_deletions`).
+    ///
+    /// Uses [`find_concrete_table_provider_with`] with a *write-transparent* set
+    /// of accessors rather than the runtime-wide `DEFAULT_INNER_FNS`: only
+    /// wrappers whose `insert_into` is a pass-through may be peeled here.
+    ///
+    /// NOTE: `UpsertDedupTableProvider` is intentionally absent from the set.
+    /// Unlike `PolyTableProvider` (delegates writes) and `IndexedTableProvider`
+    /// (`insert_into` is a pass-through), it *rewrites* the write on insert
+    /// (dedup / last-write-wins via `UpsertDedupExec`). Routing CDC past it to the
+    /// inner provider would bypass that transform, so a dedup-configured table
+    /// instead stays on the synchronous path (through the wrapper, preserving its
+    /// semantics) and emits the fallback warning below.
     #[cfg(not(windows))]
     fn cayenne_accelerator(&self) -> Option<&CayenneTableProvider> {
-        let mut current: &Arc<dyn TableProvider> = &self.accelerator;
-        loop {
-            if let Some(cayenne) = current.downcast_ref::<CayenneTableProvider>() {
-                return Some(cayenne);
-            }
-            if let Some(poly) = current.downcast_ref::<data_components::poly::PolyTableProvider>() {
-                current = poly.writer_ref();
-                continue;
-            }
-            // NOTE: `UpsertDedupTableProvider` is intentionally NOT peeled. Unlike
-            // `PolyTableProvider` (delegates writes) and `IndexedTableProvider`
-            // (`insert_into` is a pass-through), it *rewrites* the write on insert
-            // (dedup / last-write-wins via `UpsertDedupExec`). Routing CDC past it to
-            // the inner provider would bypass that transform, so a dedup-configured
-            // table instead stays on the synchronous path (through the wrapper,
-            // preserving its semantics) and emits the fallback warning below. Only
-            // write-transparent wrappers are peeled here.
-            if let Some(indexed) =
-                current.downcast_ref::<runtime_datafusion_index::IndexedTableProvider>()
-            {
-                current = indexed.get_underlying_ref();
-                continue;
-            }
-            return None;
-        }
+        /// Peels [`PolyTableProvider`] to its writer side (write-transparent).
+        const POLY_WRITER_INNER: InnerProviderFn = |tbl| {
+            tbl.downcast_ref::<data_components::poly::PolyTableProvider>()
+                .map(data_components::poly::PolyTableProvider::writer_ref)
+        };
+
+        find_concrete_table_provider_with::<CayenneTableProvider>(
+            &self.accelerator,
+            &[POLY_WRITER_INNER, INDEXED_INNER],
+        )
     }
 
     /// Effective per-plan delete-key cap for this dataset: the process-global

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -21,66 +21,77 @@ use crate::accelerated_table::AcceleratedTable;
 use data_components::MetadataEnrichedTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion_federation::FederatedTableProviderAdaptor;
-use runtime_datafusion_index::{Index, IndexedTableProvider};
+use runtime_datafusion_index::{
+    INDEXED_INNER, Index, IndexedTableProvider, InnerProviderFn, find_concrete_table_provider_with,
+};
 use runtime_search::embeddings::table::EmbeddingTable;
 use runtime_search::table_provider_explorer::TableProviderExplorer;
 
 use crate::dataconnector::iceberg_cluster::IcebergClusterTableProvider;
 use data_components::iceberg::delete::IcebergDeletionProvider;
 
-/// Attempt to return a concrete [`TableProvider`] type from a given [`impl TableProvider`],
-/// unwrapping known wrapper layers including `AcceleratedTable`.
+/// Inner-provider accessor for [`FederatedTableProviderAdaptor`].
+pub const FEDERATED_ADAPTOR_INNER: InnerProviderFn = |tbl| {
+    tbl.downcast_ref::<FederatedTableProviderAdaptor>()
+        .and_then(|adaptor| adaptor.table_provider.as_ref())
+};
+
+/// Inner-provider accessor for [`MetadataEnrichedTableProvider`].
+pub const METADATA_ENRICHED_INNER: InnerProviderFn = |tbl| {
+    tbl.downcast_ref::<MetadataEnrichedTableProvider>()
+        .map(MetadataEnrichedTableProvider::get_inner_ref)
+};
+
+/// Inner-provider accessor for [`IcebergClusterTableProvider`].
+pub const ICEBERG_CLUSTER_INNER: InnerProviderFn = |tbl| {
+    tbl.downcast_ref::<IcebergClusterTableProvider>()
+        .map(IcebergClusterTableProvider::inner)
+};
+
+/// Inner-provider accessor for [`IcebergDeletionProvider`].
+pub const ICEBERG_DELETION_INNER: InnerProviderFn = |tbl| {
+    tbl.downcast_ref::<IcebergDeletionProvider>()
+        .map(IcebergDeletionProvider::inner)
+};
+
+/// Inner-provider accessor for [`EmbeddingTable`].
+pub const EMBEDDING_INNER: InnerProviderFn = |tbl| {
+    tbl.downcast_ref::<EmbeddingTable>()
+        .map(EmbeddingTable::get_underlying_ref)
+};
+
+/// Inner-provider accessor for [`AcceleratedTable`]. Resolves to the federated
+/// provider only if it is available synchronously (a deferred provider that is
+/// not yet ready yields `None`).
+pub const ACCELERATED_INNER: InnerProviderFn = |tbl| {
+    tbl.downcast_ref::<AcceleratedTable>()
+        .and_then(|accelerated| {
+            accelerated
+                .get_federated_table_ref()
+                .try_table_provider_sync_ref()
+        })
+};
+
+/// The full set of runtime wrapper layers understood by
+/// [`find_concrete_table_provider`].
+pub const DEFAULT_INNER_FNS: &[InnerProviderFn] = &[
+    INDEXED_INNER,
+    FEDERATED_ADAPTOR_INNER,
+    METADATA_ENRICHED_INNER,
+    ICEBERG_CLUSTER_INNER,
+    ICEBERG_DELETION_INNER,
+    EMBEDDING_INNER,
+    ACCELERATED_INNER,
+];
+
+/// Attempt to return a concrete [`TableProvider`] type from a given
+/// [`impl TableProvider`], unwrapping all known runtime wrapper layers
+/// (including `AcceleratedTable`). See [`find_concrete_table_provider_with`]
+/// to restrict which layers are peeled.
 pub fn find_concrete_table_provider<T: TableProvider + 'static>(
     tbl: &Arc<dyn TableProvider>,
 ) -> Option<&T> {
-    let mut current_tbl = tbl;
-
-    loop {
-        if let Some(found_table) = current_tbl.downcast_ref::<T>() {
-            return Some(found_table);
-        }
-
-        if let Some(index_table) = current_tbl.downcast_ref::<IndexedTableProvider>() {
-            current_tbl = index_table.get_underlying_ref();
-            continue;
-        }
-
-        if let Some(adaptor) = current_tbl.downcast_ref::<FederatedTableProviderAdaptor>()
-            && let Some(adapted_tbl) = adaptor.table_provider.as_ref()
-        {
-            current_tbl = adapted_tbl;
-            continue;
-        }
-
-        if let Some(metadata_table) = current_tbl.downcast_ref::<MetadataEnrichedTableProvider>() {
-            current_tbl = metadata_table.get_inner_ref();
-            continue;
-        }
-
-        if let Some(cluster_table) = current_tbl.downcast_ref::<IcebergClusterTableProvider>() {
-            current_tbl = cluster_table.inner();
-            continue;
-        }
-
-        if let Some(deletion_table) = current_tbl.downcast_ref::<IcebergDeletionProvider>() {
-            current_tbl = deletion_table.inner();
-            continue;
-        }
-
-        if let Some(embedding_table) = current_tbl.downcast_ref::<EmbeddingTable>() {
-            current_tbl = embedding_table.get_underlying_ref();
-            continue;
-        }
-
-        if let Some(accelerated_table) = current_tbl.downcast_ref::<AcceleratedTable>() {
-            current_tbl = accelerated_table
-                .get_federated_table_ref()
-                .try_table_provider_sync_ref()?;
-            continue;
-        }
-
-        return None;
-    }
+    find_concrete_table_provider_with::<T>(tbl, DEFAULT_INNER_FNS)
 }
 
 pub fn find_index_in_table_provider<T: Index + 'static>(
@@ -192,6 +203,54 @@ mod tests {
         assert!(
             find_concrete_table_provider::<MemTable>(&wrapped).is_some(),
             "find_concrete_table_provider must peel IcebergClusterTableProvider"
+        );
+    }
+
+    #[test]
+    fn test_find_concrete_table_provider_with_respects_restricted_layer_set() {
+        let base_table: Arc<dyn TableProvider> = Arc::new(
+            MemTable::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "search_field",
+                    DataType::Utf8,
+                    false,
+                )])),
+                vec![],
+            )
+            .expect("failed to make table"),
+        );
+
+        let index = Arc::new(
+            FullTextDatabaseIndex::try_new(
+                Arc::clone(&base_table),
+                vec!["search_field".to_string()],
+                Some(vec!["search_field".to_string()]),
+                None,
+                &[],
+            )
+            .expect("cannot make full text table"),
+        );
+
+        let wrapped = Arc::new(IndexedTableProvider::new(base_table).add_index(index))
+            as Arc<dyn TableProvider>;
+
+        // The default set peels the IndexedTableProvider down to the MemTable.
+        assert!(
+            find_concrete_table_provider::<MemTable>(&wrapped).is_some(),
+            "default unwrappers must peel IndexedTableProvider"
+        );
+
+        // A restricted set that lacks the indexed-table accessor must not peel it.
+        assert!(
+            find_concrete_table_provider_with::<MemTable>(&wrapped, &[ICEBERG_CLUSTER_INNER])
+                .is_none(),
+            "restricted accessors must not peel layers outside the provided set"
+        );
+
+        // The layer itself is still reachable directly under a restricted set.
+        assert!(
+            find_concrete_table_provider_with::<IndexedTableProvider>(&wrapped, &[]).is_some(),
+            "an empty unwrapper set must still match the outermost provider"
         );
     }
 }


### PR DESCRIPTION
## Summary
Refactor `find_concrete_table_provider` to be type-agnostic. New function type
```rust
pub type InnerProviderFn = for<'a> fn(&'a dyn TableProvider) -> Option<&'a Arc<dyn TableProvider>>;
```

With this, we can 
1. Move `find_concrete_table_provider` to `runtime-datafusion-index`. 
2. Avoid reproduced logic in `fn cayenne_accelerator`  (see `crates/runtime/src/accelerated_table/refresh_task/changes.rs`). 