### PR TITLE
refactor(layering): prepare DynamoDB for extraction from runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16462,6 +16462,7 @@ dependencies = [
  "runtime-api-types",
  "runtime-async",
  "runtime-auth",
+ "runtime-checkpoint-api",
  "runtime-cluster",
  "runtime-datafusion",
  "runtime-datafusion-index",
@@ -16613,6 +16614,14 @@ dependencies = [
  "tower 0.5.3",
  "tracing",
  "x509-certificate",
+]
+
+[[package]]
+name = "runtime-checkpoint-api"
+version = "2.2.0-unstable"
+dependencies = [
+ "async-trait",
+ "snafu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/package",
     "crates/runtime",
     "crates/runtime-api-types",
+    "crates/runtime-checkpoint-api",
     "crates/runtime-auth",
     "crates/runtime-metrics",
     "crates/runtime-async",

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -799,9 +799,6 @@ impl DataConnector for MongoDB {
         &self,
         federated_table: Arc<FederatedTable>,
         dataset: &Dataset,
-        _accelerated_table_provider: Arc<dyn TableProvider>,
-        _accelerator_write_mutex: Arc<tokio::sync::Mutex<()>>,
-        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<data_components::cdc::ChangesStream> {
         Some(changes::build_changes_stream(
             Arc::clone(&self.pool),

--- a/crates/data-connectors/connector-mysql/src/lib.rs
+++ b/crates/data-connectors/connector-mysql/src/lib.rs
@@ -603,9 +603,6 @@ impl DataConnector for MySQL {
         &self,
         federated_table: Arc<runtime::federated_table::FederatedTable>,
         dataset: &Dataset,
-        _accelerated_table_provider: Arc<dyn TableProvider>,
-        _accelerator_write_mutex: Arc<tokio::sync::Mutex<()>>,
-        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<data_components::cdc::ChangesStream> {
         Some(replication::build_changes_stream(
             &self.params,

--- a/crates/data-connectors/connector-postgres/src/lib.rs
+++ b/crates/data-connectors/connector-postgres/src/lib.rs
@@ -1052,9 +1052,6 @@ impl DataConnector for Postgres {
         &self,
         federated_table: Arc<runtime::federated_table::FederatedTable>,
         dataset: &Dataset,
-        _accelerated_table_provider: Arc<dyn TableProvider>,
-        _accelerator_write_mutex: Arc<tokio::sync::Mutex<()>>,
-        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<data_components::cdc::ChangesStream> {
         Some(replication::build_changes_stream(
             &self.params,

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -119,9 +119,10 @@ pub enum StreamError {
     Arrow(String),
     /// External error not originating from `ChangesStream` core logic, such as index processing failure.
     External(String),
-    #[cfg(feature = "dynamodb")]
-    /// Error from `DynamoDB`, such as failure during streaming or subscription.
-    DynamoDB(crate::dynamodb::stream::StreamError),
+    /// Error surfaced by a data-source connector's change stream: the connector maps
+    /// its own concrete error into this variant and attaches it as the boxed cause,
+    /// keeping this CDC contract connector-agnostic.
+    Connector(Box<dyn std::error::Error + Send + Sync>),
     #[cfg(feature = "mongodb")]
     /// Error from `MongoDB`, such as failure during change stream processing.
     MongoDB(crate::mongodb::stream::StreamError),
@@ -148,8 +149,7 @@ impl std::fmt::Display for StreamError {
             StreamError::Flight(e) => write!(f, "Arrow Flight error: {e}"),
             StreamError::Arrow(e) => write!(f, "Arrow error: {e}"),
             StreamError::External(e) => write!(f, "External error: {e}"),
-            #[cfg(feature = "dynamodb")]
-            StreamError::DynamoDB(e) => write!(f, "DynamoDB error: {e}"),
+            StreamError::Connector(e) => write!(f, "{e}"),
             #[cfg(feature = "mongodb")]
             StreamError::MongoDB(e) => write!(f, "MongoDB error: {e}"),
         }

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -128,7 +128,19 @@ pub enum StreamError {
     MongoDB(crate::mongodb::stream::StreamError),
 }
 
-impl std::error::Error for StreamError {}
+impl std::error::Error for StreamError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            #[cfg(any(feature = "debezium", feature = "kafka"))]
+            StreamError::Kafka(e) => Some(e),
+            StreamError::Connector(e) => Some(&**e),
+            #[cfg(feature = "mongodb")]
+            StreamError::MongoDB(e) => Some(e),
+            // String-carrying variants have no underlying `Error` source.
+            _ => None,
+        }
+    }
+}
 
 impl From<ChangeBatchError> for StreamError {
     fn from(e: ChangeBatchError) -> Self {

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -119,10 +119,16 @@ pub enum StreamError {
     Arrow(String),
     /// External error not originating from `ChangesStream` core logic, such as index processing failure.
     External(String),
-    /// Error surfaced by a data-source connector's change stream: the connector maps
-    /// its own concrete error into this variant and attaches it as the boxed cause,
-    /// keeping this CDC contract connector-agnostic.
-    Connector(Box<dyn std::error::Error + Send + Sync>),
+    /// Error surfaced by a data-source connector's change stream: the connector
+    /// names itself (`connector`) and attaches its own concrete error as the boxed
+    /// `source` cause, keeping this CDC contract connector-agnostic.
+    Connector {
+        /// Static name of the connector that produced the error (e.g. `"DynamoDB"`),
+        /// so logs that print only `{err}` still identify the source connector.
+        connector: &'static str,
+        /// The connector's concrete error, preserved as the chained cause.
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     #[cfg(feature = "mongodb")]
     /// Error from `MongoDB`, such as failure during change stream processing.
     MongoDB(crate::mongodb::stream::StreamError),
@@ -133,7 +139,7 @@ impl std::error::Error for StreamError {
         match self {
             #[cfg(any(feature = "debezium", feature = "kafka"))]
             StreamError::Kafka(e) => Some(e),
-            StreamError::Connector(e) => Some(&**e),
+            StreamError::Connector { source, .. } => Some(&**source),
             #[cfg(feature = "mongodb")]
             StreamError::MongoDB(e) => Some(e),
             // String-carrying variants have no underlying `Error` source.
@@ -161,7 +167,9 @@ impl std::fmt::Display for StreamError {
             StreamError::Flight(e) => write!(f, "Arrow Flight error: {e}"),
             StreamError::Arrow(e) => write!(f, "Arrow error: {e}"),
             StreamError::External(e) => write!(f, "External error: {e}"),
-            StreamError::Connector(e) => write!(f, "{e}"),
+            StreamError::Connector { connector, source } => {
+                write!(f, "{connector} error: {source}")
+            }
             #[cfg(feature = "mongodb")]
             StreamError::MongoDB(e) => write!(f, "MongoDB error: {e}"),
         }

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -29,7 +29,9 @@ use crate::dynamodb::json_nest::project_dynamodb_row;
 use crate::dynamodb::request_builder::DynamoDBRequestPlanBuilder;
 use crate::dynamodb::request_plan::{DynamoDBRequestPlan, QueryParams, ScanParams};
 use crate::dynamodb::schema::infer_arrow_schema_from_rows;
-use crate::dynamodb::stream::{StreamError, process_batch, record_batch_to_change_batch};
+use crate::dynamodb::stream::{
+    StreamError, process_batch, record_batch_to_change_batch, truncate_change_batch,
+};
 use crate::dynamodb::table_schema::DynamoDBTableSchema;
 use crate::dynamodb::unnest::unnest_dynamodb_rows;
 use crate::schema_discovery::merge_inferred_and_declared_schemas;
@@ -567,6 +569,38 @@ impl DynamoDBTableProvider {
             });
 
         Ok(stream.boxed())
+    }
+
+    /// Full-overwrite bootstrap as a CDC change stream: a leading `op="t"`
+    /// truncate barrier followed by the table scan as `op="c"` inserts.
+    ///
+    /// Chained ahead of the live changes stream, this replaces the accelerator's
+    /// contents — dropping rows deleted at the source since the last checkpoint —
+    /// using only the CDC change contract, so the connector needs no direct
+    /// accelerator write path (`TableSink`/`InsertOp::Overwrite`). The truncate is
+    /// a no-op on an empty accelerator.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the truncate batch can't be built or the underlying
+    /// [`Self::bootstrap_stream`] scan fails to start.
+    pub async fn overwrite_bootstrap_stream(
+        self: Arc<Self>,
+    ) -> Result<BoxStream<'static, Result<ChangeBatch, crate::cdc::StreamError>>> {
+        // A truncate-build failure flows as the stream's first element (like the
+        // per-batch scan errors below), not as a setup error — the accelerator
+        // then surfaces it on the changes stream rather than silently skipping.
+        let truncate = truncate_change_batch(
+            self.table_schema.schema(),
+            &self.table_schema.primary_keys(),
+        )
+        .map_err(crate::cdc::StreamError::from);
+
+        let snapshot = Arc::clone(&self).bootstrap_stream().await?;
+
+        Ok(stream::once(async move { truncate })
+            .chain(snapshot)
+            .boxed())
     }
 
     #[must_use]

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -513,7 +513,7 @@ impl DynamoDBTableProvider {
                     &time_format,
                     projection.as_ref(),
                 )
-                .map_err(crate::cdc::StreamError::DynamoDB)
+                .map_err(crate::cdc::StreamError::from)
             });
 
         Ok(Box::pin(stream))
@@ -561,11 +561,9 @@ impl DynamoDBTableProvider {
                         record_batch.num_rows()
                     );
                     record_batch_to_change_batch(record_batch, &schema, &primary_keys)
-                        .map_err(crate::cdc::StreamError::DynamoDB)
+                        .map_err(crate::cdc::StreamError::from)
                 }
-                Err(e) => Err(crate::cdc::StreamError::DynamoDB(
-                    StreamError::FailedToReadRecordBatch { source: e },
-                )),
+                Err(e) => Err(StreamError::FailedToReadRecordBatch { source: e }.into()),
             });
 
         Ok(stream.boxed())

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -582,8 +582,11 @@ impl DynamoDBTableProvider {
     ///
     /// # Errors
     ///
-    /// Returns an error if the truncate batch can't be built or the underlying
-    /// [`Self::bootstrap_stream`] scan fails to start.
+    /// Returns an error only if the underlying [`Self::bootstrap_stream`] scan
+    /// fails to start. A truncate-batch build failure is *not* returned here — it
+    /// is surfaced as the stream's first element (like the per-batch scan errors),
+    /// so the accelerator fails the changes stream visibly rather than skipping the
+    /// truncate.
     pub async fn overwrite_bootstrap_stream(
         self: Arc<Self>,
     ) -> Result<BoxStream<'static, Result<ChangeBatch, crate::cdc::StreamError>>> {

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -43,7 +43,7 @@ pub enum StreamError {
     FailedToReceiveMessage { source: dynamodb_streams::Error },
 
     #[snafu(display(
-        "DynamoDB Stream is beyond its 24-hour retention window; delete the acceleration to re-bootstrap the table: {source}"
+        "DynamoDB Stream is beyond its 24-hour retention window; drop this dataset's accelerated data (its acceleration files/tables) to force a fresh full re-bootstrap of the table: {source}"
     ))]
     StreamBeyondRetention { source: dynamodb_streams::Error },
 
@@ -162,6 +162,13 @@ fn get_primary_keys_array(primary_keys: &[String], row_count: usize) -> ListArra
         .downcast_mut::<ListBuilder<Box<dyn ArrayBuilder>>>()
         .unwrap_or_else(|| unreachable!("created above as a list builder"));
     for _ in 0..row_count {
+        // Match `process_batch`: encode "no primary keys" as a null list rather than
+        // a valid empty list, so every CDC batch this connector emits (snapshot,
+        // truncate, live) agrees on null-vs-empty semantics.
+        if primary_keys.is_empty() {
+            list_builder.append(false);
+            continue;
+        }
         let str_builder = list_builder
             .values()
             .as_any_mut()

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -133,23 +133,19 @@ pub fn truncate_change_batch(
 
     let primary_keys_array = get_primary_keys_array(primary_keys, 1);
 
-    // Truncate carries no data; a single all-null row keeps the data struct's
-    // type identical to the snapshot/live batches so the apply path can coalesce.
-    let data_columns: Vec<arrow_array::ArrayRef> = table_schema
-        .fields()
-        .iter()
-        .map(|f| arrow::array::new_null_array(f.data_type(), 1))
-        .collect();
-    let data_array = StructArray::new(table_schema.fields().clone(), data_columns, None);
+    // Truncate carries no data. Build the whole `data` value as a single NULL
+    // struct row (the `data` field is nullable in `changes_schema`). A *valid*
+    // struct with all-null children would violate Arrow nullability for any
+    // non-nullable child field (`StructArray::new` rejects unmasked child nulls);
+    // a null struct masks child validity entirely while keeping the type identical
+    // to the snapshot/live batches so the apply path can still coalesce them.
+    let data_array =
+        arrow::array::new_null_array(&DataType::Struct(table_schema.fields().clone()), 1);
 
     let new_schema = Arc::new(changes_schema(table_schema.as_ref()));
     let new_record_batch = RecordBatch::try_new(
         new_schema,
-        vec![
-            Arc::new(op_array),
-            Arc::new(primary_keys_array),
-            Arc::new(data_array),
-        ],
+        vec![Arc::new(op_array), Arc::new(primary_keys_array), data_array],
     )
     .context(FailedToCreateRecordBatchSnafu)?;
 
@@ -382,6 +378,26 @@ mod tests {
             .expect("should build truncate batch");
 
         // Exactly one row, op = "t" (Truncate) — the delete-all barrier.
+        assert_eq!(batch.record.num_rows(), 1);
+        assert!(matches!(batch.op(0), ChangeOperation::Truncate));
+    }
+
+    #[test]
+    fn truncate_change_batch_allows_non_nullable_fields() {
+        // A declared (non-inferred) schema can mark fields non-nullable. The
+        // truncate barrier carries no data, so its `data` value must be a NULL
+        // struct row rather than a valid struct with null children — otherwise
+        // Arrow rejects the unmasked null in the non-nullable child and this
+        // (correctness-critical rebootstrap) path fails.
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let primary_keys = vec!["id".to_string()];
+
+        let batch = truncate_change_batch(&table_schema, &primary_keys)
+            .expect("truncate batch must build for schemas with non-nullable fields");
+
         assert_eq!(batch.record.num_rows(), 1);
         assert!(matches!(batch.op(0), ChangeOperation::Truncate));
     }

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -42,6 +42,11 @@ pub enum StreamError {
     #[snafu(display("Failed to receive DynamoDB Stream record: {source}"))]
     FailedToReceiveMessage { source: dynamodb_streams::Error },
 
+    #[snafu(display(
+        "DynamoDB Stream is beyond its 24-hour retention window; delete the acceleration to re-bootstrap the table: {source}"
+    ))]
+    StreamBeyondRetention { source: dynamodb_streams::Error },
+
     #[snafu(display("Unable to downcast ArrayBuilder"))]
     DowncastBuilder,
 
@@ -59,6 +64,15 @@ pub enum StreamError {
 
     #[snafu(display("Failed to read RecordBatch: {}", format_datafusion_error(source)))]
     FailedToReadRecordBatch { source: DataFusionError },
+}
+
+/// The `DynamoDB` connector owns the mapping from its concrete stream error to the
+/// connector-agnostic CDC contract error: it boxes itself as the cause so the CDC
+/// contract (and the runtime) never names `DynamoDB`-specific types.
+impl From<StreamError> for crate::cdc::StreamError {
+    fn from(e: StreamError) -> Self {
+        crate::cdc::StreamError::Connector(Box::new(e))
+    }
 }
 
 // This function is used for bootstrapping stream which doesn't have checkpoints.

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -108,6 +108,50 @@ pub fn record_batch_to_change_batch(
     Ok(change_batch)
 }
 
+/// Builds a single-row `op="t"` (Truncate) change batch.
+///
+/// Emitted ahead of a bootstrap snapshot, the accelerator applies it as a
+/// delete-all barrier (`process_truncate` → `DELETE FROM <table> WHERE TRUE`) so
+/// a re-bootstrap over a persistent accelerator drops rows deleted at the source
+/// — the same overwrite semantics the old direct `InsertOp::Overwrite` gave,
+/// expressed entirely through the CDC change contract.
+///
+/// The row payload is all-null (Truncate ignores it) and uses the same
+/// [`changes_schema`] as [`record_batch_to_change_batch`], so the truncate and
+/// snapshot batches coalesce. `DynamoDB` infers an all-nullable schema, so the
+/// null payload validates against every field.
+pub fn truncate_change_batch(
+    table_schema: &Arc<Schema>,
+    primary_keys: &[String],
+) -> Result<ChangeBatch, StreamError> {
+    // "t" stands for ChangeOperation::Truncate
+    let op_array = StringArray::from(vec!["t"]);
+
+    let primary_keys_array = get_primary_keys_array(primary_keys, 1);
+
+    // Truncate carries no data; a single all-null row keeps the data struct's
+    // type identical to the snapshot/live batches so the apply path can coalesce.
+    let data_columns: Vec<arrow_array::ArrayRef> = table_schema
+        .fields()
+        .iter()
+        .map(|f| arrow::array::new_null_array(f.data_type(), 1))
+        .collect();
+    let data_array = StructArray::new(table_schema.fields().clone(), data_columns, None);
+
+    let new_schema = Arc::new(changes_schema(table_schema.as_ref()));
+    let new_record_batch = RecordBatch::try_new(
+        new_schema,
+        vec![
+            Arc::new(op_array),
+            Arc::new(primary_keys_array),
+            Arc::new(data_array),
+        ],
+    )
+    .context(FailedToCreateRecordBatchSnafu)?;
+
+    ChangeBatch::try_new(new_record_batch).context(FailedToCreateChangeBatchSnafu)
+}
+
 fn get_primary_keys_array(primary_keys: &[String], row_count: usize) -> ListArray {
     let mut list_builder_generic = make_builder(
         &DataType::List(Arc::new(Field::new("item", DataType::Utf8, false))),
@@ -323,6 +367,36 @@ mod tests {
             },
             watermark: None,
         }
+    }
+
+    #[test]
+    fn truncate_change_batch_is_single_truncate_row() {
+        let table_schema = create_test_table_schema();
+        let primary_keys = vec!["id".to_string()];
+
+        let batch = truncate_change_batch(&table_schema, &primary_keys)
+            .expect("should build truncate batch");
+
+        // Exactly one row, op = "t" (Truncate) — the delete-all barrier.
+        assert_eq!(batch.record.num_rows(), 1);
+        assert!(matches!(batch.op(0), ChangeOperation::Truncate));
+    }
+
+    #[test]
+    fn truncate_and_insert_batches_share_a_schema() {
+        // The truncate barrier and the snapshot inserts must carry the same
+        // `changes_schema` so the accelerator's apply path can coalesce them
+        // into one write; a mismatch would fail the Arrow concat at apply time.
+        let table_schema = create_test_table_schema();
+        let primary_keys = vec!["id".to_string()];
+
+        let insert_rows = RecordBatch::new_empty(Arc::clone(&table_schema));
+        let insert = record_batch_to_change_batch(insert_rows, &table_schema, &primary_keys)
+            .expect("should build insert batch");
+        let truncate = truncate_change_batch(&table_schema, &primary_keys)
+            .expect("should build truncate batch");
+
+        assert_eq!(insert.record.schema(), truncate.record.schema());
     }
 
     mod process_batch {

--- a/crates/data_components/src/dynamodb/stream.rs
+++ b/crates/data_components/src/dynamodb/stream.rs
@@ -67,11 +67,15 @@ pub enum StreamError {
 }
 
 /// The `DynamoDB` connector owns the mapping from its concrete stream error to the
-/// connector-agnostic CDC contract error: it boxes itself as the cause so the CDC
-/// contract (and the runtime) never names `DynamoDB`-specific types.
+/// connector-agnostic CDC contract error: it tags the `"DynamoDB"` connector name and
+/// boxes itself as the cause, so the CDC contract (and the runtime) never names
+/// `DynamoDB`-specific types while logs still identify the source connector.
 impl From<StreamError> for crate::cdc::StreamError {
     fn from(e: StreamError) -> Self {
-        crate::cdc::StreamError::Connector(Box::new(e))
+        crate::cdc::StreamError::Connector {
+            connector: "DynamoDB",
+            source: Box::new(e),
+        }
     }
 }
 

--- a/crates/runtime-checkpoint-api/Cargo.toml
+++ b/crates/runtime-checkpoint-api/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "runtime-checkpoint-api"
+description = "CDC checkpoint/offset store interface: a per-dataset keyed blob store the accelerator implements and data-source connectors call."
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+snafu.workspace = true
+
+[lints]
+workspace = true

--- a/crates/runtime-checkpoint-api/src/lib.rs
+++ b/crates/runtime-checkpoint-api/src/lib.rs
@@ -1,0 +1,65 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The CDC checkpoint-store interface.
+//!
+//! A CDC data-source connector needs to persist and reload its stream position
+//! (offsets, sequence numbers, …) across restarts. That persistence is provided by
+//! the accelerator, which owns the sidecar tables. This crate is the small seam
+//! between the two: the accelerator *satisfies* [`CheckpointStore`] (hence the
+//! `runtime-` prefix — the runtime side owns the obligation), and a connector merely
+//! *calls* it, so the connector never depends on the accelerator or the runtime
+//! orchestrator.
+//!
+//! The stored payload is an opaque `String` the connector serializes itself: this
+//! crate is deliberately connector-agnostic and names no source-specific type.
+
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use snafu::Snafu;
+
+/// A persisted CDC checkpoint for a single dataset: the connector-serialized, opaque
+/// `data` blob plus the store-managed timestamp of its last write (connectors use
+/// `updated_at` for staleness/expiry decisions).
+#[derive(Clone, Debug)]
+pub struct CheckpointRecord {
+    /// Opaque, connector-serialized checkpoint payload.
+    pub data: String,
+    /// When the checkpoint was last written, as recorded by the store.
+    pub updated_at: Option<SystemTime>,
+}
+
+#[derive(Debug, Snafu)]
+pub enum CheckpointError {
+    #[snafu(display("Checkpoint store operation failed: {source}"))]
+    Store {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+/// A per-dataset checkpoint store, satisfied by the accelerator and called by a
+/// data-source connector. Object-safe and `#[async_trait]` so it is used as
+/// `Arc<dyn CheckpointStore>`.
+#[async_trait]
+pub trait CheckpointStore: Send + Sync {
+    /// Load the current checkpoint for this dataset, if one has been persisted.
+    async fn get(&self) -> Option<CheckpointRecord>;
+
+    /// Persist `data` as the current checkpoint for this dataset, overwriting any
+    /// previously stored value.
+    async fn upsert(&self, data: &str) -> Result<(), CheckpointError>;
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -135,6 +135,7 @@ rmcp = { workspace = true, optional = true, features = [
 runtime-acceleration = { path = "../runtime-acceleration" }
 runtime-api-types = { path = "../runtime-api-types" }
 runtime-async = { path = "../runtime-async" }
+runtime-checkpoint-api = { path = "../runtime-checkpoint-api" }
 runtime-metrics = { path = "../runtime-metrics" }
 runtime-auth = { path = "../runtime-auth" }
 runtime-cluster = { path = "../runtime-cluster" }

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -32,8 +32,6 @@ use cache::Caching;
 use cayenne::{CayenneCdcWrite, CayenneTableProvider};
 use data_components::arrow::{IndexedMemTable, write::MemTable};
 use data_components::cdc::{self, ChangeBatch, ChangeOperation, ChangesStream};
-#[cfg(feature = "dynamodb")]
-use data_components::dynamodb::stream::StreamError as DynamoDBStreamError;
 use data_components::index_maintenance::perform_index_maintenance;
 #[cfg(any(feature = "debezium", feature = "kafka"))]
 use data_components::kafka::{
@@ -3748,19 +3746,6 @@ fn handle_stream_error(err: &cdc::StreamError, dataset_name: &TableReference) ->
                 );
             }
         }
-        return StreamErrorType::Fatal;
-    }
-
-    #[cfg(feature = "dynamodb")]
-    if matches!(
-        err,
-        cdc::StreamError::DynamoDB(DynamoDBStreamError::FailedToReceiveMessage {
-            source: dynamodb_streams::Error::StreamBeyondRetention,
-        })
-    ) {
-        tracing::error!(
-            "DynamoDB Stream for dataset '{dataset_name}' is beyond 24 hour retention policy. Delete acceleration to initiate table bootstrapping"
-        );
         return StreamErrorType::Fatal;
     }
 

--- a/crates/runtime/src/dataaccelerator/spice_sys/dynamodb/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dynamodb/mod.rs
@@ -16,6 +16,8 @@ limitations under the License.
 
 use super::{AccelerationConnection, Error, Result, acceleration_connection};
 use crate::{component::dataset::Dataset, dataaccelerator::spice_sys::OpenOption};
+use async_trait::async_trait;
+use runtime_checkpoint_api::{CheckpointError, CheckpointRecord, CheckpointStore};
 use serde::{Deserialize, Serialize};
 
 const DYNAMODB_STREAMS_TABLE_NAME: &str = "spice_sys_dynamodb_streams";
@@ -51,9 +53,15 @@ impl DynamoDBSys {
                 .await?,
         })
     }
+}
 
-    pub async fn get(&self) -> Option<DynamoDBCheckpointMetadata> {
-        match &self.acceleration_connection {
+#[async_trait]
+impl CheckpointStore for DynamoDBSys {
+    async fn get(&self) -> Option<CheckpointRecord> {
+        // Annotate the type explicitly: with no accelerator backend feature
+        // compiled in, only the `_ => None` arm survives and the type can't be
+        // inferred from the arms alone.
+        let metadata: Option<DynamoDBCheckpointMetadata> = match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => self.get_duckdb(pool),
             #[cfg(feature = "postgres-accel")]
@@ -71,21 +79,40 @@ impl DynamoDBSys {
                 feature = "turso"
             )))]
             _ => None,
-        }
+        };
+        metadata.map(|m| CheckpointRecord {
+            data: m.checkpoint_data,
+            updated_at: m.updated_at,
+        })
     }
 
-    pub async fn upsert(&self, metadata: &DynamoDBCheckpointMetadata) -> Result<()> {
-        match &self.acceleration_connection {
+    async fn upsert(&self, data: &str) -> Result<(), CheckpointError> {
+        // Consumed only by the accelerator-backed arms below; with no backend
+        // feature compiled in, the `_ => Err` arm leaves it unused.
+        #[cfg_attr(
+            not(any(
+                feature = "duckdb",
+                feature = "sqlite",
+                feature = "postgres-accel",
+                feature = "turso"
+            )),
+            expect(unused_variables, reason = "no accelerator backend compiled in")
+        )]
+        let metadata = DynamoDBCheckpointMetadata {
+            checkpoint_data: data.to_string(),
+            updated_at: None,
+        };
+        let result = match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.upsert_duckdb(pool, metadata),
+            AccelerationConnection::DuckDB(pool) => self.upsert_duckdb(pool, &metadata),
             #[cfg(feature = "postgres-accel")]
-            AccelerationConnection::Postgres(pool) => self.upsert_postgres(pool, metadata).await,
+            AccelerationConnection::Postgres(pool) => self.upsert_postgres(pool, &metadata).await,
             #[cfg(feature = "sqlite")]
-            AccelerationConnection::SQLite(conn) => self.upsert_sqlite(conn, metadata).await,
+            AccelerationConnection::SQLite(conn) => self.upsert_sqlite(conn, &metadata).await,
             #[cfg(feature = "turso")]
-            AccelerationConnection::Turso(pool) => self.upsert_turso(pool, metadata).await,
+            AccelerationConnection::Turso(pool) => self.upsert_turso(pool, &metadata).await,
             #[cfg(all(not(windows), feature = "sqlite"))]
-            AccelerationConnection::Cayenne(conn) => self.upsert_sqlite(conn, metadata).await,
+            AccelerationConnection::Cayenne(conn) => self.upsert_sqlite(conn, &metadata).await,
             #[cfg(not(any(
                 feature = "sqlite",
                 feature = "duckdb",
@@ -93,6 +120,9 @@ impl DynamoDBSys {
                 feature = "turso"
             )))]
             _ => Err(Error::NoAccelerationConnection),
-        }
+        };
+        result.map_err(|e| CheckpointError::Store {
+            source: Box::new(e),
+        })
     }
 }

--- a/crates/runtime/src/dataaccelerator/spice_sys/dynamodb/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dynamodb/mod.rs
@@ -27,7 +27,10 @@ use serde::{Deserialize, Serialize};
         feature = "postgres-accel",
         feature = "turso"
     )),
