### PR TITLE
fix(cayenne): correct stale mem_checkpoint_lock comment

### DIFF
--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1355,10 +1355,11 @@ pub struct CayenneTableProvider {
     /// attestation is observed by scanning clones and invalidated for all on a write.
     current_sorted_snapshot: Arc<ArcSwap<Option<String>>>,
     /// Serializes mem-tier checkpoints (spills) for this table so a single
-    /// checkpoint is in flight at a time. The write path uses
-    /// `try_lock()` on this to detect "a checkpoint is already running" and take
-    /// the spill-then-fallback path rather than growing the tier unboundedly
-    /// (the OOM-safety guard). Shared across writer clones.
+    /// checkpoint is in flight at a time. The write path blocks on
+    /// `.lock().await`/`.lock_owned().await` when it needs a spill (the
+    /// OOM-safety guard), so a second writer simply waits for the in-flight
+    /// checkpoint to finish rather than racing it — natural backpressure, not
+    /// a try-lock-with-fallback. Shared across writer clones.
     mem_checkpoint_lock: Arc<tokio::sync::Mutex<()>>,
     /// Serializes the mem-tier *publish* (the `ArcSwap` swap + sequence
     /// reservation) across all writers — DECOUPLED from [`Self::listing_fence`]


### PR DESCRIPTION
## Summary
- The doc comment on `mem_checkpoint_lock` (`table.rs:1357-1361`) claimed the write path uses `try_lock()` to detect an in-flight checkpoint and take a spill-then-fallback path.
- Every actual call site (`spill_mem_tier_if_cap_breached`, `spill_mem_tier_unless_reserved`, the background tick, the seal path) blocks on `.lock().await`/`.lock_owned().await` instead.
- Updated the comment to describe the real mechanism: a single blocking lock providing natural backpressure, with one checkpoint/spill in flight at a time.

No behavior change, no flag, no new tests needed.

## Test plan
- [x] `cargo check -p cayenne` passes
- [x] Existing test suite is unaffected (comment-only change)