### PR TITLE
feat: generic spiced env-var passthrough for HTAP testoperator runs

### DIFF
--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -67,7 +67,7 @@ on:
         default: false
         type: boolean
       spiced_env:
-        description: 'Extra environment variables for the spiced process under test, one KEY=VALUE per line. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary and run logs.'
+        description: 'Extra environment variables for the spiced process under test, one SPICE*=VALUE per line (name must start with SPICE, e.g. SPICE_CAYENNE_EAGER_NDV). Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary and run logs.'
         required: false
         default: ''
         type: string
@@ -230,12 +230,17 @@ jobs:
           # is parsed, not just as inert data.
           SPICED_ENV_INPUT: ${{ github.event.inputs.spiced_env }}
         run: |
+          # Allowlist names starting with SPICE (covers both the SPICE_* and SPICED_*
+          # conventions used across the codebase, e.g. SPICE_CAYENNE_EAGER_NDV,
+          # SPICED_METRICS_ADDR) so a dispatcher can never overwrite reserved
+          # runner/Actions variables (GITHUB_*, RUNNER_*, ACTIONS_*, PATH, HOME, ...)
+          # or otherwise alter the runner environment outside spiced's own config.
           while IFS= read -r line; do
             line="${line%$'\r'}"
             [ -z "$line" ] && continue
             key="${line%%=*}"
