### PR TITLE
ci: inherit sign-off across clean base merges

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,9 +56,9 @@ env:
 jobs:
   # On a pull request this is the ONLY job that runs. It validates the developer
   # sign-off — the `signoff` commit status posted by `make signoff` — for the PR's
-  # head commit. It can also inherit the first parent's sign-off when HEAD is an
-  # unmodified, conflict-free merge of the current base commit. A green
-  # Attestation (plus review) is what lets the PR into the merge queue, where the
+  # head commit. It can also walk through clean, unmodified base-merge commits
+  # on the first-parent chain to find an earlier sign-off. A green Attestation
+  # (plus review) is what lets the PR into the merge queue, where the
   # heavy jobs below and the other workflows run the full suite. This is what
   # replaces running all checks on every PR push.
   attestation:
@@ -81,6 +81,7 @@ jobs:
             const repo = context.repo.repo;
             const headSha = context.payload.pull_request.head.sha;
             const baseSha = context.payload.pull_request.base.sha;
+            const maxInheritedMerges = 100;
 
             // 'signoff' matches the hardcoded STATUS_CONTEXT in scripts/signoff.
             async function successfulSignoff(sha) {
@@ -93,55 +94,70 @@ jobs:
               return signoff?.state === 'success' ? signoff : undefined;
             }
 
-            const headSignoff = await successfulSignoff(headSha);
-            if (headSignoff) {
-              core.notice(
-                `Signed off by ${headSignoff.creator?.login ?? 'unknown'}: ` +
-                `${headSignoff.description ?? ''}`
-              );
-              return;
-            }
+            const merges = [];
+            let currentSha = headSha;
+            for (let depth = 0; depth <= maxInheritedMerges; depth += 1) {
+              const signoff = await successfulSignoff(currentSha);
+              if (signoff) {
+                if (merges.length === 0) {
+                  core.notice(
+                    `Signed off by ${signoff.creator?.login ?? 'unknown'}: ` +
+                    `${signoff.description ?? ''}`
+                  );
+                  return;
+                }
 
-            const { data: headCommit } = await github.rest.repos.getCommit({
-              owner,
-              repo,
-              ref: headSha,
-            });
-            const [previousHead, mergedBase, ...extraParents] = headCommit.parents;
-            if (
-              !previousHead ||
-              !mergedBase ||
-              extraParents.length > 0 ||
-              mergedBase.sha !== baseSha
-            ) {
-              core.setFailed(
-                `No developer sign-off found for ${headSha}. HEAD is not a two-parent merge ` +
-                `of the current base commit (${baseSha}), so it cannot inherit an earlier sign-off.\n\n` +
-                `On your machine, with this commit pushed, run:\n\n` +
-                `    make signoff\n\n` +
-                `See docs/dev/ci_signoff.md.`
-              );
-              return;
-            }
+                core.setOutput('inheritance-candidate', 'true');
+                core.setOutput('merge-chain', JSON.stringify(merges));
+                core.setOutput('signed-sha', currentSha);
+                core.setOutput('current-base-sha', baseSha);
+                core.notice(
+                  `Found sign-off on ${currentSha} behind ${merges.length} base merge(s); ` +
+                  `verifying each automatic merge result.`
+                );
+                return;
+              }
 
-            const previousSignoff = await successfulSignoff(previousHead.sha);
-            if (!previousSignoff) {
-              core.setFailed(
-                `No developer sign-off found for ${headSha} or its pre-merge parent ` +
-                `${previousHead.sha}. Run make signoff on the pushed HEAD. ` +
-                `See docs/dev/ci_signoff.md.`
-              );
-              return;
-            }
+              if (depth === maxInheritedMerges) {
+                core.setFailed(
+                  `No developer sign-off found within ${maxInheritedMerges} base merges of ` +
+                  `${headSha}. Run make signoff on the pushed HEAD.`
+                );
+                return;
+              }
 
-            core.setOutput('inheritance-candidate', 'true');
-            core.setOutput('previous-sha', previousHead.sha);
-            core.setOutput('base-sha', mergedBase.sha);
-            core.setOutput('head-tree', headCommit.commit.tree.sha);
-            core.notice(
-              `Found sign-off on pre-merge parent ${previousHead.sha}; ` +
-              `verifying that HEAD is the unmodified automatic merge result.`
-            );
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: currentSha,
+              });
+              const [previousHead, mergedBase, ...extraParents] = commit.parents;
+              if (!previousHead || !mergedBase || extraParents.length > 0) {
+                core.setFailed(
+                  `No developer sign-off found for ${headSha}. The first-parent chain reaches ` +
+                  `unsigned commit ${currentSha}, which is not a two-parent merge and cannot ` +
+                  `inherit an earlier sign-off.\n\nRun make signoff on the pushed HEAD. ` +
+                  `See docs/dev/ci_signoff.md.`
+                );
+                return;
+              }
+              if (merges.length === 0 && mergedBase.sha !== baseSha) {
+                core.setFailed(
+                  `No developer sign-off found for ${headSha}. HEAD does not merge the current ` +
+                  `base commit (${baseSha}), so it cannot inherit an earlier sign-off.\n\n` +
+                  `Run make signoff on the pushed HEAD. See docs/dev/ci_signoff.md.`
+                );
+                return;
+              }
+
+              merges.push({
+                head: currentSha,
+                previous: previousHead.sha,
+                base: mergedBase.sha,
+                tree: commit.commit.tree.sha,
+              });
+              currentSha = previousHead.sha;
+            }
 
       # Only an otherwise-valid inheritance candidate needs repository history
       # and blobs to reproduce the merge without relying on a lazy network fetch.
