### PR TITLE
Cayenne transactions (8/9): durable federated write-back

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -767,6 +767,7 @@ impl CayenneCatalog {
         snapshot_sequence: Option<&SnapshotSequenceCommit>,
         inline_tombstone: Option<&InlinedDelete>,
         pending_durable_flips: &[String],
+        dirty_pk_bytes: &[Vec<u8>],
     ) -> CatalogResult<()> {
         const MAX_PARAMS: usize = 32_000;
         const DELETE_FILE_PARAMS_PER_ROW: usize = 10;
@@ -788,6 +789,19 @@ impl CayenneCatalog {
                 ],
             })
             .await?;
+        }
+
+        // Durable federated write-back (#11838): mark the written PKs dirty in
+        // the SAME commit transaction, so a crash after commit / before delivery
+        // re-delivers on the next worker wake. Gated by the caller (only a
+        // durable-write-back table passes a non-empty `dirty_pk_bytes`), and the
+        // marker sequence is the commit's snapshot sequence — directly comparable
+        // with the per-key OCC sequences and monotone across re-marks.
+        if !dirty_pk_bytes.is_empty()
+            && let Some(seq) = snapshot_sequence
+        {
+            self.mark_dirty_keys_in_txn(txn, table_id, dirty_pk_bytes, seq.sequence_number)
+                .await?;
         }
 
         if let Some(tombstone) = inline_tombstone {
@@ -815,6 +829,117 @@ impl CayenneCatalog {
         }
 
         Ok(())
+    }
+
+    /// Mark primary keys dirty for durable federated write-back (#11838) inside
+    /// the caller's commit transaction. Chunked monotone upsert into
+    /// `cayenne_pending_write_back`: an existing marker keeps `MAX(old, new)`
+    /// sequence (never regresses) and its original `first_marked_at`.
+    ///
+    /// `dirty_pk_bytes` are the `RowConverter` `OwnedRow` encodings of the full
+    /// primary keys (bit-identical to the keyset/footprint `pk_digest` input).
+    pub(crate) async fn mark_dirty_keys_in_txn(
+        &self,
+        txn: &mut dyn MetastoreTransaction,
+        table_id: &str,
+        dirty_pk_bytes: &[Vec<u8>],
+        sequence_number: i64,
+    ) -> CatalogResult<()> {
+        use std::fmt::Write as _;
+        const MAX_PARAMS: usize = 32_000;
+        const PARAMS_PER_ROW: usize = 3;
+        const MAX_ROWS_PER_CHUNK: usize = MAX_PARAMS / PARAMS_PER_ROW;
+
+        for chunk in dirty_pk_bytes.chunks(MAX_ROWS_PER_CHUNK) {
+            const PREFIX: &str = "INSERT INTO cayenne_pending_write_back \
+                 (table_id, pk_bytes, sequence_number) VALUES ";
+            const SUFFIX: &str = " ON CONFLICT(table_id, pk_bytes) DO UPDATE SET \
+                 sequence_number = MAX(cayenne_pending_write_back.sequence_number, excluded.sequence_number)";
+            let mut sql = String::with_capacity(PREFIX.len() + SUFFIX.len() + chunk.len() * 20);
+            sql.push_str(PREFIX);
+            let mut params = Vec::with_capacity(chunk.len() * PARAMS_PER_ROW);
+            for (i, pk_bytes) in chunk.iter().enumerate() {
+                let base = i * PARAMS_PER_ROW + 1; // 1-indexed
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                let _ = write!(sql, "(?{}, ?{}, ?{})", base, base + 1, base + 2);
+                params.push(insert_record_table_id_value(table_id));
+                params.push(MetastoreValue::Blob(pk_bytes.clone()));
+                params.push(MetastoreValue::Integer(sequence_number));
+            }
+            sql.push_str(SUFFIX);
+            txn.execute(ExecuteParams { sql: &sql, params }).await?;
+        }
+        Ok(())
+    }
+
+    /// List up to `limit` undelivered write-back markers for `table_id`, oldest
+    /// commit sequence first. Returns `(pk_bytes, sequence_number)` pairs.
+    pub(crate) async fn list_pending_write_back(
+        &self,
+        table_id: &str,
+        limit: usize,
+    ) -> CatalogResult<Vec<(Vec<u8>, i64)>> {
+        self.metastore
+            .query_helper(
+                QueryParams {
+                    sql: "SELECT pk_bytes, sequence_number FROM cayenne_pending_write_back \
+                          WHERE table_id = ?1 ORDER BY sequence_number ASC LIMIT ?2",
+                    params: vec![
+                        insert_record_table_id_value(table_id),
+                        MetastoreValue::Integer(i64::try_from(limit).unwrap_or(i64::MAX)),
+                    ],
+                },
+                |row| Ok((row.get_blob(0)?, row.get_i64(1)?)),
+            )
+            .await
+    }
+
+    /// Compare-and-clear delivered markers: for each `(pk_bytes, claimed_seq)`,
+    /// delete the marker only if its stored sequence is still `<= claimed_seq`
+    /// (a newer commit that bumped it above `claimed_seq` during delivery leaves
+    /// it in place, so the stale delivery never clears a fresh mark). Batched in
+    /// one transaction.
+    pub(crate) async fn clear_pending_write_back(
+        &self,
+        table_id: &str,
+        keys: &[(Vec<u8>, i64)],
+    ) -> CatalogResult<()> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let txn = self.metastore.begin_transaction().await?;
+        let table_id_value = insert_record_table_id_value(table_id);
+        for (pk_bytes, claimed_seq) in keys {
+            txn.execute(ExecuteParams {
+                sql: "DELETE FROM cayenne_pending_write_back \
+                      WHERE table_id = ?1 AND pk_bytes = ?2 AND sequence_number <= ?3",
+                params: vec![
+                    table_id_value.clone(),
+                    MetastoreValue::Blob(pk_bytes.clone()),
+                    MetastoreValue::Integer(*claimed_seq),
+                ],
+            })
+            .await?;
+        }
+        txn.commit().await?;
+        Ok(())
+    }
+
+    /// Count undelivered write-back markers for `table_id` (backlog gauge).
+    pub(crate) async fn pending_write_back_count(&self, table_id: &str) -> CatalogResult<i64> {
+        let rows = self
+            .metastore
+            .query_helper(
+                QueryParams {
+                    sql: "SELECT COUNT(*) FROM cayenne_pending_write_back WHERE table_id = ?1",
+                    params: vec![insert_record_table_id_value(table_id)],
+                },
+                |row| row.get_i64(0),
+            )
+            .await?;
+        Ok(rows.into_iter().next().unwrap_or(0))
     }
 
     /// Reconcile the datalake (cold tier) fields of a reopened table's stored
