### PR TITLE
ci: add remote signoff workflow

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -1,0 +1,94 @@
+---
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Remote developer sign-off — run the same fast checks as `make signoff`
+# on a self-hosted runner, then post the `signoff` commit status on the
+# branch HEAD so the PR's Attestation check turns green.
+#
+# Use this when you can't (or don't want to) run the checks locally:
+#   gh workflow run signoff.yml -f branch=<your-branch>
+name: Remote Sign-off
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to sign off (must be pushed to origin)'
+        required: true
+        type: string
+
+concurrency:
+  group: signoff-${{ github.event.inputs.branch }}
+  cancel-in-progress: true
+
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_TIMEOUT: 60
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
+jobs:
+  sign-off:
+    name: Sign off on ${{ github.event.inputs.branch }}
+    runs-on: spiceai-macos
+    permissions:
+      contents: read
+      statuses: write
+    env:
+      HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 1
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Set up Nextest
+        uses: ./.github/actions/setup-nextest
+
+      - name: Set up spiceio
+        if: runner.os == 'macOS' && env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@973bc49a7be396ec9430255ad0f7ed684d7a1317 # v0.5.8
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: sccache
+          region: us-west-1
+
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
+
+      - name: Install Protoc
+        uses: ./.github/actions/install-protoc
+
+      - name: Set up make
+        uses: ./.github/actions/setup-make
+
+      - name: Set up cc
+        uses: ./.github/actions/setup-cc
+
+      - name: Sign off
+        run: scripts/signoff -f
+        env:
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+
+      - name: Show sccache stats
+        if: env.SCCACHE_SETUP == 'true'
+        run: sccache --show-stats
+
+      - name: Kill spiceio
+        if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true


### PR DESCRIPTION
## Summary
Adds a `workflow_dispatch` workflow that runs `scripts/signoff -f` on a self-hosted runner, for cases where you can't or don't want to run `make signoff` locally.

```
gh workflow run signoff.yml -f branch=<your-branch>
```

Runs `make lint-rust` + `make build-cli nextest` on `spiceai-macos`, then posts the `signoff` commit status on the branch HEAD — identical result to running `make signoff` locally.