### PR TITLE
Cayenne transactions (4/9): per-key read-footprint OCC

### DIFF
--- a/crates/cayenne/src/provider/mutation_writer.rs
+++ b/crates/cayenne/src/provider/mutation_writer.rs
@@ -515,8 +515,9 @@ impl<'a> AppendMutationWriter<'a> {
                 rows,
                 post_validation,
             } => {
+                let record_seq = self.table.sequence_high_water().await;
                 self.table
-                    .record_inlined_pk_keys(&post_validation.validated_keys);
+                    .record_inlined_pk_keys(&post_validation.validated_keys, record_seq);
                 tracing::debug!(
                     table = self.table.table_name(),
                     rows,
@@ -635,7 +636,8 @@ impl<'a> AppendMutationWriter<'a> {
                 };
 
                 if stage_on_conflict {
-                    self.table.record_file_pk_keys(&validated_keys);
+                    let record_seq = self.table.sequence_high_water().await;
+                    self.table.record_file_pk_keys(&validated_keys, record_seq);
                 }
                 drop(held_write_guard);
 
@@ -833,7 +835,8 @@ impl<'a> AppendMutationWriter<'a> {
         };
         // Record the inlined PK keys so a subsequent same-table upsert sees this
         // batch's rows as present (same bookkeeping as the durable inline path).
-        self.table.record_inlined_pk_keys(&validated_keys);
+        let record_seq = self.table.sequence_high_water().await;
+        self.table.record_inlined_pk_keys(&validated_keys, record_seq);
 
         drop(write_guard);
         record_cayenne_write_phase(self.table.table_name(), "cdc_path_inmemory", write_start);
@@ -1052,8 +1055,9 @@ impl<'a> AppendMutationWriter<'a> {
                     rows,
                     post_validation,
                 } => {
+                    let record_seq = self.table.sequence_high_water().await;
                     self.table
-                        .record_inlined_pk_keys(&post_validation.validated_keys);
+                        .record_inlined_pk_keys(&post_validation.validated_keys, record_seq);
                     return Ok(rows);
                 }
                 InlineMutationOutcome::Fallback {
@@ -1150,7 +1154,8 @@ impl<'a> AppendMutationWriter<'a> {
             // count and cleared only when retention had actually deleted rows).
             self.table.clear_cached_pk_keyset();
         } else {
-            self.table.record_file_pk_keys(&validated_keys);
+            let record_seq = self.table.sequence_high_water().await;
+            self.table.record_file_pk_keys(&validated_keys, record_seq);
         }
 
         Ok(total_rows)

--- a/crates/cayenne/src/provider/pk_index.rs
+++ b/crates/cayenne/src/provider/pk_index.rs
@@ -131,6 +131,13 @@ impl PkDigestSet {
 struct PkKeysetEntry {
     row: OwnedRow,
     location: RowLocation,
+    /// Sequence of the last commit that wrote this key's live row (0 = unknown,
+    /// treated as "older than any transaction"). Used by transaction per-key OCC:
+    /// a read-footprint / write-set key whose stored `sequence` exceeds the
+    /// transaction's begin high-water was modified after the transaction began →
+    /// conflict. Stamped by `record_sequence` on every committed write and by the
+    /// keyset rebuild's end-of-scan high-water.
+    sequence: i64,
 }
 
 // Approximate per-entry `HashMap` control/allocation overhead used for the
@@ -243,7 +250,7 @@ impl CachedPkKeyset {
                 self.approx_bytes = self
                     .approx_bytes
                     .saturating_add(approx_pk_keyset_entry_bytes(&key));
-                entry.insert(PkKeysetEntry { row: key, location });
+                entry.insert(PkKeysetEntry { row: key, location, sequence: 0 });
             }
         }
     }
@@ -280,6 +287,7 @@ impl CachedPkKeyset {
                 entry.insert(PkKeysetEntry {
                     row: key.clone(),
                     location,
+                    sequence: 0,
                 });
                 PkKeysetInsertOutcome::Inserted
             }
@@ -296,7 +304,7 @@ impl CachedPkKeyset {
             self.approx_bytes = self
                 .approx_bytes
                 .saturating_add(approx_pk_keyset_entry_bytes(&key));
-            entry.insert(PkKeysetEntry { row: key, location });
+            entry.insert(PkKeysetEntry { row: key, location, sequence: 0 });
         }
     }
 
@@ -305,6 +313,32 @@ impl CachedPkKeyset {
     #[inline]
     pub(crate) fn location_by_digest(&self, digest: u128) -> Option<&RowLocation> {
         self.keys.get(&digest).map(|entry| &entry.location)
+    }
+
+    /// The stored commit sequence for a key with this precomputed digest, or
+    /// `None` if the key is absent. Drives per-key transaction OCC re-check.
+    #[inline]
+    pub(crate) fn sequence_by_digest(&self, digest: u128) -> Option<i64> {
+        self.keys.get(&digest).map(|entry| entry.sequence)
+    }
+
+    /// Stamp a present key's last-commit sequence (monotonic max). Called after a
+    /// committed write records the key. No-op if the key is absent (over budget /
+    /// bloomed) — those tables fall back to per-table OCC.
+    pub(crate) fn record_sequence(&mut self, digest: u128, sequence: i64) {
+        if let Some(entry) = self.keys.get_mut(&digest) {
+            entry.sequence = entry.sequence.max(sequence);
+        }
+    }
+
+    /// Raise every entry's sequence to at least `sequence` — the end-of-scan
+    /// high-water after a full keyset rebuild, so any key that might have been
+    /// modified concurrently during the rebuild is conservatively treated as
+    /// changed (over-abort, never a missed conflict).
+    pub(crate) fn stamp_all_sequences_min(&mut self, sequence: i64) {
+        for entry in self.keys.values_mut() {
+            entry.sequence = entry.sequence.max(sequence);
+        }
     }
 
     /// Mutable access to a key's [`RowLocation`] (position-capture upgrade).

--- a/crates/cayenne/src/provider/staged_upsert.rs
+++ b/crates/cayenne/src/provider/staged_upsert.rs
@@ -140,9 +140,11 @@ impl CayenneStagedUpsert {
     /// Publish the staged rows, making the upsert visible to readers.
     ///
     /// Acquires `write_lock` now (staging ran off-lock) and re-checks the
-    /// optimistic-concurrency token first, aborting with [`Error::WriteConflict`]
-    /// (staged dir cleaned up) if the table changed since the transaction began.
-    /// It then mirrors the fenced tail of the sync on-conflict publish: apply the
+    /// transaction's per-key read footprint + write-set first, aborting with
+    /// [`Error::WriteConflict`] (staged dir cleaned up) if any of those keys was
+    /// committed after the transaction began (or, when per-key state is
+    /// unavailable, if the table's high-water moved at all). It then mirrors the
+    /// fenced tail of the sync on-conflict publish: apply the
     /// on-conflict deletions, reserve the protected-snapshot sequence, record it
     /// durably, then flip the deletion caches + protected snapshot under one
     /// listing-fence write.
@@ -153,15 +155,27 @@ impl CayenneStagedUpsert {
     /// error if applying the deletions, reserving the sequence, or the durable
     /// snapshot-sequence write fails. On a hard error the staged snapshot
     /// directory is left in place so the caller can retry the commit or roll back.
-    pub async fn commit(mut self) -> Result<u64> {
+    pub async fn commit(
+        mut self,
+        footprint: std::collections::HashSet<u128>,
+        footprint_complete: bool,
+    ) -> Result<u64> {
         // Acquire the write lock now (staging ran off-lock), then re-check the
-        // token before touching anything visible — a moved sequence high-water
-        // (or a dirty staging bit at capture) means a concurrent commit could
-        // have changed a key we wrote, so this transaction must abort and retry.
+        // transaction's read footprint + write-set per-key before touching
+        // anything visible: if any of those keys was committed after this
+        // transaction began, it must abort and retry. Keys not in the footprint
+        // are unaffected, so disjoint-key transactions commit concurrently.
         let _write_guard = self.table.write_lock_arc().lock_owned().await;
         self.table.ensure_no_incomplete_write().await?;
+        let current_high_water = self.table.sequence_high_water().await;
         if !self.token.staging_clean
-            || self.table.sequence_high_water().await != self.token.stage_seq
+            || self.table.transaction_has_conflict(
+                self.token.stage_seq,
+                &footprint,
+                footprint_complete,
+                &self.validated_keys,
+                current_high_water,
+            )
         {
             drop(_write_guard);
             cleanup_orphan_snapshot_dir(&self.table, &self.new_snapshot_id).await;
@@ -208,7 +222,7 @@ impl CayenneStagedUpsert {
         if retention_requested {
             self.table.clear_cached_pk_keyset();
         } else {
-            self.table.record_file_pk_keys(&self.validated_keys);
+            self.table.record_file_pk_keys(&self.validated_keys, new_sequence);
         }
 
         Ok(self.row_count)

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -454,7 +454,9 @@ impl CayenneCdcWrite {
                 // `AppendMutationWriter::write_prepared_stream`.
                 self.table.clear_cached_pk_keyset();
             } else {
-                self.table.record_file_pk_keys(&self.validated_file_keys);
+                let record_seq = self.table.sequence_high_water().await;
+                self.table
+                    .record_file_pk_keys(&self.validated_file_keys, record_seq);
             }
             // Live `num_rows` delta is inserted rows minus upsert replacements.
             // The staged path has no standalone deletes, so this remains a pure
@@ -6159,7 +6161,12 @@ impl CayenneTableProvider {
         }
     }
 
-    fn record_pk_keys_with_location(&self, keys: &PkDigestSet, location: &RowLocation) {
+    fn record_pk_keys_with_location(
+        &self,
+        keys: &PkDigestSet,
+        location: &RowLocation,
+        sequence: i64,
+    ) {
         if keys.is_empty() {
             return;
         }
@@ -6193,7 +6200,10 @@ impl CayenneTableProvider {
                             convert_to_bloom = true;
                             break;
                         }
-                        PkKeysetInsertOutcome::Updated | PkKeysetInsertOutcome::Inserted => {}
+                        PkKeysetInsertOutcome::Updated | PkKeysetInsertOutcome::Inserted => {
+                            // Stamp the key's last-commit sequence for per-key OCC.
+                            keyset.record_sequence(digest, sequence);
+                        }
                     }
                 }
             }
@@ -6233,8 +6243,8 @@ impl CayenneTableProvider {
         self.table_memory.set_keyset_bytes(bytes);
     }
 
-    pub(crate) fn record_inlined_pk_keys(&self, keys: &PkDigestSet) {
-        self.record_pk_keys_with_location(keys, &RowLocation::Inlined);
+    pub(crate) fn record_inlined_pk_keys(&self, keys: &PkDigestSet, sequence: i64) {
+        self.record_pk_keys_with_location(keys, &RowLocation::Inlined, sequence);
     }
 
     /// Store the per-shard PK index back into the sharded cache after validation
@@ -6250,8 +6260,45 @@ impl CayenneTableProvider {
         self.table_memory.set_keyset_bytes(bytes);
     }
 
-    pub(crate) fn record_file_pk_keys(&self, keys: &PkDigestSet) {
-        self.record_pk_keys_with_location(keys, &RowLocation::FileUnlocated);
+    pub(crate) fn record_file_pk_keys(&self, keys: &PkDigestSet, sequence: i64) {
+        self.record_pk_keys_with_location(keys, &RowLocation::FileUnlocated, sequence);
+    }
+
+    /// Per-key optimistic-concurrency re-check for a transaction commit, run
+    /// under `write_lock`. Returns `true` (→ abort with a write conflict) iff a
+    /// key in the read footprint or the write-set was committed after the
+    /// transaction's begin high-water `stage_seq`.
+    ///
+    /// When per-key state is unavailable — an incomplete footprint (a read
+    /// without a bounded PK predicate) or a bloomed / cleared keyset — it falls
+    /// back to the conservative per-table check (`current_high_water !=
+    /// stage_seq`), which aborts on any concurrent commit to the table.
+    pub(crate) fn transaction_has_conflict(
+        &self,
+        stage_seq: i64,
+        footprint: &std::collections::HashSet<u128>,
+        footprint_complete: bool,
+        write_set: &PkDigestSet,
+        current_high_water: i64,
+    ) -> bool {
+        let guard = self.pk_keyset_cache.lock();
+        match guard.as_ref() {
+            Some(CachedPkIndex::Exact(keyset)) if footprint_complete => {
+                let write_digests = write_set.iter_with_digest().map(|(digest, _)| digest);
+                footprint
+                    .iter()
+                    .copied()
+                    .chain(write_digests)
+                    .any(|digest| {
+                        keyset
+                            .sequence_by_digest(digest)
+                            .is_some_and(|seq| seq > stage_seq)
+                    })
+            }
+            // Bloom / cleared keyset, or an incomplete footprint: conservative
+            // per-table fallback.
+            _ => current_high_water != stage_seq,
+        }
     }
 
     /// Whether this table should capture file-local row positions for upsert
@@ -23007,6 +23054,31 @@ impl CayenneTableProvider {
         })
     }
 
+    /// Digest of the single primary-key point this scan's filters constrain, for
+    /// transaction read-footprint capture. Returns `None` unless the filters pin
+    /// every PK column to an equality literal (a partial-key or unbounded read),
+    /// which makes the caller fall back to per-table OCC. The digest is built
+    /// with the table's PK `RowConverter`, so it is bit-identical to the write
+    /// path's keyset digest for the same key.
+    fn footprint_digest_for(&self, filters: &[Expr]) -> Option<u128> {
+        if self.pk_column_indices.is_empty() {
+            return None;
+        }
+        let table_schema = self.table_schema();
+        let converter = self.build_pk_converter(&self.pk_column_indices).ok()?;
+        let mut pk_columns = Vec::with_capacity(self.pk_column_indices.len());
+        for &idx in &self.pk_column_indices {
+            let field = table_schema.field(idx);
+            let scalar = filters.iter().find_map(|f| pk_scalar_for(f, field.name()))?;
+            // Cast to the PK column's stored type so the encoded digest matches
+            // the write path's (e.g. `id = '5'` against an Int64 PK column).
+            let casted = scalar.cast_to(field.data_type()).ok()?;
+            pk_columns.push(casted.to_array_of_size(1).ok()?);
+        }
+        let rows = converter.convert_columns(&pk_columns).ok()?;
+        Some(pk_digest(&rows.row(0).owned()))
+    }
+
     /// Returns `true` when scan filters are selective enough that byte-range
     /// file-group fan-out is wasted work: point equality on every PK column,
     /// or (single-column Int64 PK only) a small `IN` list or tight `BETWEEN`.
@@ -23133,6 +23205,39 @@ fn pk_column_equals_literal(expr: &Expr, pk_name: &str) -> bool {
                 || pk_column_equals_literal(&bin.right, pk_name)
         }
         _ => false,
+    }
+}
+
+/// Extract the equality-literal `ScalarValue` constraining `pk_name` from a
+/// conjunctive filter (`pk_name = <lit>`, either operand order, `Cast`-wrapped
+/// column or literal, recursing through `AND`). `None` if `pk_name` is not
+/// pinned to a single literal — the caller then marks the read footprint
+/// incomplete. Mirrors [`pk_column_equals_literal`], returning the value.
+fn pk_scalar_for(expr: &Expr, pk_name: &str) -> Option<ScalarValue> {
+    match expr {
+        Expr::BinaryExpr(bin) if bin.op == Operator::Eq => {
+            if matches_column(&bin.left, pk_name) {
+                literal_scalar(&bin.right)
+            } else if matches_column(&bin.right, pk_name) {
+                literal_scalar(&bin.left)
+            } else {
+                None
+            }
+        }
+        Expr::BinaryExpr(bin) if bin.op == Operator::And => {
+            pk_scalar_for(&bin.left, pk_name).or_else(|| pk_scalar_for(&bin.right, pk_name))
+        }
+        _ => None,
+    }
+}
+
+/// The innermost literal `ScalarValue` of `expr`, unwrapping `Cast`/`TryCast`.
+fn literal_scalar(expr: &Expr) -> Option<ScalarValue> {
+    match expr {
+        Expr::Literal(scalar, _) => Some(scalar.clone()),
+        Expr::Cast(c) => literal_scalar(&c.expr),
+        Expr::TryCast(c) => literal_scalar(&c.expr),
+        _ => None,
     }
 }
 
@@ -23335,6 +23440,19 @@ impl TableProvider for CayenneTableProvider {
         // after the warm store already claimed the per-env slot.
         if let Some(ref cold_config) = self.cold_object_store_config {
             Self::register_object_store_if_needed(state.runtime_env(), cold_config);
+        }
+
+        // Transaction read-footprint capture: when a transaction is active for
+        // this table, record the primary keys this scan reads — extracted from
+        // the pushed-down PK equality predicate — so per-key OCC can re-check
+        // only those keys at commit. A scan without a bounded full-PK predicate
+        // marks the footprint incomplete, forcing the commit to fall back to the
+        // conservative per-table OCC check.
+        if let Some(txn) = active_transaction(state, self.table_id()) {
+            match self.footprint_digest_for(filters) {
+                Some(digest) => txn.record_read_keys([digest]),
+                None => txn.mark_footprint_incomplete(),
+            }
         }
 
         // End-to-end data-file integrity: when enabled, verify each manifest
@@ -24144,22 +24262,22 @@ impl TableProvider for CayenneTableProvider {
 
         let source_plan = state.create_physical_plan(&plan).await?;
 
-        // Conditional-commit transaction: `UpdateExec` runs delete + insert, and
-        // its delete leg publishes deletion vectors immediately — that breaks
-        // atomicity (a rollback would lose rows, and even a successful commit
-        // exposes a torn "row missing" window between the delete and the insert
-        // publish). When a transaction is active for this table, run only the
-        // insert (upsert) leg: the staged upsert supersedes each prior row by
-        // primary key, and the executor applies those deletions atomically under
-        // the fence at COMMIT.
-        if transaction_active_for(state, self.table_id()) {
+        // Transaction: `UpdateExec` runs delete + insert, and its delete leg
+        // publishes deletion vectors immediately — that breaks atomicity (a
+        // rollback would lose rows, and even a successful commit exposes a torn
+        // "row missing" window between the delete and the insert publish). When a
+        // transaction is active for this table, run only the insert (upsert)
+        // leg: the staged upsert supersedes each prior row by primary key, and
+        // the executor applies those deletions atomically under the fence at
+        // COMMIT.
+        if active_transaction(state, self.table_id()).is_some() {
             // The staged upsert supersedes by primary key, so a reassigned PK
             // column would leave the prior row in place. Reject it (v1 supports
             // value updates only).
             for (col, _) in &assignments {
                 if self.metadata().primary_key.iter().any(|pk| pk == col) {
                     return Err(datafusion_common::DataFusionError::Execution(format!(
-                        "conditional-commit UPDATE cannot reassign primary-key column '{col}'"
+                        "transaction UPDATE cannot reassign primary-key column '{col}'"
                     )));
                 }
             }
@@ -24185,19 +24303,22 @@ impl TableProvider for CayenneTableProvider {
     }
 }
 
-/// Whether a conditional-commit transaction is active for `table_id` on this
-/// session's request context.
+/// The transaction active for `table_id` on this session's request context, if
+/// any.
 ///
 /// Reads the transaction from the [`runtime_request_context::RequestContext`]
 /// typed extension on the session config — the same context the query builder
-/// installed for this request — so the check matches the one the sink makes at
+/// installed for this request — so it matches what the sink resolves at
 /// execution time.
-fn transaction_active_for(state: &dyn Session, table_id: &str) -> bool {
+fn active_transaction(
+    state: &dyn Session,
+    table_id: &str,
+) -> Option<super::transaction::CayenneTransaction> {
     state
         .config()
         .get_extension::<runtime_request_context::RequestContext>()
         .and_then(|rc| rc.extension::<super::transaction::CayenneTransaction>())
-        .is_some_and(|txn| txn.table_id() == table_id)
+        .filter(|txn| txn.table_id() == table_id)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27270,7 +27391,10 @@ mod tests {
             "staged rows must be invisible before commit"
         );
 
-        let rows = staged.commit().await.expect("commit staged upsert");
+        let rows = staged
+            .commit(std::collections::HashSet::new(), true)
+            .await
+            .expect("commit staged upsert");
         assert_eq!(rows, 2);
         assert_eq!(
             scan_sorted_ids(&provider).await,
@@ -27325,7 +27449,10 @@ mod tests {
             "pre-commit state must be unchanged"
         );
 
-        staged.commit().await.expect("commit staged upsert");
+        staged
+            .commit(std::collections::HashSet::new(), true)
+            .await
+            .expect("commit staged upsert");
 
         // Exactly one id=1 (superseded, not duplicated) plus the new id=3.
         assert_eq!(scan_sorted_ids(&provider).await, vec![1, 3]);

--- a/crates/cayenne/src/provider/transaction.rs
+++ b/crates/cayenne/src/provider/transaction.rs
@@ -44,6 +44,8 @@ limitations under the License.
 //! immediately (an undetectable atomicity break).
 
 use std::any::Any;
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use super::staged_upsert::{CayenneStagedUpsert, TransactionWriteToken};
@@ -65,6 +67,14 @@ struct TxnInner {
     /// `None` only transiently, while the sink moves the token into a staged
     /// handle. Never held across an await.
     stage: Mutex<Option<TxnStage>>,
+    /// Read footprint: digests of the primary keys the transaction's statements
+    /// read (extracted from pushed-down PK equality/IN predicates). Re-checked
+    /// per-key at commit against each key's stored commit sequence.
+    footprint: Mutex<HashSet<u128>>,
+    /// Set when a statement read this table with a predicate the footprint
+    /// capture could not resolve to a bounded key set (an unbounded-scan gate).
+    /// Forces the commit to fall back to the conservative per-table OCC check.
+    footprint_incomplete: AtomicBool,
 }
 
 /// A transaction handle. Cloning is a cheap `Arc` clone; the
@@ -88,6 +98,8 @@ impl CayenneTransaction {
         Self(Arc::new(TxnInner {
             table_id,
             stage: Mutex::new(Some(TxnStage::Armed(token))),
+            footprint: Mutex::new(HashSet::new()),
+            footprint_incomplete: AtomicBool::new(false),
         }))
     }
 
@@ -95,6 +107,35 @@ impl CayenneTransaction {
     #[must_use]
     pub fn table_id(&self) -> &str {
         &self.0.table_id
+    }
+
+    /// Record primary-key digests read by a statement into the transaction's
+    /// read footprint (called from the scan when a bounded PK predicate is
+    /// pushed down for this table).
+    pub fn record_read_keys(&self, digests: impl IntoIterator<Item = u128>) {
+        if let Ok(mut fp) = self.0.footprint.lock() {
+            fp.extend(digests);
+        }
+    }
+
+    /// Mark the read footprint incomplete — a statement read this table without
+    /// a bounded PK predicate, so commit must fall back to per-table OCC.
+    pub fn mark_footprint_incomplete(&self) {
+        self.0.footprint_incomplete.store(true, Ordering::Relaxed);
+    }
+
+    /// Take the accumulated read footprint and whether it is complete. Returns
+    /// `(digests, complete)`; `complete == false` forces per-table fallback.
+    #[must_use]
+    pub fn take_footprint(&self) -> (HashSet<u128>, bool) {
+        let complete = !self.0.footprint_incomplete.load(Ordering::Relaxed);
+        let digests = self
+            .0
+            .footprint
+            .lock()
+            .map(|mut fp| std::mem::take(&mut *fp))
+            .unwrap_or_default();
+        (digests, complete)
     }
 
     /// Take the armed OCC token so the caller can hand it to

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -483,7 +483,9 @@ async fn execute_transaction(
                 SqlErrorKind::General,
             );
         };
-        match staged.commit().await {
+        // Per-key OCC: re-check the read footprint + write-set at commit.
+        let (footprint, footprint_complete) = write.txn.take_footprint();
+        match staged.commit(footprint, footprint_complete).await {
             Ok(_) => {}
             Err(cayenne::provider::Error::WriteConflict { table }) => {
                 // Optimistic-concurrency conflict: the table was committed to


### PR DESCRIPTION
<!-- stack-nav -->
> **Cayenne transactions — stacked PR 4 of 9**
> ← Previous: #11859 &nbsp;·&nbsp; Next: #11863 →
>
> Review/merge bottom-up: #11848 · #11849 · #11859 · #11861 · #11863 · #11865 · #11866 · #11868 · #11869 &nbsp;→&nbsp; all squashed into #11870 (targets `trunk`). Part of #11830.

---

Part of #11830. Advances #11834 (per-key read-version capture + commit re-check) and adds the per-key version signal from #11856. Stacked on #11859 — review/merge that first; this PR's diff is against that branch.

## What

Replaces the per-table sequence gate (from #11859) with **per-key optimistic concurrency**, so transactions touching disjoint keys commit concurrently instead of all contending on the table.

## How

- **Read-footprint capture.** In `CayenneTableProvider::scan`, when a transaction is active for the table, the pushed-down PK equality predicate (`WHERE id = <lit>`) is resolved to a key digest — built with the table's PK `RowConverter`, so it is bit-identical to the write-path keyset digest — and recorded on the transaction. Capturing from the *predicate* (not emitted rows) is phantom-safe and independent of projection. A read without a bounded full-PK predicate marks the footprint incomplete.
- **Per-key version.** `PkKeysetEntry` gains a `sequence`, stamped with the committing write's sequence on every recorded write (transaction commits, appends, inline, refresh) and with the end-of-scan high-water on a keyset rebuild.
- **Commit re-check.** Under `write_lock`, the transaction aborts (retryable `409`) iff any key in its read footprint or write-set has a stored `sequence` greater than the transaction's begin high-water. Disjoint keys are untouched, so their commits don't conflict.
- **Fallback.** When per-key state is unavailable — an incomplete footprint or a bloomed/cleared keyset — it falls back to the per-table high-water check, so correctness never depends on capture succeeding.

## Results (txn-bench, throughput commits/s, same budget both builds)

Independent-counter workload (each client increments a random key), vs the per-table baseline (#11859):

| clients | per-table | per-key |
|--:|--:|--:|
| 5 | 12.0 | 30.8 |
| 10 | 7.6 | 27.3 |
| 20 | 4.4 | 20.1 |
| 30 | 2.9 | 15.7 |

The baseline collapses and can't finish past ~30 clients within budget; per-key scales with concurrency and completes out to 75. Same-key contention (one hot counter) is unchanged — per-key can't help when every transaction hits the same key. Conflicts fell ~8x. No over-admit / lost updates; cap enforcement, atomicity (write-then-fail rollback), read-only bodies, and DELETE/multi-write rejection all still hold.

## Scope / follow-ups

- Only a single full-PK equality point (`id = <lit>`) is captured per read; composite-PK cartesian sets, `IN` lists, and unbounded gates fall back to per-table (correct, just not concurrent). Rejecting unbounded gates outright (rather than falling back) is a later refinement.
- Concurrent deletes are caught via the keyset-clear → per-table fallback; an explicit per-key tombstone probe is deferred.
- Still accelerator-only and single-write per transaction (durable write-back #11838, multi-table #11837).

---

## Stacked-PR review notes

**Implements #11834** (per-key read-version capture + commit-time re-check).

Reworked by later PRs in the stack:

- A rebuild floor-stamp bug in the per-key sequence stamping (a mid-transaction keyset rebuild reset per-key stamps to 0 → missed conflict) is fixed in #11863.

