### PR TITLE
fix(cloud-connect): accept the portal's 5-char adoption-code segments

### DIFF
--- a/bin/spice/src/commands/connect.rs
+++ b/bin/spice/src/commands/connect.rs
@@ -422,7 +422,9 @@ mod tests {
     #[test]
     fn looks_like_adoption_code_matches_prefix() {
         // Well-formed and malformed adoption codes both look like codes.
-        assert!(looks_like_adoption_code("SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F"));
+        assert!(looks_like_adoption_code(
+            "SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F"
+        ));
         assert!(looks_like_adoption_code("SPICE-ADOPT-AAA-BBBB"));
         assert!(looks_like_adoption_code("SPICE-ADOPT-aaaa-BBBB"));
         assert!(looks_like_adoption_code("SPICE-ADOPT"));

--- a/bin/spice/src/commands/connect.rs
+++ b/bin/spice/src/commands/connect.rs
@@ -23,7 +23,7 @@ limitations under the License.
 //!    Spice Cloud portal:
 //!
 //!    ```text
-//!    spice connect SPICE-ADOPT-7K2P-9XYZ-A1B2
+//!    spice connect SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F
 //!    ```
 //!
 //!    or one of the explicit subcommands `status`/`forget`.
@@ -47,7 +47,7 @@ use clap::{Args, Subcommand};
     long_about = r#"`spice connect` has two modes:
 
 CLOUD CONNECT ADOPTION:
-  spice connect SPICE-ADOPT-XXXX-XXXX     Stage an adoption code so the next
+  spice connect SPICE-ADOPT-XXXXX-XXXXX-XXXXX-XXXXX   Stage an adoption code so the next
                                           `spiced` start connects to Spice Cloud
                                           and is shown as "Pending Adoption" in
                                           the portal.
@@ -68,7 +68,7 @@ LEGACY POD-ADD BEHAVIOR:
                                           fetched.
 
 EXAMPLES
-  spice connect SPICE-ADOPT-7K2P-9XYZ-A1B2
+  spice connect SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F
   spice connect status
   spice connect forget
   spice connect spiceai/quickstart
@@ -134,7 +134,7 @@ pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
         return Err(crate::error::Error::InvalidArgument {
             message: format!(
                 "'{target}' looks like a Spice Cloud adoption code but is malformed. \
-                 Expected SPICE-ADOPT-XXXX-XXXX-... (each segment is 4 uppercase \
+                 Expected SPICE-ADOPT-XXXXX-XXXXX-XXXXX-XXXXX (each segment is 5 uppercase \
                  letters or digits). Copy the code from your Spice Cloud portal and retry."
             ),
         });
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn looks_like_adoption_code_matches_prefix() {
         // Well-formed and malformed adoption codes both look like codes.
-        assert!(looks_like_adoption_code("SPICE-ADOPT-7K2P-9XYZ-A1B2"));
+        assert!(looks_like_adoption_code("SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F"));
         assert!(looks_like_adoption_code("SPICE-ADOPT-AAA-BBBB"));
         assert!(looks_like_adoption_code("SPICE-ADOPT-aaaa-BBBB"));
         assert!(looks_like_adoption_code("SPICE-ADOPT"));

--- a/crates/runtime-cloud-connect/src/lib.rs
+++ b/crates/runtime-cloud-connect/src/lib.rs
@@ -255,7 +255,9 @@ mod tests {
     #[test]
     fn accepts_canonical_adoption_code() {
         // The portal mints four 5-char base32 segments.
-        assert!(is_valid_adoption_code("SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F"));
+        assert!(is_valid_adoption_code(
+            "SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F"
+        ));
         assert!(is_valid_adoption_code("SPICE-ADOPT-AAAAA-BBBBB"));
         assert!(is_valid_adoption_code(
             "SPICE-ADOPT-11111-22222-33333-44444-55555"

--- a/crates/runtime-cloud-connect/src/lib.rs
+++ b/crates/runtime-cloud-connect/src/lib.rs
@@ -212,10 +212,10 @@ impl CloudConnect {
 
 /// Validate an adoption code shape.
 ///
-/// Format: `SPICE-ADOPT-XXXX-XXXX-...` where each `XXXX` segment is 4
-/// uppercase ASCII alphanumeric characters, and there are between 2 and 5
-/// segments. The actual code may be looser server-side; this is the
-/// client-side sanity check.
+/// Format: `SPICE-ADOPT-XXXXX-XXXXX-...` where each `XXXXX` segment is 5
+/// uppercase ASCII alphanumeric characters (the portal mints RFC4648 base32,
+/// A-Z2-7), and there are between 2 and 5 segments (the portal mints 4). The
+/// actual code may be looser server-side; this is the client-side sanity check.
 #[must_use]
 pub fn is_valid_adoption_code(code: &str) -> bool {
     let mut parts = code.split('-');
@@ -227,7 +227,7 @@ pub fn is_valid_adoption_code(code: &str) -> bool {
     }
     let mut segments = 0_usize;
     for part in parts {
-        if part.len() != 4
+        if part.len() != 5
             || !part
                 .chars()
                 .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
@@ -248,28 +248,29 @@ mod tests {
 
     #[test]
     fn rejects_codes_with_wrong_prefix() {
-        assert!(!is_valid_adoption_code("FOO-BAR-AAAA-BBBB"));
-        assert!(!is_valid_adoption_code("SPICE-CONNECT-AAAA-BBBB"));
+        assert!(!is_valid_adoption_code("FOO-BAR-AAAAA-BBBBB"));
+        assert!(!is_valid_adoption_code("SPICE-CONNECT-AAAAA-BBBBB"));
     }
 
     #[test]
     fn accepts_canonical_adoption_code() {
-        assert!(is_valid_adoption_code("SPICE-ADOPT-7K2P-9XYZ-A1B2"));
-        assert!(is_valid_adoption_code("SPICE-ADOPT-AAAA-BBBB"));
+        // The portal mints four 5-char base32 segments.
+        assert!(is_valid_adoption_code("SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F"));
+        assert!(is_valid_adoption_code("SPICE-ADOPT-AAAAA-BBBBB"));
         assert!(is_valid_adoption_code(
-            "SPICE-ADOPT-1111-2222-3333-4444-5555"
+            "SPICE-ADOPT-11111-22222-33333-44444-55555"
         ));
     }
 
     #[test]
     fn rejects_codes_with_lowercase_or_wrong_length() {
-        assert!(!is_valid_adoption_code("SPICE-ADOPT-aaaa-BBBB"));
-        assert!(!is_valid_adoption_code("SPICE-ADOPT-AAA-BBBB"));
-        assert!(!is_valid_adoption_code("SPICE-ADOPT-AAAAA-BBBB"));
+        assert!(!is_valid_adoption_code("SPICE-ADOPT-aaaaa-BBBBB"));
+        assert!(!is_valid_adoption_code("SPICE-ADOPT-AAAA-BBBBB")); // 4-char segment
+        assert!(!is_valid_adoption_code("SPICE-ADOPT-AAAAAA-BBBBB")); // 6-char segment
         assert!(!is_valid_adoption_code("SPICE-ADOPT"));
         // 6 segments — too many.
         assert!(!is_valid_adoption_code(
-            "SPICE-ADOPT-1111-2222-3333-4444-5555-6666"
+            "SPICE-ADOPT-11111-22222-33333-44444-55555-66666"
         ));
     }
 }


### PR DESCRIPTION
The CLI adoption-code validator (`runtime_cloud_connect::is_valid_adoption_code`) required 4-character segments, but adoption codes are minted as `SPICE-ADOPT-` + four **5-character** base32 groups — so `spice connect <code>` rejected every valid code as malformed.

Accept 5-character segments; also updates the error message, the `spice connect --help` examples, and the unit tests.

Touches `bin/spice/src/commands/connect.rs` and `crates/runtime-cloud-connect/src/lib.rs`.
