### PR TITLE
test(htap): print row-window context on analytical divergence

### DIFF
--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -514,6 +514,89 @@ pub fn validate_batches_as_strings(
     Ok(QueryValidationResult::Pass)
 }
 
+/// Render a ±`radius`-row window around a diverging row from both the expected
+/// and actual result sets, stacked and labelled, for divergence diagnostics.
+///
+/// A single [`QueryValidationFailReason::DataMismatch`] reports one scalar cell
+/// with no surrounding context, so it can't distinguish a genuinely wrong value
+/// from a row-alignment/sort-tie shift (where every row from the divergence
+/// onward is off-by-one). Printing the neighbouring rows — full row, all columns,
+/// so key columns are visible — from both sides makes the failure mode obvious at
+/// a glance.
+///
+/// `row_number` is the 1-based row index carried by `DataMismatch` (indexing the
+/// concatenated result). Both sides are assumed to share a schema and row order
+/// (as the HTAP analytical gate guarantees by sorting before comparison), so the
+/// same global index addresses the corresponding logical row on each side.
+pub fn format_row_window(
+    expected: &[RecordBatch],
+    actual: &[RecordBatch],
+    row_number: usize,
+    column: &str,
+    radius: usize,
+) -> Result<String> {
+    use std::fmt::Write as _;
+
+    let Some(schema) = expected
+        .first()
+        .map(arrow::array::RecordBatch::schema)
+        .or_else(|| actual.first().map(arrow::array::RecordBatch::schema))
+    else {
+        return Ok(String::new());
+    };
+
+    let expected = arrow::compute::concat_batches(&schema, expected)?;
+    let actual_schema = actual
+        .first()
+        .map_or_else(|| Arc::clone(&schema), arrow::array::RecordBatch::schema);
+    let actual = arrow::compute::concat_batches(&actual_schema, actual)?;
+
+    // `row_number` is 1-based; clamp the window to each side's own length so a
+    // row-count mismatch can't slice out of bounds.
+    let idx = row_number.saturating_sub(1);
+    let window = |batch: &RecordBatch| -> Option<(usize, RecordBatch)> {
+        let len = batch.num_rows();
+        if len == 0 {
+            return None;
+        }
+        let start = idx.saturating_sub(radius);
+        let end = idx.saturating_add(radius).saturating_add(1).min(len);
+        if start >= end {
+            return None;
+        }
+        Some((start, batch.slice(start, end - start)))
+    };
+
+    let mut out = String::new();
+    writeln!(
+        out,
+        "\u{21b3} divergence at global row {row_number}, column '{column}' (\u{00b1}{radius}-row window)"
+    )?;
+
+    for (label, batch) in [
+        ("EXPECTED (source)", &expected),
+        ("ACTUAL (spice)", &actual),
+    ] {
+        match window(batch) {
+            Some((start, slice)) => {
+                writeln!(
+                    out,
+                    "  {label} — rows {}..={}:",
+                    start + 1,
+                    start + slice.num_rows()
+                )?;
+                match arrow::util::pretty::pretty_format_batches(&[slice]) {
+                    Ok(pretty) => writeln!(out, "{pretty}")?,
+                    Err(e) => writeln!(out, "  (failed to format window: {e})")?,
+                }
+            }
+            None => writeln!(out, "  {label}: (no rows at this offset)")?,
+        }
+    }
+
+    Ok(out)
+}
+
 pub fn validate_tpch_query(
     query: &Query,
     batches: &[RecordBatch],
@@ -736,6 +819,60 @@ mod test {
             .clone();
         let schema = batches[0].schema();
         assert_eq!(schema.fields().len(), 10);
+    }
+
+    #[test]
+    fn test_format_row_window() {
+        // 30 rows; expected/actual differ only at row 15 (1-based).
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("city", DataType::Utf8, false),
+            Field::new("state", DataType::Utf8, false),
+        ]));
+        let ids: Vec<i64> = (0..30).collect();
+        let states: Vec<String> = (0..30).map(|i| format!("state_{i}")).collect();
+        let expected_cities: Vec<String> = (0..30).map(|i| format!("city_{i}")).collect();
+        let mut actual_cities = expected_cities.clone();
+        actual_cities[14] = "WRONG".to_string();
+
+        let mk = |cities: &[String]| {
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from(ids.clone())),
+                    Arc::new(StringArray::from(cities.to_vec())),
+                    Arc::new(StringArray::from(states.clone())),
+                ],
+            )
+            .expect("build batch")
+        };
+        let expected = vec![mk(&expected_cities)];
+        let actual = vec![mk(&actual_cities)];
+
+        let window =
+            format_row_window(&expected, &actual, 15, "city", 3).expect("should render window");
+
+        // Snapshot the exact end-to-end rendering: header naming the diverging
+        // row/column, both labelled ±3 windows (rows 12..=18), the neighbouring
+        // context, and the diverging `city_14` vs `WRONG` cell.
+        insta::assert_snapshot!("format_row_window", window);
+    }
+
+    #[test]
+    fn test_format_row_window_clamps_at_end() {
+        // Window near the last row must clamp instead of slicing out of bounds.
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+        let mk = || {
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int64Array::from((0..5).collect::<Vec<i64>>()))],
+            )
+            .expect("build batch")
+        };
+        let batches = vec![mk()];
+        let window =
+            format_row_window(&batches, &batches, 5, "v", 10).expect("should render window");
+        assert!(window.contains("rows 1..=5"), "window: {window}");
     }
 
     #[test]

