### PR TITLE
Revert "perf(cayenne): light delta encoding + higher CDC coalescing defaults"

### DIFF
--- a/crates/cayenne/benches/compaction_write_amplification.rs
+++ b/crates/cayenne/benches/compaction_write_amplification.rs
@@ -21,9 +21,9 @@ limitations under the License.
 //! Every row on this path is written to disk TWICE. A delta / mem-tier
 //! checkpoint (`WriteClass::Delta`) writes each protected snapshot with a LIGHT
 //! encoding — it skips the `BtrBlocks` per-column strategy search + FSST
-//! symbol-table training that dominate encode cost (see
+//! symbol-table training that dominate small-write encode cost (see
 //! `provider::delta_encoding`, `effective_level` returns `AUTO_LIGHT_LEVEL` for
-//! every `auto` delta, regardless of size). Those light files are LESS compressed, so
+//! a small/unknown-size `auto` delta). Those light files are LESS compressed, so
 //! they inflate on-disk bytes (read-amp in bytes) until compaction folds them.
 //! Compaction (`WriteClass::Maintenance`) then RE-ENCODES the merged corpus with
 //! the FULL cascade — the expensive strategy search + FSST it skipped — so the

--- a/crates/cayenne/src/metadata.rs
+++ b/crates/cayenne/src/metadata.rs
@@ -342,9 +342,10 @@ pub enum CompressionStrategy {
 ///
 /// zstd-style level scale (`cayenne_delta_encoding` param):
 ///
-/// - `auto` (default) — every delta write encodes at a light level: a delta
-///   is transient by definition (the tiered compactor folds it into a
-///   properly-encoded file), so it skips the full cascade regardless of size.
+/// - `auto` (default) — size-gated: a write smaller than a quarter of the
+///   target file size encodes at a light level (the file is transient by
+///   definition — compaction exists to fold it); larger or unknown-size
+///   writes use the full default encoding.
 /// - `0` — no compression (canonical arrays; cheapest encode).
 /// - `1`–`6` — progressively richer scheme sets. The cheap levels skip the
 ///   per-file encoder-strategy search and FSST symbol-table training.
@@ -362,15 +363,14 @@ pub enum CompressionStrategy {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum DeltaEncoding {
-    /// `Auto` — light encoding for every delta write. Deltas are transient
-    /// (compaction re-encodes them at the full cascade), so the CDC hot path
-    /// skips the per-file encoder-strategy search + FSST symbol-table training
-    /// regardless of delta size. The SF1000 CH-benCHmark HTAP sweep validated
-    /// this at production scale: shedding checkpoint encode CPU lets the apply
-    /// loop keep up (it enables replication convergence where full-encode does
-    /// not, and gives the best analytic QPH on top of coalescing).
+    /// Size-gated: light for small deltas, full for large writes.
+    /// Local micro A/B (2026-06-06) was neutral on the
+    /// upsert/bulk lanes; the aggregate CPU-per-delta benefit targets
+    /// production-scale CDC and is to be validated there. Set the
+    /// param to `7` to opt out (pre-feature behavior).
     ///
-    /// This is also what pre-feature stored table configs deserialize to via
+    /// `Auto` — size-gated light encoding for small deltas. This is also what
+    /// pre-feature stored table configs deserialize to via
     /// `#[serde(default)]`, so existing tables pick up the policy on upgrade
     /// (write-time only; existing data files are unaffected and a level
     /// change never forces a table re-create). Set the
@@ -752,11 +752,11 @@ pub struct VortexConfig {
     /// Defaults to Btrblocks
     pub compression_strategy: CompressionStrategy,
     /// Encoding effort for delta writes (fresh CDC/append snapshot files).
-    /// `auto` (default) encodes every delta light (deltas are transient and
-    /// folded into properly-encoded files by compaction); explicit `0..=10`
-    /// pins the level (`7` = the full default cascade, the pre-feature
-    /// behavior). Maintenance writes (compaction, rewrites) always use the full
-    /// default encoding. See [`DeltaEncoding`].
+    /// `auto` (default) size-gates: small deltas encode light and are folded
+    /// into properly-encoded files by compaction; explicit `0..=10` pins the
+    /// level (`7` = the full default cascade, the pre-feature behavior).
+    /// Maintenance writes (compaction, rewrites) always use the full default
+    /// encoding. See [`DeltaEncoding`].
     #[serde(default)]
     pub delta_encoding: DeltaEncoding,
     /// Maximum number of concurrent file uploads when writing multiple Vortex files.
@@ -1436,10 +1436,11 @@ impl Default for VortexConfig {
             // Shard key derives from the primary key unless overridden
             shard_key_columns: Vec::new(),
             compression_strategy: CompressionStrategy::default(),
-            // `auto`: light encoding for every delta (re-encoded by
-            // compaction). Validated at production scale by the SF1000
-            // CH-benCHmark HTAP sweep (frees apply CPU → convergence + QPH).
-            // Set the param to `7` to opt out (pre-feature behavior).
+            // `auto`: size-gated light encoding for small deltas (re-encoded
+            // by compaction). Local micro A/B (2026-06-06) was neutral on the
+            // upsert/bulk lanes; the aggregate CPU-per-delta benefit targets
+            // production-scale CDC and is to be validated there. Set the
+            // param to `7` to opt out (pre-feature behavior).
             delta_encoding: DeltaEncoding::default(),
             upload_concurrency: default_upload_concurrency(),
             write_concurrency: None,

--- a/crates/cayenne/src/provider/delta_encoding.rs
+++ b/crates/cayenne/src/provider/delta_encoding.rs
@@ -49,12 +49,13 @@ limitations under the License.
 //! | 4–6 | full default **minus FSST** (skips symbol-table training, keeps the rest) |
 //! | 7–10 | full default `BtrBlocks` cascade (today's behavior; upper levels reserved) |
 //!
-//! `auto` (the default) encodes every delta at [`AUTO_LIGHT_LEVEL`]: a delta is
-//! a transient staged stream (e.g. the off-fence mem-tier checkpoint) that
-//! compaction rewrites, so it skips the full cascade regardless of size. Level
-//! `7` is the explicit opt-out (byte-for-byte the pre-feature behavior).
-//! Maintenance writes ([`WriteClass::Maintenance`]) always use the full default
-//! regardless of the configured level.
+//! `auto` (the default) size-gates: a delta smaller than a quarter of the
+//! target file size — or of unknown size (a transient staged stream that
+//! compaction rewrites) — encodes at [`AUTO_LIGHT_LEVEL`]; only a known-large
+//! write uses the full default. Level `7` is the explicit opt-out
+//! (byte-for-byte the pre-feature behavior). Maintenance writes
+//! ([`WriteClass::Maintenance`]) always use the full default regardless of
+//! the configured level.
 
 use vortex::file::WriteStrategyBuilder;
 use vortex_btrblocks::schemes::{float, integer, string};
@@ -120,38 +121,56 @@ pub(crate) enum WriteClass {
     Maintenance,
 }
 
-/// Level used for every [`WriteClass::Maintenance`] write: the full default
-/// `BtrBlocks` cascade. Aliases the metadata constant so the config default
-/// and the mapping boundary can't drift apart.
+/// Level used for every [`WriteClass::Maintenance`] write and for large
+/// known-size deltas under `auto`: the full default `BtrBlocks` cascade.
+/// Aliases the metadata constant so the config default and the mapping
+/// boundary can't drift apart.
 pub(crate) const FULL_LEVEL: u8 = DELTA_ENCODING_FULL_LEVEL;
 
-/// Level chosen by `auto` for every delta write. `Constant + Sparse + Dict`
-/// keeps the big repetitive-CDC wins (often 3-5×) while skipping the per-file
-/// `BtrBlocks` strategy search and FSST symbol-table training that dominate
-/// encode cost. Every delta is transient — compaction re-encodes it at
-/// [`FULL_LEVEL`] — so the light scheme set trades a larger transient file
-/// (compaction folds it) for materially cheaper CDC-hot-path encode; the full
-/// cascade is reserved for the durable [`WriteClass::Maintenance`] artifacts
-/// whose encoding quality pays for scan throughput.
+/// Level chosen by `auto` for small deltas. `Constant + Sparse + Dict` keeps
+/// the big repetitive-CDC wins (often 3-5×) while skipping the per-file
+/// strategy search and FSST training that dominate small-write encode cost.
 pub(crate) const AUTO_LIGHT_LEVEL: u8 = 2;
+
+/// Under `auto`, a delta is "small" when its estimated bytes are below
+/// `target_file_size / AUTO_LIGHT_DENOMINATOR` — the same quarter-of-a-target
+/// classification the compaction picker uses for "small" files, on the
+/// rationale that a write smaller than a target file is transient by
+/// definition (compaction exists to fold it).
+pub(crate) const AUTO_LIGHT_DENOMINATOR: u64 = 4;
 
 /// Resolve the effective encoding level for one snapshot write.
 ///
-/// Under `auto`, every [`WriteClass::Delta`] write encodes LIGHT
-/// ([`AUTO_LIGHT_LEVEL`]): deltas are transient staged CDC streams (e.g. the
-/// off-fence mem-tier checkpoint) that compaction rewrites at [`FULL_LEVEL`],
-/// so paying the full `BtrBlocks` cascade (incl. the FSST symbol-table
-/// double-train) on the CDC hot path is wasted work — the file is re-encoded
-/// before it becomes long-lived. Only durable [`WriteClass::Maintenance`]
-/// writes take [`FULL_LEVEL`] under `auto`; an explicit
-/// [`DeltaEncoding::Level`] overrides the delta path with a fixed level.
-pub(crate) fn effective_level(encoding: DeltaEncoding, write_class: WriteClass) -> u8 {
+/// `estimated_bytes` is the caller's pre-encode size estimate (`None` when
+/// the stream size is unknown, e.g. opaque staged streams). Under `auto`, an
+/// unknown size resolves to [`AUTO_LIGHT_LEVEL`]: it is a transient staged
+/// stream (e.g. the off-fence mem-tier checkpoint) that compaction rewrites,
+/// so only a known-large delta takes [`FULL_LEVEL`].
+pub(crate) fn effective_level(
+    encoding: DeltaEncoding,
+    write_class: WriteClass,
+    estimated_bytes: Option<u64>,
+    target_size_bytes: usize,
+) -> u8 {
     if write_class == WriteClass::Maintenance {
         return FULL_LEVEL;
     }
     match encoding {
         DeltaEncoding::Level(level) => level.min(DELTA_ENCODING_MAX_LEVEL),
-        DeltaEncoding::Auto => AUTO_LIGHT_LEVEL,
+        DeltaEncoding::Auto => {
+            let threshold =
+                u64::try_from(target_size_bytes).unwrap_or(u64::MAX) / AUTO_LIGHT_DENOMINATOR;
+            match estimated_bytes {
+                Some(bytes) if bytes < threshold.max(1) => AUTO_LIGHT_LEVEL,
+                // Unknown size means an opaque staged CDC stream (e.g. the
+                // off-fence mem-tier checkpoint) — transient and rewritten by
+                // compaction, so encode it LIGHT rather than paying the full
+                // BtrBlocks cascade (incl. the FSST symbol-table double-train)
+                // on the CDC hot path. Only a known-large delta takes FULL.
+                None => AUTO_LIGHT_LEVEL,
+                Some(_) => FULL_LEVEL,
+            }
+        }
     }
 }
 
@@ -228,6 +247,8 @@ pub(crate) fn strategy_builder_for_level(level: u8) -> Option<WriteStrategyBuild
 mod tests {
     use super::*;
 
+    const TARGET: usize = 256 * 1024 * 1024; // 256 MiB target file size
+
     #[test]
     fn parse_accepts_auto_and_levels() {
         assert_eq!("auto".parse::<DeltaEncoding>(), Ok(DeltaEncoding::Auto));
@@ -244,64 +265,101 @@ mod tests {
     }
 
     #[test]
-    fn default_is_auto_with_light_deltas_and_full_opt_out() {
-        // Product decision: `auto` ships as the default — every delta (a
-        // transient, compaction-rewritten write) encodes light; maintenance
-        // stays on the full cascade. Level 7 is the explicit opt-out.
+    fn default_is_auto_with_light_small_deltas_and_full_opt_out() {
+        // Product decision: `auto` ships as the default — small known-size
+        // deltas and unknown-size (transient, compaction-rewritten) writes
+        // encode light; large known-size writes and maintenance stay on the
+        // full cascade. Level 7 is the explicit opt-out.
         assert_eq!(DeltaEncoding::default(), DeltaEncoding::Auto);
         assert!(
             strategy_builder_for_level(effective_level(
                 DeltaEncoding::default(),
                 WriteClass::Delta,
+                Some(1),
+                TARGET
             ))
             .is_some(),
-            "default auto must light-encode a delta write"
+            "default auto must light-encode a small known-size delta"
+        );
+        assert!(
+            strategy_builder_for_level(effective_level(
+                DeltaEncoding::default(),
+                WriteClass::Delta,
+                None,
+                TARGET
+            ))
+            .is_some(),
+            "default auto must light-encode unknown-size (transient) writes"
         );
         assert!(
             strategy_builder_for_level(effective_level(
                 DeltaEncoding::Level(FULL_LEVEL),
                 WriteClass::Delta,
+                Some(1),
+                TARGET
             ))
             .is_none(),
-            "level 7 must be the explicit opt-out (full strategy) for a delta"
+            "level 7 must be the explicit opt-out (full strategy) even for tiny deltas"
         );
     }
 
     #[test]
-    fn auto_lights_every_delta_regardless_of_size() {
-        // No size gate: under `auto` a delta encodes LIGHT whether it is a
-        // small fresh write or a large mem-tier checkpoint. Every delta is
-        // transient (compaction re-encodes it at FULL), so the CDC hot path
-        // never pays the full BtrBlocks + FSST cascade.
+    fn auto_gates_by_estimated_size() {
+        // Small delta (1 MiB << 64 MiB threshold) -> light level.
         assert_eq!(
-            effective_level(DeltaEncoding::Auto, WriteClass::Delta),
-            AUTO_LIGHT_LEVEL,
-            "auto must light-encode a delta write"
+            effective_level(
+                DeltaEncoding::Auto,
+                WriteClass::Delta,
+                Some(1024 * 1024),
+                TARGET
+            ),
+            AUTO_LIGHT_LEVEL
         );
-        // Maintenance is the one class that keeps the full cascade under auto.
+        // Large write (at the threshold) -> full.
         assert_eq!(
-            effective_level(DeltaEncoding::Auto, WriteClass::Maintenance),
-            FULL_LEVEL,
-            "auto maintenance must use the full cascade"
+            effective_level(
+                DeltaEncoding::Auto,
+                WriteClass::Delta,
+                Some(64 * 1024 * 1024),
+                TARGET
+            ),
+            FULL_LEVEL
+        );
+        // Unknown size -> light: an unknown-size staged delta is a transient
+        // CDC stream (the off-fence mem-tier checkpoint) that compaction
+        // rewrites, so it skips the full BtrBlocks cascade on the hot path.
+        assert_eq!(
+            effective_level(DeltaEncoding::Auto, WriteClass::Delta, None, TARGET),
+            AUTO_LIGHT_LEVEL
         );
     }
 
     #[test]
     fn maintenance_always_full_even_with_explicit_level() {
         assert_eq!(
-            effective_level(DeltaEncoding::Level(0), WriteClass::Maintenance),
+            effective_level(
+                DeltaEncoding::Level(0),
+                WriteClass::Maintenance,
+                Some(1),
+                TARGET
+            ),
             FULL_LEVEL
         );
     }
 
     #[test]
-    fn explicit_level_applies_to_a_delta() {
+    fn explicit_level_applies_to_any_delta_size() {
         assert_eq!(
-            effective_level(DeltaEncoding::Level(3), WriteClass::Delta),
+            effective_level(
+                DeltaEncoding::Level(3),
+                WriteClass::Delta,
+                Some(u64::MAX),
+                TARGET
+            ),
             3
         );
         assert_eq!(
-            effective_level(DeltaEncoding::Level(9), WriteClass::Delta),
+            effective_level(DeltaEncoding::Level(9), WriteClass::Delta, None, TARGET),
             9
         );
     }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -5568,13 +5568,17 @@ impl CayenneTableProvider {
         // regardless of `target_partitions` (see `snapshot_shard_count`).
         //
         // Delta writes additionally resolve a `cayenne_delta_encoding` level:
-        // under `auto` every delta encodes with a light scheme set (skipping the
+        // small fresh deltas encode with a light scheme set (skipping the
         // per-file BtrBlocks strategy search + FSST training that dominate
-        // encode cost) and is re-encoded properly when compaction folds it.
-        // Maintenance writes (compaction, rewrites, overwrites) always use the
-        // full default strategy. See `provider::delta_encoding`.
-        let encoding_level =
-            super::delta_encoding::effective_level(self.context.delta_encoding(), write_class);
+        // small-write encode cost) and are re-encoded properly when compaction
+        // folds them. Maintenance writes (compaction, rewrites, overwrites)
+        // always use the full default strategy. See `provider::delta_encoding`.
+        let encoding_level = super::delta_encoding::effective_level(
+            self.context.delta_encoding(),
+            write_class,
+            estimated_bytes,
+            target_size_bytes,
+        );
         let write_format = match super::delta_encoding::strategy_builder_for_level(encoding_level) {
             Some(strategy) => self.context.write_format_with_strategy(
                 strategy,

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-1slot.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-1slot.yaml
@@ -5,10 +5,9 @@ name: postgres-cayenne[file]-adaptive-1slot
 # SINGLE-SHARED-SLOT variant of the default `postgres-cayenne[file]-adaptive` (which is 4-slot +
 # deep prefetch). IDENTICAL to that pod — adaptive self-tuning (`cayenne_tuning: adaptive` +
 # `schema_inference: extended`), the global `cayenne_goal_*` SLOs, and the SAME deep CDC prefetch
-# (16384) + higher-coalescing (512 MB byte budget / 2000ms linger) — EXCEPT every changes-mode
-# table shares ONE replication slot instead of the default four. Kept as a SEPARATE pod to A/B the
-# slot-count effect against the 4-slot default with everything else (adaptive tuning + prefetch +
-# coalescing) held constant.
+# (16384) — EXCEPT every changes-mode table shares ONE replication slot instead of the default
+# four. Kept as a SEPARATE pod to A/B the slot-count effect against the 4-slot default with
+# everything else (adaptive tuning + prefetch depth) held constant.
 #
 # This is the TARGET topology we are driving toward: ONE shared slot (`spice_all`) spawns ONE
 # walsender that decodes the FULL WAL stream exactly once (server decode at 1x — the minimum), and
@@ -43,13 +42,10 @@ runtime:
   # dataset. These are the high-level targets the closed loop converges toward — NOT
   # actuator knobs. QPH is GLOBAL-ONLY (measured across all datasets).
   params:
-    # Deep prefetch + higher-coalescing (byte budget + linger window), matching the default
-    # `-adaptive` pod so this 1-slot config differs from it ONLY in slot count (isolating the
-    # slot-count effect at the standard prefetch + coalescing settings).
+    # Deep prefetch, matching the default `-adaptive` pod so this 1-slot config differs from it
+    # ONLY in slot count (isolating the slot-count effect at the standard prefetch depth).
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
-    cdc_max_coalesce_age_ms: '2000'
     cayenne_goal_replication_lag: '5s'
     cayenne_goal_freshness: '30s'
     cayenne_goal_query_latency: '10s'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
@@ -31,13 +31,10 @@ name: postgres-cayenne[file]-adaptive
 #   - It supplies the inferred row_count/table_bytes the adaptive loop's data-aware warm-start
 #     gates on; without extended inference adaptive silently falls back to `auto` (static).
 # Background compaction stays at the auto-derived (non-zero) default — the controller rides its
-# tick. The pinned CDC knobs under `runtime.params` below are the deep prefetch buffers
-# (`cdc_prefetch_buffer` / `cdc_max_coalesced_envelopes` = 16384, the runtime max) plus the
-# higher-coalescing byte budget + linger window (`cdc_max_coalesced_bytes` = 512 MB /
-# `cdc_max_coalesce_age_ms` = 2000): the sweep showed deep prefetch is a clear, stable win and
-# that coalescing is the strongest convergence lever at SF1000, so we fix both here (this
-# collapses those knobs' adaptive bounds to a point; adaptive still moves every other per-actuator
-# knob freely).
+# tick. The ONLY pinned knobs are the two CDC prefetch buffers (`cdc_prefetch_buffer` /
+# `cdc_max_coalesced_envelopes` = 16384, the runtime max) under `runtime.params` below: the sweep
+# showed deep prefetch is a clear, stable win, so we fix it here (this collapses those two knobs'
+# adaptive bounds to a point; adaptive still moves every other per-actuator knob freely).
 # The `cayenne_goal_*` SLOs (set globally under `runtime.params`) are NOT actuator knobs — they
 # are the high-level targets the closed loop converges toward (it still moves the un-pinned
 # actuators freely to hit them).
@@ -74,15 +71,6 @@ runtime:
     # replication lag ~435s at default buffers → ~320s deep).
     cdc_prefetch_buffer: '16384'
     cdc_max_coalesced_envelopes: '16384'
-    # Higher-coalescing default: raise the byte budget and add a linger window so the
-    # apply loop forms big bursts (fewer, larger applies amortize per-burst
-    # stats/checkpoint/publish over more rows). In the SF1000 sweep this was the
-    # strongest single convergence lever — 4-slot converged fastest (~801s) with
-    # coalescing on, where the no-coalesce default failed to converge. The linger
-    # deadline is anchored at the previous apply's start, so apply-bound tables barely
-    # wait; 2000ms bounds the added freshness latency for lighter tables.
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
-    cdc_max_coalesce_age_ms: '2000'
     cayenne_goal_replication_lag: '5s'
     cayenne_goal_freshness: '30s'
     cayenne_goal_query_latency: '10s'


### PR DESCRIPTION
Reverts spiceai/spiceai#11826

This is suspected of causing data correctness failures in CH-BenCH SF1000:

```
  chbench_q10         DIVERGE          -
    └─ DataMismatch { column: "c_city", row_number: 48348, expected: "\"9rahWs5Q4H\"", actual: "\"Qg8T0oFQE4T\"" } (source rows=24373970, spice rows=24373970)
```