### PR TITLE
Cayenne transactions (3/9): serializable executor with off-lock optimistic concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,6 +3534,7 @@ dependencies = [
  "roaring",
  "rstest 0.26.1",
  "runtime-datafusion",
+ "runtime-request-context",
  "runtime-table-partition",
  "rusqlite",
  "rustc-hash 2.1.2",

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -40,6 +40,7 @@ object_store = { workspace = true }
 parking_lot = { workspace = true }
 roaring = { workspace = true }
 runtime-datafusion = { path = "../runtime-datafusion" }
+runtime-request-context = { path = "../runtime-request-context" }
 runtime-table-partition = { path = "../runtime-table-partition", optional = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }

--- a/crates/cayenne/src/lib.rs
+++ b/crates/cayenne/src/lib.rs
@@ -98,7 +98,8 @@ pub use metadata::{
 pub use metastore::sqlite::{SqliteAutoVacuum, SqliteMetastoreConfig, set_sqlite_metastore_config};
 pub use provider::constants::{STAGING_DIR_NAME, STAGING_WAL_FILENAME, STAGING_WAL_TMP_FILENAME};
 pub use provider::{
-    CayenneCdcWrite, CayenneContext, CayenneStagedAppend, CayenneStagedUpsert, CayenneTableProvider,
+    CayenneCdcWrite, CayenneTransaction, CayenneContext, CayenneStagedAppend,
+    CayenneStagedUpsert, CayenneTableProvider,
     CayenneTableProviderBuilder, EncodeBudgetSnapshot, PARTITIONED_WAL_DIR, PartitionedWal,
     PartitionedWalEntry, PreparedOverwrite, PreparedStagedAppend, QueryObservations, SlotAdvancer,
     TimeRetentionFilterBuilder, begin_compaction_shutdown, cap_global_encode_concurrency,

--- a/crates/cayenne/src/provider/mod.rs
+++ b/crates/cayenne/src/provider/mod.rs
@@ -75,6 +75,7 @@ pub(crate) mod cold_partition;
 pub(crate) mod column_stats;
 pub(crate) mod compaction;
 pub(crate) mod compaction_writer;
+pub(crate) mod transaction;
 pub(crate) mod constants;
 pub(crate) mod context;
 pub(crate) mod delete;
@@ -116,6 +117,7 @@ pub use compaction::{
     begin_compaction_shutdown, drain_compaction_tasks, in_flight_compaction_tasks,
     reset_compaction_shutdown, set_compaction_runtime_env, set_compaction_runtime_handle,
 };
+pub use transaction::CayenneTransaction;
 pub use context::CayenneContext;
 pub use mem_tier::SlotAdvancer;
 pub use mem_tier_budget::{
@@ -245,6 +247,12 @@ pub enum Error {
     /// Operation is not yet implemented.
     #[snafu(display("Unsupported operation: {operation}"))]
     Unsupported { operation: &'static str },
+
+    /// A transaction lost an optimistic-concurrency race: the
+    /// target table was committed to between this transaction's start and its
+    /// commit. Retryable at the newest committed state.
+    #[snafu(display("Transaction write conflict on table '{table}': the table changed since the transaction started; retry"))]
+    WriteConflict { table: String },
 
     /// Invalid number of children provided to an execution plan.
     #[snafu(display(

--- a/crates/cayenne/src/provider/on_conflict.rs
+++ b/crates/cayenne/src/provider/on_conflict.rs
@@ -867,6 +867,13 @@ pub(crate) struct OnConflictValidationStream {
     pub(crate) deleted_inlined_row_keys: Vec<Box<[u8]>>,
     reinserted_over_tombstone: usize,
     post_validation: Arc<ParkingMutex<Option<PostValidationState>>>,
+    /// Whether the validation keyset is stored back into the table's shared PK
+    /// index cache when the stream finishes. `true` for the ordinary write path
+    /// (the keyset was taken from the shared cache and is returned). `false` for
+    /// off-lock conditional-commit staging, which validates against a **private**
+    /// keyset without holding `write_lock` — storing it back would clobber a
+    /// concurrent ordinary writer's cache update and drop committed keys.
+    store_back: bool,
     finalized: bool,
 }
 
@@ -879,6 +886,7 @@ impl OnConflictValidationStream {
         existing_keys: CachedPkIndex,
         on_conflict: OnConflict,
         post_validation: Arc<ParkingMutex<Option<PostValidationState>>>,
+        store_back: bool,
     ) -> Self {
         let schema = inner.schema();
         let upsert_options = on_conflict.get_upsert_options();
@@ -900,6 +908,7 @@ impl OnConflictValidationStream {
             deleted_inlined_row_keys: Vec::new(),
             reinserted_over_tombstone: 0,
             post_validation,
+            store_back,
             finalized: false,
         }
     }
@@ -969,7 +978,10 @@ impl OnConflictValidationStream {
     }
 
     fn store_existing_keyset(&mut self) {
-        if let Some(existing_keys) = self.existing_keys.take() {
+        let existing_keys = self.existing_keys.take();
+        // Off-lock staging validates against a private keyset and must never
+        // publish it to the shared cache (see `store_back`). Drop it instead.
+        if self.store_back && let Some(existing_keys) = existing_keys {
             self.table.store_cached_pk_index(existing_keys);
         }
     }

--- a/crates/cayenne/src/provider/sink.rs
+++ b/crates/cayenne/src/provider/sink.rs
@@ -30,6 +30,9 @@ use datafusion_execution::TaskContext;
 use datafusion_expr::dml::InsertOp;
 use futures::StreamExt;
 
+use runtime_datafusion::extension::request_context::resolve_request_context;
+
+use super::transaction::CayenneTransaction;
 use super::context::CayenneContext;
 use super::mutation_writer::AppendMutationWriter;
 use super::table::CayenneTableProvider;
@@ -153,6 +156,18 @@ impl DataSink for CayenneDataSink {
             }),
         ));
 
+        // Transaction: when one is active for this table on
+        // the request context, the write must STAGE rather than publish, so the
+        // executor can publish it atomically at COMMIT (or roll it back). This is
+        // checked before the memory-mode and streaming-publish branches below,
+        // both of which publish immediately.
+        if let Some(txn) = self.active_transaction(context) {
+            return self
+                .write_all_transaction(&txn, normalized, context)
+                .await
+                .map_err(Into::into);
+        }
+
         // Memory mode (`mode: memory`): all data lives in the RAM mem-tier, so
         // collect the stream and route it there — an atomic replace on
         // overwrite/full refresh, otherwise an append. Nothing is ever encoded to
@@ -221,6 +236,77 @@ impl DataSink for CayenneDataSink {
 }
 
 impl CayenneDataSink {
+    /// Resolve the transaction active on this write's request
+    /// context, if any.
+    ///
+    /// Reads it from the [`runtime_request_context::RequestContext`] typed
+    /// extension on the task context (source 1 of `resolve_request_context`) —
+    /// the exact context the query builder installed — rather than the
+    /// task-local `RequestContext::current`, whose silent internal-context
+    /// fallback would make a missed installation publish immediately (an
+    /// undetectable atomicity break). Returns the transaction regardless of its
+    /// target table; [`Self::write_all_transaction`] enforces the table match
+    /// (fail-closed).
+    fn active_transaction(
+        &self,
+        context: &Arc<TaskContext>,
+    ) -> Option<CayenneTransaction> {
+        resolve_request_context(context, false)?.extension::<CayenneTransaction>()
+    }
+
+    /// Stage a write for an active transaction instead of
+    /// publishing it: take the transaction's pre-acquired write guard, stage the
+    /// rows to an invisible snapshot via
+    /// [`CayenneTableProvider::begin_staged_upsert_with_guard`], and register the
+    /// handle on the transaction. The executor publishes (or rolls back) at
+    /// COMMIT.
+    ///
+    /// Fail-closed: any shape the staged-upsert substrate cannot publish
+    /// atomically — a write to a different table, an overwrite, a memory-mode
+    /// table, or a second write in the same transaction — is rejected rather
+    /// than silently published.
+    async fn write_all_transaction(
+        &self,
+        txn: &CayenneTransaction,
+        data: SendableRecordBatchStream,
+        context: &Arc<TaskContext>,
+    ) -> super::Result<u64> {
+        if txn.table_id() != self.table.table_id() {
+            return Err(super::Error::Unsupported {
+                operation:
+                    "transaction write to a table other than the transaction's target",
+            });
+        }
+        if self.overwrite != InsertOp::Append {
+            return Err(super::Error::Unsupported {
+                operation: "transaction overwrite write",
+            });
+        }
+        if self.table.is_memory_resident_mode() {
+            return Err(super::Error::Unsupported {
+                operation: "transaction write on a memory-mode table",
+            });
+        }
+        // `None` here means the transaction is no longer armed — a second write
+        // in the same body (v1 supports exactly one). Reject rather than publish.
+        let Some(token) = txn.take_token() else {
+            return Err(super::Error::Unsupported {
+                operation: "transaction with more than one write statement",
+            });
+        };
+        let target_partitions = context.session_config().target_partitions();
+        // Off-lock staging: encode into an invisible snapshot without holding the
+        // write lock. The executor publishes (or rolls back) at COMMIT, where the
+        // token is re-checked for an optimistic-concurrency conflict.
+        let staged = self
+            .table
+            .begin_staged_upsert_occ(token, data, target_partitions)
+            .await?;
+        let row_count = staged.row_count();
+        txn.set_staged(staged);
+        Ok(row_count)
+    }
+
     /// Append with bounded ingest-to-queryable latency: consume the input in
     /// segments, each capped by age (`interval`, measured from the segment's
     /// first buffered batch) and by in-memory size, and run the full existing

--- a/crates/cayenne/src/provider/staged_upsert.rs
+++ b/crates/cayenne/src/provider/staged_upsert.rs
@@ -14,48 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Staged **upsert** lifecycle for `CayenneTableProvider` (Analytical Replica
-//! dual-apply).
+//! Staged **upsert** lifecycle for `CayenneTableProvider`: a PK/on-conflict
+//! write is encoded into a fresh, **unreferenced** snapshot directory
+//! (invisible to readers) and published — or discarded — at a later moment.
+//! It is a split of the synchronous on-conflict path at the listing fence.
 //!
-//! [`super::staging_wal::CayenneStagedAppend`] stages append-only writes; it
-//! rejects primary-key / on-conflict tables. This module adds the PK-aware
-//! counterpart: a write into a table with a primary key and `on_conflict`
-//! upsert is staged **invisibly** and published (or discarded) at a later
-//! moment — the point at which the dual-apply driver has an ack (or a failure)
-//! from the federated source.
+//! Staging is **off-lock optimistic** ([`CayenneTableProvider::begin_staged_upsert_occ`]):
+//! validation (private keyset) + Vortex encode run **without** `write_lock`, so
+//! many transactions stage concurrently; the lock is taken only at
+//! [`CayenneStagedUpsert::commit`], briefly, to re-check the optimistic-concurrency
+//! token and publish. Detection is at per-table granularity: if any commit landed
+//! on the table between the token capture (at transaction begin, before the gate
+//! read) and this commit, the sequence high-water moved → the commit aborts with
+//! [`Error::WriteConflict`] (a retryable conflict) rather than risking a lost
+//! update.
 //!
-//! It is a split of the synchronous on-conflict path
-//! ([`CayenneTableProvider::write_new_snapshot_after_validation`]) at the
-//! listing fence:
+//! [`CayenneStagedUpsert::commit`] runs the fenced publish: apply the
+//! on-conflict deletions, reserve the protected-snapshot sequence (strictly
+//! above the delete sequence, so the staged rows survive their own conflict
+//! deletes), durably record it, then flip the deletion caches and the protected
+//! snapshot in one listing-fence write. [`CayenneStagedUpsert::rollback`]
+//! discards the staged snapshot directory.
 //!
-//! - [`CayenneTableProvider::begin_staged_upsert`] validates the incoming rows
-//!   for PK conflicts and writes them into a fresh, **unreferenced** snapshot
-//!   directory (`{table_id}/{new_snapshot}/`). Nothing durable in the catalog
-//!   is touched, so the rows are invisible to every reader and there is nothing
-//!   to compensate on abort. The captured [`OnConflictDeletions`] (which prior
-//!   versions this write supersedes) rides the returned handle.
-//! - [`CayenneStagedUpsert::commit`] runs the fenced publish: apply the
-//!   on-conflict deletions, reserve the protected-snapshot sequence (strictly
-//!   above the delete sequence, so the staged rows survive their own conflict
-//!   deletes), durably record it, then flip the deletion caches and the
-//!   protected snapshot in one listing-fence write. After this the rows are
-//!   visible.
-//! - [`CayenneStagedUpsert::rollback`] discards the staged snapshot directory.
+//! Sequence stamping is deferred by construction: the sync path already reserves
+//! every sequence at publish time, and the protected snapshot's deletion
+//! threshold is its own (highest) sequence, so a commit that lands between stage
+//! and publish never mis-orders the staged rows.
 //!
-//! Sequence stamping is deferred by construction: the sync path already
-//! reserves every sequence at publish time, and the protected snapshot's
-//! deletion threshold is its own (highest) sequence, so a commit that lands
-//! between stage and publish never mis-orders the staged rows.
-//!
-//! The stage is deliberately **not** durable: the federated source is the
-//! system of record and CDC (`refresh_mode: changes`) is the crash backstop, so
-//! a crash before commit simply drops the staged directory (recovered, if the
-//! source committed, by CDC replay).
+//! The stage is deliberately **not** durable: the federated source is the system
+//! of record and CDC (`refresh_mode: changes`) is the crash backstop, so a crash
+//! before commit simply drops the staged directory.
 
 use std::sync::Arc;
 
 use datafusion::execution::SendableRecordBatchStream;
-use tokio::sync::OwnedMutexGuard;
 
 use super::Error;
 use super::Result;
@@ -65,15 +57,45 @@ use super::on_conflict::{OnConflictDeletions, PostValidationState};
 use super::pk_index::PkDigestSet;
 use super::table::CayenneTableProvider;
 
-/// A staged upsert: the replacement rows have been written to a fresh snapshot
-/// directory, but no catalog visibility change has been made yet.
+/// Optimistic-concurrency token for an off-lock transaction write.
 ///
-/// The handle owns the table's write guard, so concurrent writers on the same
-/// table block until it is either committed via [`Self::commit`] or discarded
-/// via [`Self::rollback`] (or dropped — see the note on `Drop`).
+/// Captured at transaction **begin** (before the gate read) under a brief
+/// `write_lock` hold, and re-checked at commit under `write_lock`. It is the
+/// per-table sequence high-water plus a "no staging append in flight" bit —
+/// together, everything that changes key liveness on the table either advances
+/// the sequence or sets the staging bit, so an unchanged token at commit proves
+/// no intervening commit touched the table (see the module docs).
+#[derive(Debug, Clone, Copy)]
+pub struct TransactionWriteToken {
+    /// The table's sequence high-water at capture (`allocator.next - 1`).
+    stage_seq: i64,
+    /// Whether no pipelined staging append was in flight at capture. A staging
+    /// append's Stage-B finalize publishes without drawing a sequence, so it is
+    /// covered by this bit rather than by `stage_seq`.
+    staging_clean: bool,
+}
+
+/// The staged bits: rows written to a fresh invisible snapshot dir, plus the
+/// on-conflict deletions and validated keys captured during validation.
+struct StagedData {
+    new_snapshot_id: String,
+    on_conflict_deletions: OnConflictDeletions,
+    validated_keys: PkDigestSet,
+    stats: Arc<ColumnStatsAccumulator>,
+    row_count: u64,
+    /// Existing rows this upsert replaces (for the live-row-count delta),
+    /// captured before `on_conflict_deletions` is consumed.
+    superseded: usize,
+}
+
+/// A staged upsert: the replacement rows have been written to a fresh snapshot
+/// directory, but no catalog visibility change has been made yet. The rows are
+/// published (or discarded) at [`Self::commit`] / [`Self::rollback`].
 pub struct CayenneStagedUpsert {
     table: CayenneTableProvider,
-    write_guard: Option<OwnedMutexGuard<()>>,
+    /// Optimistic-concurrency token captured at transaction begin, re-checked at
+    /// commit against the table's live sequence high-water.
+    token: TransactionWriteToken,
     new_snapshot_id: String,
     /// The prior versions this upsert supersedes, captured at validation time
     /// and applied under the fence at commit. Taken (`mem::take`) on commit.
@@ -81,8 +103,6 @@ pub struct CayenneStagedUpsert {
     validated_keys: PkDigestSet,
     stats: Arc<ColumnStatsAccumulator>,
     row_count: u64,
-    /// Existing rows replaced by this upsert (for the live-row-count delta),
-    /// captured before `on_conflict_deletions` is consumed.
     superseded: usize,
 }
 
@@ -93,12 +113,24 @@ impl std::fmt::Debug for CayenneStagedUpsert {
             .field("new_snapshot_id", &self.new_snapshot_id)
             .field("row_count", &self.row_count)
             .field("superseded", &self.superseded)
-            .field("has_write_guard", &self.write_guard.is_some())
             .finish_non_exhaustive()
     }
 }
 
 impl CayenneStagedUpsert {
+    fn new(table: CayenneTableProvider, token: TransactionWriteToken, staged: StagedData) -> Self {
+        Self {
+            table,
+            token,
+            new_snapshot_id: staged.new_snapshot_id,
+            on_conflict_deletions: staged.on_conflict_deletions,
+            validated_keys: staged.validated_keys,
+            stats: staged.stats,
+            row_count: staged.row_count,
+            superseded: staged.superseded,
+        }
+    }
+
     /// Number of rows staged for commit.
     #[must_use]
     pub fn row_count(&self) -> u64 {
@@ -107,18 +139,37 @@ impl CayenneStagedUpsert {
 
     /// Publish the staged rows, making the upsert visible to readers.
     ///
-    /// Mirrors the fenced tail of
-    /// [`CayenneTableProvider::write_new_snapshot_after_validation`]: apply the
+    /// Acquires `write_lock` now (staging ran off-lock) and re-checks the
+    /// optimistic-concurrency token first, aborting with [`Error::WriteConflict`]
+    /// (staged dir cleaned up) if the table changed since the transaction began.
+    /// It then mirrors the fenced tail of the sync on-conflict publish: apply the
     /// on-conflict deletions, reserve the protected-snapshot sequence, record it
     /// durably, then flip the deletion caches + protected snapshot under one
     /// listing-fence write.
     ///
     /// # Errors
     ///
-    /// Returns an error if applying the deletions, reserving the sequence, or the
-    /// durable snapshot-sequence write fails. The staged snapshot directory is
-    /// left in place on error so the caller can retry the commit or roll back.
+    /// Returns [`Error::WriteConflict`] on a lost OCC race (retryable), or an
+    /// error if applying the deletions, reserving the sequence, or the durable
+    /// snapshot-sequence write fails. On a hard error the staged snapshot
+    /// directory is left in place so the caller can retry the commit or roll back.
     pub async fn commit(mut self) -> Result<u64> {
+        // Acquire the write lock now (staging ran off-lock), then re-check the
+        // token before touching anything visible — a moved sequence high-water
+        // (or a dirty staging bit at capture) means a concurrent commit could
+        // have changed a key we wrote, so this transaction must abort and retry.
+        let _write_guard = self.table.write_lock_arc().lock_owned().await;
+        self.table.ensure_no_incomplete_write().await?;
+        if !self.token.staging_clean
+            || self.table.sequence_high_water().await != self.token.stage_seq
+        {
+            drop(_write_guard);
+            cleanup_orphan_snapshot_dir(&self.table, &self.new_snapshot_id).await;
+            return Err(Error::WriteConflict {
+                table: self.table.table_name().to_string(),
+            });
+        }
+
         // visibility lock then listing fence — the same order as
         // `apply_under_barrier` and the sync on-conflict publish.
         let _visibility = self.table.visibility_lock_arc().lock_owned().await;
@@ -161,7 +212,7 @@ impl CayenneStagedUpsert {
         }
 
         Ok(self.row_count)
-        // `_fence`, `_visibility`, and `self.write_guard` drop here, in that order.
+        // `_fence`, `_visibility`, and `_write_guard` drop here, in that order.
     }
 
     /// Discard the staged upsert and remove its staged snapshot directory.
@@ -175,45 +226,69 @@ impl CayenneStagedUpsert {
     /// Infallible today; returns `Result` for symmetry with the other staged
     /// lifecycles and to allow future durable-cleanup steps.
     pub async fn rollback(self) -> Result<()> {
-        // Hold the write guard across cleanup so another writer cannot start a
-        // commit while the staged directory is mid-deletion.
-        let _write_guard = self.write_guard;
+        // Staging held no lock and the catalog was never touched, so this just
+        // removes the orphan directory.
         cleanup_orphan_snapshot_dir(&self.table, &self.new_snapshot_id).await;
         Ok(())
     }
 }
 
 impl CayenneTableProvider {
-    /// Stage a primary-key upsert without making the new rows visible.
+    /// Capture the optimistic-concurrency token for a transaction write.
     ///
-    /// Validates the incoming stream for PK conflicts and writes the rows into a
-    /// fresh snapshot directory, returning a [`CayenneStagedUpsert`] that the
-    /// caller commits (on federated-source ack) or rolls back (on source
-    /// failure). See the module documentation for the full lifecycle.
+    /// Must be called at transaction **begin**, before the gate read — a commit
+    /// landing between the gate read and staging would otherwise be invisible to
+    /// the staged validation while making the gate verdict stale (a lost update).
+    /// Holds `write_lock` only long enough to read the sequence high-water and
+    /// the staging-append flag (the documented soundness condition on
+    /// `sequence_high_water`).
+    pub async fn transaction_write_token(&self) -> TransactionWriteToken {
+        let _guard = self.write_lock_arc().lock_owned().await;
+        let stage_seq = self.sequence_high_water().await;
+        let staging_clean = !self.has_inflight_staging_appends();
+        TransactionWriteToken {
+            stage_seq,
+            staging_clean,
+        }
+    }
+
+    /// Stage a primary-key upsert **off-lock** for a transaction: validation +
+    /// encode run without `write_lock`; the guard is acquired and `token`
+    /// re-checked at [`CayenneStagedUpsert::commit`]. The caller must have
+    /// captured `token` via [`Self::transaction_write_token`] before the
+    /// transaction's gate read.
     ///
     /// # Errors
     ///
-    /// Returns an error if the table has an incomplete write, is partitioned
-    /// (unsupported for the staged-upsert MVP), or if writing the staged data
-    /// fails.
-    pub async fn begin_staged_upsert(
+    /// Returns an error if the table is partitioned (unsupported for the MVP) or
+    /// if writing the staged data fails.
+    pub async fn begin_staged_upsert_occ(
         &self,
+        token: TransactionWriteToken,
         data: SendableRecordBatchStream,
         target_partitions: usize,
     ) -> Result<CayenneStagedUpsert> {
-        let write_guard = self.write_lock_arc().lock_owned().await;
-        self.ensure_no_incomplete_write().await?;
+        let staged = self.stage_upsert_data(data, target_partitions).await?;
+        Ok(CayenneStagedUpsert::new(self.clone_for_write(), token, staged))
+    }
 
+    /// Validate the incoming rows for PK conflicts (off-lock: private keyset, no
+    /// shared-cache take/store) and encode them into a fresh, unreferenced
+    /// snapshot directory.
+    async fn stage_upsert_data(
+        &self,
+        data: SendableRecordBatchStream,
+        target_partitions: usize,
+    ) -> Result<StagedData> {
         // Partitioned tables publish across partitions; their visibility flip
-        // cannot be a single protected-snapshot publish. Out of scope for the MVP
-        // (§10 conditional Phase 3).
+        // cannot be a single protected-snapshot publish. Out of scope for the MVP.
         if self.metadata().partition_column.is_some() {
             return Err(Error::Unsupported {
                 operation: "staged upsert for partitioned Cayenne tables",
             });
         }
 
-        let prepared = self.prepare_stream_for_insert(data).await?;
+        let prepared = self.prepare_stream_for_insert_offlock(data).await?;
         let post_validation = prepared.post_validation();
 
         let new_snapshot_id = uuid::Uuid::now_v7().to_string();
@@ -242,17 +317,14 @@ impl CayenneTableProvider {
         // On-conflict deletions are computed by the validation stream as it is
         // consumed by `write_to_snapshot` above, so take them only now. A table
         // without a primary key (or with conflict detection disabled) yields the
-        // default (empty) state — a plain insert published as a protected
-        // snapshot.
+        // default (empty) state — a plain insert published as a protected snapshot.
         let PostValidationState {
             on_conflict_deletions,
             validated_keys,
         } = post_validation.lock().take().unwrap_or_default();
         let superseded = on_conflict_deletions.total_superseded();
 
-        Ok(CayenneStagedUpsert {
-            table: self.clone_for_write(),
-            write_guard: Some(write_guard),
+        Ok(StagedData {
             new_snapshot_id,
             on_conflict_deletions,
             validated_keys,

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -5783,7 +5783,7 @@ impl CayenneTableProvider {
     /// sound compaction cutoff — a rewrite scan taken after this read sees every
     /// mutation `<= cutoff`, and mutations that arrive afterward (`> cutoff`) are
     /// carried forward rather than cleared.
-    async fn sequence_high_water(&self) -> i64 {
+    pub(crate) async fn sequence_high_water(&self) -> i64 {
         self.seq_allocator.lock().await.next - 1
     }
 
@@ -7353,6 +7353,27 @@ impl CayenneTableProvider {
         &self,
         stream: SendableRecordBatchStream,
     ) -> Result<PreparedInsertStream> {
+        self.prepare_stream_for_insert_inner(stream, false).await
+    }
+
+    /// Off-lock variant for conditional-commit staging: validates against a
+    /// **private** keyset (never taken from, nor stored back to, the shared PK
+    /// index cache), so it is safe to run WITHOUT holding `write_lock` while
+    /// ordinary writers concurrently update the shared cache. Optimistic
+    /// concurrency is re-checked at commit; a private keyset that is stale by
+    /// commit is caught there (the transaction's sequence gate aborts).
+    pub(crate) async fn prepare_stream_for_insert_offlock(
+        &self,
+        stream: SendableRecordBatchStream,
+    ) -> Result<PreparedInsertStream> {
+        self.prepare_stream_for_insert_inner(stream, true).await
+    }
+
+    async fn prepare_stream_for_insert_inner(
+        &self,
+        stream: SendableRecordBatchStream,
+        offlock: bool,
+    ) -> Result<PreparedInsertStream> {
         let Some(pk_indices) = self.primary_key_indices()? else {
             return Ok(PreparedInsertStream::immediate(stream));
         };
@@ -7366,7 +7387,13 @@ impl CayenneTableProvider {
         }
 
         let converter = self.build_pk_converter(&pk_indices)?;
-        let existing_keys = if let Some(existing_keys) = self.take_cached_pk_index() {
+        // Off-lock staging must NOT take/store the shared cache (it runs without
+        // `write_lock`); it builds a private keyset every time. The ordinary path
+        // reuses the shared cache and stores it back on finish.
+        let existing_keys = if offlock {
+            self.load_pk_index_for_validation(&pk_indices, &converter)
+                .await?
+        } else if let Some(existing_keys) = self.take_cached_pk_index() {
             tracing::trace!(
                 "prepare_stream_for_insert: reused {} cached existing keys for table {}",
                 existing_keys.len(),
@@ -7374,50 +7401,8 @@ impl CayenneTableProvider {
             );
             existing_keys
         } else {
-            // The full-table keyset rebuild is the dominant CDC-upsert cost for
-            // tables whose keyset exceeds the cache budget, yet it runs *before*
-            // the `vortex_write` phase timer and is otherwise invisible in
-            // per-phase telemetry. Time it explicitly (emitted only on a cache
-            // miss / cold rebuild) so retests attribute the cost correctly.
-            let keyset_rebuild_start = Instant::now();
-            // Resolve the datalake (cold) tier contribution first (rebuilds the
-            // cold PK existence bloom from the manifest, no object-store I/O).
-            // `Bloom` skips the cold scan; `Scan` forces a full rebuild (the
-            // warm-only checkpoint can't cover the incomplete-bloom case).
-            let cold_source = self.resolve_cold_keyset_source().await?;
-            let fold_cold = !matches!(cold_source, ColdKeysetSource::Bloom);
-            let allow_checkpoint = !matches!(cold_source, ColdKeysetSource::Scan);
-            // Fast path: reconstruct the index from the persisted bloom checkpoint
-            // (+ bounded post-checkpoint delta) and skip the full-table keyset
-            // scan. Falls back to the full scan on any miss/mismatch/corruption.
-            let existing_keys = if allow_checkpoint {
-                match self
-                    .try_load_persisted_pk_index(&pk_indices, &converter)
-                    .await
-                {
-                    Ok(Some(index)) => index,
-                    _ => CachedPkIndex::Exact(
-                        self.load_existing_keyset(&pk_indices, &converter, fold_cold)
-                            .await?,
-                    ),
-                }
-            } else {
-                CachedPkIndex::Exact(
-                    self.load_existing_keyset(&pk_indices, &converter, fold_cold)
-                        .await?,
-                )
-            };
-            record_cayenne_write_phase(
-                self.table_metadata.table_name.as_str(),
-                "keyset_rebuild",
-                keyset_rebuild_start,
-            );
-            tracing::debug!(
-                "prepare_stream_for_insert: loaded {} existing keys for table {}",
-                existing_keys.len(),
-                self.table_metadata.table_name
-            );
-            existing_keys
+            self.load_pk_index_for_validation(&pk_indices, &converter)
+                .await?
         };
 
         let on_conflict = self
@@ -7436,6 +7421,9 @@ impl CayenneTableProvider {
             existing_keys,
             on_conflict,
             Arc::clone(&post_validation),
+            // Ordinary path returns the keyset to the shared cache; off-lock
+            // staging drops its private keyset (never publishes it).
+            !offlock,
         );
 
         Ok(PreparedInsertStream::deferred(
@@ -7443,6 +7431,57 @@ impl CayenneTableProvider {
             post_validation,
             may_have_on_conflict_deletions,
         ))
+    }
+
+    /// Build a fresh PK existence index for validation from the persisted bloom
+    /// checkpoint (+ bounded delta) or, failing that, a full keyset scan. Does
+    /// not touch the shared cache — callers decide whether to store it back.
+    async fn load_pk_index_for_validation(
+        &self,
+        pk_indices: &[usize],
+        converter: &RowConverter,
+    ) -> Result<CachedPkIndex> {
+        // The full-table keyset rebuild is the dominant CDC-upsert cost for
+        // tables whose keyset exceeds the cache budget, yet it runs *before*
+        // the `vortex_write` phase timer and is otherwise invisible in
+        // per-phase telemetry. Time it explicitly (emitted only on a cache
+        // miss / cold rebuild) so retests attribute the cost correctly.
+        let keyset_rebuild_start = Instant::now();
+        // Resolve the datalake (cold) tier contribution first (rebuilds the
+        // cold PK existence bloom from the manifest, no object-store I/O).
+        // `Bloom` skips the cold scan; `Scan` forces a full rebuild (the
+        // warm-only checkpoint can't cover the incomplete-bloom case).
+        let cold_source = self.resolve_cold_keyset_source().await?;
+        let fold_cold = !matches!(cold_source, ColdKeysetSource::Bloom);
+        let allow_checkpoint = !matches!(cold_source, ColdKeysetSource::Scan);
+        // Fast path: reconstruct the index from the persisted bloom checkpoint
+        // (+ bounded post-checkpoint delta) and skip the full-table keyset
+        // scan. Falls back to the full scan on any miss/mismatch/corruption.
+        let existing_keys = if allow_checkpoint {
+            match self.try_load_persisted_pk_index(pk_indices, converter).await {
+                Ok(Some(index)) => index,
+                _ => CachedPkIndex::Exact(
+                    self.load_existing_keyset(pk_indices, converter, fold_cold)
+                        .await?,
+                ),
+            }
+        } else {
+            CachedPkIndex::Exact(
+                self.load_existing_keyset(pk_indices, converter, fold_cold)
+                    .await?,
+            )
+        };
+        record_cayenne_write_phase(
+            self.table_metadata.table_name.as_str(),
+            "keyset_rebuild",
+            keyset_rebuild_start,
+        );
+        tracing::debug!(
+            "prepare_stream_for_insert: loaded {} existing keys for table {}",
+            existing_keys.len(),
+            self.table_metadata.table_name
+        );
+        Ok(existing_keys)
     }
 
     /// Sharded analog of [`Self::prepare_stream_for_insert`] for the N>1 in-memory
@@ -24104,6 +24143,29 @@ impl TableProvider for CayenneTableProvider {
             .build()?;
 
         let source_plan = state.create_physical_plan(&plan).await?;
+
+        // Conditional-commit transaction: `UpdateExec` runs delete + insert, and
+        // its delete leg publishes deletion vectors immediately — that breaks
+        // atomicity (a rollback would lose rows, and even a successful commit
+        // exposes a torn "row missing" window between the delete and the insert
+        // publish). When a transaction is active for this table, run only the
+        // insert (upsert) leg: the staged upsert supersedes each prior row by
+        // primary key, and the executor applies those deletions atomically under
+        // the fence at COMMIT.
+        if transaction_active_for(state, self.table_id()) {
+            // The staged upsert supersedes by primary key, so a reassigned PK
+            // column would leave the prior row in place. Reject it (v1 supports
+            // value updates only).
+            for (col, _) in &assignments {
+                if self.metadata().primary_key.iter().any(|pk| pk == col) {
+                    return Err(datafusion_common::DataFusionError::Execution(format!(
+                        "conditional-commit UPDATE cannot reassign primary-key column '{col}'"
+                    )));
+                }
+            }
+            return self.insert_into(state, source_plan, InsertOp::Append).await;
+        }
+
         let session_state = state
             .as_any()
             .downcast_ref::<datafusion::execution::SessionState>()
@@ -24121,6 +24183,21 @@ impl TableProvider for CayenneTableProvider {
             filters,
         )))
     }
+}
+
+/// Whether a conditional-commit transaction is active for `table_id` on this
+/// session's request context.
+///
+/// Reads the transaction from the [`runtime_request_context::RequestContext`]
+/// typed extension on the session config — the same context the query builder
+/// installed for this request — so the check matches the one the sink makes at
+/// execution time.
+fn transaction_active_for(state: &dyn Session, table_id: &str) -> bool {
+    state
+        .config()
+        .get_extension::<runtime_request_context::RequestContext>()
+        .and_then(|rc| rc.extension::<super::transaction::CayenneTransaction>())
+        .is_some_and(|txn| txn.table_id() == table_id)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27116,10 +27193,10 @@ mod tests {
         ids
     }
 
-    // ── Staged upsert (Analytical Replica dual-apply, `begin_staged_upsert`) ──
+    // ── Off-lock staged upsert (`begin_staged_upsert_occ`) ──
 
     /// Build a file-mode provider with an `id` primary key and `on_conflict:
-    /// upsert` — the shape the Analytical Replica staged-upsert path targets.
+    /// upsert` — the shape the off-lock staged-upsert path targets.
     async fn build_staged_upsert_provider(
         ctx: &SessionContext,
         name: &str,
@@ -27179,14 +27256,15 @@ mod tests {
         let (provider, _tmp, schema) = build_staged_upsert_provider(&ctx, "su_commit").await;
 
         let stream = single_batch_stream(id_name_batch(&schema, &[1, 2], &["alice", "bob"]));
+        let token = provider.transaction_write_token().await;
         let staged = provider
-            .begin_staged_upsert(stream, 1)
+            .begin_staged_upsert_occ(token, stream, 1)
             .await
             .expect("begin staged upsert");
         assert_eq!(staged.row_count(), 2);
 
-        // Held handle keeps the write guard; scans do not need it, so the staged
-        // rows are observably invisible before commit.
+        // The catalog is untouched until commit, so the staged rows are
+        // observably invisible to scans.
         assert!(
             scan_sorted_ids(&provider).await.is_empty(),
             "staged rows must be invisible before commit"
@@ -27208,8 +27286,9 @@ mod tests {
         let (provider, _tmp, schema) = build_staged_upsert_provider(&ctx, "su_rollback").await;
 
         let stream = single_batch_stream(id_name_batch(&schema, &[1, 2], &["alice", "bob"]));
+        let token = provider.transaction_write_token().await;
         let staged = provider
-            .begin_staged_upsert(stream, 1)
+            .begin_staged_upsert_occ(token, stream, 1)
             .await
             .expect("begin staged upsert");
         staged.rollback().await.expect("rollback staged upsert");
@@ -27233,8 +27312,9 @@ mod tests {
 
         // Stage an upsert: id=1 -> alice2 (supersede), id=3 -> carol (new).
         let stream = single_batch_stream(id_name_batch(&schema, &[1, 3], &["alice2", "carol"]));
+        let token = provider.transaction_write_token().await;
         let staged = provider
-            .begin_staged_upsert(stream, 1)
+            .begin_staged_upsert_occ(token, stream, 1)
             .await
             .expect("begin staged upsert");
 

--- a/crates/cayenne/src/provider/transaction.rs
+++ b/crates/cayenne/src/provider/transaction.rs
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Per-request transaction, threaded from the HTTP executor
+//! to the write path via the [`RequestContext`] extensions.
+//!
+//! A transaction (`BEGIN; SELECT assert(<gate>); UPDATE …;
+//! COMMIT;`) must run **every** statement through the query builder (so authz,
+//! masking, logging, and tracing apply uniformly) while still being atomic. The
+//! executor cannot intercept the write plan without bypassing those checks, so
+//! instead it installs this object on the request context and the write path
+//! reads it back:
+//!
+//! 1. The executor captures the target table's optimistic-concurrency token
+//!    ([`TransactionWriteToken`]) **before** the gate read and installs a
+//!    [`Self::armed`] txn. Staging runs lock-free; the token is re-checked at
+//!    commit (see the staged-upsert module).
+//! 2. [`super::sink::CayenneDataSink`] (and the UPDATE insert leg) detects the
+//!    active txn for its table, takes the token, and **stages** the write via
+//!    [`super::table::CayenneTableProvider::begin_staged_upsert_occ`] instead of
+//!    publishing, registering the [`CayenneStagedUpsert`] handle.
+//! 3. At `COMMIT` the executor takes the staged handle and publishes it
+//!    atomically (aborting with a retryable conflict if the token no longer
+//!    holds); on a gate abort or any error it rolls it back.
+//!
+//! The object rides on the [`RequestContext`] typed extension (source 1 of
+//! [`runtime_datafusion::extension::request_context::resolve_request_context`]),
+//! so the write path reads the exact same context installed by the query
+//! builder — never the task-local `RequestContext::current`, whose silent
+//! internal-context fallback would make a missed installation publish
+//! immediately (an undetectable atomicity break).
+
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use super::staged_upsert::{CayenneStagedUpsert, TransactionWriteToken};
+
+/// The mutable stage of a transaction.
+///
+/// Only ever holds one of the two: the optimistic-concurrency token captured at
+/// transaction begin (before the write stages), or the staged handle after.
+enum TxnStage {
+    /// Token captured by the executor; no write staged yet.
+    Armed(TransactionWriteToken),
+    /// Write staged (not yet published).
+    Staged(CayenneStagedUpsert),
+}
+
+struct TxnInner {
+    /// Identifies the single table this transaction may write to.
+    table_id: String,
+    /// `None` only transiently, while the sink moves the token into a staged
+    /// handle. Never held across an await.
+    stage: Mutex<Option<TxnStage>>,
+}
+
+/// A transaction handle. Cloning is a cheap `Arc` clone; the
+/// executor and the write path share one inner object.
+#[derive(Clone)]
+pub struct CayenneTransaction(Arc<TxnInner>);
+
+impl std::fmt::Debug for CayenneTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CayenneTransaction")
+            .field("table_id", &self.0.table_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CayenneTransaction {
+    /// Create a transaction armed with the target table's optimistic-concurrency
+    /// token (captured before the gate read).
+    #[must_use]
+    pub fn armed(table_id: String, token: TransactionWriteToken) -> Self {
+        Self(Arc::new(TxnInner {
+            table_id,
+            stage: Mutex::new(Some(TxnStage::Armed(token))),
+        }))
+    }
+
+    /// The single table this transaction may write to.
+    #[must_use]
+    pub fn table_id(&self) -> &str {
+        &self.0.table_id
+    }
+
+    /// Take the armed OCC token so the caller can hand it to
+    /// [`super::table::CayenneTableProvider::begin_staged_upsert_occ`].
+    ///
+    /// Returns `None` if the transaction is not in the armed state — i.e. a
+    /// second write in the same transaction (already staged) or a poisoned
+    /// lock. The write path treats `None` as fail-closed (rejects the write)
+    /// rather than publishing.
+    #[must_use]
+    pub fn take_token(&self) -> Option<TransactionWriteToken> {
+        let mut stage = self.0.stage.lock().ok()?;
+        match stage.take() {
+            Some(TxnStage::Armed(token)) => Some(token),
+            other => {
+                *stage = other;
+                None
+            }
+        }
+    }
+
+    /// Register the staged write. Called by the write path after
+    /// [`Self::take_token`] and a successful stage.
+    pub fn set_staged(&self, upsert: CayenneStagedUpsert) {
+        if let Ok(mut stage) = self.0.stage.lock() {
+            *stage = Some(TxnStage::Staged(upsert));
+        }
+    }
+
+    /// Take the staged handle for commit or rollback. Returns `None` if no
+    /// write was staged (the transaction is still armed, or already consumed).
+    #[must_use]
+    pub fn take_staged(&self) -> Option<CayenneStagedUpsert> {
+        let mut stage = self.0.stage.lock().ok()?;
+        match stage.take() {
+            Some(TxnStage::Staged(upsert)) => Some(upsert),
+            other => {
+                *stage = other;
+                None
+            }
+        }
+    }
+
+    /// Discard any remaining stage. Used on the abort path when the write never
+    /// reached the sink (e.g. a gate assert failed before the write statement
+    /// ran). Off-lock staging holds no write guard, so there is nothing to
+    /// release beyond dropping the token / staged handle.
+    pub fn release(&self) {
+        if let Ok(mut stage) = self.0.stage.lock() {
+            let _ = stage.take();
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl runtime_request_context::Extension for CayenneTransaction {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -1227,6 +1227,15 @@ impl AcceleratedTable {
         self.write_mode.is_dual_write()
     }
 
+    /// Whether writes are directed to the local accelerator only (the
+    /// `on_conflict` / read-only-source case). Conditional-commit transactions
+    /// require this: their staging + atomic publish live in the accelerator
+    /// write path, which the write-through/write-back/dual-write modes bypass.
+    #[must_use]
+    pub(crate) fn is_accelerator_only(&self) -> bool {
+        matches!(self.write_mode, WriteMode::AcceleratorOnly)
+    }
+
     #[must_use]
     pub fn get_accelerator(&self) -> Arc<dyn TableProvider> {
         Arc::clone(&self.accelerator)

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -35,9 +35,13 @@ pub mod status;
 pub mod tools;
 pub mod workers;
 
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use crate::{
+    accelerated_table::{
+        AcceleratedTable,
+        write::{CayenneWriteTarget, dual_write::extract_cayenne_write_target},
+    },
     component::dataset::Dataset,
     datafusion::{
         DataFusion,
@@ -50,6 +54,9 @@ use crate::{
     egress::EgressAccount,
     status::ComponentStatus,
 };
+use cayenne::CayenneTransaction;
+use datafusion::common::TableReference;
+use datafusion::logical_expr::LogicalPlan;
 use arrow::{array::RecordBatch, util::pretty::pretty_format_batches};
 use async_stream::try_stream;
 use axum::{
@@ -63,7 +70,6 @@ use cache::result::CacheStatus;
 use csv::Writer;
 use datafusion::common::ParamValues;
 use datafusion::execution::{SendableRecordBatchStream, memory_pool::MemoryPool};
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 use datafusion::sql::sqlparser::{ast::Statement as SqlStatement, dialect::PostgreSqlDialect};
 use headers_accept::Accept;
@@ -74,7 +80,6 @@ use http::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use snafu::ResultExt;
-use tokio::sync::{Mutex, OwnedMutexGuard};
 
 use futures::{StreamExt, TryStreamExt};
 
@@ -324,13 +329,6 @@ async fn query_stream_to_http_response(
     (StatusCode::OK, headers, body).into_response()
 }
 
-/// Process-global serialization lock for `/v1/sql` transactions.
-///
-/// v1 is pessimistic and single-instance: each complete `BEGIN … COMMIT` body
-/// runs while holding this lock. Per-key optimistic concurrency, which would let
-/// transactions touching disjoint keys run in parallel, is tracked separately.
-static TRANSACTION_LOCK: LazyLock<Arc<Mutex<()>>> = LazyLock::new(|| Arc::new(Mutex::new(())));
-
 /// Returns the statements inside a well-formed `BEGIN … COMMIT` transaction.
 /// Transaction-control statements are stripped. A single statement or a
 /// multi-statement string not wrapped in `BEGIN … COMMIT` returns `None` and is
@@ -392,39 +390,49 @@ async fn run_transaction_statement(
     QueryBuilder::new(sql, Arc::clone(df))
         .parameters(parameters)
         .read_only(read_only)
-        // Every statement must observe current state and must not replace a
-        // previously cached result while the transaction lock is held.
+        // Gate + inner reads must see live committed state, not a (stale) cached
+        // result — the transaction is the serialization point, not the cache.
         .results_cache_mode(ResultsCacheMode::Bypass)
         .build()
         .run()
         .await
 }
 
-/// Keeps the transaction lock until the final statement's lazy result stream is
-/// fully consumed or dropped.
-fn attach_transaction_guard_to_stream(
-    stream: SendableRecordBatchStream,
-    guard: OwnedMutexGuard<()>,
-) -> SendableRecordBatchStream {
-    let schema = stream.schema();
-    let guarded = futures::stream::unfold((stream, guard), |(mut stream, guard)| async move {
-        stream
-            .next()
-            .await
-            .map(|batch_result| (batch_result, (stream, guard)))
-    });
-    Box::pin(RecordBatchStreamAdapter::new(schema, guarded))
+/// A stageable transaction write, resolved from the transaction body.
+struct TransactionWrite {
+    /// The write's target table, as it appears in the DML plan (used for the
+    /// post-commit results-cache invalidation).
+    table_ref: TableReference,
+    /// The armed transaction handle: carries the target table's
+    /// optimistic-concurrency token (captured before the gate read) and, after
+    /// the write stages, the staged handle. Installed on the request context so
+    /// the Cayenne write path stages (off-lock) instead of publishing.
+    txn: CayenneTransaction,
 }
 
-/// Executes each statement in a transaction in order under the process-wide
-/// serialization lock. Any statement error stops subsequent execution and is
-/// returned to the client.
+/// Executes a transaction body atomically.
 ///
-/// Intermediate result streams are drained batch-by-batch without buffering so
-/// writes finish and execution errors surface before the next statement. The
-/// final statement's result is streamed to the client. This executor does not
-/// provide rollback: writes completed by an earlier statement remain applied if
-/// a later statement fails.
+/// The whole `BEGIN … COMMIT` body runs through [`QueryBuilder`] — the single
+/// place authz, masking, logging, and tracing are applied — so the write is
+/// governed identically to any other query. Atomicity and lost-update
+/// prevention come from the Cayenne write path rather than from intercepting
+/// the plan:
+///
+/// 1. Resolve the single write's target, which must be a **non-partitioned,
+///    accelerator-only** Cayenne table, acquire its per-table write guard, and
+///    install a [`CayenneTransaction`] on the request context. Holding
+///    the guard from before the gate read closes the lost-update window.
+/// 2. Run every statement through `QueryBuilder` with the results cache
+///    bypassed (gate reads must see live committed state). The write's sink
+///    detects the active transaction and *stages* the rows instead of
+///    publishing them; a failed `assert()` gate (or any error) aborts.
+/// 3. On success, publish the staged write atomically at COMMIT and invalidate
+///    the results cache; on any failure, roll back the staged write.
+///
+/// v1 supports a single INSERT/UPDATE write per transaction (no DELETE/MERGE,
+/// no PK reassignment). Bound parameters are supported across statements via
+/// [`normalize_transaction_parameters`]. Durable propagation of the committed
+/// write back to the federated source is tracked separately.
 async fn execute_transaction(
     df: Arc<DataFusion>,
     statements: Vec<String>,
@@ -432,48 +440,226 @@ async fn execute_transaction(
     read_only: bool,
     format: ResponseMimeType,
 ) -> Response {
-    let Some((final_statement, intermediate_statements)) = statements.split_last() else {
-        return (StatusCode::OK, "COMMIT").into_response();
+    // Prepare the transaction: identify the single write, validate its target,
+    // acquire the guard, and install the transaction on the request context.
+    // A body with no write is a plain read-only transaction (no guard needed).
+    let write = match prepare_transaction(&df, &statements).await {
+        Ok(write) => write,
+        Err(response) => return response,
     };
 
-    let memory_pool = Arc::clone(&df.ctx.runtime_env().memory_pool);
     let parameters = normalize_transaction_parameters(parameters);
-    let transaction_guard = Arc::clone(&TRANSACTION_LOCK).lock_owned().await;
-
-    for statement in intermediate_statements {
+    let mut last: Option<(Vec<RecordBatch>, CacheStatus)> = None;
+    for statement in &statements {
         let query_res =
             match run_transaction_statement(&df, statement, parameters.clone(), read_only).await {
                 Ok(result) => result,
                 Err(error) => {
+                    abort_transaction(write.as_ref()).await;
                     let kind = SqlErrorKind::of_query_error(&error);
                     return sql_error_response(error.to_string(), kind);
                 }
             };
 
-        // Drain and immediately drop each batch. This executes writes and
-        // surfaces stream errors without materializing intermediate SELECTs.
-        let mut data_stream = query_res.data;
-        while let Some(batch_result) = data_stream.next().await {
-            if let Err(error) = batch_result {
-                return sql_error_response(
-                    error.to_string(),
-                    SqlErrorKind::of_datafusion_error(&error),
-                );
+        let cache_status = query_res.cache_status;
+        // Drain each statement fully so writes execute and any error (including a
+        // gate abort) surfaces before the next statement runs.
+        match query_res.data.try_collect::<Vec<RecordBatch>>().await {
+            Ok(batches) => last = Some((batches, cache_status)),
+            Err(e) => {
+                abort_transaction(write.as_ref()).await;
+                return sql_error_response(e.to_string(), SqlErrorKind::of_datafusion_error(&e));
             }
         }
     }
 
-    let query_res =
-        match run_transaction_statement(&df, final_statement, parameters, read_only).await {
-            Ok(result) => result,
-            Err(error) => {
-                let kind = SqlErrorKind::of_query_error(&error);
-                return sql_error_response(error.to_string(), kind);
-            }
+    // Every statement succeeded (the gate passed). Publish the staged write
+    // atomically; if it never staged, that is an internal invariant failure.
+    if let Some(write) = &write {
+        let Some(staged) = write.txn.take_staged() else {
+            abort_transaction(Some(write)).await;
+            return sql_error_response(
+                "transaction committed without a staged write".to_string(),
+                SqlErrorKind::General,
+            );
         };
+        match staged.commit().await {
+            Ok(_) => {}
+            Err(cayenne::provider::Error::WriteConflict { table }) => {
+                // Optimistic-concurrency conflict: the table was committed to
+                // between this transaction's start and commit. Retryable — map to
+                // 409 so the client can re-run at the newest committed state.
+                return (
+                    StatusCode::CONFLICT,
+                    format!(
+                        "transaction write conflict on '{table}': the table changed since the transaction started; retry"
+                    ),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                return sql_error_response(
+                    format!("transaction publish failed: {e}"),
+                    SqlErrorKind::General,
+                );
+            }
+        }
+        // The write's plan-time cache invalidation ran before the rows were
+        // visible, so a concurrent SELECT could have repopulated the cache with
+        // pre-commit state. Re-invalidate now that the write is published.
+        if let Err(e) = df.caching().invalidate_for_table(write.table_ref.clone()) {
+            tracing::warn!(
+                "transaction: post-commit cache invalidation for {} failed: {e}",
+                write.table_ref
+            );
+        }
+    }
 
-    let data_stream = attach_transaction_guard_to_stream(query_res.data, transaction_guard);
-    query_stream_to_http_response(data_stream, query_res.cache_status, format, memory_pool).await
+    // Return the final statement's result (for the canonical gate+write shape,
+    // the write's row-count summary).
+    match last {
+        Some((batches, cache_status)) => {
+            to_http_response(batches, cache_status, format, ResponseMetadata::empty())
+                .await
+                .into_response()
+        }
+        None => (StatusCode::OK, "COMMIT").into_response(),
+    }
+}
+
+/// Identify the transaction's single write, validate its target as a
+/// non-partitioned accelerator-only Cayenne table, acquire the table write
+/// guard, and install the armed [`CayenneTransaction`] on the current
+/// request context.
+///
+/// Returns `Ok(None)` for a body with no write (a read-only transaction), or an
+/// error `Response` if the body is not a valid v1 transaction.
+async fn prepare_transaction(
+    df: &Arc<DataFusion>,
+    inner_sqls: &[String],
+) -> Result<Option<TransactionWrite>, Response> {
+    let session = df.ctx.state();
+    let mut write_table: Option<TableReference> = None;
+    for stmt_sql in inner_sqls {
+        let plan = session.create_logical_plan(stmt_sql).await.map_err(|e| {
+            sql_error_response(e.to_string(), SqlErrorKind::of_datafusion_error(&e))
+        })?;
+        match classify_transaction_write(&plan) {
+            None => {}
+            Some(Err(op)) => {
+                return Err(sql_error_response(
+                    format!(
+                        "transactions do not support {op} (v1 supports a single gated INSERT/UPDATE)"
+                    ),
+                    SqlErrorKind::General,
+                ));
+            }
+            Some(Ok(table)) => {
+                if write_table.is_some() {
+                    return Err(sql_error_response(
+                        "transactions support a single write statement (v1)"
+                            .to_string(),
+                        SqlErrorKind::General,
+                    ));
+                }
+                write_table = Some(table);
+            }
+        }
+    }
+
+    let Some(table_ref) = write_table else {
+        return Ok(None);
+    };
+
+    let cc_err = |msg: String| sql_error_response(msg, SqlErrorKind::General);
+
+    // Resolve the target to its underlying Cayenne provider. Only an
+    // accelerator-only table stages through the Cayenne write path — the
+    // write-through/write-back/dual-write modes route writes elsewhere, where
+    // the gate would not govern the write.
+    let table_name = table_ref.table();
+    let provider = df
+        .get_accelerated_table_provider(table_name)
+        .await
+        .map_err(|e| {
+            cc_err(format!(
+                "transaction target '{table_name}' is not an accelerated table: {e}"
+            ))
+        })?;
+    let Some(accel) = provider.downcast_ref::<AcceleratedTable>() else {
+        return Err(cc_err(format!(
+            "transaction target '{table_name}' is not an accelerated table"
+        )));
+    };
+    if !accel.is_accelerator_only() {
+        return Err(cc_err(format!(
+            "transaction target '{table_name}' must be an accelerator-only dataset (configure on_conflict without CDC); its writes route to the federated source"
+        )));
+    }
+    let accelerator = accel.get_accelerator();
+    let Some(CayenneWriteTarget::Staged(cayenne)) = extract_cayenne_write_target(&accelerator)
+    else {
+        return Err(cc_err(format!(
+            "transaction target '{table_name}' must be backed by a non-partitioned Cayenne table"
+        )));
+    };
+
+    // Capture the optimistic-concurrency token BEFORE any gate read runs, and
+    // arm the transaction. Staging is lock-free; at commit the write_lock is
+    // taken briefly and the token re-checked, so a concurrent commit to the
+    // table between here and commit makes this transaction abort (retryable
+    // conflict) rather than lose an update. Capturing before the gate read is
+    // load-bearing: a commit landing between the gate and the staged write would
+    // otherwise leave the gate verdict stale.
+    let token = cayenne.transaction_write_token().await;
+    let txn = CayenneTransaction::armed(cayenne.table_id().to_string(), token);
+    RequestContext::current(AsyncMarker::new().await).insert_extension(txn.clone());
+
+    Ok(Some(TransactionWrite { table_ref, txn }))
+}
+
+/// Classify an inner statement for a transaction:
+/// `None` for a read, `Some(Ok(table))` for a stageable INSERT/UPDATE write, or
+/// `Some(Err(op))` for a write form v1 cannot stage atomically (its sink is not
+/// transaction-aware), which must abort the transaction rather than publish.
+fn classify_transaction_write(
+    plan: &LogicalPlan,
+) -> Option<Result<TableReference, &'static str>> {
+    use datafusion::logical_expr::WriteOp;
+    match plan {
+        LogicalPlan::Dml(dml) => Some(match &dml.op {
+            WriteOp::Insert(_) | WriteOp::Update => Ok(dml.table_name.clone()),
+            WriteOp::Delete => Err("DELETE"),
+            WriteOp::Ctas | WriteOp::Truncate => Err("this operation"),
+        }),
+        LogicalPlan::Extension(ext) => {
+            let dml = ext
+                .node
+                .as_any()
+                .downcast_ref::<datafusion_dml::DmlExtensionNode>()?;
+            Some(match &dml.op {
+                datafusion_dml::DmlNodeOp::Insert(p) => Ok(p.table_name.clone()),
+                datafusion_dml::DmlNodeOp::Update(p) => Ok(p.table_name.clone()),
+                datafusion_dml::DmlNodeOp::Delete(_) => Err("DELETE"),
+                datafusion_dml::DmlNodeOp::Merge(_) => Err("MERGE"),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Roll back a transaction: discard the staged write (if the
+/// write reached the sink) and release the table write guard.
+async fn abort_transaction(write: Option<&TransactionWrite>) {
+    let Some(write) = write else { return };
+    if let Some(staged) = write.txn.take_staged() {
+        if let Err(e) = staged.rollback().await {
+            tracing::warn!("transaction rollback cleanup failed: {e}");
+        }
+    }
+    // Release the still-armed guard when the write never staged (e.g. the gate
+    // failed before the write statement ran).
+    write.txn.release();
 }
 
 /// Classifies a query error for HTTP status mapping: client-initiated


### PR DESCRIPTION
<!-- stack-nav -->
> **Cayenne transactions — stacked PR 3 of 9**
> ← Previous: #11849 &nbsp;·&nbsp; Next: #11861 →
>
> Review/merge bottom-up: #11848 · #11849 · #11859 · #11861 · #11863 · #11865 · #11866 · #11868 · #11869 &nbsp;→&nbsp; all squashed into #11870 (targets `trunk`). Part of #11830.

---

Part of #11830. Stacked on #11849 (staged-upsert substrate) — review/merge that first; this PR's diff is against that branch.

## What

Runs a standard `BEGIN … COMMIT` body submitted to `/v1/sql` as a **serializable transaction** over a Cayenne accelerator-only table, with a small `assert(<expr>)` gate. Whether a transaction is "conditional" is up to the caller's use of `assert()` — the mechanism is just a transaction.

Example — enforce a limit atomically and concurrently:

```sql
BEGIN;
SELECT assert((SELECT n FROM counters WHERE id = 'x') < (SELECT cap FROM counters WHERE id = 'x'));
UPDATE counters SET n = n + 1 WHERE id = 'x';
COMMIT;
```

## How

- **Everything runs through `QueryBuilder`.** Both the gate reads and the write execute via the normal query path, so authorization, row/column masking, logging, tracing, and the read-only gate apply to the write exactly as to any other query. There is no plan interception.
- **Off-lock optimistic staging.** Validation and Vortex encode run **without** the per-table write lock, so transactions stage concurrently into an invisible snapshot. The lock is taken only at commit, briefly, to re-check an optimistic-concurrency token (the table's sequence high-water, captured *before* the gate read) and publish. A concurrent commit to the table makes this one abort with a retryable **409** rather than lose an update.
- **Atomicity.** The staged write publishes at `COMMIT` or not at all; a later statement failing (e.g. a gate `assert` after the write) rolls the staged write back. An `UPDATE` stages only its insert (upsert) leg so its delete cannot publish early.
- The write path detects the active transaction via the `RequestContext` typed extension on the task context (never the task-local, whose silent fallback would publish immediately).

## v1 scope / follow-ups

- One `INSERT`/`UPDATE` write per transaction — multi-write/multi-table is **rejected** with a clear error (atomic multi-table commit is #11837).
- Per-**table** conflict granularity — correct (no lost updates / no over-admit), over-aborts concurrent same-table commits; per-**key** granularity needs a new stored per-key version (#11856).
- Accelerator-only tables — durable federated write-back is #11838.
- Single hot-key OCC thrash (each conflict re-stages) is the deferred "thrash detector" case in #11830.

## Verification

Built `spiced` locally against a Postgres source + Cayenne file accelerator (`on_conflict: upsert`, `refresh_mode: full` → accelerator-only):

- Cap enforcement + atomicity (sequential): 5 commits, 2 aborts, `n=5`.
- No lost update / no over-admit (8-way concurrent, retry-on-409): 5 commits, `n=5` exactly, 0.58s; a 150-way/cap-100 stress run also converged to exactly 100.
- Write-then-fail rollback: `assert(false)` after an `UPDATE` leaves the row unchanged.
- Read-only body, `DELETE`-in-txn rejection, multi-write rejection: all as expected.
- Single transaction latency ~60ms.



---
**Implements:** #11835 (request-scoped transaction executor) and #11836 (transaction-body entry plumbing); completes the off-lock half of #11833.

---

## Stacked-PR review notes

**Implements #11835** (request-scoped transaction executor) and **#11836** (transaction-body entry plumbing); completes the off-lock rework of #11833.

Reworked by later PRs in the stack:

- The **per-table** OCC gate here (`TransactionWriteToken` = the table's sequence high-water) is replaced by **per-key** read-footprint OCC in #11861 (with a rebuild floor-stamp fix in #11863).
- The **single-table** executor (`TransactionWrite`, one staged commit) is generalized to **multi-table** in #11865 (`TransactionHandle` + a per-table participant map + the `CayenneTransaction::commit` orchestrator).
- The executor lives in `http/v1` here; it is **extracted** into the shared `datafusion::query::transaction` module (used by both HTTP and FlightSQL) in #11866.
- Admission accepts accelerator-only tables here; it is extended to durable-write-back tables in the write-back PR (#11838).