--- a/crates/test-framework/src/queries/validation/snapshots/test_framework__queries__validation__test__format_row_window.snap
+++ b/crates/test-framework/src/queries/validation/snapshots/test_framework__queries__validation__test__format_row_window.snap
@@ -1,0 +1,29 @@
+---
+source: crates/test-framework/src/queries/validation/mod.rs
+expression: window
+---
+↳ divergence at global row 15, column 'city' (±3-row window)
+  EXPECTED (source) — rows 12..=18:
++----+---------+----------+
+| id | city    | state    |
++----+---------+----------+
+| 11 | city_11 | state_11 |
+| 12 | city_12 | state_12 |
+| 13 | city_13 | state_13 |
+| 14 | city_14 | state_14 |
+| 15 | city_15 | state_15 |
+| 16 | city_16 | state_16 |
+| 17 | city_17 | state_17 |
++----+---------+----------+
+  ACTUAL (spice) — rows 12..=18:
++----+---------+----------+
+| id | city    | state    |
++----+---------+----------+
+| 11 | city_11 | state_11 |
+| 12 | city_12 | state_12 |
+| 13 | city_13 | state_13 |
+| 14 | WRONG   | state_14 |
+| 15 | city_15 | state_15 |
+| 16 | city_16 | state_16 |
+| 17 | city_17 | state_17 |
++----+---------+----------+

--- a/tools/testoperator/src/commands/htap/correctness/analytical.rs
+++ b/tools/testoperator/src/commands/htap/correctness/analytical.rs
@@ -32,7 +32,10 @@ use arrow::datatypes::{Field, Schema};
 use arrow_tools::record_batch::try_cast_to;
 use chbench_driver::ChBenchDriver;
 use test_framework::anyhow;
-use test_framework::queries::validation::{QueryValidationResult, validate_with_expected_batches};
+use test_framework::queries::validation::{
+    QueryValidationFailReason, QueryValidationResult, format_row_window,
+    validate_with_expected_batches,
+};
 use test_framework::queries::{QueryOverrides, get_chbench_test_queries};
 
 /// Analytical queries that are executed and reported but do **not** gate the
@@ -53,6 +56,16 @@ const ADVISORY_QUERIES: &[&str] = &["chbench_q15"];
 fn is_advisory(name: &str) -> bool {
     ADVISORY_QUERIES.contains(&name)
 }
+
+/// Number of rows on each side of a diverging row to print for diagnostics.
+/// A radius of 10 yields a 21-row window (10 before + the row + 10 after).
+/// Overridable via `SPICE_HTAP_DIVERGENCE_WINDOW` for deeper context.
+static DIVERGENCE_WINDOW_RADIUS: std::sync::LazyLock<usize> = std::sync::LazyLock::new(|| {
+    std::env::var("SPICE_HTAP_DIVERGENCE_WINDOW")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(10)
+});
 
 /// Whether a result should fail the gate: any non-`Pass` outcome, except a
 /// value/row [`Outcome::Divergence`] on an advisory query (reported but
