### PR TITLE
Cayenne transactions (2/9): staged-upsert substrate

### DIFF
--- a/crates/cayenne/src/lib.rs
+++ b/crates/cayenne/src/lib.rs
@@ -98,7 +98,7 @@ pub use metadata::{
 pub use metastore::sqlite::{SqliteAutoVacuum, SqliteMetastoreConfig, set_sqlite_metastore_config};
 pub use provider::constants::{STAGING_DIR_NAME, STAGING_WAL_FILENAME, STAGING_WAL_TMP_FILENAME};
 pub use provider::{
-    CayenneCdcWrite, CayenneContext, CayenneStagedAppend, CayenneTableProvider,
+    CayenneCdcWrite, CayenneContext, CayenneStagedAppend, CayenneStagedUpsert, CayenneTableProvider,
     CayenneTableProviderBuilder, EncodeBudgetSnapshot, PARTITIONED_WAL_DIR, PartitionedWal,
     PartitionedWalEntry, PreparedOverwrite, PreparedStagedAppend, QueryObservations, SlotAdvancer,
     TimeRetentionFilterBuilder, begin_compaction_shutdown, cap_global_encode_concurrency,

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -100,6 +100,7 @@ pub(crate) mod query_admission;
 pub(crate) mod retention;
 pub(crate) mod scan;
 pub(crate) mod sink;
+pub(crate) mod staged_upsert;
 pub(crate) mod staging_wal;
 pub(crate) mod streaming;
 pub(crate) mod table;
@@ -126,6 +127,7 @@ pub use partitioned_wal::{PARTITIONED_WAL_DIR, PartitionedWal, PartitionedWalEnt
 pub use query_admission::set_query_admission_governor;
 pub use retention::TimeRetentionFilterBuilder;
 pub use scan::CayenneAccelerationExec;
+pub use staged_upsert::CayenneStagedUpsert;
 pub use staging_wal::{CayenneStagedAppend, PreparedStagedAppend};
 pub use table::{CayenneCdcWrite, CayenneTableProvider, CayenneTableProviderBuilder};
 pub use tuning::{

--- a/crates/cayenne/src/provider/staged_upsert.rs
+++ b/crates/cayenne/src/provider/staged_upsert.rs
@@ -1,0 +1,288 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Staged **upsert** lifecycle for `CayenneTableProvider` (Analytical Replica
+//! dual-apply).
+//!
+//! [`super::staging_wal::CayenneStagedAppend`] stages append-only writes; it
+//! rejects primary-key / on-conflict tables. This module adds the PK-aware
+//! counterpart: a write into a table with a primary key and `on_conflict`
+//! upsert is staged **invisibly** and published (or discarded) at a later
+//! moment — the point at which the dual-apply driver has an ack (or a failure)
+//! from the federated source.
+//!
+//! It is a split of the synchronous on-conflict path
+//! ([`CayenneTableProvider::write_new_snapshot_after_validation`]) at the
+//! listing fence:
+//!
+//! - [`CayenneTableProvider::begin_staged_upsert`] validates the incoming rows
+//!   for PK conflicts and writes them into a fresh, **unreferenced** snapshot
+//!   directory (`{table_id}/{new_snapshot}/`). Nothing durable in the catalog
+//!   is touched, so the rows are invisible to every reader and there is nothing
+//!   to compensate on abort. The captured [`OnConflictDeletions`] (which prior
+//!   versions this write supersedes) rides the returned handle.
+//! - [`CayenneStagedUpsert::commit`] runs the fenced publish: apply the
+//!   on-conflict deletions, reserve the protected-snapshot sequence (strictly
+//!   above the delete sequence, so the staged rows survive their own conflict
+//!   deletes), durably record it, then flip the deletion caches and the
+//!   protected snapshot in one listing-fence write. After this the rows are
+//!   visible.
+//! - [`CayenneStagedUpsert::rollback`] discards the staged snapshot directory.
+//!
+//! Sequence stamping is deferred by construction: the sync path already
+//! reserves every sequence at publish time, and the protected snapshot's
+//! deletion threshold is its own (highest) sequence, so a commit that lands
+//! between stage and publish never mis-orders the staged rows.
+//!
+//! The stage is deliberately **not** durable: the federated source is the
+//! system of record and CDC (`refresh_mode: changes`) is the crash backstop, so
+//! a crash before commit simply drops the staged directory (recovered, if the
+//! source committed, by CDC replay).
+
+use std::sync::Arc;
+
+use datafusion::execution::SendableRecordBatchStream;
+use tokio::sync::OwnedMutexGuard;
+
+use super::Error;
+use super::Result;
+use super::column_stats::ColumnStatsAccumulator;
+use super::delta_encoding::WriteClass;
+use super::on_conflict::{OnConflictDeletions, PostValidationState};
+use super::pk_index::PkDigestSet;
+use super::table::CayenneTableProvider;
+
+/// A staged upsert: the replacement rows have been written to a fresh snapshot
+/// directory, but no catalog visibility change has been made yet.
+///
+/// The handle owns the table's write guard, so concurrent writers on the same
+/// table block until it is either committed via [`Self::commit`] or discarded
+/// via [`Self::rollback`] (or dropped — see the note on `Drop`).
+pub struct CayenneStagedUpsert {
+    table: CayenneTableProvider,
+    write_guard: Option<OwnedMutexGuard<()>>,
+    new_snapshot_id: String,
+    /// The prior versions this upsert supersedes, captured at validation time
+    /// and applied under the fence at commit. Taken (`mem::take`) on commit.
+    on_conflict_deletions: OnConflictDeletions,
+    validated_keys: PkDigestSet,
+    stats: Arc<ColumnStatsAccumulator>,
+    row_count: u64,
+    /// Existing rows replaced by this upsert (for the live-row-count delta),
+    /// captured before `on_conflict_deletions` is consumed.
+    superseded: usize,
+}
+
+impl std::fmt::Debug for CayenneStagedUpsert {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CayenneStagedUpsert")
+            .field("table", &self.table.table_name())
+            .field("new_snapshot_id", &self.new_snapshot_id)
+            .field("row_count", &self.row_count)
+            .field("superseded", &self.superseded)
+            .field("has_write_guard", &self.write_guard.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl CayenneStagedUpsert {
+    /// Number of rows staged for commit.
+    #[must_use]
+    pub fn row_count(&self) -> u64 {
+        self.row_count
+    }
+
+    /// Publish the staged rows, making the upsert visible to readers.
+    ///
+    /// Mirrors the fenced tail of
+    /// [`CayenneTableProvider::write_new_snapshot_after_validation`]: apply the
+    /// on-conflict deletions, reserve the protected-snapshot sequence, record it
+    /// durably, then flip the deletion caches + protected snapshot under one
+    /// listing-fence write.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if applying the deletions, reserving the sequence, or the
+    /// durable snapshot-sequence write fails. The staged snapshot directory is
+    /// left in place on error so the caller can retry the commit or roll back.
+    pub async fn commit(mut self) -> Result<u64> {
+        // visibility lock then listing fence — the same order as
+        // `apply_under_barrier` and the sync on-conflict publish.
+        let _visibility = self.table.visibility_lock_arc().lock_owned().await;
+        let _fence = self.table.lock_listing_fence_write_owned().await;
+
+        let on_conflict_deletions = std::mem::take(&mut self.on_conflict_deletions);
+        let update = self.table.apply_on_conflict_deletions(on_conflict_deletions).await?;
+
+        // Reserve the snapshot sequence AFTER `apply_on_conflict_deletions` (which
+        // reserves the lower delete/insert sequences), so the protected snapshot's
+        // deletion threshold is strictly above them and the staged rows survive
+        // their own conflict deletes.
+        let new_sequence = self.table.reserve_sequences_local(1).await?;
+        self.table
+            .record_written_snapshot_sequence(&self.new_snapshot_id, new_sequence)
+            .await?;
+        // Atomically publish the deletion-cache update and the protected snapshot
+        // so a concurrent scan never sees the new rows without the deletes that
+        // hide their prior versions.
+        self.table
+            .commit_on_conflict_publish(update, Some((&self.new_snapshot_id, new_sequence)))
+            .await;
+
+        let retention_requested = self.table.has_retention_delete_filters();
+        let live_rows_delta = i64::try_from(self.row_count)
+            .unwrap_or(i64::MAX)
+            .saturating_sub(i64::try_from(self.superseded).unwrap_or(i64::MAX));
+        self.table.schedule_post_write_maintenance(
+            Some(Arc::clone(&self.stats)),
+            // The publish above already refreshed listing visibility; only stats
+            // / retention / row-count maintenance is scheduled here.
+            false,
+            retention_requested,
+            live_rows_delta,
+        );
+        if retention_requested {
+            self.table.clear_cached_pk_keyset();
+        } else {
+            self.table.record_file_pk_keys(&self.validated_keys);
+        }
+
+        Ok(self.row_count)
+        // `_fence`, `_visibility`, and `self.write_guard` drop here, in that order.
+    }
+
+    /// Discard the staged upsert and remove its staged snapshot directory.
+    ///
+    /// The catalog was never touched, so this only cleans the orphan directory
+    /// (best-effort; object-store orphans are pruned by the next successful
+    /// snapshot cleanup cycle).
+    ///
+    /// # Errors
+    ///
+    /// Infallible today; returns `Result` for symmetry with the other staged
+    /// lifecycles and to allow future durable-cleanup steps.
+    pub async fn rollback(self) -> Result<()> {
+        // Hold the write guard across cleanup so another writer cannot start a
+        // commit while the staged directory is mid-deletion.
+        let _write_guard = self.write_guard;
+        cleanup_orphan_snapshot_dir(&self.table, &self.new_snapshot_id).await;
+        Ok(())
+    }
+}
+
+impl CayenneTableProvider {
+    /// Stage a primary-key upsert without making the new rows visible.
+    ///
+    /// Validates the incoming stream for PK conflicts and writes the rows into a
+    /// fresh snapshot directory, returning a [`CayenneStagedUpsert`] that the
+    /// caller commits (on federated-source ack) or rolls back (on source
+    /// failure). See the module documentation for the full lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the table has an incomplete write, is partitioned
+    /// (unsupported for the staged-upsert MVP), or if writing the staged data
+    /// fails.
+    pub async fn begin_staged_upsert(
+        &self,
+        data: SendableRecordBatchStream,
+        target_partitions: usize,
+    ) -> Result<CayenneStagedUpsert> {
+        let write_guard = self.write_lock_arc().lock_owned().await;
+        self.ensure_no_incomplete_write().await?;
+
+        // Partitioned tables publish across partitions; their visibility flip
+        // cannot be a single protected-snapshot publish. Out of scope for the MVP
+        // (§10 conditional Phase 3).
+        if self.metadata().partition_column.is_some() {
+            return Err(Error::Unsupported {
+                operation: "staged upsert for partitioned Cayenne tables",
+            });
+        }
+
+        let prepared = self.prepare_stream_for_insert(data).await?;
+        let post_validation = prepared.post_validation();
+
+        let new_snapshot_id = uuid::Uuid::now_v7().to_string();
+        let target_size_bytes = self.target_file_size_bytes();
+
+        let (row_count, _writer_ops, stats) = match self
+            .write_to_snapshot(
+                prepared.stream,
+                target_size_bytes,
+                &new_snapshot_id,
+                target_partitions,
+                // Unknown size (the validation stream is consumed lazily); shard
+                // across the full write concurrency, matching `begin_staged_append`.
+                None,
+                WriteClass::Delta,
+            )
+            .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                cleanup_orphan_snapshot_dir(self, &new_snapshot_id).await;
+                return Err(e);
+            }
+        };
+
+        // On-conflict deletions are computed by the validation stream as it is
+        // consumed by `write_to_snapshot` above, so take them only now. A table
+        // without a primary key (or with conflict detection disabled) yields the
+        // default (empty) state — a plain insert published as a protected
+        // snapshot.
+        let PostValidationState {
+            on_conflict_deletions,
+            validated_keys,
+        } = post_validation.lock().take().unwrap_or_default();
+        let superseded = on_conflict_deletions.total_superseded();
+
+        Ok(CayenneStagedUpsert {
+            table: self.clone_for_write(),
+            write_guard: Some(write_guard),
+            new_snapshot_id,
+            on_conflict_deletions,
+            validated_keys,
+            stats,
+            row_count,
+            superseded,
+        })
+    }
+}
+
+/// Best-effort removal of an unreferenced staged snapshot directory.
+///
+/// The catalog never referenced the directory (no `cayenne_snapshot_sequence`
+/// row, `current_snapshot_id` unchanged), so leaving it is safe; object stores
+/// (S3) have no atomic "remove dir" and are left to the next successful
+/// snapshot-cleanup cycle, mirroring [`super::overwrite::PreparedOverwrite::rollback`].
+async fn cleanup_orphan_snapshot_dir(table: &CayenneTableProvider, snapshot_id: &str) {
+    if table.table_path().starts_with("s3://") {
+        return;
+    }
+    let snapshot_dir = table.snapshot_dir_path_for(snapshot_id);
+    match tokio::fs::remove_dir_all(&snapshot_dir).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            tracing::warn!(
+                "Failed to clean up staged snapshot dir {} for table {}: {e}",
+                snapshot_dir.display(),
+                table.table_name()
+            );
+        }
+    }
+}

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -27116,6 +27116,167 @@ mod tests {
         ids
     }
 
+    // ── Staged upsert (Analytical Replica dual-apply, `begin_staged_upsert`) ──
+
+    /// Build a file-mode provider with an `id` primary key and `on_conflict:
+    /// upsert` — the shape the Analytical Replica staged-upsert path targets.
+    async fn build_staged_upsert_provider(
+        ctx: &SessionContext,
+        name: &str,
+    ) -> (CayenneTableProvider, TempDir, SchemaRef) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let metadata_dir = format!("{}/metadata", temp_dir.path().to_str().expect("path"));
+        let data_dir = format!("{}/data", temp_dir.path().to_str().expect("path"));
+        std::fs::create_dir_all(&metadata_dir).expect("metadata dir");
+        let connection_string = format!("sqlite://{metadata_dir}/cayenne.db");
+        let catalog = Arc::new(CayenneCatalog::new(connection_string).expect("catalog"))
+            as Arc<dyn MetadataCatalog>;
+        catalog.init().await.expect("catalog init");
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let vortex_config = VortexConfig::default();
+        let context = CayenneContext::new(&vortex_config, ctx.runtime_env(), name);
+        let options = CreateTableOptions {
+            table_name: name.to_string(),
+            schema: Arc::clone(&schema),
+            primary_key: vec!["id".to_string()],
+            on_conflict: Some(OnConflict::Upsert(
+                datafusion_table_providers::util::column_reference::ColumnReference::new(vec![
+                    "id".to_string(),
+                ]),
+            )),
+            base_path: data_dir,
+            partition_column: None,
+            vortex_config,
+        };
+        let provider = CayenneTableProviderBuilder::new(Arc::clone(&catalog), ctx.runtime_env())
+            .with_context(context)
+            .create(options)
+            .await
+            .expect("table created");
+        (provider, temp_dir, schema)
+    }
+
+    fn id_name_batch(schema: &SchemaRef, ids: &[i64], names: &[&str]) -> RecordBatch {
+        use arrow::array::StringArray;
+        RecordBatch::try_new(
+            Arc::clone(schema),
+            vec![
+                Arc::new(Int64Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(names.to_vec())),
+            ],
+        )
+        .expect("valid id/name batch")
+    }
+
+    /// A staged upsert is invisible to scans until `commit`, then fully visible.
+    #[tokio::test]
+    async fn staged_upsert_invisible_until_commit() {
+        let ctx = SessionContext::new();
+        let (provider, _tmp, schema) = build_staged_upsert_provider(&ctx, "su_commit").await;
+
+        let stream = single_batch_stream(id_name_batch(&schema, &[1, 2], &["alice", "bob"]));
+        let staged = provider
+            .begin_staged_upsert(stream, 1)
+            .await
+            .expect("begin staged upsert");
+        assert_eq!(staged.row_count(), 2);
+
+        // Held handle keeps the write guard; scans do not need it, so the staged
+        // rows are observably invisible before commit.
+        assert!(
+            scan_sorted_ids(&provider).await.is_empty(),
+            "staged rows must be invisible before commit"
+        );
+
+        let rows = staged.commit().await.expect("commit staged upsert");
+        assert_eq!(rows, 2);
+        assert_eq!(
+            scan_sorted_ids(&provider).await,
+            vec![1, 2],
+            "rows are visible after commit"
+        );
+    }
+
+    /// Rolling back a staged upsert leaves nothing visible (catalog untouched).
+    #[tokio::test]
+    async fn staged_upsert_rollback_discards() {
+        let ctx = SessionContext::new();
+        let (provider, _tmp, schema) = build_staged_upsert_provider(&ctx, "su_rollback").await;
+
+        let stream = single_batch_stream(id_name_batch(&schema, &[1, 2], &["alice", "bob"]));
+        let staged = provider
+            .begin_staged_upsert(stream, 1)
+            .await
+            .expect("begin staged upsert");
+        staged.rollback().await.expect("rollback staged upsert");
+
+        assert!(
+            scan_sorted_ids(&provider).await.is_empty(),
+            "rollback must leave nothing visible"
+        );
+    }
+
+    /// A staged upsert supersedes the prior version of a conflicting PK (no
+    /// duplicate) and adds new PKs, all published atomically on commit.
+    #[tokio::test]
+    async fn staged_upsert_supersedes_existing_pk() {
+        let ctx = SessionContext::new();
+        let (provider, _tmp, schema) = build_staged_upsert_provider(&ctx, "su_conflict").await;
+
+        // Committed initial state: id=1 -> alice.
+        insert_batch(&provider, id_name_batch(&schema, &[1], &["alice"])).await;
+        assert_eq!(scan_sorted_ids(&provider).await, vec![1]);
+
+        // Stage an upsert: id=1 -> alice2 (supersede), id=3 -> carol (new).
+        let stream = single_batch_stream(id_name_batch(&schema, &[1, 3], &["alice2", "carol"]));
+        let staged = provider
+            .begin_staged_upsert(stream, 1)
+            .await
+            .expect("begin staged upsert");
+
+        // Pre-commit state is unchanged.
+        assert_eq!(
+            scan_sorted_ids(&provider).await,
+            vec![1],
+            "pre-commit state must be unchanged"
+        );
+
+        staged.commit().await.expect("commit staged upsert");
+
+        // Exactly one id=1 (superseded, not duplicated) plus the new id=3.
+        assert_eq!(scan_sorted_ids(&provider).await, vec![1, 3]);
+
+        // The surviving id=1 carries the staged (new) value.
+        use arrow::array::StringArray;
+        let batches = read_all(&ctx, &provider, "su_conflict").await;
+        let mut got = std::collections::BTreeMap::new();
+        for b in &batches {
+            let ids = b
+                .column(b.schema().index_of("id").expect("id col"))
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id Int64");
+            let names = b
+                .column(b.schema().index_of("name").expect("name col"))
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("name Utf8");
+            for i in 0..b.num_rows() {
+                got.insert(ids.value(i), names.value(i).to_string());
+            }
+        }
+        assert_eq!(
+            got.get(&1).map(String::as_str),
+            Some("alice2"),
+            "conflicting id=1 must reflect the staged value"
+        );
+        assert_eq!(got.get(&3).map(String::as_str), Some("carol"));
+    }
+
     /// Crash-recovery exactly-once (correctness item #5, gates promotion past
     /// P1): rows appended to the in-memory CDC tier are DISCARDED on a crash
     /// before any checkpoint (the slot is the source of truth), and re-applying


### PR DESCRIPTION
<!-- stack-nav -->
> **Cayenne transactions — stacked PR 2 of 9**
> ← Previous: #11848 &nbsp;·&nbsp; Next: #11859 →
>
> Review/merge bottom-up: #11848 · #11849 · #11859 · #11861 · #11863 · #11865 · #11866 · #11868 · #11869 &nbsp;→&nbsp; all squashed into #11870 (targets `trunk`). Part of #11830.

---

Part of #11830. **Stacked on #11848** (base: `phillip/conditional-commits`) — review/merge that first.

PR-2 of the conditional-commits stack: the **staged-commit substrate** the transaction executor (PR-3) will use to publish — or roll back — a write atomically.

## What this adds

`CayenneTableProvider::begin_staged_upsert(rows, target_partitions) -> CayenneStagedUpsert`, with `CayenneStagedUpsert::{commit, rollback, row_count}`:

- **stage** — validate PK conflicts, write the replacement rows to a fresh **unreferenced** snapshot dir, capture the on-conflict deletions, and hold the table write guard. The catalog is untouched, so the rows are invisible to every reader and there's nothing to compensate on abort.
- **commit** — under the visibility + listing-fence write lock: apply the on-conflict deletions, reserve + durably record the snapshot sequence (strictly above the delete sequence so the staged rows survive their own conflict deletes), then flip the protected snapshot in one fence write. The rows become visible atomically.
- **rollback** — discard the staged snapshot dir.

This splits the synchronous on-conflict write path at the listing fence so a caller can stage a PK upsert now and publish/discard it later. **Nothing calls it yet** — PR-3 (the transaction executor) will; it's `pub` so there's no dead-code warning.

Ported from the analytical-replica dual-apply work, with one adaptation to current trunk (`HashSet<OwnedRow>` → `PkDigestSet`).

## Verified

- `cargo build -p cayenne` — clean (no errors/warnings).
- `cargo test -p cayenne staged_upsert` — **3/3**: `staged_upsert_invisible_until_commit`, `staged_upsert_rollback_discards`, `staged_upsert_supersedes_existing_pk`.



---
**Implements:** #11833 (staged-upsert substrate; made off-lock in #11859).

---

## Stacked-PR review notes

**Implements #11833** (off-lock staged upsert + Drop guard).

Reworked by later PRs in the stack:

- `begin_staged_upsert` here holds the table **write guard across staging *and* commit** (pessimistic). The transaction path is reworked to **off-lock optimistic concurrency** in #11859 (`begin_staged_upsert_occ`: staging is lock-free; the write guard is taken only briefly at commit). The held-guard version remains, but only for the analytical-replica dual-apply path.
- The single-table `CayenneStagedUpsert::commit` is later split into `prepare_commit` / `apply_in_txn` / `finish` so N tables fuse into one metastore transaction (#11865).

