### PR TITLE
release: cherry-pick v2.1.1 fixes onto release/2.1

### DIFF
--- a/crates/cayenne/src/partition_creator.rs
+++ b/crates/cayenne/src/partition_creator.rs
@@ -115,7 +115,8 @@ impl CayennePartitionCreator {
         on_conflict: Option<datafusion_table_providers::util::on_conflict::OnConflict>,
         runtime_env: Arc<RuntimeEnv>,
     ) -> Self {
-        let context = CayenneContext::new(&vortex_config, runtime_env, &table_name);
+        let context =
+            CayenneContext::new_for_partition_child(&vortex_config, runtime_env, &table_name);
         Self {
             table_name,
             base_path,

--- a/crates/cayenne/src/provider/context.rs
+++ b/crates/cayenne/src/provider/context.rs
@@ -111,6 +111,23 @@ pub struct CayenneContext {
     /// inter-batch arrival interval (the offered-load signal). `None` until the
     /// first write.
     last_write: parking_lot::Mutex<Option<std::time::Instant>>,
+    /// Whether this table's writes are COUPLED to sibling writers through a
+    /// shared input demux — true for the partition child tables of a
+    /// partitioned dataset, whose per-partition writes are all fed by one
+    /// router over bounded channels. Coupled writes must never park on the
+    /// global encode budget: a parked child stalls the router, which starves
+    /// the permit-holding siblings of input — a hold-and-wait deadlock that
+    /// left partitioned tables permanently unready (spiceai/spiceai#11818).
+    /// Set only at construction ([`Self::new_for_partition_child`]); read by
+    /// the write path to bypass `write_budget` permit acquisition. Runtime-only
+    /// state — never persisted.
+    coupled_writer: std::sync::atomic::AtomicBool,
+    /// Set of data files whose integrity digest has already been verified this
+    /// process, keyed by `"<snapshot_id>/<file_path>"`. Used only when
+    /// `integrity_checksums` is enabled, to bound verification to one whole-file
+    /// read per file per process ("verify on first read"). Data files are
+    /// immutable once published, so a verified file never needs re-checking.
+    verified_data_files: parking_lot::Mutex<std::collections::HashSet<String>>,
 }
 
 /// Default byte budget for the in-memory PK keyset cache when
@@ -270,7 +287,37 @@ impl CayenneContext {
             bake_gate_last_samples: std::sync::atomic::AtomicU64::new(0),
             goal_stuck_ticks: std::sync::atomic::AtomicU64::new(0),
             last_write: parking_lot::Mutex::new(None),
+            coupled_writer: std::sync::atomic::AtomicBool::new(false),
+            verified_data_files: parking_lot::Mutex::new(std::collections::HashSet::new()),
         })
+    }
+
+    /// Create the shared context for the partition CHILD tables of a
+    /// partitioned dataset. Identical to [`Self::new`] except the tables are
+    /// marked as coupled writers (see [`Self::is_coupled_writer`]): their
+    /// writes are all fed by one routing demux over bounded channels, so they
+    /// must never park on the global encode budget.
+    #[must_use]
+    pub fn new_for_partition_child(
+        config: &VortexConfig,
+        runtime_env: Arc<RuntimeEnv>,
+        dataset: &str,
+    ) -> Arc<Self> {
+        let context = Self::new(config, runtime_env, dataset);
+        context
+            .coupled_writer
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        context
+    }
+
+    /// Whether this table's writes are coupled to sibling writers through a
+    /// shared input demux (partition child tables). Coupled writes bypass the
+    /// global encode budget — parking there deadlocks the demux
+    /// (spiceai/spiceai#11818).
+    #[must_use]
+    pub fn is_coupled_writer(&self) -> bool {
+        self.coupled_writer
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Encoding effort configured for delta writes (`cayenne_delta_encoding`).
@@ -869,6 +916,56 @@ mod tests {
         assert_eq!(
             context.file_format().options().projection_pushdown,
             ProjectionPushdown::On
+        );
+    }
+
+    /// Partition child contexts are marked as coupled writers (their writes
+    /// share one routing demux and must bypass the global encode budget —
+    /// spiceai/spiceai#11818); ordinary contexts are not.
+    #[test]
+    fn partition_child_context_is_coupled_writer() {
+        let runtime_env = Arc::new(RuntimeEnv::default());
+        let ordinary =
+            CayenneContext::new(&VortexConfig::default(), Arc::clone(&runtime_env), "test");
+        assert!(!ordinary.is_coupled_writer());
+
+        let child =
+            CayenneContext::new_for_partition_child(&VortexConfig::default(), runtime_env, "test");
+        assert!(child.is_coupled_writer());
+    }
+
+    /// Regression: the cold (datalake) promotion write must roll files at
+    /// `cayenne_datalake_target_file_size_mb`, not the warm `target_vortex_file_size_mb`.
+    ///
+    /// Every sorted / PK-upsert table earns a single write shard, so the warm
+    /// `write_shard_format` path returns the base format unchanged — whose
+    /// `target_file_size_mb` is the warm size. Cold promotion therefore silently
+    /// rolled files at the warm size, leaving `cayenne_datalake_target_file_size_mb`
+    /// inert. `cold_write_format` must build a format carrying the cold size.
+    #[test]
+    fn cold_write_format_rolls_files_at_cold_target_size() {
+        let runtime_env = Arc::new(RuntimeEnv::default());
+        let config = VortexConfig {
+            target_vortex_file_size_mb: 256,
+            cold_target_file_size_mb: 1024,
+            ..VortexConfig::default()
+        };
+        let context = CayenneContext::new(&config, runtime_env, "test");
+
+        // Baseline: the warm/base format rolls at the warm target size.
+        assert_eq!(
+            context.file_format().options().target_file_size_mb,
+            256,
+            "base (warm) format must use target_vortex_file_size_mb"
+        );
+
+        // Datalake: the cold format rolls at the cold target size, independent of the warm size;
+        // previously this file size was silently 256 (the warm size).
+        let cold = context.cold_write_format(config.cold_target_file_size_mb, None);
+        assert_eq!(
+            cold.options().target_file_size_mb,
+            1024,
+            "cold format must use cayenne_datalake_target_file_size_mb, not the warm size"
         );
     }
 

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -4564,8 +4564,28 @@ impl CayenneTableProvider {
         // use the whole budget; `Maintenance` (compaction outputs, sorted
         // rewrites, overwrites) is capped below it so a latency-bound delta
         // encode never queues behind a whole multi-shard compaction pass.
-        let _encode_permits =
-            super::write_budget::acquire_encode_permits(encode_shards, write_class).await;
+        // Attribute the time blocked on the shared encode budget to a dedicated
+        // write phase so `cayenne_write_phase_duration_ms{phase="encode_permit_wait"}`
+        // splits semaphore-wait out of the aggregate write cost (the outer
+        // `cdc_apply_fixed_cost_ms{phase="write"}` in the runtime apply loop). The
+        // `cayenne_encode_acquire_wait_ms{class}` histogram inside `acquire_from`
+        // carries the same signal without the table label; this one keys by table.
+        // Coupled writers (partition child tables, fed by a shared routing
+        // demux) bypass the budget entirely — parking a coupled write here
+        // deadlocks the demux against the permit holders (see `write_budget`
+        // module docs; spiceai/spiceai#11818).
+        let encode_permit_wait_start = Instant::now();
+        let _encode_permits = super::write_budget::acquire_encode_permits(
+            encode_shards,
+            write_class,
+            self.context.is_coupled_writer(),
+        )
+        .await;
+        record_cayenne_write_phase(
+            self.table_name(),
+            "encode_permit_wait",
+            encode_permit_wait_start,
+        );
 
         // Construct snapshot directory URL
         let snapshot_dir_url = Self::snapshot_dir_url(

--- a/crates/cayenne/src/provider/write_budget.rs
+++ b/crates/cayenne/src/provider/write_budget.rs
@@ -35,6 +35,22 @@ limitations under the License.
 //! cap deadlock-free: a write can never hold some permits while waiting for the
 //! rest, so independent writes can't form a hold-and-wait cycle.
 //!
+//! That argument only holds for writes that are **independent**. Writes into a
+//! partitioned table are not: the partition insert path demuxes one input
+//! stream into per-partition writes over bounded channels
+//! (`runtime_table_partition::insert`), so a child write parked on this budget
+//! stalls the demux, which starves the permit-holding sibling writes of input —
+//! a hold-and-wait cycle *through the channels* that left partitioned tables
+//! permanently unready (spiceai/spiceai#11818). Such COUPLED writers — tables
+//! whose writes someone else stands behind, marked at construction via
+//! `CayenneContext::new_for_partition_child` — are therefore **exempt from the
+//! budget** ([`acquire_for_write`]): an exempt write can always drain its
+//! input, so the demux always makes progress, for any partition count. The
+//! exemption is safe because coupled tables are also forced to serial writes
+//! (one encode shard — the pre-budget baseline; the budget exists to cap
+//! encode *fan-out*), so an exempt child contributes the minimum possible
+//! encode footprint. Every uncoupled write, serial included, still queues.
+//!
 //! When unset (unit tests, embedders that don't wire it up) acquisition is a
 //! no-op and writes proceed ungated, preserving the prior per-table behavior.
 
@@ -267,17 +283,51 @@ pub fn cap_global_encode_concurrency(max_permits: usize) {
 /// Acquire up to `shards` encode permits from the global budget, atomically.
 ///
 /// Returns the held permits (which release on drop, so callers scope them to
-/// the write) or `None` when no budget is installed (proceed ungated). `shards`
+/// the write) or `None` when the write proceeds ungated: no budget installed,
+/// or a coupled writer (see [`acquire_for_write`]). For gated writes, `shards`
 /// is clamped to `[1, class cap]` so the request is always satisfiable and can
 /// never block forever waiting for more permits than the budget can ever hold.
 /// `Delta` writes may use the whole budget; `Maintenance` writes are capped to
 /// [`maintenance_gate_cap`] in aggregate (see `maintenance_gate`).
+///
+/// `coupled_writer` is `CayenneContext::is_coupled_writer()` — whether this
+/// table's writes are fed by a shared demux alongside sibling writers
+/// (partition child tables).
 pub(crate) async fn acquire_encode_permits(
     shards: usize,
     class: WriteClass,
+    coupled_writer: bool,
 ) -> Option<EncodePermits> {
     let budget = GLOBAL_ENCODE_BUDGET.read().clone()?;
-    acquire_from(&budget, shards, class).await
+    acquire_for_write(&budget, shards, class, coupled_writer).await
+}
+
+/// Budget policy for a write: independent writes acquire permits
+/// ([`acquire_from`]); **coupled writers are exempt** and proceed ungated
+/// (`None`).
+///
+/// The exemption is load-bearing, not an optimization. Coupled writers — the
+/// partition child tables of a partitioned dataset — are all fed by one
+/// routing demux over bounded channels, and deadlock if any of them can park
+/// on this budget: the parked write stalls the demux, starving the
+/// permit-holding siblings of input, and no permit is ever released
+/// (spiceai/spiceai#11818). An exempt write never parks, so the demux always
+/// drains, for any partition count. The budget's purpose — capping aggregate
+/// encode *fan-out* — is preserved: coupled tables are also forced to serial
+/// (single-shard) writes at creation, the pre-budget baseline of one encode
+/// stream per writer, and compaction's aggregate concurrency stays bounded by
+/// the `BackgroundCompactor` semaphore independently of this gate. Uncoupled
+/// writes — including serial ones — queue exactly as before.
+async fn acquire_for_write(
+    budget: &EncodeBudget,
+    shards: usize,
+    class: WriteClass,
+    coupled_writer: bool,
+) -> Option<EncodePermits> {
+    if coupled_writer {
+        return None;
+    }
+    acquire_from(budget, shards, class).await
 }
 
 /// Acquire `min(shards, class cap)` permits from a specific budget. Extracted
@@ -562,6 +612,81 @@ mod tests {
     /// here — keeping this free of cross-test interference.
     #[tokio::test]
     async fn acquire_encode_permits_is_noop_when_unset() {
-        assert!(acquire_encode_permits(8, WriteClass::Delta).await.is_none());
+        assert!(
+            acquire_encode_permits(8, WriteClass::Delta, false)
+                .await
+                .is_none()
+        );
+    }
+
+    /// REGRESSION (spiceai/spiceai#11818): a coupled write must proceed
+    /// ungated even when the budget is fully held. Partitioned-table inserts
+    /// feed their per-partition writes through one bounded-channel demux, so a
+    /// child write that parks on the budget stalls the demux, starves the
+    /// permit-holding siblings of input, and deadlocks the whole insert —
+    /// datasets loaded but the table never ready.
+    #[tokio::test]
+    async fn coupled_write_is_exempt_even_at_zero_headroom() {
+        let b = budget(2);
+        let held = acquire_from(&b, 2, WriteClass::Delta).await;
+        assert!(held.is_some());
+        assert_eq!(b.semaphore.available_permits(), 0, "budget fully held");
+
+        let exempt = tokio::time::timeout(
+            Duration::from_millis(500),
+            acquire_for_write(&b, 1, WriteClass::Delta, true),
+        )
+        .await
+        .expect("a coupled write must never block on the budget");
+        assert!(exempt.is_none(), "exempt writes hold no permits");
+        assert_eq!(
+            b.semaphore.available_permits(),
+            0,
+            "the exemption consumes no budget"
+        );
+    }
+
+    /// The exemption applies to `Maintenance` too: a coupled table's
+    /// compaction output must not park on the gate — its aggregate concurrency
+    /// is bounded by the compactor's own semaphore, not this budget.
+    #[tokio::test]
+    async fn coupled_maintenance_is_exempt() {
+        let total = 16;
+        let b = budget(total);
+        let gate = maintenance_gate_cap(total);
+        let _held = acquire_from(&b, gate, WriteClass::Maintenance).await;
+        assert_eq!(b.maintenance_gate.available_permits(), 0, "gate exhausted");
+
+        let exempt = tokio::time::timeout(
+            Duration::from_millis(500),
+            acquire_for_write(&b, 1, WriteClass::Maintenance, true),
+        )
+        .await
+        .expect("a coupled maintenance write must never block on the gate");
+        assert!(exempt.is_none());
+    }
+
+    /// Uncoupled writes stay gated — the exemption is strictly for coupled
+    /// writers. A serial (1-shard) independent write still claims its permit
+    /// and queues at zero headroom, preserving the budget's aggregate
+    /// accounting for everything outside partitioned inserts.
+    #[tokio::test]
+    async fn uncoupled_writes_stay_gated() {
+        let b = budget(2);
+        let held = acquire_for_write(&b, 2, WriteClass::Delta, false).await;
+        assert!(held.is_some(), "a gated acquire succeeds under headroom");
+        assert_eq!(b.semaphore.available_permits(), 0);
+
+        let mut pending = std::pin::pin!(acquire_for_write(&b, 1, WriteClass::Delta, false));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut pending)
+                .await
+                .is_err(),
+            "an uncoupled serial write queues while the budget is held"
+        );
+        drop(held);
+        tokio::time::timeout(Duration::from_millis(500), &mut pending)
+            .await
+            .expect("the queued write proceeds once permits release");
     }
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -2532,6 +2532,8 @@ impl DataAccelerator for CayenneAccelerator {
                 vortex_config.schema_evolution = cayenne::metadata::SchemaEvolutionMode::Disabled;
             }
 
+            serialize_partition_child_writes(&mut vortex_config, &table_name);
+
             // Log S3 Express configuration for partitioned tables
             if is_s3_express {
                 tracing::info!(
@@ -2813,6 +2815,45 @@ impl DataAccelerator for CayenneAccelerator {
     }
 }
 
+/// Force partition child tables to encode serially (one write shard).
+///
+/// Two reasons, both specific to partitioned datasets:
+///
+/// 1. **Parallelism already comes from the partition fan-out.** The insert
+///    path runs one concurrent insert task per partition
+///    (`runtime_table_partition::insert`), so intra-write encode sharding
+///    would multiply the aggregate encode-shard count by the partition count.
+/// 2. **Child writes bypass the global encode budget, so they must stay
+///    serial.** The per-partition insert tasks are coupled through one
+///    routing demux over bounded channels; a child write parked on the encode
+///    budget stalls the demux, starving the permit-holding sibling writes of
+///    input — a hold-and-wait cycle that left partitioned tables permanently
+///    unready (spiceai/spiceai#11818). Child tables are therefore created as
+///    coupled writers (`CayenneContext::new_for_partition_child`), exempt
+///    from the budget (see `cayenne::provider::write_budget`) — and an
+///    unmetered writer must contribute the minimum encode footprint, one
+///    shard, which this clamp guarantees.
+///
+/// An operator-pinned `cayenne_write_concurrency > 1` is IGNORED (clamped to
+/// 1, with a warning), like schema evolution above: there is no safe way to
+/// honor it — child writes are budget-exempt, so a multi-shard child would
+/// fan out unmetered, multiplied by a partition count that isn't statically
+/// bounded (time-based partitions grow indefinitely).
+fn serialize_partition_child_writes(
+    config: &mut cayenne::metadata::VortexConfig,
+    table_name: &str,
+) {
+    if config.pinned_tuning_actuators.write_concurrency && config.write_concurrency.unwrap_or(1) > 1
+    {
+        tracing::warn!(
+            dataset = table_name,
+            write_concurrency = ?config.write_concurrency,
+            "cayenne_write_concurrency is not supported for partitioned Cayenne tables (partition writes bypass the global encode budget, so intra-partition sharding would fan out unmetered); writing each partition serially instead"
+        );
+    }
+    config.write_concurrency = Some(1);
+}
+
 /// Partition creator for Cayenne accelerator.
 ///
 /// Supports single and composite partition keys (e.g., `partition_by: [year, month, day]`).
@@ -2888,7 +2929,11 @@ impl CayennePartitionCreator {
         // Create shared Cayenne context with cache once, to be shared across all partitions.
         // This ensures all partitions share the same footer/segment caches instead of
         // each partition creating its own cache.
-        let context = cayenne::CayenneContext::new(&vortex_config, runtime_env, &table_name);
+        let context = cayenne::CayenneContext::new_for_partition_child(
+            &vortex_config,
+            runtime_env,
+            &table_name,
+        );
 
         Self {
             table_name,
@@ -3189,6 +3234,41 @@ mod tests {
     use datafusion_table_providers::UnsupportedTypeAction;
     use search::index::{SearchIndex, VectorIndex};
     use std::sync::Arc;
+
+    /// Partition child tables default to serial writes (`write_concurrency: 1`):
+    /// multi-shard child writes can deadlock the partition insert demux against
+    /// the global encode budget (spiceai/spiceai#11818).
+    #[test]
+    fn partition_child_writes_default_to_serial() {
+        let mut config = cayenne::metadata::VortexConfig {
+            write_concurrency: None,
+            ..Default::default()
+        };
+        serialize_partition_child_writes(&mut config, "t");
+        assert_eq!(config.write_concurrency, Some(1));
+
+        // Auto-tuned (unpinned) values are overridden too.
+        let mut config = cayenne::metadata::VortexConfig {
+            write_concurrency: Some(8),
+            ..Default::default()
+        };
+        serialize_partition_child_writes(&mut config, "t");
+        assert_eq!(config.write_concurrency, Some(1));
+    }
+
+    /// An operator-pinned `cayenne_write_concurrency > 1` is clamped to serial
+    /// for partition children — safety depends on the host-sized encode budget
+    /// and the (unbounded) partition count, so it cannot be honored safely.
+    #[test]
+    fn partition_child_writes_clamp_pinned_write_concurrency() {
+        let mut config = cayenne::metadata::VortexConfig {
+            write_concurrency: Some(4),
+            ..Default::default()
+        };
+        config.pinned_tuning_actuators.write_concurrency = true;
+        serialize_partition_child_writes(&mut config, "t");
+        assert_eq!(config.write_concurrency, Some(1));
+    }
 
     #[test]
     fn resolve_goal_raw_global_default_then_per_dataset_override() {

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -36,6 +36,7 @@ use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
 use datafusion::error::DataFusionError;
+use datafusion::execution::cache::file_statistics_cache::DefaultFileStatisticsCache;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::physical_plan::empty::EmptyExec;
@@ -1228,14 +1229,25 @@ pub trait ListingTableConnector: DataConnector {
             .with_schema(final_schema);
 
         // This shouldn't error because we're passing the schema and options correctly.
-        let table =
-            ListingTable::try_new(config)
-                .boxed()
-                .context(crate::dataconnector::InternalSnafu {
-                    dataconnector: format!("{self}"),
-                    connector_component: ConnectorComponent::from(dataset),
-                    code: "LTC-RP-LTTN".to_string(), // ListingTableConnector-ReadProvider-ListingTableTryNew
-                })?;
+        //
+        // Attach a file-statistics cache. With `collect_stat = true` (the
+        // DataFusion default), resolving a scan's statistics parses every
+        // file's Parquet footer; without a cache, `ListingTable` re-parses all
+        // footers on every plan. That makes stat-only queries (e.g. an
+        // unfiltered `COUNT(*)`, which the `AggregateStatistics` rule answers
+        // purely from statistics) scale linearly with file count on each query.
+        // The stock DataFusion `CREATE EXTERNAL TABLE` path wires this same
+        // cache; we mirror it so per-file footer stats are reused across
+        // queries. The cache invalidates per file on `ObjectMeta` change, so
+        // refreshing datasets still pick up new data.
+        let table = ListingTable::try_new(config)
+            .boxed()
+            .context(crate::dataconnector::InternalSnafu {
+                dataconnector: format!("{self}"),
+                connector_component: ConnectorComponent::from(dataset),
+                code: "LTC-RP-LTTN".to_string(), // ListingTableConnector-ReadProvider-ListingTableTryNew
+            })?
+            .with_cache(Some(Arc::new(DefaultFileStatisticsCache::default())));
 
         // For S3 single-file datasets with acceleration enabled, wrap with a caching layer
         // that checks ETag/Version ID to skip unnecessary re-fetches when file hasn't changed.

--- a/crates/runtime/src/embeddings/params/bedrock.rs
+++ b/crates/runtime/src/embeddings/params/bedrock.rs
@@ -16,20 +16,49 @@ limitations under the License.
 
 use crate::parameters::ParameterSpec;
 
-const BEDROCK_PARAM_LEN: usize = 5;
+const BEDROCK_PARAM_LEN: usize = 14;
 
 pub const PARAMETERS: &[ParameterSpec] = &BEDROCK_PARAMETERS;
 
 pub(crate) const BEDROCK_PARAMETERS: [ParameterSpec; BEDROCK_PARAM_LEN] = [
-    ParameterSpec::component("dimensions")
+    // AWS credential/config params — runtime (no prefix), matching the LLM bedrock convention.
+    ParameterSpec::runtime("aws_access_key_id")
+        .description("The AWS access key ID.")
+        .secret(),
+    ParameterSpec::runtime("aws_secret_access_key")
+        .description("The AWS secret access key.")
+        .secret(),
+    ParameterSpec::runtime("aws_session_token")
+        .description("The AWS session token.")
+        .secret(),
+    ParameterSpec::runtime("aws_region")
+        .description("The AWS region to use for Bedrock embeddings."),
+    ParameterSpec::runtime("aws_iam_role_source")
+        .description("IAM role credential source. 'auto' uses the default AWS credential chain, 'metadata' uses only instance/container metadata (IMDS, ECS, EKS/IRSA), 'env' uses only environment variables.")
+        .one_of(&["auto", "metadata", "env"]),
+    ParameterSpec::runtime("aws_profile")
+        .description("The AWS profile name to use for credential resolution."),
+    ParameterSpec::runtime("requests_per_min_limit")
+        .description("Maximum number of Bedrock API requests per minute.")
+        .default("1500"),
+    ParameterSpec::runtime("max_concurrent_invocations")
+        .description("Maximum number of concurrent Bedrock API invocations.")
+        .default("40"),
+    // Model-specific params — runtime (no prefix) to preserve backward compatibility with
+    // pre-#10853 configs where these were bare keys.
+    ParameterSpec::runtime("dimensions")
         .description("The number of dimensions for the embedding output."),
-    ParameterSpec::component("normalize")
+    ParameterSpec::runtime("normalize")
         .description("Whether to normalize the embedding output.")
         .one_of(&["true", "false"]),
-    ParameterSpec::component("truncate_mode")
+    ParameterSpec::runtime("truncate_mode")
         .description("Truncation mode for input text that exceeds the model's token limit."),
-    ParameterSpec::component("input_type")
+    ParameterSpec::runtime("truncate")
+        .description("Alias for `truncate_mode`; prefer `truncate_mode`.")
+        .deprecated("Use `truncate_mode` instead."),
+    ParameterSpec::runtime("input_type")
         .description("The input type for Cohere embedding models."),
-    ParameterSpec::component("embedding_purpose")
-        .description("The embedding purpose for Nova multimodal embedding models."),
+    ParameterSpec::runtime("embedding_purpose")
+        .description("The embedding purpose for Nova multimodal embedding models.")
+        .one_of(&["GENERIC_INDEX", "GENERIC_RETRIEVAL", "TEXT_RETRIEVAL", "IMAGE_RETRIEVAL", "VIDEO_RETRIEVAL", "DOCUMENT_RETRIEVAL", "AUDIO_RETRIEVAL", "CLASSIFICATION", "CLUSTERING"]),
 ];

--- a/crates/runtime/src/embeddings/params/google.rs
+++ b/crates/runtime/src/embeddings/params/google.rs
@@ -24,6 +24,7 @@ pub(crate) const GOOGLE_PARAMETERS: [ParameterSpec; GOOGLE_PARAM_LEN] = [
     ParameterSpec::component("api_key")
         .secret()
         .description("The Google API key."),
-    ParameterSpec::component("dimensions")
+    // runtime (no prefix) to match docs and preserve backward compatibility.
+    ParameterSpec::runtime("dimensions")
         .description("The number of dimensions for the embedding output."),
 ];

--- a/crates/runtime/src/embeddings/params/huggingface.rs
+++ b/crates/runtime/src/embeddings/params/huggingface.rs
@@ -21,7 +21,8 @@ const HF_PARAM_LEN: usize = 3;
 pub const PARAMETERS: &[ParameterSpec] = &HF_PARAMETERS;
 
 pub(crate) const HF_PARAMETERS: [ParameterSpec; HF_PARAM_LEN] = [
-    ParameterSpec::component("hf_token")
+    // runtime (no prefix) to match docs and preserve backward compatibility.
+    ParameterSpec::runtime("hf_token")
         .secret()
         .description("The Hugging Face access token."),
     ParameterSpec::runtime("pooling")

--- a/crates/runtime/src/embeddings/params/mod.rs
+++ b/crates/runtime/src/embeddings/params/mod.rs
@@ -44,80 +44,171 @@ pub fn get_params_spec(source: &EmbeddingPrefix) -> &'static [ParameterSpec] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parameters::Parameters;
+    use runtime_secrets::Secrets;
     use spicepod::component::embeddings::EmbeddingPrefix;
+    use spicepod::param::Params;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
 
-    #[test]
-    fn test_openai_params_includes_api_key() {
-        let params = get_params_spec(&EmbeddingPrefix::OpenAi);
-        assert!(params.iter().any(|p| p.name == "api_key"));
+    /// Parse YAML into a string map, construct `Parameters`, then exercise every
+    /// `params.get(key)` the provider function calls. A panic here means a key
+    /// is missing from the `ParameterSpec`.
+    async fn build_params(prefix: &EmbeddingPrefix, yaml: &str) -> Parameters {
+        let string_map: std::collections::HashMap<String, String> = yaml::from_str::<Params>(yaml)
+            .expect("YAML must parse")
+            .as_string_map();
+        let secrets = Arc::new(RwLock::new(Secrets::default()));
+        let params_with_secrets =
+            runtime_secrets::get_params_with_secrets(Arc::clone(&secrets), &string_map)
+                .await
+                .into_iter()
+                .collect::<Vec<_>>();
+        Parameters::try_new(
+            &format!("embedding test_{prefix}"),
+            params_with_secrets,
+            prefix.to_string().leak(),
+            Arc::clone(&secrets),
+            get_params_spec(prefix),
+        )
+        .await
+        .expect("Parameters::try_new must not fail")
     }
 
-    #[test]
-    fn test_openai_params_includes_endpoint() {
-        let params = get_params_spec(&EmbeddingPrefix::OpenAi);
-        assert!(params.iter().any(|p| p.name == "endpoint"));
+    #[tokio::test]
+    async fn test_openai_params_roundtrip() {
+        let params = build_params(
+            &EmbeddingPrefix::OpenAi,
+            "openai_api_key: sk-test\nopenai_org_id: org-1\nopenai_project_id: proj-1\nendpoint: https://api.openai.com\nopenai_usage_tier: tier1\n",
+        )
+        .await;
+        // Every key that embed.rs accesses for openai
+        let _ = params.get("api_key");
+        let _ = params.get("endpoint");
+        let _ = params.get("org_id");
+        let _ = params.get("project_id");
+        let _ = params.get("usage_tier");
     }
 
-    #[test]
-    fn test_azure_params_includes_api_key() {
-        let params = get_params_spec(&EmbeddingPrefix::Azure);
-        assert!(params.iter().any(|p| p.name == "api_key"));
+    #[tokio::test]
+    async fn test_azure_params_roundtrip() {
+        let params = build_params(
+            &EmbeddingPrefix::Azure,
+            "azure_api_key: key\nazure_api_version: 2024-02-01\nazure_deployment_name: my-deploy\nendpoint: https://my.azure.com\nazure_entra_token: tok\n",
+        )
+        .await;
+        let _ = params.get("api_key");
+        let _ = params.get("api_version");
+        let _ = params.get("deployment_name");
+        let _ = params.get("endpoint");
+        let _ = params.get("entra_token");
     }
 
-    #[test]
-    fn test_azure_params_includes_endpoint() {
-        let params = get_params_spec(&EmbeddingPrefix::Azure);
-        assert!(params.iter().any(|p| p.name == "endpoint"));
+    #[tokio::test]
+    async fn test_google_params_roundtrip() {
+        let params = build_params(
+            &EmbeddingPrefix::Google,
+            "google_api_key: key\ndimensions: 768\n",
+        )
+        .await;
+        let _ = params.get("api_key");
+        let _ = params.get("dimensions");
     }
 
-    #[test]
-    fn test_google_params_includes_api_key() {
-        let params = get_params_spec(&EmbeddingPrefix::Google);
-        assert!(params.iter().any(|p| p.name == "api_key"));
+    #[tokio::test]
+    async fn test_huggingface_params_roundtrip() {
+        let params = build_params(
+            &EmbeddingPrefix::HuggingFace,
+            "hf_token: hf_abc\npooling: mean\nmax_seq_length: 512\n",
+        )
+        .await;
+        let _ = params.get("hf_token");
+        let _ = params.get("pooling");
+        let _ = params.get("max_seq_length");
     }
 
-    #[test]
-    fn test_huggingface_params_includes_hf_token() {
-        let params = get_params_spec(&EmbeddingPrefix::HuggingFace);
-        assert!(params.iter().any(|p| p.name == "hf_token"));
+    #[tokio::test]
+    async fn test_databricks_params_roundtrip() {
+        let params = build_params(
+            &EmbeddingPrefix::Databricks,
+            "databricks_endpoint: https://my.databricks.com\ndatabricks_token: dapi-abc\ndatabricks_client_id: cid\ndatabricks_client_secret: csec\n",
+        )
+        .await;
+        let _ = params.get("endpoint");
+        let _ = params.get("token");
+        let _ = params.get("client_id");
+        let _ = params.get("client_secret");
     }
 
-    #[test]
-    fn test_databricks_params_includes_endpoint() {
-        let params = get_params_spec(&EmbeddingPrefix::Databricks);
-        assert!(params.iter().any(|p| p.name == "endpoint"));
+    #[tokio::test]
+    async fn test_bedrock_params_roundtrip() {
+        let params = build_params(
+            &EmbeddingPrefix::Bedrock,
+            // AWS params (no prefix — runtime type)
+            "aws_region: us-east-1\naws_access_key_id: AKIA\naws_secret_access_key: secret\naws_session_token: token\naws_iam_role_source: auto\n\
+             # Titan/Nova model params\ndimensions: 256\nnormalize: true\n\
+             # Cohere/Nova truncation params\ntruncate_mode: END\ntruncate: END\ninput_type: classification\nembedding_purpose: GENERIC_INDEX\n\
+             # Rate-limit and profile overrides\naws_profile: default\nrequests_per_min_limit: 1500\nmax_concurrent_invocations: 10\n",
+        )
+        .await;
+        // AWS params consumed via get_runtime_params()
+        let runtime = params.get_runtime_params();
+        assert!(
+            runtime.contains_key("aws_region"),
+            "aws_region missing from runtime params"
+        );
+        assert!(
+            runtime.contains_key("aws_access_key_id"),
+            "aws_access_key_id missing from runtime params"
+        );
+        assert!(
+            runtime.contains_key("aws_secret_access_key"),
+            "aws_secret_access_key missing from runtime params"
+        );
+        assert!(
+            runtime.contains_key("aws_profile"),
+            "aws_profile missing from runtime params"
+        );
+        assert!(
+            runtime.contains_key("requests_per_min_limit"),
+            "requests_per_min_limit missing from runtime params"
+        );
+        assert!(
+            runtime.contains_key("max_concurrent_invocations"),
+            "max_concurrent_invocations missing from runtime params"
+        );
+        // Model-specific params accessed directly in embed.rs
+        let _ = params.get("dimensions");
+        let _ = params.get("normalize");
+        let _ = params.get("truncate_mode");
+        let _ = params.get("truncate"); // alias — must not panic
+        let _ = params.get("input_type");
+        let _ = params.get("embedding_purpose");
     }
 
-    #[test]
-    fn test_databricks_params_includes_token() {
-        let params = get_params_spec(&EmbeddingPrefix::Databricks);
-        assert!(params.iter().any(|p| p.name == "token"));
+    #[tokio::test]
+    async fn test_file_params_roundtrip() {
+        let params = build_params(
+            &EmbeddingPrefix::File,
+            "pooling: cls\nmax_seq_length: 256\n",
+        )
+        .await;
+        let _ = params.get("pooling");
+        let _ = params.get("max_seq_length");
     }
 
-    #[test]
-    fn test_bedrock_params_includes_dimensions() {
-        let params = get_params_spec(&EmbeddingPrefix::Bedrock);
-        assert!(params.iter().any(|p| p.name == "dimensions"));
-    }
-
-    #[test]
-    fn test_all_providers_return_non_empty_params() {
-        let providers = vec![
-            EmbeddingPrefix::OpenAi,
-            EmbeddingPrefix::Azure,
-            EmbeddingPrefix::Google,
-            EmbeddingPrefix::HuggingFace,
-            EmbeddingPrefix::Databricks,
-            EmbeddingPrefix::Bedrock,
-            EmbeddingPrefix::File,
-            EmbeddingPrefix::Model2Vec,
-        ];
-        for provider in providers {
-            let params = get_params_spec(&provider);
-            assert!(
-                !params.is_empty(),
-                "Provider should have at least one param"
-            );
-        }
+    #[tokio::test]
+    async fn test_model2vec_params_roundtrip() {
+        let params = build_params(
+            &EmbeddingPrefix::Model2Vec,
+            "hf_token: hf_abc\nsubfolder: onnx\nnormalize: true\nparallelism: 4\nembed_max_token_length: 512\nembed_custom_batch_size: 32\n",
+        )
+        .await;
+        let _ = params.get("hf_token");
+        let _ = params.get("subfolder");
+        let _ = params.get("normalize");
+        let _ = params.get("parallelism");
+        let _ = params.get("embed_max_token_length");
+        let _ = params.get("embed_custom_batch_size");
     }
 }

--- a/crates/runtime/src/embeddings/params/model2vec.rs
+++ b/crates/runtime/src/embeddings/params/model2vec.rs
@@ -21,12 +21,13 @@ const MODEL2VEC_PARAM_LEN: usize = 6;
 pub const PARAMETERS: &[ParameterSpec] = &MODEL2VEC_PARAMETERS;
 
 pub(crate) const MODEL2VEC_PARAMETERS: [ParameterSpec; MODEL2VEC_PARAM_LEN] = [
-    ParameterSpec::component("hf_token")
+    // runtime (no prefix) to match docs and preserve backward compatibility.
+    ParameterSpec::runtime("hf_token")
         .secret()
         .description("The Hugging Face access token."),
-    ParameterSpec::component("subfolder")
+    ParameterSpec::runtime("subfolder")
         .description("The subfolder within the Hugging Face repo containing the model."),
-    ParameterSpec::component("normalize")
+    ParameterSpec::runtime("normalize")
         .description("Whether to normalize the embedding output.")
         .one_of(&["true", "false"]),
     ParameterSpec::runtime("parallelism")


### PR DESCRIPTION
## Summary

Cherry-picks all merged PRs from the `v2.1.1` milestone onto `release/2.1`:

- #11793
- #11825
- #11788

TODO: /#11825 has cherry-pick issues (predates the `coupled_writer`/`verified_data_files` struct fields).