### PR TITLE
Cayenne transactions (1/9): assert() gate UDF + two-class error protocol

### DIFF
--- a/crates/runtime-datafusion-udfs/src/assert.rs
+++ b/crates/runtime-datafusion-udfs/src/assert.rs
@@ -1,0 +1,165 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `assert(<bool>)` scalar UDF — the gate primitive for conditional-commit transactions.
+//!
+//! Returns its boolean argument unchanged when it is `TRUE`; returns an error when it is
+//! `FALSE` or `NULL`. The error is a [`DataFusionError::Execution`] whose message begins with
+//! the marker [`ASSERT_FAILED_MARKER`] so a transaction executor can distinguish a gate abort
+//! (terminal — return to the client) from a serialization conflict (retryable).
+//!
+//! The UDF is declared [`Volatility::Volatile`] so the optimizer never const-folds or elides it:
+//! `assert(1 > 2)` must fail at *execution* time (as an execution error), not be pre-evaluated at
+//! planning time.
+
+use arrow::array::{Array, BooleanArray};
+use arrow::datatypes::DataType;
+use datafusion::common::DataFusionError;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion::scalar::ScalarValue;
+
+pub static ASSERT_SCALAR_UDF_NAME: &str = "assert";
+
+/// Prefix on the error message of every `assert()` failure, so callers can recognize a gate
+/// abort without relying on the (shared) `ErrorCode`.
+pub static ASSERT_FAILED_MARKER: &str = "assertion failed:";
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub struct Assert {
+    signature: Signature,
+}
+
+impl Default for Assert {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Assert {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            // Volatile => never const-folded/elided; evaluated at execution time.
+            signature: Signature::exact(vec![DataType::Boolean], Volatility::Volatile),
+        }
+    }
+
+    fn failed() -> DataFusionError {
+        DataFusionError::Execution(format!(
+            "{ASSERT_FAILED_MARKER} gate expression was false or NULL"
+        ))
+    }
+}
+
+impl ScalarUDFImpl for Assert {
+    fn name(&self) -> &'static str {
+        ASSERT_SCALAR_UDF_NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType, DataFusionError> {
+        Ok(DataType::Boolean)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {
+        let arg = args.args.into_iter().next().ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "{ASSERT_FAILED_MARKER} assert() requires exactly one boolean argument"
+            ))
+        })?;
+
+        match arg {
+            // Scalar TRUE -> pass through.
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => {
+                Ok(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))))
+            }
+            // Scalar FALSE or NULL -> abort.
+            ColumnarValue::Scalar(ScalarValue::Boolean(_)) => Err(Self::failed()),
+            // Array: abort on any FALSE or NULL, otherwise pass through.
+            ColumnarValue::Array(array) => {
+                let bools = array
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "{ASSERT_FAILED_MARKER} assert() argument must be Boolean"
+                        ))
+                    })?;
+                for i in 0..bools.len() {
+                    if bools.is_null(i) || !bools.value(i) {
+                        return Err(Self::failed());
+                    }
+                }
+                Ok(ColumnarValue::Array(array))
+            }
+            other => Err(DataFusionError::Execution(format!(
+                "{ASSERT_FAILED_MARKER} assert() argument must be Boolean, got {}",
+                other.data_type()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::config::ConfigOptions;
+    use datafusion::logical_expr::ScalarFunctionArgs;
+
+    fn call(arg: ColumnarValue) -> Result<ColumnarValue, DataFusionError> {
+        Assert::new().invoke_with_args(ScalarFunctionArgs {
+            args: vec![arg],
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: std::sync::Arc::new(arrow::datatypes::Field::new(
+                "r",
+                DataType::Boolean,
+                true,
+            )),
+            config_options: std::sync::Arc::new(ConfigOptions::new()),
+        })
+    }
+
+    #[test]
+    fn assert_true_passes() {
+        let r = call(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))));
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn assert_false_aborts() {
+        let e = call(ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)))).unwrap_err();
+        assert!(e.to_string().contains(ASSERT_FAILED_MARKER));
+    }
+
+    #[test]
+    fn assert_null_aborts() {
+        let e = call(ColumnarValue::Scalar(ScalarValue::Boolean(None))).unwrap_err();
+        assert!(e.to_string().contains(ASSERT_FAILED_MARKER));
+    }
+
+    #[test]
+    fn assert_array_any_false_aborts() {
+        let arr = std::sync::Arc::new(BooleanArray::from(vec![Some(true), Some(false)]));
+        let e = call(ColumnarValue::Array(arr)).unwrap_err();
+        assert!(e.to_string().contains(ASSERT_FAILED_MARKER));
+    }
+}

--- a/crates/runtime-datafusion-udfs/src/assert.rs
+++ b/crates/runtime-datafusion-udfs/src/assert.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -80,11 +80,13 @@ impl ScalarUDFImpl for Assert {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {
-        let arg = args.args.into_iter().next().ok_or_else(|| {
+        let args: [ColumnarValue; 1] = args.args.try_into().map_err(|args: Vec<_>| {
             DataFusionError::Execution(format!(
-                "{ASSERT_FAILED_MARKER} assert() requires exactly one boolean argument"
+                "{ASSERT_FAILED_MARKER} assert() requires exactly one boolean argument, got {}",
+                args.len()
             ))
         })?;
+        let [arg] = args;
 
         match arg {
             // Scalar TRUE -> pass through.
@@ -110,7 +112,7 @@ impl ScalarUDFImpl for Assert {
                 }
                 Ok(ColumnarValue::Array(array))
             }
-            other => Err(DataFusionError::Execution(format!(
+            other @ ColumnarValue::Scalar(_) => Err(DataFusionError::Execution(format!(
                 "{ASSERT_FAILED_MARKER} assert() argument must be Boolean, got {}",
                 other.data_type()
             ))),
@@ -124,9 +126,9 @@ mod tests {
     use datafusion::config::ConfigOptions;
     use datafusion::logical_expr::ScalarFunctionArgs;
 
-    fn call(arg: ColumnarValue) -> Result<ColumnarValue, DataFusionError> {
+    fn call_args(args: Vec<ColumnarValue>) -> Result<ColumnarValue, DataFusionError> {
         Assert::new().invoke_with_args(ScalarFunctionArgs {
-            args: vec![arg],
+            args,
             arg_fields: vec![],
             number_rows: 1,
             return_field: std::sync::Arc::new(arrow::datatypes::Field::new(
@@ -138,28 +140,49 @@ mod tests {
         })
     }
 
+    fn call(arg: ColumnarValue) -> Result<ColumnarValue, DataFusionError> {
+        call_args(vec![arg])
+    }
+
     #[test]
     fn assert_true_passes() {
-        let r = call(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))));
-        assert!(r.is_ok());
+        let _ = call(ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))))
+            .expect("TRUE should pass the assertion");
     }
 
     #[test]
     fn assert_false_aborts() {
-        let e = call(ColumnarValue::Scalar(ScalarValue::Boolean(Some(false)))).unwrap_err();
+        let e = call(ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))))
+            .expect_err("FALSE should fail the assertion");
         assert!(e.to_string().contains(ASSERT_FAILED_MARKER));
     }
 
     #[test]
     fn assert_null_aborts() {
-        let e = call(ColumnarValue::Scalar(ScalarValue::Boolean(None))).unwrap_err();
+        let e = call(ColumnarValue::Scalar(ScalarValue::Boolean(None)))
+            .expect_err("NULL should fail the assertion");
         assert!(e.to_string().contains(ASSERT_FAILED_MARKER));
     }
 
     #[test]
     fn assert_array_any_false_aborts() {
         let arr = std::sync::Arc::new(BooleanArray::from(vec![Some(true), Some(false)]));
-        let e = call(ColumnarValue::Array(arr)).unwrap_err();
+        let e = call(ColumnarValue::Array(arr))
+            .expect_err("an array containing FALSE should fail the assertion");
         assert!(e.to_string().contains(ASSERT_FAILED_MARKER));
+    }
+
+    #[test]
+    fn assert_rejects_wrong_argument_count() {
+        for args in [
+            vec![],
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))),
+                ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))),
+            ],
+        ] {
+            let e = call_args(args).expect_err("wrong argument count should fail");
+            assert!(e.to_string().contains("requires exactly one"));
+        }
     }
 }

