### PR TITLE
ci(e2e): strip ANSI before duckdb_append graceful-shutdown log whitelist

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -2025,7 +2025,12 @@ jobs:
           # first: "TProtocolException: Invalid data" (corrupt Thrift footer)
           # or "don't know what type:" with an empty type (schema element not
           # yet written). Tolerate both variants of that specific transient.
-          if grep -iE "(failed|error)" spice.log \
+          #
+          # Strip ANSI first: spiced logs with_ansi(true), so whitelist
+          # patterns like `WARN +runtime::...` miss `WARN\e[0m \e[2mruntime::...`
+          # and the same transient fails the job (see run 29659183104).
+          if sed $'s/\x1b\\[[0-9;]*m//g' spice.log \
+             | grep -iE "(failed|error)" \
              | grep -vE "WARN +runtime::accelerated_table::refresh_task: Failed to load data for dataset" \
              | grep -vE "^Invalid Error: TProtocolException: Invalid data$" \
              | grep -vE "^Invalid Error: don't know what type: *$"; then
@@ -2062,10 +2067,12 @@ jobs:
         run: |
           killall spice || true
           cat spice.log
-          # See note above: tolerate transient parquet-rename races emitted
-          # at WARN level by the refresh task (both the "TProtocolException:
-          # Invalid data" and empty-type "don't know what type:" variants).
-          if grep -iE "(failed|error)" spice.log \
+          # See note above: strip ANSI, then tolerate transient parquet-rename
+          # races emitted at WARN level by the refresh task (both the
+          # "TProtocolException: Invalid data" and empty-type "don't know what
+          # type:" variants).
+          if sed $'s/\x1b\\[[0-9;]*m//g' spice.log \
+             | grep -iE "(failed|error)" \
              | grep -vE "WARN +runtime::accelerated_table::refresh_task: Failed to load data for dataset" \
              | grep -vE "^Invalid Error: TProtocolException: Invalid data$" \
              | grep -vE "^Invalid Error: don't know what type: *$"; then


### PR DESCRIPTION
## Summary
- The `duckdb_append_with_pk.yaml` graceful-shutdown job intermittently fails Check logs on the already-tolerated parquet-rename race (`TProtocolException` / empty-type), because `spiced` logs with ANSI colors and the `WARN +runtime::...` whitelist never matches.
- Strip ANSI escape codes before the grep pipeline in both `graceful_shutdown_test_append` Check logs steps so the existing whitelist works.
- Reproduced from https://github.com/spiceai/spiceai/actions/runs/29659183104/job/88125237320 (same transient class as #11636).

## Test plan
- [x] Synthetic `spice.log` with ANSI-colored WARN + `TProtocolException`: old pipeline fails, new pipeline passes
- [x] Same log plus a genuine `ERROR` line: new pipeline still fails
- [x] Workflow YAML parses
- [ ] CI: `duckdb_append_with_pk.yaml acceleration and graceful shutdown on Linux x64` (and sibling append spicepods) green