### PR TITLE
fix: HashJoin dimension tables first in distributed acceleration broadcast joins

### DIFF
--- a/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/broadcast_join.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/flightsql/broadcast_join.rs
@@ -30,12 +30,15 @@ limitations under the License.
 //! `executor_table` UDTF, and ships only the joined rows:
 //! ```text
 //! UnionExec[
-//!   BroadcastJoinFlightSqlExec(exec0): SELECT ... FROM (fact) f
-//!       JOIN (SELECT * FROM executor_table('e0',dim) UNION ALL ...) d ON ...
+//!   BroadcastJoinFlightSqlExec(exec0): SELECT ...
+//!       FROM (SELECT * FROM executor_table('e0',dim) UNION ALL ...) d
+//!       JOIN (fact) f ON ...
 //!   BroadcastJoinFlightSqlExec(exec1): <same SQL, run on exec1>
 //!   ...
 //! ]
 //! ```
+//! The dim union is the join's LEFT input so the executor hash-builds the
+//! small broadcast side, never its own fact slice (see `build_join_sql`).
 //! The per-executor SQL is identical (each executor's `FROM dim_or_fact` resolves
 //! to its own partition; the `executor_table` UNION addresses are the same), so
 //! it is built once and run against each fact-partition executor's client.
@@ -604,8 +607,18 @@ fn build_join_sql(
     }
     let select_list = select_items.join(", ");
 
+    // The dimension union is rendered FIRST — as the left input of the
+    // executor-local join — so the executor hash-builds the small broadcast
+    // side. The executor plans this SQL with its own `JoinSelection`, but it
+    // cannot cost-swap the sides: the `executor_table` scans carry only
+    // best-effort statistics (the local slice's, stamped as inexact), while
+    // the fact side is its local exact-stats scan, and an unknown-vs-known
+    // comparison never swaps. With the fact rendered first, each executor hash-built its
+    // ENTIRE fact slice — gigabytes, non-spillable — and exhausted its memory
+    // pool at scale (TPC-H q17 at SF100). Alias attribution in the ON and
+    // SELECT lists is order-independent, so only the build side changes.
     Some(format!(
-        "SELECT {select_list} FROM ({fact_sql}) f INNER JOIN ({dim_union}) d ON {on_clause}"
+        "SELECT {select_list} FROM ({dim_union}) d INNER JOIN ({fact_sql}) f ON {on_clause}"
     ))
 }
 

--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -38,6 +38,7 @@ use snafu::prelude::*;
 use tokio::sync::{RwLock, mpsc};
 
 use crate::correlated::{CorrelatedResponses, CorrelationError, send_correlated};
+use crate::metadata::normalized_table_name;
 use crate::{PartitionStore, PartitionValue, executor_selection, metrics};
 
 /// Error type for executor registry operations.
