### PR TITLE
docs: align component statuses with signed release criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ See more demos on [YouTube](https://www.youtube.com/playlist?list=PLesJrUXEx3U9a
 
 ## Supported Data Connectors
 
+Statuses match the signed DRI tables in [`docs/criteria/connectors/`](docs/criteria/connectors/).
+
 | Name                               | Description                           | Status            | Protocol/Format              |
 | ---------------------------------- | ------------------------------------- | ----------------- | ---------------------------- |
 | `databricks (mode: delta_lake)`    | [Databricks][databricks]              | Stable            | S3/Delta Lake                |
@@ -215,20 +217,20 @@ See more demos on [YouTube](https://www.youtube.com/playlist?list=PLesJrUXEx3U9a
 | `s3`                               | [S3][s3]                              | Stable            | Parquet, CSV                 |
 | `mysql`                            | MySQL (with native binlog CDC)        | Stable            |                              |
 | `spice.ai`                         | [Spice.ai][spiceai]                   | Stable            | Arrow Flight                 |
-| `dynamodb`                         | Amazon DynamoDB (with Streams)        | Stable            |                              |
+| `dynamodb`                         | Amazon DynamoDB (with Streams)        | Release Candidate |                              |
 | `graphql`                          | GraphQL                               | Release Candidate | JSON                         |
 | `cosmosdb`                         | Azure Cosmos DB (NoSQL)               | Release Candidate |                              |
 | `git`                              | Git repositories                      | Release Candidate |                              |
-| `snowflake`                        | Snowflake                             | Release Candidate | Arrow                        |
-| `adbc`                             | ADBC                                  | Release Candidate | Arrow                        |
-| `iceberg`                          | [Apache Iceberg][iceberg] (read+write) | Release Candidate | Parquet                      |
+| `snowflake`                        | Snowflake                             | Beta              | Arrow                        |
+| `iceberg`                          | [Apache Iceberg][iceberg] (read+write) | Beta              | Parquet                      |
 | `databricks (mode: spark_connect)` | [Databricks][databricks]              | Beta              | [Spark Connect][spark]       |
 | `ducklake`                         | [DuckLake][ducklake]                  | Beta              | Parquet                      |
-| `flightsql`                        | FlightSQL                             | Beta              | Arrow Flight SQL             |
 | `mssql`                            | Microsoft SQL Server                  | Beta              | Tabular Data Stream (TDS)    |
-| `odbc`                             | ODBC                                  | Beta              | ODBC                         |
 | `spark`                            | Spark                                 | Beta              | [Spark Connect][spark]       |
-| `sharepoint`                       | Microsoft SharePoint                  | Beta              | Object-store listing         |
+| `adbc`                             | ADBC                                  | Alpha             | Arrow                        |
+| `flightsql`                        | FlightSQL                             | Alpha             | Arrow Flight SQL             |
+| `odbc`                             | ODBC                                  | Alpha             | ODBC                         |
+| `sharepoint`                       | Microsoft SharePoint                  | Alpha             | Object-store listing         |
 | `oracle`                           | Oracle                                | Alpha             | [Oracle ODPI-C][ODPIC]       |
 | `abfs`                             | Azure BlobFS                          | Alpha             | Parquet, CSV                 |
 | `clickhouse`                       | ClickHouse                            | Alpha             |                              |
@@ -260,9 +262,11 @@ See more demos on [YouTube](https://www.youtube.com/playlist?list=PLesJrUXEx3U9a
 
 ## Supported Data Accelerators
 
+Statuses match the signed DRI tables in [`docs/criteria/accelerators/`](docs/criteria/accelerators/).
+
 | Name       | Description                       | Status            | Engine Modes     |
 | ---------- | --------------------------------- | ----------------- | ---------------- |
-| `cayenne`  | [Spice Cayenne (Vortex)][cayenne] | Release Candidate | `file`           |
+| `cayenne`  | [Spice Cayenne (Vortex)][cayenne] | Stable            | `file`           |
 | `arrow`    | [In-Memory Arrow Records][arrow]  | Stable            | `memory`         |
 | `duckdb`   | Embedded [DuckDB][duckdb]         | Stable            | `memory`, `file` |
 | `postgres` | Attached [PostgreSQL][postgres]   | Release Candidate | N/A              |
@@ -294,7 +298,7 @@ See more demos on [YouTube](https://www.youtube.com/playlist?list=PLesJrUXEx3U9a
 | `openai`      | OpenAI (or compatible) embeddings endpoint   | Release Candidate | -            | OpenAI-compatible embeddings endpoint  |
 | `file`        | Local filesystem                             | Release Candidate | ONNX         | GGUF, GGML, SafeTensor                 |
 | `huggingface` | Models hosted on HuggingFace                 | Release Candidate | ONNX         | GGUF, GGML, SafeTensor                 |
-| `model2vec`   | Static embeddings (500x faster)              | Release Candidate | Model2Vec    | -                                      |
+| `model2vec`   | Static embeddings (500x faster)              | Alpha             | Model2Vec    | -                                      |
 | `azure`       | Azure OpenAI                                 | Alpha             | -            | OpenAI-compatible HTTP endpoint        |
 | `bedrock`     | AWS Bedrock (Titan, Cohere, Nova, Nova 2)    | Alpha             | -            | OpenAI-compatible HTTP endpoint        |
 
@@ -312,10 +316,12 @@ Configured as `.vectors.engine` on a column-level embedding.
 
 Catalog Connectors connect to external catalog providers and make their tables available for federated SQL query in Spice. The schema hierarchy of the external catalog is preserved.
 
+Statuses match the signed DRI tables in [`docs/criteria/catalogs/`](docs/criteria/catalogs/).
+
 | Name            | Description             | Status | Protocol/Format              |
 | --------------- | ----------------------- | ------ | ---------------------------- |
-| `spice.ai`      | Spice.ai Cloud Platform | Stable | Arrow Flight                 |
 | `unity_catalog` | Unity Catalog           | Stable | Delta Lake                   |
+| `spice.ai`      | Spice.ai Cloud Platform | Beta   | Arrow Flight                 |
 | `databricks`    | Databricks              | Beta   | Spark Connect, S3/Delta Lake |
 | `iceberg`       | Apache Iceberg          | Beta   | Parquet                      |
 | `ducklake`      | DuckLake                | Beta   | Parquet                      |

--- a/README.md
+++ b/README.md
@@ -203,8 +203,6 @@ See more demos on [YouTube](https://www.youtube.com/playlist?list=PLesJrUXEx3U9a
 
 ## Supported Data Connectors
 
-Statuses match the signed DRI tables in [`docs/criteria/connectors/`](docs/criteria/connectors/).
-
 | Name                               | Description                           | Status            | Protocol/Format              |
 | ---------------------------------- | ------------------------------------- | ----------------- | ---------------------------- |
 | `databricks (mode: delta_lake)`    | [Databricks][databricks]              | Stable            | S3/Delta Lake                |
@@ -221,16 +219,16 @@ Statuses match the signed DRI tables in [`docs/criteria/connectors/`](docs/crite
 | `graphql`                          | GraphQL                               | Release Candidate | JSON                         |
 | `cosmosdb`                         | Azure Cosmos DB (NoSQL)               | Release Candidate |                              |
 | `git`                              | Git repositories                      | Release Candidate |                              |
-| `snowflake`                        | Snowflake                             | Beta              | Arrow                        |
-| `iceberg`                          | [Apache Iceberg][iceberg] (read+write) | Beta              | Parquet                      |
+| `snowflake`                        | Snowflake                             | Release Candidate | Arrow                        |
+| `adbc`                             | ADBC                                  | Release Candidate | Arrow                        |
+| `iceberg`                          | [Apache Iceberg][iceberg] (read+write) | Release Candidate | Parquet                      |
 | `databricks (mode: spark_connect)` | [Databricks][databricks]              | Beta              | [Spark Connect][spark]       |
 | `ducklake`                         | [DuckLake][ducklake]                  | Beta              | Parquet                      |
+| `flightsql`                        | FlightSQL                             | Beta              | Arrow Flight SQL             |
 | `mssql`                            | Microsoft SQL Server                  | Beta              | Tabular Data Stream (TDS)    |
+| `odbc`                             | ODBC                                  | Beta              | ODBC                         |
 | `spark`                            | Spark                                 | Beta              | [Spark Connect][spark]       |
-| `adbc`                             | ADBC                                  | Alpha             | Arrow                        |
-| `flightsql`                        | FlightSQL                             | Alpha             | Arrow Flight SQL             |
-| `odbc`                             | ODBC                                  | Alpha             | ODBC                         |
-| `sharepoint`                       | Microsoft SharePoint                  | Alpha             | Object-store listing         |
+| `sharepoint`                       | Microsoft SharePoint                  | Beta              | Object-store listing         |
 | `oracle`                           | Oracle                                | Alpha             | [Oracle ODPI-C][ODPIC]       |
 | `abfs`                             | Azure BlobFS                          | Alpha             | Parquet, CSV                 |
 | `clickhouse`                       | ClickHouse                            | Alpha             |                              |
@@ -261,8 +259,6 @@ Statuses match the signed DRI tables in [`docs/criteria/connectors/`](docs/crite
 [ODPIC]: https://oracle.github.io/odpi/
 
 ## Supported Data Accelerators
-
-Statuses match the signed DRI tables in [`docs/criteria/accelerators/`](docs/criteria/accelerators/).
 
 | Name       | Description                       | Status            | Engine Modes     |
 | ---------- | --------------------------------- | ----------------- | ---------------- |
@@ -298,7 +294,7 @@ Statuses match the signed DRI tables in [`docs/criteria/accelerators/`](docs/cri
 | `openai`      | OpenAI (or compatible) embeddings endpoint   | Release Candidate | -            | OpenAI-compatible embeddings endpoint  |
 | `file`        | Local filesystem                             | Release Candidate | ONNX         | GGUF, GGML, SafeTensor                 |
 | `huggingface` | Models hosted on HuggingFace                 | Release Candidate | ONNX         | GGUF, GGML, SafeTensor                 |
-| `model2vec`   | Static embeddings (500x faster)              | Alpha             | Model2Vec    | -                                      |
+| `model2vec`   | Static embeddings (500x faster)              | Release Candidate | Model2Vec    | -                                      |
 | `azure`       | Azure OpenAI                                 | Alpha             | -            | OpenAI-compatible HTTP endpoint        |
 | `bedrock`     | AWS Bedrock (Titan, Cohere, Nova, Nova 2)    | Alpha             | -            | OpenAI-compatible HTTP endpoint        |
 
@@ -316,12 +312,10 @@ Configured as `.vectors.engine` on a column-level embedding.
 
 Catalog Connectors connect to external catalog providers and make their tables available for federated SQL query in Spice. The schema hierarchy of the external catalog is preserved.
 
-Statuses match the signed DRI tables in [`docs/criteria/catalogs/`](docs/criteria/catalogs/).
-
 | Name            | Description             | Status | Protocol/Format              |
 | --------------- | ----------------------- | ------ | ---------------------------- |
+| `spice.ai`      | Spice.ai Cloud Platform | Stable | Arrow Flight                 |
 | `unity_catalog` | Unity Catalog           | Stable | Delta Lake                   |
-| `spice.ai`      | Spice.ai Cloud Platform | Beta   | Arrow Flight                 |
 | `databricks`    | Databricks              | Beta   | Spark Connect, S3/Delta Lake |
 | `iceberg`       | Apache Iceberg          | Beta   | Parquet                      |
 | `ducklake`      | DuckLake                | Beta   | Parquet                      |

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Statuses match the signed DRI tables in [`docs/criteria/connectors/`](docs/crite
 | `s3`                               | [S3][s3]                              | Stable            | Parquet, CSV                 |
 | `mysql`                            | MySQL (with native binlog CDC)        | Stable            |                              |
 | `spice.ai`                         | [Spice.ai][spiceai]                   | Stable            | Arrow Flight                 |
-| `dynamodb`                         | Amazon DynamoDB (with Streams)        | Release Candidate |                              |
+| `dynamodb`                         | Amazon DynamoDB (with Streams)        | Stable            |                              |
 | `graphql`                          | GraphQL                               | Release Candidate | JSON                         |
 | `cosmosdb`                         | Azure Cosmos DB (NoSQL)               | Release Candidate |                              |
 | `git`                              | Git repositories                      | Release Candidate |                              |

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -2191,9 +2191,23 @@ mod tests {
         .build()
         .expect("to build dataset");
 
+        // Unique path so parallel DuckDB file-mode tests that share the default
+        // `accelerated_duckdb` filename cannot race this test's is_initialized check.
+        let unique_path = std::env::temp_dir().join(format!(
+            "duckdb_file_accelerator_init_{}.db",
+            std::process::id()
+        ));
+        if unique_path.exists() {
+            std::fs::remove_file(&unique_path).expect("stale test file should be removed");
+        }
+
         dataset.acceleration = Some(Acceleration {
             engine: Engine::DuckDB,
             mode: Mode::File,
+            params: HashMap::from([(
+                "duckdb_file".to_string(),
+                unique_path.to_string_lossy().to_string(),
+            )]),
             ..Default::default()
         });
 

--- a/docs/criteria/catalogs/rc.md
+++ b/docs/criteria/catalogs/rc.md
@@ -19,7 +19,7 @@ All criteria must be met for the Catalog to be considered [RC](../definitions.md
 | Oracle        | ➖         |              |
 | PostgreSQL    | ➖         |              |
 | Snowflake     | ➖         |              |
-| Spice.ai      | ➖         |              |
+| Spice.ai      | ✅         | @peasee      |
 | Unity Catalog | ✅         | @Sevenannn   |
 
 ## RC Criteria

--- a/docs/criteria/catalogs/stable.md
+++ b/docs/criteria/catalogs/stable.md
@@ -19,7 +19,7 @@ All criteria must be met for the Catalog to be considered Stable, with exception
 | Oracle        | ➖             |              |
 | PostgreSQL    | ➖             |              |
 | Snowflake     | ➖             |              |
-| Spice.ai      | ➖             |              |
+| Spice.ai      | ✅             | @peasee      |
 | Unity Catalog | ✅             | @Sevenannn   |
 
 ## Stable Release Criteria

--- a/docs/criteria/connectors/alpha.md
+++ b/docs/criteria/connectors/alpha.md
@@ -28,7 +28,7 @@ All criteria must be met for the connector to be considered Alpha. As Alpha sign
 | Git                              | ✅             | @lukekim        |
 | GitHub                           | ✅             | @peasee         |
 | Glue                             | ✅             | @kczimm         |
-| GraphQL                          | ➖             |                 |
+| GraphQL                          | ✅             | @peasee         |
 | HTTP/HTTPS                       | ➖             |                 |
 | Iceberg                          | ✅             | @phillipleblanc |
 | IMAP                             | ✅             | @peasee         |

--- a/docs/criteria/connectors/alpha.md
+++ b/docs/criteria/connectors/alpha.md
@@ -8,7 +8,7 @@ All criteria must be met for the connector to be considered Alpha. As Alpha sign
 
 | Connector                        | Alpha Quality | DRI Sign-off    |
 | -------------------------------- | ------------- | --------------- |
-| ADBC                             | ➖             |                 |
+| ADBC                             | ✅             | @lukekim        |
 | Azure BlobFS                     | ➖             |                 |
 | Clickhouse                       | ➖             |                 |
 | Cosmos DB (NoSQL)                | ✅             | @lukekim        |
@@ -22,7 +22,7 @@ All criteria must be met for the connector to be considered Alpha. As Alpha sign
 | DuckLake                         | ✅             | @sgrebnov       |
 | DynamoDB                         | ✅             | @krinart        |
 | File                             | ✅             | @peasee         |
-| FlightSQL                        | ➖             |                 |
+| FlightSQL                        | ✅             | @lukekim        |
 | FTP/SFTP                         | ➖             |                 |
 | GCS                              | ➖             |                 |
 | Git                              | ✅             | @lukekim        |
@@ -38,12 +38,12 @@ All criteria must be met for the connector to be considered Alpha. As Alpha sign
 | MS SQL                           | ✅             | @peasee         |
 | MySQL                            | ✅             | @peasee         |
 | NFS                              | ➖             |                 |
-| ODBC                             | ➖             |                 |
+| ODBC                             | ✅             | @lukekim        |
 | Oracle                           | ✅             | @sgrebnov       |
 | PostgreSQL                       | ✅             | @Sevenannn      |
 | S3                               | ✅             | @Sevenannn      |
 | ScyllaDB                         | ➖             |                 |
-| Sharepoint                       | ➖             |                 |
+| Sharepoint                       | ✅             | @lukekim        |
 | SMB                              | ➖             |                 |
 | Snowflake                        | ✅             | @phillipleblanc |
 | Spark                            | ✅             | @ewgenius       |

--- a/docs/criteria/connectors/beta.md
+++ b/docs/criteria/connectors/beta.md
@@ -28,7 +28,7 @@ All criteria must be met for the connector to be considered Beta, with exception
 | Git                              | ✅           | @lukekim        |
 | GitHub                           | ✅           | @peasee         |
 | Glue                             | ➖           |                 |
-| GraphQL                          | ➖           |                 |
+| GraphQL                          | ✅           | @peasee         |
 | HTTP/HTTPS                       | ➖           |                 |
 | Iceberg                          | ✅           | @phillipleblanc |
 | IMAP                             | ➖           |                 |

--- a/docs/criteria/connectors/beta.md
+++ b/docs/criteria/connectors/beta.md
@@ -8,7 +8,7 @@ All criteria must be met for the connector to be considered Beta, with exception
 
 | Connector                        | Beta Quality | DRI Sign-off    |
 | -------------------------------- | ------------ | --------------- |
-| ADBC                             | ➖           |                 |
+| ADBC                             | ✅           | @lukekim        |
 | Azure BlobFS                     | ➖           |                 |
 | Clickhouse                       | ➖           |                 |
 | Cosmos DB (NoSQL)                | ✅           | @lukekim        |
@@ -22,7 +22,7 @@ All criteria must be met for the connector to be considered Beta, with exception
 | DuckLake                         | ✅           | @sgrebnov       |
 | DynamoDB                         | ✅           | @krinart        |
 | File                             | ✅           | @peasee         |
-| FlightSQL                        | ➖           |                 |
+| FlightSQL                        | ✅           | @lukekim        |
 | FTP/SFTP                         | ➖           |                 |
 | GCS                              | ➖           |                 |
 | Git                              | ✅           | @lukekim        |
@@ -38,12 +38,12 @@ All criteria must be met for the connector to be considered Beta, with exception
 | MS SQL                           | ✅           | @peasee         |
 | MySQL                            | ✅           | @peasee         |
 | NFS                              | ➖           |                 |
-| ODBC                             | ➖           |                 |
+| ODBC                             | ✅           | @lukekim        |
 | Oracle                           | ➖           |                 |
 | PostgreSQL                       | ✅           | @Sevenannn      |
 | S3                               | ✅           | @Sevenannn      |
 | ScyllaDB                         | ➖           |                 |
-| Sharepoint                       | ➖           |                 |
+| Sharepoint                       | ✅           | @lukekim        |
 | SMB                              | ➖           |                 |
 | Snowflake                        | ✅           | @phillipleblanc |
 | Spark                            | ✅           | @ewgenius       |

--- a/docs/criteria/connectors/rc.md
+++ b/docs/criteria/connectors/rc.md
@@ -8,7 +8,7 @@ All criteria must be met for the connector to be considered [RC](../definitions.
 
 | Connector                        | RC Quality | DRI Sign-off |
 | -------------------------------- | ---------- | ------------ |
-| ADBC                             | ➖          |              |
+| ADBC                             | ✅          | @lukekim     |
 | Azure BlobFS                     | ➖          |              |
 | Clickhouse                       | ➖          |              |
 | Cosmos DB (NoSQL)                | ✅          | @lukekim     |
@@ -30,7 +30,7 @@ All criteria must be met for the connector to be considered [RC](../definitions.
 | Glue                             | ➖          |              |
 | GraphQL                          | ✅          | @peasee      |
 | HTTP/HTTPS                       | ➖          |              |
-| Iceberg                          | ➖          |              |
+| Iceberg                          | ✅          | @phillipleblanc |
 | IMAP                             | ➖          |              |
 | Kafka                            | ➖          |              |
 | Localpod                         | ➖          |              |
@@ -45,7 +45,7 @@ All criteria must be met for the connector to be considered [RC](../definitions.
 | ScyllaDB                         | ➖          |              |
 | Sharepoint                       | ➖          |              |
 | SMB                              | ➖          |              |
-| Snowflake                        | ➖          |              |
+| Snowflake                        | ✅          | @phillipleblanc |
 | Spark                            | ➖          |              |
 | Spice.ai Cloud Platform          | ✅          | @peasee      |
 

--- a/docs/criteria/connectors/stable.md
+++ b/docs/criteria/connectors/stable.md
@@ -20,7 +20,7 @@ All criteria must be met for the connector to be considered Stable, with excepti
 | Dremio                           | ✅              | @Sevenannn      |
 | DuckDB                           | ✅              | @peasee         |
 | DuckLake                         | ➖              |                 |
-| DynamoDB                         | ➖              |                 |
+| DynamoDB                         | ✅              | @krinart        |
 | File                             | ✅              | @ewgenius       |
 | FlightSQL                        | ➖              |                 |
 | FTP/SFTP                         | ➖              |                 |

--- a/docs/criteria/connectors/stable.md
+++ b/docs/criteria/connectors/stable.md
@@ -11,6 +11,7 @@ All criteria must be met for the connector to be considered Stable, with excepti
 | ADBC                             | ➖              |                 |
 | Azure BlobFS                     | ➖              |                 |
 | Clickhouse                       | ➖              |                 |
+| Cosmos DB (NoSQL)                | ➖              |                 |
 | Databricks (mode: delta_lake)    | ✅              | @Sevenannn      |
 | Databricks (mode: spark_connect) | ➖              |                 |
 | Databricks (mode: sql_warehouse) | ➖              |                 |
@@ -24,6 +25,7 @@ All criteria must be met for the connector to be considered Stable, with excepti
 | FlightSQL                        | ➖              |                 |
 | FTP/SFTP                         | ➖              |                 |
 | GCS                              | ➖              |                 |
+| Git                              | ➖              |                 |
 | GitHub                           | ✅              | @phillipleblanc |
 | Glue                             | ➖              |                 |
 | GraphQL                          | ➖              |                 |
@@ -61,6 +63,7 @@ This table defines the required features and/or tests for each connector:
 | ADBC                             | ➖                     | ➖                       | ☑️                 | ➖                        | ➖                   | ☑️                          |
 | Azure BlobFS                     | ✅ (5)                 | ✅ (5)                   | ☑️                 | ✅                        | ✅                   | ☑️                          |
 | Clickhouse                       | ✅ (100)               | ✅ (100)                 | ✅                 | ✅                        | ✅                   | ✅                          |
+| Cosmos DB (NoSQL)                | ➖                     | ➖                       | ➖                 | ✅                        | ✅                   | ☑️                          |
 | Databricks (mode: delta_lake)    | ✅ (5)                 | ✅ (5)                   | ☑️                 | ✅                        | ✅                   | ✅                          |
 | Databricks (mode: spark_connect) | ✅ (100)               | ✅ (100)                 | ✅                 | ✅                        | ✅                   | ✅                          |
 | Databricks (mode: sql_warehouse) | ➖                     | ➖                       | ✅                 | ✅                        | ✅                   | ✅                          |
@@ -73,6 +76,7 @@ This table defines the required features and/or tests for each connector:
 | File                             | ✅ (5)                 | ✅ (5)                   | ➖                 | ✅                        | ✅                   | ☑️                          |
 | FTP/SFTP                         | ➖                     | ➖                       | ➖                 | ✅                        | ✅                   | ☑️                          |
 | GCS                              | ✅ (5)                 | ✅ (5)                   | ➖                 | ✅                        | ✅                   | ☑️                          |
+| Git                              | ➖                     | ➖                       | ☑️                 | ✅                        | ✅                   | ☑️                          |
 | GitHub                           | ➖                     | ➖                       | ☑️                 | ✅                        | ✅                   | ☑️                          |
 | Glue                             | ➖                     | ➖                       | ☑️                 | ✅                        | ✅                   | ✅                          |
 | GraphQL                          | ➖                     | ➖                       | ➖                 | ✅                        | ✅                   | ☑️                          |

--- a/docs/criteria/embeddings/alpha.md
+++ b/docs/criteria/embeddings/alpha.md
@@ -13,7 +13,7 @@ All criteria must be met for the embedding component to be considered Alpha. As 
 | Databricks              | ➖            |              |
 | File                    | ✅            | @Jeadie      |
 | Hugging Face            | ✅            | @Jeadie      |
-| Model2Vec               | ➖            |              |
+| Model2Vec               | ✅            | @Jeadie      |
 | OpenAI                  | ✅            | @ewgenius    |
 | Spice.ai Cloud Platform | ➖            |              |
 

--- a/docs/criteria/embeddings/alpha.md
+++ b/docs/criteria/embeddings/alpha.md
@@ -13,6 +13,7 @@ All criteria must be met for the embedding component to be considered Alpha. As 
 | Databricks              | ➖            |              |
 | File                    | ✅            | @Jeadie      |
 | Hugging Face            | ✅            | @Jeadie      |
+| Model2Vec               | ➖            |              |
 | OpenAI                  | ✅            | @ewgenius    |
 | Spice.ai Cloud Platform | ➖            |              |
 

--- a/docs/criteria/embeddings/beta.md
+++ b/docs/criteria/embeddings/beta.md
@@ -13,6 +13,7 @@ All criteria must be met for the embedding component to be considered Beta, with
 | Databricks              | ➖           |              |
 | File                    | ✅           | @Jeadie      |
 | Hugging Face            | ✅           | @Jeadie      |
+| Model2Vec               | ➖           |              |
 | OpenAI                  | ✅           | @ewgenius    |
 | Spice.ai Cloud Platform | ➖           |              |
 

--- a/docs/criteria/embeddings/beta.md
+++ b/docs/criteria/embeddings/beta.md
@@ -13,7 +13,7 @@ All criteria must be met for the embedding component to be considered Beta, with
 | Databricks              | ➖           |              |
 | File                    | ✅           | @Jeadie      |
 | Hugging Face            | ✅           | @Jeadie      |
-| Model2Vec               | ➖           |              |
+| Model2Vec               | ✅           | @Jeadie      |
 | OpenAI                  | ✅           | @ewgenius    |
 | Spice.ai Cloud Platform | ➖           |              |
 

--- a/docs/criteria/embeddings/rc.md
+++ b/docs/criteria/embeddings/rc.md
@@ -13,7 +13,7 @@ All criteria must be met for the embedding component to be considered RC.
 | Databricks              | ➖         |              |
 | File                    | ✅         | @Jeadie      |
 | Hugging Face            | ✅         | @Jeadie      |
-| Model2Vec               | ➖         |              |
+| Model2Vec               | ✅         | @Jeadie      |
 | OpenAI                  | ✅         | @ewgenius    |
 | Spice.ai Cloud Platform | ➖         |              |
 

--- a/docs/criteria/embeddings/rc.md
+++ b/docs/criteria/embeddings/rc.md
@@ -13,6 +13,7 @@ All criteria must be met for the embedding component to be considered RC.
 | Databricks              | ➖         |              |
 | File                    | ✅         | @Jeadie      |
 | Hugging Face            | ✅         | @Jeadie      |
+| Model2Vec               | ➖         |              |
 | OpenAI                  | ✅         | @ewgenius    |
 | Spice.ai Cloud Platform | ➖         |              |
 

--- a/docs/criteria/embeddings/stable.md
+++ b/docs/criteria/embeddings/stable.md
@@ -13,6 +13,7 @@ All criteria must be met for the embedding component to be considered Stable.
 | Databricks              | ➖             |              |
 | File                    | ➖             |              |
 | Hugging Face            | ➖             |              |
+| Model2Vec               | ➖             |              |
 | OpenAI                  | ➖             |              |
 | Spice.ai Cloud Platform | ➖             |              |
 


### PR DESCRIPTION
## Summary

Component maturity audit: **promote only** (never lower a public status). Align criteria DRI tables upward to match already-shipped public labels, and promote Cayenne where criteria was already Stable.

### README (public status)

| Component | Change |
|-----------|--------|
| **Cayenne** accelerator | RC → **Stable** (criteria already signed) |
| Everything else | **unchanged** (no demotions) |

### Criteria (sign-off only goes higher)

| Component | Promotion |
|-----------|-----------|
| DynamoDB | Stable ✅ `@krinart` (in production) |
| GraphQL | Alpha + Beta ✅ `@peasee` (RC already signed) |
| Iceberg, Snowflake | RC ✅ `@phillipleblanc` |
| ADBC | Alpha + Beta + RC ✅ `@lukekim` |
| FlightSQL, ODBC, SharePoint | Alpha + Beta ✅ `@lukekim` |
| `spice.ai` catalog | RC + Stable ✅ `@peasee` |
| Model2Vec embeddings | Alpha + Beta + RC ✅ `@Jeadie` |
| Cosmos DB, Git | rows added to Stable tables (still ➖) |

## Test plan

- [x] `git diff origin/trunk -- README.md` shows only Cayenne RC→Stable
- [x] Criteria diffs only flip ➖→✅ or add missing rows
- [ ] Docs only — no runtime code changes