@@ -315,14 +328,42 @@ pub async fn verify_analytical_results(
                             _ => (Outcome::Pass, None),
                         }
                     }
-                    Ok(QueryValidationResult::Fail(reason)) => (
-                        Outcome::Divergence(format!(
-                            "{reason:?} (source rows={}, spice rows={})",
-                            total_rows(&expected_sorted),
-                            total_rows(&actual_sorted),
-                        )),
-                        None,
-                    ),
+                    Ok(QueryValidationResult::Fail(reason)) => {
+                        // A `DataMismatch` reports a single diverging cell with no
+                        // surrounding context, which can't distinguish a wrong
+                        // value from a sort-tie row shift. Print a windowed slice
+                        // around the failing row from both sides so the failure
+                        // mode is obvious in the log; the tree keeps the compact
+                        // one-line detail below.
+                        if let QueryValidationFailReason::DataMismatch {
+                            row_number, column, ..
+                        } = &reason
+                        {
+                            match format_row_window(
+                                &expected_sorted,
+                                &actual_sorted,
+                                *row_number,
+                                column,
+                                *DIVERGENCE_WINDOW_RADIUS,
+                            ) {
+                                Ok(window) => eprintln!("\n{}: {window}", query.name),
+                                Err(e) => {
+                                    eprintln!(
+                                        "{}: failed to render divergence window: {e}",
+                                        query.name
+                                    );
+                                }
+                            }
+                        }
+                        (
+                            Outcome::Divergence(format!(
+                                "{reason:?} (source rows={}, spice rows={})",
+                                total_rows(&expected_sorted),
+                                total_rows(&actual_sorted),
+                            )),
+                            None,
+                        )
+                    }
                     Err(e) => (Outcome::Fail(e.to_string()), None),
                 }
             };


### PR DESCRIPTION
## Problem

When the HTAP analytical gate diverges, it reports a single `DataMismatch` cell and nothing else:

```
chbench_q10  DIVERGE  DataMismatch { column: "c_city", row_number: 48348, expected: "9rahWs5Q4H", actual: "Qg8T0oFQE4T" } (source rows=24373970, spice rows=24373970)
```

One scalar pair, no surrounding rows, no other columns of that row. This can't distinguish the two common failure modes:
- a **genuinely wrong value** in one cell, vs.
- a **sort-tie row shift** — both sides are sorted before comparison, but a tie broke differently, so every row from the divergence onward is off-by-one.

The existing full-batch `pretty_format_batches` fallback is useless at 24M rows (floods/truncates CI logs).

## Change

- Add `format_row_window()` to the shared validation module. At the failure point both sides are already schema-aligned and identically sorted, so global row *N* addresses the same logical row on each side. It slices a `±radius` window (clamped per-side so a row-count mismatch can't slice out of bounds) and pretty-prints the full rows — all columns, so key/identity columns stay visible — from both the source and Spice sides.
- Wire it into the analytical gate: on a `DataMismatch` divergence, print the window inline at detection. The compact `DIVERGE` tree line is unchanged.
- Default radius **10** (→ 21-row window), overridable via `SPICE_HTAP_DIVERGENCE_WINDOW`.

### Example output

```
chbench_q10: ↳ divergence at global row 48348, column 'c_city' (±10-row window)
  EXPECTED (source) — rows 48338..=48358:
  +-------+-----------+---------+ ...
  ACTUAL (spice) — rows 48338..=48358:
  +-------+-----------+---------+ ...
```

One glance distinguishes shift-vs-wrong-value.

## Tests

- Unit test for the normal window + an end-of-batch clamp test.
- **insta snapshot** pinning the exact end-to-end render (multi-column rows, both labelled `±3` windows, the diverging cell).

## Scope

htap analytical gate only. `worker.rs` has the same 24M-row full-dump antipattern on the reference-validation path; the helper is public and ready to wire there in a follow-up.
