### PR TITLE
test(chbench): stronger content fingerprint + MySQL sidecar template caching

### DIFF
--- a/.github/scripts/chbench_template_mysql.sh
+++ b/.github/scripts/chbench_template_mysql.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Ensure the CH-benCH source DB `chbench` is ready WITHOUT re-seeding every run,
+# by keeping a pristine tablespace snapshot on the long-lived CI MySQL pod and
+# restoring from it with a fast local file copy. The physical file work is done
+# by the file-agent SIDECAR in the MySQL pod (chbench-mysql chart, sidecar.enabled);
+# this script only DRIVES it over the ordinary MySQL connection — it INSERTs a
+# command row into `chbench._file_cmd` and polls for completion. MySQL has no
+# server-side DB-clone primitive and the runner has no filesystem access to the
+# pod, so the sidecar (co-located, sharing the data volume) performs the
+# `FLUSH ... FOR EXPORT` + copy (snapshot) and `DISCARD`/copy/`IMPORT` (restore).
+#
+# Only meaningful on the dedicated, persistent MySQL pod (xlarge runner): its
+# node-local data dir and the sidecar's cache both survive between runs (wiped
+# together only on pod restart). On an ephemeral per-run docker MySQL there is
+# no sidecar and nothing to cache, so the caller gates this step to the pod path
+# and the main run seeds normally.
+#
+# Flow (mirrors chbench_template.sh, but the "copy" is the sidecar's job):
+#   fingerprint = sf=<N> driver=<chbench-driver tree hash> mysql<major>
+#   HIT  (sidecar reports a cached snapshot with a matching fingerprint):
+#        issue a `restore` command and wait. On restore failure, fall back to a
+#        full reseed so the run is never blocked by a bad cache.
+#   MISS: seed once via `testoperator run htap --prepare-only`, then issue a
+#        `snapshot` command so the next run can HIT. `chbench` is already freshly
+#        seeded, so no restore is needed on a miss.
+# Either way `chbench` ends up seeded, so the caller runs with `--skip-prepare`.
+#
+# Env (from the workflow step):
+#   SCALE_FACTOR (req), TERMINALS (opt), SPICEPOD_PATH (req), SPICED_BIN (req),
+#   CHBENCH_MYSQL_HOST/PORT/USER/PASS (req), CHBENCH_MYSQL_DB (opt, default
+#   chbench), TESTOP_PREFIX (opt), REPO_ROOT (default: $GITHUB_WORKSPACE) for the
+#   chbench-driver fingerprint, CMD_TIMEOUT_SECONDS (opt, default 3600) and
+#   SIDECAR_WAIT_SECONDS (opt, default 180) for the poll bounds.
+set -euo pipefail
+
+SF="${SCALE_FACTOR:?}"
+MYH="${CHBENCH_MYSQL_HOST:?}"; MYP="${CHBENCH_MYSQL_PORT:-3306}"
+MYU="${CHBENCH_MYSQL_USER:-bench}"; MYDB="${CHBENCH_MYSQL_DB:-chbench}"
+export MYSQL_PWD="${CHBENCH_MYSQL_PASS:-bench}"
+REPO_ROOT="${REPO_ROOT:-${GITHUB_WORKSPACE:-$PWD}}"
+TESTOP_PREFIX="${TESTOP_PREFIX:-}"
+CMD_TIMEOUT="${CMD_TIMEOUT_SECONDS:-3600}"
+SIDECAR_WAIT="${SIDECAR_WAIT_SECONDS:-180}"
+
+# The mysql client may not be preinstalled on the runner.
+if ! command -v mysql >/dev/null 2>&1; then
+  sudo apt-get update -qq && sudo apt-get install -y -qq default-mysql-client || true
+fi
+
+# Scalar/one-row query against `chbench` (-N no headers, -B tab-separated).
+my() { mysql -h "$MYH" -P "$MYP" -u "$MYU" -D "$MYDB" -N -B -e "$1"; }
+
+mysqlmajor=$(my "SELECT SUBSTRING_INDEX(VERSION(), '.', 1)")
+driver=$(git -C "$REPO_ROOT" rev-parse "HEAD:tools/chbench-driver" 2>/dev/null || echo nogit)
+fp="sf=${SF} driver=${driver} mysql${mysqlmajor}"
+echo "template fingerprint: $fp"
+
+# Wait for the sidecar to have created its control table (it does so shortly
+# after the pod starts). Absent after the bound => the sidecar isn't running.
+table_exists() {
+  local n
+  n=$(my "SELECT COUNT(*) FROM information_schema.tables
+          WHERE table_schema='${MYDB}' AND table_name='$1'")
+  [ "${n:-0}" != "0" ]
+}
+wait_for_control_table() {
+  local waited=0
+  until table_exists _file_cmd; do
+    if [ "$waited" -ge "$SIDECAR_WAIT" ]; then
+      echo "ERROR: chbench._file_cmd not present after ${SIDECAR_WAIT}s — is the MySQL pod's file-agent sidecar enabled (sidecar.enabled)?" >&2
+      return 1
+    fi
+    sleep 3; waited=$((waited + 3))
+  done
+}
+
+# SQL-escape a single-quoted literal.
+esc() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+# Issue a command to the sidecar and wait for it to finish. Echoes the final
+# state ("done"/"error"/"timeout") on stdout; the sidecar's message goes to the
+# log. INSERT + LAST_INSERT_ID() run in one session so we get our own row's id.
+issue_and_wait() {
+  local cmd="$1" id state waited=0
+  id=$(my "INSERT INTO _file_cmd (cmd, fp) VALUES ('$(esc "$cmd")', '$(esc "$fp")'); SELECT LAST_INSERT_ID()")
+  echo "  issued $cmd command id=$id, waiting (timeout ${CMD_TIMEOUT}s)..." >&2
+  while :; do
+    state=$(my "SELECT state FROM _file_cmd WHERE id=$id" || echo "")
+    case "$state" in
+      done|error)
+        echo "  $cmd id=$id -> $state: $(my "SELECT COALESCE(msg,'') FROM _file_cmd WHERE id=$id" | tr '\n' ' ')" >&2
+        echo "$state"; return 0 ;;
+    esac
+    if [ "$waited" -ge "$CMD_TIMEOUT" ]; then
+      echo "  $cmd id=$id -> timeout after ${CMD_TIMEOUT}s (last state '${state:-?}')" >&2
+      echo "timeout"; return 0
+    fi
+    sleep 2; waited=$((waited + 2))
+  done
+}
+
+seed_via_prepare_only() {
+  echo "seeding chbench via testoperator --prepare-only (SF$SF)"
+  CHBENCH_MYSQL_HOST="$MYH" CHBENCH_MYSQL_PORT="$MYP" CHBENCH_MYSQL_USER="$MYU" \
+  CHBENCH_MYSQL_PASS="$MYSQL_PWD" CHBENCH_MYSQL_DB="$MYDB" \
+    $TESTOP_PREFIX testoperator run htap \
+      -s "$SPICED_BIN" -p "$SPICEPOD_PATH" --query-set chbench --source-type mysql \
+      --scale-factor "$SF" ${TERMINALS:+--terminals $TERMINALS} \
+      --duration 1 --concurrency 1 --ready-wait 60 \
+      --prepare-only --disable-progress-bars
+}
+
+do_miss() {
+  echo "template MISS for SF$SF -> seed once, then snapshot for future runs"
+  seed_via_prepare_only
+  if [ "$(issue_and_wait snapshot)" != "done" ]; then
+    # Non-fatal: chbench is already freshly seeded, so the run can proceed with
+    # --skip-prepare; only the cache for the *next* run is missing.
+    echo "WARNING: snapshot did not complete; next run will reseed (MISS again)" >&2
+  fi
+}
+
+wait_for_control_table
+
+# HIT if the sidecar reports a cached snapshot whose fingerprint matches.
+cached=""
+if table_exists _file_cache; then
+  cached=$(my "SELECT COALESCE(MAX(fp),'') FROM _file_cache WHERE k=1")
+fi
+
+if [ "$cached" = "$fp" ]; then
+  echo "template HIT for SF$SF -> restoring chbench from sidecar snapshot"
+  if [ "$(issue_and_wait restore)" = "done" ]; then
+    echo "restore complete — run with --skip-prepare"
+  else
+    echo "WARNING: restore failed/timed out; falling back to a full reseed" >&2
+    do_miss
+  fi
+else
+  [ -n "$cached" ] && echo "cached fingerprint '$cached' != '$fp' -> reseeding"
+  do_miss
+fi
+
+echo "chbench is ready — run with --skip-prepare"

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -222,6 +222,27 @@ jobs:
           CHBENCH_PG_USER: bench
           CHBENCH_PG_PASS: bench
 
