### PR TITLE
fix(ci): download MinIO client from public-data mirror

### DIFF
--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -24,7 +24,8 @@ runs:
           exit 0
         fi
 
-        mc_url="https://dl.min.io/client/mc/release/linux-amd64/mc"
+        # Mirror of mc; dl.min.io currently serves an expired TLS cert.
+        mc_url="https://public-data.spiceai.org/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z"
         tmp_mc="$(mktemp)"
         if command -v curl >/dev/null 2>&1; then
           curl --fail --silent --show-error --location --output "$tmp_mc" "$mc_url"

--- a/.github/actions/upload-to-minio/action.yml
+++ b/.github/actions/upload-to-minio/action.yml
@@ -31,7 +31,8 @@ runs:
       run: |
         if ! command -v mc &> /dev/null; then
           sudo apt update && sudo apt install wget -y
-          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          # Mirror of mc; dl.min.io currently serves an expired TLS cert.
+          sudo wget https://public-data.spiceai.org/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
         fi
         mc alias set spice-minio ${{ inputs.minio_endpoint }} ${{ inputs.minio_access_key }} ${{ inputs.minio_secret_key }}

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -214,7 +214,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install wget -y
-          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo wget https://public-data.spiceai.org/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ env.MINIO_ENDPOINT }} ${{ env.MINIO_ACCESS_KEY }} ${{ env.MINIO_SECRET_KEY }}
 

--- a/crates/data_components/tests/hadoop_data/Dockerfile
+++ b/crates/data_components/tests/hadoop_data/Dockerfile
@@ -1,7 +1,7 @@
 FROM spark:3.5.6
 USER root
 WORKDIR /data
-RUN apt-get update && apt-get install wget -y && wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
+RUN apt-get update && apt-get install wget -y && wget https://public-data.spiceai.org/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z -O /usr/local/bin/mc && \
     chmod +x /usr/local/bin/mc
 COPY ./setup_spark.sh /usr/local/bin/setup_spark.sh
 RUN /usr/local/bin/setup_spark.sh


### PR DESCRIPTION
## Summary
- `dl.min.io` currently serves an expired TLS certificate, which breaks the `setup-minio` composite action (`curl: (60) SSL certificate problem: certificate has expired`) and related CI steps that download `mc`.
- Point Linux MinIO client downloads at the pinned Spice public-data mirror: `https://public-data.spiceai.org/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z`.

## Test plan
- [x] Confirm CI jobs that use `setup-minio` (e.g. Build Test Binary / integration) get past the MinIO client install step
- [x] Spot-check that `mc` still authenticates against the test MinIO endpoint after install