### PR TITLE
chore: remove unused BlueOak license allowance

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -57,7 +57,6 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "BSL-1.0",
-  "BlueOak-1.0.0",
   "CC0-1.0",
   "ISC",
   "MIT",


### PR DESCRIPTION
## 📝 Summary

Removes the unused `BlueOak-1.0.0` license allowance from `deny.toml`.

`unused-allowed-license = "deny"` makes cargo-deny fail when an allowed license is no longer present in the dependency graph. After the ML/ONNX dependency cleanup on trunk, no remaining dependency uses `BlueOak-1.0.0`, so the allowance now breaks `Check Rust Licenses`.

## 📚 Docs

No docs changes required.

## 👀 Notes for Reviewers

This is a config-only cleanup to restore cargo-deny license checks.

## Test plan

- [x] `cargo deny check licenses`
