### PR TITLE
perf: avoid unnecessary allocations on query hot paths

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -4161,7 +4161,7 @@ impl DataFusion {
             .table_names())
     }
 
-    pub fn query_builder<'a>(self: &Arc<Self>, sql: &'a str) -> QueryBuilder<'a> {
+    pub fn query_builder(self: &Arc<Self>, sql: &str) -> QueryBuilder {
         QueryBuilder::new(sql, Arc::clone(self))
     }
 

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -607,8 +607,10 @@ impl Query {
         // Get the session state for planning
         let session = session_ctx.state();
 
-        // Get logical plan and cache key, reusing existing cache infrastructure
-        let (plan, mut tracker, cache_key) = match &self.sql {
+        // Get logical plan and cache key, reusing existing cache infrastructure.
+        // Match by value so a pre-parsed plan / parameters can be moved rather
+        // than deep-cloned on the distributed submit path.
+        let (plan, mut tracker, cache_key) = match self.sql {
             QueryMethod::Text {
                 sql,
                 parameters,
@@ -620,19 +622,19 @@ impl Query {
                     // never short-circuit on a cached result (that would skip
                     // recover_job and leave the running job orphaned) nor write a
                     // fresh cache entry. Plan without consulting the result cache.
-                    let plan = if let Some(plan) = pre_parsed_plan.clone() {
+                    let plan = if let Some(plan) = pre_parsed_plan {
                         *plan
                     } else {
                         let cache_namespace = request_context.cache_namespace();
                         let (ns_tag, ns_id) = cache_namespace.hash_inputs();
-                        let sql_raw_cache_key = CacheKey::Query(sql, parameters.as_ref())
+                        let sql_raw_cache_key = CacheKey::Query(sql.as_ref(), parameters.as_ref())
                             .as_raw_key_in_namespace(Self::plan_hasher(&self.df), ns_tag, ns_id);
                         Query::get_plan(
                             &self.df,
                             &session,
-                            sql,
+                            sql.as_ref(),
                             &sql_raw_cache_key,
-                            parameters.clone(),
+                            parameters,
                         )
                         .await?
                     };
@@ -647,10 +649,10 @@ impl Query {
                         &self.df,
                         &session,
                         Arc::clone(&request_context),
-                        sql,
-                        parameters.clone(),
+                        sql.as_ref(),
+                        parameters,
                         tracker,
-                        pre_parsed_plan.clone(),
+                        pre_parsed_plan,
                     )
                     .await?
                     {
@@ -688,7 +690,7 @@ impl Query {
                 // never served across principals (mirrors the text-query path).
                 let cache_namespace = request_context.cache_namespace();
                 let (ns_tag, ns_id) = cache_namespace.hash_inputs();
-                let plan_cache_key = CacheKey::LogicalPlan(logical_plan).as_raw_key_in_namespace(
+                let plan_cache_key = CacheKey::LogicalPlan(&logical_plan).as_raw_key_in_namespace(
                     Self::plan_hasher(&self.df),
                     ns_tag,
                     ns_id,
@@ -729,7 +731,7 @@ impl Query {
 
                 // Don't cache results for a recovered job.
                 let cache_key = (mode != DistributedSubmitMode::Resume).then_some(plan_cache_key);
-                (logical_plan.as_ref().clone(), tracker, cache_key)
+                (*logical_plan, tracker, cache_key)
             }
         };
 
@@ -893,9 +895,10 @@ impl Query {
         // cancel endpoints can locate this query by id. The guard is captured
         // by the returned stream so the registration is removed on completion,
         // drop, or cancellation.
-        let sql_preview = match &self.sql {
-            QueryMethod::Text { sql, .. } => sql.as_ref(),
-            QueryMethod::Plan(_) => "<logical plan>",
+        // Own the SQL preview before moving `self.sql` into the planning match.
+        let sql_preview: Arc<str> = match &self.sql {
+            QueryMethod::Text { sql, .. } => Arc::clone(sql),
+            QueryMethod::Plan(_) => Arc::from("<logical plan>"),
         };
         let active_query_guard = self.df.query_cancel_registry().register(
             self.query_id,
@@ -903,7 +906,7 @@ impl Query {
             request_context.protocol(),
             query_cancel_token.clone(),
         );
-        let query_id_str = self.query_id.to_string();
+        let query_id_str: Arc<str> = Arc::from(self.query_id.to_string());
 
         let inner_span = span.clone();
 
@@ -921,26 +924,27 @@ impl Query {
                     .config_mut()
                     .set_extension(Arc::clone(&request_context));
 
-                // Get the `LogicalPlan` or cached results
-                let (plan, mut tracker, cache_manager) = match &ctx.sql {
+                // Get the `LogicalPlan` or cached results. Match by value so a
+                // pre-parsed plan / parameters can be moved rather than deep-cloned.
+                let (plan, mut tracker, cache_manager) = match ctx.sql {
                     QueryMethod::Text {
                         sql,
                         parameters,
                         table_allowlist: Some(allowlist),
                         pre_parsed_plan,
                     } => {
-                        let raw_cache_key = CacheKey::Query(sql, parameters.as_ref())
+                        let raw_cache_key = CacheKey::Query(sql.as_ref(), parameters.as_ref())
                             .as_raw_key(Query::plan_hasher(&ctx.df));
                         let plan = if let Some(plan) = pre_parsed_plan {
-                            plan.clone()
+                            plan
                         } else {
                             Self::ensure_not_cancelled(&query_cancel_token, &query_id_str)?;
                             match Self::get_plan(
                                 &ctx.df,
                                 &session,
-                                sql,
+                                sql.as_ref(),
                                 &raw_cache_key,
-                                parameters.clone(),
+                                parameters,
                             )
                             .await
                             {
@@ -989,10 +993,10 @@ impl Query {
                             &ctx.df,
                             &session,
                             Arc::clone(&request_context),
-                            sql,
-                            parameters.clone(),
+                            sql.as_ref(),
+                            parameters,
                             tracker,
-                            pre_parsed_plan.clone(),
+                            pre_parsed_plan,
                         )
                         .await?
                         {
@@ -1005,7 +1009,7 @@ impl Query {
                                 return Ok(attach_cancellation_to_query_result(
                                     query_result,
                                     query_cancel_token.clone(),
-                                    query_id_str.clone(),
+                                    Arc::clone(&query_id_str),
                                     active_query_guard,
                                 ));
                             }
@@ -1018,13 +1022,13 @@ impl Query {
                         let (ns_tag, ns_id) = cache_namespace.hash_inputs();
                         let cache_manager = RequestCacheManager::new(
                             CacheStatus::CacheMiss,
-                            CacheKey::LogicalPlan(logical_plan).as_raw_key_in_namespace(
+                            CacheKey::LogicalPlan(&logical_plan).as_raw_key_in_namespace(
                                 Query::plan_hasher(&ctx.df),
                                 ns_tag,
                                 ns_id,
                             ),
                         );
-                        (logical_plan.clone(), None, cache_manager)
+                        (logical_plan, None, cache_manager)
                     }
                 };
 
@@ -1140,7 +1144,7 @@ impl Query {
                                 biased;
                                 () = query_cancel_token.cancelled() => {
                                     return Err(Error::QueryCancelled {
-                                        query_id: query_id_str.clone(),
+                                        query_id: query_id_str.to_string(),
                                     });
                                 }
                                 permit = semaphore.acquire_owned() => permit.ok(),
@@ -1371,7 +1375,7 @@ impl Query {
                 let final_stream = attach_cancellation_to_stream(
                     final_stream,
                     query_cancel_token.clone(),
-                    query_id_str.clone(),
+                    Arc::clone(&query_id_str),
                     // Bundle the admission permit with the active-query guard so
                     // BOTH release exactly when the result stream is fully drained
                     // (completion, error, or cancellation) — the permit thus spans
@@ -1693,7 +1697,7 @@ fn attach_query_active_guard_to_stream(
 fn attach_cancellation_to_query_result<G>(
     query_result: QueryResult,
     cancellation_token: tokio_util::sync::CancellationToken,
-    query_id: String,
+    query_id: Arc<str>,
     guard: G,
 ) -> QueryResult
 where
@@ -1721,7 +1725,7 @@ where
 fn attach_cancellation_to_stream<G>(
     stream: SendableRecordBatchStream,
     cancellation_token: tokio_util::sync::CancellationToken,
-    query_id: String,
+    query_id: Arc<str>,
     guard: G,
 ) -> SendableRecordBatchStream
 where
@@ -1730,7 +1734,7 @@ where
     struct State<G> {
         stream: Option<SendableRecordBatchStream>,
         token: tokio_util::sync::CancellationToken,
-        query_id: String,
+        query_id: Arc<str>,
         guard: Option<G>,
         emitted_cancel: bool,
     }
@@ -3557,11 +3561,11 @@ mod tests {
         .expect("batch");
         let cancel_token = CancellationToken::new();
         let guard_dropped = Arc::new(AtomicBool::new(false));
-        let query_id = uuid::Uuid::new_v4().to_string();
+        let query_id = Arc::<str>::from(uuid::Uuid::new_v4().to_string());
         let mut stream = attach_cancellation_to_stream(
             stream_from_batches(&schema, vec![batch]),
             cancel_token.clone(),
-            query_id.clone(),
+            Arc::clone(&query_id),
             DropFlag::new(Arc::clone(&guard_dropped)),
         );
 
@@ -3595,11 +3599,11 @@ mod tests {
         )]));
         let cancel_token = CancellationToken::new();
         let guard_dropped = Arc::new(AtomicBool::new(false));
-        let query_id = uuid::Uuid::new_v4().to_string();
+        let query_id = Arc::<str>::from(uuid::Uuid::new_v4().to_string());
         let mut stream = attach_cancellation_to_stream(
             pending_stream(&schema),
             cancel_token.clone(),
-            query_id.clone(),
+            Arc::clone(&query_id),
             DropFlag::new(Arc::clone(&guard_dropped)),
         );
 

--- a/crates/runtime/src/datafusion/query/builder.rs
+++ b/crates/runtime/src/datafusion/query/builder.rs
@@ -27,15 +27,15 @@ use crate::datafusion::{DataFusion, query::QueryMethod};
 
 use super::{Query, tracker::QueryTracker};
 
-enum SqlOrPlan<'a> {
-    Sql(&'a str),
+enum SqlOrPlan {
+    Sql(Arc<str>),
     /// Pre-parsed plan with the original SQL retained for cache key compatibility.
     Plan(Box<LogicalPlan>, Arc<str>),
 }
 
-pub struct QueryBuilder<'a> {
+pub struct QueryBuilder {
     df: Arc<DataFusion>,
-    method: SqlOrPlan<'a>,
+    method: SqlOrPlan,
     parameters: Option<ParamValues>,
     table_allowlist: Option<ResolvedTableAwareAllowlist>,
     query_id: Uuid,
@@ -43,8 +43,25 @@ pub struct QueryBuilder<'a> {
     read_only: bool,
 }
 
-impl<'a> QueryBuilder<'a> {
-    pub fn new(sql: &'a str, df: Arc<DataFusion>) -> Self {
+impl QueryBuilder {
+    pub fn new(sql: &str, df: Arc<DataFusion>) -> Self {
+        Self {
+            df,
+            method: SqlOrPlan::Sql(Arc::from(sql)),
+            parameters: None,
+            query_id: Uuid::new_v4(),
+            table_allowlist: None,
+            cancellation_token: None,
+            read_only: false,
+        }
+    }
+
+    /// Build a query from an already-owned [`Arc<str>`] SQL string.
+    ///
+    /// Prefer this over [`Self::new`] when the caller already holds an
+    /// `Arc<str>` (for example after decoding an HTTP body) so the SQL is not
+    /// copied again.
+    pub fn new_arc(sql: Arc<str>, df: Arc<DataFusion>) -> Self {
         Self {
             df,
             method: SqlOrPlan::Sql(sql),
@@ -144,7 +161,7 @@ impl<'a> QueryBuilder<'a> {
 
         let query_method = match self.method {
             SqlOrPlan::Sql(sql) => QueryMethod::Text {
-                sql: sql.into(),
+                sql,
                 parameters: self.parameters,
                 table_allowlist: self.table_allowlist,
                 pre_parsed_plan: None,

--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -81,17 +81,19 @@ impl QueryTracker {
             tags.push("error");
         }
 
+        // Build the datasets label once and reuse it for OTel metrics and
+        // task-history logging. Sort so the same set of datasets always
+        // produces the same joined string — HashSet iteration order would
+        // otherwise split identical workloads across multiple telemetry series
+        // (e.g. "a,b" vs "b,a").
         let mut dataset_names: Vec<String> =
             self.datasets.iter().map(ToString::to_string).collect();
-        // Sort so that the same set of datasets always produces the same
-        // joined string. Without this, HashSet iteration order would cause
-        // identical workloads to land on multiple distinct telemetry series
-        // (e.g. "a,b" vs "b,a").
         dataset_names.sort();
+        let datasets_label = dataset_names.join(",");
 
         let mut labels = vec![
             KeyValue::new("tags", tags.join(",")),
-            KeyValue::new("datasets", dataset_names.join(",")),
+            KeyValue::new("datasets", datasets_label.clone()),
         ];
 
         labels.extend(request_context.to_dimensions());
@@ -136,7 +138,7 @@ impl QueryTracker {
             metrics::FAILURES.add(1, &labels);
         }
 
-        trace_query(request_context, &self, captured_output);
+        trace_query(request_context, &self, captured_output, &datasets_label);
     }
 
     #[must_use]
@@ -168,6 +170,7 @@ fn trace_query(
     request_context: &RequestContext,
     query_tracker: &QueryTracker,
     captured_output: &str,
+    datasets_label: &str,
 ) {
     if let Some(error_code) = &query_tracker.error_code {
         tracing::info!(target: "task_history", error_code = %error_code, "labels");
@@ -191,12 +194,6 @@ fn trace_query(
         tracing::info!(target: "task_history", accelerated = true, "labels");
     }
 
-    let datasets_str = query_tracker
-        .datasets
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<String>>()
-        .join(",");
-    tracing::info!(target: "task_history", protocol = ?request_context.protocol(), datasets = datasets_str, "labels");
+    tracing::info!(target: "task_history", protocol = ?request_context.protocol(), datasets = datasets_label, "labels");
     tracing::info!(target: "task_history", captured_output = %captured_output);
 }

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -250,7 +250,7 @@ fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
 // columns — still buffer via `to_http_response`.
 pub async fn sql_to_http_response(
     df: Arc<DataFusion>,
-    sql: &str,
+    sql: Arc<str>,
     parameters: Option<ParamValues>,
     format: ResponseMimeType,
     read_only: bool,
@@ -260,7 +260,7 @@ pub async fn sql_to_http_response(
     // under (see `EgressAccount`).
     let memory_pool = Arc::clone(&df.ctx.runtime_env().memory_pool);
 
-    let query_res = match QueryBuilder::new(sql, df)
+    let query_res = match QueryBuilder::new_arc(sql, df)
         .parameters(parameters)
         .read_only(read_only)
         .build()

--- a/crates/runtime/src/http/v1/query.rs
+++ b/crates/runtime/src/http/v1/query.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::sync::Arc;
+
 use axum::{
     body::Bytes,
     http::StatusCode,
@@ -205,7 +207,8 @@ pub(crate) async fn post(
                     }
                 };
 
-                (sql, Some(parameters))
+                // Move the deserialized String into Arc<str> without a second copy.
+                (Arc::<str>::from(sql), Some(parameters))
             }
             Err(e) => {
                 tracing::debug!("Error parsing JSON: {e}");
@@ -213,9 +216,9 @@ pub(crate) async fn post(
             }
         }
     } else {
-        // Use &body directly to avoid unnecessary copy of Bytes
+        // Decode once into Arc<str> so QueryBuilder does not re-copy the SQL body.
         let sql = match std::str::from_utf8(&body) {
-            Ok(query) => query.to_string(),
+            Ok(query) => Arc::<str>::from(query),
             Err(e) => {
                 tracing::debug!("Error reading query: {e}");
                 return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
@@ -226,7 +229,7 @@ pub(crate) async fn post(
 
     sql_to_http_response(
         df,
-        &sql,
+        sql,
         parameters,
         ResponseMimeType::from_accept_header(accept.as_ref()),
         current_principal_requires_read_only().await,


### PR DESCRIPTION
## Summary

Remove avoidable allocations on the SQL query hot path (distinct from search-path work in #11767):

1. **Move plans/params by value** — `run_internal` / `submit_distributed_internal` take ownership of `QueryMethod` so pre-parsed `LogicalPlan`s and `ParamValues` are moved into planning instead of deep-cloned (important for FlightSQL read-only paths that already parsed once).
2. **`/v1/sql` Arc-first SQL** — decode the request body into `Arc<str>` and pass it through `QueryBuilder::new_arc`, avoiding an extra SQL string copy before execution.
3. **Reuse datasets telemetry label** — build the sorted `datasets` label once in `QueryTracker::finish` and reuse it for OTel metrics and task-history logging.

## Related

Hot-path allocation audit in `~/code/spiceai/five` (query path). Does not overlap with #11767 (search cache / keyword ILIKE).

## Test plan

- [x] `make lint-rust`
- [ ] CI green
- [ ] Spot-check `/v1/sql` text/plain and JSON parameterized queries still work