### PR TITLE
chore(cluster): pin Ballista to upstream 54 merge tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.1",
  "http-body 1.0.1",
- "lru",
+ "lru 0.16.4",
  "percent-encoding",
  "regex-lite",
  "sha2 0.11.0",
@@ -2396,8 +2396,8 @@ dependencies = [
 
 [[package]]
 name = "ballista-core"
-version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f#ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f"
+version = "54.0.0"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f754fed271d19e1ac7c30182a5cf0eb0b3844586#f754fed271d19e1ac7c30182a5cf0eb0b3844586"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2411,7 +2411,7 @@ dependencies = [
  "datafusion-proto",
  "datafusion-proto-common",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "md-5 0.10.6",
  "object_store 0.13.2",
@@ -2433,8 +2433,8 @@ dependencies = [
 
 [[package]]
 name = "ballista-executor"
-version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f#ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f"
+version = "54.0.0"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f754fed271d19e1ac7c30182a5cf0eb0b3844586#f754fed271d19e1ac7c30182a5cf0eb0b3844586"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2442,6 +2442,7 @@ dependencies = [
  "backoff",
  "ballista-core",
  "bytes",
+ "bytesize",
  "clap",
  "dashmap",
  "datafusion",
@@ -2449,8 +2450,12 @@ dependencies = [
  "futures",
  "libc",
  "log",
+ "lru 0.18.1",
+ "memory-stats",
  "mimalloc",
  "parking_lot",
+ "serde",
+ "sysinfo 0.38.4",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2464,8 +2469,8 @@ dependencies = [
 
 [[package]]
 name = "ballista-scheduler"
-version = "52.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f#ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f"
+version = "54.0.0"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f754fed271d19e1ac7c30182a5cf0eb0b3844586#f754fed271d19e1ac7c30182a5cf0eb0b3844586"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2475,10 +2480,10 @@ dependencies = [
  "dashmap",
  "datafusion",
  "datafusion-proto",
- "datafusion-substrait",
  "futures",
  "http 1.4.1",
  "insta",
+ "itertools 0.15.0",
  "log",
  "object_store 0.13.2",
  "parking_lot",
@@ -2489,8 +2494,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-prost",
- "tonic-prost-build",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -3196,6 +3200,12 @@ dependencies = [
  "bytes",
  "either",
 ]
+
+[[package]]
+name = "bytesize"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "bzip2"
@@ -4029,7 +4039,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8572,8 +8582,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -9677,7 +9687,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9712,7 +9722,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -11297,6 +11307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11632,6 +11651,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12212,7 +12241,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lru",
+ "lru 0.16.4",
  "mysql_common",
  "native-tls",
  "pem",
@@ -13129,7 +13158,7 @@ dependencies = [
  "snafu",
  "tokio",
  "tower 0.5.3",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
  "url",
  "web-time",
@@ -14290,7 +14319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.5.0",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -14756,8 +14785,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -14778,7 +14807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15106,7 +15135,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15144,7 +15173,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -15959,7 +15988,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -16009,7 +16038,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -16514,7 +16543,7 @@ dependencies = [
  "tonic-health",
  "tools",
  "tower 0.5.3",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
@@ -17872,7 +17901,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -18433,7 +18462,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -19552,7 +19581,7 @@ dependencies = [
  "itertools 0.14.0",
  "levenshtein_automata",
  "log",
- "lru",
+ "lru 0.16.4",
  "lz4_flex 0.13.1",
  "measure_time",
  "memmap2",
@@ -20772,6 +20801,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "http 1.4.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -23081,7 +23125,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "ballista-core"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f754fed271d19e1ac7c30182a5cf0eb0b3844586#f754fed271d19e1ac7c30182a5cf0eb0b3844586"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0#f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "ballista-executor"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f754fed271d19e1ac7c30182a5cf0eb0b3844586#f754fed271d19e1ac7c30182a5cf0eb0b3844586"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0#f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "ballista-scheduler"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f754fed271d19e1ac7c30182a5cf0eb0b3844586#f754fed271d19e1ac7c30182a5cf0eb0b3844586"
+source = "git+https://github.com/spiceai/datafusion-ballista.git?rev=f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0#f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4039,7 +4039,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8582,8 +8582,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -9687,7 +9687,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9722,7 +9722,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -14785,8 +14785,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -14807,7 +14807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15135,7 +15135,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15173,7 +15173,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -18462,7 +18462,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -20032,7 +20032,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",
@@ -23125,7 +23125,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,9 +185,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f754fed271d19e1ac7c30182a5cf0eb0b3844586" } # branch: phillip/merge-upstream-ballista-54 (PR #64 → spiceai-54)
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f754fed271d19e1ac7c30182a5cf0eb0b3844586" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f754fed271d19e1ac7c30182a5cf0eb0b3844586" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0" } # branch: spiceai-54 (merged PR #64)
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,9 +185,9 @@ aws-smithy-runtime = "1.11.1"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.5"
 axum = { version = "0.8", features = ["macros"] }
-ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f" } # branch: spiceai-54
-ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f" }
-ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "ab207a1c0f5649e0fcbb8ac1b85d6a4a6732820f" }
+ballista-core = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f754fed271d19e1ac7c30182a5cf0eb0b3844586" } # branch: phillip/merge-upstream-ballista-54 (PR #64 → spiceai-54)
+ballista-executor = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f754fed271d19e1ac7c30182a5cf0eb0b3844586" }
+ballista-scheduler = { git = "https://github.com/spiceai/datafusion-ballista.git", rev = "f754fed271d19e1ac7c30182a5cf0eb0b3844586" }
 base64 = "0.22.1"
 bb8 = "0.9"
 bb8-postgres = "0.9"

--- a/crates/runtime/src/cluster/control_stream_client.rs
+++ b/crates/runtime/src/cluster/control_stream_client.rs
@@ -508,7 +508,7 @@ async fn handle_scheduler_message(
                 match executor
                     .cancel_task(
                         task.task_id as usize,
-                        task.job_id.clone(),
+                        task.job_id.clone().into(),
                         task.stage_id as usize,
                         task.partition_id as usize,
                     )

--- a/crates/runtime/src/cluster/datafusion/datafusion_scheduler_ext.rs
+++ b/crates/runtime/src/cluster/datafusion/datafusion_scheduler_ext.rs
@@ -34,8 +34,14 @@ pub trait DataFusionSchedulerExtensions<T: 'static + AsLogicalPlan, U: 'static +
         if let Some(scheduler_state) = self.scheduler_state() {
             scheduler_state
                 .executor_manager
-                .get_executor_state()
+                .get_executors_state()
                 .await
+                .map(|states| {
+                    states
+                        .into_iter()
+                        .map(|(metadata, duration, _metrics)| (metadata, duration))
+                        .collect()
+                })
                 .map_err(|e| DataFusionError::External(Box::new(e)))
         } else {
             Ok(vec![])

--- a/crates/runtime/src/cluster/metrics_collector.rs
+++ b/crates/runtime/src/cluster/metrics_collector.rs
@@ -21,6 +21,7 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use ballista_core::JobId;
 use ballista_core::error::Result;
 use ballista_core::extension::{ResultFetchMetricsCallback, ShuffleReadMetricsCallback};
 use ballista_executor::execution_engine::QueryStageExecutor;
@@ -48,7 +49,7 @@ impl OtelExecutorMetricsCollector {
 }
 
 impl ExecutorMetricsCollector for OtelExecutorMetricsCollector {
-    fn record_task_started(&self, _job_id: &str, _stage_id: usize, _partition: usize) {
+    fn record_task_started(&self, _job_id: &JobId, _stage_id: usize, _partition: usize) {
         cluster::record_task_started(&self.node_id, "executor");
 
         // Also update executor-specific active task count
@@ -58,7 +59,7 @@ impl ExecutorMetricsCollector for OtelExecutorMetricsCollector {
 
     fn record_stage(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         _plan: Arc<dyn QueryStageExecutor>,
@@ -82,7 +83,7 @@ impl ExecutorMetricsCollector for OtelExecutorMetricsCollector {
 
     fn record_task_failed(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         error_type: &str,
@@ -108,7 +109,7 @@ impl ExecutorMetricsCollector for OtelExecutorMetricsCollector {
 
     fn record_shuffle_write(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         bytes: u64,
@@ -122,7 +123,7 @@ impl ExecutorMetricsCollector for OtelExecutorMetricsCollector {
 
     fn record_shuffle_read(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         _bytes: u64,
@@ -136,7 +137,7 @@ impl ExecutorMetricsCollector for OtelExecutorMetricsCollector {
 
     fn record_shuffle_read_local(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         bytes: u64,
@@ -150,7 +151,7 @@ impl ExecutorMetricsCollector for OtelExecutorMetricsCollector {
 
     fn record_shuffle_read_remote(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         _source_executor_id: &str,
@@ -198,7 +199,7 @@ impl OtelShuffleReadMetricsCallback {
 impl ShuffleReadMetricsCallback for OtelShuffleReadMetricsCallback {
     fn record_local_read(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         _source_executor_id: &str,
@@ -213,7 +214,7 @@ impl ShuffleReadMetricsCallback for OtelShuffleReadMetricsCallback {
 
     fn record_remote_read(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         _source_executor_id: &str,
@@ -254,7 +255,7 @@ impl OtelResultFetchMetricsCallback {
 impl ResultFetchMetricsCallback for OtelResultFetchMetricsCallback {
     fn record_result_fetch(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _partition: usize,
         _source_executor_id: &str,
@@ -290,20 +291,20 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
     // Job lifecycle events
     // =========================================================================
 
-    fn record_submitted(&self, _job_id: &str, _queued_at: u64, _submitted_at: u64) {
+    fn record_submitted(&self, _job_id: &JobId, _queued_at: u64, _submitted_at: u64) {
         // Job metrics are tracked at a higher level; we focus on stage/task metrics here.
         // This could be extended to track job queue latency if needed.
     }
 
-    fn record_completed(&self, _job_id: &str, _queued_at: u64, _completed_at: u64) {
+    fn record_completed(&self, _job_id: &JobId, _queued_at: u64, _completed_at: u64) {
         // Job completion is tracked at a higher level.
     }
 
-    fn record_failed(&self, _job_id: &str, _queued_at: u64, _failed_at: u64) {
+    fn record_failed(&self, _job_id: &JobId, _queued_at: u64, _failed_at: u64) {
         // Job failure is tracked at a higher level.
     }
 
-    fn record_cancelled(&self, _job_id: &str) {
+    fn record_cancelled(&self, _job_id: &JobId) {
         // Job cancellation is tracked at a higher level.
     }
 
@@ -325,13 +326,13 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
     // Stage lifecycle events
     // =========================================================================
 
-    fn record_stage_started(&self, _job_id: &str, _stage_id: usize, task_count: usize) {
+    fn record_stage_started(&self, _job_id: &JobId, _stage_id: usize, task_count: usize) {
         // Record the number of tasks per stage when it starts
         let labels = [KeyValue::new("node_id", self.node_id.clone())];
         cluster::SCHEDULER_TASKS_PER_STAGE.record(task_count as u64, &labels);
     }
 
-    fn record_stage_completed(&self, _job_id: &str, _stage_id: usize, duration_ms: u64) {
+    fn record_stage_completed(&self, _job_id: &JobId, _stage_id: usize, duration_ms: u64) {
         #[expect(clippy::cast_precision_loss)]
         let duration_ms_f64 = duration_ms as f64;
         // task_count is recorded in record_stage_started, use 0 here as placeholder
@@ -339,11 +340,11 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
         cluster::record_stage_completed(&self.node_id, duration_ms_f64, 0);
     }
 
-    fn record_stage_failed(&self, _job_id: &str, _stage_id: usize, error_type: &str) {
+    fn record_stage_failed(&self, _job_id: &JobId, _stage_id: usize, error_type: &str) {
         cluster::record_stage_failed(&self.node_id, error_type);
     }
 
-    fn record_stage_retry(&self, _job_id: &str, _stage_id: usize) {
+    fn record_stage_retry(&self, _job_id: &JobId, _stage_id: usize) {
         cluster::record_stage_retry(&self.node_id);
     }
 
@@ -353,7 +354,7 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
 
     fn record_task_scheduled(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _executor_id: &str,
         latency_ms: u64,
@@ -369,7 +370,7 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
         cluster::record_task_started(&self.node_id, "scheduler");
     }
 
-    fn record_task_completed(&self, _job_id: &str, _stage_id: usize, _executor_id: &str) {
+    fn record_task_completed(&self, _job_id: &JobId, _stage_id: usize, _executor_id: &str) {
         // Task completed - decrement active count
         // Duration is tracked on the executor side
         let labels = [
@@ -388,7 +389,7 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
 
     fn record_task_failed(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _executor_id: &str,
         error_type: &str,
@@ -396,13 +397,13 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
         cluster::record_task_failed(&self.node_id, "scheduler", error_type);
     }
 
-    fn record_task_retry(&self, _job_id: &str, _stage_id: usize) {
+    fn record_task_retry(&self, _job_id: &JobId, _stage_id: usize) {
         cluster::record_task_retry(&self.node_id, "scheduler");
     }
 
     fn record_task_shuffle_affinity_hit(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _executor_id: &str,
     ) {
@@ -414,7 +415,7 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
 
     fn record_task_shuffle_affinity_miss(
         &self,
-        _job_id: &str,
+        _job_id: &JobId,
         _stage_id: usize,
         _executor_id: &str,
     ) {
@@ -446,7 +447,7 @@ impl SchedulerMetricsCollector for OtelSchedulerMetricsCollector {
     // Planning events
     // =========================================================================
 
-    fn record_planning_duration(&self, _job_id: &str, duration_ms: u64) {
+    fn record_planning_duration(&self, _job_id: &JobId, duration_ms: u64) {
         #[expect(clippy::cast_precision_loss)]
         cluster::record_planning_duration(&self.node_id, duration_ms as f64);
     }
@@ -470,28 +471,28 @@ mod tests {
     fn test_executor_record_task_started() {
         let collector = OtelExecutorMetricsCollector::new("test-executor".to_string());
         // Should not panic
-        collector.record_task_started("job-1", 1, 0);
+        collector.record_task_started(&JobId::new("job-1"), 1, 0);
     }
 
     #[test]
     fn test_executor_record_task_failed() {
         let collector = OtelExecutorMetricsCollector::new("test-executor".to_string());
         // Should not panic
-        collector.record_task_failed("job-1", 1, 0, "timeout");
+        collector.record_task_failed(&JobId::new("job-1"), 1, 0, "timeout");
     }
 
     #[test]
     fn test_executor_record_shuffle_write() {
         let collector = OtelExecutorMetricsCollector::new("test-executor".to_string());
         // Should not panic
-        collector.record_shuffle_write("job-1", 1, 0, 1024, 100, 50);
+        collector.record_shuffle_write(&JobId::new("job-1"), 1, 0, 1024, 100, 50);
     }
 
     #[test]
     fn test_executor_record_shuffle_read() {
         let collector = OtelExecutorMetricsCollector::new("test-executor".to_string());
         // Should not panic
-        collector.record_shuffle_read("job-1", 1, 0, 2048, 200, 75);
+        collector.record_shuffle_read(&JobId::new("job-1"), 1, 0, 2048, 200, 75);
     }
 
     #[test]
@@ -517,10 +518,10 @@ mod tests {
         let now = 1_000_000_u64;
 
         // Job lifecycle methods should not panic
-        collector.record_submitted("job-1", now, now + 100);
-        collector.record_completed("job-1", now, now + 5000);
-        collector.record_failed("job-2", now, now + 1000);
-        collector.record_cancelled("job-3");
+        collector.record_submitted(&JobId::new("job-1"), now, now + 100);
+        collector.record_completed(&JobId::new("job-1"), now, now + 5000);
+        collector.record_failed(&JobId::new("job-2"), now, now + 1000);
+        collector.record_cancelled(&JobId::new("job-3"));
     }
 
     #[test]
@@ -547,10 +548,10 @@ mod tests {
         let collector = OtelSchedulerMetricsCollector::new("test-scheduler".to_string());
 
         // Stage lifecycle methods should not panic
-        collector.record_stage_started("job-1", 1, 4);
-        collector.record_stage_completed("job-1", 1, 1000);
-        collector.record_stage_failed("job-2", 2, "resource_exhausted");
-        collector.record_stage_retry("job-3", 3);
+        collector.record_stage_started(&JobId::new("job-1"), 1, 4);
+        collector.record_stage_completed(&JobId::new("job-1"), 1, 1000);
+        collector.record_stage_failed(&JobId::new("job-2"), 2, "resource_exhausted");
+        collector.record_stage_retry(&JobId::new("job-3"), 3);
     }
 
     #[test]
@@ -558,10 +559,10 @@ mod tests {
         let collector = OtelSchedulerMetricsCollector::new("test-scheduler".to_string());
 
         // Task scheduling methods should not panic
-        collector.record_task_scheduled("job-1", 1, "executor-1", 50);
-        collector.record_task_completed("job-1", 1, "executor-1");
-        collector.record_task_failed("job-2", 2, "executor-2", "network_error");
-        collector.record_task_retry("job-3", 3);
+        collector.record_task_scheduled(&JobId::new("job-1"), 1, "executor-1", 50);
+        collector.record_task_completed(&JobId::new("job-1"), 1, "executor-1");
+        collector.record_task_failed(&JobId::new("job-2"), 2, "executor-2", "network_error");
+        collector.record_task_retry(&JobId::new("job-3"), 3);
     }
 
     #[test]
@@ -579,7 +580,7 @@ mod tests {
         let collector = OtelSchedulerMetricsCollector::new("test-scheduler".to_string());
 
         // Planning duration should not panic
-        collector.record_planning_duration("job-1", 250);
+        collector.record_planning_duration(&JobId::new("job-1"), 250);
     }
 
     // =========================================================================
@@ -595,20 +596,20 @@ mod tests {
         let scheduler = OtelSchedulerMetricsCollector::new("scheduler-1".to_string());
 
         // Scheduler receives job and schedules task
-        scheduler.record_stage_started("job-1", 1, 4);
-        scheduler.record_task_scheduled("job-1", 1, "executor-1", 10);
+        scheduler.record_stage_started(&JobId::new("job-1"), 1, 4);
+        scheduler.record_task_scheduled(&JobId::new("job-1"), 1, "executor-1", 10);
 
         // Executor picks up and runs task
-        executor.record_task_started("job-1", 1, 0);
-        executor.record_shuffle_read_local("job-1", 1, 0, 512, 50, 10);
-        executor.record_shuffle_read_remote("job-1", 1, 0, "executor-2", 512, 50, 20);
+        executor.record_task_started(&JobId::new("job-1"), 1, 0);
+        executor.record_shuffle_read_local(&JobId::new("job-1"), 1, 0, 512, 50, 10);
+        executor.record_shuffle_read_remote(&JobId::new("job-1"), 1, 0, "executor-2", 512, 50, 20);
 
         // Task completes (simulated without calling record_stage)
-        executor.record_shuffle_write("job-1", 1, 0, 512, 50, 15);
+        executor.record_shuffle_write(&JobId::new("job-1"), 1, 0, 512, 50, 15);
 
         // Scheduler records completion
-        scheduler.record_task_completed("job-1", 1, "executor-1");
-        scheduler.record_stage_completed("job-1", 1, 600);
+        scheduler.record_task_completed(&JobId::new("job-1"), 1, "executor-1");
+        scheduler.record_stage_completed(&JobId::new("job-1"), 1, 600);
     }
 
     #[test]
@@ -618,15 +619,15 @@ mod tests {
         let scheduler = OtelSchedulerMetricsCollector::new("scheduler-1".to_string());
 
         // Scheduler schedules task
-        scheduler.record_task_scheduled("job-fail", 1, "executor-2", 5);
+        scheduler.record_task_scheduled(&JobId::new("job-fail"), 1, "executor-2", 5);
 
         // Executor starts task but it fails
-        executor.record_task_started("job-fail", 1, 0);
-        executor.record_task_failed("job-fail", 1, 0, "out_of_memory");
+        executor.record_task_started(&JobId::new("job-fail"), 1, 0);
+        executor.record_task_failed(&JobId::new("job-fail"), 1, 0, "out_of_memory");
 
         // Scheduler records failure and retries
-        scheduler.record_task_failed("job-fail", 1, "executor-2", "out_of_memory");
-        scheduler.record_task_retry("job-fail", 1);
-        scheduler.record_stage_retry("job-fail", 1);
+        scheduler.record_task_failed(&JobId::new("job-fail"), 1, "executor-2", "out_of_memory");
+        scheduler.record_task_retry(&JobId::new("job-fail"), 1);
+        scheduler.record_stage_retry(&JobId::new("job-fail"), 1);
     }
 }

--- a/crates/runtime/src/cluster/mod.rs
+++ b/crates/runtime/src/cluster/mod.rs
@@ -336,6 +336,7 @@ fn spawn_scheduler_poll_loop(
                         tcp_keepalive_seconds: grpc_client.tcp_keep_alive_seconds,
                         http2_keepalive_interval_seconds: grpc_client
                             .http2_keep_alive_interval_seconds,
+                        ..Default::default()
                     };
                     let scheduler_endpoint =
                         match create_grpc_client_endpoint(endpoint_url.clone(), Some(&grpc_config))
@@ -1487,6 +1488,7 @@ pub async fn initialize_cluster_executor(
                 resource: Some(Resource::TaskSlots(concurrent_tasks)),
             }],
         }),
+        os_info: None,
     };
 
     // Use advertise address as node_id for metrics
@@ -1985,7 +1987,7 @@ async fn create_scheduler_server(
 
                     Some(TaskCancelInfo {
                         task_id,
-                        job_id: task.job_id,
+                        job_id: task.job_id.to_string(),
                         stage_id,
                         partition_id,
                     })

--- a/crates/runtime/src/cluster/shared_job_state.rs
+++ b/crates/runtime/src/cluster/shared_job_state.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::error::TrySendError;
 use uuid::Uuid;
 
+use ballista_core::JobId;
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::serde::BallistaCodec;
 use ballista_core::serde::protobuf::{JobStatus, job_status::Status};
@@ -226,7 +227,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SharedJobState<T,
 
 #[async_trait]
 impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for SharedJobState<T, U> {
-    fn accept_job(&self, job_id: &str, job_name: &str, queued_at: u64) -> Result<()> {
+    fn accept_job(&self, job_id: &JobId, job_name: &str, queued_at: u64) -> Result<()> {
         self.queued_jobs
             .insert(job_id.to_string(), (job_name.to_string(), queued_at));
         Ok(())
@@ -238,11 +239,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
 
     async fn submit_job(
         &self,
-        job_id: String,
+        job_id: JobId,
         graph: &ExecutionGraphBox,
         subscriber: Option<JobStatusSubscriber>,
     ) -> Result<()> {
-        let Some((_, (_, queued_at))) = self.queued_jobs.remove(&job_id) else {
+        let Some((_, (_, queued_at))) = self.queued_jobs.remove(job_id.as_str()) else {
             return Err(BallistaError::Internal(format!(
                 "failed to submit job {job_id}, not found in queued jobs"
             )));
@@ -253,11 +254,17 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         // Claim ownership via OCC *before* writing the graph blob. Writing the
         // graph first would overwrite an existing owner's graph for the same
         // job_id on a metadata conflict, corrupting their recovery state.
-        let mut meta = Self::metadata(&job_id, &status, Some(self.owner_instance_id), 0, queued_at);
+        let mut meta = Self::metadata(
+            job_id.as_str(),
+            &status,
+            Some(self.owner_instance_id),
+            0,
+            queued_at,
+        );
         meta.session_id = graph.session_id().to_string();
         if let object_store_occ::WriteResult::Conflict { .. } = self
             .meta
-            .insert_or_update(&job_id, &meta)
+            .insert_or_update(job_id.as_str(), &meta)
             .await
             .map_err(|e| BallistaError::Internal(format!("failed to persist job meta: {e}")))?
         {
@@ -268,8 +275,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         // With the claim in place, persist the graph. If that fails, best-effort
         // roll back the metadata so other schedulers never observe meta pointing
         // at a missing graph.
-        if let Err(e) = self.put_graph(&job_id, graph).await {
-            if let Err(cleanup) = self.meta.delete(&job_id).await {
+        if let Err(e) = self.put_graph(job_id.as_str(), graph).await {
+            if let Err(cleanup) = self.meta.delete(job_id.as_str()).await {
                 tracing::warn!(
                     "failed to roll back job meta for {job_id} after graph write failed: {cleanup}"
                 );
@@ -278,7 +285,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         }
 
         self.local_jobs
-            .insert(job_id.clone(), LocalJob { status, subscriber });
+            .insert(job_id.to_string(), LocalJob { status, subscriber });
         self.event_sender.send(&JobStateEvent::JobAcquired {
             job_id,
             owner: self.scheduler.clone(),
@@ -286,8 +293,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         Ok(())
     }
 
-    async fn get_job_status(&self, job_id: &str) -> Result<Option<JobStatus>> {
-        if let Some((job_name, queued_at)) = self.queued_jobs.get(job_id).as_deref() {
+    async fn get_job_status(&self, job_id: &JobId) -> Result<Option<JobStatus>> {
+        if let Some((job_name, queued_at)) = self.queued_jobs.get(job_id.as_str()).as_deref() {
             return Ok(Some(JobStatus {
                 job_id: job_id.to_string(),
                 job_name: job_name.clone(),
@@ -296,12 +303,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
                 })),
             }));
         }
-        if let Some(local) = self.local_jobs.get(job_id) {
+        if let Some(local) = self.local_jobs.get(job_id.as_str()) {
             return Ok(Some(local.status.clone()));
         }
         match self
             .meta
-            .get(job_id)
+            .get(job_id.as_str())
             .await
             .map_err(|e| BallistaError::Internal(format!("failed to read job meta: {e}")))?
         {
@@ -310,24 +317,24 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         }
     }
 
-    async fn get_execution_graph(&self, job_id: &str) -> Result<Option<ExecutionGraphBox>> {
+    async fn get_execution_graph(&self, job_id: &JobId) -> Result<Option<ExecutionGraphBox>> {
         let Some(meta) = self
             .meta
-            .get(job_id)
+            .get(job_id.as_str())
             .await
             .map_err(|e| BallistaError::Internal(format!("failed to read job meta: {e}")))?
         else {
             return Ok(None);
         };
-        Ok(Some(self.load_graph(job_id, &meta).await?))
+        Ok(Some(self.load_graph(job_id.as_str(), &meta).await?))
     }
 
-    async fn save_job(&self, job_id: &str, graph: &ExecutionGraphBox) -> Result<()> {
+    async fn save_job(&self, job_id: &JobId, graph: &ExecutionGraphBox) -> Result<()> {
         let status = graph.status().clone();
 
         let current = self
             .meta
-            .get(job_id)
+            .get(job_id.as_str())
             .await
             .map_err(|e| BallistaError::Internal(format!("failed to read job meta: {e}")))?;
         // A scheduler that has lost ownership must not touch shared state. Drop
@@ -339,7 +346,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
                 "job {job_id} owned by another scheduler (epoch {}); yielding",
                 m.epoch
             );
-            self.local_jobs.remove(job_id);
+            self.local_jobs.remove(job_id.as_str());
             return Ok(());
         }
         let (epoch, queued_at, session_id) = current
@@ -348,7 +355,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
             .unwrap_or((0, 0, graph.session_id().to_string()));
 
         let mut meta = Self::metadata(
-            job_id,
+            job_id.as_str(),
             &status,
             Some(self.owner_instance_id),
             epoch,
@@ -359,7 +366,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         // scheduler racing a takeover cannot clobber the shared graph blob.
         match self
             .meta
-            .update(job_id, &meta)
+            .update(job_id.as_str(), &meta)
             .await
             .map_err(|e| BallistaError::Internal(format!("failed to persist job meta: {e}")))?
         {
@@ -370,42 +377,42 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
                     epoch,
                     current.epoch
                 );
-                self.local_jobs.remove(job_id);
+                self.local_jobs.remove(job_id.as_str());
                 return Ok(());
             }
             object_store_occ::UpdateResult::NotFound => {
-                self.local_jobs.remove(job_id);
+                self.local_jobs.remove(job_id.as_str());
                 return Err(BallistaError::Internal(format!(
                     "job {job_id} metadata no longer exists; cannot persist state"
                 )));
             }
         }
-        self.put_graph(job_id, graph).await?;
+        self.put_graph(job_id.as_str(), graph).await?;
 
         let terminal = matches!(
             status.status,
             Some(Status::Successful(_) | Status::Failed(_))
         );
         if terminal {
-            if let Some((_, local)) = self.local_jobs.remove(job_id) {
+            if let Some((_, local)) = self.local_jobs.remove(job_id.as_str()) {
                 local.notify(status.clone());
             }
-        } else if let Some(mut local) = self.local_jobs.get_mut(job_id) {
+        } else if let Some(mut local) = self.local_jobs.get_mut(job_id.as_str()) {
             local.status = status.clone();
             local.notify(status.clone());
         }
 
         self.event_sender.send(&JobStateEvent::JobUpdated {
-            job_id: job_id.to_string(),
+            job_id: job_id.clone(),
             status,
         });
         Ok(())
     }
 
-    async fn try_acquire_job(&self, job_id: &str) -> Result<Option<ExecutionGraphBox>> {
+    async fn try_acquire_job(&self, job_id: &JobId) -> Result<Option<ExecutionGraphBox>> {
         let Some(meta) = self
             .meta
-            .get(job_id)
+            .get(job_id.as_str())
             .await
             .map_err(|e| BallistaError::Internal(format!("failed to read job meta: {e}")))?
         else {
@@ -426,7 +433,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         // removed under us (NotFound) — either way we don't own it.
         if !matches!(
             self.meta
-                .update(job_id, &claimed)
+                .update(job_id.as_str(), &claimed)
                 .await
                 .map_err(|e| BallistaError::Internal(format!("failed to acquire job: {e}")))?,
             object_store_occ::UpdateResult::Ok
@@ -434,7 +441,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
             return Ok(None);
         }
 
-        let graph = self.load_graph(job_id, &claimed).await?;
+        let graph = self.load_graph(job_id.as_str(), &claimed).await?;
         self.local_jobs.insert(
             job_id.to_string(),
             LocalJob {
@@ -443,7 +450,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
             },
         );
         self.event_sender.send(&JobStateEvent::JobAcquired {
-            job_id: job_id.to_string(),
+            job_id: job_id.clone(),
             owner: self.scheduler.clone(),
         });
         Ok(Some(graph))
@@ -453,19 +460,19 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         Ok(Box::pin(self.event_sender.subscribe()))
     }
 
-    async fn remove_job(&self, job_id: &str) -> Result<()> {
-        self.local_jobs.remove(job_id);
-        self.queued_jobs.remove(job_id);
+    async fn remove_job(&self, job_id: &JobId) -> Result<()> {
+        self.local_jobs.remove(job_id.as_str());
+        self.queued_jobs.remove(job_id.as_str());
         // Delete metadata first, and only delete the graph if that succeeds.
         // `ObjectState::delete` treats NotFound as success, so an error here is a
         // real object-store failure: keep the graph so meta still points at a
         // valid blob rather than dangling to a missing graph. (A graph-delete
         // failure afterwards is then only a storage leak, not a correctness bug.)
-        if let Err(e) = self.meta.delete(job_id).await {
+        if let Err(e) = self.meta.delete(job_id.as_str()).await {
             tracing::warn!("failed to delete job meta for {job_id}; keeping graph: {e}");
             return Ok(());
         }
-        if let Err(e) = self.store.delete(&self.graph_path(job_id)).await
+        if let Err(e) = self.store.delete(&self.graph_path(job_id.as_str())).await
             && !matches!(e, object_store::Error::NotFound { .. })
         {
             tracing::warn!("failed to delete job graph for {job_id}: {e}");
@@ -473,17 +480,37 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
         Ok(())
     }
 
-    async fn get_jobs(&self) -> Result<HashSet<String>> {
+    async fn get_jobs(&self) -> Result<HashSet<JobId>> {
         let keys = self
             .meta
             .list_keys()
             .await
             .map_err(|e| BallistaError::Internal(format!("failed to list jobs: {e}")))?;
-        Ok(keys.into_iter().collect())
+        Ok(keys.into_iter().map(JobId::from).collect())
     }
 
-    async fn fail_unscheduled_job(&self, job_id: &str, reason: String) -> Result<()> {
-        let Some((_, (job_name, queued_at))) = self.queued_jobs.remove(job_id) else {
+    async fn get_all_jobs(&self) -> Result<HashSet<JobId>> {
+        let mut all_jobs: HashSet<JobId> = self
+            .queued_jobs
+            .iter()
+            .map(|pair| JobId::from(pair.key().as_str()))
+            .collect();
+        all_jobs.extend(
+            self.local_jobs
+                .iter()
+                .map(|pair| JobId::from(pair.key().as_str())),
+        );
+        let keys = self
+            .meta
+            .list_keys()
+            .await
+            .map_err(|e| BallistaError::Internal(format!("failed to list jobs: {e}")))?;
+        all_jobs.extend(keys.into_iter().map(JobId::from));
+        Ok(all_jobs)
+    }
+
+    async fn fail_unscheduled_job(&self, job_id: &JobId, reason: String) -> Result<()> {
+        let Some((_, (job_name, queued_at))) = self.queued_jobs.remove(job_id.as_str()) else {
             return Err(BallistaError::Internal(format!(
                 "could not fail unscheduled job {job_id}, not found in queued jobs"
             )));
@@ -498,9 +525,15 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> JobState for Shar
                 ended_at: now_ms(),
             })),
         };
-        let mut meta = Self::metadata(job_id, &status, Some(self.owner_instance_id), 0, queued_at);
+        let mut meta = Self::metadata(
+            job_id.as_str(),
+            &status,
+            Some(self.owner_instance_id),
+            0,
+            queued_at,
+        );
         meta.session_id = String::new();
-        if let Err(e) = self.meta.insert_or_update(job_id, &meta).await {
+        if let Err(e) = self.meta.insert_or_update(job_id.as_str(), &meta).await {
             tracing::warn!("failed to persist failed status for unscheduled job {job_id}: {e}");
         }
         Ok(())
@@ -607,7 +640,7 @@ mod tests {
         // Unknown job: nothing to acquire.
         assert!(
             state
-                .try_acquire_job("missing")
+                .try_acquire_job(&JobId::new("missing"))
                 .await
                 .expect("acquire")
                 .is_none(),
@@ -628,7 +661,7 @@ mod tests {
             .expect("persist self-owned meta");
         assert!(
             state
-                .try_acquire_job("self")
+                .try_acquire_job(&JobId::new("self"))
                 .await
                 .expect("acquire")
                 .is_none(),
@@ -651,7 +684,7 @@ mod tests {
             .expect("persist corrupt meta");
         assert!(
             state
-                .try_acquire_job("corrupt")
+                .try_acquire_job(&JobId::new("corrupt"))
                 .await
                 .expect("acquire")
                 .is_none(),
@@ -681,14 +714,22 @@ mod tests {
             .expect("persist graph blob");
 
         assert!(
-            state.get_job_status("j1").await.expect("status").is_some(),
+            state
+                .get_job_status(&JobId::new("j1"))
+                .await
+                .expect("status")
+                .is_some(),
             "job should be visible before removal"
         );
 
-        state.remove_job("j1").await.expect("remove");
+        state.remove_job(&JobId::new("j1")).await.expect("remove");
 
         assert!(
-            state.get_job_status("j1").await.expect("status").is_none(),
+            state
+                .get_job_status(&JobId::new("j1"))
+                .await
+                .expect("status")
+                .is_none(),
             "metadata should be gone after removal"
         );
         assert!(

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -904,7 +904,7 @@ impl Query {
         // the Ballista job id so it can be addressed across schedulers.
         let ballista_job_id = if mode == DistributedSubmitMode::Resume {
             scheduler
-                .recover_job(job_id)
+                .recover_job(&ballista_core::JobId::from(job_id))
                 .await
                 .map_err(|e| Error::JobSubmissionFailed {
                     message: e.to_string(),

--- a/crates/runtime/src/datafusion/query/handle.rs
+++ b/crates/runtime/src/datafusion/query/handle.rs
@@ -30,6 +30,7 @@ use crate::datafusion::query::QueryTracker;
 use crate::datafusion::query::error_code::ErrorCode;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
+use ballista_core::JobId;
 use ballista_core::extension::BallistaConfigGrpcEndpoint;
 use ballista_core::serde::protobuf::job_status;
 use ballista_core::serde::scheduler::PartitionLocation;
@@ -302,6 +303,11 @@ impl QueryHandle {
         self.cancel_token.clone()
     }
 
+    /// Ballista job id as the typed [`JobId`] expected by scheduler APIs.
+    fn ballista_job_id_typed(&self) -> JobId {
+        JobId::from(self.ballista_job_id.as_str())
+    }
+
     /// Polls the current status of the job.
     ///
     /// Returns the job status or an error if the status cannot be retrieved.
@@ -315,7 +321,7 @@ impl QueryHandle {
         let status = scheduler
             .state
             .task_manager
-            .get_job_status(&self.ballista_job_id)
+            .get_job_status(&self.ballista_job_id_typed())
             .await
             .map_err(|e| QueryHandleError::StatusError {
                 message: e.to_string(),
@@ -407,7 +413,7 @@ impl QueryHandle {
                     match event_result {
                         Ok(event) => {
                             // Only process events for our job
-                            if event.job_id != self.ballista_job_id {
+                            if event.job_id.as_str() != self.ballista_job_id {
                                 continue;
                             }
 
@@ -479,7 +485,7 @@ impl QueryHandle {
         let status = scheduler
             .state
             .task_manager
-            .get_job_status(&self.ballista_job_id)
+            .get_job_status(&self.ballista_job_id_typed())
             .await
             .map_err(|e| {
                 let err = QueryHandleError::StatusError {
@@ -523,7 +529,7 @@ impl QueryHandle {
             let status = scheduler
                 .state
                 .task_manager
-                .get_job_status(&self.ballista_job_id)
+                .get_job_status(&self.ballista_job_id_typed())
                 .await
                 .map_err(|e| {
                     let err = QueryHandleError::StatusError {
@@ -750,7 +756,7 @@ impl QueryHandle {
                     let already_terminal = match scheduler_for_cancel
                         .state
                         .task_manager
-                        .get_job_status(&cancel_job_id)
+                        .get_job_status(&JobId::from(cancel_job_id.as_str()))
                         .await
                     {
                         Ok(Some(job_status)) => match job_status.status {
@@ -787,7 +793,7 @@ impl QueryHandle {
                 let graph = scheduler
                     .state
                     .task_manager
-                    .get_job_execution_graph(&job_id)
+                    .get_job_execution_graph(&JobId::from(job_id.as_str()))
                     .await
                     .ok()
                     .flatten();
@@ -1004,6 +1010,10 @@ impl PartitionResultStream {
                 MAX_PARTITION_RETRIEVAL_MESSAGE_SIZE,
                 use_tls,
                 customize_endpoint,
+                3,          // io_retries_times
+                3000,       // io_retry_wait_time_ms
+                67_108_864, // initial_connection_window_size (64 MiB)
+                16_777_216, // initial_stream_window_size (16 MiB)
             )
             .await
             .map_err(|e| {

--- a/crates/runtime/tests/cluster/cancel_tasks.rs
+++ b/crates/runtime/tests/cluster/cancel_tasks.rs
@@ -50,7 +50,7 @@ async fn wait_for_executor_count(
     let start = Instant::now();
     loop {
         let count = executor_manager
-            .get_executor_state()
+            .get_executors_state()
             .await
             .map_err(|err| anyhow::Error::msg(err.to_string()))?
             .len();

--- a/crates/runtime/tests/cluster/harness.rs
+++ b/crates/runtime/tests/cluster/harness.rs
@@ -184,7 +184,7 @@ impl ClusterHarness {
             sleep(Duration::from_millis(200)).await;
             let count = self
                 .executor_manager
-                .get_executor_state()
+                .get_executors_state()
                 .await
                 .map_err(|e| anyhow::Error::msg(e.to_string()))?
                 .len();

--- a/crates/runtime/tests/cluster/in_memory_shuffle.rs
+++ b/crates/runtime/tests/cluster/in_memory_shuffle.rs
@@ -78,7 +78,7 @@ async fn wait_for_executor_count(
     let start = Instant::now();
     loop {
         let count = executor_manager
-            .get_executor_state()
+            .get_executors_state()
             .await
             .map_err(|err| anyhow::Error::msg(err.to_string()))?
             .len();

--- a/crates/runtime/tests/cluster/scheduler_failover.rs
+++ b/crates/runtime/tests/cluster/scheduler_failover.rs
@@ -303,7 +303,7 @@ async fn wait_for_executor_count(
     let start = Instant::now();
     loop {
         let count = manager
-            .get_executor_state()
+            .get_executors_state()
             .await
             .map_err(|e| anyhow::Error::msg(e.to_string()))?
             .len();

--- a/crates/runtime/tests/cluster/simple.rs
+++ b/crates/runtime/tests/cluster/simple.rs
@@ -139,7 +139,7 @@ async fn wait_for_executor_count(
     let start = Instant::now();
     loop {
         let count = executor_manager
-            .get_executor_state()
+            .get_executors_state()
             .await
             .map_err(|err| anyhow::Error::msg(err.to_string()))?
             .len();


### PR DESCRIPTION
## Summary
- Pin `ballista-{core,executor,scheduler}` to [spiceai/datafusion-ballista#64](https://github.com/spiceai/datafusion-ballista/pull/64) tip `f754fed` (upstream Ballista 54.0.0 merge into `spiceai-54`).
- Adapt cluster integration for Ballista 54 APIs: typed `JobId`, `GrpcClientConfig` window/retry fields, `ExecutorRegistration.os_info`, `get_executors_state`, and expanded `BallistaClient::try_new`.

## Test plan
- [x] `cargo check -p runtime`
- [x] `cargo test -p runtime --lib cluster::shared_job_state` (4/4 pass)
- [x] CI: Rust Lint / Build and Test / cluster e2e