### PR TITLE
perf: avoid unnecessary allocations on search hot paths

### DIFF
--- a/crates/runtime-search/src/request.rs
+++ b/crates/runtime-search/src/request.rs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 
+use std::sync::Arc;
+
 use cache::key::SearchKey;
 use datafusion::common::Column;
 use datafusion::sql::TableReference;
@@ -139,10 +141,30 @@ impl From<SearchRequest> for SearchKey {
             Some(
                 req.additional_columns
                     .into_iter()
-                    .map(|c| c.to_string().as_str().into())
+                    .map(|c| c.to_string().into())
                     .collect(),
             ),
             req.keywords.into_iter().map(Into::into).collect(),
+        )
+    }
+}
+
+impl From<&SearchRequest> for SearchKey {
+    fn from(req: &SearchRequest) -> Self {
+        SearchKey::new(
+            Arc::from(req.text.as_str()),
+            req.datasets
+                .as_ref()
+                .map(|d| d.iter().map(|s| Arc::from(s.as_str())).collect()),
+            req.limit,
+            req.where_cond.clone(),
+            Some(
+                req.additional_columns
+                    .iter()
+                    .map(|c| Arc::from(c.to_string()))
+                    .collect(),
+            ),
+            req.keywords.iter().map(|k| Arc::from(k.as_str())).collect(),
         )
     }
 }

--- a/crates/runtime-search/src/search_engine.rs
+++ b/crates/runtime-search/src/search_engine.rs
@@ -40,7 +40,6 @@ use datafusion::error::DataFusionError;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::sql::TableReference;
 use datafusion_expr::Expr;
-use datafusion_expr::sqlparser::ast;
 use futures::StreamExt;
 use itertools::Itertools;
 #[cfg(feature = "models")]