--- a/crates/runtime-datafusion-udfs/src/lib.rs
+++ b/crates/runtime-datafusion-udfs/src/lib.rs
@@ -17,6 +17,7 @@ limitations under the License.
 #[cfg(feature = "models")]
 pub mod ai;
 pub mod alias;
+pub mod assert;
 pub mod bucket;
 pub mod cosine_distance;
 pub mod digest_many;

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -238,6 +238,11 @@ pub struct Query {
     /// regardless of per-catalog writability. Set via [`QueryBuilder::read_only`];
     /// used by `/v1/tools/sql` and `/v1/nsql` to contain LLM-generated SQL.
     read_only: bool,
+    /// When true, this query bypasses the SQL results cache entirely (no lookup,
+    /// no store) — equivalent to `Cache-Control: no-cache`. Set via
+    /// [`QueryBuilder::bypass_cache`]; used by the conditional-commit transaction
+    /// executor so a gate read always sees live committed state.
+    bypass_cache: bool,
 }
 
 macro_rules! handle_error {
@@ -1032,6 +1037,7 @@ impl Query {
                 let mut session = self.get_session_state(&request_context);
 
                 let ctx = self;
+                let bypass_cache = ctx.bypass_cache;
                 let tracker = ctx.tracker;
 
                 // Sets the request context as an extension on DataFusion, to allow recovering it to track telemetry
@@ -1112,38 +1118,95 @@ impl Query {
                         table_allowlist: None,
                         pre_parsed_plan,
                     } => {
-                        match Self::get_plan_or_cached(
-                            &ctx.df,
-                            &session,
-                            Arc::clone(&request_context),
-                            sql.as_ref(),
-                            parameters,
-                            tracker,
-                            pre_parsed_plan,
-                        )
-                        .await?
-                        {
-                            PlanOrCached::Plan(plan, tracker, cache_manager) => {
+                        if bypass_cache {
+                            // Gate/inner reads in a conditional-commit transaction must
+                            // see live committed state, so skip the results cache entirely
+                            // (no lookup, no store) — mirrors the table-allowlist arm.
+                            let raw_cache_key = CacheKey::Query(sql.as_ref(), parameters.as_ref())
+                                .as_raw_key(Query::plan_hasher(&ctx.df));
+                            let plan = if let Some(plan) = pre_parsed_plan {
+                                plan
+                            } else {
                                 Self::ensure_not_cancelled(
                                     &query_cancel_token,
                                     &query_id_str,
                                     &timeout_state,
                                 )?;
-                                (plan, tracker, cache_manager)
-                            }
-                            PlanOrCached::Cached(query_result) => {
-                                Self::ensure_not_cancelled(
-                                    &query_cancel_token,
-                                    &query_id_str,
-                                    &timeout_state,
-                                )?;
-                                return Ok(attach_cancellation_to_query_result(
-                                    query_result,
-                                    query_cancel_token.clone(),
-                                    Arc::clone(&query_id_str),
-                                    timeout_state.clone(),
-                                    (active_query_guard, timeout_timer_guard),
-                                ));
+                                match Self::get_plan(
+                                    &ctx.df,
+                                    &session,
+                                    sql.as_ref(),
+                                    &raw_cache_key,
+                                    parameters,
+                                )
+                                .await
+                                {
+                                    Ok(plan) => Box::new(plan),
+                                    Err(e) => match e {
+                                        Error::UnableToExecuteQuery { source } => {
+                                            let code = ErrorCode::from(&source);
+                                            let snafu_err =
+                                                Error::UnableToExecuteQuery { source };
+                                            if let Some(t) = tracker {
+                                                t.finish_with_error(
+                                                    &request_context,
+                                                    snafu_err.to_string(),
+                                                    code,
+                                                );
+                                            }
+                                            return Err(snafu_err);
+                                        }
+                                        _ => return Err(e),
+                                    },
+                                }
+                            };
+                            Self::ensure_not_cancelled(
+                                &query_cancel_token,
+                                &query_id_str,
+                                &timeout_state,
+                            )?;
+                            (
+                                plan,
+                                tracker,
+                                RequestCacheManager::new(
+                                    CacheStatus::CacheDisabled,
+                                    raw_cache_key,
+                                ),
+                            )
+                        } else {
+                            match Self::get_plan_or_cached(
+                                &ctx.df,
+                                &session,
+                                Arc::clone(&request_context),
+                                sql.as_ref(),
+                                parameters,
+                                tracker,
+                                pre_parsed_plan,
+                            )
+                            .await?
+                            {
+                                PlanOrCached::Plan(plan, tracker, cache_manager) => {
+                                    Self::ensure_not_cancelled(
+                                        &query_cancel_token,
+                                        &query_id_str,
+                                        &timeout_state,
+                                    )?;
+                                    (plan, tracker, cache_manager)
+                                }
+                                PlanOrCached::Cached(query_result) => {
+                                    Self::ensure_not_cancelled(
+                                        &query_cancel_token,
+                                        &query_id_str,
+                                        &timeout_state,
+                                    )?;
+                                    return Ok(attach_cancellation_to_query_result(
+                                        query_result,
+                                        query_cancel_token.clone(),
+                                        Arc::clone(&query_id_str),
+                                        timeout_state.clone(),
+                                        (active_query_guard, timeout_timer_guard),
+                                    ));
+                                }
                             }
                         }
                     }
@@ -1566,6 +1629,7 @@ impl Query {
             query_id: uuid::Uuid::new_v4(),
             cancellation_token: None,
             read_only: false,
+            bypass_cache: false,
         }
     }
 

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -220,6 +220,16 @@ impl Display for QueryMethod {
     }
 }
 
+/// Controls how a query interacts with the SQL results cache.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ResultsCacheMode {
+    /// Apply the request context's normal results-cache behavior.
+    #[default]
+    Default,
+    /// Skip both results-cache lookup and storage.
+    Bypass,
+}
+
 pub struct Query {
     df: Arc<crate::datafusion::DataFusion>,
     sql: QueryMethod,
@@ -238,11 +248,9 @@ pub struct Query {
     /// regardless of per-catalog writability. Set via [`QueryBuilder::read_only`];
     /// used by `/v1/tools/sql` and `/v1/nsql` to contain LLM-generated SQL.
     read_only: bool,
-    /// When true, this query bypasses the SQL results cache entirely (no lookup,
-    /// no store) — equivalent to `Cache-Control: no-cache`. Set via
-    /// [`QueryBuilder::bypass_cache`]; used by the conditional-commit transaction
-    /// executor so a gate read always sees live committed state.
-    bypass_cache: bool,
+    /// Controls results-cache lookup and storage. Set via
+    /// [`QueryBuilder::results_cache_mode`].
+    results_cache_mode: ResultsCacheMode,
 }
 
 macro_rules! handle_error {
@@ -657,6 +665,7 @@ impl Query {
         // Get the scheduler server
         let scheduler = Self::get_scheduler_server(&self.df)?;
         let tracker = self.tracker;
+        let results_cache_mode = self.results_cache_mode;
         let query_start = std::time::Instant::now();
         let sql_preview: Arc<str> = match &self.sql {
             QueryMethod::Text { sql, .. } => Arc::clone(sql),
@@ -722,17 +731,33 @@ impl Query {
                     // cache itself is namespaced per principal and refuses to
                     // store write-capable plans, so a read-only caller cannot
                     // observe a cached entry produced by a write-capable plan.
-                    match Query::get_plan_or_cached(
-                        &self.df,
-                        &session,
-                        Arc::clone(&request_context),
-                        sql.as_ref(),
-                        parameters,
-                        tracker,
-                        pre_parsed_plan,
-                    )
-                    .await?
-                    {
+                    let plan_or_cached = match results_cache_mode {
+                        ResultsCacheMode::Default => {
+                            Query::get_plan_or_cached(
+                                &self.df,
+                                &session,
+                                Arc::clone(&request_context),
+                                sql.as_ref(),
+                                parameters,
+                                tracker,
+                                pre_parsed_plan,
+                            )
+                            .await?
+                        }
+                        ResultsCacheMode::Bypass => {
+                            Query::get_plan_without_results_cache(
+                                &self.df,
+                                &session,
+                                &request_context,
+                                sql.as_ref(),
+                                parameters,
+                                tracker,
+                                pre_parsed_plan,
+                            )
+                            .await?
+                        }
+                    };
+                    match plan_or_cached {
                         cache::PlanOrCached::Cached(cached_result) => {
                             tracing::debug!(
                                 job_id,
@@ -778,6 +803,7 @@ impl Query {
                 // Resume drives the persisted graph, so skip the short-circuit
                 // entirely (returning a cached result would orphan the job).
                 if mode != DistributedSubmitMode::Resume
+                    && results_cache_mode == ResultsCacheMode::Default
                     && let Some(cache_provider) = self.df.results_cache_provider()
                     && let Ok(Some(cached_result)) =
                         cache_provider.get_raw_key(&plan_cache_key).await
@@ -808,8 +834,10 @@ impl Query {
                     }
                 }
 
-                // Don't cache results for a recovered job.
-                let cache_key = (mode != DistributedSubmitMode::Resume).then_some(plan_cache_key);
+                // Don't cache results for a recovered job or a query that bypasses caching.
+                let cache_key = (mode != DistributedSubmitMode::Resume
+                    && results_cache_mode == ResultsCacheMode::Default)
+                    .then_some(plan_cache_key);
                 (*logical_plan, tracker, cache_key)
             }
         };
@@ -1037,7 +1065,7 @@ impl Query {
                 let mut session = self.get_session_state(&request_context);
 
                 let ctx = self;
-                let bypass_cache = ctx.bypass_cache;
+                let results_cache_mode = ctx.results_cache_mode;
                 let tracker = ctx.tracker;
 
                 // Sets the request context as an extension on DataFusion, to allow recovering it to track telemetry
@@ -1118,95 +1146,54 @@ impl Query {
                         table_allowlist: None,
                         pre_parsed_plan,
                     } => {
-                        if bypass_cache {
-                            // Gate/inner reads in a conditional-commit transaction must
-                            // see live committed state, so skip the results cache entirely
-                            // (no lookup, no store) — mirrors the table-allowlist arm.
-                            let raw_cache_key = CacheKey::Query(sql.as_ref(), parameters.as_ref())
-                                .as_raw_key(Query::plan_hasher(&ctx.df));
-                            let plan = if let Some(plan) = pre_parsed_plan {
-                                plan
-                            } else {
+                        let plan_or_cached = match results_cache_mode {
+                            ResultsCacheMode::Default => {
+                                Self::get_plan_or_cached(
+                                    &ctx.df,
+                                    &session,
+                                    Arc::clone(&request_context),
+                                    sql.as_ref(),
+                                    parameters,
+                                    tracker,
+                                    pre_parsed_plan,
+                                )
+                                .await?
+                            }
+                            ResultsCacheMode::Bypass => {
+                                Self::get_plan_without_results_cache(
+                                    &ctx.df,
+                                    &session,
+                                    &request_context,
+                                    sql.as_ref(),
+                                    parameters,
+                                    tracker,
+                                    pre_parsed_plan,
+                                )
+                                .await?
+                            }
+                        };
+                        match plan_or_cached {
+                            PlanOrCached::Plan(plan, tracker, cache_manager) => {
                                 Self::ensure_not_cancelled(
                                     &query_cancel_token,
                                     &query_id_str,
                                     &timeout_state,
                                 )?;
-                                match Self::get_plan(
-                                    &ctx.df,
-                                    &session,
-                                    sql.as_ref(),
-                                    &raw_cache_key,
-                                    parameters,
-                                )
-                                .await
-                                {
-                                    Ok(plan) => Box::new(plan),
-                                    Err(e) => match e {
-                                        Error::UnableToExecuteQuery { source } => {
-                                            let code = ErrorCode::from(&source);
-                                            let snafu_err =
-                                                Error::UnableToExecuteQuery { source };
-                                            if let Some(t) = tracker {
-                                                t.finish_with_error(
-                                                    &request_context,
-                                                    snafu_err.to_string(),
-                                                    code,
-                                                );
-                                            }
-                                            return Err(snafu_err);
-                                        }
-                                        _ => return Err(e),
-                                    },
-                                }
-                            };
-                            Self::ensure_not_cancelled(
-                                &query_cancel_token,
-                                &query_id_str,
-                                &timeout_state,
-                            )?;
-                            (
-                                plan,
-                                tracker,
-                                RequestCacheManager::new(
-                                    CacheStatus::CacheDisabled,
-                                    raw_cache_key,
-                                ),
-                            )
-                        } else {
-                            match Self::get_plan_or_cached(
-                                &ctx.df,
-                                &session,
-                                Arc::clone(&request_context),
-                                sql.as_ref(),
-                                parameters,
-                                tracker,
-                                pre_parsed_plan,
-                            )
-                            .await?
-                            {
-                                PlanOrCached::Plan(plan, tracker, cache_manager) => {
-                                    Self::ensure_not_cancelled(
-                                        &query_cancel_token,
-                                        &query_id_str,
-                                        &timeout_state,
-                                    )?;
-                                    (plan, tracker, cache_manager)
-                                }
-                                PlanOrCached::Cached(query_result) => {
-                                    Self::ensure_not_cancelled(
-                                        &query_cancel_token,
-                                        &query_id_str,
-                                        &timeout_state,
-                                    )?;
-                                    return Ok(attach_cancellation_to_query_result(
-                                        query_result,
-                                        query_cancel_token.clone(),
-                                        Arc::clone(&query_id_str),
-                                        timeout_state.clone(),
-                                        (active_query_guard, timeout_timer_guard),
-                                    ));
-                                }
+                                (plan, tracker, cache_manager)
+                            }
+                            PlanOrCached::Cached(query_result) => {
+                                Self::ensure_not_cancelled(
+                                    &query_cancel_token,
+                                    &query_id_str,
+                                    &timeout_state,
+                                )?;
+                                return Ok(attach_cancellation_to_query_result(
+                                    query_result,
+                                    query_cancel_token.clone(),
+                                    Arc::clone(&query_id_str),
+                                    timeout_state.clone(),
+                                    (active_query_guard, timeout_timer_guard),
+                                ));
                             }
                         }
                     }
@@ -1215,8 +1202,12 @@ impl Query {
                         // plan-submitted result is never reused across principals.
                         let cache_namespace = request_context.cache_namespace();
                         let (ns_tag, ns_id) = cache_namespace.hash_inputs();
+                        let cache_status = match results_cache_mode {
+                            ResultsCacheMode::Default => CacheStatus::CacheMiss,
+                            ResultsCacheMode::Bypass => CacheStatus::CacheDisabled,
+                        };
                         let cache_manager = RequestCacheManager::new(
-                            CacheStatus::CacheMiss,
+                            cache_status,
                             CacheKey::LogicalPlan(&logical_plan).as_raw_key_in_namespace(
                                 Query::plan_hasher(&ctx.df),
                                 ns_tag,
@@ -1629,7 +1620,7 @@ impl Query {
             query_id: uuid::Uuid::new_v4(),
             cancellation_token: None,
             read_only: false,
-            bypass_cache: false,
+            results_cache_mode: ResultsCacheMode::default(),
         }
     }
 

--- a/crates/runtime/src/datafusion/query/builder.rs
+++ b/crates/runtime/src/datafusion/query/builder.rs
@@ -41,6 +41,7 @@ pub struct QueryBuilder {
     query_id: Uuid,
     cancellation_token: Option<CancellationToken>,
     read_only: bool,
+    bypass_cache: bool,
 }
 
 impl QueryBuilder {
@@ -53,6 +54,7 @@ impl QueryBuilder {
             table_allowlist: None,
             cancellation_token: None,
             read_only: false,
+            bypass_cache: false,
         }
     }
 
@@ -70,6 +72,7 @@ impl QueryBuilder {
             table_allowlist: None,
             cancellation_token: None,
             read_only: false,
+            bypass_cache: false,
         }
     }
 
@@ -90,6 +93,7 @@ impl QueryBuilder {
             table_allowlist: None,
             read_only: false,
             cancellation_token: None,
+            bypass_cache: false,
         }
     }
 
@@ -139,6 +143,15 @@ impl QueryBuilder {
         self
     }
 
+    /// Bypass the SQL results cache for this query (no lookup, no store),
+    /// equivalent to `Cache-Control: no-cache`. Used by the conditional-commit
+    /// transaction executor so a gate read always sees live committed state.
+    #[must_use]
+    pub fn bypass_cache(mut self, bypass_cache: bool) -> Self {
+        self.bypass_cache = bypass_cache;
+        self
+    }
+
     #[must_use]
     pub fn build(self) -> Query {
         let tracker = if self.df.task_history_enabled {
@@ -181,6 +194,7 @@ impl QueryBuilder {
             query_id: self.query_id,
             cancellation_token: self.cancellation_token,
             read_only: self.read_only,
+            bypass_cache: self.bypass_cache,
         }
     }
 }

--- a/crates/runtime/src/datafusion/query/builder.rs
+++ b/crates/runtime/src/datafusion/query/builder.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use crate::datafusion::{DataFusion, query::QueryMethod};
 
-use super::{Query, tracker::QueryTracker};
+use super::{Query, ResultsCacheMode, tracker::QueryTracker};
 
 enum SqlOrPlan {
     Sql(Arc<str>),
@@ -41,7 +41,7 @@ pub struct QueryBuilder {
     query_id: Uuid,
     cancellation_token: Option<CancellationToken>,
     read_only: bool,
-    bypass_cache: bool,
+    results_cache_mode: ResultsCacheMode,
 }
 
 impl QueryBuilder {
@@ -54,7 +54,7 @@ impl QueryBuilder {
             table_allowlist: None,
             cancellation_token: None,
             read_only: false,
-            bypass_cache: false,
+            results_cache_mode: ResultsCacheMode::default(),
         }
     }
 
@@ -72,7 +72,7 @@ impl QueryBuilder {
             table_allowlist: None,
             cancellation_token: None,
             read_only: false,
-            bypass_cache: false,
+            results_cache_mode: ResultsCacheMode::default(),
         }
     }
 
@@ -93,7 +93,7 @@ impl QueryBuilder {
             table_allowlist: None,
             read_only: false,
             cancellation_token: None,
-            bypass_cache: false,
+            results_cache_mode: ResultsCacheMode::default(),
         }
     }
 
@@ -143,12 +143,13 @@ impl QueryBuilder {
         self
     }
 
-    /// Bypass the SQL results cache for this query (no lookup, no store),
-    /// equivalent to `Cache-Control: no-cache`. Used by the conditional-commit
-    /// transaction executor so a gate read always sees live committed state.
+    /// Sets how this query interacts with the SQL results cache.
+    ///
+    /// [`ResultsCacheMode::Bypass`] skips both lookup and storage, ensuring the
+    /// query executes against the current table state.
     #[must_use]
-    pub fn bypass_cache(mut self, bypass_cache: bool) -> Self {
-        self.bypass_cache = bypass_cache;
+    pub fn results_cache_mode(mut self, results_cache_mode: ResultsCacheMode) -> Self {
+        self.results_cache_mode = results_cache_mode;
         self
     }
 
@@ -194,7 +195,7 @@ impl QueryBuilder {
             query_id: self.query_id,
             cancellation_token: self.cancellation_token,
             read_only: self.read_only,
-            bypass_cache: self.bypass_cache,
+            results_cache_mode: self.results_cache_mode,
         }
     }
 }

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -222,6 +222,47 @@ impl Query {
         ))
     }
 
+    /// Plans a query without consulting or populating the SQL results cache.
+    pub(super) async fn get_plan_without_results_cache(
+        df: &Arc<DataFusion>,
+        session: &SessionState,
+        request_context: &RequestContext,
+        sql: &str,
+        parameters: Option<ParamValues>,
+        tracker: Option<QueryTracker>,
+        pre_parsed_plan: Option<Box<LogicalPlan>>,
+    ) -> super::Result<PlanOrCached> {
+        let cache_namespace = request_context.cache_namespace();
+        let (ns_tag, ns_id) = cache_namespace.hash_inputs();
+        let raw_cache_key = CacheKey::Query(sql, parameters.as_ref()).as_raw_key_in_namespace(
+            Self::plan_hasher(df),
+            ns_tag,
+            ns_id,
+        );
+        let plan = if let Some(plan) = pre_parsed_plan {
+            plan
+        } else {
+            match Self::get_plan(df, session, sql, &raw_cache_key, parameters).await {
+                Ok(plan) => Box::new(plan),
+                Err(super::Error::UnableToExecuteQuery { source }) => {
+                    let code = ErrorCode::from(&source);
+                    let error = super::Error::UnableToExecuteQuery { source };
+                    if let Some(tracker) = tracker {
+                        tracker.finish_with_error(request_context, error.to_string(), code);
+                    }
+                    return Err(error);
+                }
+                Err(error) => return Err(error),
+            }
+        };
+
+        Ok(PlanOrCached::Plan(
+            plan,
+            tracker,
+            RequestCacheManager::new(CacheStatus::CacheDisabled, raw_cache_key),
+        ))
+    }
+
     /// Get the logical plan for the given SQL query, applying parameter values if provided.
     pub(super) async fn get_plan(
         df: &Arc<DataFusion>,
@@ -720,7 +761,10 @@ mod tests {
 
     use crate::{
         builder::RuntimeBuilder,
-        datafusion::{DataFusion, query::QueryBuilder},
+        datafusion::{
+            DataFusion,
+            query::{QueryBuilder, ResultsCacheMode},
+        },
         status,
     };
     use runtime_request_context::{
@@ -798,6 +842,69 @@ mod tests {
 
         let manager = RequestCacheManager::new(cache_status, raw_cache_key);
         assert!(manager.should_cache_results());
+    }
+
+    async fn run_i64_query(
+        df: &Arc<DataFusion>,
+        sql: &str,
+        results_cache_mode: ResultsCacheMode,
+    ) -> (CacheStatus, i64) {
+        let result = QueryBuilder::new(sql, Arc::clone(df))
+            .results_cache_mode(results_cache_mode)
+            .build()
+            .run()
+            .await
+            .expect("query should succeed");
+        let cache_status = result.cache_status;
+        let records = result
+            .data
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("query should return records");
+        let value = records
+            .first()
+            .expect("query should return one batch")
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("query should return an Int64 column")
+            .value(0);
+        (cache_status, value)
+    }
+
+    #[tokio::test]
+    async fn test_results_cache_bypass_skips_lookup_and_storage() {
+        let df = prepare_runtime(Some(SQLResultsCacheConfig {
+            item_ttl: Some("10m".to_string()),
+            cache_key_type: spicepod::component::caching::CacheKeyType::Sql,
+            ..Default::default()
+        }))
+        .await;
+        let request_context = create_test_request_context(
+            CacheControl::Cache(CacheKeyType::ClientSupplied),
+            Some("bypass-regression".to_string()),
+        );
+
+        let (status, value) = Arc::clone(&request_context)
+            .scope(run_i64_query(&df, "SELECT 1", ResultsCacheMode::Default))
+            .await;
+        assert_eq!(status, CacheStatus::CacheMiss);
+        assert_eq!(value, 1);
+
+        // The same client cache key is warm, but bypass must execute SELECT 2.
+        let (status, value) = Arc::clone(&request_context)
+            .scope(run_i64_query(&df, "SELECT 2", ResultsCacheMode::Bypass))
+            .await;
+        assert_eq!(status, CacheStatus::CacheDisabled);
+        assert_eq!(value, 2);
+
+        // Bypass must not replace the warm entry. A normal request with the same
+        // client key still returns the original SELECT 1 result, not SELECT 2.
+        let (status, value) = request_context
+            .scope(run_i64_query(&df, "SELECT 3", ResultsCacheMode::Default))
+            .await;
+        assert_eq!(status, CacheStatus::CacheHit);
+        assert_eq!(value, 1);
     }
 
     /// SWR background revalidation must run under the originating user's

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -52,6 +52,7 @@ use runtime_secrets::{ExposeSecret, get_params_with_secrets};
 const EMBED_UDF_NAME: &str = "embed";
 use runtime_datafusion_udfs::{
     alias::ScalarUDFAlias,
+    assert::Assert,
     bucket::{BUCKET_SCALAR_UDF_NAME, Bucket},
     cosine_distance::{COSINE_DISTANCE_UDF_NAME, CosineDistance},
     digest_many::{DIGEST_UDF_NAME, INSTANCE},
@@ -79,6 +80,7 @@ pub fn register_core_scalar_udfs(ctx: &SessionContext) {
     ctx.register_udf(L2SquaredDistance::new().into());
     ctx.register_udf(L2Norm::new().into());
     ctx.register_udf(Truncate::new().into());
+    ctx.register_udf(Assert::new().into());
     ctx.register_udf(INSTANCE.clone());
     register_postgres_comment_udfs(ctx);
 }

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -62,6 +62,10 @@ use cache::result::CacheStatus;
 use csv::Writer;
 use datafusion::common::ParamValues;
 use datafusion::execution::SendableRecordBatchStream;
+use datafusion::sql::parser::{DFParser, Statement as DFStatement};
+use datafusion::sql::sqlparser::{ast::Statement as SqlStatement, dialect::PostgreSqlDialect};
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
 use headers_accept::Accept;
 use http::{
     HeaderValue,
@@ -255,6 +259,12 @@ pub async fn sql_to_http_response(
     format: ResponseMimeType,
     read_only: bool,
 ) -> Response {
+    // Conditional commits: a `BEGIN … COMMIT` transaction body is run by a dedicated
+    // serializing executor rather than the (rejected) single-statement path.
+    if let Some(inner) = detect_conditional_commit_transaction(&sql) {
+        return execute_conditional_commit(df, inner, read_only, format).await;
+    }
+
     // Capture the query memory pool before `df` is moved into the builder, so a
     // streamed body can charge its egress buffers against the pool the query ran
     // under (see `EgressAccount`).
@@ -300,6 +310,109 @@ pub async fn sql_to_http_response(
     let account = EgressAccount::register(&memory_pool, "http_egress");
     let body = Body::from_stream(json_array_body_stream(first, data_stream, account));
     (StatusCode::OK, headers, body).into_response()
+}
+
+/// Process-global serialization lock for conditional-commit transactions.
+///
+/// v1 is pessimistic and single-instance: the whole `BEGIN … COMMIT` body (the
+/// `assert()` gate read + the writes) runs while holding this lock, so concurrent
+/// gated transactions are serialized and a gate cannot be raced (no over-admit).
+/// Per-key optimistic concurrency — so transactions touching disjoint keys run in
+/// parallel — is the tracked follow-up (spiceai#11834/#11835).
+static CONDITIONAL_COMMIT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// Detects a `BEGIN … COMMIT` transaction body and returns its inner statements as
+/// SQL strings (transaction-control statements stripped), or `None` if `sql` is not
+/// a well-formed `BEGIN … COMMIT` body. A non-transaction (single statement, or a
+/// multi-statement string not wrapped in `BEGIN … COMMIT`) returns `None` and is
+/// handled by the ordinary path unchanged.
+fn detect_conditional_commit_transaction(sql: &str) -> Option<Vec<String>> {
+    let statements: Vec<DFStatement> = DFParser::parse_sql_with_dialect(sql, &PostgreSqlDialect {})
+        .ok()?
+        .into_iter()
+        .collect();
+    if statements.len() < 2 {
+        return None;
+    }
+    let first_is_begin = matches!(
+        statements.first(),
+        Some(DFStatement::Statement(s)) if matches!(s.as_ref(), SqlStatement::StartTransaction { .. })
+    );
+    let last_is_commit = matches!(
+        statements.last(),
+        Some(DFStatement::Statement(s)) if matches!(s.as_ref(), SqlStatement::Commit { .. })
+    );
+    if !(first_is_begin && last_is_commit) {
+        return None;
+    }
+    let inner: Vec<String> = statements[1..statements.len() - 1]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    if inner.is_empty() {
+        return None;
+    }
+    Some(inner)
+}
+
+/// Executes a conditional-commit transaction body: runs each inner statement in
+/// order while holding the serialization lock, so the `assert()` gate read and the
+/// writes are atomic with respect to other gated transactions. A failed `assert()`
+/// (or any statement error) aborts the transaction — subsequent statements do not
+/// run and the error is returned to the client.
+///
+/// v1 reuses the ordinary write path, so a Cayenne-accelerated `write_mode:
+/// write_back` dataset commits to the accelerator and propagates to the source as
+/// usual. It is not multi-statement atomic on failure (writes applied by an earlier
+/// statement are not rolled back); the canonical shape — gate first, then writes —
+/// means a gate failure applies no writes. Transaction-level bound parameters are
+/// not yet supported (use literal values in the body).
+async fn execute_conditional_commit(
+    df: Arc<DataFusion>,
+    inner_sqls: Vec<String>,
+    read_only: bool,
+    format: ResponseMimeType,
+) -> Response {
+    let _guard = CONDITIONAL_COMMIT_LOCK.lock().await;
+
+    let mut last: Option<(Vec<RecordBatch>, CacheStatus)> = None;
+    for stmt_sql in &inner_sqls {
+        let query_res = match QueryBuilder::new(stmt_sql, Arc::clone(&df))
+            .read_only(read_only)
+            // Gate + inner reads must see live committed state, not a (stale) cached
+            // result — the transaction is the serialization point, not the cache.
+            .bypass_cache(true)
+            .build()
+            .run()
+            .await
+        {
+            Ok(res) => res,
+            Err(e) => {
+                let kind = SqlErrorKind::of_query_error(&e);
+                return sql_error_response(e.to_string(), kind);
+            }
+        };
+        let cache_status = query_res.cache_status;
+        // Drain each statement fully so writes execute and any error (including a
+        // gate abort) surfaces before the next statement runs.
+        match query_res.data.try_collect::<Vec<RecordBatch>>().await {
+            Ok(batches) => last = Some((batches, cache_status)),
+            Err(e) => {
+                return sql_error_response(e.to_string(), SqlErrorKind::of_datafusion_error(&e));
+            }
+        }
+    }
+
+    // All statements succeeded — the transaction is committed. Return the final
+    // statement's result (for the canonical gate+write shape, the write's summary).
+    match last {
+        Some((batches, cache_status)) => {
+            to_http_response(batches, cache_status, format, ResponseMetadata::empty())
+                .await
+                .into_response()
+        }
+        None => (StatusCode::OK, "COMMIT").into_response(),
+    }
 }
 
 /// Classifies a query error for HTTP status mapping: client-initiated

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -35,15 +35,16 @@ pub mod status;
 pub mod tools;
 pub mod workers;
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use crate::{
     component::dataset::Dataset,
     datafusion::{
         DataFusion,
         query::{
-            Error as QueryError, QueryBuilder, is_cancellation_error, is_timeout_error,
-            json_array_writer, schema_has_union_columns, write_to_json_string, write_to_json_value,
+            Error as QueryError, QueryBuilder, ResultsCacheMode, is_cancellation_error,
+            is_timeout_error, json_array_writer, schema_has_union_columns, write_to_json_string,
+            write_to_json_value,
         },
     },
     egress::EgressAccount,
@@ -61,11 +62,10 @@ use bytes::Bytes;
 use cache::result::CacheStatus;
 use csv::Writer;
 use datafusion::common::ParamValues;
-use datafusion::execution::SendableRecordBatchStream;
+use datafusion::execution::{SendableRecordBatchStream, memory_pool::MemoryPool};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 use datafusion::sql::sqlparser::{ast::Statement as SqlStatement, dialect::PostgreSqlDialect};
-use std::sync::LazyLock;
-use tokio::sync::Mutex;
 use headers_accept::Accept;
 use http::{
     HeaderValue,
@@ -74,6 +74,7 @@ use http::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use snafu::ResultExt;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
 use futures::{StreamExt, TryStreamExt};
 
@@ -259,10 +260,10 @@ pub async fn sql_to_http_response(
     format: ResponseMimeType,
     read_only: bool,
 ) -> Response {
-    // Conditional commits: a `BEGIN … COMMIT` transaction body is run by a dedicated
-    // serializing executor rather than the (rejected) single-statement path.
-    if let Some(inner) = detect_conditional_commit_transaction(&sql) {
-        return execute_conditional_commit(df, inner, read_only, format).await;
+    // A `BEGIN … COMMIT` body is run by the transaction executor rather than
+    // the ordinary single-statement path.
+    if let Some(statements) = transaction_statements(&sql) {
+        return execute_transaction(df, statements, parameters, read_only, format).await;
     }
 
     // Capture the query memory pool before `df` is moved into the builder, so a
@@ -284,9 +285,20 @@ pub async fn sql_to_http_response(
         }
     };
 
-    let cache_status = query_res.cache_status;
-    let mut data_stream = query_res.data;
+    query_stream_to_http_response(query_res.data, query_res.cache_status, format, memory_pool).await
+}
 
+/// Converts a query stream to the requested HTTP response format.
+///
+/// Default JSON responses stream batch-by-batch. Formats that require complete
+/// result metadata, and JSON schemas containing union columns, use the buffered
+/// response path.
+async fn query_stream_to_http_response(
+    mut data_stream: SendableRecordBatchStream,
+    cache_status: CacheStatus,
+    format: ResponseMimeType,
+    memory_pool: Arc<dyn MemoryPool>,
+) -> Response {
     // Stream only the default JSON format with non-union columns; csv/plain/vnd
     // buffer via `to_http_response`, and union columns (which the arrow-json array
     // writer can't render) fall back to the buffered JSON path. Streamability is a
@@ -312,21 +324,18 @@ pub async fn sql_to_http_response(
     (StatusCode::OK, headers, body).into_response()
 }
 
-/// Process-global serialization lock for conditional-commit transactions.
+/// Process-global serialization lock for `/v1/sql` transactions.
 ///
-/// v1 is pessimistic and single-instance: the whole `BEGIN … COMMIT` body (the
-/// `assert()` gate read + the writes) runs while holding this lock, so concurrent
-/// gated transactions are serialized and a gate cannot be raced (no over-admit).
-/// Per-key optimistic concurrency — so transactions touching disjoint keys run in
-/// parallel — is the tracked follow-up (spiceai#11834/#11835).
-static CONDITIONAL_COMMIT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+/// v1 is pessimistic and single-instance: each complete `BEGIN … COMMIT` body
+/// runs while holding this lock. Per-key optimistic concurrency, which would let
+/// transactions touching disjoint keys run in parallel, is tracked separately.
+static TRANSACTION_LOCK: LazyLock<Arc<Mutex<()>>> = LazyLock::new(|| Arc::new(Mutex::new(())));
 
-/// Detects a `BEGIN … COMMIT` transaction body and returns its inner statements as
-/// SQL strings (transaction-control statements stripped), or `None` if `sql` is not
-/// a well-formed `BEGIN … COMMIT` body. A non-transaction (single statement, or a
-/// multi-statement string not wrapped in `BEGIN … COMMIT`) returns `None` and is
-/// handled by the ordinary path unchanged.
-fn detect_conditional_commit_transaction(sql: &str) -> Option<Vec<String>> {
+/// Returns the statements inside a well-formed `BEGIN … COMMIT` transaction.
+/// Transaction-control statements are stripped. A single statement or a
+/// multi-statement string not wrapped in `BEGIN … COMMIT` returns `None` and is
+/// handled by the ordinary query path.
+fn transaction_statements(sql: &str) -> Option<Vec<String>> {
     let statements: Vec<DFStatement> = DFParser::parse_sql_with_dialect(sql, &PostgreSqlDialect {})
         .ok()?
         .into_iter()
@@ -355,64 +364,116 @@ fn detect_conditional_commit_transaction(sql: &str) -> Option<Vec<String>> {
     Some(inner)
 }
 
-/// Executes a conditional-commit transaction body: runs each inner statement in
-/// order while holding the serialization lock, so the `assert()` gate read and the
-/// writes are atomic with respect to other gated transactions. A failed `assert()`
-/// (or any statement error) aborts the transaction — subsequent statements do not
-/// run and the error is returned to the client.
+/// Makes positional parameters reusable across transaction statements.
 ///
-/// v1 reuses the ordinary write path, so a Cayenne-accelerated `write_mode:
-/// write_back` dataset commits to the accelerator and propagates to the source as
-/// usual. It is not multi-statement atomic on failure (writes applied by an earlier
-/// statement are not rolled back); the canonical shape — gate first, then writes —
-/// means a gate failure applies no writes. Transaction-level bound parameters are
-/// not yet supported (use literal values in the body).
-async fn execute_conditional_commit(
+/// Each statement is planned independently, so a positional list containing
+/// `$1` and `$2` would otherwise fail validation when one statement references
+/// only a subset. Named values preserve the transaction-wide placeholder
+/// indexes while allowing each statement to bind the values it uses.
+fn normalize_transaction_parameters(parameters: Option<ParamValues>) -> Option<ParamValues> {
+    match parameters {
+        Some(ParamValues::List(values)) => Some(ParamValues::Map(
+            values
+                .into_iter()
+                .enumerate()
+                .map(|(index, value)| ((index + 1).to_string(), value))
+                .collect(),
+        )),
+        parameters => parameters,
+    }
+}
+
+async fn run_transaction_statement(
+    df: &Arc<DataFusion>,
+    sql: &str,
+    parameters: Option<ParamValues>,
+    read_only: bool,
+) -> Result<cache::result::query::QueryResult, QueryError> {
+    QueryBuilder::new(sql, Arc::clone(df))
+        .parameters(parameters)
+        .read_only(read_only)
+        // Every statement must observe current state and must not replace a
+        // previously cached result while the transaction lock is held.
+        .results_cache_mode(ResultsCacheMode::Bypass)
+        .build()
+        .run()
+        .await
+}
+
+/// Keeps the transaction lock until the final statement's lazy result stream is
+/// fully consumed or dropped.
+fn attach_transaction_guard_to_stream(
+    stream: SendableRecordBatchStream,
+    guard: OwnedMutexGuard<()>,
+) -> SendableRecordBatchStream {
+    let schema = stream.schema();
+    let guarded = futures::stream::unfold((stream, guard), |(mut stream, guard)| async move {
+        stream
+            .next()
+            .await
+            .map(|batch_result| (batch_result, (stream, guard)))
+    });
+    Box::pin(RecordBatchStreamAdapter::new(schema, guarded))
+}
+
+/// Executes each statement in a transaction in order under the process-wide
+/// serialization lock. Any statement error stops subsequent execution and is
+/// returned to the client.
+///
+/// Intermediate result streams are drained batch-by-batch without buffering so
+/// writes finish and execution errors surface before the next statement. The
+/// final statement's result is streamed to the client. This executor does not
+/// provide rollback: writes completed by an earlier statement remain applied if
+/// a later statement fails.
+async fn execute_transaction(
     df: Arc<DataFusion>,
-    inner_sqls: Vec<String>,
+    statements: Vec<String>,
+    parameters: Option<ParamValues>,
     read_only: bool,
     format: ResponseMimeType,
 ) -> Response {
-    let _guard = CONDITIONAL_COMMIT_LOCK.lock().await;
+    let Some((final_statement, intermediate_statements)) = statements.split_last() else {
+        return (StatusCode::OK, "COMMIT").into_response();
+    };
 
-    let mut last: Option<(Vec<RecordBatch>, CacheStatus)> = None;
-    for stmt_sql in &inner_sqls {
-        let query_res = match QueryBuilder::new(stmt_sql, Arc::clone(&df))
-            .read_only(read_only)
-            // Gate + inner reads must see live committed state, not a (stale) cached
-            // result — the transaction is the serialization point, not the cache.
-            .bypass_cache(true)
-            .build()
-            .run()
-            .await
-        {
-            Ok(res) => res,
-            Err(e) => {
-                let kind = SqlErrorKind::of_query_error(&e);
-                return sql_error_response(e.to_string(), kind);
+    let memory_pool = Arc::clone(&df.ctx.runtime_env().memory_pool);
+    let parameters = normalize_transaction_parameters(parameters);
+    let transaction_guard = Arc::clone(&TRANSACTION_LOCK).lock_owned().await;
+
+    for statement in intermediate_statements {
+        let query_res =
+            match run_transaction_statement(&df, statement, parameters.clone(), read_only).await {
+                Ok(result) => result,
+                Err(error) => {
+                    let kind = SqlErrorKind::of_query_error(&error);
+                    return sql_error_response(error.to_string(), kind);
+                }
+            };
+
+        // Drain and immediately drop each batch. This executes writes and
+        // surfaces stream errors without materializing intermediate SELECTs.
+        let mut data_stream = query_res.data;
+        while let Some(batch_result) = data_stream.next().await {
+            if let Err(error) = batch_result {
+                return sql_error_response(
+                    error.to_string(),
+                    SqlErrorKind::of_datafusion_error(&error),
+                );
+            }
+        }
+    }
+
+    let query_res =
+        match run_transaction_statement(&df, final_statement, parameters, read_only).await {
+            Ok(result) => result,
+            Err(error) => {
+                let kind = SqlErrorKind::of_query_error(&error);
+                return sql_error_response(error.to_string(), kind);
             }
         };
-        let cache_status = query_res.cache_status;
-        // Drain each statement fully so writes execute and any error (including a
-        // gate abort) surfaces before the next statement runs.
-        match query_res.data.try_collect::<Vec<RecordBatch>>().await {
-            Ok(batches) => last = Some((batches, cache_status)),
-            Err(e) => {
-                return sql_error_response(e.to_string(), SqlErrorKind::of_datafusion_error(&e));
-            }
-        }
-    }
 
-    // All statements succeeded — the transaction is committed. Return the final
-    // statement's result (for the canonical gate+write shape, the write's summary).
-    match last {
-        Some((batches, cache_status)) => {
-            to_http_response(batches, cache_status, format, ResponseMetadata::empty())
-                .await
-                .into_response()
-        }
-        None => (StatusCode::OK, "COMMIT").into_response(),
-    }
+    let data_stream = attach_transaction_guard_to_stream(query_res.data, transaction_guard);
+    query_stream_to_http_response(data_stream, query_res.cache_status, format, memory_pool).await
 }
 
 /// Classifies a query error for HTTP status mapping: client-initiated
@@ -766,7 +827,13 @@ mod tests {
     use super::*;
     use arrow::array::{Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::scalar::ScalarValue;
     use std::sync::Arc;
+
+    use crate::{
+        dataaccelerator::AcceleratorEngineRegistry, datafusion::builder::DataFusionBuilder,
+        status::RuntimeStatus,
+    };
 
     /// `/v1/sql` must let clients distinguish outcomes by status code: a
     /// `runtime.query.timeout` expiry maps to 504 Gateway Timeout, a
@@ -815,6 +882,47 @@ mod tests {
             SqlErrorKind::of_datafusion_error(&stream_cancel),
         );
         assert_eq!(response.status().as_u16(), 499);
+    }
+
+    #[test]
+    fn transaction_statements_requires_begin_and_commit() {
+        assert_eq!(
+            transaction_statements("BEGIN; SELECT 1; COMMIT"),
+            Some(vec!["SELECT 1".to_string()])
+        );
+        assert!(transaction_statements("SELECT 1; SELECT 2").is_none());
+        assert!(transaction_statements("BEGIN; COMMIT").is_none());
+    }
+
+    #[tokio::test]
+    async fn transaction_executes_bound_parameters_and_returns_final_result() {
+        let df = Arc::new(
+            DataFusionBuilder::new(
+                RuntimeStatus::new(),
+                Arc::new(AcceleratorEngineRegistry::new()),
+                tokio::runtime::Handle::current(),
+            )
+            .build(),
+        );
+        let parameters = ParamValues::from(vec![
+            ScalarValue::Int64(Some(41)),
+            ScalarValue::Int64(Some(42)),
+        ]);
+
+        let response = sql_to_http_response(
+            df,
+            Arc::from("BEGIN; SELECT $1 AS ignored; SELECT $2 AS value; COMMIT"),
+            Some(parameters),
+            ResponseMimeType::Json,
+            false,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("transaction response body should be readable");
+        assert_eq!(body.as_ref(), br#"[{"value":42}]"#);
     }
 
     #[test]


### PR DESCRIPTION
<!-- stack-nav -->
> **Cayenne transactions — stacked PR 1 of 9**
> Previous: _(none — base of stack)_ &nbsp;·&nbsp; Next: #11849 →
>
> Review/merge bottom-up: #11848 · #11849 · #11859 · #11861 · #11863 · #11865 · #11866 · #11868 · #11869 &nbsp;→&nbsp; all squashed into #11870 (targets `trunk`). Part of #11830.

---

Part of #11830.

First working slice of the conditional-commits transaction API: a serializable, gated `BEGIN … COMMIT` transaction over a Cayenne accelerated table, with write-back to the federated source. This lands the end-to-end skeleton; several v1 requirements are explicitly deferred to follow-up PRs (below).

## What's in this PR

- **`assert(bool)` scalar UDF** (`runtime-datafusion-udfs`) — `Volatile`, returns a terminal error on a false/NULL gate (message marker `assertion failed:` so a gate abort is distinguishable from a retryable conflict). Registered in `register_core_scalar_udfs`, so it is callable on every SQL surface. Unit-tested.
- **`BEGIN … COMMIT` transaction executor** on the HTTP `/v1/sql` path (`http/v1/mod.rs`) — detects a transaction body via `DFParser`, runs each inner statement, and aborts the transaction if the `assert()` gate fails. Reuses the accelerated-table write path, so a `write_mode: write_back` Cayenne dataset commits to the accelerator and propagates to the source.
- **`QueryBuilder::bypass_cache`** — transaction gate/inner reads skip the SQL results cache (no lookup/store, equivalent to `Cache-Control: no-cache`) so the gate always reads live committed state. (Without this, the 1s results cache served stale gate reads and caused over-admit.)

## Verified

- `assert()` unit tests (4/4).
- Manual e2e against a Postgres-backed Cayenne `write_back` dataset, with the SQL results cache **on** (default):
  - gate pass / fail;
  - cap enforcement (a capped counter stops at its limit; further admits abort);
  - 200 concurrent admits to one capped key → exactly the cap, no over-admit;
  - the source (Postgres) converges with the accelerator.

## Deferred to follow-up PRs (tracked)

This slice serializes gated transactions under a single process lock and reuses the existing async write-back — not the full v1. Remaining v1 work:

- **Per-key OCC** (#11834) — replace the global serialization lock with per-key read-version capture + commit-time re-check, so transactions touching disjoint keys commit concurrently.
- **True atomicity — staged commit + rollback** (#11833, #11837) — stage writes and publish all-or-nothing at `COMMIT` (a later statement failing must roll back earlier writes), instead of the current gate-first, execute-immediately model.
- **Durable write-back** (#11838) — dirty-key reconciliation recorded in the commit transaction (this slice reuses the async best-effort path).
- **FlightSQL (and cluster) entry** (#11836) — currently HTTP `/v1/sql` only.
- Automated integration tests for the executor.

## Notes

No spicepod or API surface change: the transaction body is submitted as ordinary SQL to the existing `/v1/sql` endpoint.



---
**Implements:** #11831 (assert() scalar UDF + two-class error protocol). Seeds the request-scoped executor (#11835) and transaction-body entry detection (#11836) completed in #11859.

---

## Stacked-PR review notes

**Implements #11831** (assert() UDF + two-class error protocol).

Part of the #11830 stack — the plan is to merge one squashed PR into `trunk`; these stacked PRs are the reviewable evolution of the feature, so a few pieces here are intentionally reworked by later PRs:

- The transaction-executor scaffolding introduced here (in `http/v1`) is superseded: the request-scoped executor lands in #11859, and is then **extracted** out of `http/v1` into the shared `datafusion::query::transaction` module in #11866 so HTTP and FlightSQL drive the same code.

