### PR TITLE
perf(cayenne): light delta encoding + higher CDC coalescing defaults

### DIFF
--- a/crates/cayenne/benches/compaction_write_amplification.rs
+++ b/crates/cayenne/benches/compaction_write_amplification.rs
@@ -21,9 +21,9 @@ limitations under the License.
 //! Every row on this path is written to disk TWICE. A delta / mem-tier
 //! checkpoint (`WriteClass::Delta`) writes each protected snapshot with a LIGHT
 //! encoding — it skips the `BtrBlocks` per-column strategy search + FSST
-//! symbol-table training that dominate small-write encode cost (see
+//! symbol-table training that dominate encode cost (see
 //! `provider::delta_encoding`, `effective_level` returns `AUTO_LIGHT_LEVEL` for
-//! a small/unknown-size `auto` delta). Those light files are LESS compressed, so
+//! every `auto` delta, regardless of size). Those light files are LESS compressed, so
 //! they inflate on-disk bytes (read-amp in bytes) until compaction folds them.
 //! Compaction (`WriteClass::Maintenance`) then RE-ENCODES the merged corpus with
 //! the FULL cascade — the expensive strategy search + FSST it skipped — so the

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -339,10 +339,9 @@ pub enum CompressionStrategy {
 ///
 /// zstd-style level scale (`cayenne_delta_encoding` param):
 ///
-/// - `auto` (default) — size-gated: a write smaller than a quarter of the
-///   target file size encodes at a light level (the file is transient by
-///   definition — compaction exists to fold it); larger or unknown-size
-///   writes use the full default encoding.
+/// - `auto` (default) — every delta write encodes at a light level: a delta
+///   is transient by definition (the tiered compactor folds it into a
+///   properly-encoded file), so it skips the full cascade regardless of size.
 /// - `0` — no compression (canonical arrays; cheapest encode).
 /// - `1`–`6` — progressively richer scheme sets. The cheap levels skip the
 ///   per-file encoder-strategy search and FSST symbol-table training.
@@ -360,14 +359,15 @@ pub enum CompressionStrategy {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum DeltaEncoding {
-    /// Size-gated: light for small deltas, full for large writes.
-    /// Local micro A/B (2026-06-06) was neutral on the
-    /// upsert/bulk lanes; the aggregate CPU-per-delta benefit targets
-    /// production-scale CDC and is to be validated there. Set the
-    /// param to `7` to opt out (pre-feature behavior).
+    /// `Auto` — light encoding for every delta write. Deltas are transient
+    /// (compaction re-encodes them at the full cascade), so the CDC hot path
+    /// skips the per-file encoder-strategy search + FSST symbol-table training
+    /// regardless of delta size. The SF1000 CH-benCHmark HTAP sweep validated
+    /// this at production scale: shedding checkpoint encode CPU lets the apply
+    /// loop keep up (it enables replication convergence where full-encode does
+    /// not, and gives the best analytic QPH on top of coalescing).
     ///
-    /// `Auto` — size-gated light encoding for small deltas. This is also what
-    /// pre-feature stored table configs deserialize to via
+    /// This is also what pre-feature stored table configs deserialize to via
     /// `#[serde(default)]`, so existing tables pick up the policy on upgrade
     /// (write-time only; existing data files are unaffected and a level
     /// change never forces a table re-create). Set the
@@ -749,11 +749,11 @@ pub struct VortexConfig {
     /// Defaults to Btrblocks
     pub compression_strategy: CompressionStrategy,
     /// Encoding effort for delta writes (fresh CDC/append snapshot files).
-    /// `auto` (default) size-gates: small deltas encode light and are folded
-    /// into properly-encoded files by compaction; explicit `0..=10` pins the
-    /// level (`7` = the full default cascade, the pre-feature behavior).
-    /// Maintenance writes (compaction, rewrites) always use the full default
-    /// encoding. See [`DeltaEncoding`].
+    /// `auto` (default) encodes every delta light (deltas are transient and
+    /// folded into properly-encoded files by compaction); explicit `0..=10`
+    /// pins the level (`7` = the full default cascade, the pre-feature
+    /// behavior). Maintenance writes (compaction, rewrites) always use the full
+    /// default encoding. See [`DeltaEncoding`].
     #[serde(default)]
     pub delta_encoding: DeltaEncoding,
     /// Maximum number of concurrent file uploads when writing multiple Vortex files.
@@ -1398,11 +1398,10 @@ impl Default for VortexConfig {
             // Shard key derives from the primary key unless overridden
             shard_key_columns: Vec::new(),
             compression_strategy: CompressionStrategy::default(),
-            // `auto`: size-gated light encoding for small deltas (re-encoded
-            // by compaction). Local micro A/B (2026-06-06) was neutral on the
-            // upsert/bulk lanes; the aggregate CPU-per-delta benefit targets
-            // production-scale CDC and is to be validated there. Set the
-            // param to `7` to opt out (pre-feature behavior).
+            // `auto`: light encoding for every delta (re-encoded by
+            // compaction). Validated at production scale by the SF1000
+            // CH-benCHmark HTAP sweep (frees apply CPU → convergence + QPH).
+            // Set the param to `7` to opt out (pre-feature behavior).
             delta_encoding: DeltaEncoding::default(),
             upload_concurrency: default_upload_concurrency(),
             write_concurrency: None,

--- a/crates/cayenne/src/provider/delta_encoding.rs
+++ b/crates/cayenne/src/provider/delta_encoding.rs
@@ -49,13 +49,12 @@ limitations under the License.
 //! | 4–6 | full default **minus FSST** (skips symbol-table training, keeps the rest) |
 //! | 7–10 | full default `BtrBlocks` cascade (today's behavior; upper levels reserved) |
 //!
-//! `auto` (the default) size-gates: a delta smaller than a quarter of the
-//! target file size — or of unknown size (a transient staged stream that
-//! compaction rewrites) — encodes at [`AUTO_LIGHT_LEVEL`]; only a known-large
-//! write uses the full default. Level `7` is the explicit opt-out
-//! (byte-for-byte the pre-feature behavior). Maintenance writes
-//! ([`WriteClass::Maintenance`]) always use the full default regardless of
-//! the configured level.
+//! `auto` (the default) encodes every delta at [`AUTO_LIGHT_LEVEL`]: a delta is
+//! a transient staged stream (e.g. the off-fence mem-tier checkpoint) that
+//! compaction rewrites, so it skips the full cascade regardless of size. Level
+//! `7` is the explicit opt-out (byte-for-byte the pre-feature behavior).
+//! Maintenance writes ([`WriteClass::Maintenance`]) always use the full default
+//! regardless of the configured level.
 
 use vortex::file::WriteStrategyBuilder;
 use vortex_btrblocks::schemes::{float, integer, string};
@@ -121,56 +120,38 @@ pub(crate) enum WriteClass {
     Maintenance,
 }
 
-/// Level used for every [`WriteClass::Maintenance`] write and for large
-/// known-size deltas under `auto`: the full default `BtrBlocks` cascade.
-/// Aliases the metadata constant so the config default and the mapping
-/// boundary can't drift apart.
+/// Level used for every [`WriteClass::Maintenance`] write: the full default
+/// `BtrBlocks` cascade. Aliases the metadata constant so the config default
+/// and the mapping boundary can't drift apart.
 pub(crate) const FULL_LEVEL: u8 = DELTA_ENCODING_FULL_LEVEL;
 
-/// Level chosen by `auto` for small deltas. `Constant + Sparse + Dict` keeps
-/// the big repetitive-CDC wins (often 3-5×) while skipping the per-file
-/// strategy search and FSST training that dominate small-write encode cost.
+/// Level chosen by `auto` for every delta write. `Constant + Sparse + Dict`
+/// keeps the big repetitive-CDC wins (often 3-5×) while skipping the per-file
+/// `BtrBlocks` strategy search and FSST symbol-table training that dominate
+/// encode cost. Every delta is transient — compaction re-encodes it at
+/// [`FULL_LEVEL`] — so the light scheme set trades a larger transient file
+/// (compaction folds it) for materially cheaper CDC-hot-path encode; the full
+/// cascade is reserved for the durable [`WriteClass::Maintenance`] artifacts
+/// whose encoding quality pays for scan throughput.
 pub(crate) const AUTO_LIGHT_LEVEL: u8 = 2;
-
-/// Under `auto`, a delta is "small" when its estimated bytes are below
-/// `target_file_size / AUTO_LIGHT_DENOMINATOR` — the same quarter-of-a-target
-/// classification the compaction picker uses for "small" files, on the
-/// rationale that a write smaller than a target file is transient by
-/// definition (compaction exists to fold it).
-pub(crate) const AUTO_LIGHT_DENOMINATOR: u64 = 4;
 
 /// Resolve the effective encoding level for one snapshot write.
 ///
-/// `estimated_bytes` is the caller's pre-encode size estimate (`None` when
-/// the stream size is unknown, e.g. opaque staged streams). Under `auto`, an
-/// unknown size resolves to [`AUTO_LIGHT_LEVEL`]: it is a transient staged
-/// stream (e.g. the off-fence mem-tier checkpoint) that compaction rewrites,
-/// so only a known-large delta takes [`FULL_LEVEL`].
-pub(crate) fn effective_level(
-    encoding: DeltaEncoding,
-    write_class: WriteClass,
-    estimated_bytes: Option<u64>,
-    target_size_bytes: usize,
-) -> u8 {
+/// Under `auto`, every [`WriteClass::Delta`] write encodes LIGHT
+/// ([`AUTO_LIGHT_LEVEL`]): deltas are transient staged CDC streams (e.g. the
+/// off-fence mem-tier checkpoint) that compaction rewrites at [`FULL_LEVEL`],
+/// so paying the full `BtrBlocks` cascade (incl. the FSST symbol-table
+/// double-train) on the CDC hot path is wasted work — the file is re-encoded
+/// before it becomes long-lived. Only durable [`WriteClass::Maintenance`]
+/// writes take [`FULL_LEVEL`] under `auto`; an explicit
+/// [`DeltaEncoding::Level`] overrides the delta path with a fixed level.
+pub(crate) fn effective_level(encoding: DeltaEncoding, write_class: WriteClass) -> u8 {
     if write_class == WriteClass::Maintenance {
         return FULL_LEVEL;
     }
     match encoding {
         DeltaEncoding::Level(level) => level.min(DELTA_ENCODING_MAX_LEVEL),
-        DeltaEncoding::Auto => {
-            let threshold =
-                u64::try_from(target_size_bytes).unwrap_or(u64::MAX) / AUTO_LIGHT_DENOMINATOR;
-            match estimated_bytes {
-                Some(bytes) if bytes < threshold.max(1) => AUTO_LIGHT_LEVEL,
-                // Unknown size means an opaque staged CDC stream (e.g. the
-                // off-fence mem-tier checkpoint) — transient and rewritten by
-                // compaction, so encode it LIGHT rather than paying the full
-                // BtrBlocks cascade (incl. the FSST symbol-table double-train)
-                // on the CDC hot path. Only a known-large delta takes FULL.
-                None => AUTO_LIGHT_LEVEL,
-                Some(_) => FULL_LEVEL,
-            }
-        }
+        DeltaEncoding::Auto => AUTO_LIGHT_LEVEL,
     }
 }
 
@@ -247,8 +228,6 @@ pub(crate) fn strategy_builder_for_level(level: u8) -> Option<WriteStrategyBuild
 mod tests {
     use super::*;
 
-    const TARGET: usize = 256 * 1024 * 1024; // 256 MiB target file size
-
     #[test]
     fn parse_accepts_auto_and_levels() {
         assert_eq!("auto".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Auto));
@@ -265,101 +244,64 @@ mod tests {
     }
 
     #[test]
-    fn default_is_auto_with_light_small_deltas_and_full_opt_out() {
-        // Product decision: `auto` ships as the default — small known-size
-        // deltas and unknown-size (transient, compaction-rewritten) writes
-        // encode light; large known-size writes and maintenance stay on the
-        // full cascade. Level 7 is the explicit opt-out.
+    fn default_is_auto_with_light_deltas_and_full_opt_out() {
+        // Product decision: `auto` ships as the default — every delta (a
+        // transient, compaction-rewritten write) encodes light; maintenance
+        // stays on the full cascade. Level 7 is the explicit opt-out.
         assert_eq!(DeltaEncoding::default(), DeltaEncoding::Auto);
         assert!(
             strategy_builder_for_level(effective_level(
                 DeltaEncoding::default(),
                 WriteClass::Delta,
-                Some(1),
-                TARGET
             ))
             .is_some(),
-            "default auto must light-encode a small known-size delta"
-        );
-        assert!(
-            strategy_builder_for_level(effective_level(
-                DeltaEncoding::default(),
-                WriteClass::Delta,
-                None,
-                TARGET
-            ))
-            .is_some(),
-            "default auto must light-encode unknown-size (transient) writes"
+            "default auto must light-encode a delta write"
         );
         assert!(
             strategy_builder_for_level(effective_level(
                 DeltaEncoding::Level(FULL_LEVEL),
                 WriteClass::Delta,
-                Some(1),
-                TARGET
             ))
             .is_none(),
-            "level 7 must be the explicit opt-out (full strategy) even for tiny deltas"
+            "level 7 must be the explicit opt-out (full strategy) for a delta"
         );
     }
 
     #[test]
-    fn auto_gates_by_estimated_size() {
-        // Small delta (1 MiB << 64 MiB threshold) -> light level.
+    fn auto_lights_every_delta_regardless_of_size() {
+        // No size gate: under `auto` a delta encodes LIGHT whether it is a
+        // small fresh write or a large mem-tier checkpoint. Every delta is
+        // transient (compaction re-encodes it at FULL), so the CDC hot path
+        // never pays the full BtrBlocks + FSST cascade.
         assert_eq!(
-            effective_level(
-                DeltaEncoding::Auto,
-                WriteClass::Delta,
-                Some(1024 * 1024),
-                TARGET
-            ),
-            AUTO_LIGHT_LEVEL
+            effective_level(DeltaEncoding::Auto, WriteClass::Delta),
+            AUTO_LIGHT_LEVEL,
+            "auto must light-encode a delta write"
         );
-        // Large write (at the threshold) -> full.
+        // Maintenance is the one class that keeps the full cascade under auto.
         assert_eq!(
-            effective_level(
-                DeltaEncoding::Auto,
-                WriteClass::Delta,
-                Some(64 * 1024 * 1024),
-                TARGET
-            ),
-            FULL_LEVEL
-        );
-        // Unknown size -> light: an unknown-size staged delta is a transient
-        // CDC stream (the off-fence mem-tier checkpoint) that compaction
-        // rewrites, so it skips the full BtrBlocks cascade on the hot path.
-        assert_eq!(
-            effective_level(DeltaEncoding::Auto, WriteClass::Delta, None, TARGET),
-            AUTO_LIGHT_LEVEL
+            effective_level(DeltaEncoding::Auto, WriteClass::Maintenance),
+            FULL_LEVEL,
+            "auto maintenance must use the full cascade"
         );
     }
 
     #[test]
     fn maintenance_always_full_even_with_explicit_level() {
         assert_eq!(
-            effective_level(
-                DeltaEncoding::Level(0),
-                WriteClass::Maintenance,
-                Some(1),
-                TARGET
-            ),
+            effective_level(DeltaEncoding::Level(0), WriteClass::Maintenance),
             FULL_LEVEL
         );
     }
 
     #[test]
-    fn explicit_level_applies_to_any_delta_size() {
+    fn explicit_level_applies_to_a_delta() {
         assert_eq!(
-            effective_level(
-                DeltaEncoding::Level(3),
-                WriteClass::Delta,
-                Some(u64::MAX),
-                TARGET
-            ),
+            effective_level(DeltaEncoding::Level(3), WriteClass::Delta),
             3
         );
         assert_eq!(
-            effective_level(DeltaEncoding::Level(9), WriteClass::Delta, None, TARGET),
+            effective_level(DeltaEncoding::Level(9), WriteClass::Delta),
             9
         );
     }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -5061,17 +5061,13 @@ impl CayenneTableProvider {
         // regardless of `target_partitions` (see `snapshot_shard_count`).
         //
         // Delta writes additionally resolve a `cayenne_delta_encoding` level:
-        // small fresh deltas encode with a light scheme set (skipping the
+        // under `auto` every delta encodes with a light scheme set (skipping the
         // per-file BtrBlocks strategy search + FSST training that dominate
-        // small-write encode cost) and are re-encoded properly when compaction
-        // folds them. Maintenance writes (compaction, rewrites, overwrites)
-        // always use the full default strategy. See `provider::delta_encoding`.
-        let encoding_level = super::delta_encoding::effective_level(
-            self.context.delta_encoding(),
-            write_class,
-            estimated_bytes,
-            target_size_bytes,
-        );
+        // encode cost) and is re-encoded properly when compaction folds it.
+        // Maintenance writes (compaction, rewrites, overwrites) always use the
+        // full default strategy. See `provider::delta_encoding`.
+        let encoding_level =
+            super::delta_encoding::effective_level(self.context.delta_encoding(), write_class);
         let write_format = match super::delta_encoding::strategy_builder_for_level(encoding_level) {
             Some(strategy) => self.context.write_format_with_strategy(
                 strategy,

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-1slot.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-1slot.yaml
@@ -5,9 +5,10 @@ name: postgres-cayenne[file]-adaptive-1slot
 # SINGLE-SHARED-SLOT variant of the default `postgres-cayenne[file]-adaptive` (which is 4-slot +
 # deep prefetch). IDENTICAL to that pod — adaptive self-tuning (`cayenne_tuning: adaptive` +
 # `schema_inference: extended`), the global `cayenne_goal_*` SLOs, and the SAME deep CDC prefetch
-# (16384) — EXCEPT every changes-mode table shares ONE replication slot instead of the default
-# four. Kept as a SEPARATE pod to A/B the slot-count effect against the 4-slot default with
-# everything else (adaptive tuning + prefetch depth) held constant.
+# (16384) + higher-coalescing (512 MB byte budget / 2000ms linger) — EXCEPT every changes-mode
+# table shares ONE replication slot instead of the default four. Kept as a SEPARATE pod to A/B the
+# slot-count effect against the 4-slot default with everything else (adaptive tuning + prefetch +
+# coalescing) held constant.
 #
 # This is the TARGET topology we are driving toward: ONE shared slot (`spice_all`) spawns ONE
 # walsender that decodes the FULL WAL stream exactly once (server decode at 1x — the minimum), and
@@ -42,10 +43,13 @@ runtime:
   # dataset. These are the high-level targets the closed loop converges toward — NOT
   # actuator knobs. QPH is GLOBAL-ONLY (measured across all datasets).
   params:
-    # Deep prefetch, matching the default `-adaptive` pod so this 1-slot config differs from it
-    # ONLY in slot count (isolating the slot-count effect at the standard prefetch depth).
+    # Deep prefetch + higher-coalescing (byte budget + linger window), matching the default
+    # `-adaptive` pod so this 1-slot config differs from it ONLY in slot count (isolating the
+    # slot-count effect at the standard prefetch + coalescing settings).
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
+    cdc_max_coalesced_bytes: '536870912' # 512 MB
+    cdc_max_coalesce_age_ms: '2000'
     cayenne_goal_replication_lag: '5s'
     cayenne_goal_freshness: '30s'
     cayenne_goal_query_latency: '10s'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
@@ -31,10 +31,13 @@ name: postgres-cayenne[file]-adaptive
 #   - It supplies the inferred row_count/table_bytes the adaptive loop's data-aware warm-start
 #     gates on; without extended inference adaptive silently falls back to `auto` (static).
 # Background compaction stays at the auto-derived (non-zero) default — the controller rides its
-# tick. The ONLY pinned knobs are the two CDC prefetch buffers (`cdc_prefetch_buffer` /
-# `cdc_max_coalesced_envelopes` = 16384, the runtime max) under `runtime.params` below: the sweep
-# showed deep prefetch is a clear, stable win, so we fix it here (this collapses those two knobs'
-# adaptive bounds to a point; adaptive still moves every other per-actuator knob freely).
+# tick. The pinned CDC knobs under `runtime.params` below are the deep prefetch buffers
+# (`cdc_prefetch_buffer` / `cdc_max_coalesced_envelopes` = 16384, the runtime max) plus the
+# higher-coalescing byte budget + linger window (`cdc_max_coalesced_bytes` = 512 MB /
+# `cdc_max_coalesce_age_ms` = 2000): the sweep showed deep prefetch is a clear, stable win and
+# that coalescing is the strongest convergence lever at SF1000, so we fix both here (this
+# collapses those knobs' adaptive bounds to a point; adaptive still moves every other per-actuator
+# knob freely).
 # The `cayenne_goal_*` SLOs (set globally under `runtime.params`) are NOT actuator knobs — they
 # are the high-level targets the closed loop converges toward (it still moves the un-pinned
 # actuators freely to hit them).
@@ -71,6 +74,15 @@ runtime:
     # replication lag ~435s at default buffers → ~320s deep).
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
+    # Higher-coalescing default: raise the byte budget and add a linger window so the
+    # apply loop forms big bursts (fewer, larger applies amortize per-burst
+    # stats/checkpoint/publish over more rows). In the SF1000 sweep this was the
+    # strongest single convergence lever — 4-slot converged fastest (~801s) with
+    # coalescing on, where the no-coalesce default failed to converge. The linger
+    # deadline is anchored at the previous apply's start, so apply-bound tables barely
+    # wait; 2000ms bounds the added freshness latency for lighter tables.
+    cdc_max_coalesced_bytes: '536870912' # 512 MB
+    cdc_max_coalesce_age_ms: '2000'
     cayenne_goal_replication_lag: '5s'
     cayenne_goal_freshness: '30s'
     cayenne_goal_query_latency: '10s'


### PR DESCRIPTION
## What

Two performance defaults validated by the SF1000 CH-benCHmark HTAP sweep:

1. **`perf(cayenne)`: default `auto` delta encoding to light for all deltas.** `effective_level` now resolves every `auto` `WriteClass::Delta` write to the light scheme set (level 2: `Constant + Sparse + Dict`) regardless of estimated size, instead of size-gating large deltas up to the full BtrBlocks + FSST cascade. Every delta is a transient staged CDC write that compaction re-encodes at FULL before it becomes long-lived, so paying the per-file strategy search + FSST symbol-table double-train on the CDC hot path is wasted work. Maintenance writes still use the full cascade; `cayenne_delta_encoding: 7` is the explicit opt-out. Removes the now-dead size-gate machinery (`estimated_bytes`/`target_size_bytes` params, `AUTO_LIGHT_DENOMINATOR`).

2. **`perf(chbench)`: enable higher CDC coalescing in the adaptive pods.** Pin `cdc_max_coalesced_bytes` = 512 MB and add a `cdc_max_coalesce_age_ms` = 2000ms linger window to the 4-slot and 1-slot adaptive pods, on top of the deep prefetch already fixed there. Bigger coalesced bursts → fewer, larger applies → per-burst stats/checkpoint/publish amortize over more rows.

## Why / evidence

In the SF1000 HTAP sweep:

- **Light-always encoding** is what lets the CDC apply loop keep up: it *enables replication convergence* where the full-encode default fails to converge, and delivers the best analytic QPH on top of coalescing (encode frees cores for concurrent apply + queries). Inert at SF100 (checkpoints are already small/light there).
- **Coalescing** was the strongest single convergence lever: the 4-slot adaptive pod converged fastest (~801s) with coalescing on, where the no-coalesce default failed to converge at all. The linger deadline is anchored at the previous apply's start, so apply-bound tables barely wait; 2000ms bounds the added freshness latency for lighter tables.

## Scope / blast radius

- The encoding change is cayenne-internal and bounded: light deltas are larger transient files until compaction folds them (`cayenne_delta_encoding: 7` opts back into full).
- Coalescing is scoped to the benchmark pods (matching the deep-prefetch precedent) rather than the global CDC defaults, so it does not alter memory/freshness behavior for other connectors' CDC.

## Tests

- `cargo test -p cayenne --lib provider::delta_encoding` — 8/8 pass (rewrote the size-gate tests to assert light-for-all-deltas).
- Behavior validated end-to-end by the SF1000 CH-benCHmark HTAP runs.