### PR TITLE
Remove unnecessary allocations from results-cache and hot conversion paths

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -54,7 +54,7 @@ pub use metrics::CacheMetrics;
 pub use simple_cache::SimpleCache;
 use spicepod::component::caching::SQLResultsCacheConfig;
 pub use utils::RESPONSE_STATUS_COLUMN;
-pub use utils::batches_to_cache;
+pub use utils::batches_cacheable;
 pub use utils::filter_transient_error_responses;
 pub use utils::get_logical_plan_input_tables;
 pub use utils::to_cached_record_batch_stream;

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -565,7 +565,7 @@ mod tests {
         let encoder = crate::encoding::get_encoder(spicepod::component::caching::Encoding::None);
 
         CachedQueryResult::from_batches(
-            &[record_batch],
+            vec![record_batch],
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
             Arc::new(input_tables),
             std::time::Instant::now(),
@@ -1105,7 +1105,7 @@ mod tests {
         });
         let encoder = crate::encoding::get_encoder(spicepod::component::caching::Encoding::None);
         let result_other_table = CachedQueryResult::from_batches(
-            &[different_table_batch],
+            vec![different_table_batch],
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
             Arc::new(different_input_tables),
             std::time::Instant::now(),

--- a/crates/cache/src/result/query.rs
+++ b/crates/cache/src/result/query.rs
@@ -108,7 +108,7 @@ impl CachedQueryResult {
     ///
     /// Returns an error if encoding fails.
     pub async fn from_batches(
-        records: &[RecordBatch],
+        records: Vec<RecordBatch>,
         schema: SchemaRef,
         input_tables: Arc<HashSet<TableReference>>,
         cached_at: Instant,
@@ -116,10 +116,10 @@ impl CachedQueryResult {
     ) -> Result<Self, crate::encoding::Error> {
         // Only store encoded data if an encoder is provided
         let data = if let Some(encoder) = encoder.as_ref() {
-            let encoded_data = encoder.encode(records).await?;
+            let encoded_data = encoder.encode(&records).await?;
             CachedData::Encoded(Bytes::from(encoded_data))
         } else {
-            CachedData::Raw(Arc::new(records.to_vec()))
+            CachedData::Raw(Arc::new(records))
         };
 
         Ok(Self {
@@ -136,12 +136,12 @@ impl CachedQueryResult {
     /// # Errors
     ///
     /// Returns an error if decoding fails.
-    pub async fn records(&self) -> Result<Vec<RecordBatch>, crate::encoding::Error> {
+    pub async fn records(&self) -> Result<Arc<Vec<RecordBatch>>, crate::encoding::Error> {
         match &self.data {
-            CachedData::Raw(batches) => Ok((**batches).clone()),
+            CachedData::Raw(batches) => Ok(Arc::clone(batches)),
             CachedData::Encoded(bytes) => {
                 if let Some(encoder) = &self.encoder {
-                    encoder.decode(bytes).await
+                    encoder.decode(bytes).await.map(Arc::new)
                 } else {
                     Err(crate::encoding::Error::NoEncoderSpecified)
                 }
@@ -452,7 +452,7 @@ mod tests {
         ]));
 
         let cached_result = CachedQueryResult::from_batches(
-            &[],
+            Vec::new(),
             Arc::clone(&schema),
             Arc::new(HashSet::new()),
             Instant::now(),
@@ -472,7 +472,7 @@ mod tests {
         let records = cached_result.records().await.expect("should decode");
         assert!(records.is_empty(), "Should have no record batches");
 
-        let stream = CachedStream::new(Arc::new(records), Arc::clone(&cached_result.schema));
+        let stream = CachedStream::new(records, Arc::clone(&cached_result.schema));
         assert_eq!(
             stream.schema().fields().len(),
             3,

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -210,7 +210,7 @@ mod tests {
         let encoder = crate::encoding::get_encoder(spicepod::component::caching::Encoding::None);
 
         CachedQueryResult::from_batches(
-            &[record_batch],
+            vec![record_batch],
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
             Arc::new(input_tables),
             std::time::Instant::now(),

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -156,19 +156,15 @@ fn has_transient_http_error_responses(batches: &[RecordBatch]) -> bool {
     false
 }
 
-/// Returns the batches that should be written to cache.
+/// Returns whether the batches should be written to cache.
 ///
 /// For HTTP-shaped results, any presence of a transient error response (5xx/429)
 /// skips the entire cache write to avoid storing a partial result set. Non-HTTP
-/// results are returned unchanged, even if they contain a `response_status`
-/// column for unrelated business logic.
+/// results are cacheable, even if they contain a `response_status` column for
+/// unrelated business logic.
 #[must_use]
-pub fn batches_to_cache(batches: &[RecordBatch]) -> Option<Vec<RecordBatch>> {
-    if has_transient_http_error_responses(batches) {
-        return None;
-    }
-
-    Some(batches.to_vec())
+pub fn batches_cacheable(batches: &[RecordBatch]) -> bool {
+    !has_transient_http_error_responses(batches)
 }
 
 #[must_use]
@@ -208,53 +204,49 @@ pub fn to_cached_record_batch_stream(
         // When an encoder is present, defer the size check until after encoding
         // so that compressed results that fit in the cache are not prematurely rejected.
         if records_size < cache_max_size || has_encoder {
-            match batches_to_cache(&records) {
-                // `batches_to_cache` only returns `None` when transient HTTP
-                // error responses (5xx/429) are present, which requires a
-                // non-empty result set — skip the write to avoid caching a
-                // partial result.
-                None => {
-                    tracing::debug!(
-                        "Transient HTTP error responses were present, skipping cache storage"
-                    );
-                }
+            // `batches_cacheable` is false only when transient HTTP error
+            // responses (5xx/429) are present, which requires a non-empty
+            // result set — skip the write to avoid caching a partial result.
+            if batches_cacheable(&records) {
                 // Cache the result, including genuinely empty (0-row / 0-batch)
                 // result sets. The schema is stored separately in
                 // `CachedQueryResult`, so an empty result round-trips with the
                 // correct schema, and caching it lets repeat queries that
                 // legitimately return no rows be served from cache instead of
                 // re-executing on every request.
-                Some(records_to_cache) => {
-                    let cached_at = std::time::Instant::now();
-                    let encoder = cache_provider.encoder();
+                let cached_at = std::time::Instant::now();
+                let encoder = cache_provider.encoder();
 
-                    match CachedQueryResult::from_batches(
-                        &records_to_cache,
-                        cache_schema,
-                        input_tables,
-                        cached_at,
-                        encoder,
-                    )
-                    .await
-                    {
-                        Ok(cached_result) => {
-                            // Check the actual (possibly encoded) size before caching
-                            let actual_size = cached_result.get_memory_size();
-                            if actual_size > cache_max_size {
-                                tracing::debug!(
-                                    actual_size,
-                                    cache_max_size,
-                                    "Encoded query result still exceeds cache max size, skipping"
-                                );
-                            } else if let Err(e) = cache_provider.put_raw_key(&raw_cache_key, cached_result).await {
-                                tracing::error!("Failed to cache query results: {e}");
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!("Failed to encode query results for caching: {e}");
+                match CachedQueryResult::from_batches(
+                    records,
+                    cache_schema,
+                    input_tables,
+                    cached_at,
+                    encoder,
+                )
+                .await
+                {
+                    Ok(cached_result) => {
+                        // Check the actual (possibly encoded) size before caching
+                        let actual_size = cached_result.get_memory_size();
+                        if actual_size > cache_max_size {
+                            tracing::debug!(
+                                actual_size,
+                                cache_max_size,
+                                "Encoded query result still exceeds cache max size, skipping"
+                            );
+                        } else if let Err(e) = cache_provider.put_raw_key(&raw_cache_key, cached_result).await {
+                            tracing::error!("Failed to cache query results: {e}");
                         }
                     }
+                    Err(e) => {
+                        tracing::error!("Failed to encode query results for caching: {e}");
+                    }
                 }
+            } else {
+                tracing::debug!(
+                    "Transient HTTP error responses were present, skipping cache storage"
+                );
             }
         }
     };

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -167,6 +167,13 @@ pub fn batches_cacheable(batches: &[RecordBatch]) -> bool {
     !has_transient_http_error_responses(batches)
 }
 
+/// How much larger than the cache limit a raw result may grow while
+/// accumulating for an encoded (compressed) cache write. Encoding can shrink
+/// a result well below its raw in-memory size, so accumulation continues past
+/// the cache limit up to this factor; beyond it the result cannot plausibly
+/// fit once encoded, and caching is abandoned to bound the memory held.
+const MAX_ENCODING_COMPRESSION_RATIO: usize = 16;
+
 #[must_use]
 #[expect(clippy::implicit_hasher)]
 pub fn to_cached_record_batch_stream(
@@ -185,15 +192,25 @@ pub fn to_cached_record_batch_stream(
         // moka-rs operates by `u32` for records size, so max single record size is `u32::MAX` / 4 GB
         let cache_max_size = usize::try_from(cache_provider.max_size().min(u64::from(u32::MAX))).unwrap_or_default();
 
+        // When an encoder is present, the encoded result may be much smaller
+        // than the raw size, so keep accumulating past the cache limit (up to
+        // the optimistic compression bound) and check the encoded size after
+        // encoding. Without an encoder the raw size is the stored size.
+        let raw_size_limit = if has_encoder {
+            cache_max_size.saturating_mul(MAX_ENCODING_COMPRESSION_RATIO)
+        } else {
+            cache_max_size
+        };
+
         while let Some(batch_result) = stream.next().await {
-            if records_size < cache_max_size && let Ok(batch) = &batch_result {
+            if records_size < raw_size_limit && let Ok(batch) = &batch_result {
                 records.push(batch.clone());
-                records_size += batch.get_array_memory_size();
-            } else if !records.is_empty() && records_size >= cache_max_size && !has_encoder {
-                // Eagerly clear the cached records when there is no encoder, as
-                // the unencoded result won't fit in the cache. When an encoder is
-                // present, the encoded size may be much smaller than the raw size,
-                // so we keep accumulating and check the encoded size later.
+                records_size = records_size.saturating_add(batch.get_array_memory_size());
+            } else if !records.is_empty() && records_size >= raw_size_limit {
+                // The result can no longer fit in the cache: eagerly drop the
+                // accumulated batches. Caching must be abandoned entirely —
+                // a prefix of the result set must never be cached, as it would
+                // be served as a complete result.
                 records.clear();
                 records.shrink_to_fit();
             }
@@ -201,9 +218,7 @@ pub fn to_cached_record_batch_stream(
             yield batch_result;
         }
 
-        // When an encoder is present, defer the size check until after encoding
-        // so that compressed results that fit in the cache are not prematurely rejected.
-        if records_size < cache_max_size || has_encoder {
+        if records_size < raw_size_limit {
             // `batches_cacheable` is false only when transient HTTP error
             // responses (5xx/429) are present, which requires a non-empty
             // result set — skip the write to avoid caching a partial result.
@@ -964,6 +979,146 @@ pub(crate) mod tests {
             .expect("cached result should decode");
         assert_eq!(cached_batches.len(), 1);
         assert_eq!(cached_batches[0].num_rows(), n);
+    }
+
+    /// Regression test: with an encoder, accumulation must continue past the
+    /// raw cache limit across **multiple batches**. Previously accumulation
+    /// stopped at the limit while the encoded write still proceeded, caching a
+    /// prefix of the result set that would then be served as a complete result.
+    #[tokio::test]
+    async fn test_encoded_multi_batch_result_cached_in_full() {
+        use arrow::array::{Array, Int32Array};
+        use datafusion::error::DataFusionError;
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::TryStreamExt;
+        use spicepod::component::caching::SQLResultsCacheConfig;
+
+        let cache_provider = Arc::new(
+            crate::QueryResultsCacheProvider::try_new(
+                &SQLResultsCacheConfig {
+                    item_ttl: Some("10m".to_string()),
+                    max_size: Some("2KiB".to_string()),
+                    encoding: spicepod::component::caching::Encoding::Zstd,
+                    ..Default::default()
+                },
+                Box::new([]),
+            )
+            .expect("valid cache provider"),
+        );
+
+        // Two compressible batches, each alone larger than the 2 KiB cache
+        // limit, so the raw limit is crossed before the second batch arrives.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let n = 300; // 300 rows × 2 cols × 4 bytes = 2400 bytes raw > 2048 limit
+        let make_batch = || {
+            let col: Arc<dyn Array> = Arc::new(Int32Array::from(vec![0i32; n]));
+            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::clone(&col), col])
+                .expect("to create batch")
+        };
+
+        let raw_cache_key = crate::key::CacheKey::Query("zstd-multi-batch", None)
+            .as_raw_key(cache_provider.hasher());
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![
+                Ok::<RecordBatch, DataFusionError>(make_batch()),
+                Ok::<RecordBatch, DataFusionError>(make_batch()),
+            ]),
+        ));
+
+        let cached_stream = to_cached_record_batch_stream(
+            Arc::clone(&cache_provider),
+            stream,
+            raw_cache_key,
+            Arc::new(HashSet::from(["test_table".into()])),
+        );
+
+        let _output = cached_stream
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("stream should be collected successfully");
+
+        let cached = cache_provider
+            .get_raw_key(&raw_cache_key)
+            .await
+            .expect("cache lookup should succeed")
+            .expect("compressed multi-batch result should be cached");
+
+        let cached_batches = cached.records().await.expect("cached result should decode");
+        let cached_rows: usize = cached_batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(
+            cached_rows,
+            2 * n,
+            "The full result set must be cached, never a prefix"
+        );
+    }
+
+    /// A result whose raw size exceeds the optimistic compression bound
+    /// (`MAX_ENCODING_COMPRESSION_RATIO` × cache limit) must not be cached at
+    /// all — in particular, no prefix of it.
+    #[tokio::test]
+    async fn test_encoded_result_beyond_compression_bound_not_cached() {
+        use arrow::array::{Array, Int32Array};
+        use datafusion::error::DataFusionError;
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::TryStreamExt;
+        use spicepod::component::caching::SQLResultsCacheConfig;
+
+        let cache_provider = Arc::new(
+            crate::QueryResultsCacheProvider::try_new(
+                &SQLResultsCacheConfig {
+                    item_ttl: Some("10m".to_string()),
+                    max_size: Some("2KiB".to_string()),
+                    encoding: spicepod::component::caching::Encoding::Zstd,
+                    ..Default::default()
+                },
+                Box::new([]),
+            )
+            .expect("valid cache provider"),
+        );
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        // Each batch is ~8 KiB raw; five batches (~40 KiB) exceed the
+        // 16 × 2 KiB = 32 KiB accumulation bound.
+        let n = 2048;
+        let make_batch = || {
+            let col: Arc<dyn Array> = Arc::new(Int32Array::from(vec![0i32; n]));
+            RecordBatch::try_new(Arc::clone(&schema), vec![col]).expect("to create batch")
+        };
+        let batches: Vec<Result<RecordBatch, DataFusionError>> =
+            (0..5).map(|_| Ok(make_batch())).collect();
+
+        let raw_cache_key = crate::key::CacheKey::Query("zstd-beyond-bound", None)
+            .as_raw_key(cache_provider.hasher());
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(batches),
+        ));
+
+        let cached_stream = to_cached_record_batch_stream(
+            Arc::clone(&cache_provider),
+            stream,
+            raw_cache_key,
+            Arc::new(HashSet::from(["test_table".into()])),
+        );
+
+        let output = cached_stream
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("stream should be collected successfully");
+        assert_eq!(output.len(), 5, "All batches must reach the caller");
+
+        let cached = cache_provider
+            .get_raw_key(&raw_cache_key)
+            .await
+            .expect("cache lookup should succeed");
+        assert!(
+            cached.is_none(),
+            "A result beyond the accumulation bound must not be cached (not even a prefix)"
+        );
     }
 
     /// Regression test: a query that returns an empty result set by yielding

--- a/crates/otel-arrow/src/converter.rs
+++ b/crates/otel-arrow/src/converter.rs
@@ -564,9 +564,10 @@ impl OtelToArrowConverter {
 
             self.flags_builder.append_null();
 
-            let attributes: Vec<opentelemetry::KeyValue> =
-                data_point.attributes().cloned().collect();
-            Self::add_attributes_to_builder(&mut self.attributes_builder, &attributes)?;
+            Self::add_attributes_to_builder(
+                &mut self.attributes_builder,
+                data_point.attributes().map(|kv| (&kv.key, &kv.value)),
+            )?;
 
             data_point.value().append(&mut self.data_number_builder)?;
             self.data_histogram_builder.append(false);
@@ -602,9 +603,10 @@ impl OtelToArrowConverter {
 
             self.flags_builder.append_null();
 
-            let attributes: Vec<opentelemetry::KeyValue> =
-                data_point.attributes().cloned().collect();
-            Self::add_attributes_to_builder(&mut self.attributes_builder, &attributes)?;
+            Self::add_attributes_to_builder(
+                &mut self.attributes_builder,
+                data_point.attributes().map(|kv| (&kv.key, &kv.value)),
+            )?;
 
             data_point.value().append(&mut self.data_number_builder)?;
             self.data_histogram_builder.append(false);
@@ -642,9 +644,10 @@ impl OtelToArrowConverter {
 
             self.flags_builder.append_null();
 
-            let attributes: Vec<opentelemetry::KeyValue> =
-                data_point.attributes().cloned().collect();
-            Self::add_attributes_to_builder(&mut self.attributes_builder, &attributes)?;
+            Self::add_attributes_to_builder(
+                &mut self.attributes_builder,
+                data_point.attributes().map(|kv| (&kv.key, &kv.value)),
+            )?;
 
             self.data_number_builder.append(false);
 
@@ -681,13 +684,9 @@ impl OtelToArrowConverter {
             .schema_url_builder
             .append_option(resource.schema_url().as_ref());
 
-        let attributes: Vec<opentelemetry::KeyValue> = resource
-            .iter()
-            .map(|(key, value)| opentelemetry::KeyValue::new(key.clone(), value.clone()))
-            .collect();
         Self::add_attributes_to_builder(
             &mut self.resource_builder.attributes_builder,
-            &attributes,
+            resource.iter(),
         )?;
 
         self.resource_builder
@@ -707,7 +706,7 @@ impl OtelToArrowConverter {
 
         Self::add_attributes_to_builder(
             &mut self.scope_builder.attributes_builder,
-            scope.attributes().cloned().collect::<Vec<_>>().as_slice(),
+            scope.attributes().map(|kv| (&kv.key, &kv.value)),
         )?;
 
         self.scope_builder
@@ -720,13 +719,13 @@ impl OtelToArrowConverter {
         Ok(())
     }
 
-    fn add_attributes_to_builder(
+    fn add_attributes_to_builder<'a>(
         builder: &mut AttributesBuilder,
-        attributes: &[opentelemetry::KeyValue],
+        attributes: impl IntoIterator<Item = (&'a opentelemetry::Key, &'a opentelemetry::Value)>,
     ) -> Result<(), ConversionError> {
-        for kv in attributes {
-            builder.key_builder.append_value(kv.key.as_str());
-            match &kv.value {
+        for (key, value) in attributes {
+            builder.key_builder.append_value(key.as_str());
+            match value {
                 opentelemetry::Value::String(s) => {
                     builder
                         .type_builder

--- a/crates/runtime/src/accelerated_table/caching.rs
+++ b/crates/runtime/src/accelerated_table/caching.rs
@@ -722,7 +722,7 @@ impl CacheRefreshHelper {
         let batches = Self::fetch_from_source(&federated, dataset_name, filters, None).await?;
 
         // Skip cache writes if the source response contains transient HTTP errors.
-        let Some(batches) = cache::batches_to_cache(&batches) else {
+        if !cache::batches_cacheable(&batches) {
             tracing::debug!(
                 "No cacheable data for dataset={dataset_name} (source returned transient HTTP error responses)"
             );
@@ -730,7 +730,7 @@ impl CacheRefreshHelper {
             let mut in_flight = in_flight_revalidations.lock().await;
             in_flight.remove(&cache_key);
             return Ok(0);
-        };
+        }
 
         if batches.is_empty() {
             tracing::debug!("No cacheable data for dataset={dataset_name} (source returned empty)");
@@ -1421,23 +1421,26 @@ impl CacheRefreshHelper {
 
                 // Skip cache writes if the source response contains transient HTTP
                 // errors. User still receives all fetched data.
-                let batches_for_cache = cache::batches_to_cache(&batches);
+                let batches_cacheable = cache::batches_cacheable(&batches);
 
                 // Clone batches for propagation to children.
                 // RecordBatch::clone() is cheap - only clones Arc pointers, not the underlying data.
-                let batches_for_propagate = batches_for_cache.clone().unwrap_or_default();
+                let batches_for_propagate = if batches_cacheable {
+                    batches.clone()
+                } else {
+                    Vec::new()
+                };
                 let filters_clone: Vec<Expr> = filters.to_vec();
                 let cache_key =
                     compute_cache_key_from_filters_and_namespace(filters, namespace.storage_id());
 
-                if let Some(batches_for_cache) = batches_for_cache {
-                    if batches_for_cache.is_empty() {
+                if batches_cacheable {
+                    if batches.is_empty() {
                         tracing::debug!(
                             "Fetch returned no rows, skipping cache write for dataset={dataset_name}"
                         );
                     } else {
-                        let cache_rows: usize =
-                            batches_for_cache.iter().map(RecordBatch::num_rows).sum();
+                        let cache_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
 
                         // Send write request to batched consumer. The flush
                         // task is the one that stamps `__spice_cache_namespace`
@@ -1446,7 +1449,7 @@ impl CacheRefreshHelper {
                         // actual storage schema (extended in real deployments,
                         // unextended in unit-test mocks).
                         let write_request = CacheWriteRequest {
-                            batches: batches_for_cache,
+                            batches: batches.clone(),
                             filters: filters.to_vec(),
                             is_upsert: is_expired,
                             cache_key,

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -823,7 +823,7 @@ impl Query {
                             "Returning cached result for distributed query (plan)"
                         );
                         let stream = ::cache::result::query::CachedStream::new(
-                            Arc::new(records),
+                            records,
                             cached_result.schema,
                         );
                         return Ok(QueryHandle::new_with_cached_result(

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -433,7 +433,7 @@ impl Query {
         });
 
         let records = match cached_result.records().await {
-            Ok(records) => Arc::new(records),
+            Ok(records) => records,
             Err(e) => {
                 tracing::error!("Failed to decode cached query result: {e}");
                 return Ok(CacheResponse::from(
@@ -548,13 +548,13 @@ impl Query {
             // Skip cache writes if the revalidation result contains transient HTTP
             // error responses. Preserve the existing stale cache entry instead of
             // storing a partial result set.
-            let Some(batches_to_cache) = cache::batches_to_cache(&batches) else {
+            if !cache::batches_cacheable(&batches) {
                 tracing::debug!(
                     cache_key = cache_key_u64,
                     "Background revalidation returned transient HTTP error responses, preserving stale cache"
                 );
                 return;
-            };
+            }
 
             // Empty (0-row) revalidation results are cached too. The schema is
             // preserved separately in `CachedQueryResult`, so an empty result
@@ -564,7 +564,7 @@ impl Query {
             let encoder = cache_provider.encoder();
 
             match cache::result::query::CachedQueryResult::from_batches(
-                &batches_to_cache,
+                batches,
                 schema,
                 input_tables,
                 cached_at,

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -311,10 +311,13 @@ fn build_documents(
             }
             value_buf.clear();
             encoder.encode(row, &mut value_buf);
-            let v: Value =
-                serde_json::from_slice(&value_buf).context(IssueWithJsonProcessingSnafu {
+            // `with_context` keeps the error-message allocation off the happy
+            // path — this runs once per cell (rows x columns).
+            let v: Value = serde_json::from_slice(&value_buf).with_context(|_| {
+                IssueWithJsonProcessingSnafu {
                     index: es_index.to_string(),
-                })?;
+                }
+            })?;
             doc.insert(name.clone(), v);
         }
 


### PR DESCRIPTION
## 📝 Summary

Removes unnecessary memory allocations from three hot paths, found in an allocation audit of per-query / per-row code:

**1. SQL results cache — copy on every hit, double copy on every write** (`cache`, `runtime`)
- `CachedQueryResult::records()` cloned the stored `Vec<RecordBatch>` on every cache hit, and both callers immediately re-wrapped the copy in a new `Arc` to stream it. It now returns `Arc::clone` of the stored vec: one refcount bump, no allocation on the hit path.
- On the write path, `batches_to_cache()` cloned the full batch vec just to signal "ok to cache", then `from_batches()` cloned it again via `records.to_vec()` on the default (`encoding: none`) path. `batches_to_cache` is replaced with the borrow-only predicate `batches_cacheable`, and `from_batches` takes `Vec<RecordBatch>` by value so callers move the owned result into the cache. The accelerator-cache `refresh_entry` path loses a full copy as well.

**2. OTel→Arrow converter — per-data-point attribute deep clones** (`otel-arrow`)
Every metric data point materialized three throwaway `Vec<KeyValue>`s, deep-cloning the data-point attributes plus the entire resource and scope attribute sets — identical data recloned for every row. `add_attributes_to_builder` now takes an iterator of borrowed `(&Key, &Value)` pairs and all call sites pass borrows straight through.

**3. Elasticsearch ingest — a `String` per cell on the happy path** (`search`)
The per-cell JSON decode in `build_documents` used an eager snafu `.context(...)` that built the error-message `String` for every cell (rows × columns) even on success. Switched to the lazy `.with_context(|_| ...)` so it only allocates on an actual error.

## 👀 Notes for Reviewers

- `records()` returning `Arc<Vec<RecordBatch>>` and `from_batches` taking `Vec<RecordBatch>` are workspace-internal API changes; all callers are in `cache` and `runtime` and are updated here.
- No behavior changes intended: the transient-HTTP-error skip semantics, empty-result caching, and SWR revalidation flow are preserved (covered by existing tests).
- Validated with `cargo check`, scoped clippy using the `lint-rust` gate's flags/features (clean), `cargo test -p cache --lib` (79 passed), and `cargo test -p runtime --lib` filtered to `datafusion::query::cache` + `accelerated_table::caching` (49 passed).
