### PR TITLE
Auto-refresh the Attestation check after signoff

### DIFF
--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -57,9 +57,10 @@ make signoff          # runs `make lint-rust` + `make build-cli nextest`, then a
 On success it posts a `signoff` commit status on your current `HEAD`. If the
 **Attestation** check already ran and failed before the sign-off existed, the
 script re-runs that job via the `gh` CLI so it turns green without you having
-to open or refresh the PR (if `gh` isn't installed, it prints a reminder and
-falls back to opening/refreshing the PR yourself). That, together with a
-review, lets a maintainer add the PR to the merge queue.
+to open or refresh the PR. (If no run is found yet — e.g. before the PR's
+first CI run — or the rerun call fails, it falls back to prompting you to
+open/refresh the PR yourself.) That, together with a review, lets a
+maintainer add the PR to the merge queue.
 
 The sign-off is normally bound to the **exact commit** you pushed. If you push a
 code change, the old sign-off no longer applies and you must run `make signoff`

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -54,9 +54,12 @@ and up to date:
 make signoff          # runs `make lint-rust` + `make build-cli nextest`, then attests
 ```
 
-On success it posts a `signoff` commit status on your current `HEAD`. Open or
-refresh the PR and the **Attestation** check turns green, which — together with a
-review — lets a maintainer add the PR to the merge queue.
+On success it posts a `signoff` commit status on your current `HEAD`. If the
+**Attestation** check already ran and failed before the sign-off existed, the
+script re-runs that job via the `gh` CLI so it turns green without you having
+to open or refresh the PR (if `gh` isn't installed, it prints a reminder and
+falls back to opening/refreshing the PR yourself). That, together with a
+review, lets a maintainer add the PR to the merge queue.
 
 The sign-off is normally bound to the **exact commit** you pushed. If you push a
 code change, the old sign-off no longer applies and you must run `make signoff`

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -276,7 +276,10 @@ refresh_attestation_check() {
     return 0
   fi
 
-  if gh run rerun "$run_id" --repo "$repo" --failed >/dev/null 2>&1; then
+  # Not `--failed`: that only reruns jobs with conclusion=failure and no-ops
+  # on cancelled/skipped runs. Rerunning the whole run is fine here — on a
+  # `pull_request` event, pr.yml executes nothing but the Attestation job.
+  if gh run rerun "$run_id" --repo "$repo" >/dev/null 2>&1; then
     echo "  Re-ran the 'Attestation' check (run ${run_id}) — it will turn green shortly."
   else
     info "  Could not auto-refresh the 'Attestation' check — ${fallback}"

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -235,6 +235,52 @@ run_checks() {
   make build-cli nextest
 }
 
+# After a successful sign-off, the PR's `Attestation` job (pr.yml) only
+# re-evaluates the `signoff` commit status when its workflow run executes. If
+# that run already completed — e.g. sign-off happened after the PR's checks
+# ran — `Attestation` is stuck showing a stale failure until something
+# re-triggers it. Re-run that job instead of making the developer open or
+# refresh the PR by hand. `gh` is already required by require_tools() before
+# cmd_signoff can reach this point, but the check stays here so this function
+# remains correct if it's ever called on its own.
+refresh_attestation_check() {
+  local sha="$1" repo="$2"
+  local fallback="Open/refresh the PR and it will pick up the sign-off."
+  local run run_id run_status run_conclusion
+
+  if ! command -v gh >/dev/null 2>&1; then
+    info "  Install the GitHub CLI (https://cli.github.com) so signoff can auto-refresh the 'Attestation' check."
+    info "  ${fallback}"
+    return 0
+  fi
+
+  run=$(gh run list --repo "$repo" --commit "$sha" --workflow pr.yml --event pull_request \
+    --json databaseId,status,conclusion --jq 'first(.[]) | "\(.databaseId) \(.status) \(.conclusion)"' 2>/dev/null) \
+    || { debug "could not list 'pr' workflow runs for ${sha} on ${repo}"; info "  ${fallback}"; return 0; }
+
+  if [[ -z "$run" ]]; then
+    debug "no 'pr' workflow run found yet for ${sha} — nothing to refresh"
+    info "  ${fallback}"
+    return 0
+  fi
+
+  read -r run_id run_status run_conclusion <<<"$run"
+  if [[ "$run_status" != "completed" ]]; then
+    debug "run ${run_id} is still ${run_status} — it will evaluate the sign-off once it finishes"
+    return 0
+  fi
+  if [[ "$run_conclusion" == "success" ]]; then
+    debug "run ${run_id} already succeeded — nothing to refresh"
+    return 0
+  fi
+
+  if gh run rerun "$run_id" --repo "$repo" --failed >/dev/null 2>&1; then
+    echo "  Re-ran the 'Attestation' check (run ${run_id}) — it will turn green shortly."
+  else
+    info "  Could not auto-refresh the 'Attestation' check — ${fallback}"
+  fi
+}
+
 cmd_signoff() {
   local force=false verify=true
   while [[ $# -gt 0 ]]; do
@@ -273,7 +319,7 @@ cmd_signoff() {
     || fail "failed to post the sign-off status (do you have write access to ${repo}?)"
 
   echo "${OK} Signed off on ${sha:0:12} — ${description}"
-  echo "  Push is already up to date; open/refresh the PR and it will enter the merge queue."
+  refresh_attestation_check "$sha" "$repo"
 }
 
 cmd_status() {

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -258,15 +258,17 @@ refresh_attestation_check() {
     --json databaseId,status,conclusion --jq 'first(.[]) | "\(.databaseId) \(.status) \(.conclusion)"' 2>/dev/null) \
     || { debug "could not list 'pr' workflow runs for ${sha} on ${repo}"; info "  ${fallback}"; return 0; }
 
-  if [[ -z "$run" ]]; then
+  read -r run_id run_status run_conclusion <<<"$run"
+  # A missing run renders as an empty string, but an empty `--jq` match can
+  # also render as the literal word "null" for each field — check run_id
+  # looks like a real numeric database id rather than trusting non-emptiness.
+  if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
     debug "no 'pr' workflow run found yet for ${sha} — nothing to refresh"
     info "  ${fallback}"
     return 0
   fi
-
-  read -r run_id run_status run_conclusion <<<"$run"
   if [[ "$run_status" != "completed" ]]; then
-    debug "run ${run_id} is still ${run_status} — it will evaluate the sign-off once it finishes"
+    info "  The 'Attestation' check (run ${run_id}) is still ${run_status} — it will evaluate the sign-off once it finishes."
     return 0
   fi
   if [[ "$run_conclusion" == "success" ]]; then


### PR DESCRIPTION
## Summary
- `make signoff` posts the `signoff` commit status, but if the PR's `Attestation` job already ran (and failed) before that status existed, it stayed stuck red until the developer manually opened/refreshed the PR.
- `scripts/signoff` now re-runs that job automatically via the `gh` CLI right after a successful sign-off, so `Attestation` turns green without manual intervention.
- If `gh` isn't installed (it's already a hard requirement for `make signoff` itself, but the check is defensive so the new function stays correct standalone), it prints a message suggesting installing it and falls back to the old "open/refresh the PR" guidance — same fallback used when no run is found yet, the run is still in progress, or the rerun call fails.
- Updated `docs/dev/ci_signoff.md` to describe the new behavior.

## Test plan
- [x] `bash -n scripts/signoff`
- [x] Manually verified the `gh run list --workflow pr.yml --event pull_request` query and id/status/conclusion parsing against real runs on spiceai/spiceai PRs
- [ ] `make signoff` on a PR where `Attestation` already failed, confirming it flips green automatically