@@ -157,38 +173,74 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && steps.signoff.outputs.inheritance-candidate == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PREVIOUS_SHA: ${{ steps.signoff.outputs.previous-sha }}
-          BASE_SHA: ${{ steps.signoff.outputs.base-sha }}
-          HEAD_TREE: ${{ steps.signoff.outputs.head-tree }}
+          MERGE_CHAIN: ${{ steps.signoff.outputs.merge-chain }}
+          SIGNED_SHA: ${{ steps.signoff.outputs.signed-sha }}
+          CURRENT_BASE_SHA: ${{ steps.signoff.outputs.current-base-sha }}
         with:
           script: |
-            const previousSha = process.env.PREVIOUS_SHA;
-            const baseSha = process.env.BASE_SHA;
-            const expectedTree = process.env.HEAD_TREE;
-            const merge = await exec.getExecOutput(
+            const merges = JSON.parse(process.env.MERGE_CHAIN);
+            const signedSha = process.env.SIGNED_SHA;
+            const currentBaseSha = process.env.CURRENT_BASE_SHA;
+            const baseHistory = await exec.getExecOutput(
               'git',
-              ['merge-tree', '--write-tree', '--no-messages', previousSha, baseSha],
-              { ignoreReturnCode: true, silent: true }
+              ['rev-list', '--first-parent', currentBaseSha],
+              { silent: true }
             );
-            const reproducedTree = merge.stdout.trim();
-            if (merge.exitCode !== 0) {
-              core.setFailed(
-                `The merge of ${baseSha} into ${previousSha} is not conflict-free, so HEAD ` +
-                `cannot inherit the earlier sign-off. Resolve the merge, then run make signoff ` +
-                `on the pushed HEAD.`
+            const basePositions = new Map(
+              baseHistory.stdout.trim().split('\n').map((sha, index) => [sha, index])
+            );
+            let newerBasePosition = -1;
+
+            for (const mergeCommit of merges) {
+              const basePosition = basePositions.get(mergeCommit.base);
+              if (basePosition === undefined || basePosition < newerBasePosition) {
+                core.setFailed(
+                  `Merge ${mergeCommit.head} uses base commit ${mergeCommit.base} out of order ` +
+                  `or outside the current base branch's first-parent history. Run make signoff ` +
+                  `on the pushed HEAD.`
+                );
+                return;
+              }
+
+              const merge = await exec.getExecOutput(
+                'git',
+                [
+                  'merge-tree',
+                  '--write-tree',
+                  '--no-messages',
+                  mergeCommit.previous,
+                  mergeCommit.base,
+                ],
+                { ignoreReturnCode: true, silent: true }
               );
-              return;
-            }
-            if (!/^[0-9a-f]{40,64}$/.test(reproducedTree) || reproducedTree !== expectedTree) {
-              core.setFailed(
-                `HEAD contains changes beyond Git's automatic merge of ${baseSha} into ` +
-                `${previousSha}, so it cannot inherit the earlier sign-off. Run make signoff ` +
-                `on the pushed HEAD.`
-              );
-              return;
+              const reproducedTree = merge.stdout.trim();
+              if (merge.exitCode !== 0) {
+                core.setFailed(
+                  `Merge ${mergeCommit.head} of ${mergeCommit.base} into ` +
+                  `${mergeCommit.previous} is not conflict-free. Resolve the merge, then run ` +
+                  `make signoff on the pushed HEAD.`
+                );
+                return;
+              }
+              if (
+                !/^[0-9a-f]{40,64}$/.test(reproducedTree) ||
+                reproducedTree !== mergeCommit.tree
+              ) {
+                core.setFailed(
+                  `Merge ${mergeCommit.head} contains changes beyond Git's automatic merge of ` +
+                  `${mergeCommit.base} into ${mergeCommit.previous}. Run make signoff on the ` +
+                  `pushed HEAD.`
+                );
+                return;
+              }
+
+              newerBasePosition = basePosition;
             }
 
-            core.notice(`Inherited developer sign-off from ${previousSha}.`);
+            core.notice(
+              `Inherited developer sign-off from ${signedSha} across ${merges.length} ` +
+              `clean base merge(s).`
+            );
       - name: Merge queue passthrough
         if: ${{ github.event_name != 'pull_request' }}
         run: echo "Sign-off was validated at queue entry; the full suite runs in this merge_group run."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,44 +56,139 @@ env:
 jobs:
   # On a pull request this is the ONLY job that runs. It validates the developer
   # sign-off — the `signoff` commit status posted by `make signoff` — for the PR's
-  # head commit. A green Attestation (plus review) is what lets the PR into the
-  # merge queue, where the heavy jobs below and the other workflows run the full
-  # suite. This is what replaces running all checks on every PR push.
+  # head commit. It can also inherit the first parent's sign-off when HEAD is an
+  # unmodified, conflict-free merge of the current base commit. A green
+  # Attestation (plus review) is what lets the PR into the merge queue, where the
+  # heavy jobs below and the other workflows run the full suite. This is what
+  # replaces running all checks on every PR push.
   attestation:
-    # GitHub-hosted: this job only calls the API, and self-hosted runners don't
-    # run for fork PRs — which would leave external contributors' required
-    # Attestation check unreported and stuck.
+    # GitHub-hosted: self-hosted runners don't run for fork PRs, which would
+    # leave external contributors' required Attestation check unreported and
+    # stuck.
     name: Attestation
     runs-on: ubuntu-latest
     permissions:
       contents: read
       statuses: read
     steps:
-      - name: Validate developer sign-off
+      - name: Inspect developer sign-off
+        id: signoff
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const sha = context.payload.pull_request.head.sha;
-            const { data } = await github.rest.repos.getCombinedStatusForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: sha,
-            });
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headSha = context.payload.pull_request.head.sha;
+            const baseSha = context.payload.pull_request.base.sha;
+
             // 'signoff' matches the hardcoded STATUS_CONTEXT in scripts/signoff.
-            const signoff = data.statuses.find((s) => s.context === 'signoff');
-            if (signoff && signoff.state === 'success') {
-              core.notice(`Signed off by ${signoff.creator?.login ?? 'unknown'}: ${signoff.description ?? ''}`);
+            async function successfulSignoff(sha) {
+              const { data } = await github.rest.repos.getCombinedStatusForRef({
+                owner,
+                repo,
+                ref: sha,
+              });
+              const signoff = data.statuses.find((status) => status.context === 'signoff');
+              return signoff?.state === 'success' ? signoff : undefined;
+            }
+
+            const headSignoff = await successfulSignoff(headSha);
+            if (headSignoff) {
+              core.notice(
+                `Signed off by ${headSignoff.creator?.login ?? 'unknown'}: ` +
+                `${headSignoff.description ?? ''}`
+              );
               return;
             }
-            core.setFailed(
-              `No developer sign-off found for ${sha}.\n\n` +
-              `On your machine, with this commit pushed, run:\n\n` +
-              `    make signoff\n\n` +
-              `It runs lint + unit tests locally and records a sign-off on this exact\n` +
-              `commit (push a new commit and you must sign off again). The full test\n` +
-              `suite then runs in the merge queue. See docs/dev/ci_signoff.md.`
+
+            const { data: headCommit } = await github.rest.repos.getCommit({
+              owner,
+              repo,
+              ref: headSha,
+            });
+            const [previousHead, mergedBase, ...extraParents] = headCommit.parents;
+            if (
+              !previousHead ||
+              !mergedBase ||
+              extraParents.length > 0 ||
+              mergedBase.sha !== baseSha
+            ) {
+              core.setFailed(
+                `No developer sign-off found for ${headSha}. HEAD is not a two-parent merge ` +
+                `of the current base commit (${baseSha}), so it cannot inherit an earlier sign-off.\n\n` +
+                `On your machine, with this commit pushed, run:\n\n` +
+                `    make signoff\n\n` +
+                `See docs/dev/ci_signoff.md.`
+              );
+              return;
+            }
+
+            const previousSignoff = await successfulSignoff(previousHead.sha);
+            if (!previousSignoff) {
+              core.setFailed(
+                `No developer sign-off found for ${headSha} or its pre-merge parent ` +
+                `${previousHead.sha}. Run make signoff on the pushed HEAD. ` +
+                `See docs/dev/ci_signoff.md.`
+              );
+              return;
+            }
+
+            core.setOutput('inheritance-candidate', 'true');
+            core.setOutput('previous-sha', previousHead.sha);
+            core.setOutput('base-sha', mergedBase.sha);
+            core.setOutput('head-tree', headCommit.commit.tree.sha);
+            core.notice(
+              `Found sign-off on pre-merge parent ${previousHead.sha}; ` +
+              `verifying that HEAD is the unmodified automatic merge result.`
             );
+
+      # Only an otherwise-valid inheritance candidate needs repository history
+      # and blobs to reproduce the merge without relying on a lazy network fetch.
+      - name: Check out pull request history
+        if: ${{ github.event_name == 'pull_request' && steps.signoff.outputs.inheritance-candidate == 'true' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate inherited developer sign-off
+        if: ${{ github.event_name == 'pull_request' && steps.signoff.outputs.inheritance-candidate == 'true' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIOUS_SHA: ${{ steps.signoff.outputs.previous-sha }}
+          BASE_SHA: ${{ steps.signoff.outputs.base-sha }}
+          HEAD_TREE: ${{ steps.signoff.outputs.head-tree }}
+        with:
+          script: |
+            const previousSha = process.env.PREVIOUS_SHA;
+            const baseSha = process.env.BASE_SHA;
+            const expectedTree = process.env.HEAD_TREE;
+            const merge = await exec.getExecOutput(
+              'git',
+              ['merge-tree', '--write-tree', '--no-messages', previousSha, baseSha],
+              { ignoreReturnCode: true, silent: true }
+            );
+            const reproducedTree = merge.stdout.trim();
+            if (merge.exitCode !== 0) {
+              core.setFailed(
+                `The merge of ${baseSha} into ${previousSha} is not conflict-free, so HEAD ` +
+                `cannot inherit the earlier sign-off. Resolve the merge, then run make signoff ` +
+                `on the pushed HEAD.`
+              );
+              return;
+            }
+            if (!/^[0-9a-f]{40,64}$/.test(reproducedTree) || reproducedTree !== expectedTree) {
+              core.setFailed(
+                `HEAD contains changes beyond Git's automatic merge of ${baseSha} into ` +
+                `${previousSha}, so it cannot inherit the earlier sign-off. Run make signoff ` +
+                `on the pushed HEAD.`
+              );
+              return;
+            }
+
+            core.notice(`Inherited developer sign-off from ${previousSha}.`);
       - name: Merge queue passthrough
         if: ${{ github.event_name != 'pull_request' }}
         run: echo "Sign-off was validated at queue entry; the full suite runs in this merge_group run."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,10 +107,10 @@ jobs:
                   return;
                 }
 
-                core.setOutput('inheritance-candidate', 'true');
-                core.setOutput('merge-chain', JSON.stringify(merges));
-                core.setOutput('signed-sha', currentSha);
-                core.setOutput('current-base-sha', baseSha);
+                core.setOutput('inheritance_candidate', 'true');
+                core.setOutput('merge_chain', JSON.stringify(merges));
+                core.setOutput('signed_sha', currentSha);
+                core.setOutput('current_base_sha', baseSha);
                 core.notice(
                   `Found sign-off on ${currentSha} behind ${merges.length} base merge(s); ` +
                   `verifying each automatic merge result.`
@@ -162,7 +162,7 @@ jobs:
       # Only an otherwise-valid inheritance candidate needs repository history
       # and blobs to reproduce the merge without relying on a lazy network fetch.
       - name: Check out pull request history
-        if: ${{ github.event_name == 'pull_request' && steps.signoff.outputs.inheritance-candidate == 'true' }}
+        if: ${{ github.event_name == 'pull_request' && steps.signoff.outputs.inheritance_candidate == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -170,12 +170,12 @@ jobs:
           persist-credentials: false
 
       - name: Validate inherited developer sign-off
-        if: ${{ github.event_name == 'pull_request' && steps.signoff.outputs.inheritance-candidate == 'true' }}
+        if: ${{ github.event_name == 'pull_request' && steps.signoff.outputs.inheritance_candidate == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          MERGE_CHAIN: ${{ steps.signoff.outputs.merge-chain }}
-          SIGNED_SHA: ${{ steps.signoff.outputs.signed-sha }}
-          CURRENT_BASE_SHA: ${{ steps.signoff.outputs.current-base-sha }}
+          MERGE_CHAIN: ${{ steps.signoff.outputs.merge_chain }}
+          SIGNED_SHA: ${{ steps.signoff.outputs.signed_sha }}
+          CURRENT_BASE_SHA: ${{ steps.signoff.outputs.current_base_sha }}
         with:
           script: |
             const merges = JSON.parse(process.env.MERGE_CHAIN);

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -60,12 +60,15 @@ review — lets a maintainer add the PR to the merge queue.
 
 The sign-off is normally bound to the **exact commit** you pushed. If you push a
 code change, the old sign-off no longer applies and you must run `make signoff`
-again. The only exception is merging the PR's current base branch: when `HEAD`
-is exactly Git's conflict-free automatic merge result, **Attestation** accepts
-the sign-off on the first parent. A conflict resolution, amended merge, octopus
-merge, or merge of an outdated base commit still requires a new sign-off.
-`scripts/signoff status` reports only a commit's own status; the inheritance check
-runs in the PR's **Attestation** workflow.
+again. The only exception is merging the PR's base branch. **Attestation** walks
+up to 100 successive merge commits on the first-parent chain to find a sign-off.
+`HEAD` must merge the current base commit, each older merged base must appear in
+order on the current base branch's first-parent history, and every merge tree
+must exactly match Git's conflict-free automatic result. A conflict resolution,
+amended merge, octopus merge, or merge from another branch still requires a new
+sign-off.
+`scripts/signoff status` reports only a commit's own status; the inheritance
+check runs in the PR's **Attestation** workflow.
 
 Options:
 
@@ -102,10 +105,10 @@ path, so existing Git behavior is unchanged.
 ### "No developer sign-off found for &lt;sha&gt;"
 
 The Attestation check couldn't find an applicable green `signoff` status. It
-checks the PR's head commit first, then its first parent only when `HEAD` is an
-unmodified, conflict-free merge of the PR's current base commit. Make sure the
-commit under review is pushed, then run `make signoff` again. Any new code or
-manual merge resolution needs a fresh sign-off.
+checks the PR's head commit first, then walks backward through clean, unmodified
+base merges on the first-parent chain. Make sure the commit under review is
+pushed, then run `make signoff` again. Any new code or manual merge resolution
+needs a fresh sign-off.
 
 ### External contributors (forks)
 

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -58,15 +58,21 @@ On success it posts a `signoff` commit status on your current `HEAD`. Open or
 refresh the PR and the **Attestation** check turns green, which — together with a
 review — lets a maintainer add the PR to the merge queue.
 
-The sign-off is bound to the **exact commit** you pushed. If you push a new
-commit, the old sign-off no longer applies and you must run `make signoff` again.
+The sign-off is normally bound to the **exact commit** you pushed. If you push a
+code change, the old sign-off no longer applies and you must run `make signoff`
+again. The only exception is merging the PR's current base branch: when `HEAD`
+is exactly Git's conflict-free automatic merge result, **Attestation** accepts
+the sign-off on the first parent. A conflict resolution, amended merge, octopus
+merge, or merge of an outdated base commit still requires a new sign-off.
+`scripts/signoff status` reports only a commit's own status; the inheritance check
+runs in the PR's **Attestation** workflow.
 
 Options:
 
 ```bash
 scripts/signoff -f            # sign off even with an uncommitted/unpushed tree
 scripts/signoff --no-verify   # attest without running the checks (honor system)
-scripts/signoff status        # is HEAD signed off?
+scripts/signoff status        # does HEAD have its own sign-off?
 scripts/signoff --help        # full usage
 ```
 
@@ -95,9 +101,11 @@ path, so existing Git behavior is unchanged.
 
 ### "No developer sign-off found for &lt;sha&gt;"
 
-The Attestation check couldn't find a green `signoff` status for the PR's head
-commit. Make sure the commit under review is pushed, then run `make signoff`
-again. A new push always needs a fresh sign-off.
+The Attestation check couldn't find an applicable green `signoff` status. It
+checks the PR's head commit first, then its first parent only when `HEAD` is an
+unmodified, conflict-free merge of the PR's current base commit. Make sure the
+commit under review is pushed, then run `make signoff` again. Any new code or
+manual merge resolution needs a fresh sign-off.
 
 ### External contributors (forks)
 

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -417,8 +417,8 @@ Maintainers:
 
 The sign-off is a '${STATUS_CONTEXT}' commit status bound to the exact commit you
 pushed. Sign off again after any code change or manual conflict resolution. The
-Attestation check can carry a sign-off across one unmodified, conflict-free merge
-of the PR's current base commit. The full test suite runs in the merge queue.
+Attestation check can carry a sign-off across a first-parent chain of unmodified,
+conflict-free base merges. The full test suite runs in the merge queue.
 EOF
 }
 

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -416,8 +416,9 @@ Maintainers:
   scripts/signoff install --yes  Apply it (needs admin on the repo)
 
 The sign-off is a '${STATUS_CONTEXT}' commit status bound to the exact commit you
-pushed. Push a new commit and you must sign off again. The full test suite runs
-in the merge queue, not on your PR.
+pushed. Sign off again after any code change or manual conflict resolution. The
+Attestation check can carry a sign-off across one unmodified, conflict-free merge
+of the PR's current base commit. The full test suite runs in the merge queue.
 EOF
 }
 


### PR DESCRIPTION
## 📝 Summary

- Let the `Attestation` check inherit a successful sign-off through a first-parent chain of clean base merges.
- Require `HEAD` to merge the PR's current base commit.
- Require older merged bases to appear in order on the base branch's first-parent history.
- Reproduce every merge with `git merge-tree` and require exact tree matches.
- Reject conflicted, amended, octopus, reversed-parent, out-of-order, and non-base merges.
- Fetch repository history only for valid inheritance candidates, so normal signed commits keep the API-only fast path.

## 📚 Docs

Updated `docs/dev/ci_signoff.md` and `scripts/signoff` help with recursive clean-merge inheritance and its limits.

## ✅ Validation

- Parsed `.github/workflows/pr.yml` and syntax-checked both embedded JavaScript blocks.
- Ran `bash -n scripts/signoff`.
- Tested recursive sign-off discovery through two successive merge commits.
- Tested merge-tree validation through two real synthetic merges.
- Confirmed that an amended intermediate merge is rejected.
- Verified against existing PR histories that an unchanged clean merge reproduces the same tree and an amended merge does not.

## 👀 Notes for Reviewers

Inheritance is limited to 100 successive base merges. Every commit between `HEAD` and the signed commit must be an exact, conflict-free automatic merge. Any manual content change requires a new sign-off.
