### PR TITLE
chore(chbench): extend scheduled HTAP runs to 15m

### DIFF
--- a/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file]-adaptive.yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/mysql-cayenne[file]-adaptive.yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 600
+    duration: 900
     ready_wait: 60
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file].yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/mysql-cayenne[file].yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 600
+    duration: 900
     ready_wait: 60
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1/mysql-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/mysql-duckdb[file].yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/mysql-duckdb[file].yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 600
+    duration: 900
     ready_wait: 60
     query_overrides: duckdb
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive.yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file]-adaptive.yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 600
+    duration: 900
     ready_wait: 60
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 600
+    duration: 900
     ready_wait: 60
     rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 600
+    duration: 900
     ready_wait: 60
     query_overrides: duckdb
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000-adaptive/mysql-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-adaptive/mysql-cayenne[file]-adaptive.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 600
+    duration: 900
     ready_wait: 900
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000-adaptive/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-adaptive/postgres-cayenne[file]-adaptive.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 600
+    duration: 900
     ready_wait: 900
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 600
+    duration: 900
     ready_wait: 900
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/mysql-cayenne[file]-adaptive-turso.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/mysql-cayenne[file]-adaptive-turso.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 600
+    duration: 900
     ready_wait: 900
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/mysql-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/mysql-duckdb[file].yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 600
+    duration: 900
     ready_wait: 900
     query_overrides: duckdb
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-adaptive-turso.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-adaptive-turso.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 600
+    duration: 900
     ready_wait: 900
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 600
+    duration: 900
     ready_wait: 900
     query_overrides: duckdb
     rate: 9250


### PR DESCRIPTION
## 📝 Summary

Bumps the scheduled HTAP CH-benCHmark run duration from **600s (10m)** to **900s (15m)** for every scale-factor group that fires on a cron schedule in `testoperator_dispatch_htap.yml`:

| Group | Cadence |
| --- | --- |
| `sf1000-adaptive` | every 6h (`0 */6 * * *`) |
| `sf1000` | daily 01:00 (`0 1 * * *`) |
| `sf1` | twice daily 06:00 / 18:00 (`0 6,18 * * *`) |
| `sf1000-cold` | daily 08:00 (`0 8 * * *`) |

The longer window gives steadier-state QPH and replication-lag numbers, letting CDC reach equilibrium before the measurement window closes. 13 dispatch configs, one `duration:` line each.

## 🔗 Related

None.

## 🚨 Breaking Changes

None. The dispatcher's per-run job `timeout-minutes: 120` comfortably covers the extra 5 minutes.

## 👀 Notes for Reviewers

Scope is deliberately limited to the **scheduled** groups. Left unchanged:
- Manual-`workflow_dispatch`-only HTAP configs (`sf10`, `sf100`).
- The `duration: '600'` default in `testoperator_run_htap.yml` (only used by a bare manual run-workflow trigger; scheduled runs get their duration from the dispatch configs).
- The scheduled `sf100` job in `testoperator_dispatch.yml` is an explain-plan `bench` run (no OLTP), not HTAP.

Happy to fold in the `sf10`/`sf100` manual configs and/or the run-workflow default if we'd rather keep all durations aligned at 15m.