### PR TITLE
test(cayenne): limit property-test concurrency

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,6 +9,14 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 # to a fixed number of threads or a lower expression (for example, "num-cpus/2").
 test-threads = "num-cpus"
 
+# These property tests create multi-threaded Tokio runtimes and continuously run
+# background compaction. Letting nextest start one per logical CPU oversubscribes
+# the runner (for example, each mutation concurrency test has four Tokio workers)
+# and can make deterministic tests exceed the timeout. Keep enough parallelism to
+# exercise cross-task races without running every stress test at once.
+[test-groups]
+cayenne-property-tests = { max-threads = 2 }
+
 # Correctness/convergence property tests: the accelerated table MUST converge to
 # the reference model on every run. These are deterministic correctness checks,
 # not best-effort work — so a retry that happens to pass only HIDES a real bug
@@ -17,4 +25,5 @@ test-threads = "num-cpus"
 # never a silently-recovered flake.
 [[profile.default.overrides]]
 filter = 'binary(=mutation_property_test) | binary(=cdc_compaction_delete_race_test) | binary(=maintained_aggregate_filter_test)'
+test-group = 'cayenne-property-tests'
 retries = 0


### PR DESCRIPTION
## 📝 Summary

Cap the Cayenne correctness/property-test group at two concurrent test processes.

These tests each create multi-threaded Tokio runtimes and continuously compact in the background. Running one test process per logical CPU oversubscribes the runner: in [the flaky run](https://github.com/spiceai/spiceai/actions/runs/29062677681/job/86267887971), all concurrent mutation tests slowed from their typical 20–50 seconds to 298–360+ seconds, and the two tests that started earliest crossed Nextest's 360-second timeout. Keeping two property tests active preserves concurrent race coverage while preventing the stress binaries from starving one another.

## 🔗 Related

- Flaky CI job: https://github.com/spiceai/spiceai/actions/runs/29062677681/job/86267887971

## 👀 Notes for Reviewers

Validated with the same Cayenne test command run by CI:

```text
cargo nextest run -p cayenne --tests
Summary [161.231s] 1234 tests run: 1234 passed, 6 skipped
```

The 15 `mutation_property_test` cases completed in 145 seconds with the group limit, with the longest individual case at 42.6 seconds.
