### PR TITLE
fix(tests): synchronize chat expect prompts correctly

### DIFF
--- a/test/models/chat_01_simple.exp
+++ b/test/models/chat_01_simple.exp
@@ -8,15 +8,6 @@ spawn spice chat
 proc chat {message}  {
     global timeout
 
-    # Wait for the chat prompt to be ready before sending
-    expect {
-        "chat> " {}
-        timeout {
-            send_user "Timeout waiting for chat prompt\n"
-            exit 1
-        }
-    }
-
     send "$message\r"
 
     expect {
@@ -29,6 +20,10 @@ proc chat {message}  {
         "chat> " {
             # end of model response
         }
+        eof {
+            send_user "Chat process exited before returning a response\n"
+            exit 1
+        }
         timeout {
             send_user "Timeout waiting for expected response\n"
             exit 1
@@ -36,6 +31,21 @@ proc chat {message}  {
     }
 
     send_user "Model returned expected response\n"
+}
+
+# Wait once for the initial prompt. Each chat call consumes the prompt that
+# terminates its response, so waiting again at the start of the next call would
+# block while the REPL is already ready for input.
+expect {
+    "chat> " {}
+    eof {
+        send_user "Chat process exited before showing the initial prompt\n"
+        exit 1
+    }
+    timeout {
+        send_user "Timeout waiting for initial chat prompt\n"
+        exit 1
+    }
 }
 
 chat "What datasets you have access to?"


### PR DESCRIPTION
## Summary

- Fix the Hugging Face chat E2E test timing out before its second message.
- Wait for the REPL prompt once at startup, then let each chat turn consume only its response-ending prompt.
- Report an explicit failure if the chat process exits before startup or mid-response.

The previous flow consumed the response-ending `chat> ` prompt, then waited for another prompt before sending the next message. Since the REPL was already waiting for input, that prompt never arrived. This failed merge-queue runs [29125029705](https://github.com/spiceai/spiceai/actions/runs/29125029705/job/86476886744) and [29121105235](https://github.com/spiceai/spiceai/actions/runs/29121105235/job/86466065874).

## Test plan

- Ran `chat_01_simple.exp` against a mock REPL that emits one initial prompt and one prompt after each response; both chat turns completed.
- Confirmed the previous script times out before its second turn against the same mock.