### PR TITLE
fix(postgres catalog): honor unsupported_type_action for catalog-discovered tables

### DIFF
--- a/crates/runtime/src/catalogconnector/postgres.rs
+++ b/crates/runtime/src/catalogconnector/postgres.rs
@@ -41,15 +41,18 @@ fn parse_unsupported_type_action(
 ) -> Result<UnsupportedTypeAction, String> {
     match dataset_params.get("unsupported_type_action") {
         None => Ok(UnsupportedTypeAction::String),
-        Some(value) => match value.trim().to_lowercase().as_str() {
-            "string" => Ok(UnsupportedTypeAction::String),
-            "error" => Ok(UnsupportedTypeAction::Error),
-            "warn" => Ok(UnsupportedTypeAction::Warn),
-            "ignore" => Ok(UnsupportedTypeAction::Ignore),
-            other => Err(format!(
-                "Invalid value '{other}' for `unsupported_type_action`. Expected one of: error, warn, ignore, string."
-            )),
-        },
+        Some(value) => {
+            let trimmed = value.trim();
+            match trimmed.to_ascii_lowercase().as_str() {
+                "string" => Ok(UnsupportedTypeAction::String),
+                "error" => Ok(UnsupportedTypeAction::Error),
+                "warn" => Ok(UnsupportedTypeAction::Warn),
+                "ignore" => Ok(UnsupportedTypeAction::Ignore),
+                _ => Err(format!(
+                    "Invalid value '{trimmed}' for `unsupported_type_action`. Expected one of: error, warn, ignore, string."
+                )),
+            }
+        }
     }
 }
 

