### PR TITLE
Increase ready_wait timeout for chbench sf1000 cold-tier configs

### DIFF
--- a/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold-auto.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold-auto.yaml
@@ -5,5 +5,5 @@ tests:
     scale_factor: 1000
     terminals: 100
     duration: 900
-    ready_wait: 900
+    ready_wait: 1800
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold.yaml
@@ -5,5 +5,5 @@ tests:
     scale_factor: 1000
     terminals: 100
     duration: 900
-    ready_wait: 900
+    ready_wait: 1800
     rate: 9250


### PR DESCRIPTION
Increases `ready_wait` from 900s to 1800s in the sf1000 cold-tier chbench dispatch configs (`postgres-cayenne[file]-adaptive-cold` and `-cold-auto`), as cold-tier readiness at SF1000 can exceed the previous 15-minute wait.