+      # MySQL counterpart: the long-lived pod runs a file-agent sidecar
+      # (chbench-mysql chart, sidecar.enabled) that keeps a pristine tablespace
+      # snapshot and restores it with a fast local file copy. This step only
+      # drives it over the MySQL connection: on a hit it issues a `restore`, on a
+      # miss it seeds once via `testoperator --prepare-only` then issues a
+      # `snapshot`. After this the run below uses `--skip-prepare`. Ephemeral
+      # docker-MySQL runners have no sidecar, so they skip this and seed normally.
+      - name: Restore or seed CH-benCH MySQL from template
+        if: steps.set_spicepod_path.outputs.SOURCE_TYPE == 'mysql' && github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners'
+        run: bash .github/scripts/chbench_template_mysql.sh
+        env:
+          SCALE_FACTOR: ${{ github.event.inputs.scale_factor }}
+          TERMINALS: ${{ github.event.inputs.terminals }}
+          SPICEPOD_PATH: ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}
+          SPICED_BIN: /usr/local/bin/spiced
+          CHBENCH_MYSQL_HOST: chbench-mysql.dataplatform.svc.cluster.local
+          CHBENCH_MYSQL_PORT: '3306'
+          CHBENCH_MYSQL_USER: bench
+          CHBENCH_MYSQL_PASS: bench
+          CHBENCH_MYSQL_DB: chbench
+
       # Deliberately placed after template restore/seed above: these vars must never be
       # visible to the `--prepare-only` seed run, or an experiment could silently change
       # what gets frozen into the cached template. $GITHUB_ENV persists for every later
