### PR TITLE
fix(ci): make CH-benCH template restore robust to leftover replication slots

### DIFF
--- a/.github/scripts/chbench_template.sh
+++ b/.github/scripts/chbench_template.sh
@@ -42,7 +42,31 @@ drop_template() {  # un-freeze (IS_TEMPLATE blocks DROP) then drop
   psql_pg "DROP DATABASE IF EXISTS $1 WITH (FORCE)" >/dev/null 2>&1 || true
 }
 
-psql_pg "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots" >/dev/null 2>&1 || true
+# A crashed/cancelled prior run can leave a logical replication slot on chbench.
+# A slot pins its database, so DROP DATABASE fails even WITH (FORCE) until the
+# slot is gone; and an *active* slot won't drop until its walsender is killed.
+# Terminate holders, then drop, retrying until none remain.
+drop_all_replication_slots() {
+  for _ in 1 2 3 4 5; do
+    n=$(psql_pg "SELECT count(*) FROM pg_replication_slots" 2>/dev/null || echo 0)
+    [ "${n:-0}" = 0 ] && return 0
+    psql_pg "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE active_pid IS NOT NULL" >/dev/null 2>&1 || true
+    psql_pg "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE NOT active" >/dev/null 2>&1 || true
+    sleep 1
+  done
+  stuck=$(psql_pg "SELECT string_agg(slot_name || '(active_pid=' || coalesce(active_pid::text,'none') || ')', ', ') FROM pg_replication_slots" 2>/dev/null || true)
+  [ -n "$stuck" ] && echo "WARNING: replication slots still present after cleanup: $stuck"
+}
+
+# Terminate lingering backends then drop; fail loud (no error suppression) so a
+# genuine failure surfaces here instead of masking into a later CREATE
+# 'database already exists'.
+drop_working_db() {  # $1 = dbname
+  psql_pg "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$1' AND pid <> pg_backend_pid()" >/dev/null 2>&1 || true
+  psql_pg "DROP DATABASE IF EXISTS $1 WITH (FORCE)"
+}
+
+drop_all_replication_slots
 
 exists=$(psql_pg "SELECT 1 FROM pg_database WHERE datname='$TMPL'" 2>/dev/null)
 hit=0
@@ -73,7 +97,7 @@ else
 fi
 
 # Restore the working chbench from the template (fast physical copy).
-psql_pg "DROP DATABASE IF EXISTS chbench WITH (FORCE)" >/dev/null 2>&1 || true
+drop_working_db chbench
 psql_pg "CREATE DATABASE chbench TEMPLATE $TMPL OWNER $PGU STRATEGY=FILE_COPY" >/dev/null
 psql_pg "ALTER DATABASE chbench WITH ALLOW_CONNECTIONS true" >/dev/null 2>&1 || true
 echo "chbench restored from $TMPL — run with --skip-prepare"

--- a/.github/scripts/chbench_template.sh
+++ b/.github/scripts/chbench_template.sh
@@ -45,17 +45,20 @@ drop_template() {  # un-freeze (IS_TEMPLATE blocks DROP) then drop
 # A crashed/cancelled prior run can leave a logical replication slot on chbench.
 # A slot pins its database, so DROP DATABASE fails even WITH (FORCE) until the
 # slot is gone; and an *active* slot won't drop until its walsender is killed.
-# Terminate holders, then drop, retrying until none remain.
-drop_all_replication_slots() {
+# Terminate holders, then drop, retrying until none remain. Scoped to Spice's
+# own chbench slots (matching the cleanup step's 'spice_%' convention) so we
+# never disturb unrelated slots on this shared, long-lived CI pod.
+SLOT_FILTER="slot_name LIKE 'spice_%' AND database = 'chbench'"
+drop_chbench_replication_slots() {
   for _ in 1 2 3 4 5; do
-    n=$(psql_pg "SELECT count(*) FROM pg_replication_slots" 2>/dev/null || echo 0)
+    n=$(psql_pg "SELECT count(*) FROM pg_replication_slots WHERE $SLOT_FILTER" 2>/dev/null || echo 0)
     [ "${n:-0}" = 0 ] && return 0
-    psql_pg "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE active_pid IS NOT NULL" >/dev/null 2>&1 || true
-    psql_pg "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE NOT active" >/dev/null 2>&1 || true
+    psql_pg "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE $SLOT_FILTER AND active_pid IS NOT NULL" >/dev/null 2>&1 || true
+    psql_pg "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE $SLOT_FILTER AND NOT active" >/dev/null 2>&1 || true
     sleep 1
   done
-  stuck=$(psql_pg "SELECT string_agg(slot_name || '(active_pid=' || coalesce(active_pid::text,'none') || ')', ', ') FROM pg_replication_slots" 2>/dev/null || true)
-  [ -n "$stuck" ] && echo "WARNING: replication slots still present after cleanup: $stuck"
+  stuck=$(psql_pg "SELECT string_agg(slot_name || '(active_pid=' || coalesce(active_pid::text,'none') || ')', ', ') FROM pg_replication_slots WHERE $SLOT_FILTER" 2>/dev/null || true)
+  [ -n "$stuck" ] && echo "WARNING: chbench replication slots still present after cleanup: $stuck"
 }
 
 # Terminate lingering backends then drop; fail loud (no error suppression) so a
@@ -66,7 +69,7 @@ drop_working_db() {  # $1 = dbname
   psql_pg "DROP DATABASE IF EXISTS $1 WITH (FORCE)"
 }
 
-drop_all_replication_slots
+drop_chbench_replication_slots
 
 exists=$(psql_pg "SELECT 1 FROM pg_database WHERE datname='$TMPL'" 2>/dev/null)
 hit=0


### PR DESCRIPTION
## Problem

The `Restore or seed CH-benCH from template` step in `testoperator_run_htap.yml` intermittently fails on a `template HIT` with:

```
template HIT: chbench_tmpl_sf1000 -> restoring chbench (FILE_COPY)
ERROR:  database "chbench" already exists
```

This happens after a **crashed or cancelled prior run**. Root cause chain:

1. A leftover **logical replication slot** on `chbench` survives, still **active** (walsender holds `active_pid`).
2. `pg_drop_replication_slot(...)` fails on active slots — error swallowed by `|| true`, so the slot survives.
3. `DROP DATABASE chbench WITH (FORCE)` terminates ordinary backends but a **logical replication slot pins its database**, so the drop errors — also swallowed by `>/dev/null 2>&1 || true`.
4. `CREATE DATABASE chbench` then hits the still-existing DB → `already exists`.

## Fix

`.github/scripts/chbench_template.sh`:

- **`drop_all_replication_slots()`** — terminate the walsender holding each active slot, then drop the now-inactive slots, retrying until none remain (slots need a moment to release after the backend is killed). Logs a `WARNING` naming any slot still stuck so the cause is visible instead of hidden.
- **`drop_working_db()`** — terminate lingering backends, then `DROP DATABASE ... WITH (FORCE)` **without error suppression**, so a genuine failure fails the step loudly at its real cause rather than masking into a later `already exists`.

Makes the restore path idempotent across crashed/cancelled prior runs and fail-fast with a diagnosable message. The template-seeding path is untouched — frozen templates never carry replication slots.