@@ -4125,6 +4250,20 @@ impl MetadataCatalog for CayenneCatalog {
             .await
             .map_err(|e| CatalogError::InvalidOperation {
                 message: "Failed to delete insert records.".to_string(),
+                source: Box::new(e),
+            })?;
+
+        // 1b. Delete durable write-back markers (#11838). Unlike the other
+        // tables this is never cleared at checkpoint/overwrite, so drop_table is
+        // the only place its rows are removed.
+        self.metastore
+            .execute_helper(ExecuteParams {
+                sql: "DELETE FROM cayenne_pending_write_back WHERE table_id = ?1",
+                params: vec![insert_record_table_id_value(&table_id)],
+            })
+            .await
+            .map_err(|e| CatalogError::InvalidOperation {
+                message: "Failed to delete pending write-back markers.".to_string(),
                 source: Box::new(e),
             })?;
 

--- a/crates/cayenne/src/metastore.rs
+++ b/crates/cayenne/src/metastore.rs
@@ -157,6 +157,15 @@ pub const EXPECTED_TABLES: &[ExpectedTable] = &[
         columns: &["table_id", "pk_bytes", "sequence_number"],
     },
     ExpectedTable {
+        // Durable federated write-back marker set (#11838): one row per PK a
+        // durable-write-back table has committed to the accelerator but not yet
+        // reconciled to the federated source. Same (table_id, pk_bytes) shape as
+        // cayenne_insert_record plus first_marked_at (lag metric). Never cleared
+        // at checkpoint/overwrite.
+        name: "cayenne_pending_write_back",
+        columns: &["table_id", "pk_bytes", "sequence_number", "first_marked_at"],
+    },
+    ExpectedTable {
         name: "cayenne_snapshot_sequence",
         columns: &["table_id", "snapshot_id", "sequence_number"],
     },

--- a/crates/cayenne/src/metastore/sqlite.rs
+++ b/crates/cayenne/src/metastore/sqlite.rs
@@ -629,6 +629,38 @@ impl SqliteMetastore {
         ) WITHOUT ROWID
     ";
 
+    /// Schema for the `cayenne_pending_write_back` table (durable federated
+    /// write-back, #11838).
+    ///
+    /// Tracks the primary keys that a durable-write-back table has committed to
+    /// the accelerator but not yet reconciled to the federated source. One row
+    /// per undelivered key; the delivery worker claims rows, reconciles the
+    /// key's current committed value to the source, then clears the row.
+    ///
+    /// `table_id` is the 16 raw UUID bytes (as in `cayenne_insert_record`);
+    /// `pk_bytes` is the `RowConverter` `OwnedRow` encoding of the full primary
+    /// key (bit-identical to the keyset/footprint `pk_digest` input) so the
+    /// worker can rebuild both the accelerator point-scan filter and the source
+    /// key. `sequence_number` is the table commit sequence that last dirtied the
+    /// key; the marker upsert is **monotone** (keeps `MAX`) and the worker's
+    /// compare-and-clear is `<= claimed_seq`, so a newer commit landing during
+    /// delivery leaves the marker above the claimed sequence and the stale clear
+    /// no-ops. `first_marked_at` is the oldest-undelivered timestamp (lag metric)
+    /// and is never overwritten on re-mark.
+    ///
+    /// Unlike `cayenne_insert_record`, this table is **never** cleared at
+    /// checkpoint/overwrite (that would drop acked-but-undelivered writes);
+    /// `drop_table` deletes its rows explicitly.
+    const PENDING_WRITE_BACK_TABLE_DDL: &'static str = r"
+        CREATE TABLE IF NOT EXISTS cayenne_pending_write_back (
+            table_id BLOB NOT NULL,
+            pk_bytes BLOB NOT NULL,
+            sequence_number BIGINT NOT NULL,
+            first_marked_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            PRIMARY KEY (table_id, pk_bytes)
+        ) WITHOUT ROWID
+    ";
+
     /// Schema for the `cayenne_snapshot_sequence` table.
     ///
     /// Tracks the sequence number for each snapshot. This enables Iceberg-style
@@ -927,12 +959,13 @@ impl MetastoreBackend for SqliteMetastore {
             .call(|conn| {
                 // Create tables in a transaction
                 conn.execute_batch(&format!(
-                    "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
+                    "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
                     Self::TABLE_TABLE_DDL,
                     Self::TABLE_NAME_UNIQUE_INDEX_DDL,
                     Self::DELETE_FILE_TABLE_DDL,
                     Self::PARTITION_TABLE_DDL,
                     Self::INSERT_RECORD_TABLE_DDL,
+                    Self::PENDING_WRITE_BACK_TABLE_DDL,
                     Self::SNAPSHOT_SEQUENCE_TABLE_DDL,
                     Self::TABLE_STATISTICS_DDL,
                     Self::SNAPSHOT_FILE_STATISTICS_TABLE_DDL,

--- a/crates/cayenne/src/metastore/turso.rs
+++ b/crates/cayenne/src/metastore/turso.rs
@@ -300,6 +300,19 @@ impl TursoMetastore {
         )
     ";
 
+    /// Schema for the `cayenne_pending_write_back` table (durable federated
+    /// write-back, #11838). See the `SQLite` `PENDING_WRITE_BACK_TABLE_DDL` doc
+    /// for semantics. Plain rowid table (Turso rejects `WITHOUT ROWID` in MVCC).
+    const PENDING_WRITE_BACK_TABLE_DDL: &'static str = r"
+        CREATE TABLE IF NOT EXISTS cayenne_pending_write_back (
+            table_id BLOB NOT NULL,
+            pk_bytes BLOB NOT NULL,
+            sequence_number BIGINT NOT NULL,
+            first_marked_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            PRIMARY KEY (table_id, pk_bytes)
+        )
+    ";
+
     /// Schema for the `cayenne_snapshot_sequence` table.
     ///
     /// Tracks the sequence number for each snapshot. This enables Iceberg-style
@@ -592,12 +605,13 @@ impl MetastoreBackend for TursoMetastore {
 
         // Create tables
         let schema_sql = format!(
-            "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
+            "{}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {}; {};",
             Self::TABLE_TABLE_DDL,
             Self::TABLE_NAME_UNIQUE_INDEX_DDL,
             Self::DELETE_FILE_TABLE_DDL,
             Self::PARTITION_TABLE_DDL,
             Self::INSERT_RECORD_TABLE_DDL,
+            Self::PENDING_WRITE_BACK_TABLE_DDL,
             Self::SNAPSHOT_SEQUENCE_TABLE_DDL,
             Self::TABLE_STATISTICS_DDL,
             Self::SNAPSHOT_FILE_STATISTICS_TABLE_DDL,

--- a/crates/cayenne/src/provider/staged_upsert.rs
+++ b/crates/cayenne/src/provider/staged_upsert.rs
@@ -346,6 +346,18 @@ impl PreparedTxnCommit {
         catalog: &crate::CayenneCatalog,
         txn: &mut dyn crate::metastore::MetastoreTransaction,
     ) -> crate::catalog::CatalogResult<()> {
+        // Durable federated write-back (#11838): on a durable-write-back table,
+        // durably mark the written PKs (their `OwnedRow` encodings) in the same
+        // commit transaction so the delivery worker reconciles them to the
+        // source. Empty otherwise — a non-write-back table never marks.
+        let dirty_pk_bytes: Vec<Vec<u8>> = if self.table.is_durable_write_back() {
+            self.validated_keys
+                .iter()
+                .map(|row| row.as_ref().to_vec())
+                .collect()
+        } else {
+            Vec::new()
+        };
         catalog
             .commit_staged_upsert_in_txn(
                 txn,
@@ -354,6 +366,7 @@ impl PreparedTxnCommit {
                 Some(&self.snapshot_commit),
                 None,
                 &[],
+                &dirty_pk_bytes,
             )
             .await
     }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1054,6 +1054,13 @@ pub struct CayenneTableProvider {
     pk_row_converter: Option<Arc<RowConverter>>,
     /// Indices of primary key columns in the table schema.
     pk_column_indices: Vec<usize>,
+    /// Durable federated write-back (#11838): when set, every committed write on
+    /// this table durably marks its primary keys in `cayenne_pending_write_back`
+    /// (inside the commit transaction) so a per-table delivery worker can
+    /// reconcile them to the federated source. Not persisted in `TableMetadata`;
+    /// derived from the acceleration settings and set via the builder, and shared
+    /// across writer clones (a plain in-memory `bool`, `Copy`).
+    durable_write_back: bool,
     /// Write lock to serialize insert operations and prevent concurrent write races.
     /// This ensures that:
     /// - Only one `insert()` runs at a time per table
@@ -1627,6 +1634,7 @@ pub struct CayenneTableProviderBuilder {
     cold_object_store_config: Option<crate::metadata::ObjectStoreConfig>,
     context: Option<Arc<CayenneContext>>,
     maintained_aggregates: Vec<MaintainedAggregateSpec>,
+    durable_write_back: bool,
 }
 
 struct PendingMaintainedAggregateInsert {
@@ -1683,6 +1691,7 @@ struct CayenneTableProviderOpenOptions {
     cold_object_store_config: Option<crate::metadata::ObjectStoreConfig>,
     context: Option<Arc<CayenneContext>>,
     maintained_aggregate_specs: Vec<MaintainedAggregateSpec>,
+    durable_write_back: bool,
 }
 
 impl CayenneTableProviderBuilder {
@@ -1698,6 +1707,7 @@ impl CayenneTableProviderBuilder {
             cold_object_store_config: None,
             context: None,
             maintained_aggregates: Vec::new(),
+            durable_write_back: false,
         }
     }
 
@@ -1761,6 +1771,14 @@ impl CayenneTableProviderBuilder {
         self
     }
 
+    /// Enable durable federated write-back (#11838): every committed write marks
+    /// its primary keys in `cayenne_pending_write_back` for the delivery worker.
+    #[must_use]
+    pub fn with_durable_write_back(mut self, enabled: bool) -> Self {
+        self.durable_write_back = enabled;
+        self
+    }
+
     /// Open an existing table by name.
     ///
     /// # Errors
@@ -1775,6 +1793,7 @@ impl CayenneTableProviderBuilder {
             cold_object_store_config: self.cold_object_store_config,
             context: self.context,
             maintained_aggregate_specs: self.maintained_aggregates,
+            durable_write_back: self.durable_write_back,
         };
 
         CayenneTableProvider::new_internal(table_name, self.catalog, self.runtime_env, options)
@@ -1797,6 +1816,7 @@ impl CayenneTableProviderBuilder {
             cold_object_store_config: self.cold_object_store_config,
             context: self.context,
             maintained_aggregate_specs: self.maintained_aggregates,
+            durable_write_back: self.durable_write_back,
         };
 
         CayenneTableProvider::new_internal(&table_name, self.catalog, self.runtime_env, options)
@@ -4451,6 +4471,7 @@ impl CayenneTableProvider {
             cold_object_store_config,
             context,
             maintained_aggregate_specs,
+            durable_write_back,
         } = options;
 
         let table_metadata = catalog.get_table(table_name).await?;
@@ -4680,6 +4701,7 @@ impl CayenneTableProvider {
             pk_deletion_strategy,
             pk_row_converter,
             pk_column_indices,
+            durable_write_back,
             write_lock: Arc::new(tokio::sync::Mutex::new(())),
             visibility_lock: Arc::new(tokio::sync::Mutex::new(())),
             scan_state_lock: Arc::new(tokio::sync::RwLock::new(())),
@@ -4882,6 +4904,92 @@ impl CayenneTableProvider {
     #[must_use]
     pub fn catalog(&self) -> &Arc<dyn MetadataCatalog> {
         &self.catalog
+    }
+
+    /// Durable federated write-back (#11838): whether committed writes on this
+    /// table mark their primary keys for reconciliation to the federated source.
+    #[must_use]
+    pub fn is_durable_write_back(&self) -> bool {
+        self.durable_write_back
+    }
+
+    /// Downcast the metadata catalog to the concrete Cayenne catalog — the
+    /// write-back marker CRUD is a Cayenne-specific concern (not on the trait).
+    fn cayenne_catalog(&self) -> Option<&crate::CayenneCatalog> {
+        self.catalog
+            .as_any()
+            .downcast_ref::<crate::CayenneCatalog>()
+    }
+
+    /// List up to `limit` undelivered write-back markers (oldest commit first)
+    /// as `(pk_bytes, sequence_number)`. The `pk_bytes` are opaque `OwnedRow`
+    /// encodings — feed them back to [`Self::decode_pk_keys`] /
+    /// [`Self::clear_dirty_keys`].
+    ///
+    /// # Errors
+    /// Propagates the underlying metastore error.
+    pub async fn list_dirty_keys(&self, limit: usize) -> Result<Vec<(Vec<u8>, i64)>> {
+        let Some(catalog) = self.cayenne_catalog() else {
+            return Ok(Vec::new());
+        };
+        Ok(catalog.list_pending_write_back(self.table_id(), limit).await?)
+    }
+
+    /// Compare-and-clear delivered write-back markers (see
+    /// [`crate::CayenneCatalog::clear_pending_write_back`]).
+    ///
+    /// # Errors
+    /// Propagates the underlying metastore error.
+    pub async fn clear_dirty_keys(&self, keys: &[(Vec<u8>, i64)]) -> Result<()> {
+        let Some(catalog) = self.cayenne_catalog() else {
+            return Ok(());
+        };
+        catalog
+            .clear_pending_write_back(self.table_id(), keys)
+            .await?;
+        Ok(())
+    }
+
+    /// Count undelivered write-back markers (backlog gauge).
+    ///
+    /// # Errors
+    /// Propagates the underlying metastore error.
+    pub async fn dirty_key_count(&self) -> Result<i64> {
+        let Some(catalog) = self.cayenne_catalog() else {
+            return Ok(0);
+        };
+        Ok(catalog.pending_write_back_count(self.table_id()).await?)
+    }
+
+    /// Decode marker `pk_bytes` (`RowConverter` `OwnedRow` encodings) back into
+    /// the primary-key column arrays, in key order — for the accelerator
+    /// point-scan filter and the source delivery key.
+    ///
+    /// # Errors
+    /// Returns an error if the table has no PK converter or the bytes are
+    /// malformed for its key schema.
+    pub fn decode_pk_keys(&self, pk_bytes: &[Vec<u8>]) -> Result<Vec<ArrayRef>> {
+        let converter = self.pk_row_converter.as_ref().ok_or_else(|| Error::Internal {
+            table: self.table_name().to_string(),
+            message: "decode_pk_keys requires a primary-key RowConverter".to_string(),
+        })?;
+        let rows = pk_bytes
+            .iter()
+            .map(|bytes| crate::row_converter::Row::from_encoded(bytes));
+        converter.convert_rows(rows).map_err(|e| Error::Internal {
+            table: self.table_name().to_string(),
+            message: format!("failed to decode write-back marker primary keys: {e}"),
+        })
+    }
+
+    /// The primary-key column names in key order (for the delivery adapter).
+    #[must_use]
+    pub fn pk_column_names(&self) -> Vec<String> {
+        let schema = self.table_schema();
+        self.pk_column_indices
+            .iter()
+            .filter_map(|&i| schema.fields().get(i).map(|f| f.name().clone()))
+            .collect()
     }
 
     /// Get the table metadata.
@@ -5656,6 +5764,7 @@ impl CayenneTableProvider {
             pk_deletion_strategy: self.pk_deletion_strategy.clone(),
             pk_row_converter: self.pk_row_converter.as_ref().map(Arc::clone),
             pk_column_indices: self.pk_column_indices.clone(),
+            durable_write_back: self.durable_write_back,
             write_lock: Arc::clone(&self.write_lock), // Shared across all clones for same table
             visibility_lock: Arc::clone(&self.visibility_lock),
             scan_state_lock: Arc::clone(&self.scan_state_lock),

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -73,6 +73,7 @@ pub(crate) mod snapshots;
 mod synchronized_table;
 mod timestamp_metrics_utils;
 pub mod write;
+mod write_back_worker;
 
 pub(crate) use write::WriteMode;
 
@@ -1110,6 +1111,22 @@ impl Builder {
             WriteMode::WriteThrough
         };
 
+        // Durable federated write-back (#11838): a WriteBack Cayenne table whose
+        // commit path marks dirty keys gets a per-table delivery worker that
+        // reconciles those keys to the federated source. Aborted on drop with
+        // the other handlers.
+        if matches!(write_mode, WriteMode::WriteBack)
+            && let Some(write::CayenneWriteTarget::Staged(cayenne)) =
+                write::dual_write::extract_cayenne_write_target(&self.accelerator)
+            && cayenne.is_durable_write_back()
+        {
+            handlers.push(write_back_worker::WriteBackWorker::spawn(
+                *cayenne,
+                Arc::clone(&self.federated),
+                self.dataset_name.to_string(),
+            ));
+        }
+
         Ok(AcceleratedTable {
             dataset_name: self.dataset_name,
             accelerator: self.accelerator,
@@ -1234,6 +1251,25 @@ impl AcceleratedTable {
     #[must_use]
     pub(crate) fn is_accelerator_only(&self) -> bool {
         matches!(self.write_mode, WriteMode::AcceleratorOnly)
+    }
+
+    /// Durable federated write-back (#11838): `WriteMode::WriteBack` backed by a
+    /// Cayenne Staged accelerator whose commit path marks dirty keys. Writes
+    /// commit to the accelerator (staged/gated) and a per-table worker reconciles
+    /// them to the source, so — like accelerator-only — a gated transaction may
+    /// safely stage against it.
+    #[must_use]
+    pub(crate) fn is_durable_write_back(&self) -> bool {
+        matches!(self.write_mode, WriteMode::WriteBack)
+            && crate::accelerated_table::write::dual_write::extract_cayenne_write_target(
+                &self.accelerator,
+            )
+            .is_some_and(|target| match target {
+                crate::accelerated_table::write::CayenneWriteTarget::Staged(provider) => {
+                    provider.is_durable_write_back()
+                }
+                _ => false,
+            })
     }
 
     #[must_use]

--- a/crates/runtime/src/accelerated_table/write/write_back.rs
+++ b/crates/runtime/src/accelerated_table/write/write_back.rs
@@ -54,6 +54,8 @@ use datafusion_datasource::source::DataSourceExec;
 use futures::StreamExt;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 
+use runtime_datafusion::extension::request_context::resolve_request_context;
+
 use crate::accelerated_table::refresh::Refresher;
 use crate::federated_table::FederatedTable;
 
@@ -166,6 +168,20 @@ impl DataSink for WriteBackDataSink {
         })?;
 
         self.refresher.set_initial_load_completed(true);
+
+        // Durable federated write-back (#11838): a write inside a Cayenne
+        // transaction STAGES to the accelerator and is reconciled to the source
+        // by the delivery worker (from the dirty-key markers written in the same
+        // commit) — NOT by this fire-and-forget forward. Forwarding here would
+        // push staged-but-uncommitted batches to the source before COMMIT (and
+        // duplicate what the worker delivers), so skip it when a transaction is
+        // active on this request context. Non-transaction writes keep the
+        // ordinary write-back forward.
+        let in_transaction = resolve_request_context(context, false)
+            .is_some_and(|rc| rc.extension::<cayenne::CayenneTransaction>().is_some());
+        if in_transaction {
+            return Ok(row_count);
+        }
 
         // Forward the same buffered batches to the federated source in the
         // background. Failures are logged but do not affect the synchronous
@@ -363,7 +379,7 @@ pub(super) fn extract_dml_count(batches: &[RecordBatch]) -> u64 {
 /// cast to the target provider's schema so differences between the
 /// accelerator and federated source schemas (extra columns, differing
 /// types) don't cause incorrect writes.
-async fn execute_insert(
+pub(crate) async fn execute_insert(
     table: Arc<dyn TableProvider>,
     input_schema: SchemaRef,
     batches: Vec<RecordBatch>,

--- a/crates/runtime/src/accelerated_table/write_back_worker.rs
+++ b/crates/runtime/src/accelerated_table/write_back_worker.rs
@@ -1,0 +1,212 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Durable federated write-back delivery worker (#11838).
+//!
+//! One worker per durable-write-back Cayenne dataset, spawned onto the
+//! [`AcceleratedTable`](super::AcceleratedTable)'s `handlers` (aborted on drop).
+//! It reconciles the dirty-key markers a committed write leaves in
+//! `cayenne_pending_write_back` to the federated source, in strict order:
+//!
+//! 1. **Claim** a batch of markers (oldest commit sequence first).
+//! 2. **Read** the claimed keys' *current* committed values from the accelerator
+//!    (a fenced point scan), AFTER the claim.
+//! 3. **Deliver** to the source idempotently: delete the claimed keys, then
+//!    insert the rows that are still present (delete-all-then-insert-present is
+//!    the same regardless of how many times it runs, so a re-delivery after a
+//!    crash converges).
+//! 4. **Compare-and-clear** the markers whose stored sequence is still
+//!    `<= claimed_seq` — a newer commit that bumped a marker during delivery
+//!    leaves it in place, so the stale delivery never clears a fresh mark.
+//!
+//! Delivery failure never blocks accelerator commits; the dirty set simply
+//! grows until the next successful pass. Marking happens only in the
+//! commit-publish transaction (never in the CDC apply path), so an echo of our
+//! own write cannot spawn a fresh delivery.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow::array::{Array, ArrayRef};
+use cayenne::CayenneTableProvider;
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::dml::InsertOp;
+use datafusion::logical_expr::{Expr, col, lit};
+use datafusion::prelude::SessionContext;
+use datafusion::scalar::ScalarValue;
+use tokio::task::JoinHandle;
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
+
+use super::write::write_back::execute_insert;
+use crate::federated_table::FederatedTable;
+
+/// Markers claimed per delivery pass.
+const CLAIM_BATCH: usize = 1024;
+/// Idle poll interval when the dirty set is empty (not a failure — the error
+/// backoff must not grow on empty polls).
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+pub(crate) struct WriteBackWorker {
+    /// A write-clone of the durable-write-back Cayenne provider — shares the
+    /// live table's catalog, listing fence, and keyset, so the marker CRUD and
+    /// the point scan observe committed state.
+    provider: Arc<CayenneTableProvider>,
+    /// The federated source (upsert emulation = delete-by-PK + insert).
+    federated: Arc<FederatedTable>,
+    /// Primary-key column names, in key order.
+    pk_columns: Vec<String>,
+    dataset_name: String,
+}
+
+impl WriteBackWorker {
+    /// Spawn the delivery loop; the returned handle is pushed onto the
+    /// accelerated table's `handlers` and aborted when the table drops.
+    pub(crate) fn spawn(
+        provider: CayenneTableProvider,
+        federated: Arc<FederatedTable>,
+        dataset_name: String,
+    ) -> JoinHandle<()> {
+        let pk_columns = provider.pk_column_names();
+        let worker = Self {
+            provider: Arc::new(provider),
+            federated,
+            pk_columns,
+            dataset_name,
+        };
+        tokio::spawn(async move { worker.run().await })
+    }
+
+    async fn run(&self) {
+        // v1 delivers single-column primary keys (the common `id` shape). A
+        // composite/absent key can't be turned into a simple `pk IN (...)`
+        // filter here; leave those markers for a follow-up rather than deliver
+        // incorrectly.
+        if self.pk_columns.len() != 1 {
+            tracing::warn!(
+                dataset = %self.dataset_name,
+                pk_columns = self.pk_columns.len(),
+                "durable write-back worker: only single-column primary keys are supported in v1; \
+                 markers for this dataset will accumulate undelivered"
+            );
+            return;
+        }
+
+        // Infinite Fibonacci backoff on delivery ERRORS (delivery must never
+        // permanently give up). Rebuilt after every successful pass so a
+        // transient failure never leaves us stuck at a long delay, and never
+        // advanced by an empty poll (an empty dirty set is not a failure).
+        let mut backoff = FibonacciBackoffBuilder::new().max_retries(None).build();
+        loop {
+            match self.deliver_batch().await {
+                Ok(delivered) => {
+                    // Success — reset the error backoff.
+                    backoff = FibonacciBackoffBuilder::new().max_retries(None).build();
+                    if delivered < CLAIM_BATCH {
+                        // Dirty set drained (fewer than a full batch remained);
+                        // idle-poll for the next commit — NOT an error, so the
+                        // backoff stays reset.
+                        tokio::time::sleep(POLL_INTERVAL).await;
+                    }
+                    // Else a full batch was claimed — more may remain; loop
+                    // immediately to keep draining.
+                }
+                Err(e) => {
+                    let delay = backoff.next_duration().unwrap_or(POLL_INTERVAL);
+                    tracing::warn!(
+                        dataset = %self.dataset_name,
+                        error = %e,
+                        "durable write-back delivery failed; retrying in {delay:?}"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    /// One claim → read → deliver → clear pass. Returns the number of markers
+    /// delivered (0 when the dirty set is empty).
+    async fn deliver_batch(&self) -> DataFusionResult<usize> {
+        let claimed = self
+            .provider
+            .list_dirty_keys(CLAIM_BATCH)
+            .await
+            .map_err(to_df_err)?;
+        if claimed.is_empty() {
+            return Ok(0);
+        }
+
+        let pk_bytes: Vec<Vec<u8>> = claimed.iter().map(|(bytes, _)| bytes.clone()).collect();
+        let pk_arrays = self.provider.decode_pk_keys(&pk_bytes).map_err(to_df_err)?;
+        let Some(pk_values) = pk_arrays.into_iter().next() else {
+            return Ok(0);
+        };
+        let filter = pk_in_filter(&self.pk_columns[0], &pk_values)?;
+
+        // Read the claimed keys' current committed values from the accelerator,
+        // AFTER the claim (a newer commit bumps the marker above the claimed
+        // sequence, so the clear below no-ops for it).
+        let ctx = SessionContext::new();
+        let accelerator: Arc<dyn TableProvider> = self.provider.clone();
+        let current = ctx
+            .read_table(accelerator)?
+            .filter(filter.clone())?
+            .collect()
+            .await?;
+        let session_state = ctx.state();
+
+        // Idempotent upsert emulation: delete the claimed keys from the source,
+        // then insert the rows still present in the accelerator. Absent keys stay
+        // deleted; present keys are re-inserted with their current value.
+        let federated_provider = self.federated.table_provider().await;
+        let delete_plan = federated_provider
+            .delete_from(&session_state, vec![filter])
+            .await?;
+        let _ = datafusion::physical_plan::collect(delete_plan, session_state.task_ctx()).await?;
+
+        if current.iter().any(|batch| batch.num_rows() > 0) {
+            execute_insert(
+                Arc::clone(&federated_provider),
+                self.provider.table_schema(),
+                current,
+                InsertOp::Append,
+                &session_state,
+                None,
+            )
+            .await?;
+        }
+
+        // Ack: clear only markers still at/below the claimed sequence.
+        self.provider
+            .clear_dirty_keys(&claimed)
+            .await
+            .map_err(to_df_err)?;
+        Ok(claimed.len())
+    }
+}
+
+/// Build `pk_col IN (values…)` from a decoded primary-key array.
+fn pk_in_filter(pk_col: &str, values: &ArrayRef) -> DataFusionResult<Expr> {
+    let mut list: Vec<Expr> = Vec::with_capacity(values.len());
+    for index in 0..values.len() {
+        list.push(lit(ScalarValue::try_from_array(values.as_ref(), index)?));
+    }
+    Ok(col(pk_col).in_list(list, false))
+}
+
+fn to_df_err(e: cayenne::provider::Error) -> DataFusionError {
+    DataFusionError::Execution(format!("durable write-back: {e}"))
+}

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -58,6 +58,7 @@ use super::{
     get_primary_keys_from_constraints, upsert_dedup,
 };
 use crate::component::dataset::acceleration::{Acceleration, Engine, Mode, RefreshMode};
+use spicepod::acceleration::WriteMode;
 use crate::dataaccelerator::cayenne::s3::{S3_PARAMETERS, S3_PARAMS_LEN};
 use crate::dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed};
 use crate::parameters::ParameterSpec;
@@ -2055,11 +2056,23 @@ impl CayenneAccelerator {
             table_name,
         );
 
+        // Durable federated write-back (#11838): a write_back + on_conflict +
+        // refresh_mode:changes Cayenne dataset resolves to WriteMode::WriteBack
+        // (on_conflict with a non-`changes` refresh forces AcceleratorOnly). When
+        // so configured, every committed write durably marks its PKs so the
+        // delivery worker reconciles them to the federated source.
+        let durable_write_back = source.acceleration().is_some_and(|acceleration| {
+            acceleration.write_mode == WriteMode::WriteBack
+                && !acceleration.on_conflict.is_empty()
+                && acceleration.refresh_mode == Some(RefreshMode::Changes)
+        });
+
         // Create CayenneTableProvider with object store for S3 Express One Zone
         let mut builder = CayenneTableProviderBuilder::new(catalog, runtime_env)
             .with_context(context)
             .with_retention_filters(retention_filters)
-            .with_maintained_aggregates(maintained_aggregate_specs);
+            .with_maintained_aggregates(maintained_aggregate_specs)
+            .with_durable_write_back(durable_write_back);
         if let Some(retention_builder) = time_retention_filter_builder {
             builder = builder.with_time_retention_filter_builder(retention_builder);
         }

--- a/crates/runtime/src/datafusion/query/transaction.rs
+++ b/crates/runtime/src/datafusion/query/transaction.rs
@@ -370,7 +370,11 @@ async fn resolve_cayenne_staged(
 ) -> Option<CayenneTableProvider> {
     let provider = df.get_accelerated_table_provider(table_name).await.ok()?;
     let accel = provider.downcast_ref::<AcceleratedTable>()?;
-    if !accel.is_accelerator_only() {
+    // Accelerator-only (the gate governs the sole accelerator write) OR durable
+    // write-back (the write stages to the accelerator, marks its keys, and a
+    // per-table worker reconciles them to the source — see #11838). Both stage
+    // through the Cayenne write path, so a gated transaction is safe.
+    if !accel.is_accelerator_only() && !accel.is_durable_write_back() {
         return None;
     }
     match extract_cayenne_write_target(&accel.get_accelerator()) {


### PR DESCRIPTION
<!-- stack-nav -->
> **Cayenne transactions — stacked PR 8 of 9**
> ← Previous: #11866 &nbsp;·&nbsp; Next: #11869 →
>
> Review/merge bottom-up: #11848 · #11849 · #11859 · #11861 · #11863 · #11865 · #11866 · #11868 · #11869 &nbsp;→&nbsp; all squashed into #11870 (targets `trunk`). Part of #11830.

---

## What

A durable-write-back Cayenne dataset now reconciles its committed accelerator writes back to the federated source. A committed write records its primary keys in a metastore marker table **inside the same commit transaction**, and a per-table delivery worker reconciles those keys to the source. This is the last v1 gap for #11830.

## How

- **Marker table** `cayenne_pending_write_back(table_id, pk_bytes, sequence_number, first_marked_at)` (SQLite + Turso + `EXPECTED_TABLES`). Marking is a monotone `MAX(sequence_number)` upsert; excluded from every checkpoint/overwrite clear; `drop_table` deletes its rows.
- **Marking rides the commit txn**: `mark_dirty_keys_in_txn` is emitted inside `commit_staged_upsert_in_txn` (the multi-table commit seam), so a table's markers are durable atomically with its publish. Gated by a `CayenneTableProvider::durable_write_back` flag set at creation from the acceleration settings (`write_back ∧ on_conflict ∧ changes`) — a non-write-back table never marks. Marking is confined to the commit-publish path (never the CDC apply path, which uses `write_cdc_append_stream`), so an echo of our own write can't spawn a fresh delivery.
- **Delivery worker** (per durable-write-back table, spawned in `Builder::build`, aborted on drop): claim oldest markers → read the claimed keys' current committed values from the accelerator (fenced point scan, **after** the claim) → deliver idempotently (delete-by-PK + insert-present) → compare-and-clear markers whose stored sequence is still `<= claimed_seq`. Infinite Fibonacci backoff on delivery error (reset on success; empty polls don't advance it). A newer commit bumps a marker above `claimed_seq`, so a stale delivery never clears a fresh mark.
- **Admission/routing**: the executor admits durable-write-back tables (`is_durable_write_back`) alongside accelerator-only; durable-write-back writes stay on the accelerator (the worker owns propagation).

Delivery reuses the connector's existing `insert_into` + `delete_from` (delete-by-PK + insert = idempotent upsert emulation), so **no datafusion-table-providers fork change is needed**; native `ON CONFLICT` upsert is a follow-up.

## Config

```yaml
- from: postgres:public.kv
  name: kv
  access: read_write
  replication:
    enabled: true          # required for write_mode: write_back
  params: { …, pg_replication_slot: spice_kv, pg_replication_initial_snapshot: 'true' }
  acceleration:
    engine: cayenne
    refresh_mode: changes
    write_mode: write_back
    primary_key: id
    on_conflict: { id: upsert }
```

## Scope (v1)

- Single-column primary keys.
- Marking on the transaction commit path — plain non-transaction writes commit to the accelerator but don't yet mark (a safe follow-up; the CDC apply path uses a separate commit path, so extending it won't cause echo loops).
- Single-arbiter (only the writing node runs the worker).
- CDC authority echo-drop (an old-value echo transiently regressing the accelerator) is tracked in #11840.

## Testing

End-to-end against a live runtime (Postgres CDC source + `write_back` `kv` dataset): a gated increment and a new-key insert each commit to the accelerator, mark their PKs, and are delivered to Postgres by the worker; the marker set drains after delivery. `cargo check -p cayenne` / `-p runtime` green.

## Stack

Cayenne transactions **(8/8)**, top of the stack. Stacked on #11866. Merge bottom-up; the squashed PR → `trunk` will carry the `Closes #…` keywords.

---

## Stacked-PR review notes

**Implements #11838** (durable federated write-back); the CDC authority echo-drop residual is tracked in **#11840**.

Extends earlier PRs in the stack: reuses the `commit_staged_upsert_in_txn` seam introduced for multi-table (#11865) to make markers durable atomically with the publish, and broadens the executor's accelerator-only admission (#11859) to durable-write-back tables.

