### PR TITLE
fix(cayenne): partitioned datasets deadlock against the global encode budget and never become ready

### DIFF
--- a/crates/cayenne/src/partition_creator.rs
+++ b/crates/cayenne/src/partition_creator.rs
@@ -115,7 +115,8 @@ impl CayennePartitionCreator {
         on_conflict: Option<datafusion_table_providers::util::on_conflict::OnConflict>,
         runtime_env: Arc<RuntimeEnv>,
     ) -> Self {
-        let context = CayenneContext::new(&vortex_config, runtime_env, &table_name);
+        let context =
+            CayenneContext::new_for_partition_child(&vortex_config, runtime_env, &table_name);
         Self {
             table_name,
             base_path,

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -113,6 +113,17 @@ pub struct CayenneContext {
     /// inter-batch arrival interval (the offered-load signal). `None` until the
     /// first write.
     last_write: parking_lot::Mutex<Option<std::time::Instant>>,
+    /// Whether this table's writes are COUPLED to sibling writers through a
+    /// shared input demux — true for the partition child tables of a
+    /// partitioned dataset, whose per-partition writes are all fed by one
+    /// router over bounded channels. Coupled writes must never park on the
+    /// global encode budget: a parked child stalls the router, which starves
+    /// the permit-holding siblings of input — a hold-and-wait deadlock that
+    /// left partitioned tables permanently unready (spiceai/spiceai#11818).
+    /// Set only at construction ([`Self::new_for_partition_child`]); read by
+    /// the write path to bypass `write_budget` permit acquisition. Runtime-only
+    /// state — never persisted.
+    coupled_writer: std::sync::atomic::AtomicBool,
     /// Set of data files whose integrity digest has already been verified this
     /// process, keyed by `"<snapshot_id>/<file_path>"`. Used only when
     /// `integrity_checksums` is enabled, to bound verification to one whole-file
@@ -286,8 +297,37 @@ impl CayenneContext {
             bake_gate_last_samples: std::sync::atomic::AtomicU64::new(0),
             goal_stuck_ticks: std::sync::atomic::AtomicU64::new(0),
             last_write: parking_lot::Mutex::new(None),
+            coupled_writer: std::sync::atomic::AtomicBool::new(false),
             verified_data_files: parking_lot::Mutex::new(std::collections::HashSet::new()),
         })
+    }
+
+    /// Create the shared context for the partition CHILD tables of a
+    /// partitioned dataset. Identical to [`Self::new`] except the tables are
+    /// marked as coupled writers (see [`Self::is_coupled_writer`]): their
+    /// writes are all fed by one routing demux over bounded channels, so they
+    /// must never park on the global encode budget.
+    #[must_use]
+    pub fn new_for_partition_child(
+        config: &VortexConfig,
+        runtime_env: Arc<RuntimeEnv>,
+        dataset: &str,
+    ) -> Arc<Self> {
+        let context = Self::new(config, runtime_env, dataset);
+        context
+            .coupled_writer
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        context
+    }
+
+    /// Whether this table's writes are coupled to sibling writers through a
+    /// shared input demux (partition child tables). Coupled writes bypass the
+    /// global encode budget — parking there deadlocks the demux
+    /// (spiceai/spiceai#11818).
+    #[must_use]
+    pub fn is_coupled_writer(&self) -> bool {
+        self.coupled_writer
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Encoding effort configured for delta writes (`cayenne_delta_encoding`).
@@ -1010,6 +1050,21 @@ mod tests {
             context.file_format().options().projection_pushdown,
             ProjectionPushdown::On
         );
+    }
+
+    /// Partition child contexts are marked as coupled writers (their writes
+    /// share one routing demux and must bypass the global encode budget —
+    /// spiceai/spiceai#11818); ordinary contexts are not.
+    #[test]
+    fn partition_child_context_is_coupled_writer() {
+        let runtime_env = Arc::new(RuntimeEnv::default());
+        let ordinary =
+            CayenneContext::new(&VortexConfig::default(), Arc::clone(&runtime_env), "test");
+        assert!(!ordinary.is_coupled_writer());
+
+        let child =
+            CayenneContext::new_for_partition_child(&VortexConfig::default(), runtime_env, "test");
+        assert!(child.is_coupled_writer());
     }
 
     /// Regression: the cold (datalake) promotion write must roll files at

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -5035,9 +5035,17 @@ impl CayenneTableProvider {
         // `cdc_apply_fixed_cost_ms{phase="write"}` in the runtime apply loop). The
         // `cayenne_encode_acquire_wait_ms{class}` histogram inside `acquire_from`
         // carries the same signal without the table label; this one keys by table.
+        // Coupled writers (partition child tables, fed by a shared routing
+        // demux) bypass the budget entirely — parking a coupled write here
+        // deadlocks the demux against the permit holders (see `write_budget`
+        // module docs; spiceai/spiceai#11818).
         let encode_permit_wait_start = Instant::now();
-        let _encode_permits =
-            super::write_budget::acquire_encode_permits(encode_shards, write_class).await;
+        let _encode_permits = super::write_budget::acquire_encode_permits(
+            encode_shards,
+            write_class,
+            self.context.is_coupled_writer(),
+        )
+        .await;
         record_cayenne_write_phase(
             self.table_name(),
             "encode_permit_wait",

--- a/crates/cayenne/src/provider/write_budget.rs
+++ b/crates/cayenne/src/provider/write_budget.rs
@@ -41,13 +41,15 @@ limitations under the License.
 //! (`runtime_table_partition::insert`), so a child write parked on this budget
 //! stalls the demux, which starves the permit-holding sibling writes of input —
 //! a hold-and-wait cycle *through the channels* that left partitioned tables
-//! permanently unready (spiceai/spiceai#11818). To keep such coupled writers
-//! live regardless of partition count, **single-shard writes are exempt from
-//! the budget** ([`acquire_for_write`]): a serial write is the pre-budget
-//! baseline the budget was never needed for (it exists to cap encode *fan-out*,
-//! and aggregate compaction concurrency is separately bounded by the
-//! compactor's own semaphore), and an exempt serial write can always drain its
-//! input, so the demux always makes progress.
+//! permanently unready (spiceai/spiceai#11818). Such COUPLED writers — tables
+//! whose writes someone else stands behind, marked at construction via
+//! `CayenneContext::new_for_partition_child` — are therefore **exempt from the
+//! budget** ([`acquire_for_write`]): an exempt write can always drain its
+//! input, so the demux always makes progress, for any partition count. The
+//! exemption is safe because coupled tables are also forced to serial writes
+//! (one encode shard — the pre-budget baseline; the budget exists to cap
+//! encode *fan-out*), so an exempt child contributes the minimum possible
+//! encode footprint. Every uncoupled write, serial included, still queues.
 //!
 //! When unset (unit tests, embedders that don't wire it up) acquisition is a
 //! no-op and writes proceed ungated, preserving the prior per-table behavior.
@@ -316,41 +318,47 @@ pub fn encode_budget_snapshot() -> Option<EncodeBudgetSnapshot> {
 ///
 /// Returns the held permits (which release on drop, so callers scope them to
 /// the write) or `None` when the write proceeds ungated: no budget installed,
-/// or a single-shard write (see [`acquire_for_write`]). For gated writes,
-/// `shards` is clamped to `[2, class cap]` so the request is always satisfiable
-/// and can never block forever waiting for more permits than the budget can
-/// ever hold. `Delta` writes may use the whole budget; `Maintenance` writes are
-/// capped to [`maintenance_gate_cap`] in aggregate (see `maintenance_gate`).
+/// or a coupled writer (see [`acquire_for_write`]). For gated writes, `shards`
+/// is clamped to `[1, class cap]` so the request is always satisfiable and can
+/// never block forever waiting for more permits than the budget can ever hold.
+/// `Delta` writes may use the whole budget; `Maintenance` writes are capped to
+/// [`maintenance_gate_cap`] in aggregate (see `maintenance_gate`).
+///
+/// `coupled_writer` is `CayenneContext::is_coupled_writer()` — whether this
+/// table's writes are fed by a shared demux alongside sibling writers
+/// (partition child tables).
 pub(crate) async fn acquire_encode_permits(
     shards: usize,
     class: WriteClass,
+    coupled_writer: bool,
 ) -> Option<EncodePermits> {
     let budget = GLOBAL_ENCODE_BUDGET.read().clone()?;
-    acquire_for_write(&budget, shards, class).await
+    acquire_for_write(&budget, shards, class, coupled_writer).await
 }
 
-/// Budget policy for a write with the given shard count: multi-shard writes
-/// acquire permits ([`acquire_from`]); **single-shard writes are exempt** and
-/// proceed ungated (`None`).
+/// Budget policy for a write: independent writes acquire permits
+/// ([`acquire_from`]); **coupled writers are exempt** and proceed ungated
+/// (`None`).
 ///
-/// The exemption is load-bearing, not an optimization. Writes coupled through
-/// a shared input demux — partitioned-table inserts route one stream into
-/// per-partition writes over bounded channels — deadlock if a child write can
-/// park on this budget: the parked write stalls the demux, starving the
+/// The exemption is load-bearing, not an optimization. Coupled writers — the
+/// partition child tables of a partitioned dataset — are all fed by one
+/// routing demux over bounded channels, and deadlock if any of them can park
+/// on this budget: the parked write stalls the demux, starving the
 /// permit-holding siblings of input, and no permit is ever released
-/// (spiceai/spiceai#11818). A single-shard write is guaranteed to make
-/// progress without ever parking here, which keeps any demux it is coupled to
-/// draining. The budget's purpose — capping aggregate encode *fan-out* — is
-/// unaffected: a serial write contributes exactly the one encode stream per
-/// writer that existed before intra-write sharding (and before this budget),
-/// and compaction's aggregate concurrency stays bounded by the
-/// `BackgroundCompactor` semaphore independently of this gate.
+/// (spiceai/spiceai#11818). An exempt write never parks, so the demux always
+/// drains, for any partition count. The budget's purpose — capping aggregate
+/// encode *fan-out* — is preserved: coupled tables are also forced to serial
+/// (single-shard) writes at creation, the pre-budget baseline of one encode
+/// stream per writer, and compaction's aggregate concurrency stays bounded by
+/// the `BackgroundCompactor` semaphore independently of this gate. Uncoupled
+/// writes — including serial ones — queue exactly as before.
 async fn acquire_for_write(
     budget: &EncodeBudget,
     shards: usize,
     class: WriteClass,
+    coupled_writer: bool,
 ) -> Option<EncodePermits> {
-    if shards <= 1 {
+    if coupled_writer {
         return None;
     }
     acquire_from(budget, shards, class).await
@@ -651,17 +659,21 @@ mod tests {
     /// here — keeping this free of cross-test interference.
     #[tokio::test]
     async fn acquire_encode_permits_is_noop_when_unset() {
-        assert!(acquire_encode_permits(8, WriteClass::Delta).await.is_none());
+        assert!(
+            acquire_encode_permits(8, WriteClass::Delta, false)
+                .await
+                .is_none()
+        );
     }
 
-    /// REGRESSION (spiceai/spiceai#11818): a single-shard write must proceed
+    /// REGRESSION (spiceai/spiceai#11818): a coupled write must proceed
     /// ungated even when the budget is fully held. Partitioned-table inserts
-    /// couple their per-partition writes through one bounded-channel demux, so
-    /// a serial child write that parks on the budget stalls the demux, starves
-    /// the permit-holding siblings of input, and deadlocks the whole insert —
+    /// feed their per-partition writes through one bounded-channel demux, so a
+    /// child write that parks on the budget stalls the demux, starves the
+    /// permit-holding siblings of input, and deadlocks the whole insert —
     /// datasets loaded but the table never ready.
     #[tokio::test]
-    async fn single_shard_write_is_exempt_even_at_zero_headroom() {
+    async fn coupled_write_is_exempt_even_at_zero_headroom() {
         let b = budget(2);
         let held = acquire_from(&b, 2, WriteClass::Delta).await;
         assert!(held.is_some());
@@ -669,10 +681,10 @@ mod tests {
 
         let exempt = tokio::time::timeout(
             Duration::from_millis(500),
-            acquire_for_write(&b, 1, WriteClass::Delta),
+            acquire_for_write(&b, 1, WriteClass::Delta, true),
         )
         .await
-        .expect("a single-shard write must never block on the budget");
+        .expect("a coupled write must never block on the budget");
         assert!(exempt.is_none(), "exempt writes hold no permits");
         assert_eq!(
             b.semaphore.available_permits(),
@@ -681,12 +693,11 @@ mod tests {
         );
     }
 
-    /// The exemption applies to `Maintenance` too: a single-shard compaction
-    /// output (compaction pins its output to one shard) must not park on the
-    /// gate — its aggregate concurrency is bounded by the compactor's own
-    /// semaphore, not this budget.
+    /// The exemption applies to `Maintenance` too: a coupled table's
+    /// compaction output must not park on the gate — its aggregate concurrency
+    /// is bounded by the compactor's own semaphore, not this budget.
     #[tokio::test]
-    async fn single_shard_maintenance_is_exempt() {
+    async fn coupled_maintenance_is_exempt() {
         let total = 16;
         let b = budget(total);
         let gate = maintenance_gate_cap(total);
@@ -695,27 +706,30 @@ mod tests {
 
         let exempt = tokio::time::timeout(
             Duration::from_millis(500),
-            acquire_for_write(&b, 1, WriteClass::Maintenance),
+            acquire_for_write(&b, 1, WriteClass::Maintenance, true),
         )
         .await
-        .expect("a single-shard maintenance write must never block on the gate");
+        .expect("a coupled maintenance write must never block on the gate");
         assert!(exempt.is_none());
     }
 
-    /// Multi-shard writes stay gated: the exemption is strictly `shards <= 1`.
+    /// Uncoupled writes stay gated — the exemption is strictly for coupled
+    /// writers. A serial (1-shard) independent write still claims its permit
+    /// and queues at zero headroom, preserving the budget's aggregate
+    /// accounting for everything outside partitioned inserts.
     #[tokio::test]
-    async fn multi_shard_write_is_still_gated() {
+    async fn uncoupled_writes_stay_gated() {
         let b = budget(2);
-        let held = acquire_for_write(&b, 2, WriteClass::Delta).await;
+        let held = acquire_for_write(&b, 2, WriteClass::Delta, false).await;
         assert!(held.is_some(), "a gated acquire succeeds under headroom");
         assert_eq!(b.semaphore.available_permits(), 0);
 
-        let mut pending = std::pin::pin!(acquire_for_write(&b, 2, WriteClass::Delta));
+        let mut pending = std::pin::pin!(acquire_for_write(&b, 1, WriteClass::Delta, false));
         assert!(
             tokio::time::timeout(Duration::from_millis(100), &mut pending)
                 .await
                 .is_err(),
-            "a second multi-shard write queues while the budget is held"
+            "an uncoupled serial write queues while the budget is held"
         );
         drop(held);
         tokio::time::timeout(Duration::from_millis(500), &mut pending)

--- a/crates/cayenne/src/provider/write_budget.rs
+++ b/crates/cayenne/src/provider/write_budget.rs
@@ -35,6 +35,20 @@ limitations under the License.
 //! cap deadlock-free: a write can never hold some permits while waiting for the
 //! rest, so independent writes can't form a hold-and-wait cycle.
 //!
+//! That argument only holds for writes that are **independent**. Writes into a
+//! partitioned table are not: the partition insert path demuxes one input
+//! stream into per-partition writes over bounded channels
+//! (`runtime_table_partition::insert`), so a child write parked on this budget
+//! stalls the demux, which starves the permit-holding sibling writes of input —
+//! a hold-and-wait cycle *through the channels* that left partitioned tables
+//! permanently unready (spiceai/spiceai#11818). To keep such coupled writers
+//! live regardless of partition count, **single-shard writes are exempt from
+//! the budget** ([`acquire_for_write`]): a serial write is the pre-budget
+//! baseline the budget was never needed for (it exists to cap encode *fan-out*,
+//! and aggregate compaction concurrency is separately bounded by the
+//! compactor's own semaphore), and an exempt serial write can always drain its
+//! input, so the demux always makes progress.
+//!
 //! When unset (unit tests, embedders that don't wire it up) acquisition is a
 //! no-op and writes proceed ungated, preserving the prior per-table behavior.
 
@@ -301,17 +315,45 @@ pub fn encode_budget_snapshot() -> Option<EncodeBudgetSnapshot> {
 /// Acquire up to `shards` encode permits from the global budget, atomically.
 ///
 /// Returns the held permits (which release on drop, so callers scope them to
-/// the write) or `None` when no budget is installed (proceed ungated). `shards`
-/// is clamped to `[1, class cap]` so the request is always satisfiable and can
-/// never block forever waiting for more permits than the budget can ever hold.
-/// `Delta` writes may use the whole budget; `Maintenance` writes are capped to
-/// [`maintenance_gate_cap`] in aggregate (see `maintenance_gate`).
+/// the write) or `None` when the write proceeds ungated: no budget installed,
+/// or a single-shard write (see [`acquire_for_write`]). For gated writes,
+/// `shards` is clamped to `[2, class cap]` so the request is always satisfiable
+/// and can never block forever waiting for more permits than the budget can
+/// ever hold. `Delta` writes may use the whole budget; `Maintenance` writes are
+/// capped to [`maintenance_gate_cap`] in aggregate (see `maintenance_gate`).
 pub(crate) async fn acquire_encode_permits(
     shards: usize,
     class: WriteClass,
 ) -> Option<EncodePermits> {
     let budget = GLOBAL_ENCODE_BUDGET.read().clone()?;
-    acquire_from(&budget, shards, class).await
+    acquire_for_write(&budget, shards, class).await
+}
+
+/// Budget policy for a write with the given shard count: multi-shard writes
+/// acquire permits ([`acquire_from`]); **single-shard writes are exempt** and
+/// proceed ungated (`None`).
+///
+/// The exemption is load-bearing, not an optimization. Writes coupled through
+/// a shared input demux — partitioned-table inserts route one stream into
+/// per-partition writes over bounded channels — deadlock if a child write can
+/// park on this budget: the parked write stalls the demux, starving the
+/// permit-holding siblings of input, and no permit is ever released
+/// (spiceai/spiceai#11818). A single-shard write is guaranteed to make
+/// progress without ever parking here, which keeps any demux it is coupled to
+/// draining. The budget's purpose — capping aggregate encode *fan-out* — is
+/// unaffected: a serial write contributes exactly the one encode stream per
+/// writer that existed before intra-write sharding (and before this budget),
+/// and compaction's aggregate concurrency stays bounded by the
+/// `BackgroundCompactor` semaphore independently of this gate.
+async fn acquire_for_write(
+    budget: &EncodeBudget,
+    shards: usize,
+    class: WriteClass,
+) -> Option<EncodePermits> {
+    if shards <= 1 {
+        return None;
+    }
+    acquire_from(budget, shards, class).await
 }
 
 /// Acquire `min(shards, class cap)` permits from a specific budget. Extracted
@@ -610,5 +652,74 @@ mod tests {
     #[tokio::test]
     async fn acquire_encode_permits_is_noop_when_unset() {
         assert!(acquire_encode_permits(8, WriteClass::Delta).await.is_none());
+    }
+
+    /// REGRESSION (spiceai/spiceai#11818): a single-shard write must proceed
+    /// ungated even when the budget is fully held. Partitioned-table inserts
+    /// couple their per-partition writes through one bounded-channel demux, so
+    /// a serial child write that parks on the budget stalls the demux, starves
+    /// the permit-holding siblings of input, and deadlocks the whole insert —
+    /// datasets loaded but the table never ready.
+    #[tokio::test]
+    async fn single_shard_write_is_exempt_even_at_zero_headroom() {
+        let b = budget(2);
+        let held = acquire_from(&b, 2, WriteClass::Delta).await;
+        assert!(held.is_some());
+        assert_eq!(b.semaphore.available_permits(), 0, "budget fully held");
+
+        let exempt = tokio::time::timeout(
+            Duration::from_millis(500),
+            acquire_for_write(&b, 1, WriteClass::Delta),
+        )
+        .await
+        .expect("a single-shard write must never block on the budget");
+        assert!(exempt.is_none(), "exempt writes hold no permits");
+        assert_eq!(
+            b.semaphore.available_permits(),
+            0,
+            "the exemption consumes no budget"
+        );
+    }
+
+    /// The exemption applies to `Maintenance` too: a single-shard compaction
+    /// output (compaction pins its output to one shard) must not park on the
+    /// gate — its aggregate concurrency is bounded by the compactor's own
+    /// semaphore, not this budget.
+    #[tokio::test]
+    async fn single_shard_maintenance_is_exempt() {
+        let total = 16;
+        let b = budget(total);
+        let gate = maintenance_gate_cap(total);
+        let _held = acquire_from(&b, gate, WriteClass::Maintenance).await;
+        assert_eq!(b.maintenance_gate.available_permits(), 0, "gate exhausted");
+
+        let exempt = tokio::time::timeout(
+            Duration::from_millis(500),
+            acquire_for_write(&b, 1, WriteClass::Maintenance),
+        )
+        .await
+        .expect("a single-shard maintenance write must never block on the gate");
+        assert!(exempt.is_none());
+    }
+
+    /// Multi-shard writes stay gated: the exemption is strictly `shards <= 1`.
+    #[tokio::test]
+    async fn multi_shard_write_is_still_gated() {
+        let b = budget(2);
+        let held = acquire_for_write(&b, 2, WriteClass::Delta).await;
+        assert!(held.is_some(), "a gated acquire succeeds under headroom");
+        assert_eq!(b.semaphore.available_permits(), 0);
+
+        let mut pending = std::pin::pin!(acquire_for_write(&b, 2, WriteClass::Delta));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut pending)
+                .await
+                .is_err(),
+            "a second multi-shard write queues while the budget is held"
+        );
+        drop(held);
+        tokio::time::timeout(Duration::from_millis(500), &mut pending)
+            .await
+            .expect("the queued write proceeds once permits release");
     }
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -3176,33 +3176,32 @@ impl DataAccelerator for CayenneAccelerator {
 ///    path runs one concurrent insert task per partition
 ///    (`runtime_table_partition::insert`), so intra-write encode sharding
 ///    would multiply the aggregate encode-shard count by the partition count.
-/// 2. **Multi-shard child writes can deadlock the insert.** The per-partition
-///    insert tasks are coupled through one routing demux over bounded
-///    channels; a child write parked on the global encode budget stalls the
-///    demux, starving the permit-holding sibling writes of input — a
-///    hold-and-wait cycle that left partitioned tables permanently unready
-///    (spiceai/spiceai#11818). Single-shard writes are exempt from the encode
-///    budget (see `cayenne::provider::write_budget`), so serial children keep
-///    the demux draining for any partition count.
+/// 2. **Child writes bypass the global encode budget, so they must stay
+///    serial.** The per-partition insert tasks are coupled through one
+///    routing demux over bounded channels; a child write parked on the encode
+///    budget stalls the demux, starving the permit-holding sibling writes of
+///    input — a hold-and-wait cycle that left partitioned tables permanently
+///    unready (spiceai/spiceai#11818). Child tables are therefore created as
+///    coupled writers (`CayenneContext::new_for_partition_child`), exempt
+///    from the budget (see `cayenne::provider::write_budget`) — and an
+///    unmetered writer must contribute the minimum encode footprint, one
+///    shard, which this clamp guarantees.
 ///
 /// An operator-pinned `cayenne_write_concurrency > 1` is IGNORED (clamped to
 /// 1, with a warning), like schema evolution above: there is no safe way to
-/// honor it. Whether multi-shard children deadlock depends on
-/// `partitions × concurrency` versus the host-sized encode budget — the same
-/// spicepod is fine on one machine and hangs on another — and partition counts
-/// aren't statically bounded (time-based partitions grow indefinitely), so a
-/// config that is safe today can start deadlocking later.
+/// honor it — child writes are budget-exempt, so a multi-shard child would
+/// fan out unmetered, multiplied by a partition count that isn't statically
+/// bounded (time-based partitions grow indefinitely).
 fn serialize_partition_child_writes(
     config: &mut cayenne::metadata::VortexConfig,
     table_name: &str,
 ) {
-    if config.pinned_tuning_actuators.write_concurrency
-        && config.write_concurrency.unwrap_or(1) > 1
+    if config.pinned_tuning_actuators.write_concurrency && config.write_concurrency.unwrap_or(1) > 1
     {
         tracing::warn!(
             dataset = table_name,
             write_concurrency = ?config.write_concurrency,
-            "cayenne_write_concurrency is not supported for partitioned Cayenne tables (concurrent partition writes above the global encode budget deadlock the insert); writing each partition serially instead"
+            "cayenne_write_concurrency is not supported for partitioned Cayenne tables (partition writes bypass the global encode budget, so intra-partition sharding would fan out unmetered); writing each partition serially instead"
         );
     }
     config.write_concurrency = Some(1);
@@ -3283,7 +3282,11 @@ impl CayennePartitionCreator {
         // Create shared Cayenne context with cache once, to be shared across all partitions.
         // This ensures all partitions share the same footer/segment caches instead of
         // each partition creating its own cache.
-        let context = cayenne::CayenneContext::new(&vortex_config, runtime_env, &table_name);
+        let context = cayenne::CayenneContext::new_for_partition_child(
+            &vortex_config,
+            runtime_env,
+            &table_name,
+        );
 
         Self {
             table_name,

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -2885,6 +2885,8 @@ impl DataAccelerator for CayenneAccelerator {
                 vortex_config.schema_evolution = cayenne::metadata::SchemaEvolutionMode::Disabled;
             }
 
+            serialize_partition_child_writes(&mut vortex_config, &table_name);
+
             // Log S3 Express configuration for partitioned tables
             if is_s3_express {
                 tracing::info!(
@@ -3164,6 +3166,43 @@ impl DataAccelerator for CayenneAccelerator {
 
         Ok(())
     }
+}
+
+/// Force partition child tables to encode serially (one write shard), unless
+/// the operator pinned `cayenne_write_concurrency` explicitly.
+///
+/// Two reasons, both specific to partitioned datasets:
+///
+/// 1. **Parallelism already comes from the partition fan-out.** The insert
+///    path runs one concurrent insert task per partition
+///    (`runtime_table_partition::insert`), so intra-write encode sharding
+///    would multiply the aggregate encode-shard count by the partition count.
+/// 2. **Multi-shard child writes can deadlock the insert.** The per-partition
+///    insert tasks are coupled through one routing demux over bounded
+///    channels; a child write parked on the global encode budget stalls the
+///    demux, starving the permit-holding sibling writes of input — a
+///    hold-and-wait cycle that left partitioned tables permanently unready
+///    (spiceai/spiceai#11818). Single-shard writes are exempt from the encode
+///    budget (see `cayenne::provider::write_budget`), so serial children keep
+///    the demux draining for any partition count.
+///
+/// An operator-pinned `cayenne_write_concurrency` is honored as configured,
+/// with a warning when it re-introduces the multi-shard deadlock risk.
+fn serialize_partition_child_writes(
+    config: &mut cayenne::metadata::VortexConfig,
+    table_name: &str,
+) {
+    if config.pinned_tuning_actuators.write_concurrency {
+        if config.write_concurrency.unwrap_or(1) > 1 {
+            tracing::warn!(
+                dataset = table_name,
+                write_concurrency = ?config.write_concurrency,
+                "cayenne_write_concurrency > 1 on a partitioned dataset can deadlock inserts when concurrent partition writes exhaust the global encode budget; remove the parameter to use the safe serial default"
+            );
+        }
+        return;
+    }
+    config.write_concurrency = Some(1);
 }
 
 /// Partition creator for Cayenne accelerator.
@@ -3542,6 +3581,40 @@ mod tests {
     use datafusion_table_providers::UnsupportedTypeAction;
     use search::index::{SearchIndex, VectorIndex};
     use std::sync::Arc;
+
+    /// Partition child tables default to serial writes (`write_concurrency: 1`):
+    /// multi-shard child writes can deadlock the partition insert demux against
+    /// the global encode budget (spiceai/spiceai#11818).
+    #[test]
+    fn partition_child_writes_default_to_serial() {
+        let mut config = cayenne::metadata::VortexConfig {
+            write_concurrency: None,
+            ..Default::default()
+        };
+        serialize_partition_child_writes(&mut config, "t");
+        assert_eq!(config.write_concurrency, Some(1));
+
+        // Auto-tuned (unpinned) values are overridden too.
+        let mut config = cayenne::metadata::VortexConfig {
+            write_concurrency: Some(8),
+            ..Default::default()
+        };
+        serialize_partition_child_writes(&mut config, "t");
+        assert_eq!(config.write_concurrency, Some(1));
+    }
+
+    /// An operator-pinned `cayenne_write_concurrency` wins over the serial
+    /// default for partition children.
+    #[test]
+    fn partition_child_writes_honor_pinned_write_concurrency() {
+        let mut config = cayenne::metadata::VortexConfig {
+            write_concurrency: Some(4),
+            ..Default::default()
+        };
+        config.pinned_tuning_actuators.write_concurrency = true;
+        serialize_partition_child_writes(&mut config, "t");
+        assert_eq!(config.write_concurrency, Some(4));
+    }
 
     #[test]
     fn resolve_goal_raw_global_default_then_per_dataset_override() {

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -3168,8 +3168,7 @@ impl DataAccelerator for CayenneAccelerator {
     }
 }
 
-/// Force partition child tables to encode serially (one write shard), unless
-/// the operator pinned `cayenne_write_concurrency` explicitly.
+/// Force partition child tables to encode serially (one write shard).
 ///
 /// Two reasons, both specific to partitioned datasets:
 ///
@@ -3186,21 +3185,25 @@ impl DataAccelerator for CayenneAccelerator {
 ///    budget (see `cayenne::provider::write_budget`), so serial children keep
 ///    the demux draining for any partition count.
 ///
-/// An operator-pinned `cayenne_write_concurrency` is honored as configured,
-/// with a warning when it re-introduces the multi-shard deadlock risk.
+/// An operator-pinned `cayenne_write_concurrency > 1` is IGNORED (clamped to
+/// 1, with a warning), like schema evolution above: there is no safe way to
+/// honor it. Whether multi-shard children deadlock depends on
+/// `partitions × concurrency` versus the host-sized encode budget — the same
+/// spicepod is fine on one machine and hangs on another — and partition counts
+/// aren't statically bounded (time-based partitions grow indefinitely), so a
+/// config that is safe today can start deadlocking later.
 fn serialize_partition_child_writes(
     config: &mut cayenne::metadata::VortexConfig,
     table_name: &str,
 ) {
-    if config.pinned_tuning_actuators.write_concurrency {
-        if config.write_concurrency.unwrap_or(1) > 1 {
-            tracing::warn!(
-                dataset = table_name,
-                write_concurrency = ?config.write_concurrency,
-                "cayenne_write_concurrency > 1 on a partitioned dataset can deadlock inserts when concurrent partition writes exhaust the global encode budget; remove the parameter to use the safe serial default"
-            );
-        }
-        return;
+    if config.pinned_tuning_actuators.write_concurrency
+        && config.write_concurrency.unwrap_or(1) > 1
+    {
+        tracing::warn!(
+            dataset = table_name,
+            write_concurrency = ?config.write_concurrency,
+            "cayenne_write_concurrency is not supported for partitioned Cayenne tables (concurrent partition writes above the global encode budget deadlock the insert); writing each partition serially instead"
+        );
     }
     config.write_concurrency = Some(1);
 }
@@ -3603,17 +3606,18 @@ mod tests {
         assert_eq!(config.write_concurrency, Some(1));
     }
 
-    /// An operator-pinned `cayenne_write_concurrency` wins over the serial
-    /// default for partition children.
+    /// An operator-pinned `cayenne_write_concurrency > 1` is clamped to serial
+    /// for partition children — safety depends on the host-sized encode budget
+    /// and the (unbounded) partition count, so it cannot be honored safely.
     #[test]
-    fn partition_child_writes_honor_pinned_write_concurrency() {
+    fn partition_child_writes_clamp_pinned_write_concurrency() {
         let mut config = cayenne::metadata::VortexConfig {
             write_concurrency: Some(4),
             ..Default::default()
         };
         config.pinned_tuning_actuators.write_concurrency = true;
         serialize_partition_child_writes(&mut config, "t");
-        assert_eq!(config.write_concurrency, Some(4));
+        assert_eq!(config.write_concurrency, Some(1));
     }
 
     #[test]


### PR DESCRIPTION
## Bug

A cayenne dataset with `partition_by` never becomes ready when its initial refresh is non-trivial in size (roughly ≳32 MiB). The runtime reports every dataset loaded and healthy, but `/v1/ready` stays 503 forever — reproduced with readiness waits up to 900s, and reproduced locally (TPC-H SF1 `customer`, `bucket(5, c_name)`, 1M-row `refresh_sql`): spiced sits at 0% CPU with the refresh permanently stuck. Every partitioned-cayenne benchmark CI run has failed this way since #11144 merged (~Jun 4). Small refreshes and non-partitioned tables of any size are unaffected.

Fixes #11818.

## Root cause

The partition router and the encode budget deadlock each other. A partitioned refresh works like a conveyor belt with a router at its head. The refresh reads the source as one stream; the router hashes each batch by the partition key and drops the pieces into small bounded bins, one per partition. Behind each bin, a writer for that partition pulls rows and encodes files. The writers run concurrently (cross-partition concurrency is where its improved indexing throughput is from). 

Separately, #11144 introduced a process-global vortex compression encoding budget: a fixed pool of encode slots (sized from the host's cores) that a write must claim. It must claim all of its slots, atomically, before consuming any input, and then release once it has finished writes. The budget's deadlock-freedom argument was that atomic all-or-nothing acquisition prevents hold-and-wait cycles between writes.

That argument assumes writes are **independent**. Partition writes are not:

1. A large refresh makes each partition writer want several slots (the size gate in `snapshot_shard_count`; an opaque stream defaults to the full per-table write concurrency). The first few writers drain the pool.
2. A later writer finds no slots and parks in line, before it has pulled anything from its bin.
3. Hash partitioning spreads rows evenly, so the router soon produces rows for the parked writer's partition. Its bin fills. The router stops, mid-hand-off, and can no longer feed anyone.
4. The slot-holding writers finish their bins and wait for more input that will never arrive. A partition write only ends when the router signals end-of-stream, so they hold every slot, forever.

## Fix

The invariant the deadlock violates: `a writer that someone stands behind must never park.` The fix makes exactly that set of writers, and no other, unable to park, in two coordinated parts:

1. Partition child tables are marked as coupled writers, and coupled writers bypass the budget. A writer that cannot park cannot freeze the router.

2. Partition child tables are clamped to serial writes (1 encoding shard; the pre-#11144 baseline ). An operator-pinned `cayenne_write_concurrency > 1` is ignored (clamped, with a warning).

Known accepted trade-off: a high-partition-count refresh runs partition-count serial encoders unmetered (identical to pre-#11144 behavior). This degrades throughput on small hosts but never liveness-threatening. The composable follow-up, if wanted, is capping concurrently-open partition writers in the partition insert layer, which owns the bins and can own the buffering decision that cap forces.
