### PR TITLE
docs: correct sort-kernel SIMD note (AVX2, not AVX-512)

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -9935,7 +9935,7 @@ impl CayenneTableProvider {
     /// Uses `DataFusion`'s `SortExec` which provides:
     /// - **Automatic disk spilling**: Handles datasets larger than available memory
     /// - **Streaming external merge sort**: Processes data incrementally without loading all into RAM
-    /// - **SIMD-optimized kernels**: Hardware-accelerated sorting (NEON on arm64, AVX2/AVX-512 on amd64)
+    /// - **SIMD-optimized kernels**: Hardware-accelerated sorting (NEON on arm64, AVX2 on amd64)
     /// - **Configurable spill compression**: Supports zstd, `lz4_frame`, or uncompressed spill files
     /// - **Memory management**: Integrates with `DataFusion`'s memory pool and reservation system
     ///

--- a/crates/util/src/stream_utils.rs
+++ b/crates/util/src/stream_utils.rs
@@ -46,7 +46,7 @@ use parking_lot::Mutex;
 /// Uses `DataFusion`'s `SortExec` which provides:
 /// - **Automatic disk spilling**: Handles datasets larger than available memory
 /// - **Streaming external merge sort**: Processes data incrementally without loading all into RAM
-/// - **SIMD-optimized kernels**: Hardware-accelerated sorting (NEON on arm64, AVX2/AVX-512 on amd64)
+/// - **SIMD-optimized kernels**: Hardware-accelerated sorting (NEON on arm64, AVX2 on amd64)
 /// - **Configurable spill compression**: Supports zstd, `lz4_frame`, or uncompressed spill files
 /// - **Memory management**: Integrates with `DataFusion`'s memory pool and reservation system
 ///


### PR DESCRIPTION
Two doc comments describe DataFusion's `SortExec` as using "SIMD-optimized kernels: Hardware-accelerated sorting (NEON on arm64, AVX2/AVX-512 on amd64)". The AVX-512 part is inaccurate for our shipped binary:

- The x86_64 Linux release is compiled for an **AVX2 + FMA + BMI** baseline (`bin/spiced/.cargo/config.toml`), deliberately capped for portability across the AWS x86 fleet (AMD C6a/C7a and Graviton have no AVX-512).
- Arrow/DataFusion sort relies on LLVM autovectorization, which can only emit up to that AVX2 baseline in the shipped binary — never AVX-512.

Drops `/AVX-512` from both comments (`crates/cayenne/src/provider/table.rs`, `crates/util/src/stream_utils.rs`). Docs-only, no behavior change.