@@ -320,7 +341,7 @@ jobs:
             --concurrency ${{ github.event.inputs.concurrency }} \
             ${{ github.event.inputs.query_overrides != '' && format('--query-overrides {0}', github.event.inputs.query_overrides) || '' }} \
             --ready-wait ${{ github.event.inputs.ready_wait }} \
-            ${{ steps.set_spicepod_path.outputs.SOURCE_TYPE != 'mysql' && github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners' && '--skip-prepare' || '' }} \
+            ${{ github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners' && '--skip-prepare' || '' }} \
             ${{ github.event.inputs.skip_analytic_gate == 'true' && '--skip-analytic-gate' || '' }} \
             --disable-progress-bars \
             --metrics \

--- a/tools/testoperator/src/commands/htap/correctness/compare.rs
+++ b/tools/testoperator/src/commands/htap/correctness/compare.rs
@@ -84,6 +84,15 @@ fn is_float(dt: &DataType) -> bool {
     )
 }
 
+/// Whether a column is numeric *and* exact — integers and decimals, never
+/// floats. `SUM` over such a column is bit-identical across engines (no
+/// order-dependent rounding), so the fingerprint gate can compare it with zero
+/// tolerance; a floating `SUM` legitimately drifts and must not be summed.
+#[must_use]
+pub fn is_exact_numeric(dt: &DataType) -> bool {
+    is_numeric(dt) && !is_float(dt)
+}
+
 /// Per-column float-ness of a batch's schema, for the `actual_source_floats`
 /// argument of [`numeric_delta`].
 ///

--- a/tools/testoperator/src/commands/htap/correctness/row_count.rs
+++ b/tools/testoperator/src/commands/htap/correctness/row_count.rs
@@ -27,7 +27,7 @@ use super::compare;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use chbench_driver::ChBenchDriver;
-use datafusion::functions_aggregate::expr_fn::{count, max, min};
+use datafusion::functions_aggregate::expr_fn::{count, max, min, sum};
 use datafusion::logical_expr::{
     Expr, LogicalPlanBuilder, TableSource, builder::LogicalTableSource,
 };
