### PR TITLE
perf(cayenne): reuse per-batch scratch allocations in KeyBasedDeletionFilterStream

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -357,6 +357,10 @@ name = "int64_pk_filter_keep_mask_alloc"
 
 [[bench]]
 harness = false
+name = "key_based_filter_scratch_reuse_alloc"
+
+[[bench]]
+harness = false
 name = "position_delete_redundant_walks"
 
 [[bench]]

--- a/crates/cayenne/benches/key_based_filter_scratch_reuse_alloc.rs
+++ b/crates/cayenne/benches/key_based_filter_scratch_reuse_alloc.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crates/cayenne/benches/key_based_filter_scratch_reuse_alloc.rs
+++ b/crates/cayenne/benches/key_based_filter_scratch_reuse_alloc.rs
@@ -1,0 +1,356 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Before/after bench for BEN-14: per-batch scratch-allocation reuse in
+//! `KeyBasedDeletionFilterStream` (`crates/cayenne/src/provider/delete/filter_exec.rs`).
+//!
+//! CPU profiling of a local CH-benCHmark HTAP run (sf10, directional) showed
+//! this stream as the single biggest query-path hotspot (~10.7% of
+//! query-stage spiced CPU). Most of that cost is the algorithmically
+//! necessary per-row `RowConverter` encode + XXH3-128 hash, but two things
+//! were allocated fresh on every single `poll_next` call instead of being
+//! reused across the stream's lifetime:
+//!
+//!   1. The `pk_columns`/`deleted` `Vec`s (`filter_exec.rs:615-616,653`);
+//!      `deleted` in particular started at zero capacity, so a batch with
+//!      many deletions re-grew it geometrically from scratch every poll.
+//!   2. `KeyDeletionIndex::get_batch`'s internal chunk-sweep buffers
+//!      (`deletion_index.rs:1425-1426`) — two `BATCH_SWEEP_CHUNK`-sized
+//!      (~40 KB total) `Vec`s per call.
+//!
+//! Two lanes, each processing the *same* fixed batch repeatedly (criterion's
+//! own iteration repetition stands in for "many `poll_next` calls over a
+//! stream's lifetime" — scratch buffers declared outside `b.iter` persist
+//! across those repeated calls exactly as stream fields would):
+//!
+//!   - `fresh_alloc`   — mirrors the pre-fix code: every simulated batch
+//!     allocates `pk_columns`/`deleted` from scratch and probes via the
+//!     allocating `KeyDeletionIndex::get_batch`.
+//!   - `scratch_reuse` — mirrors the fix: `pk_columns`/`deleted`/`hashes`/
+//!     `candidates` are declared once outside the timed loop and `clear()`ed
+//!     (capacity retained) per simulated batch, probing via
+//!     `get_batch_with_scratch`.
+//!
+//! Both lanes produce a bit-identical filtered `RecordBatch`; the only
+//! difference is allocation churn. Four visibility shapes exercise the
+//! realistic-steady-state / sparse / mixed-keep / no-keep range, matching
+//! `int64_pk_filter_keep_mask_alloc`'s convention (extended with `sparse`).
+//! The index is seeded with a realistic ~100K-entry background of unrelated
+//! tombstones before each shape's own deletions (see `seed_background_churn`),
+//! fed in via chained `extend_max_deletes` calls so it actually freezes into
+//! several `RunData` tiers — matching what a table accumulates under
+//! sustained merge-on-read churn, not a single small, freshly-fused map. This
+//! also keeps `delete_count > 0` so the full bloom-sweep + tier-walk runs for
+//! every shape, including `all_visible`, rather than short-circuiting on
+//! `get_batch`'s own `delete_count == 0` early return.
+//!
+//! This bench models a composite Int64 PK (2 columns); string/UUID composite
+//! keys cost more to row-encode, which would dilute the allocation-reuse
+//! share somewhat. `sparse`/`half_visible`/`none_visible` are reasoned-about
+//! brackets for plausible per-batch deletion ratios (steady churn / a
+//! churny queue-like table / a stale uncompacted partition), not a ratio
+//! read directly off a production trace.
+//!
+//! Measured result (aarch64, Apple Silicon, two consecutive clean runs after
+//! letting the machine settle — a run taken right after a 14-minute release
+//! compile was contaminated by that background load per the "one cargo
+//! invocation at a time" guidance and is not reported): `scratch_reuse` is
+//! **consistently faster across all four shapes**, by roughly **9-10 %** on
+//! `all_visible`/`sparse` (where the per-row hash+bloom+tier-walk cost
+//! dominates, since little or nothing is filtered out) and **1-4 %** on
+//! `half_visible`/`none_visible` (where `arrow::compute::filter_record_batch`,
+//! unchanged in both lanes, or the cost of the tier walk actually finding a
+//! hit for every row, eats a larger share of the total).
+//!
+//! `cargo bench --bench key_based_filter_scratch_reuse_alloc -p cayenne`.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_precision_loss)]
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, BooleanArray, BooleanBufferBuilder, Int64Array, RecordBatch};
+use arrow::compute::filter_record_batch;
+use arrow::datatypes::{DataType, Field, Schema};
+use cayenne::provider::deletion_index::KeyDeletionIndex;
+use cayenne::row_converter::{RowConverter, SortField};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+const ROWS_PER_BATCH: usize = 8_192;
+/// Visibility shapes — the second value is the deletion ratio applied to
+/// *this probed batch's* PKs. `sparse` (1 %) is the realistic steady-state
+/// shape for a table under continuous CDC churn (most rows in most batches
+/// are untouched); `half_visible`/`none_visible` bracket a churny queue-like
+/// table (e.g. TPC-C `new_order`, inserted and deleted at similar rates) and
+/// a stale, not-yet-compacted partition under a bulk retention delete,
+/// respectively — extremes, not the median case.
+const SHAPES: &[(&str, f64)] = &[
+    ("all_visible", 0.0),
+    ("sparse", 0.01),
+    ("half_visible", 0.5),
+    ("none_visible", 1.0),
+];
+
+/// Background tombstone volume seeded into the index *before* each shape's
+/// batch-specific deletions, so probes exercise the same frozen-run layering
+/// a table accumulates under sustained merge-on-read churn — not a single
+/// small, freshly-fused map. `KeyDeletionIndex` freezes its hot `active` delta
+/// into a new frozen `run` once `active.len()` crosses `DELTA_MERGE_MIN`
+/// (16,384 outside `cfg(test)`, which this bench binary is); seeding in
+/// `BACKGROUND_CHUNK`-sized calls means each call's `active` fills and
+/// freezes independently, so `BACKGROUND_TOMBSTONES` ends up spread across
+/// several `RunData` tiers plus a partial active delta — the same shape
+/// `KeyDeletionIndex::get_batch`'s tier-walk has to probe in production,
+/// with a correspondingly realistically-sized bloom filter.
+const BACKGROUND_TOMBSTONES: usize = 100_000;
+const BACKGROUND_CHUNK: usize = 20_000;
+
+/// A composite two-column (`shop_id`, `line_id`) PK, matching the shape that
+/// routes to `KeyBasedDeletionFilterExec` (composite/non-Int64 PKs).
+fn make_batch(rows: usize) -> (RecordBatch, RowConverter) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("shop_id", DataType::Int64, false),
+        Field::new("line_id", DataType::Int64, false),
+        Field::new("qty", DataType::Int64, false),
+    ]));
+    let shop_ids: Vec<i64> = (0..rows as i64).map(|i| i % 64).collect();
+    let line_ids: Vec<i64> = (0..rows as i64).collect();
+    let qty: Vec<i64> = (0..rows as i64).collect();
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(shop_ids)),
+            Arc::new(Int64Array::from(line_ids)),
+            Arc::new(Int64Array::from(qty)),
+        ],
+    )
+    .expect("batch");
+    let row_converter = RowConverter::new(vec![
+        SortField::new(DataType::Int64),
+        SortField::new(DataType::Int64),
+    ])
+    .expect("row converter");
+    (batch, row_converter)
+}
+
+/// Seed a realistic, multi-run background of unrelated tombstones (disjoint
+/// key space from any probed batch: `shop_id`/`line_id` offset well above the
+/// batch's own range) by chaining `extend_max_deletes` in `BACKGROUND_CHUNK`
+/// pieces, so `KeyDeletionIndex`'s freeze threshold triggers repeatedly and
+/// the result has several frozen `RunData` tiers, not one flat map.
+fn seed_background_churn(row_converter: &RowConverter) -> KeyDeletionIndex {
+    let mut index = KeyDeletionIndex::empty();
+    let mut start = 0_i64;
+    let mut seq = 1_i64;
+    while (start as usize) < BACKGROUND_TOMBSTONES {
+        let end = ((start as usize + BACKGROUND_CHUNK).min(BACKGROUND_TOMBSTONES)) as i64;
+        let shop_ids: Vec<i64> = (start..end).map(|i| 10_000_000 + i % 64).collect();
+        let line_ids: Vec<i64> = (start..end).map(|i| 10_000_000 + i).collect();
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(shop_ids)),
+            Arc::new(Int64Array::from(line_ids)),
+        ];
+        let rows = row_converter.convert_columns(&columns).expect("rows");
+        let additions: Vec<(Box<[u8]>, i64)> = rows
+            .iter()
+            .map(|row| (Box::from(row.data()), seq))
+            .collect();
+        index = index.extend_max_deletes(additions);
+        seq += 1;
+        start = end;
+    }
+    index
+}
+
+/// Extend `background` with the first `(rows * ratio)` PK tuples of the
+/// *probed* batch, row-encoded the same way, so this shape's probes hit real
+/// hits/misses against realistic encoding on top of the realistic background.
+fn build_index(
+    background: &KeyDeletionIndex,
+    batch: &RecordBatch,
+    row_converter: &RowConverter,
+    ratio: f64,
+) -> KeyDeletionIndex {
+    let count = ((ROWS_PER_BATCH as f64) * ratio) as usize;
+    let pk_columns = vec![Arc::clone(batch.column(0)), Arc::clone(batch.column(1))];
+    let rows = row_converter.convert_columns(&pk_columns).expect("rows");
+    let additions: Vec<(Box<[u8]>, i64)> = rows
+        .iter()
+        .take(count)
+        .map(|row| (Box::from(row.data()), i64::MAX))
+        .collect();
+    background.extend_max_deletes(additions)
+}
+
+/// Mirror of the pre-fix `KeyBasedDeletionFilterStream::poll_next`: fresh
+/// `pk_columns`/`deleted` `Vec`s and the allocating `get_batch` every call.
+fn probe_fresh_alloc(
+    batch: &RecordBatch,
+    row_converter: &RowConverter,
+    tombstones: &KeyDeletionIndex,
+) -> RecordBatch {
+    let batch_size = batch.num_rows();
+    let pk_columns: Vec<ArrayRef> = vec![Arc::clone(batch.column(0)), Arc::clone(batch.column(1))];
+    let rows = row_converter.convert_columns(&pk_columns).expect("rows");
+
+    let mut deleted: Vec<usize> = Vec::new();
+    tombstones.get_batch(rows.iter(), |i, tombstone| {
+        let visible = tombstone
+            .insert_sequence
+            .is_some_and(|insert_seq| insert_seq > tombstone.delete_sequence);
+        if !visible {
+            deleted.push(i);
+        }
+    });
+
+    if deleted.is_empty() {
+        return batch.clone();
+    }
+    if deleted.len() == batch_size {
+        return RecordBatch::new_empty(batch.schema());
+    }
+    let mut keep_mask = BooleanBufferBuilder::new(batch_size);
+    keep_mask.append_n(batch_size, true);
+    for &i in &deleted {
+        keep_mask.set_bit(i, false);
+    }
+    let filter_array = BooleanArray::new(keep_mask.finish(), None);
+    filter_record_batch(batch, &filter_array).expect("filter")
+}
+
+/// Per-stream scratch, reused across every simulated `poll_next` call —
+/// mirrors the `KeyBasedDeletionFilterStream` fields added for BEN-14.
+struct ScratchReuseState {
+    pk_columns: Vec<ArrayRef>,
+    deleted: Vec<usize>,
+    hashes: Vec<u128>,
+    candidates: Vec<u32>,
+}
+
+impl ScratchReuseState {
+    fn new() -> Self {
+        Self {
+            pk_columns: Vec::new(),
+            deleted: Vec::new(),
+            hashes: Vec::new(),
+            candidates: Vec::new(),
+        }
+    }
+}
+
+/// Mirror of the post-fix `KeyBasedDeletionFilterStream::poll_next`: scratch
+/// buffers are cleared (capacity retained), not reallocated, and probing
+/// goes through `get_batch_with_scratch`.
+fn probe_scratch_reuse(
+    state: &mut ScratchReuseState,
+    batch: &RecordBatch,
+    row_converter: &RowConverter,
+    tombstones: &KeyDeletionIndex,
+) -> RecordBatch {
+    let batch_size = batch.num_rows();
+    state.pk_columns.clear();
+    state.pk_columns.push(Arc::clone(batch.column(0)));
+    state.pk_columns.push(Arc::clone(batch.column(1)));
+    let rows = row_converter
+        .convert_columns(&state.pk_columns)
+        .expect("rows");
+
+    state.deleted.clear();
+    state.deleted.reserve(batch_size);
+    tombstones.get_batch_with_scratch(
+        rows.iter(),
+        &mut state.hashes,
+        &mut state.candidates,
+        |i, tombstone| {
+            let visible = tombstone
+                .insert_sequence
+                .is_some_and(|insert_seq| insert_seq > tombstone.delete_sequence);
+            if !visible {
+                state.deleted.push(i);
+            }
+        },
+    );
+
+    if state.deleted.is_empty() {
+        return batch.clone();
+    }
+    if state.deleted.len() == batch_size {
+        return RecordBatch::new_empty(batch.schema());
+    }
+    let mut keep_mask = BooleanBufferBuilder::new(batch_size);
+    keep_mask.append_n(batch_size, true);
+    for &i in &state.deleted {
+        keep_mask.set_bit(i, false);
+    }
+    let filter_array = BooleanArray::new(keep_mask.finish(), None);
+    filter_record_batch(batch, &filter_array).expect("filter")
+}
+
+fn bench_key_based_filter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("key_based_filter_scratch_reuse_alloc");
+    group.throughput(Throughput::Elements(ROWS_PER_BATCH as u64));
+
+    let (batch, row_converter) = make_batch(ROWS_PER_BATCH);
+    let background = seed_background_churn(&row_converter);
+
+    for (shape_name, ratio) in SHAPES {
+        let index = build_index(&background, &batch, &row_converter, *ratio);
+
+        group.bench_with_input(
+            BenchmarkId::new("fresh_alloc", shape_name),
+            shape_name,
+            |b, _| {
+                b.iter(|| {
+                    let out = probe_fresh_alloc(
+                        black_box(&batch),
+                        black_box(&row_converter),
+                        black_box(&index),
+                    );
+                    black_box(out);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("scratch_reuse", shape_name),
+            shape_name,
+            |b, _| {
+                // Declared OUTSIDE the timed closure: persists across every
+                // repeated `b.iter` call, exactly as `KeyBasedDeletionFilterStream`
+                // fields persist across `poll_next` calls over a stream's lifetime.
+                let mut state = ScratchReuseState::new();
+                b.iter(|| {
+                    let out = probe_scratch_reuse(
+                        &mut state,
+                        black_box(&batch),
+                        black_box(&row_converter),
+                        black_box(&index),
+                    );
+                    black_box(out);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_key_based_filter);
+criterion_main!(benches);

--- a/crates/cayenne/benches/key_based_filter_scratch_reuse_alloc.rs
+++ b/crates/cayenne/benches/key_based_filter_scratch_reuse_alloc.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Before/after bench for BEN-14: per-batch scratch-allocation reuse in
+//! Before/after bench for per-batch scratch-allocation reuse in
 //! `KeyBasedDeletionFilterStream` (`crates/cayenne/src/provider/delete/filter_exec.rs`).
 //!
 //! CPU profiling of a local CH-benCHmark HTAP run (sf10, directional) showed
@@ -235,7 +235,7 @@ fn probe_fresh_alloc(
 }
 
 /// Per-stream scratch, reused across every simulated `poll_next` call —
-/// mirrors the `KeyBasedDeletionFilterStream` fields added for BEN-14.
+/// mirrors the `KeyBasedDeletionFilterStream` fields added by this change.
 struct ScratchReuseState {
     pk_columns: Vec<ArrayRef>,
     deleted: Vec<usize>,

--- a/crates/cayenne/benches/key_based_filter_scratch_reuse_alloc.rs
+++ b/crates/cayenne/benches/key_based_filter_scratch_reuse_alloc.rs
@@ -24,12 +24,11 @@ limitations under the License.
 //! were allocated fresh on every single `poll_next` call instead of being
 //! reused across the stream's lifetime:
 //!
-//!   1. The `pk_columns`/`deleted` `Vec`s (`filter_exec.rs:615-616,653`);
-//!      `deleted` in particular started at zero capacity, so a batch with
-//!      many deletions re-grew it geometrically from scratch every poll.
-//!   2. `KeyDeletionIndex::get_batch`'s internal chunk-sweep buffers
-//!      (`deletion_index.rs:1425-1426`) — two `BATCH_SWEEP_CHUNK`-sized
-//!      (~40 KB total) `Vec`s per call.
+//!   1. `KeyBasedDeletionFilterStream::poll_next`'s `pk_columns`/`deleted`
+//!      `Vec`s; `deleted` in particular started at zero capacity, so a batch
+//!      with many deletions re-grew it geometrically from scratch every poll.
+//!   2. `KeyDeletionIndex::get_batch`'s internal chunk-sweep buffers — two
+//!      `BATCH_SWEEP_CHUNK`-sized (~40 KB total) `Vec`s per call.
 //!
 //! Two lanes, each processing the *same* fixed batch repeatedly (criterion's
 //! own iteration repetition stands in for "many `poll_next` calls over a

--- a/crates/cayenne/src/provider/delete/filter_exec.rs
+++ b/crates/cayenne/src/provider/delete/filter_exec.rs
@@ -559,6 +559,10 @@ impl ExecutionPlan for KeyBasedDeletionFilterExec {
             min_delete_seq_to_apply,
             schema,
             metrics,
+            pk_columns_scratch: Vec::new(),
+            deleted_scratch: Vec::new(),
+            hashes_scratch: Vec::new(),
+            candidates_scratch: Vec::new(),
         }))
     }
 }
@@ -574,6 +578,23 @@ pub struct KeyBasedDeletionFilterStream {
     min_delete_seq_to_apply: Option<i64>,
     schema: arrow_schema::SchemaRef,
     metrics: DeletionFilterMetrics,
+    /// Per-batch scratch: the current batch's PK columns. Cleared (not
+    /// reallocated) at the top of every batch — the column count is fixed
+    /// for the stream's lifetime, so capacity is reached after the first
+    /// batch and never grows again.
+    pk_columns_scratch: Vec<ArrayRef>,
+    /// Per-batch scratch: row indices with an applicable (visible-hiding)
+    /// tombstone. Cleared and `reserve`d to `batch_size` at the top of every
+    /// batch instead of starting at zero capacity each time — without the
+    /// reserve, a batch with many deletions re-grows this geometrically from
+    /// empty on every single poll.
+    deleted_scratch: Vec<usize>,
+    /// Per-batch scratch owned by this stream and handed to
+    /// [`KeyDeletionIndex::get_batch_with_scratch`], so the ~40 KB pair of
+    /// `BATCH_SWEEP_CHUNK`-sized sweep buffers is allocated once for the
+    /// stream's lifetime instead of once per batch.
+    hashes_scratch: Vec<u128>,
+    candidates_scratch: Vec<u32>,
 }
 
 impl futures::Stream for KeyBasedDeletionFilterStream {
@@ -592,18 +613,27 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                         return std::task::Poll::Ready(Some(Ok(batch)));
                     }
 
+                    // Reborrow to a plain `&mut Self` for the rest of this batch:
+                    // `Pin<&mut Self>`'s field projections don't get the same
+                    // disjoint-borrow splitting as a bare `&mut Self` (each
+                    // access goes through `DerefMut`, so the compiler can't tell
+                    // two field accesses apart), which this function needs now
+                    // that several scratch fields are borrowed independently
+                    // (some mutably) within the same batch.
+                    let this = self.as_mut().get_mut();
+
                     // Time the probe + filter kernel so the merge-on-read read-tax is
                     // visible in EXPLAIN ANALYZE. Dropped on every return/continue below.
-                    let _timer = self.metrics.baseline.elapsed_compute().timer();
+                    let _timer = this.metrics.baseline.elapsed_compute().timer();
 
                     // Fast path: no deletions to apply (insert-only entries
                     // never affect visibility)
-                    if !self.tombstones.has_deletions() {
-                        self.metrics.baseline.record_output(batch_size);
+                    if !this.tombstones.has_deletions() {
+                        this.metrics.baseline.record_output(batch_size);
                         return std::task::Poll::Ready(Some(Ok(batch)));
                     }
 
-                    if self.pk_column_indices.is_empty() {
+                    if this.pk_column_indices.is_empty() {
                         return std::task::Poll::Ready(Some(Err(
                             datafusion_common::DataFusionError::Internal(
                                 "KeyBasedDeletionFilterExec requires at least one primary key column index".to_string(),
@@ -611,10 +641,12 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                         )));
                     }
 
-                    // Extract PK columns from the batch
-                    let mut pk_columns: Vec<ArrayRef> =
-                        Vec::with_capacity(self.pk_column_indices.len());
-                    for &idx in &self.pk_column_indices {
+                    // Extract PK columns from the batch. Scratch is cleared,
+                    // not reallocated: the column count is fixed for the
+                    // stream's lifetime, so capacity is reached after the
+                    // first batch (see `pk_columns_scratch` field doc).
+                    this.pk_columns_scratch.clear();
+                    for &idx in &this.pk_column_indices {
                         let Some(column) = batch.columns().get(idx) else {
                             return std::task::Poll::Ready(Some(Err(
                                 datafusion_common::DataFusionError::Internal(format!(
@@ -623,11 +655,11 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                                 )),
                             )));
                         };
-                        pk_columns.push(Arc::clone(column));
+                        this.pk_columns_scratch.push(Arc::clone(column));
                     }
 
                     // Convert PK columns to row bytes (single batched conversion).
-                    let rows = match self.row_converter.convert_columns(&pk_columns) {
+                    let rows = match this.row_converter.convert_columns(&this.pk_columns_scratch) {
                         Ok(rows) => rows,
                         Err(e) => {
                             return std::task::Poll::Ready(Some(Err(
@@ -640,27 +672,41 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                     // row's PK key TWICE — once in a standalone bloom
                     // `might_contain` sweep, then again in the per-row `get` — on
                     // this hot loop (the dominant query-side CPU cost under
-                    // merge-on-read). `KeyDeletionIndex::get_batch` does what the
-                    // sweep+probe did but hashes each key ONCE: it runs the bloom
-                    // sweep over the precomputed XXH3-128 hashes and walks the
-                    // delta/base tiers only for bloom survivors (probed by hash
-                    // identity). It is proven equivalent to the per-row `get` by
-                    // `get_batch_matches_per_row_get_composite`, and only calls
-                    // back for rows that have a real tombstone — a row with no
-                    // tombstone is visible, exactly as `is_pk_visible_row_key`
-                    // returns `true` on `get() == None`. The bloom-empty /
-                    // all-visible fast path is preserved below via `deleted`.
-                    let mut deleted: Vec<usize> = Vec::new();
-                    self.tombstones.get_batch(rows.iter(), |i, tombstone| {
-                        if !tombstone_visible(
-                            tombstone,
-                            self.insert_record_handling,
-                            self.min_delete_seq_to_apply,
-                        ) {
-                            deleted.push(i);
-                        }
-                    });
-                    let keep_count = batch_size - deleted.len();
+                    // merge-on-read). `KeyDeletionIndex::get_batch_with_scratch`
+                    // does what the sweep+probe did but hashes each key ONCE: it
+                    // runs the bloom sweep over the precomputed XXH3-128 hashes
+                    // and walks the delta/base tiers only for bloom survivors
+                    // (probed by hash identity), using this stream's own
+                    // `hashes_scratch`/`candidates_scratch` buffers instead of
+                    // allocating a fresh pair per batch. It is proven equivalent
+                    // to the per-row `get` by `get_batch_matches_per_row_get_composite`
+                    // (and to the allocating `get_batch` by
+                    // `get_batch_with_scratch_reuse_does_not_leak_across_calls`),
+                    // and only calls back for rows that have a real tombstone —
+                    // a row with no tombstone is visible, exactly as
+                    // `is_pk_visible_row_key` returns `true` on `get() == None`.
+                    // The bloom-empty / all-visible fast path is preserved below
+                    // via `deleted_scratch`.
+                    this.deleted_scratch.clear();
+                    this.deleted_scratch.reserve(batch_size);
+                    let insert_record_handling = this.insert_record_handling;
+                    let min_delete_seq_to_apply = this.min_delete_seq_to_apply;
+                    let deleted_scratch = &mut this.deleted_scratch;
+                    this.tombstones.get_batch_with_scratch(
+                        rows.iter(),
+                        &mut this.hashes_scratch,
+                        &mut this.candidates_scratch,
+                        |i, tombstone| {
+                            if !tombstone_visible(
+                                tombstone,
+                                insert_record_handling,
+                                min_delete_seq_to_apply,
+                            ) {
+                                deleted_scratch.push(i);
+                            }
+                        },
+                    );
+                    let keep_count = batch_size - this.deleted_scratch.len();
 
                     tracing::trace!(
                         "KeyBasedDeletionFilterStream: keeping {} of {} rows",
@@ -672,14 +718,14 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                     // batch as-is. Covers both the old bloom-empty early-out and
                     // the keep_count == batch_size fast path in one check, and
                     // avoids building a mask at all.
-                    if deleted.is_empty() {
-                        self.metrics.baseline.record_output(batch_size);
+                    if this.deleted_scratch.is_empty() {
+                        this.metrics.baseline.record_output(batch_size);
                         return std::task::Poll::Ready(Some(Ok(batch)));
                     }
 
                     // If all rows are deleted, skip this batch and continue to next
                     if keep_count == 0 {
-                        self.metrics.rows_deleted.add(batch_size);
+                        this.metrics.rows_deleted.add(batch_size);
                         continue;
                     }
 
@@ -687,7 +733,7 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                     // rows kept except the deleted positions reported above.
                     let mut keep_mask = BooleanBufferBuilder::new(batch_size);
                     keep_mask.append_n(batch_size, true);
-                    for &i in &deleted {
+                    for &i in &this.deleted_scratch {
                         keep_mask.set_bit(i, false);
                     }
 
@@ -707,10 +753,10 @@ impl futures::Stream for KeyBasedDeletionFilterStream {
                         };
 
                     let filtered_row_count = filtered_batch.num_rows();
-                    self.metrics
+                    this.metrics
                         .rows_deleted
                         .add(batch_size - filtered_row_count);
-                    self.metrics.baseline.record_output(filtered_row_count);
+                    this.metrics.baseline.record_output(filtered_row_count);
 
                     return std::task::Poll::Ready(Some(Ok(filtered_batch)));
                 }
@@ -1270,6 +1316,10 @@ mod tests {
             min_delete_seq_to_apply: None,
             schema,
             metrics: DeletionFilterMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
+            pk_columns_scratch: Vec::new(),
+            deleted_scratch: Vec::new(),
+            hashes_scratch: Vec::new(),
+            candidates_scratch: Vec::new(),
         };
 
         let Some(batch) = stream.next().await.transpose()? else {
@@ -1726,6 +1776,10 @@ mod tests {
             min_delete_seq_to_apply: None,
             schema,
             metrics: DeletionFilterMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
+            pk_columns_scratch: Vec::new(),
+            deleted_scratch: Vec::new(),
+            hashes_scratch: Vec::new(),
+            candidates_scratch: Vec::new(),
         };
         let mut out = Vec::new();
         while let Some(batch) = stream.next().await {

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -2411,9 +2411,9 @@ mod tests {
             },
         );
         assert_eq!(warm_up_out, per_row_gets_key(&idx, &warm_up));
-        // `hashes`/`candidates` end each call empty (the loop's terminating
-        // chunk clears them before finding no more keys), so the reuse
-        // invariant under test is retained *capacity*, not a non-empty len.
+        // `hashes` ends each call empty (the loop's terminating iteration clears it
+        // before finding no more keys). `candidates` may retain a non-empty len,
+        // so the reuse invariant under test is retained *capacity*, not len.
         assert!(
             hashes.capacity() > 0,
             "scratch buffers should retain capacity after use"

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -2419,9 +2419,9 @@ mod tests {
             "scratch buffers should retain capacity after use"
         );
 
-        // Second probe reuses the same (non-empty) scratch buffers with a
-        // disjoint shape (chunk-spanning, mixed hit/miss); results must
-        // match a fresh per-row probe, not a mix of stale and fresh hits.
+        // Second probe reuses the same scratch buffers (retaining capacity) with a
+        // disjoint shape (chunk-spanning, mixed hit/miss); results must match a
+        // fresh per-row probe, not a mix of stale and fresh hits.
         let shapes: Vec<Vec<Box<[u8]>>> = vec![
             vec![],
             vec![byte_key(2)],

--- a/crates/cayenne/src/provider/deletion_index.rs
+++ b/crates/cayenne/src/provider/deletion_index.rs
@@ -1414,16 +1414,41 @@ impl KeyDeletionIndex {
     pub fn get_batch<K: AsRef<[u8]>>(
         &self,
         keys: impl IntoIterator<Item = K>,
-        mut on_hit: impl FnMut(usize, Tombstone),
+        on_hit: impl FnMut(usize, Tombstone),
     ) {
         // Deletion-keyed bloom: with no recorded deletions every probe would
-        // miss (insert-only entries probe as absent), so skip the sweep.
+        // miss (insert-only entries probe as absent), so skip the sweep
+        // before paying for the chunk buffers below.
+        if self.core.delete_count == 0 {
+            return;
+        }
+        let mut hashes: Vec<u128> = Vec::with_capacity(BATCH_SWEEP_CHUNK);
+        let mut candidates: Vec<u32> = Vec::with_capacity(BATCH_SWEEP_CHUNK);
+        self.get_batch_with_scratch(keys, &mut hashes, &mut candidates, on_hit);
+    }
+
+    /// Like [`get_batch`](Self::get_batch), but the chunk-sweep buffers are
+    /// owned by the caller instead of allocated fresh (~40 KB across the two
+    /// `BATCH_SWEEP_CHUNK`-sized `Vec`s) on every call. Intended for a caller
+    /// that probes many batches in a loop (e.g. a per-`RecordBatch` deletion
+    /// filter stream) and keeps `hashes`/`candidates` as `&mut self` fields
+    /// across calls.
+    ///
+    /// `hashes` and `candidates` are cleared before each chunk's sweep, so
+    /// stale contents from a prior call (or a prior chunk) never leak into
+    /// the result — passing non-empty buffers is safe and has no effect on
+    /// the reported hits, only on avoided reallocations.
+    pub fn get_batch_with_scratch<K: AsRef<[u8]>>(
+        &self,
+        keys: impl IntoIterator<Item = K>,
+        hashes: &mut Vec<u128>,
+        candidates: &mut Vec<u32>,
+        mut on_hit: impl FnMut(usize, Tombstone),
+    ) {
         if self.core.delete_count == 0 {
             return;
         }
         let mut keys = keys.into_iter();
-        let mut hashes: Vec<u128> = Vec::with_capacity(BATCH_SWEEP_CHUNK);
-        let mut candidates: Vec<u32> = Vec::with_capacity(BATCH_SWEEP_CHUNK);
         let mut chunk_base = 0_usize;
         loop {
             hashes.clear();
@@ -1445,7 +1470,7 @@ impl KeyDeletionIndex {
             }
             // Pass 2: tier walk for the bloom survivors only (probed by the
             // retained hash identity; false positives resolve to "absent").
-            for &i in &candidates {
+            for &i in candidates.iter() {
                 if let Some(tombstone) = self.core.tombstone_of(
                     &hashes[i as usize],
                     bloom_half(hashes[i as usize]),
@@ -2357,6 +2382,75 @@ mod tests {
         let many: Vec<Box<[u8]>> = (0..5000_u64).map(byte_key).collect();
         assert!(many.len() > 2 * BATCH_SWEEP_CHUNK);
         assert_eq!(batch_gets_key(&idx, &many), per_row_gets_key(&idx, &many));
+    }
+
+    /// `get_batch_with_scratch` must agree with the allocating `get_batch`
+    /// wrapper even when its scratch buffers arrive pre-populated with
+    /// unrelated contents from a prior call — the reused-buffer contract is
+    /// that `hashes`/`candidates` are cleared per chunk, so stale entries
+    /// (here, from probing a disjoint key set first) never leak into a
+    /// later probe's hits.
+    #[test]
+    fn get_batch_with_scratch_reuse_does_not_leak_across_calls() {
+        let deleted: HashMap<Box<[u8]>, i64> = (0..100_u64).map(|i| (byte_key(i * 2), 1)).collect();
+        let idx = KeyDeletionIndex::from_map(deleted);
+
+        let mut hashes: Vec<u128> = Vec::new();
+        let mut candidates: Vec<u32> = Vec::new();
+
+        // First probe: a large, all-hit batch, to populate the scratch
+        // buffers with unrelated hashes/candidates at high capacity.
+        let warm_up: Vec<Box<[u8]>> = (0..10_u64).map(|i| byte_key(i * 2)).collect();
+        let mut warm_up_out: Vec<Option<Tombstone>> = vec![None; warm_up.len()];
+        idx.get_batch_with_scratch(
+            warm_up.iter().map(AsRef::as_ref),
+            &mut hashes,
+            &mut candidates,
+            |i, t| {
+                warm_up_out[i] = Some(t);
+            },
+        );
+        assert_eq!(warm_up_out, per_row_gets_key(&idx, &warm_up));
+        // `hashes`/`candidates` end each call empty (the loop's terminating
+        // chunk clears them before finding no more keys), so the reuse
+        // invariant under test is retained *capacity*, not a non-empty len.
+        assert!(
+            hashes.capacity() > 0,
+            "scratch buffers should retain capacity after use"
+        );
+
+        // Second probe reuses the same (non-empty) scratch buffers with a
+        // disjoint shape (chunk-spanning, mixed hit/miss); results must
+        // match a fresh per-row probe, not a mix of stale and fresh hits.
+        let shapes: Vec<Vec<Box<[u8]>>> = vec![
+            vec![],
+            vec![byte_key(2)],
+            vec![byte_key(3)],
+            (0..5000_u64).map(byte_key).collect(),
+        ];
+        for keys in &shapes {
+            let mut out: Vec<Option<Tombstone>> = vec![None; keys.len()];
+            let mut last: Option<usize> = None;
+            idx.get_batch_with_scratch(
+                keys.iter().map(AsRef::as_ref),
+                &mut hashes,
+                &mut candidates,
+                |i, tombstone| {
+                    assert!(i < keys.len(), "callback index out of bounds: {i}");
+                    assert!(
+                        last.is_none_or(|prev| prev < i),
+                        "callback indices must be strictly ascending: {last:?} then {i}"
+                    );
+                    last = Some(i);
+                    out[i] = Some(tombstone);
+                },
+            );
+            assert_eq!(
+                out,
+                per_row_gets_key(&idx, keys),
+                "reused scratch buffers must not leak stale hits across calls"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- CPU profiling of a local CH-benCHmark HTAP run (sf10, directional) showed `KeyBasedDeletionFilterStream` as the single biggest query-path hotspot. Two things were allocated fresh on every `poll_next` call instead of being reused across the stream's lifetime: the `pk_columns`/`deleted` `Vec`s, and `KeyDeletionIndex::get_batch`'s internal chunk-sweep buffers (~40 KB per call).
- Both now live as `KeyBasedDeletionFilterStream` fields, `clear()`ed instead of reallocated each batch.
- `KeyDeletionIndex` gains a `get_batch_with_scratch` variant that takes caller-owned scratch buffers; `get_batch` becomes a thin allocating wrapper over it, so its other two call sites (`table.rs`) are unchanged.
- Correctness is unaffected: identical control flow, only the allocation strategy changed. Added a regression test (`get_batch_with_scratch_reuse_does_not_leak_across_calls`) proving reused buffers never leak stale results across calls.
- Microbenchmark-validated (`key_based_filter_scratch_reuse_alloc` bench, seeded with a realistic ~100K-entry, multi-tier tombstone index rather than a small flat map): `scratch_reuse` is consistently faster than `fresh_alloc` across visibility shapes — ~9-10% on `all_visible`/`sparse` (the realistic steady-state case), ~1-4% on `half_visible`/`none_visible` (where `filter_record_batch`, unchanged in both lanes, dominates).

## Test plan
- [x] `cargo test -p cayenne --lib` — 882 passed, 0 failed
- [x] `cargo clippy -p cayenne --no-deps --lib --bench key_based_filter_scratch_reuse_alloc` — clean
- [x] `cargo fmt -p cayenne -- --check` — clean
- [x] `cargo bench -p cayenne --bench key_based_filter_scratch_reuse_alloc` — confirms the win, reproduced across multiple clean runs