### PR TITLE
ci(rust): install 1.96.1 in workflows that pin the toolchain explicitly

### DIFF
--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -40,9 +40,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust 1.95.0
+      - name: Install Rust 1.96.1
         if: steps.check_pr.outputs.skip != 'true'
-        run: rustup toolchain install 1.95.0 --profile minimal
+        run: rustup toolchain install 1.96.1 --profile minimal
 
       - name: Set up make
         if: runner.os != 'macOS' && steps.check_pr.outputs.skip != 'true'

--- a/.github/workflows/generate_acknowledgements.yml
+++ b/.github/workflows/generate_acknowledgements.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup toolchain install 1.95.0 --profile minimal
+      - run: rustup toolchain install 1.96.1 --profile minimal
 
       - name: Set up make
         if: runner.os != 'macOS'

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup toolchain install 1.95.0 --profile minimal
+      - run: rustup toolchain install 1.96.1 --profile minimal
 
       - name: Set up make
         if: runner.os != 'macOS' && (github.event_name != 'workflow_dispatch' || inputs.run_build)

--- a/.github/workflows/types_check.yml
+++ b/.github/workflows/types_check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 
-      - run: rustup toolchain install 1.95.0 --profile minimal
+      - run: rustup toolchain install 1.96.1 --profile minimal
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:


### PR DESCRIPTION
Follow-up to #11743 (Rust 1.96.1 upgrade).

That PR bumped `rust-toolchain.toml` to 1.96.1, but four workflows install the toolchain explicitly via `rustup toolchain install 1.95.0 --profile minimal` instead of the shared `setup-rust` action, so they weren't covered — and #11743 merged before the review comment could be addressed.

With the channel now pinned to 1.96.1, these steps installed a stale toolchain (the real build then auto-downloaded 1.96.1 anyway). Align them to 1.96.1:

- `.github/workflows/generate-openapi.yml` (+ step label)
- `.github/workflows/types_check.yml`
- `.github/workflows/generate_json_schema.yml`
- `.github/workflows/generate_acknowledgements.yml`

Addresses the `copilot-pull-request-reviewer` feedback on #11743.