@@ -280,7 +280,9 @@ pub async fn verify_after_drain(
 /// Compute and compare a per-column content fingerprint for `table`.
 ///
 /// The fingerprint is engine-agnostic: `COUNT(*)`, a non-null `COUNT(col)` for
-/// every column, and `MIN(col)`/`MAX(col)` for numeric columns. `SUM` is
+/// every column, `MIN(col)`/`MAX(col)` for numeric columns, and `SUM(col)` for
+/// exact (integer/decimal) numeric columns — the `SUM` catches interior value
+/// corruption that COUNT/MIN/MAX miss. `SUM` over a *float* column is
 /// deliberately excluded (floating sums are order-dependent and legitimately
 /// differ across engines); text/temporal `MIN`/`MAX` are excluded (collation
 /// and timestamp precision differ across engines). The identical SQL runs
@@ -389,9 +391,10 @@ fn first_non_empty(batches: &[RecordBatch]) -> Option<&RecordBatch> {
 /// SQL is well-formed on both the source and Spice.
 ///
 /// A `COUNT(*)`, a non-null `COUNT` for every column (catches column swaps /
-/// nulled values) and `MIN`/`MAX` for numeric columns. Each aggregate is aliased
-/// (`count_<col>`, `min_<col>`, `max_<col>`) so a divergence reported by
-/// [`compare::numeric_delta`] names the offending column.
+/// nulled values), `MIN`/`MAX` for numeric columns, and `SUM` for exact
+/// (integer/decimal) numeric columns. Each aggregate is aliased
+/// (`count_<col>`, `min_<col>`, `max_<col>`, `sum_<col>`) so a divergence
+/// reported by [`compare::numeric_delta`] names the offending column.
 fn build_fingerprint_sql(table: &str, schema: &SchemaRef) -> anyhow::Result<String> {
     // The table source only carries the schema — the plan is unparsed, never run.
     let source = Arc::new(LogicalTableSource::new(Arc::clone(schema))) as Arc<dyn TableSource>;
@@ -403,6 +406,17 @@ fn build_fingerprint_sql(table: &str, schema: &SchemaRef) -> anyhow::Result<Stri
         if compare::is_numeric(field.data_type()) {
             aggs.push(min(col(name.as_str())).alias(format!("min_{name}")));
             aggs.push(max(col(name.as_str())).alias(format!("max_{name}")));
+            // SUM only for exact (integer/decimal) columns. It catches interior
+            // value corruption — a wrong upsert value, a stale/missed update —
+            // that COUNT/MIN/MAX miss (the wrong value need not be a new
+            // extreme). A floating SUM is order-dependent and legitimately
+            // drifts across engines, so it is never summed; an exact SUM is
+            // bit-identical on both sides and compared with zero tolerance. The
+            // sum relies on the f64-exactness bound documented in `compare`
+            // (magnitudes below 2^53), which holds at the scale factors we run.
+            if compare::is_exact_numeric(field.data_type()) {
+                aggs.push(sum(col(name.as_str())).alias(format!("sum_{name}")));
+            }
         }
     }
 
@@ -419,10 +433,12 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 
     #[test]
-    fn fingerprint_sql_counts_all_columns_minmax_only_numerics() {
+    fn fingerprint_sql_counts_all_columns_minmax_numerics_sum_exact_only() {
         let schema: SchemaRef = Arc::new(Schema::new(vec![
             Field::new("ol_amount", DataType::Decimal128(38, 2), true),
             Field::new("ol_quantity", DataType::Int32, true),
+            // A genuine float column: MIN/MAX yes, but never SUM (drifts).
+            Field::new("ol_ratio", DataType::Float64, true),
             Field::new("ol_dist_info", DataType::Utf8, true),
             Field::new(
                 "ol_delivery_d",
@@ -436,21 +452,25 @@ mod tests {
 
         // COUNT(*) and a non-null COUNT alias for every column.
         assert!(sql.contains("count_star"), "missing COUNT(*): {sql}");
-        for col in ["ol_amount", "ol_quantity", "ol_dist_info", "ol_delivery_d"] {
+        for col in [
+            "ol_amount",
+            "ol_quantity",
+            "ol_ratio",
+            "ol_dist_info",
+            "ol_delivery_d",
+        ] {
             assert!(
                 sql.contains(&format!("count_{col}")),
                 "missing COUNT for {col}: {sql}"
             );
         }
-        // MIN/MAX only for numeric columns.
-        assert!(
-            sql.contains("min_ol_amount") && sql.contains("max_ol_amount"),
-            "{sql}"
-        );
-        assert!(
-            sql.contains("min_ol_quantity") && sql.contains("max_ol_quantity"),
-            "{sql}"
-        );
+        // MIN/MAX for every numeric column, including the float.
+        for col in ["ol_amount", "ol_quantity", "ol_ratio"] {
+            assert!(
+                sql.contains(&format!("min_{col}")) && sql.contains(&format!("max_{col}")),
+                "missing MIN/MAX for numeric {col}: {sql}"
+            );
+        }
         // Not for text or temporal (cross-engine collation / precision differ).
         assert!(
             !sql.contains("min_ol_dist_info") && !sql.contains("max_ol_dist_info"),
@@ -460,6 +480,19 @@ mod tests {
             !sql.contains("min_ol_delivery_d") && !sql.contains("max_ol_delivery_d"),
             "{sql}"
         );
+        // SUM only for exact (integer/decimal) numerics — catches interior
+        // value corruption without the order-dependent drift of a float sum.
+        assert!(
+            sql.contains("sum_ol_amount") && sql.contains("sum_ol_quantity"),
+            "missing SUM for exact numeric columns: {sql}"
+        );
+        // Never SUM the float, text, or temporal columns.
+        for col in ["ol_ratio", "ol_dist_info", "ol_delivery_d"] {
+            assert!(
+                !sql.contains(&format!("sum_{col}")),
+                "unexpected SUM for {col}: {sql}"
+            );
+        }
         // The source table is referenced.
         assert!(sql.contains("order_line"), "{sql}");
     }


### PR DESCRIPTION
## Summary

Two CH-benCHmark CI/tooling improvements:

- **Improved analytics correctness** — the HTAP content fingerprint now adds an exact `SUM` per integer/decimal column, so value-level corruption (a wrong upsert, a stale/missed update) is caught even when row counts and MIN/MAX still agree. Verified in https://github.com/spiceai/spiceai/actions/runs/29453782298

- **MySQL sidecar templating** — the MySQL source DB is cached and restored via a file-agent sidecar co-located in the MySQL pod (fast physical file copy) instead of re-seeding from scratch every run. Only the persistent xlarge pod uses it; ephemeral runners seed normally.

CI/tooling change — no runtime behavior affected.