-            if [[ "$line" != *"="* ]] || [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-              echo "::error::Invalid spiced_env entry (expected KEY=VALUE with a valid variable name): $line"
+            if [[ "$line" != *"="* ]] || [[ ! "$key" =~ ^SPICE[A-Za-z0-9_]*$ ]]; then
+              echo "::error::Invalid spiced_env entry (expected SPICE*=VALUE with a variable name starting with SPICE): $line"
               exit 1
             fi
             printf '%s\n' "$line" >> "$GITHUB_ENV"

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -156,10 +156,16 @@ jobs:
           # CR) so a multi-entry or adversarial value can't corrupt the summary table.
           extra_spiced_env="none"
           if [ -n "$SPICED_ENV_INPUT" ]; then
+            # awk 'NF' drops blank/whitespace-only lines before joining, so input that's
+            # only blank lines (e.g. a stray trailing newline) collapses to "none" below
+            # instead of a meaningless "; ; " row. (awk never fails on zero matches, unlike
+            # grep, so this stays safe under the runner's `set -eo pipefail`.)
             extra_spiced_env=$(printf '%s' "$SPICED_ENV_INPUT" \
               | tr -d '\r' \
+              | awk 'NF' \
               | tr '\n' ';' | sed 's/;$//; s/;/; /g' \
               | sed 's/`/'"'"'/g; s/|/\\|/g')
+            [ -z "$extra_spiced_env" ] && extra_spiced_env="none"
           fi
           {
             echo "## CH-BenCHmark run"
@@ -240,7 +246,13 @@ jobs:
             [ -z "$line" ] && continue
             key="${line%%=*}"
             if [[ "$line" != *"="* ]] || [[ ! "$key" =~ ^SPICE[A-Za-z0-9_]*$ ]]; then
-              echo "::error::Invalid spiced_env entry (expected SPICE*=VALUE with a variable name starting with SPICE): $line"
+              # Workflow-command values must have %, CR, LF escaped (%25/%0D/%0A) or an
+              # untrusted line containing them could corrupt the log or smuggle in
+              # additional workflow commands.
+              escaped="${line//%/%25}"
+              escaped="${escaped//$'\r'/%0D}"
+              escaped="${escaped//$'\n'/%0A}"
+              echo "::error::Invalid spiced_env entry (expected SPICE*=VALUE with a variable name starting with SPICE): ${escaped}"
               exit 1
             fi
             printf '%s\n' "$line" >> "$GITHUB_ENV"

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -67,7 +67,7 @@ on:
         default: false
         type: boolean
       spiced_env:
-        description: 'Extra environment variables for the spiced process under test, one SPICE*=VALUE per line (name must start with SPICE, e.g. SPICE_CAYENNE_EAGER_NDV). Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary and run logs.'
+        description: 'Extra environment variables for the spiced process under test, one SPICE_KEY=VALUE or SPICED_KEY=VALUE per line (e.g. SPICE_CAYENNE_EAGER_NDV). A handful of reserved SPICE*/SPICED* names owned by this workflow (SPICED_COMMIT, SPICED_BIN, SPICED_ENV_INPUT) are rejected. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary and run logs.'
         required: false
         default: ''
         type: string
@@ -236,23 +236,34 @@ jobs:
           # is parsed, not just as inert data.
           SPICED_ENV_INPUT: ${{ github.event.inputs.spiced_env }}
         run: |
-          # Allowlist names starting with SPICE (covers both the SPICE_* and SPICED_*
-          # conventions used across the codebase, e.g. SPICE_CAYENNE_EAGER_NDV,
-          # SPICED_METRICS_ADDR) so a dispatcher can never overwrite reserved
-          # runner/Actions variables (GITHUB_*, RUNNER_*, ACTIONS_*, PATH, HOME, ...)
-          # or otherwise alter the runner environment outside spiced's own config.
+          # Allowlist SPICE_* / SPICED_* (underscore required, so e.g. SPICEAI_* or bare
+          # SPICE/SPICED don't slip through) — covers both naming conventions used across
+          # the codebase, e.g. SPICE_CAYENNE_EAGER_NDV, SPICED_METRICS_ADDR — so a
+          # dispatcher can never overwrite reserved runner/Actions variables (GITHUB_*,
+          # RUNNER_*, ACTIONS_*, PATH, HOME, ...) or otherwise alter the runner
+          # environment outside spiced's own config.
+          #
+          # A few SPICE_*/SPICED_* names ARE reserved even though they match that prefix:
+          # they're owned by this workflow (provenance, internal plumbing) rather than
+          # being spiced runtime config, so letting a dispatcher spoof them would corrupt
+          # results/metrics attribution or the export mechanism itself.
+          reserved_names="SPICED_COMMIT SPICED_BIN SPICED_ENV_INPUT"
           while IFS= read -r line; do
             line="${line%$'\r'}"
             [ -z "$line" ] && continue
             key="${line%%=*}"
-            if [[ "$line" != *"="* ]] || [[ ! "$key" =~ ^SPICE[A-Za-z0-9_]*$ ]]; then
+            reserved=0
+            for r in $reserved_names; do
+              [ "$key" = "$r" ] && reserved=1 && break
+            done
+            if [[ "$line" != *"="* ]] || [[ ! "$key" =~ ^SPICED?_[A-Za-z0-9_]+$ ]] || [ "$reserved" = "1" ]; then
               # Workflow-command values must have %, CR, LF escaped (%25/%0D/%0A) or an
               # untrusted line containing them could corrupt the log or smuggle in
               # additional workflow commands.
               escaped="${line//%/%25}"
               escaped="${escaped//$'\r'/%0D}"
               escaped="${escaped//$'\n'/%0A}"
-              echo "::error::Invalid spiced_env entry (expected SPICE*=VALUE with a variable name starting with SPICE): ${escaped}"
+              echo "::error::Invalid spiced_env entry (expected SPICE_KEY=VALUE or SPICED_KEY=VALUE, not a reserved name): ${escaped}"
               exit 1
             fi
             printf '%s\n' "$line" >> "$GITHUB_ENV"

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -67,7 +67,7 @@ on:
         default: false
         type: boolean
       spiced_env:
-        description: 'Extra environment variables for the spiced process under test, one SPICE_KEY=VALUE or SPICED_KEY=VALUE per line (e.g. SPICE_CAYENNE_EAGER_NDV=true). A handful of reserved SPICE*/SPICED* names owned by this workflow (SPICED_COMMIT, SPICED_BIN, SPICED_ENV_INPUT) are rejected. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary.'
+        description: 'Extra environment variables for the spiced process under test, one SPICE_KEY=VALUE or SPICED_KEY=VALUE per line (e.g. SPICE_CAYENNE_EAGER_NDV=true). A handful of reserved SPICE*/SPICED* names owned by this workflow or testoperator (SPICED_COMMIT, SPICED_BIN, SPICED_ENV_INPUT, SPICED_KEEP_ALIVE) are rejected. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary.'
         required: false
         default: ''
         type: string
@@ -164,7 +164,7 @@ jobs:
               | tr -d '\r' \
               | awk 'NF' \
               | tr '\n' ';' | sed 's/;$//; s/;/; /g' \
-              | sed 's/`/'"'"'/g; s/|/\\|/g')
+              | sed 's/`/\&#96;/g; s/|/\\|/g')
             [ -z "$extra_spiced_env" ] && extra_spiced_env="none"
           fi
           {
@@ -247,7 +247,10 @@ jobs:
           # they're owned by this workflow (provenance, internal plumbing) rather than
           # being spiced runtime config, so letting a dispatcher spoof them would corrupt
           # results/metrics attribution or the export mechanism itself.
-          reserved_names="SPICED_COMMIT SPICED_BIN SPICED_ENV_INPUT"
+          # SPICED_KEEP_ALIVE is a testoperator debug knob that blocks waiting on stdin
+          # (see tools/testoperator/src/commands/htap/mod.rs) — letting a dispatcher set
+          # it would hang the CI run indefinitely rather than just tweak spiced config.
+          reserved_names="SPICED_COMMIT SPICED_BIN SPICED_ENV_INPUT SPICED_KEEP_ALIVE"
           while IFS= read -r line; do
             line="${line%$'\r'}"
             # Skip blank/whitespace-only lines (consistent with the summary-header

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -250,7 +250,9 @@ jobs:
           reserved_names="SPICED_COMMIT SPICED_BIN SPICED_ENV_INPUT"
           while IFS= read -r line; do
             line="${line%$'\r'}"
-            [ -z "$line" ] && continue
+            # Skip blank/whitespace-only lines (consistent with the summary-header
+            # step's `awk 'NF'`), so copy/paste padding doesn't fail the run.
+            [[ "$line" =~ ^[[:space:]]*$ ]] && continue
             key="${line%%=*}"
             reserved=0
             for r in $reserved_names; do

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -145,7 +145,18 @@ jobs:
       # run is identifiable and reproducible even if it crashes mid-run. Results
       # are appended after the run below.
       - name: Write run summary header
+        env:
+          # Piped through env (never interpolated with ${{ }} into the script body) so an
+          # input containing shell metacharacters (e.g. `$(...)`) is inert data, not code the
+          # shell re-parses. See the "Export extra spiced env vars" step below for the same
+          # rule applied to the actual export.
+          SPICED_ENV_INPUT: ${{ github.event.inputs.spiced_env }}
         run: |
+          # Flatten to one line so a multi-entry value can't break the Markdown table row.
+          extra_spiced_env="none"
+          if [ -n "$SPICED_ENV_INPUT" ]; then
+            extra_spiced_env=$(printf '%s' "$SPICED_ENV_INPUT" | tr '\n' ';' | sed 's/;$//; s/;/; /g')
+          fi
           {
             echo "## CH-BenCHmark run"
             echo ""
@@ -163,7 +174,7 @@ jobs:
             echo "| query overrides | ${{ github.event.inputs.query_overrides || 'none' }} |"
             echo "| runner | ${{ github.event.inputs.runner_type }} |"
             echo "| analytic gate | ${{ github.event.inputs.skip_analytic_gate == 'true' && 'skipped' || 'enabled' }} |"
-            echo "| extra spiced env | ${{ github.event.inputs.spiced_env != '' && github.event.inputs.spiced_env || 'none' }} |"
+            echo "| extra spiced env | ${extra_spiced_env} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build Testoperator
@@ -207,15 +218,22 @@ jobs:
       # steps in this job, so only the "Run CH-benCHmark" step below sees them.
       - name: Export extra spiced env vars
         if: github.event.inputs.spiced_env != ''
+        env:
+          # Piped through env, not interpolated into the script via ${{ }} — the input is
+          # untrusted (free text from workflow_dispatch), and embedding it directly into the
+          # `run:` body would let shell metacharacters (e.g. `$(...)`) execute as the script
+          # is parsed, not just as inert data.
+          SPICED_ENV_INPUT: ${{ github.event.inputs.spiced_env }}
         run: |
           while IFS= read -r line; do
             [ -z "$line" ] && continue
-            if [[ "$line" != *"="* ]]; then
-              echo "::error::Invalid spiced_env entry (expected KEY=VALUE): $line"
+            key="${line%%=*}"
+            if [[ "$line" != *"="* ]] || [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+              echo "::error::Invalid spiced_env entry (expected KEY=VALUE with a valid variable name): $line"
               exit 1
             fi
             echo "$line" >> "$GITHUB_ENV"
-          done <<< "${{ github.event.inputs.spiced_env }}"
+          done <<< "$SPICED_ENV_INPUT"
 
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -67,7 +67,7 @@ on:
         default: false
         type: boolean
       spiced_env:
-        description: 'Extra environment variables for the spiced process under test, one SPICE_KEY=VALUE or SPICED_KEY=VALUE per line (e.g. SPICE_CAYENNE_EAGER_NDV). A handful of reserved SPICE*/SPICED* names owned by this workflow (SPICED_COMMIT, SPICED_BIN, SPICED_ENV_INPUT) are rejected. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary and run logs.'
+        description: 'Extra environment variables for the spiced process under test, one SPICE_KEY=VALUE or SPICED_KEY=VALUE per line (e.g. SPICE_CAYENNE_EAGER_NDV=true). A handful of reserved SPICE*/SPICED* names owned by this workflow (SPICED_COMMIT, SPICED_BIN, SPICED_ENV_INPUT) are rejected. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary.'
         required: false
         default: ''
         type: string
@@ -265,7 +265,7 @@ jobs:
               escaped="${line//%/%25}"
               escaped="${escaped//$'\r'/%0D}"
               escaped="${escaped//$'\n'/%0A}"
-              echo "::error::Invalid spiced_env entry (expected SPICE_KEY=VALUE or SPICED_KEY=VALUE, not a reserved name): ${escaped}"
+              echo "::error::Invalid spiced_env entry (must be SPICE_KEY=VALUE or SPICED_KEY=VALUE, and KEY must not be a reserved name): ${escaped}"
               exit 1
             fi
             printf '%s\n' "$line" >> "$GITHUB_ENV"

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -66,6 +66,11 @@ on:
         required: false
         default: false
         type: boolean
+      spiced_env:
+        description: 'Extra environment variables for the spiced process under test, one KEY=VALUE per line. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template.'
+        required: false
+        default: ''
+        type: string
 
 # Serialize ALL SF100 + SF1000 CH-benCHmark runs across every variant (sqlite/turso cdc-tuned,
 # adaptive, duckdb): they share ONE concurrency group keyed only by scale factor, so
@@ -158,6 +163,7 @@ jobs:
             echo "| query overrides | ${{ github.event.inputs.query_overrides || 'none' }} |"
             echo "| runner | ${{ github.event.inputs.runner_type }} |"
             echo "| analytic gate | ${{ github.event.inputs.skip_analytic_gate == 'true' && 'skipped' || 'enabled' }} |"
+            echo "| extra spiced env | ${{ github.event.inputs.spiced_env != '' && github.event.inputs.spiced_env || 'none' }} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build Testoperator
@@ -194,6 +200,22 @@ jobs:
           CHBENCH_PG_PORT: '5432'
           CHBENCH_PG_USER: bench
           CHBENCH_PG_PASS: bench
+
+      # Deliberately placed after template restore/seed above: these vars must never be
+      # visible to the `--prepare-only` seed run, or an experiment could silently change
+      # what gets frozen into the cached template. $GITHUB_ENV persists for all later
+      # steps in this job, so only the "Run CH-benCHmark" step below sees them.
+      - name: Export extra spiced env vars
+        if: github.event.inputs.spiced_env != ''
+        run: |
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            if [[ "$line" != *"="* ]]; then
+              echo "::error::Invalid spiced_env entry (expected KEY=VALUE): $line"
+              exit 1
+            fi
+            echo "$line" >> "$GITHUB_ENV"
+          done <<< "${{ github.event.inputs.spiced_env }}"
 
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}
         run: |

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -67,7 +67,7 @@ on:
         default: false
         type: boolean
       spiced_env:
-        description: 'Extra environment variables for the spiced process under test, one KEY=VALUE per line. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template.'
+        description: 'Extra environment variables for the spiced process under test, one KEY=VALUE per line. Applied only to the benchmark run, never to template seeding, so it never invalidates the cached CH-benCH template. Do not put secrets here: values are echoed into the job summary and run logs.'
         required: false
         default: ''
         type: string
@@ -152,10 +152,14 @@ jobs:
           # rule applied to the actual export.
           SPICED_ENV_INPUT: ${{ github.event.inputs.spiced_env }}
         run: |
-          # Flatten to one line so a multi-entry value can't break the Markdown table row.
+          # Flatten to one line and escape Markdown table-breaking characters (`|`, backtick,
+          # CR) so a multi-entry or adversarial value can't corrupt the summary table.
           extra_spiced_env="none"
           if [ -n "$SPICED_ENV_INPUT" ]; then
-            extra_spiced_env=$(printf '%s' "$SPICED_ENV_INPUT" | tr '\n' ';' | sed 's/;$//; s/;/; /g')
+            extra_spiced_env=$(printf '%s' "$SPICED_ENV_INPUT" \
+              | tr -d '\r' \
+              | tr '\n' ';' | sed 's/;$//; s/;/; /g' \
+              | sed 's/`/'"'"'/g; s/|/\\|/g')
           fi
           {
             echo "## CH-BenCHmark run"
@@ -214,8 +218,9 @@ jobs:
 
       # Deliberately placed after template restore/seed above: these vars must never be
       # visible to the `--prepare-only` seed run, or an experiment could silently change
-      # what gets frozen into the cached template. $GITHUB_ENV persists for all later
-      # steps in this job, so only the "Run CH-benCHmark" step below sees them.
+      # what gets frozen into the cached template. $GITHUB_ENV persists for every later
+      # step in this job (not just "Run CH-benCHmark"), so seeding is protected but
+      # subsequent diagnostics/cleanup steps also see these vars.
       - name: Export extra spiced env vars
         if: github.event.inputs.spiced_env != ''
         env:
@@ -226,13 +231,14 @@ jobs:
           SPICED_ENV_INPUT: ${{ github.event.inputs.spiced_env }}
         run: |
           while IFS= read -r line; do
+            line="${line%$'\r'}"
             [ -z "$line" ] && continue
             key="${line%%=*}"
             if [[ "$line" != *"="* ]] || [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
               echo "::error::Invalid spiced_env entry (expected KEY=VALUE with a valid variable name): $line"
               exit 1
             fi
-            echo "$line" >> "$GITHUB_ENV"
+            printf '%s\n' "$line" >> "$GITHUB_ENV"
           done <<< "$SPICED_ENV_INPUT"
 
       - name: Run CH-benCHmark - ${{ github.event.inputs.spicepod_path }}


### PR DESCRIPTION
## Summary
- Adds a free-form `spiced_env` (`KEY=VALUE` per line) `workflow_dispatch` input to the CH-benCHmark HTAP workflow, so A/B experiments can set arbitrary env vars for the benchmarked `spiced` process without a bespoke workflow input + workflow edit per experiment (as was needed for the now-removed `SPICE_CAYENNE_EAGER_NDV` toggle).
- The export step runs only *after* "Restore or seed CH-benCH from template", so the extra env vars are never visible to the `--prepare-only` seed run — this can't invalidate or silently affect what gets frozen into the cached Postgres template (the template fingerprint in `chbench_template.sh` only hashes scale factor, the `tools/chbench-driver` tree, and the Postgres major version — never env vars).
- `spiced` already inherits the full process environment (`Command::new(...).spawn()` with no `.env()` filtering), so no `tools/testoperator` code changes are needed.
- Adds a job-summary row so a dispatched run's extra env is visible for reproducibility.

## Test plan
- [x] Validated YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Manually dispatch the `htap benchmark tests` workflow with `spiced_env` set (e.g. one KEY=VALUE line) and confirm the summary row + `spiced` process picks up the var
- [ ] Confirm a run with `spiced_env` unset behaves identically to before (no regression)