### PR TITLE
Cayenne transactions (5/9): per-key OCC rebuild floor-stamp fix

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -6870,6 +6870,14 @@ impl CayenneTableProvider {
         // Finally fold in the un-checkpointed mem-tier keys (snapshotted at the top).
         Self::fold_mem_tier_keys_into_keyset(&mem_snapshots, pk_indices, converter, &mut keyset)?;
 
+        // Floor every rebuilt entry's per-key OCC sequence at the end-of-scan
+        // high-water. A commit that landed during the rebuild may not be
+        // reflected in the scanned keys, so any transaction that began before
+        // this rebuild must conservatively treat these keys as changed —
+        // stamping the end high-water makes the commit-time per-key check
+        // over-abort rather than miss the conflict (a silent lost update).
+        keyset.stamp_all_sequences_min(self.sequence_high_water().await);
+
         Ok(keyset)
     }
 


### PR DESCRIPTION
<!-- stack-nav -->
> **Cayenne transactions — stacked PR 5 of 9**
> ← Previous: #11861 &nbsp;·&nbsp; Next: #11865 →
>
> Review/merge bottom-up: #11848 · #11849 · #11859 · #11861 · #11863 · #11865 · #11866 · #11868 · #11869 &nbsp;→&nbsp; all squashed into #11870 (targets `trunk`). Part of #11830.

---

Follow-up to #11861. `stamp_all_sequences_min` was defined but never called, so a keyset rebuild reset every per-key OCC `sequence` to 0 — a transaction whose footprint key was rebuilt between begin and commit would read the stale 0 stamp and miss the conflict (silent lost update). `load_existing_keyset` now floor-stamps rebuilt entries with the end-of-scan high-water (conservative over-abort). Part of #11830.

---

## Stacked-PR review notes

**Part of #11834** — a follow-up fix to the per-key OCC introduced in #11861: wires the rebuild floor-stamp so a mid-transaction keyset rebuild can't reset per-key sequences and miss a conflict.

