### PR TITLE
fix(deps): drop unused BlueOak-1.0.0 license allowance after ONNX/Tract removal

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -57,7 +57,6 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "BSL-1.0",
-  "BlueOak-1.0.0",
   "CC0-1.0",
   "ISC",
   "MIT",


### PR DESCRIPTION
## Problem

The **Check Rust Licenses** CI job is failing on `trunk` and on every open PR:

```
error[license-not-encountered]: license was not encountered
  deny.toml:60  "BlueOak-1.0.0",
                 ━━━━━━━━━━━━━ unmatched license allowance
licenses FAILED
```

## Root cause

#11684 (`remove(ml): delete model_components crate and ONNX/Tract ML inference`) deleted the ONNX/Tract dependency stack, which in turn removed `anymap3` — licensed `BlueOak-1.0.0 OR MIT OR Apache-2.0` and the only crate in the tree that matched the `BlueOak-1.0.0` allowance in `deny.toml`.

`deny.toml` sets `unused-allowed-license = "deny"`, so an allow-list entry that no crate matches is a hard error, not a warning. The allowance became stale the moment the ONNX/Tract crates left the graph.

This is a latent trunk break: it reproduces on trunk HEAD with no other changes, and blocks the license check for all in-flight PRs.

## Fix

Remove the now-unused `BlueOak-1.0.0` entry so the allow-list matches the current dependency graph. If a future dependency reintroduces `BlueOak-1.0.0`, cargo-deny will surface it as a not-allowed license and the entry can be restored deliberately.

## Test plan

- [x] Reproduced the failure on trunk HEAD: `cargo deny check licenses` -> `licenses FAILED` (`license-not-encountered: BlueOak-1.0.0`)
- [x] After the fix: `cargo deny check licenses` -> `licenses ok`
- [x] No Rust source changed (config-only, single-line `deny.toml` deletion) — build/lint/test surface is unaffected