@@ -372,7 +371,7 @@ impl<E: TableProviderExplorer> SearchEngine<E> {
     ) -> Result<(VectorSearchResult, CacheStatus)> {
         Ok(if let Some(cache_provider) = cache_provider {
             tracing::trace!("Search cache is enabled");
-            let search_key = SearchKey::from(req.clone());
+            let search_key = SearchKey::from(req);
             let cache_control = request_context.cache_control();
 
             let scoped_user_cache_key =
@@ -484,9 +483,14 @@ impl<E: TableProviderExplorer> SearchEngine<E> {
             let table_primary_keys = get_primary_keys_with_overrides(&self.df, &tables, &self.explicit_primary_keys)
                 .await?;
 
+            // Stringify the WHERE filter once; per-table work only rebinds it to each schema.
+            // `&str` / `&[String]` are `Copy`, so each parallel task can capture them without cloning.
+            let where_filter_sql = where_cond.as_ref().map(ToString::to_string);
+            let where_filter_sql = where_filter_sql.as_deref();
+            let keywords = keywords.as_slice();
+
             // Search for each table is independent, but done in parallel.
             let response: HashMap<TableReference, AggregationResult> = futures::future::try_join_all(tables.into_iter().map(|tbl| {
-                let keywords = keywords.clone();
                 let primary_keys = table_primary_keys.get(&tbl).map_or(&[] as &[String], |v| v.as_slice());
 
                 async move {
@@ -526,7 +530,7 @@ impl<E: TableProviderExplorer> SearchEngine<E> {
                     let agg_result = pipe.run(
                         query.clone(),
                         &tbl,
-                        get_filter_for_table(&self.df, &tbl, where_cond.as_ref()).await?,
+                        get_filter_for_table(&self.df, &tbl, where_filter_sql).await?,
                         table_cols,
                         primary_keys.iter().map(|pk| Column::from_name(pk.clone()) ).collect::<Vec<Column>>(),
                         keywords,
@@ -564,9 +568,9 @@ impl<E: TableProviderExplorer> SearchEngine<E> {
 async fn get_filter_for_table(
     df: &Arc<dyn QueryEngine>,
     tbl: &TableReference,
-    filter_opt: Option<&ast::Expr>,
+    filter_sql: Option<&str>,
 ) -> Result<Option<Expr>, Error> {
-    let Some(filter) = filter_opt else {
+    let Some(filter_sql) = filter_sql else {
         return Ok(None);
     };
 
@@ -579,13 +583,12 @@ async fn get_filter_for_table(
     match df
         .session_context()
         .state()
-        .create_logical_expr(&filter.to_string(), &schema)
+        .create_logical_expr(filter_sql, &schema)
     {
         Ok(f) => Ok(Some(f)),
         Err(e) if is_field_not_found_on_unrelated_table(tbl, &e) => {
             tracing::debug!(
-                "Ignoring SQL filter ('{}') on table {tbl:?} for search request as its columns do not reference this table",
-                filter
+                "Ignoring SQL filter ('{filter_sql}') on table {tbl:?} for search request as its columns do not reference this table"
             );
             Ok(None)
         }

--- a/crates/search/src/pipeline.rs
+++ b/crates/search/src/pipeline.rs
@@ -98,7 +98,7 @@ impl<A: CandidateAggregation> SearchPipeline<A> {
         opt_filter: Option<Expr>,
         addition_projection: Vec<Expr>,
         primary_keys: Vec<Column>,
-        keywords: Vec<String>,
+        keywords: &[String],
         limit: usize,
     ) -> std::result::Result<Option<AggregationResult>, Error> {
         let columns: Vec<_> = [
@@ -117,7 +117,7 @@ impl<A: CandidateAggregation> SearchPipeline<A> {
 
                 // The column name for each `.generator` will be different, and therefore the
                 // keyword filter [`Expr`] must be made differently.
-                let mut filters = prepare_keywords(&keywords.clone(), &content_col)?;
+                let mut filters = prepare_keywords(keywords, &content_col)?;
                 if let Some(ref f) = opt_filter {
                     filters.push(f.clone());
                 }
@@ -210,7 +210,9 @@ pub fn valid_keywords(keywords: &[String]) -> Result<Vec<String>, Error> {
 }
 
 pub fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, Error> {
-    let expression = format!("{target_column} ILIKE '%{}%'", k.to_lowercase());
+    let lower = k.to_lowercase();
+    let pattern = format!("%{lower}%");
+    let expression = format!("{target_column} ILIKE '{pattern}'");
     let parser = Parser::new(&GenericDialect {});
     let mut parser = parser.try_with_sql(&expression).map_err(|err| {
         tracing::trace!("failed to parse 'keywords' for search. {err}");
@@ -227,7 +229,12 @@ pub fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, E
         }
     })?;
 
-    let SqlExpr::ILike { expr, pattern, .. } = &ilike_expr else {
+    let SqlExpr::ILike {
+        expr,
+        pattern: parsed_pattern,
+        ..
+    } = &ilike_expr
+    else {
         tracing::trace!(
             "failed to parse 'keywords' for search. expected ILIKE, but got {ilike_expr:?}"
         );
@@ -242,7 +249,7 @@ pub fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, E
             value: Value::SingleQuotedString(v),
             ..
         }),
-    ) = (*expr.clone(), *pattern.clone())
+    ) = (expr.as_ref(), parsed_pattern.as_ref())
     {
         if id.value != target_column {
             tracing::trace!(
@@ -254,11 +261,9 @@ pub fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, E
             });
         }
 
-        if v != format!("%{}%", k.to_lowercase()) {
+        if v != &pattern {
             tracing::trace!(
-                "failed to parse 'keywords' for search. expected '%{}%', but got {}",
-                k.to_lowercase(),
-                v
+                "failed to parse 'keywords' for search. expected '{pattern}', but got {v}"
             );
             return Err(Error::InvalidKeyword {
                 keyword: k.to_string(),
@@ -266,7 +271,7 @@ pub fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, E
         }
     } else {
         tracing::trace!(
-            "failed to parse 'keywords' for search. expected identifiers, but got {expr:?} - {pattern:?}"
+            "failed to parse 'keywords' for search. expected identifiers, but got {expr:?} - {parsed_pattern:?}"
         );
         return Err(Error::InvalidKeyword {
             keyword: k.to_string(),
@@ -284,7 +289,7 @@ pub fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, E
         });
     }
 
-    Ok(ident(target_column).ilike(lit(format!("%{}%", k.to_lowercase()))))
+    Ok(ident(target_column).ilike(lit(pattern)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 📝 Summary

Remove avoidable allocations on the search hot path:

1. **Search cache key** — build `SearchKey` from `&SearchRequest` instead of cloning the full request on every cached search.
2. **Multi-table WHERE filter** — stringify the SQL filter once per search and reuse it when binding to each table schema (was `filter.to_string()` per table).
3. **Keyword ILIKE prep** — pass keywords by slice into `SearchPipeline::run` (no per-generator `Vec` clone) and compute `to_lowercase` / ILIKE pattern once in `validate_keyword_to_ilike`.

## 🔗 Related

Hot-path allocation audit in `~/code/spiceai/four` (search/cache path).

## 👀 Notes for Reviewers

- Local `make lint-rust` running in parallel with this PR.
- Unit tests: `cargo test -p search --lib pipeline::tests` passed.

## Test plan

- [x] `cargo check -p search -p runtime-search --all-features`
- [x] `cargo test -p search --lib pipeline::tests`
- [ ] `make lint-rust` (in progress locally)
- [ ] CI green