@@ -271,8 +272,14 @@ pub struct ExecutorRegistry {
     /// broadcast, so its in-memory view is complete; it is re-populated by the
     /// executors' next refresh after a scheduler restart. Read at query-planning
     /// time to size the coordinator's per-executor federated scans.
+    ///
+    /// Keyed by [`normalized_table_name`] (the same canonical form the partition
+    /// store uses) so a report recorded from an executor's fully-qualified table
+    /// reference matches the bare `TableScan` reference the query planner looks
+    /// up with — a raw `TableReference` key hashes `Bare{t}` ≠ `Full{c,s,t}` and
+    /// would miss on every lookup.
     executor_statistics:
-        Arc<parking_lot::RwLock<HashMap<TableReference, HashMap<String, ExecutorTableStatistics>>>>,
+        Arc<parking_lot::RwLock<HashMap<String, HashMap<String, ExecutorTableStatistics>>>>,
 
     /// Append-only log of DDL SQL statements applied to the cluster.
     ddl_log: Arc<RwLock<DdlLog>>,
@@ -334,7 +341,7 @@ impl ExecutorRegistry {
     ) {
         self.executor_statistics
             .write()
-            .entry(table)
+            .entry(normalized_table_name(&table))
             .or_default()
             .insert(
                 executor_id,
@@ -356,7 +363,7 @@ impl ExecutorRegistry {
     ) -> HashMap<String, ExecutorTableStatistics> {
         self.executor_statistics
             .read()
-            .get(table)
+            .get(&normalized_table_name(table))
             .cloned()
             .unwrap_or_default()
     }
@@ -371,7 +378,7 @@ impl ExecutorRegistry {
     pub fn has_statistics_for(&self, table: &TableReference) -> bool {
         self.executor_statistics
             .read()
-            .get(table)
+            .get(&normalized_table_name(table))
             .is_some_and(|per_executor| !per_executor.is_empty())
     }
 
@@ -941,7 +948,7 @@ pub struct FederatedPartitionProvider {
     flight_sql_clients: Arc<RwLock<HashMap<String, FlightSqlClient>>>,
     partition_store: Arc<PartitionStore>,
     executor_statistics:
-        Arc<parking_lot::RwLock<HashMap<TableReference, HashMap<String, ExecutorTableStatistics>>>>,
+        Arc<parking_lot::RwLock<HashMap<String, HashMap<String, ExecutorTableStatistics>>>>,
     node_id: Option<Arc<str>>,
 }
 
@@ -984,7 +991,7 @@ impl TablePartitionProvider for FederatedPartitionProvider {
         let executor_statistics = self
             .executor_statistics
             .read()
-            .get(table)
+            .get(&normalized_table_name(table))
             .cloned()
             .unwrap_or_default();
 

--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -361,6 +361,20 @@ impl ExecutorRegistry {
             .unwrap_or_default()
     }
 
+    /// Returns `true` once at least one executor has reported statistics for
+    /// `table`. Used to gate a distributed table's query-readiness on having
+    /// the row-count statistics needed to size the coordinator's joins — the
+    /// report may itself carry unknown stats (the executor always reports per
+    /// served table), so this signals "we have heard from an executor", not
+    /// "the stats are usable".
+    #[must_use]
+    pub fn has_statistics_for(&self, table: &TableReference) -> bool {
+        self.executor_statistics
+            .read()
+            .get(table)
+            .is_some_and(|per_executor| !per_executor.is_empty())
+    }
+
     /// Returns the scheduler's `node_id` if one was provided at construction.
     #[must_use]
     pub fn node_id(&self) -> Option<&str> {
@@ -755,6 +769,34 @@ pub(crate) fn flight_sql_table_provider(
 /// Uses the given [`PartitionStore`] to look up partition metadata, checks readiness (both an
 /// active connection and a `FlightSQL` client) via the `executors` map, selects a minimal
 /// executor set, and returns `(FlightSQL provider, partition values)` pairs.
+/// Projects the `executor_id`'s reported statistics for `table` onto `schema`,
+/// warning when no usable plan statistics (a known `num_rows`) are available for
+/// this leaf. Absent row counts prevent DataFusion's cost-based join-side swap
+/// (`should_swap_join_order`), so a distributed plan can end up buffering the
+/// large side of a hash join — worth surfacing rather than silently degrading.
+fn stamp_executor_statistics(
+    executor_statistics: &HashMap<String, ExecutorTableStatistics>,
+    executor_id: &str,
+    table: &TableReference,
+    schema: &SchemaRef,
+) -> Option<Statistics> {
+    let statistics = executor_statistics
+        .get(executor_id)
+        .map(|ets| ets.projected_onto(schema));
+    if statistics
+        .as_ref()
+        .and_then(|s| s.num_rows.get_value())
+        .is_none()
+    {
+        tracing::warn!(
+            table = %table,
+            executor = %executor_id,
+            "No plan statistics retrieved from executor for table {table:?}; distributed join sizing may be degraded"
+        );
+    }
+    statistics
+}
+
 pub(crate) fn get_partitions_from_store(
     partition_store: &PartitionStore,
     executors: &HashMap<String, (&ExecutorConnection, &FlightSqlClient)>,
@@ -782,13 +824,17 @@ pub(crate) fn get_partitions_from_store(
         if let Some(node_id) = node_id {
             metrics::record_query_executor_count(node_id, 1);
         }
+        // Stamp the chosen executor's reported stats onto this single leaf scan
+        // so the coordinator can size joins even on this no-partition-metadata
+        // fallback path (previously this passed `None`, silently degrading plans).
+        let statistics = stamp_executor_statistics(executor_statistics, executor_id, table, schema);
         return vec![(
             flight_sql_table_provider(
                 executor_id,
                 (*client).clone(),
                 table,
                 Arc::clone(schema),
-                None,
+                statistics,
             ),
             Vec::new(),
         )];
@@ -871,9 +917,8 @@ pub(crate) fn get_partitions_from_store(
             // coordinator's planner can size joins. Project the reported per-column
             // stats onto the leaf's (possibly projected) schema by name, carrying
             // num_rows and per-column min/max.
-            let statistics = executor_statistics
-                .get(&executor_id)
-                .map(|ets| ets.projected_onto(schema));
+            let statistics =
+                stamp_executor_statistics(executor_statistics, &executor_id, table, schema);
             let provider = flight_sql_table_provider(
                 &executor_id,
                 (*client).clone(),

--- a/crates/runtime-cluster/src/lib.rs
+++ b/crates/runtime-cluster/src/lib.rs
@@ -50,4 +50,4 @@ pub use metadata::{
 pub use outbound_broadcaster::ExecutorOutboundBroadcaster;
 pub use partition_load_tracker::PartitionLoadTracker;
 pub use service::{AssignmentConfig, PartitionService};
-pub use store::{AllocationResult, AssignmentRequest, CopyAssignmentsResult, PartitionStore};
+pub use store::{AssignmentRequest, CopyAssignmentsResult, PartitionStore};

--- a/crates/runtime-cluster/src/service.rs
+++ b/crates/runtime-cluster/src/service.rs
@@ -31,6 +31,7 @@ limitations under the License.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use app::App;
@@ -192,6 +193,12 @@ pub struct PartitionService {
     pub partition_store: Arc<PartitionStore>,
     pub executor_registry: Arc<ExecutorRegistry>,
     pub app: Arc<RwLock<Option<Arc<App>>>>,
+    /// Set once the scheduler has completed its first assignment cycle. Until
+    /// then `allocate_initial_partitions` returns `Unavailable` so a connecting
+    /// executor waits for its fair share rather than loading an empty snapshot —
+    /// CDC/Changes-mode accelerations (e.g. Cayenne) only load partition data at
+    /// their initial snapshot and have no re-load path once assigned later.
+    first_assignment_complete: Arc<AtomicBool>,
 }
 
 impl PartitionService {
@@ -205,7 +212,23 @@ impl PartitionService {
             partition_store,
             executor_registry,
             app,
+            first_assignment_complete: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Whether the scheduler has completed its first assignment cycle.
+    ///
+    /// Gates `allocate_initial_partitions`: an executor waits until this is
+    /// `true` so its initial snapshot loads its assigned partitions.
+    #[must_use]
+    pub fn is_first_assignment_complete(&self) -> bool {
+        self.first_assignment_complete.load(Ordering::Acquire)
+    }
+
+    /// Mark the first assignment cycle as complete. Idempotent; called by the
+    /// periodic assignment task after its first `reconcile_all` succeeds.
+    pub fn mark_first_assignment_complete(&self) {
+        self.first_assignment_complete.store(true, Ordering::Release);
     }
 
     fn config_from_app(app: &App) -> AssignmentConfig {

--- a/crates/runtime-cluster/src/store.rs
+++ b/crates/runtime-cluster/src/store.rs
@@ -70,26 +70,6 @@ pub enum CopyAssignmentsResult {
     NoAssignments,
 }
 
-#[derive(Debug, Clone)]
-pub struct AllocationResult {
-    pub previously_assigned: Vec<PartitionValue>,
-    pub newly_assigned: Vec<PartitionValue>,
-}
-
-impl AllocationResult {
-    #[must_use]
-    pub fn all_assigned(self) -> Vec<PartitionValue> {
-        let mut all = self.previously_assigned;
-        all.extend(self.newly_assigned);
-        all
-    }
-
-    #[must_use]
-    pub fn count(&self) -> usize {
-        self.previously_assigned.len() + self.newly_assigned.len()
-    }
-}
-
 /// A single (table, partition, executor) assignment, used by the
 /// batched [`PartitionStore::apply_assignments`] API.
 #[derive(Debug, Clone)]
@@ -265,91 +245,6 @@ impl PartitionStore {
                 },
             })?;
         Ok(())
-    }
-
-    /// Allocates unassigned partitions to an executor.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the table metadata is not found, or if the cluster state mutation fails.
-    pub async fn allocate_partitions(
-        &self,
-        table: &TableReference,
-        executor_id: &str,
-        limit: usize,
-    ) -> Result<AllocationResult> {
-        let key = normalized_table_name(table);
-        let scope = self.scope;
-
-        let mut captured: Option<AllocationResult> = None;
-        let executor = executor_id.to_string();
-        let key_for_err = key.clone();
-        let res = self
-            .cluster
-            .mutate(|state| {
-                let now_ms = match crate::cluster_state::now_ms() {
-                    Ok(v) => u128::from(v),
-                    Err(e) => return MutationOutcome::Abort(e),
-                };
-                let map = scope.map_mut(state);
-                let Some(metadata) = map.get_mut(&key) else {
-                    return MutationOutcome::Abort(MutateError::Conflict {
-                        message: format!("no partition metadata for table {key}"),
-                    });
-                };
-
-                let previously_assigned: Vec<PartitionValue> = metadata
-                    .partitions
-                    .iter()
-                    .filter(|p| p.is_assigned_to(&executor))
-                    .map(|p| p.partition_value.clone())
-                    .collect();
-                let mut newly_assigned: Vec<PartitionValue> = Vec::new();
-                let mut total = previously_assigned.len();
-                let mut changes = false;
-                for partition in &mut metadata.partitions {
-                    if total >= limit {
-                        break;
-                    }
-                    if !partition.is_assigned() {
-                        partition.assign_to(executor.clone(), now_ms);
-                        newly_assigned.push(partition.partition_value.clone());
-                        total += 1;
-                        changes = true;
-                    }
-                }
-
-                let result = AllocationResult {
-                    previously_assigned,
-                    newly_assigned,
-                };
-                captured = Some(result);
-
-                if changes {
-                    metadata.updated_at = now_ms;
-                    MutationOutcome::Apply
-                } else {
-                    MutationOutcome::NoChange
-                }
-            })
-            .await
-            .map_err(|e| match e {
-                MutateError::ConcurrentModification { .. } => Error::ConcurrentModification {
-                    table: key_for_err.clone(),
-                },
-                MutateError::Conflict { message } if message.contains("no partition metadata") => {
-                    Error::TableMetadataNotFound {
-                        table: key_for_err.clone(),
-                    }
-                }
-                other => Error::MetadataAccess {
-                    table: key_for_err.clone(),
-                    source: other,
-                },
-            })?;
-
-        let _ = res;
-        captured.ok_or_else(|| Error::TableMetadataNotFound { table: key_for_err })
     }
 
     /// Assigns a single partition to an executor. Most callers should

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -121,6 +121,26 @@ pub fn get_partition_filter_exprs(
     vec![combined]
 }
 
+/// Fair-share cap for a single table's *initial* allocation to one executor.
+///
+/// Returns at most `ceil(table_partition_count / connected_executors)`, floored to
+/// `remaining_budget` (the executor's remaining per-executor soft cap). This spreads a
+/// table's partitions across all currently-connected executors instead of letting the
+/// first caller greedily claim up to the full soft cap. `connected_executors` is clamped
+/// to at least `1` (the calling executor is always connected). An empty table yields `0`
+/// and is skipped by the caller; a non-empty table always yields at least `1`.
+#[must_use]
+pub(crate) fn fair_share_limit(
+    table_partition_count: usize,
+    connected_executors: usize,
+    remaining_budget: usize,
+) -> usize {
+    let divisor = connected_executors.max(1);
+    table_partition_count
+        .div_ceil(divisor)
+        .min(remaining_budget)
+}
+
 /// Computes the per-executor [`Statistics`] for the slice of `table` this
 /// executor has accelerated locally, returning the encoded statistics bytes and
 /// the column names they're aligned to (so the coordinator can project column
@@ -276,5 +296,49 @@ fn effective_max_for_ndv(
         // Only tighten — never widen past the real max.
         (Some(syn), Some(tmax)) if &syn < tmax => Precision::Inexact(syn),
         _ => true_max,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fair_share_limit;
+
+    const BUDGET: usize = 1000;
+
+    #[test]
+    fn fair_share_even_split() {
+        assert_eq!(fair_share_limit(30, 3, BUDGET), 10);
+    }
+
+    #[test]
+    fn fair_share_rounds_up() {
+        // 10 partitions across 3 executors: ceil(10/3) = 4 so the first executors can
+        // cover the remainder rather than leaving it stranded for the next cycle.
+        assert_eq!(fair_share_limit(10, 3, BUDGET), 4);
+    }
+
+    #[test]
+    fn fair_share_more_executors_than_partitions() {
+        assert_eq!(fair_share_limit(5, 10, BUDGET), 1);
+    }
+
+    #[test]
+    fn fair_share_single_executor_gets_all() {
+        assert_eq!(fair_share_limit(30, 1, BUDGET), 30);
+    }
+
+    #[test]
+    fn fair_share_clamped_to_remaining_budget() {
+        assert_eq!(fair_share_limit(30, 3, 6), 6);
+    }
+
+    #[test]
+    fn fair_share_empty_table_is_zero() {
+        assert_eq!(fair_share_limit(0, 3, BUDGET), 0);
+    }
+
+    #[test]
+    fn fair_share_zero_executors_clamped_to_one() {
+        assert_eq!(fair_share_limit(30, 0, BUDGET), 30);
     }
 }

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -121,26 +121,6 @@ pub fn get_partition_filter_exprs(
     vec![combined]
 }
 
-/// Fair-share cap for a single table's *initial* allocation to one executor.
-///
-/// Returns at most `ceil(table_partition_count / connected_executors)`, floored to
-/// `remaining_budget` (the executor's remaining per-executor soft cap). This spreads a
-/// table's partitions across all currently-connected executors instead of letting the
-/// first caller greedily claim up to the full soft cap. `connected_executors` is clamped
-/// to at least `1` (the calling executor is always connected). An empty table yields `0`
-/// and is skipped by the caller; a non-empty table always yields at least `1`.
-#[must_use]
-pub(crate) fn fair_share_limit(
-    table_partition_count: usize,
-    connected_executors: usize,
-    remaining_budget: usize,
-) -> usize {
-    let divisor = connected_executors.max(1);
-    table_partition_count
-        .div_ceil(divisor)
-        .min(remaining_budget)
-}
-
 /// Computes the per-executor [`Statistics`] for the slice of `table` this
 /// executor has accelerated locally, returning the encoded statistics bytes and
 /// the column names they're aligned to (so the coordinator can project column
@@ -296,49 +276,5 @@ fn effective_max_for_ndv(
         // Only tighten — never widen past the real max.
         (Some(syn), Some(tmax)) if &syn < tmax => Precision::Inexact(syn),
         _ => true_max,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::fair_share_limit;
-
-    const BUDGET: usize = 1000;
-
-    #[test]
-    fn fair_share_even_split() {
-        assert_eq!(fair_share_limit(30, 3, BUDGET), 10);
-    }
-
-    #[test]
-    fn fair_share_rounds_up() {
-        // 10 partitions across 3 executors: ceil(10/3) = 4 so the first executors can
-        // cover the remainder rather than leaving it stranded for the next cycle.
-        assert_eq!(fair_share_limit(10, 3, BUDGET), 4);
-    }
-
-    #[test]
-    fn fair_share_more_executors_than_partitions() {
-        assert_eq!(fair_share_limit(5, 10, BUDGET), 1);
-    }
-
-    #[test]
-    fn fair_share_single_executor_gets_all() {
-        assert_eq!(fair_share_limit(30, 1, BUDGET), 30);
-    }
-
-    #[test]
-    fn fair_share_clamped_to_remaining_budget() {
-        assert_eq!(fair_share_limit(30, 3, 6), 6);
-    }
-
-    #[test]
-    fn fair_share_empty_table_is_zero() {
-        assert_eq!(fair_share_limit(0, 3, BUDGET), 0);
-    }
-
-    #[test]
-    fn fair_share_zero_executors_clamped_to_one() {
-        assert_eq!(fair_share_limit(30, 0, BUDGET), 30);
     }
 }

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -153,7 +153,10 @@ pub fn get_partition_filter_exprs(
 /// assignments — see `init::dataset`), so this goes through the generic table
 /// provider rather than a `PartitionTableProvider`.
 ///
-/// Best-effort: returns `None` when no statistics are available.
+/// Returns `None` only when the table has no local provider; when the provider
+/// exists but no aggregate/footer statistics are available yet, returns
+/// *unknown* statistics (num_rows `Absent`) so the executor still emits a
+/// per-table report to the coordinator.
 ///
 /// [`Statistics`]: datafusion::common::Statistics
 pub(crate) async fn local_executor_table_statistics(
@@ -194,8 +197,17 @@ pub(crate) async fn local_executor_table_statistics(
         return Some(((*stats).clone(), column_names));
     }
 
-    tracing::debug!(table = %table, "No local statistics available for executor table");
-    None
+    // Provider exists but no usable aggregate/footer stats yet. Report *unknown*
+    // stats rather than nothing so the coordinator still receives a per-table
+    // report: this lets it gate query-readiness on "heard from the executor"
+    // (see `ExecutorRegistry::has_statistics_for`) without a table that can't
+    // produce stats hanging `/v1/ready` forever. The coordinator logs a warning
+    // when the reported stats are unusable for join sizing.
+    tracing::debug!(table = %table, "No local statistics available for executor table; reporting unknown stats");
+    Some((
+        datafusion::common::Statistics::new_unknown(&schema),
+        column_names,
+    ))
 }
 
 /// Rewrite each integer column's reported max to the effective max

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -200,7 +200,14 @@ impl PartitionAssignmentTask {
         service
             .reconcile_all(self.df.as_ref())
             .await
-            .map_err(|e| Error::AssignmentCycle { source: e })
+            .map_err(|e| Error::AssignmentCycle { source: e })?;
+
+        // The first completed cycle has fairly distributed partitions across the
+        // executors connected during the startup window. Opening this gate lets
+        // `allocate_initial_partitions` return each executor its assigned share,
+        // so their initial snapshot loads the right partitions.
+        service.mark_first_assignment_complete();
+        Ok(())
     }
 
     /// Seed partition metadata for all accelerated tables that don't have metadata yet.

--- a/crates/runtime/src/cluster/partition/scheduler_task.rs
+++ b/crates/runtime/src/cluster/partition/scheduler_task.rs
@@ -108,7 +108,19 @@ impl PartitionAssignmentTask {
             }
         }
 
-        let mut interval = tokio::time::interval(self.interval);
+        // Defer the *first* assignment cycle by one full interval so executors
+        // have a window to connect before the scheduler distributes partitions.
+        // Assignment is scheduler-controlled (executors no longer allocate on
+        // connect via `allocate_initial_partitions`), so an executor that joins
+        // late — but within this window — is included in the initial fair
+        // distribution rather than being starved by peers that connected first.
+        // `tokio::time::interval` otherwise fires its first tick immediately.
+        tracing::info!(
+            delay_ms = self.interval.as_millis(),
+            "Deferring first partition assignment cycle to let executors connect"
+        );
+        let start = tokio::time::Instant::now() + self.interval;
+        let mut interval = tokio::time::interval_at(start, self.interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -64,7 +64,6 @@ use runtime_proto::{
 };
 use runtime_secrets::Secrets;
 use secrecy::ExposeSecret;
-use spicepod::component::runtime;
 use std::collections::{HashMap, HashSet};
 use std::task::{Context, Poll};
 use tokio::sync::RwLock as TokioRwLock;
@@ -668,6 +667,24 @@ impl ClusterService for ClusterServiceImpl {
             return Err(Status::unavailable(format!(
                 "partition metadata not ready: accelerated table {not_ready} still loading"
             )));
+        }
+
+        // Gate on the scheduler's first assignment cycle. Returning already-assigned
+        // partitions before the scheduler has fairly distributed them would hand this
+        // executor an empty set, and its initial snapshot would load zero rows with no
+        // way to backfill (CDC/Changes-mode accelerations only load partition data at
+        // the initial snapshot). Wait for the first cycle — the executor retries this
+        // RPC on `Unavailable` with backoff — so the returned share is the fair one.
+        if let Some(partition_service) = self.datafusion.partition_service.as_ref()
+            && !partition_service.is_first_assignment_complete()
+        {
+            tracing::debug!(
+                executor = %executor_id,
+                "Deferring allocate_initial_partitions: first assignment cycle not yet complete"
+            );
+            return Err(Status::unavailable(
+                "partition assignment pending: scheduler has not completed its first assignment cycle",
+            ));
         }
 
         let tls_config_opt = self.datafusion.cluster_config.client_tls_config();

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -695,6 +695,16 @@ impl ClusterService for ClusterServiceImpl {
                 |scheduler| scheduler.max_partitions_per_executor,
             );
 
+            // Fair-share divisor: peers register their control stream before calling
+            // this RPC, so the connected count already reflects executors that will
+            // pull shortly. Each table is capped at its fair slice so the first caller
+            // can't greedily claim every partition; the balancer mops up any remainder.
+            let connected_executors = self
+                .executor_registry()
+                .connected_executor_count()
+                .await
+                .max(1);
+
             // Find accelerated datasets with partitioning
             for table_ref in super::partition::accelerated_tables(app).keys() {
                 if total_assigned >= max_partitions_per_executor {
@@ -705,17 +715,19 @@ impl ClusterService for ClusterServiceImpl {
                 }
                 let remaining = max_partitions_per_executor.saturating_sub(total_assigned);
 
-                if partition_store
-                    .get_cached_table_metadata(table_ref)
-                    .is_none()
-                {
+                let Some(metadata) = partition_store.get_cached_table_metadata(table_ref) else {
                     tracing::info!(
                         "No cached partition metadata for table {table_ref}. Scheduler likely has not finished discovering partitions for the table. Will not assign in initial allocation, but will get assigned on future assignments"
                     );
                     continue;
-                }
+                };
+                let limit = super::partition::fair_share_limit(
+                    metadata.partitions.len(),
+                    connected_executors,
+                    remaining,
+                );
                 match partition_store
-                    .allocate_partitions(table_ref, executor_id, remaining)
+                    .allocate_partitions(table_ref, executor_id, limit)
                     .await
                 {
                     Ok(result) => {

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -688,87 +688,49 @@ impl ClusterService for ClusterServiceImpl {
 
         let partition_store = self.executor_registry().accelerations_partition_store();
         let app_guard = self.app.read().await;
-        let mut total_assigned: usize = 0;
         if let Some(app) = app_guard.as_ref() {
-            let max_partitions_per_executor = app.runtime.scheduler.as_ref().map_or(
-                runtime::default_max_partitions_per_executor(),
-                |scheduler| scheduler.max_partitions_per_executor,
-            );
-
-            // Fair-share divisor: peers register their control stream before calling
-            // this RPC, so the connected count already reflects executors that will
-            // pull shortly. Each table is capped at its fair slice so the first caller
-            // can't greedily claim every partition; the balancer mops up any remainder.
-            let connected_executors = self
-                .executor_registry()
-                .connected_executor_count()
-                .await
-                .max(1);
-
-            // Find accelerated datasets with partitioning
+            // Partition assignment is driven solely by the scheduler's periodic
+            // partition-assignment cycle, which fairly distributes partitions
+            // across all connected executors and pushes them over the control
+            // stream (`notify_executor_of_assignments`). This RPC no longer
+            // allocates — it only returns partitions *already assigned* to this
+            // executor so a reconnecting or failed-over executor recovers its
+            // existing assignments. On a cold start this is empty; the first
+            // assignment cycle assigns and pushes shortly after.
             for table_ref in super::partition::accelerated_tables(app).keys() {
-                if total_assigned >= max_partitions_per_executor {
-                    tracing::debug!(
-                        "Executor {executor_id} reached max_partitions_per_executor ({max_partitions_per_executor}) during initial allocation, skipping remaining tables"
-                    );
-                    break;
-                }
-                let remaining = max_partitions_per_executor.saturating_sub(total_assigned);
-
                 let Some(metadata) = partition_store.get_cached_table_metadata(table_ref) else {
-                    tracing::info!(
-                        "No cached partition metadata for table {table_ref}. Scheduler likely has not finished discovering partitions for the table. Will not assign in initial allocation, but will get assigned on future assignments"
-                    );
                     continue;
                 };
-                let limit = super::partition::fair_share_limit(
-                    metadata.partitions.len(),
-                    connected_executors,
-                    remaining,
-                );
-                match partition_store
-                    .allocate_partitions(table_ref, executor_id, limit)
+                let mut items = Vec::new();
+                for partition in &metadata.partitions {
+                    if !partition.is_assigned_to(executor_id) {
+                        continue;
+                    }
+                    match partition_value_to_bytes(
+                        partition.partition_value.clone(),
+                        table_ref,
+                        self.datafusion.as_ref(),
+                    )
                     .await
-                {
-                    Ok(result) => {
-                        let newly_assigned = result.newly_assigned.len();
-                        let partitions = result.all_assigned();
-                        if partitions.is_empty() {
-                            continue;
+                    {
+                        Ok(bytes) => items.push(bytes.to_vec()),
+                        Err(e) => {
+                            // The readiness gate above should make this path
+                            // unreachable for the dataset-not-ready case.
+                            // Anything that lands here is a real bug (corrupt
+                            // expression, etc.) — fail loud rather than silently
+                            // dropping the partition.
+                            tracing::error!(
+                                "Failed to serialize partition expression for table {table_ref}: {e}"
+                            );
+                            return Err(Status::internal(format!(
+                                "Failed to serialize partition expression for table {table_ref}: {e}"
+                            )));
                         }
-                        let mut items = Vec::with_capacity(partitions.len());
-                        for partition in &partitions {
-                            match partition_value_to_bytes(
-                                partition.clone(),
-                                table_ref,
-                                self.datafusion.as_ref(),
-                            )
-                            .await
-                            {
-                                Ok(bytes) => items.push(bytes.to_vec()),
-                                Err(e) => {
-                                    // The readiness gate above should make this
-                                    // path unreachable for the dataset-not-ready
-                                    // case. Anything that lands here is a real
-                                    // bug (corrupt expression, etc.) — fail loud
-                                    // rather than silently dropping the partition.
-                                    tracing::error!(
-                                        "Failed to serialize partition expression for table {table_ref}: {e}"
-                                    );
-                                    return Err(Status::internal(format!(
-                                        "Failed to serialize partition expression for table {table_ref}: {e}"
-                                    )));
-                                }
-                            }
-                        }
-                        total_assigned += newly_assigned;
-                        table_partitions.insert(table_ref.to_string(), BytesArray { items });
                     }
-                    Err(e) => {
-                        tracing::error!(
-                            "Failed to allocate partitions for table {table_ref} to executor {executor_id}: {e}",
-                        );
-                    }
+                }
+                if !items.is_empty() {
+                    table_partitions.insert(table_ref.to_string(), BytesArray { items });
                 }
             }
         }

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -865,7 +865,7 @@ async fn handle_executor_message(
             handle_partitions_loaded(executor_id, loaded, datafusion).await;
         }
         ExecutorMessage::ExecutorStatistics(stats_msg) => {
-            handle_executor_statistics(executor_id, stats_msg, datafusion);
+            handle_executor_statistics(executor_id, stats_msg, datafusion).await;
         }
         ExecutorMessage::Shutdown(shutdown) => {
             let reason = if shutdown.reason.is_empty() {
@@ -920,8 +920,11 @@ async fn notify_scheduler_executor_shutdown(
 
 /// Records a per-table [`ExecutorStatistics`] report into the scheduler's
 /// in-memory `ExecutorRegistry`, where it's read at query-planning time to size
-/// the coordinator's per-executor federated scans. Decoupled from readiness.
-fn handle_executor_statistics(
+/// the coordinator's per-executor federated scans. Also re-evaluates the
+/// table's readiness: `evaluate_table_readiness` gates `Ready` on the first
+/// stats report, so a table whose partitions loaded before its stats arrived
+/// flips to `Ready` here rather than waiting for the next periodic sweep.
+async fn handle_executor_statistics(
     executor_id: &str,
     msg: &runtime_proto::ExecutorStatistics,
     datafusion: &DataFusion,
@@ -936,11 +939,12 @@ fn handle_executor_statistics(
     let stats = runtime_cluster::decode_statistics(&msg.statistics);
     if let (Some(stats), Some(registry)) = (stats, datafusion.executor_registry()) {
         registry.record_executor_statistics(
-            table,
+            table.clone(),
             executor_id.to_string(),
             stats,
             msg.column_names.clone(),
         );
+        evaluate_table_readiness(datafusion, &table).await;
     }
 }
 
@@ -1087,6 +1091,24 @@ pub(crate) async fn evaluate_table_readiness(datafusion: &DataFusion, table: &Ta
     };
 
     if tracker.is_table_loaded(table, &metadata, datafusion).await {
+        // Gate readiness on having received at least one executor statistics
+        // report for this table. Distributed query plans need the reported
+        // row-count statistics to size joins (so DataFusion's cost-based swap
+        // builds the small side of a hash join rather than the large one); a
+        // table marked `Ready` before stats arrive can plan a query that
+        // exhausts the memory pool. The executor always reports per served
+        // table (unknown stats when unavailable — see
+        // `local_executor_table_statistics`), so a loaded table can't hang
+        // here. Only gates distributed mode: single-node has no registry.
+        if let Some(registry) = datafusion.executor_registry()
+            && !registry.has_statistics_for(table)
+        {
+            tracing::debug!(
+                table = %table,
+                "All assigned partitions loaded but awaiting first executor statistics report before marking Ready"
+            );
+            return;
+        }
         tracing::info!(
             table = %table,
             "All assigned partitions loaded; marking dataset Ready"

--- a/crates/runtime/src/datafusion/sync_table.rs
+++ b/crates/runtime/src/datafusion/sync_table.rs
@@ -36,6 +36,7 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use cayenne::catalog_provider::CayenneSchemaProvider;
 use data_components::iceberg::provider::IcebergSchemaProvider;
 use datafusion::catalog::{SchemaProvider, TableProvider};
 use runtime_datafusion::schema_provider::SpiceSchemaProvider;
@@ -59,6 +60,12 @@ impl SyncTableProvider for IcebergSchemaProvider {
     }
 }
 
+impl SyncTableProvider for CayenneSchemaProvider {
+    fn sync_table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        self.table_sync(name)
+    }
+}
+
 /// Views a `dyn SchemaProvider` as a [`SyncTableProvider`] when its concrete
 /// type supports synchronous resolution. One entry per supporting type — this
 /// list is the single extension point for adding a catalog's synchronous tables.
@@ -73,6 +80,10 @@ const SYNC_CASTS: &[SyncCast] = &[
     },
     |s| {
         s.downcast_ref::<IcebergSchemaProvider>()
+            .map(|p| p as &dyn SyncTableProvider)
+    },
+    |s| {
+        s.downcast_ref::<CayenneSchemaProvider>()
             .map(|p| p as &dyn SyncTableProvider)
     },
 ];

--- a/crates/runtime/src/executor_table.rs
+++ b/crates/runtime/src/executor_table.rs
@@ -47,7 +47,7 @@ use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::sql::client::FlightSqlServiceClient;
 use arrow_schema::SchemaRef;
 use datafusion::catalog::{TableFunctionImpl, TableProvider};
-use datafusion::common::{DataFusionError, Result as DataFusionResult};
+use datafusion::common::{DataFusionError, Result as DataFusionResult, Statistics};
 use datafusion::logical_expr::Expr;
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::TableReference;
@@ -152,13 +152,24 @@ impl TableFunctionImpl for ExecutorTableFunc {
         let client = build_peer_client(&endpoint, df.cluster_config.client_tls_config())?;
         let cookie_store = Arc::new(CookieStore::new());
 
-        Ok(Arc::new(FlightSQLTable::create_with_schema(
-            EXECUTOR_TABLE_UDTF_NAME,
-            &endpoint,
-            client,
-            table_ref,
-            schema,
-            cookie_store,
-        )))
+        // Stamp the LOCAL provider's statistics onto the peer scan, downgraded
+        // to inexact: the peer serves a different partition slice, but slices
+        // are of comparable size, so the local numbers are a usable estimate.
+        // Without any statistics this scan is an unknown-cardinality leaf, and
+        // the executor's `JoinSelection` can never cost-swap a join between a
+        // gathered broadcast dimension and its local (exact-stats) fact slice.
+        let statistics = provider.statistics().map(Statistics::to_inexact);
+
+        Ok(Arc::new(
+            FlightSQLTable::create_with_schema(
+                EXECUTOR_TABLE_UDTF_NAME,
+                &endpoint,
+                client,
+                table_ref,
+                schema,
+                cookie_store,
+            )
+            .with_statistics(statistics),
+        ))
     }
 }

--- a/crates/runtime/src/executor_table.rs
+++ b/crates/runtime/src/executor_table.rs
@@ -18,7 +18,8 @@ limitations under the License.
 //! a single peer executor's partition of a table over Flight SQL.
 //!
 //! This is the primitive behind distributed broadcast joins on the
-//! distributed-acceleration (Cayenne catalog) path. Each executor physically
+//! distributed-acceleration paths (both Cayenne catalog tables and accelerated
+//! datasets in the default `spice.public` schema). Each executor physically
 //! holds only its assigned partition of a table, so a plain `SELECT * FROM t`
 //! issued to one executor returns just that executor's slice. A small dimension
 //! table can therefore be reconstructed in full on ANY node by UNION-ing
@@ -56,7 +57,6 @@ use flight_client::{
 };
 use tonic::transport::{ClientTlsConfig, Endpoint};
 
-use cayenne::catalog_provider::CayenneSchemaProvider;
 use data_components::flightsql::{FlightSQLTable, FlightSqlClient};
 
 use crate::datafusion::DataFusion;
@@ -135,41 +135,18 @@ impl TableFunctionImpl for ExecutorTableFunc {
             )
         })?;
 
-        // Resolve the schema SYNCHRONOUSLY from the LOCAL catalog. `get_table_sync`
-        // only sees `SpiceSchemaProvider` tables (not external catalogs like
-        // Cayenne), and the generic `SchemaProvider::table()` is async — so
-        // resolve the catalog/schema (both sync) and read the Cayenne schema
-        // provider's in-memory table cache directly via `table_sync`.
-        let cat_name = table_ref.catalog().ok_or_else(|| {
+        // Resolve the schema SYNCHRONOUSLY from the LOCAL catalog (every node
+        // shares the table definition; only the data is partitioned).
+        // `get_table_sync` resolves bare/partial references against the default
+        // `spice.public` catalog — matching how the coordinator's planner
+        // resolved the same reference when it rendered this SQL — and covers
+        // every cached schema provider (`SpiceSchemaProvider` for accelerated
+        // datasets, Cayenne catalog schemas, Iceberg) via `sync_table`.
+        let provider = df.get_table_sync(&table_ref).ok_or_else(|| {
             DataFusionError::Plan(format!(
-                "executor_table: table '{table_str}' must be catalog-qualified"
+                "executor_table: table '{table_str}' not found locally"
             ))
         })?;
-        let sch_name = table_ref.schema().ok_or_else(|| {
-            DataFusionError::Plan(format!(
-                "executor_table: table '{table_str}' must be schema-qualified"
-            ))
-        })?;
-        let catalog = df.ctx.catalog(cat_name).ok_or_else(|| {
-            DataFusionError::Plan(format!("executor_table: catalog '{cat_name}' not found"))
-        })?;
-        let schema_provider = catalog.schema(sch_name).ok_or_else(|| {
-            DataFusionError::Plan(format!("executor_table: schema '{sch_name}' not found"))
-        })?;
-        let cayenne_schema = schema_provider
-            .downcast_ref::<CayenneSchemaProvider>()
-            .ok_or_else(|| {
-                DataFusionError::Plan(format!(
-                    "executor_table: schema '{cat_name}.{sch_name}' is not a Cayenne catalog schema"
-                ))
-            })?;
-        let provider = cayenne_schema
-            .table_sync(table_ref.table())
-            .ok_or_else(|| {
-                DataFusionError::Plan(format!(
-                    "executor_table: table '{table_str}' not found locally"
-                ))
-            })?;
         let schema: SchemaRef = provider.schema();
 
         let client = build_peer_client(&endpoint, df.cluster_config.client_tls_config())?;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -906,6 +906,26 @@ impl Runtime {
         table: ResolvedTableReference,
         assignments: &PartitionAssignments,
     ) -> Result<()> {
+        let table_ref = TableReference::full(
+            Arc::<str>::clone(&table.catalog),
+            Arc::<str>::clone(&table.schema),
+            Arc::<str>::clone(&table.table),
+        );
+
+        // During startup the scheduler can push an assignment before this
+        // executor has registered the table — it's still blocked in
+        // `allocate_initial_partitions` ahead of `executor_bind_app`/dataset
+        // load. Skip cleanly rather than erroring (which NACKs the scheduler and
+        // triggers retries): the table's initial snapshot reads its filters from
+        // the assignments map (see `init::dataset`) once it loads, so the
+        // partitions are applied without this path.
+        if !self.datafusion().table_exists(&table_ref) {
+            tracing::debug!(
+                "Deferring partition filter update for {table}: table not yet registered"
+            );
+            return Ok(());
+        }
+
         // This path runs only in executor partitioned mode, so the table is
         // always partition-scoped: wrap in `Some`. An empty result here means no
         // partition is assigned to this executor, which resolves to a `false`
@@ -915,11 +935,6 @@ impl Runtime {
             assignments,
         ));
 
-        let table_ref = TableReference::full(
-            Arc::<str>::clone(&table.catalog),
-            Arc::<str>::clone(&table.schema),
-            Arc::<str>::clone(&table.table),
-        );
         // Propagate the filter-update error so the caller (and the executor's
         // ack to the scheduler) sees the failure rather than just logging it.
         self.datafusion()

--- a/crates/runtime/tests/cluster/distributed_acceleration.rs
+++ b/crates/runtime/tests/cluster/distributed_acceleration.rs
@@ -440,6 +440,26 @@ async fn test_distributed_acceleration_multi_executor() -> Result<(), anyhow::Er
             harness.wait_for_executors(Duration::from_secs(15)).await?;
             wait_for_row_count(&harness, "test_data", 10, Duration::from_mins(1)).await?;
 
+            // Fair-share allocation: the 5 bucket(4, id) partitions must be spread
+            // across both executors rather than one executor greedily claiming all of
+            // them. All 10 rows being queryable means every partition is assigned and
+            // loaded, so ownership counts are stable to read here.
+            let owner_counts = harness.partition_owner_counts("test_data");
+            let total_assigned: usize = owner_counts.values().sum();
+            assert_eq!(
+                total_assigned, 5,
+                "all 5 partitions should be assigned exactly once: {owner_counts:?}"
+            );
+            assert_eq!(
+                owner_counts.len(),
+                2,
+                "partitions should be spread across both executors, not hoarded by one: {owner_counts:?}"
+            );
+            assert!(
+                owner_counts.values().all(|&count| (1..=3).contains(&count)),
+                "each executor should own its fair share (1..=3 of 5 partitions): {owner_counts:?}"
+            );
+
             // --- SELECT all rows ---
             let select_all_sql = "SELECT id, name, age, city, score FROM test_data ORDER BY id";
 

--- a/crates/runtime/tests/cluster/harness.rs
+++ b/crates/runtime/tests/cluster/harness.rs
@@ -169,6 +169,33 @@ impl ClusterHarness {
             .await
     }
 
+    /// Per-executor partition counts for `table`, read from the scheduler's
+    /// authoritative accelerations partition store. Keyed by executor id; the
+    /// value is how many of the table's partitions that executor owns.
+    ///
+    /// Returns an empty map if the scheduler has no executor registry or has no
+    /// cached partition metadata for the table yet.
+    #[must_use]
+    pub fn partition_owner_counts(&self, table: &str) -> std::collections::HashMap<String, usize> {
+        let mut counts = std::collections::HashMap::new();
+        let Some(registry) = self.executor_registry.as_ref() else {
+            return counts;
+        };
+        let table_ref = datafusion::sql::TableReference::parse_str(table);
+        let Some(metadata) = registry
+            .accelerations_partition_store()
+            .get_cached_table_metadata(&table_ref)
+        else {
+            return counts;
+        };
+        for partition in &metadata.partitions {
+            for executor in &partition.assigned_executors {
+                *counts.entry(executor.clone()).or_default() += 1;
+            }
+        }
+        counts
+    }
+
     /// Block until exactly `expected` executors are registered with the scheduler,
     /// or return an error after `timeout`.
     ///


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Expands broadcast join support from being limited to only Cayenne catalog tables (which are deprecated/removed) to `spice.public` accelerated datasets - for distributed accelerations to support broadcast joins
* Updates schema retrieval to remove duplicate code by using the DataFusion `get_table_sync` instead
* Update the broadcast join optimizer to render dimension tables first in the broadcast join - as dimension tables are inexact, the join selection optimizer will not rewrite joins in executors when comparing inexact vs exact statistics. This caused executors to previously hash build the entire fact table, instead of the smaller dimension table.