### PR TITLE
fix(mysql): retry binlog checkpoint upsert on transient accelerator write lock

### DIFF
--- a/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs
@@ -111,7 +111,41 @@ impl MySqlBinlogSys {
         }
     }
 
-    pub async fn upsert(
+    /// Persist a checkpoint, retrying briefly on a transient accelerator write
+    /// lock.
+    ///
+    /// The sidecar shares the accelerator's connection pool, so a checkpoint
+    /// upsert contends with the accelerator's own CDC-apply transactions for
+    /// the single writer lock. A large batch commit can hold that lock past the
+    /// engine's `busy_timeout`, surfacing as `SQLITE_BUSY` / "database is
+    /// locked" (and equivalents on the other file engines). Without a retry a
+    /// single contention drops the whole checkpoint interval and widens the
+    /// crash-replay window; a few short retries convert most of these into a
+    /// successful persist. Still best-effort — a persistent lock returns the
+    /// error and the replication layer retries on the next interval.
+    pub async fn upsert(&self, checkpoint: &MySqlBinlogCheckpoint) -> Result<()> {
+        let mut attempt: u32 = 1;
+        loop {
+            match self.upsert_once(checkpoint).await {
+                Ok(()) => return Ok(()),
+                Err(e) if attempt < UPSERT_MAX_ATTEMPTS && is_retryable_lock_error(&e) => {
+                    let delay = upsert_retry_delay(attempt);
+                    tracing::debug!(
+                        dataset = %self.dataset_name,
+                        attempt,
+                        delay_ms = %delay.as_millis(),
+                        error = %e,
+                        "binlog checkpoint upsert hit a transient accelerator write lock; retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    async fn upsert_once(
         &self,
         #[cfg_attr(
             not(any(
@@ -203,4 +237,38 @@ impl MySqlBinlogSys {
     fn position_to_i64(pos: u64) -> i64 {
         i64::try_from(pos).unwrap_or(i64::MAX)
     }
+}
+
+/// Max attempts for a checkpoint upsert contending with the accelerator's
+/// writer lock. Bounded and short: the worst-case added latency (see
+/// [`upsert_retry_delay`]) stays well under one checkpoint interval, and a
+/// persistent lock just retries on the next interval anyway.
+const UPSERT_MAX_ATTEMPTS: u32 = 5;
+
+/// Exponential backoff (no jitter) for [`MySqlBinlogSys::upsert`] retries:
+/// 25ms, 50ms, 100ms, 200ms across attempts 1..=4 (worst case ~375ms total).
+fn upsert_retry_delay(attempt: u32) -> std::time::Duration {
+    let shift = attempt.saturating_sub(1).min(6);
+    std::time::Duration::from_millis(25u64 << shift)
+}
+
+/// Whether a sidecar write failure is a transient lock/contention error worth
+/// retrying rather than surfacing.
+///
+/// Deliberately a string heuristic over the boxed engine error (rusqlite,
+/// Turso, `DuckDB`, and tokio-postgres all report contention differently),
+/// mirroring the reconnect classifier in
+/// `data_components::mysql_replication::resilience`. Slight over-matching is
+/// harmless: retries are bounded, so a misclassified non-lock error only costs
+/// a few short sleeps before it is returned unchanged.
+fn is_retryable_lock_error(err: &Error) -> bool {
+    const MARKERS: &[&str] = &[
+        "database is locked",
+        "database table is locked",
+        "sqlite_busy",
+        "sqlite_locked",
+        "deadlock",
+    ];
+    let msg = err.to_string().to_ascii_lowercase();
+    MARKERS.iter().any(|marker| msg.contains(marker))
 }

--- a/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs
@@ -40,6 +40,7 @@ limitations under the License.
 
 use super::{AccelerationConnection, Error, Result, acceleration_connection};
 use crate::{component::dataset::Dataset, dataaccelerator::spice_sys::OpenOption};
+use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
 
 #[cfg_attr(
     not(any(
@@ -124,25 +125,26 @@ impl MySqlBinlogSys {
     /// successful persist. Still best-effort — a persistent lock returns the
     /// error and the replication layer retries on the next interval.
     pub async fn upsert(&self, checkpoint: &MySqlBinlogCheckpoint) -> Result<()> {
-        let mut attempt: u32 = 1;
-        loop {
-            match self.upsert_once(checkpoint).await {
-                Ok(()) => return Ok(()),
-                Err(e) if attempt < UPSERT_MAX_ATTEMPTS && is_retryable_lock_error(&e) => {
-                    let delay = upsert_retry_delay(attempt);
+        let backoff = FibonacciBackoffBuilder::new()
+            .max_retries(Some(UPSERT_MAX_RETRIES))
+            .max_duration(Some(UPSERT_MAX_RETRY_DELAY))
+            .build();
+
+        retry(backoff, || async {
+            self.upsert_once(checkpoint).await.map_err(|e| {
+                if is_retryable_lock_error(&e) {
                     tracing::debug!(
                         dataset = %self.dataset_name,
-                        attempt,
-                        delay_ms = %delay.as_millis(),
                         error = %e,
-                        "binlog checkpoint upsert hit a transient accelerator write lock; retrying"
+                        "binlog checkpoint upsert hit a transient accelerator write lock"
                     );
-                    tokio::time::sleep(delay).await;
-                    attempt += 1;
+                    RetryError::transient(e)
+                } else {
+                    RetryError::permanent(e)
                 }
-                Err(e) => return Err(e),
-            }
-        }
+            })
+        })
+        .await
     }
 
     async fn upsert_once(
@@ -239,18 +241,19 @@ impl MySqlBinlogSys {
     }
 }
 
-/// Max attempts for a checkpoint upsert contending with the accelerator's
-/// writer lock. Bounded and short: the worst-case added latency (see
-/// [`upsert_retry_delay`]) stays well under one checkpoint interval, and a
-/// persistent lock just retries on the next interval anyway.
-const UPSERT_MAX_ATTEMPTS: u32 = 5;
+/// Retries for a checkpoint upsert contending with the accelerator's writer
+/// lock, on top of the initial attempt. Bounded and short: paired with
+/// [`UPSERT_MAX_RETRY_DELAY`] the worst-case added latency stays well under one
+/// checkpoint interval, and a persistent lock just retries on the next interval
+/// anyway.
+const UPSERT_MAX_RETRIES: usize = 4;
 
-/// Exponential backoff (no jitter) for [`MySqlBinlogSys::upsert`] retries:
-/// 25ms, 50ms, 100ms, 200ms across attempts 1..=4 (worst case ~375ms total).
-fn upsert_retry_delay(attempt: u32) -> std::time::Duration {
-    let shift = attempt.saturating_sub(1).min(6);
-    std::time::Duration::from_millis(25u64 << shift)
-}
+/// Per-attempt cap on the [`FibonacciBackoffBuilder`] delay for
+/// [`MySqlBinlogSys::upsert`] retries. The shared Fibonacci schedule starts at
+/// 1s, far longer than a transient writer-lock hand-off needs, so clamp each
+/// delay to keep the whole retry budget (~4 × 100ms) short relative to the
+/// checkpoint interval.
+const UPSERT_MAX_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// Whether a sidecar write failure is a transient lock/contention error worth
 /// retrying rather than surfacing.


### PR DESCRIPTION
The MySQL binlog-position sidecar shares the accelerator's connection pool, so a checkpoint upsert can lose the single writer lock to a concurrent CDC-apply transaction and fail with `database is locked` (`SQLITE_BUSY` and equivalents). Previously that dropped the whole checkpoint interval, widening the crash-replay window.

`MySqlBinlogSys::upsert` now retries briefly (up to 5 attempts, ~375ms worst case) on transient lock errors before giving up. Best-effort as before — a persistent lock still returns and re-persists next interval — so correctness is unchanged.
