### PR TITLE
fix: array_any_value panic when output is hash-repartitioned (empty list elements)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4029,7 +4029,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5826,7 +5826,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5902,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5951,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "futures",
  "log",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5998,7 +5998,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6021,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6043,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6065,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6114,12 +6114,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6140,7 +6140,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6162,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6214,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6245,7 +6245,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6289,7 +6289,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6313,7 +6313,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6328,7 +6328,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6353,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6363,7 +6363,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "chrono",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6435,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6449,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "chrono",
@@ -6465,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6517,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "chrono",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6558,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6573,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6586,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6632,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e39eb06a6a196b8f7f691ee395a7c26e97aab6a5#e39eb06a6a196b8f7f691ee395a7c26e97aab6a5"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -8572,8 +8572,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -9677,7 +9677,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9712,7 +9712,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -14290,7 +14290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.5.0",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -14756,8 +14756,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -14778,7 +14778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15106,7 +15106,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15144,7 +15144,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -17872,7 +17872,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -18433,7 +18433,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -23081,7 +23081,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,41 +448,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "e39eb06a6a196b8f7f691ee395a7c26e97aab6a5" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).


### PR DESCRIPTION
## Summary

Fixes #11945. A query that computes `array_any_value(<list>)` and then routes that value through a hash `RepartitionExec` (e.g. uses it as an equi-join key) panicked the runtime worker task with `range end index N out of range for slice of length N-1` (surfaced to Flight clients as `13 INTERNAL`).

## Root cause

`general_array_any_value` in `datafusion-functions-nested` guarded null and all-null list elements, but a non-null **empty** (length-0) element fell through to the no-nulls branch, which unconditionally read `values[start]`:

- **interior empty list** → returned the *next* element's value (silently wrong data)
- **trailing empty list** (`start == values.len()`) → out-of-bounds slice → panic

The join/repartition was only the trigger: the hash `RepartitionExec` slices batches so an empty element lands at a values-buffer boundary, tripping the out-of-bounds read on a spawned task (reported as a tokio "Join Error").

## Change

Bumps the `datafusion` git rev to the new `spiceai-54` tip (`e39eb06a6a196b8f7f691ee395a7c26e97aab6a5`), which merges spiceai/datafusion#186. That PR guards the empty-list case → returns `NULL`, and audits the sibling functions (`array_element`, `array_slice`, `array_pop_front`/`array_pop_back` are already safe).

## Tests

Regression coverage lives in the datafusion fork PR (spiceai/datafusion#186):
- kernel unit tests: interior empty (wrong-value) + trailing empty (panic), both confirmed to reproduce before the fix;
- sqllogictest cases (`List` + `LargeList`, interior + trailing empty elements).

Closes #11945