--- a/crates/runtime/src/catalogconnector/postgres.rs
+++ b/crates/runtime/src/catalogconnector/postgres.rs
@@ -39,17 +39,17 @@ use std::sync::Arc;
 fn parse_unsupported_type_action(
     dataset_params: &HashMap<String, String>,
 ) -> Result<UnsupportedTypeAction, String> {
-    match dataset_params
-        .get("unsupported_type_action")
-        .map(String::as_str)
-    {
-        None | Some("string") => Ok(UnsupportedTypeAction::String),
-        Some("error") => Ok(UnsupportedTypeAction::Error),
-        Some("warn") => Ok(UnsupportedTypeAction::Warn),
-        Some("ignore") => Ok(UnsupportedTypeAction::Ignore),
-        Some(other) => Err(format!(
-            "Invalid value '{other}' for `unsupported_type_action`. Expected one of: error, warn, ignore, string."
-        )),
+    match dataset_params.get("unsupported_type_action") {
+        None => Ok(UnsupportedTypeAction::String),
+        Some(value) => match value.trim().to_lowercase().as_str() {
+            "string" => Ok(UnsupportedTypeAction::String),
+            "error" => Ok(UnsupportedTypeAction::Error),
+            "warn" => Ok(UnsupportedTypeAction::Warn),
+            "ignore" => Ok(UnsupportedTypeAction::Ignore),
+            other => Err(format!(
+                "Invalid value '{other}' for `unsupported_type_action`. Expected one of: error, warn, ignore, string."
+            )),
+        },
     }
 }
 

--- a/crates/runtime/src/catalogconnector/postgres.rs
+++ b/crates/runtime/src/catalogconnector/postgres.rs
@@ -24,10 +24,34 @@ use crate::{Runtime, component::catalog::Catalog, dataconnector::parameters::Con
 use async_trait::async_trait;
 use data_components::RefreshableCatalogProvider;
 use data_components::postgres::provider::PostgresCatalogProvider;
+use datafusion_table_providers::UnsupportedTypeAction;
 use datafusion_table_providers::postgres::PostgresTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
+
+/// Parses the `unsupported_type_action` dataset param threaded through the
+/// catalog's `dataset_params` (the same mechanism used by the Databricks and
+/// Unity Catalog catalog connectors to pass per-table dataset params). Absent
+/// a value, defaults to `String`, matching the direct `PostgreSQL` data
+/// connector's default (see `connector-postgres`). See #11728.
+fn parse_unsupported_type_action(
+    dataset_params: &HashMap<String, String>,
+) -> Result<UnsupportedTypeAction, String> {
+    match dataset_params
+        .get("unsupported_type_action")
+        .map(String::as_str)
+    {
+        None | Some("string") => Ok(UnsupportedTypeAction::String),
+        Some("error") => Ok(UnsupportedTypeAction::Error),
+        Some("warn") => Ok(UnsupportedTypeAction::Warn),
+        Some("ignore") => Ok(UnsupportedTypeAction::Ignore),
+        Some(other) => Err(format!(
+            "Invalid value '{other}' for `unsupported_type_action`. Expected one of: error, warn, ignore, string."
+        )),
+    }
+}
 
 pub const PREFIX: &str = "pg";
 
@@ -76,13 +100,21 @@ impl CatalogConnector for PostgresCatalog {
     ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
         let connector_component = ConnectorComponent::from(catalog);
 
+        let unsupported_type_action = parse_unsupported_type_action(&catalog.dataset_params)
+            .map_err(|message| super::Error::InvalidConfigurationNoSource {
+                connector: PREFIX.to_string(),
+                connector_component: connector_component.clone(),
+                message,
+            })?;
+
         let pool = PostgresConnectionPool::new(self.params.parameters.to_secret_map())
             .await
             .map_err(|e| super::Error::UnableToGetCatalogProvider {
                 connector: PREFIX.to_string(),
                 connector_component: connector_component.clone(),
                 source: Box::new(e),
-            })?;
+            })?
+            .with_unsupported_type_action(unsupported_type_action);
 
         let pool = Arc::new(pool);
         let table_factory = Arc::new(PostgresTableFactory::new(Arc::clone(&pool)));

--- a/crates/runtime/tests/postgres/catalog.rs
+++ b/crates/runtime/tests/postgres/catalog.rs
@@ -264,7 +264,7 @@ async fn test_partitioned_table_registers_parent_only() -> Result<(), anyhow::Er
 
 /// By default (no `dataset_params` override), a table with an unsupported
 /// column type (`jsonb`) is registered with that column converted to a
-/// string — matching the direct PostgreSQL data connector's default
+/// string — matching the direct `PostgreSQL` data connector's default
 /// `unsupported_type_action: string` — rather than being dropped from the
 /// catalog entirely (#11728).
 #[tokio::test]

--- a/crates/runtime/tests/postgres/catalog.rs
+++ b/crates/runtime/tests/postgres/catalog.rs
@@ -137,9 +137,10 @@ fn pg_catalog(port: usize) -> Catalog {
 fn string_column_values(batches: &[RecordBatch], column: &str) -> Vec<String> {
     let mut values = Vec::new();
     for batch in batches {
-        let Ok(idx) = batch.schema().index_of(column) else {
-            continue;
-        };
+        let idx = batch
+            .schema()
+            .index_of(column)
+            .unwrap_or_else(|e| panic!("expected column `{column}` in query result: {e}"));
         let array = batch
             .column(idx)
             .as_any()

--- a/crates/runtime/tests/postgres/catalog.rs
+++ b/crates/runtime/tests/postgres/catalog.rs
@@ -294,6 +294,24 @@ async fn test_unsupported_type_action_defaults_to_string() -> Result<(), anyhow:
                 "a table with an unsupported jsonb column should still be registered by default"
             );
 
+            // The unsupported `metadata` (jsonb) column must still be present —
+            // converted to a string, not silently dropped — alongside `id`.
+            let columns = run_query(
+                &rt,
+                &format!(
+                    "SELECT column_name FROM information_schema.columns \
+                     WHERE table_catalog = '{CATALOG_NAME}' AND table_schema = 'public' \
+                     AND table_name = 'widgets_jsonb' \
+                     ORDER BY column_name"
+                ),
+            )
+            .await?;
+            assert_eq!(
+                string_column_values(&columns, "column_name"),
+                vec!["id".to_string(), "metadata".to_string()],
+                "the unsupported jsonb column should be kept (converted to a string), not dropped"
+            );
+
             let count = run_query(
                 &rt,
                 &format!("SELECT COUNT(*) AS n FROM {CATALOG_NAME}.public.widgets_jsonb"),

--- a/crates/runtime/tests/postgres/catalog.rs
+++ b/crates/runtime/tests/postgres/catalog.rs
@@ -29,6 +29,7 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use app::AppBuilder;
+use arrow::array::{Array, RecordBatch, StringArray};
 use datafusion::assert_batches_eq;
 use runtime::Runtime;
 use secrecy::ExposeSecret;
@@ -132,6 +133,49 @@ fn pg_catalog(port: usize) -> Catalog {
     catalog
 }
 
+/// Collect the values of a `Utf8` column across every batch, in row order.
+fn string_column_values(batches: &[RecordBatch], column: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    for batch in batches {
+        let Ok(idx) = batch.schema().index_of(column) else {
+            continue;
+        };
+        let array = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("column should be a Utf8 array");
+        for i in 0..array.len() {
+            values.push(array.value(i).to_string());
+        }
+    }
+    values
+}
+
+/// Seed a table with a `jsonb` column (the type the underlying connector
+/// documents as convertible under `unsupported_type_action: string`, see
+/// `pg_data_type_to_arrow_type` in `datafusion-table-providers`) plus real rows.
+async fn seed_unsupported_type_table(port: usize) -> Result<(), anyhow::Error> {
+    let pool = common::get_postgres_connection_pool(port, None).await?;
+    let conn = pool
+        .connect_direct()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    conn.conn
+        .simple_query(
+            "CREATE TABLE widgets_jsonb ( \
+                 id       INT  PRIMARY KEY, \
+                 metadata JSONB NOT NULL \
+             ); \
+             INSERT INTO widgets_jsonb (id, metadata) VALUES \
+                 (1, '{\"color\": \"red\"}'), (2, '{\"color\": \"blue\"}');",
+        )
+        .await?;
+
+    Ok(())
+}
+
 async fn start_runtime(catalog: Catalog) -> Result<Arc<Runtime>, anyhow::Error> {
     register_test_connectors().await;
     let app = AppBuilder::new("postgres_catalog_partition_test")
@@ -210,6 +254,92 @@ async fn test_partitioned_table_registers_parent_only() -> Result<(), anyhow::Er
                     "+---+", //
                 ],
                 &count
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// By default (no `dataset_params` override), a table with an unsupported
+/// column type (`jsonb`) is registered with that column converted to a
+/// string — matching the direct PostgreSQL data connector's default
+/// `unsupported_type_action: string` — rather than being dropped from the
+/// catalog entirely (#11728).
+#[tokio::test]
+async fn test_unsupported_type_action_defaults_to_string() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container(port).await?;
+
+            seed_unsupported_type_table(port).await?;
+
+            let rt = start_runtime(pg_catalog(port)).await?;
+
+            let tables = run_query(
+                &rt,
+                &format!(
+                    "SELECT table_name FROM information_schema.tables \
+                     WHERE table_catalog = '{CATALOG_NAME}' AND table_schema = 'public' \
+                     AND table_name = 'widgets_jsonb'"
+                ),
+            )
+            .await?;
+            assert_eq!(
+                string_column_values(&tables, "table_name"),
+                vec!["widgets_jsonb".to_string()],
+                "a table with an unsupported jsonb column should still be registered by default"
+            );
+
+            let count = run_query(
+                &rt,
+                &format!("SELECT COUNT(*) AS n FROM {CATALOG_NAME}.public.widgets_jsonb"),
+            )
+            .await?;
+            assert_batches_eq!(&["+---+", "| n |", "+---+", "| 2 |", "+---+"], &count);
+
+            Ok(())
+        })
+        .await
+}
+
+/// Setting `dataset_params.unsupported_type_action: error` on the catalog
+/// threads through to the underlying connection pool, restoring the stricter
+/// whole-table-dropped behavior for callers who want it (#11728).
+#[tokio::test]
+async fn test_unsupported_type_action_override_drops_table() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container(port).await?;
+
+            seed_unsupported_type_table(port).await?;
+
+            let mut catalog = pg_catalog(port);
+            catalog.dataset_params = Some(Params::from_string_map(HashMap::from([(
+                "unsupported_type_action".to_string(),
+                "error".to_string(),
+            )])));
+
+            let rt = start_runtime(catalog).await?;
+
+            let tables = run_query(
+                &rt,
+                &format!(
+                    "SELECT table_name FROM information_schema.tables \
+                     WHERE table_catalog = '{CATALOG_NAME}' AND table_schema = 'public' \
+                     AND table_name = 'widgets_jsonb'"
+                ),
+            )
+            .await?;
+            assert!(
+                string_column_values(&tables, "table_name").is_empty(),
+                "a table with an unsupported jsonb column should be dropped when unsupported_type_action=error"
             );
 
             Ok(())


### PR DESCRIPTION
## Summary

Found during the PostgreSQL Catalog [Beta criteria](https://github.com/spiceai/spiceai/blob/trunk/docs/criteria/catalogs/beta.md) review. Part of #10373.

The catalog connector built its `PostgresTableFactory` from a connection pool that never had `unsupported_type_action` configured, so it fell back to the underlying crate's default (`Error`). A table with a single column of an unmappable type (e.g. `jsonb`, which the connector can convert to a string but only under the `String` action) failed schema inference entirely and was skipped from the catalog — the whole table disappears, not just the one column. This diverges from the direct PostgreSQL data connector, which defaults to `unsupported_type_action: string`.

## Fix

Parse `unsupported_type_action` out of the catalog's `dataset_params` — the same generic per-table dataset param passthrough the Databricks and Unity Catalog catalog connectors already use — and thread it into the connection pool via `with_unsupported_type_action`, defaulting to `String` to match the direct connector. An invalid value returns a structured configuration error rather than being silently ignored.

```yaml
catalogs:
  - from: pg
    name: my_pg
    dataset_params:
      unsupported_type_action: warn  # error | warn | ignore | string (default)
```

## Testing

Added two Docker-based integration tests:
- `test_unsupported_type_action_defaults_to_string`: a table with a `jsonb` column is registered by default (previously dropped entirely).
- `test_unsupported_type_action_override_drops_table`: setting `dataset_params.unsupported_type_action: error` restores the stricter whole-table-dropped behavior, proving the knob threads through correctly.

Verified locally: `cargo test -p runtime --test integration --features postgres -- postgres::catalog::` — 3 passed.

Fixes #11728