-    expect(dead_code, reason = "only referenced by the accelerator backend modules")
+    expect(
+        dead_code,
+        reason = "only referenced by the accelerator backend modules"
+    )
 )]
 const DYNAMODB_STREAMS_TABLE_NAME: &str = "spice_sys_dynamodb_streams";
 

--- a/crates/runtime/src/dataaccelerator/spice_sys/dynamodb/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dynamodb/mod.rs
@@ -20,6 +20,15 @@ use async_trait::async_trait;
 use runtime_checkpoint_api::{CheckpointError, CheckpointRecord, CheckpointStore};
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(
+    not(any(
+        feature = "duckdb",
+        feature = "sqlite",
+        feature = "postgres-accel",
+        feature = "turso"
+    )),
+    expect(dead_code, reason = "only referenced by the accelerator backend modules")
+)]
 const DYNAMODB_STREAMS_TABLE_NAME: &str = "spice_sys_dynamodb_streams";
 
 #[cfg(feature = "duckdb")]
@@ -40,6 +49,15 @@ pub struct DynamoDBCheckpointMetadata {
 }
 
 pub struct DynamoDBSys {
+    #[cfg_attr(
+        not(any(
+            feature = "duckdb",
+            feature = "sqlite",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
+        expect(dead_code, reason = "only read by the accelerator backend modules")
+    )]
     dataset_name: String,
     acceleration_connection: AccelerationConnection,
 }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -568,9 +568,6 @@ impl DataConnector for Debezium {
         &self,
         federated_table: Arc<FederatedTable>,
         _dataset: &Dataset,
-        _accelerated_table_provider: Arc<dyn TableProvider>,
-        _accelerator_write_mutex: Arc<Mutex<()>>,
-        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<ChangesStream> {
         Some(Box::pin(stream! {
             let table_provider = federated_table.table_provider().await;

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -51,7 +51,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Mutex;
 
 const SCHEMA_INFERENCE_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/crates/runtime/src/dataconnector/deferred.rs
+++ b/crates/runtime/src/dataconnector/deferred.rs
@@ -97,9 +97,6 @@ impl DataConnector for DeferredConnector {
         &self,
         _federated_table: Arc<crate::federated_table::FederatedTable>,
         _dataset: &Dataset,
-        _accelerated_table_provider: Arc<dyn TableProvider>,
-        _accelerator_write_mutex: Arc<tokio::sync::Mutex<()>>,
-        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<data_components::cdc::ChangesStream> {
         None
     }

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -18,7 +18,6 @@ use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
     ParameterSpec, Parameters, parameters::aws::initiate_config_with_auth_method,
 };
-use crate::accelerated_table::sink::table::TableSink;
 use crate::component::dataset::Dataset;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::dataaccelerator::spice_sys::OpenOption;
@@ -31,9 +30,6 @@ use data_components::dynamodb::Error;
 use data_components::dynamodb::provider::DynamoDBTableProvider;
 use data_components::dynamodb::stream::StreamError as DynamoDBStreamError;
 use datafusion::datasource::TableProvider;
-use datafusion::logical_expr::dml::InsertOp;
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
 use dynamodb_streams::{Checkpoint, Metrics, MetricsCollector};
 use futures::stream::{self, StreamExt};
@@ -375,9 +371,13 @@ impl DataConnector for DynamoDB {
         &self,
         federated_table: Arc<FederatedTable>,
         dataset: &Dataset,
-        accelerated_table_provider: Arc<dyn TableProvider>,
-        accelerator_write_mutex: Arc<Mutex<()>>,
-        cpu_runtime: Option<tokio::runtime::Handle>,
+        // The DynamoDB connector no longer writes the accelerator directly: it
+        // emits a Truncate + snapshot through the CDC change contract (see
+        // `emit_overwrite_then_live`), so the runtime's accelerator write path
+        // and CPU runtime are unused here.
+        _accelerated_table_provider: Arc<dyn TableProvider>,
+        _accelerator_write_mutex: Arc<Mutex<()>>,
+        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<ChangesStream> {
         let dataset = dataset.clone();
 
@@ -434,9 +434,6 @@ impl DataConnector for DynamoDB {
                         checkpoint,
                         acceptable_lag,
                         dataset_name,
-                        accelerated_table_provider,
-                        accelerator_write_mutex,
-                        cpu_runtime,
                     )
                     .await
                 } else {
@@ -448,10 +445,7 @@ impl DataConnector for DynamoDB {
                         acceptable_lag,
                         dataset_name,
                         lag_exceeds_behavior,
-                        accelerated_table_provider,
-                        accelerator_write_mutex,
                         metrics_collector,
-                        cpu_runtime,
                     ))
                 }
             })
@@ -536,48 +530,79 @@ async fn get_latest_checkpoint(
 
 /// Initializes the accelerator from a full `DynamoDB` table scan, then transitions to
 /// the changes stream from the checkpoint captured before the scan started.
-#[expect(clippy::too_many_arguments)]
 async fn create_bootstrap_stream(
     dynamodb: Arc<DynamoDBTableProvider>,
     dynamodb_sys: Arc<Option<DynamoDBSys>>,
     checkpoint: Checkpoint,
     acceptable_lag: Duration,
     dataset_name: TableReference,
-    accelerated_table_provider: Arc<dyn TableProvider>,
-    accelerator_write_mutex: Arc<Mutex<()>>,
-    cpu_runtime: Option<tokio::runtime::Handle>,
 ) -> Option<ChangesStream> {
     tracing::info!(
         dataset = %dataset_name,
-        "No existing lag found for DynamoDB Streams table, starting initialization"
+        ready_lag = %humantime::format_duration(acceptable_lag),
+        "No existing checkpoint found for DynamoDB Streams table, starting initialization. Table will be marked as Ready once lag threshold is reached"
     );
 
-    if !scan_and_overwrite_accelerator(
-        &dynamodb,
-        accelerated_table_provider,
-        accelerator_write_mutex,
-        cpu_runtime,
-        &dataset_name,
+    emit_overwrite_then_live(
+        dynamodb,
+        dynamodb_sys,
+        checkpoint,
+        acceptable_lag,
+        dataset_name,
     )
     .await
-    {
-        return None;
-    }
+}
 
-    tracing::info!(
-        dataset = %dataset_name,
-        ready_lag = %humantime::format_duration(acceptable_lag),
-        "DynamoDB Streams table initialization complete, starting to process changes from the Stream. Table will be marked as Ready once lag threshold is reached"
+/// Emits a full-overwrite bootstrap through the CDC change contract, then
+/// transitions to the live changes stream from `checkpoint`.
+///
+/// The stream is: a `Truncate` barrier + the table scan as `op="c"` inserts
+/// ([`DynamoDBTableProvider::overwrite_bootstrap_stream`]), then a zero-row
+/// envelope whose committer persists `checkpoint` (the position captured
+/// *before* the scan) once the snapshot is durably applied, then the live
+/// changes from `checkpoint`. Committing on the post-snapshot envelope — not up
+/// front — means a crash mid-bootstrap leaves no checkpoint, so the next start
+/// re-bootstraps from scratch (the same at-least-once contract as the
+/// `MySQL`/Postgres snapshots). This replaces the old direct `TableSink` overwrite,
+/// so the connector needs no runtime accelerator-write internals. Readiness
+/// continues to be driven by the live stream's watermark, preserving prior
+/// behavior.
+async fn emit_overwrite_then_live(
+    dynamodb: Arc<DynamoDBTableProvider>,
+    dynamodb_sys: Arc<Option<DynamoDBSys>>,
+    checkpoint: Checkpoint,
+    acceptable_lag: Duration,
+    dataset_name: TableReference,
+) -> Option<ChangesStream> {
+    let table_schema = dynamodb.schema();
+
+    let snapshot = match Arc::clone(&dynamodb).overwrite_bootstrap_stream().await {
+        Ok(stream) => stream
+            .map(|res| res.map(|batch| ChangeEnvelope::new(Box::new(NoOpCommitter), batch, false))),
+        Err(e) => {
+            tracing::error!(
+                dataset = %dataset_name,
+                error = %e,
+                "Failed to start DynamoDB overwrite bootstrap stream"
+            );
+            return None;
+        }
+    };
+
+    // Zero-row barrier carrying the pre-scan checkpoint. Its committer runs only
+    // after the truncate + snapshot are durably applied (the `CommitChange`
+    // ordering contract), mirroring the MySQL bootstrap's `InitialPositionCommitter`.
+    let checkpoint_batch = empty_change_batch(&table_schema)?;
+    let checkpoint_envelope = ChangeEnvelope::from_parts(
+        Box::new(DynamoDBStreamCommitter::new(
+            Arc::clone(&dynamodb_sys),
+            checkpoint.clone(),
+        )),
+        checkpoint_batch,
+        false, // readiness comes from the live stream, preserving prior behavior
     );
 
-    // Commit the checkpoint that was captured before the scan started.
-    let committer = DynamoDBStreamCommitter::new(Arc::clone(&dynamodb_sys), checkpoint.clone());
-    if let Err(e) = committer.commit().await {
-        tracing::error!(error = ?e, "Failed to commit initialization checkpoint");
-    }
-
-    // Transition to the changes stream from the pre-scan checkpoint.
-    match changes_stream_from_checkpoint(
+    let live = match changes_stream_from_checkpoint(
         dynamodb,
         dynamodb_sys,
         checkpoint,
@@ -586,16 +611,23 @@ async fn create_bootstrap_stream(
     )
     .await
     {
-        Ok(stream) => Some(stream),
+        Ok(stream) => stream,
         Err(e) => {
             tracing::error!(
                 dataset = %dataset_name,
                 error = %e,
-                "Failed to start changes stream after initialization"
+                "Failed to start DynamoDB changes stream after initialization"
             );
-            None
+            return None;
         }
-    }
+    };
+
+    Some(
+        snapshot
+            .chain(stream::once(async move { Ok(checkpoint_envelope) }))
+            .chain(live)
+            .boxed(),
+    )
 }
 
 /// Resumes streaming from an existing checkpoint, handling shard expiration scenarios.
@@ -608,10 +640,7 @@ fn resume_from_checkpoint_stream(
     acceptable_lag: Duration,
     dataset_name: TableReference,
     lag_exceeds_behavior: LagExceedsShardRetentionBehavior,
-    accelerated_table_provider: Arc<dyn TableProvider>,
-    accelerator_write_mutex: Arc<Mutex<()>>,
     metrics_collector: Arc<MetricsCollector>,
-    cpu_runtime: Option<tokio::runtime::Handle>,
 ) -> ChangesStream {
     stream::once(async move {
             match changes_stream_from_checkpoint(
@@ -690,11 +719,8 @@ fn resume_from_checkpoint_stream(
                             &dynamodb_sys,
                             acceptable_lag,
                             &dataset_name,
-                            accelerated_table_provider,
-                            accelerator_write_mutex,
                             lag_exceeds_behavior,
                             metrics_collector,
-                            cpu_runtime,
                         )
                         .await
                     }
@@ -728,11 +754,8 @@ fn resume_from_checkpoint_stream(
                             &dynamodb_sys,
                             acceptable_lag,
                             &dataset_name,
-                            accelerated_table_provider,
-                            accelerator_write_mutex,
                             lag_exceeds_behavior,
                             metrics_collector,
-                            cpu_runtime,
                         )
                         .await
                     }
@@ -795,17 +818,13 @@ async fn changes_stream_from_checkpoint(
         .boxed())
 }
 
-#[expect(clippy::too_many_arguments)]
 async fn rebootstrap_table(
     dynamodb: &Arc<DynamoDBTableProvider>,
     dynamodb_sys: &Arc<Option<DynamoDBSys>>,
     acceptable_lag: Duration,
     dataset_name: &TableReference,
-    accelerated_table_provider: Arc<dyn TableProvider>,
-    accelerator_write_mutex: Arc<Mutex<()>>,
     behavior: LagExceedsShardRetentionBehavior,
     metrics_collector: Arc<MetricsCollector>,
-    cpu_runtime: Option<tokio::runtime::Handle>,
 ) -> Option<ChangesStream> {
     tracing::debug!(
         dataset = %dataset_name,
@@ -840,10 +859,7 @@ async fn rebootstrap_table(
                             &dynamodb_sys,
                             acceptable_lag,
                             &dataset_name,
-                            accelerated_table_provider,
-                            accelerator_write_mutex,
                             metrics_collector,
-                            cpu_runtime,
                         )
                         .await
                     })
@@ -860,34 +876,31 @@ async fn rebootstrap_table(
         dynamodb_sys,
         acceptable_lag,
         dataset_name,
-        accelerated_table_provider,
-        accelerator_write_mutex,
         metrics_collector,
-        cpu_runtime,
     )
     .await
 }
 
-/// Performs the actual re-bootstrap: scans `DynamoDB`, writes to accelerator, commits checkpoint.
-#[expect(clippy::too_many_arguments)]
+/// Performs the actual re-bootstrap: captures a fresh checkpoint, then emits a
+/// `Truncate` + full-scan snapshot through the CDC change contract, committing the
+/// new checkpoint once the snapshot is durably applied (see
+/// [`emit_overwrite_then_live`]).
 async fn do_rebootstrap(
     dynamodb: &Arc<DynamoDBTableProvider>,
     dynamodb_sys: &Arc<Option<DynamoDBSys>>,
     acceptable_lag: Duration,
     dataset_name: &TableReference,
-    accelerated_table_provider: Arc<dyn TableProvider>,
-    accelerator_write_mutex: Arc<Mutex<()>>,
     metrics_collector: Arc<MetricsCollector>,
-    cpu_runtime: Option<tokio::runtime::Handle>,
 ) -> Option<ChangesStream> {
-    // 1. Get new global checkpoint FIRST (before re-bootstrap starts)
+    // Capture a new global checkpoint FIRST (before the scan) so live changes
+    // since the scan are re-delivered by the resumed stream, not missed.
     let new_checkpoint = match dynamodb.latest_global_checkpoint().await {
         Ok(cp) => cp,
         Err(e) => {
             tracing::error!(
                 dataset = %dataset_name,
                 error = ?e,
-                "Failed to get new lag for re-initialization"
+                "Failed to get new checkpoint for re-initialization"
             );
             return None;
         }
@@ -896,225 +909,43 @@ async fn do_rebootstrap(
     tracing::debug!(
         dataset = %dataset_name,
         shards = new_checkpoint.shards.len(),
-        "Got new lag for re-initialization of DynamoDB table"
+        "Got new checkpoint for re-initialization of DynamoDB table"
     );
 
-    // 2. Scan DynamoDB and write to accelerator.
-    if !scan_and_overwrite_accelerator(
-        dynamodb,
-        accelerated_table_provider,
-        accelerator_write_mutex,
-        cpu_runtime,
-        dataset_name,
-    )
-    .await
-    {
-        return None;
-    }
-
-    // 4. Commit the checkpoint
-    let committer = DynamoDBStreamCommitter::new(Arc::clone(dynamodb_sys), new_checkpoint.clone());
-    if let Err(e) = committer.commit().await {
-        tracing::error!(
-            dataset = %dataset_name,
-            error = ?e,
-            "Failed to commit lag after re-initialization"
-        );
-        return None;
-    }
-
-    tracing::info!(
-        dataset = %dataset_name,
-        "Re-initialization complete for DynamoDB table, continuing with changes stream"
-    );
-
-    // Increment rebootstrap counter
-    metrics_collector
-        .rebootstraps
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-    // 5. Return changes stream from the checkpoint
-    match changes_stream_from_checkpoint(
+    let stream = emit_overwrite_then_live(
         Arc::clone(dynamodb),
         Arc::clone(dynamodb_sys),
         new_checkpoint,
         acceptable_lag,
         dataset_name.clone(),
     )
-    .await
-    {
-        Ok(stream) => Some(stream),
-        Err(e) => {
-            tracing::error!(
-                dataset = %dataset_name,
-                error = %e,
-                "Failed to get changes stream after re-initialization"
-            );
-            None
-        }
-    }
+    .await?;
+
+    // Count the rebootstrap once its stream is successfully set up.
+    metrics_collector
+        .rebootstraps
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    tracing::info!(
+        dataset = %dataset_name,
+        "Re-initialization stream started for DynamoDB table"
+    );
+
+    Some(stream)
 }
 
-/// Scans the full `DynamoDB` table and writes all rows into the accelerator, replacing any existing
-/// data. The scan runs on `cpu_runtime` when available — mirroring full refresh — so the scan can
-/// pre-fill the channel buffer on the dedicated runtime while the write proceeds on the main
-/// runtime. Returns `true` on success; errors are logged internally.
-async fn scan_and_overwrite_accelerator(
-    dynamodb: &Arc<DynamoDBTableProvider>,
-    accelerated_table_provider: Arc<dyn TableProvider>,
-    accelerator_write_mutex: Arc<Mutex<()>>,
-    cpu_runtime: Option<tokio::runtime::Handle>,
-    dataset_name: &TableReference,
-) -> bool {
-    use crate::datafusion::managed_runtime;
-    use runtime_request_context::{AsyncMarker, RequestContext};
-
-    let data_stream = if let Some(cpu_runtime) = cpu_runtime {
-        let request_context = RequestContext::current(AsyncMarker::new().await);
-        let span = tracing::Span::current();
-        let dynamodb_for_scan = Arc::clone(dynamodb);
-        let dataset_name_for_scan = dataset_name.clone();
-
-        match managed_runtime::run_record_batch_stream_on_runtime(
-            cpu_runtime,
-            request_context,
-            span,
-            async move {
-                let ctx = SessionContext::new();
-                let df = ctx
-                    .read_table(Arc::clone(&dynamodb_for_scan) as Arc<dyn TableProvider>)
-                    .map_err(|e| {
-                        tracing::error!(
-                            dataset = %dataset_name_for_scan,
-                            error = ?e,
-                            "Failed to create DataFrame for scan"
-                        );
-                        e
-                    })?;
-                let stream = df.execute_stream().await.map_err(|e| {
-                    tracing::error!(
-                        dataset = %dataset_name_for_scan,
-                        error = ?e,
-                        "Failed to execute scan stream"
-                    );
-                    e
-                })?;
-                Ok::<_, datafusion::error::DataFusionError>(((), stream))
-            },
-        )
-        .await
-        {
-            Ok(managed) => {
-                let ((), stream) = managed.into_parts();
-                stream
-            }
-            Err(e) => {
-                tracing::error!(
-                    dataset = %dataset_name,
-                    error = ?e,
-                    "Failed to start scan on CPU runtime"
-                );
-                return false;
-            }
-        }
-    } else {
-        let ctx = SessionContext::new();
-        let df = match ctx.read_table(Arc::clone(dynamodb) as Arc<dyn TableProvider>) {
-            Ok(df) => df,
-            Err(e) => {
-                tracing::error!(
-                    dataset = %dataset_name,
-                    error = ?e,
-                    "Failed to create DataFrame for scan"
-                );
-                return false;
-            }
-        };
-        match df.execute_stream().await {
-            Ok(stream) => stream,
-            Err(e) => {
-                tracing::error!(
-                    dataset = %dataset_name,
-                    error = ?e,
-                    "Failed to execute scan stream"
-                );
-                return false;
-            }
-        }
-    };
-
-    let instrumented_stream = with_progress_logging(data_stream, dataset_name.clone());
-    let table_sink = TableSink::new(accelerated_table_provider);
-    let _guard = accelerator_write_mutex.lock().await;
-    if let Err(e) = table_sink
-        .insert_into(instrumented_stream, InsertOp::Overwrite)
-        .await
-    {
-        tracing::error!(
-            dataset = %dataset_name,
-            error = ?e,
-            "Failed to write scan data to accelerator"
-        );
-        return false;
-    }
-    true
-}
-
-/// Wraps `data_stream` to log ingestion progress every 10 seconds in the same format as full
-/// refresh (`DataLoadTracing`): `Dataset X received N records (Y uncompressed) in Zs, W/s`.
-fn with_progress_logging(
-    data_stream: datafusion::physical_plan::SendableRecordBatchStream,
-    dataset_name: TableReference,
-) -> datafusion::physical_plan::SendableRecordBatchStream {
-    let schema = data_stream.schema();
-    let mut num_records: usize = 0;
-    let mut bytes_received: usize = 0;
-    let start_time = std::time::Instant::now();
-    let mut last_log_time = start_time;
-    let log_interval = std::time::Duration::from_secs(10);
-
-    Box::pin(RecordBatchStreamAdapter::new(
-        schema,
-        data_stream.map(move |batch_result| {
-            batch_result.inspect(|batch| {
-                num_records += batch.num_rows();
-                bytes_received += batch.get_array_memory_size();
-                if last_log_time.elapsed() > log_interval {
-                    let pretty_records = util::pretty_print_number(num_records);
-                    let elapsed = start_time.elapsed();
-                    let elapsed_secs = elapsed.as_secs_f64();
-                    #[expect(clippy::cast_precision_loss)]
-                    #[expect(clippy::cast_possible_truncation)]
-                    #[expect(clippy::cast_sign_loss)]
-                    let throughput = if elapsed_secs > 0.0 {
-                        let bytes_per_sec = (bytes_received as f64 / elapsed_secs) as usize;
-                        format!("{}/s", util::human_readable_bytes(bytes_per_sec))
-                    } else {
-                        "calculating...".to_string()
-                    };
-                    let size = util::human_readable_bytes(bytes_received);
-                    let elapsed_str = format!("{}s", elapsed.as_secs());
-                    tracing::info!(
-                        "Dataset {} received {pretty_records} records ({size} uncompressed) in {elapsed_str}, {throughput}",
-                        dataset_name
-                    );
-                    last_log_time = std::time::Instant::now();
-                }
-            })
-        }),
-    ))
-}
-
-/// Creates an empty `ChangeEnvelope` with `dataset_is_ready = true` to signal ready state.
-fn create_empty_ready_envelope(
+/// Builds a zero-row [`ChangeBatch`] in the connector's `changes_schema`.
+///
+/// Used both for the ready-signal envelope and the post-snapshot checkpoint
+/// barrier (see [`emit_overwrite_then_live`]). Matches the original schema
+/// `DynamoDB` uses for its `op="c"`/`op="t"` batches so it coalesces with them.
+fn empty_change_batch(
     table_schema: &arrow::datatypes::SchemaRef,
-) -> Option<ChangeEnvelope> {
+) -> Option<data_components::cdc::ChangeBatch> {
     use arrow::record_batch::RecordBatch;
     use data_components::cdc::{ChangeBatch, changes_schema};
 
-    // Use the canonical changes_schema function to get the correct schema
-    let schema = changes_schema(table_schema.as_ref());
-    let schema_ref = Arc::new(schema);
+    let schema_ref = Arc::new(changes_schema(table_schema.as_ref()));
 
     // Create empty arrays that match the schema exactly
     let empty_arrays: Vec<arrow::array::ArrayRef> = schema_ref
@@ -1125,7 +956,14 @@ fn create_empty_ready_envelope(
 
     let record_batch = RecordBatch::try_new(schema_ref, empty_arrays).ok()?;
 
-    let change_batch = ChangeBatch::try_new(record_batch).ok()?;
+    ChangeBatch::try_new(record_batch).ok()
+}
+
+/// Creates an empty `ChangeEnvelope` with `dataset_is_ready = true` to signal ready state.
+fn create_empty_ready_envelope(
+    table_schema: &arrow::datatypes::SchemaRef,
+) -> Option<ChangeEnvelope> {
+    let change_batch = empty_change_batch(table_schema)?;
 
     Some(ChangeEnvelope::new(
         Box::new(NoOpCommitter),

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -26,7 +26,7 @@ use crate::dataaccelerator::spice_sys::dynamodb::{DynamoDBCheckpointMetadata, Dy
 use crate::dataconnector::schema_projection::{ProjectionPolicy, parse_schema_projection};
 use crate::federated_table::FederatedTable;
 use async_trait::async_trait;
-use data_components::cdc::{ChangeEnvelope, ChangesStream, CommitChange, CommitError, StreamError};
+use data_components::cdc::{ChangeEnvelope, ChangesStream, CommitChange, CommitError};
 use data_components::dynamodb::Error;
 use data_components::dynamodb::provider::DynamoDBTableProvider;
 use data_components::dynamodb::stream::StreamError as DynamoDBStreamError;
@@ -650,11 +650,10 @@ fn resume_from_checkpoint_stream(
                         );
                         return Some(
                             stream::once(async move {
-                                Err(StreamError::DynamoDB(
-                                    DynamoDBStreamError::FailedToReceiveMessage {
-                                        source: dynamodb_streams::Error::ShardNotFound,
-                                    },
-                                ))
+                                Err(DynamoDBStreamError::FailedToReceiveMessage {
+                                    source: dynamodb_streams::Error::ShardNotFound,
+                                }
+                                .into())
                             })
                             .boxed(),
                         );
@@ -670,11 +669,10 @@ fn resume_from_checkpoint_stream(
                         );
                         Some(
                             stream::once(async move {
-                                Err(StreamError::DynamoDB(
-                                    DynamoDBStreamError::FailedToReceiveMessage {
-                                        source: dynamodb_streams::Error::ShardNotFound,
-                                    },
-                                ))
+                                Err(DynamoDBStreamError::FailedToReceiveMessage {
+                                    source: dynamodb_streams::Error::ShardNotFound,
+                                }
+                                .into())
                             })
                             .boxed(),
                         )
@@ -711,11 +709,10 @@ fn resume_from_checkpoint_stream(
                         );
                         Some(
                             stream::once(async move {
-                                Err(StreamError::DynamoDB(
-                                    DynamoDBStreamError::FailedToReceiveMessage {
-                                        source: dynamodb_streams::Error::StreamBeyondRetention,
-                                    },
-                                ))
+                                Err(DynamoDBStreamError::StreamBeyondRetention {
+                                    source: dynamodb_streams::Error::StreamBeyondRetention,
+                                }
+                                .into())
                             })
                             .boxed(),
                         )

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -592,7 +592,13 @@ async fn emit_overwrite_then_live(
     // Zero-row barrier carrying the pre-scan checkpoint. Its committer runs only
     // after the truncate + snapshot are durably applied (the `CommitChange`
     // ordering contract), mirroring the MySQL bootstrap's `InitialPositionCommitter`.
-    let checkpoint_batch = empty_change_batch(&table_schema)?;
+    let Some(checkpoint_batch) = empty_change_batch(&table_schema) else {
+        tracing::error!(
+            dataset = %dataset_name,
+            "Failed to build DynamoDB bootstrap checkpoint barrier batch; dataset will not start streaming or commit checkpoints"
+        );
+        return None;
+    };
     let checkpoint_envelope = ChangeEnvelope::from_parts(
         Box::new(DynamoDBStreamCommitter::new(
             Arc::clone(&dynamodb_sys),

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -952,9 +952,18 @@ fn empty_change_batch(
         .map(|f| arrow::array::new_empty_array(f.data_type()))
         .collect();
 
-    let record_batch = RecordBatch::try_new(schema_ref, empty_arrays).ok()?;
+    // Log the concrete Arrow/CDC cause: this batch gates both the readiness signal
+    // and the post-snapshot checkpoint barrier, so a silent failure here is hard to
+    // diagnose. Callers still degrade on `None` (see `emit_overwrite_then_live`).
+    let record_batch = RecordBatch::try_new(schema_ref, empty_arrays)
+        .inspect_err(
+            |e| tracing::error!(error = %e, "Failed to build empty change RecordBatch"),
+        )
+        .ok()?;
 
-    ChangeBatch::try_new(record_batch).ok()
+    ChangeBatch::try_new(record_batch)
+        .inspect_err(|e| tracing::error!(error = %e, "Failed to build empty ChangeBatch"))
+        .ok()
 }
 
 /// Creates an empty `ChangeEnvelope` with `dataset_is_ready = true` to signal ready state.

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -22,7 +22,7 @@ use crate::accelerated_table::sink::table::TableSink;
 use crate::component::dataset::Dataset;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::dataaccelerator::spice_sys::OpenOption;
-use crate::dataaccelerator::spice_sys::dynamodb::{DynamoDBCheckpointMetadata, DynamoDBSys};
+use crate::dataaccelerator::spice_sys::dynamodb::DynamoDBSys;
 use crate::dataconnector::schema_projection::{ProjectionPolicy, parse_schema_projection};
 use crate::federated_table::FederatedTable;
 use async_trait::async_trait;
@@ -39,6 +39,7 @@ use dynamodb_streams::{Checkpoint, Metrics, MetricsCollector};
 use futures::stream::{self, StreamExt};
 use opentelemetry::KeyValue;
 use runtime_api_types::v1::ComponentType;
+use runtime_checkpoint_api::CheckpointStore;
 use runtime_metrics::component::{MetricSpec, MetricType, MetricsProvider, ObserveMetricCallback};
 use runtime_parameters::ExposedParamLookup;
 use snafu::ResultExt;
@@ -482,7 +483,7 @@ async fn load_or_initialize_checkpoint(
 ) -> Option<(bool, Checkpoint, Option<SystemTime>)> {
     if let Some(ref dynamodb_sys) = **dynamodb_sys {
         if let Some(metadata) = dynamodb_sys.get().await {
-            match serde_json::from_str::<Checkpoint>(&metadata.checkpoint_data) {
+            match serde_json::from_str::<Checkpoint>(&metadata.data) {
                 Ok(checkpoint) => Some((false, checkpoint, metadata.updated_at)),
                 Err(err) => {
                     tracing::warn!(
@@ -1243,13 +1244,8 @@ impl CommitChange for DynamoDBStreamCommitter {
             }
         })?;
 
-        let metadata = DynamoDBCheckpointMetadata {
-            checkpoint_data: checkpoint_json,
-            updated_at: None, // Set by the database layer on upsert
-        };
-
         match self.dynamodb_sys.as_ref() {
-            Some(dynamodb_sys) => dynamodb_sys.upsert(&metadata).await.map_err(|e| {
+            Some(dynamodb_sys) => dynamodb_sys.upsert(&checkpoint_json).await.map_err(|e| {
                 CommitError::UnableToCommitChange {
                     source: Box::new(e),
                 }

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -42,7 +42,6 @@ use snafu::ResultExt;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 use std::{any::Any, future::Future, pin::Pin, sync::Arc};
-use tokio::sync::Mutex;
 use util::time_format::is_valid_format;
 
 // If we get `ShardNotFound` or `StreamBeyondRetention` on startup and checkpoint is old enough,
@@ -371,13 +370,6 @@ impl DataConnector for DynamoDB {
         &self,
         federated_table: Arc<FederatedTable>,
         dataset: &Dataset,
-        // The DynamoDB connector no longer writes the accelerator directly: it
-        // emits a Truncate + snapshot through the CDC change contract (see
-        // `emit_overwrite_then_live`), so the runtime's accelerator write path
-        // and CPU runtime are unused here.
-        _accelerated_table_provider: Arc<dyn TableProvider>,
-        _accelerator_write_mutex: Arc<Mutex<()>>,
-        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<ChangesStream> {
         let dataset = dataset.clone();
 

--- a/crates/runtime/src/dataconnector/dynamodb.rs
+++ b/crates/runtime/src/dataconnector/dynamodb.rs
@@ -956,9 +956,7 @@ fn empty_change_batch(
     // and the post-snapshot checkpoint barrier, so a silent failure here is hard to
     // diagnose. Callers still degrade on `None` (see `emit_overwrite_then_live`).
     let record_batch = RecordBatch::try_new(schema_ref, empty_arrays)
-        .inspect_err(
-            |e| tracing::error!(error = %e, "Failed to build empty change RecordBatch"),
-        )
+        .inspect_err(|e| tracing::error!(error = %e, "Failed to build empty change RecordBatch"))
         .ok()?;
 
     ChangeBatch::try_new(record_batch)

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -623,9 +623,6 @@ pub trait DataConnector: Debug + Send + Sync + 'static {
         &self,
         _federated_table: Arc<FederatedTable>,
         _dataset: &Dataset,
-        _accelerated_table_provider: Arc<dyn TableProvider>,
-        _accelerator_write_mutex: Arc<Mutex<()>>,
-        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<ChangesStream> {
         None
     }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -570,9 +570,6 @@ impl DataConnector for SpiceAI {
         &self,
         federated_table: Arc<FederatedTable>,
         _dataset: &Dataset,
-        _accelerated_table_provider: Arc<dyn TableProvider>,
-        _accelerator_write_mutex: Arc<tokio::sync::Mutex<()>>,
-        _cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<ChangesStream> {
         self.append_stream(federated_table)
     }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2889,8 +2889,7 @@ impl DataFusion {
                 },
             );
 
-            let changes_stream =
-                source.changes_stream(Arc::clone(&source_table_provider), dataset);
+            let changes_stream = source.changes_stream(Arc::clone(&source_table_provider), dataset);
 
             if let Some(changes_stream) = changes_stream {
                 accelerated_table_builder.changes_stream(changes_stream);

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -2889,13 +2889,8 @@ impl DataFusion {
                 },
             );
 
-            let changes_stream = source.changes_stream(
-                Arc::clone(&source_table_provider),
-                dataset,
-                Arc::clone(&accelerated_table_provider),
-                Arc::clone(&accelerator_write_mutex),
-                self.refresh_runtime().cloned(),
-            );
+            let changes_stream =
+                source.changes_stream(Arc::clone(&source_table_provider), dataset);
 
             if let Some(changes_stream) = changes_stream {
                 accelerated_table_builder.changes_stream(changes_stream);

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -343,7 +343,9 @@ impl DataConnector for EmbeddingConnector {
             let Some(underlying_federated_table) =
                 underlying_federated_table_for_indexed_table(&table_provider)
             else {
-                return self.inner_connector.changes_stream(federated_table, dataset);
+                return self
+                    .inner_connector
+                    .changes_stream(federated_table, dataset);
             };
 
             // Avoid reindexing full-text indexes.

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -47,7 +47,7 @@ use spicepod::semantic::ColumnLevelEmbeddingConfig;
 use spicepod::vector::VectorStore;
 use std::any::Any;
 use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 
 use runtime_search::embeddings::table::EmbeddingTable;
 
@@ -334,9 +334,6 @@ impl DataConnector for EmbeddingConnector {
         &self,
         federated_table: Arc<FederatedTable>,
         dataset: &Dataset,
-        accelerated_table_provider: Arc<dyn TableProvider>,
-        accelerator_write_mutex: Arc<Mutex<()>>,
-        cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<ChangesStream> {
         let table_provider = federated_table.try_table_provider_sync()?;
         if let Some(indexed_table) = table_provider
@@ -346,13 +343,7 @@ impl DataConnector for EmbeddingConnector {
             let Some(underlying_federated_table) =
                 underlying_federated_table_for_indexed_table(&table_provider)
             else {
-                return self.inner_connector.changes_stream(
-                    federated_table,
-                    dataset,
-                    accelerated_table_provider,
-                    accelerator_write_mutex,
-                    cpu_runtime,
-                );
+                return self.inner_connector.changes_stream(federated_table, dataset);
             };
 
             // Avoid reindexing full-text indexes.
@@ -370,13 +361,7 @@ impl DataConnector for EmbeddingConnector {
 
             let stream = self
                 .inner_connector
-                .changes_stream(
-                    underlying_federated_table,
-                    dataset,
-                    accelerated_table_provider,
-                    accelerator_write_mutex,
-                    cpu_runtime,
-                )?
+                .changes_stream(underlying_federated_table, dataset)?
                 .then(move |item| index_change_envelope(item, Arc::clone(&indexes)))
                 .boxed();
 
@@ -389,9 +374,6 @@ impl DataConnector for EmbeddingConnector {
                     &vector_scan.table_provider,
                 ))),
                 dataset,
-                accelerated_table_provider,
-                accelerator_write_mutex,
-                cpu_runtime,
             )
         } else if let Some(embedding_table) = table_provider.downcast_ref::<EmbeddingTable>() {
             let embedding_table = Arc::new(embedding_table.clone());
@@ -400,13 +382,7 @@ impl DataConnector for EmbeddingConnector {
 
             Some(
                 self.inner_connector
-                    .changes_stream(
-                        underlying_federated_table,
-                        dataset,
-                        accelerated_table_provider,
-                        accelerator_write_mutex,
-                        cpu_runtime,
-                    )?
+                    .changes_stream(underlying_federated_table, dataset)?
                     .then(move |item| {
                         Self::embed_change_envelope(item, Arc::clone(&embedding_table))
                     })

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -174,7 +174,9 @@ impl DataConnector for FullTextConnector {
         federated_table: Arc<FederatedTable>,
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
-        self.with_indexed_stream(federated_table, |inner, ft| inner.changes_stream(ft, dataset))
+        self.with_indexed_stream(federated_table, |inner, ft| {
+            inner.changes_stream(ft, dataset)
+        })
     }
 
     fn supports_append_stream(&self) -> bool {

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -32,7 +32,6 @@ use crate::search::full_text::table::add_full_text_search_to_table;
 use crate::search::util::find_concrete_table_provider;
 use futures::StreamExt;
 use runtime_metrics::component::MetricsProvider;
-use tokio::sync::Mutex;
 
 /// A [`DataConnector`] middleware that, for [`Dataset`]s needing full text search capabilies, creates a [`IndexedTableProvider`] using the underlying [`TableProvider`]s and a [`FullTextDatabaseIndex`]. If no full text search capabilities are needed it is not unnecessarily nested.
 #[derive(Debug)]
@@ -174,19 +173,8 @@ impl DataConnector for FullTextConnector {
         &self,
         federated_table: Arc<FederatedTable>,
         dataset: &Dataset,
-        accelerated_table_provider: Arc<dyn TableProvider>,
-        accelerator_write_mutex: Arc<Mutex<()>>,
-        cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<ChangesStream> {
-        self.with_indexed_stream(federated_table, |inner, ft| {
-            inner.changes_stream(
-                ft,
-                dataset,
-                Arc::clone(&accelerated_table_provider),
-                Arc::clone(&accelerator_write_mutex),
-                cpu_runtime.clone(),
-            )
-        })
+        self.with_indexed_stream(federated_table, |inner, ft| inner.changes_stream(ft, dataset))
     }
 
     fn supports_append_stream(&self) -> bool {

--- a/crates/runtime/src/search/full_text/elasticsearch.rs
+++ b/crates/runtime/src/search/full_text/elasticsearch.rs
@@ -27,7 +27,7 @@ use datafusion::datasource::TableProvider;
 use futures::StreamExt;
 use runtime_datafusion_index::IndexedTableProvider;
 use secrecy::ExposeSecret;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 
 use crate::accelerated_table::{self, AcceleratedTable};
 use crate::changes::{Indexes, index_change_envelope};

--- a/crates/runtime/src/search/full_text/elasticsearch.rs
+++ b/crates/runtime/src/search/full_text/elasticsearch.rs
@@ -265,18 +265,9 @@ impl DataConnector for ElasticsearchFullTextConnector {
         &self,
         federated_table: Arc<FederatedTable>,
         dataset: &Dataset,
-        accelerated_table_provider: Arc<dyn TableProvider>,
-        accelerator_write_mutex: Arc<Mutex<()>>,
-        cpu_runtime: Option<tokio::runtime::Handle>,
     ) -> Option<ChangesStream> {
         self.with_indexed_stream(federated_table, |inner, table| {
-            inner.changes_stream(
-                table,
-                dataset,
-                Arc::clone(&accelerated_table_provider),
-                Arc::clone(&accelerator_write_mutex),
-                cpu_runtime.clone(),
-            )
+            inner.changes_stream(table, dataset)
         })
     }
 

--- a/layers.toml
+++ b/layers.toml
@@ -108,6 +108,9 @@ otel-arrow = "foundation"
 repl = "foundation"
 runtime-api-types = "foundation"
 runtime-async = "foundation"
+# Interface crate: the accelerator (runtime side) satisfies CheckpointStore; a
+# connector only calls it, so it lives low (foundation) below both.
+runtime-checkpoint-api = "foundation"
 runtime-cloud-connect = "foundation"
 runtime-datafusion-index = "foundation"
 runtime-metrics = "foundation"


### PR DESCRIPTION
## What

Three behavior-preserving refactors that sever the `runtime` ↔ DynamoDB coupling seams, so the DynamoDB connector can be lifted out of `runtime`/`data_components` into its own `connector-dynamodb` crate in a follow-up PR. **This PR moves no code out of `runtime` yet** — it just cuts the seams that currently pin DynamoDB inside it.

## Commits

1. **cdc `StreamError` connector-agnostic** — replace the DynamoDB-named `cdc::StreamError::DynamoDB(..)` variant with a generic `Connector(Box<dyn Error>)`; the connector owns the mapping via `From<dynamodb::stream::StreamError>`. Removes a DynamoDB type name from the runtime change-apply path.

2. **Extract `runtime-checkpoint-api`** — a foundation crate with the `CheckpointStore` trait + `CheckpointRecord`. `DynamoDBSys` now implements it; the sidecar table format is byte-identical (no migration). Lets the connector serialize its checkpoint through a generic store instead of a runtime-internal type.

3. **DynamoDB rebootstrap via CDC Truncate+snapshot** *(the correctness-sensitive one — please review closely)* — DynamoDB was the only connector that wrote the accelerator **directly** (`TableSink` + `managed_runtime` under the write mutex) during shard-expiry re-bootstrap. It now emits a `Truncate` barrier + full-scan snapshot as `op="c"` inserts through the normal changes stream, committing the pre-scan checkpoint on a zero-row envelope **after** the snapshot is durably applied — the same pattern MySQL replication already uses (`InitialPositionCommitter`). This removes the last runtime-orchestration coupling, so the connector can move out with no residual `TableSink`/`managed_runtime` dependency.

## Why

Prep for extracting DynamoDB into a standalone `connector-dynamodb` crate (which deletes the `runtime/dynamodb` + `data_components/dynamodb` features and evicts the AWS SDK drivers from both closures). That move is mechanical once these seams are cut; splitting it out keeps the correctness-sensitive rebootstrap change reviewable on its own.

## Testing

- Unit tests for the truncate change batch (`op="t"` shape + schema coalesces with the insert path so the apply loop can concat them).
- The zero-row-committer / commit-after-durable ordering the checkpoint relies on was verified against the change-apply loop.
- The DynamoDB docker integration suite (`dynamodb_rebootstrap_removes_rows_deleted_from_source`, etc.) is the end-to-end overwrite guard and runs in CI.
