### PR TITLE
ci(signoff): prefer lab SSH for remote sign-off; skip Rust when no .rs changes

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -6,14 +6,16 @@
 # so the PR's Attestation check turns green.
 #
 # Same fail-fast order as local sign-off:
-#   0. Skip Rust lint/build/tests when the branch has no changed .rs files vs trunk
+#   0. Skip Rust lint/build/tests when the branch has no Rust-affecting files
+#      vs trunk (.rs, Cargo.toml/lock, rust-toolchain*, .cargo/*)
 #   1. Targeted lint of crates touched by the branch vs trunk
 #   2. Full workspace lint (make lint-rust)
 #   3. CLI build + unit tests (make build-cli nextest)
 #   4. Post signoff status + re-run Attestation if needed
 #
 # Prefer lab SSH when available (make signoff-remote probes 192.168.1.100/101
-# for ~/dev/spice2 first). This workflow is the fallback when no SSH host works:
+# for a Git $HOME/dev/spice2 first). This workflow is the fallback when no SSH
+# host works:
 #   make signoff-remote
 #   gh workflow run signoff.yml -f branch=<your-branch>
 name: Remote Sign-off

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -6,12 +6,14 @@
 # so the PR's Attestation check turns green.
 #
 # Same fail-fast order as local sign-off:
+#   0. Skip Rust lint/build/tests when the branch has no changed .rs files vs trunk
 #   1. Targeted lint of crates touched by the branch vs trunk
 #   2. Full workspace lint (make lint-rust)
 #   3. CLI build + unit tests (make build-cli nextest)
 #   4. Post signoff status + re-run Attestation if needed
 #
-# Use this when you can't (or don't want to) run the checks locally:
+# Prefer lab SSH when available (make signoff-remote probes 192.168.1.100/101
+# for ~/dev/spice2 first). This workflow is the fallback when no SSH host works:
 #   make signoff-remote
 #   gh workflow run signoff.yml -f branch=<your-branch>
 name: Remote Sign-off

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ All contributions come through pull requests. To submit a proposed change, we re
    - Code changes require tests
 1. Update relevant documentation for the change
 1. Commit and push your branch
-1. Run `make signoff` to attest your change — it skips Rust lint/build/tests when the branch has no changed `.rs` files, otherwise target-lints changed crates then full lint + unit tests, and records a sign-off on the exact commit you pushed (or `make signoff-remote` to run the same checks on a lab SSH host or self-hosted runner; see [CI Sign-off](/docs/dev/ci_signoff.md))
+1. Run `make signoff` to attest your change — it skips Rust lint/build/tests when the branch has no Rust-affecting files (`.rs`, Cargo/toolchain config), otherwise target-lints changed crates then full lint + unit tests, and records a sign-off on the exact commit you pushed (or `make signoff-remote` to run the same checks on a lab SSH host or self-hosted runner; see [CI Sign-off](/docs/dev/ci_signoff.md))
 1. Open a PR. A single **Attestation** check validates your sign-off; that plus a review is what adds the PR to the merge queue, where the full test suite runs as the required gate
 1. A maintainer of the project will be assigned, and you can expect a review within a few days
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ All contributions come through pull requests. To submit a proposed change, we re
    - Code changes require tests
 1. Update relevant documentation for the change
 1. Commit and push your branch
-1. Run `make signoff` to attest your change — it target-lints changed crates, then full lint + unit tests, and records a sign-off on the exact commit you pushed (or `make signoff-remote` to run the same checks on a self-hosted runner; see [CI Sign-off](/docs/dev/ci_signoff.md))
+1. Run `make signoff` to attest your change — it skips Rust lint/build/tests when the branch has no changed `.rs` files, otherwise target-lints changed crates then full lint + unit tests, and records a sign-off on the exact commit you pushed (or `make signoff-remote` to run the same checks on a lab SSH host or self-hosted runner; see [CI Sign-off](/docs/dev/ci_signoff.md))
 1. Open a PR. A single **Attestation** check validates your sign-off; that plus a review is what adds the PR to the merge queue, where the full test suite runs as the required gate
 1. A maintainer of the project will be assigned, and you can expect a review within a few days
 

--- a/Makefile
+++ b/Makefile
@@ -62,18 +62,20 @@ ci:
 	make -C bin/spiced
 
 # Local CI attestation ("developer sign-off"). Skips Rust lint/build/tests when
-# the branch has no changed .rs files vs trunk; otherwise target-lints changed
-# crates, then full lint + unit tests. Posts a `signoff` commit status on HEAD
-# so the PR can enter the merge queue. See scripts/signoff and docs/dev/ci_signoff.md.
+# the branch has no Rust-affecting files vs trunk (.rs, Cargo.toml/lock,
+# rust-toolchain*, .cargo/*); otherwise target-lints changed crates, then full
+# lint + unit tests. Posts a `signoff` commit status on HEAD so the PR can enter
+# the merge queue. See scripts/signoff and docs/dev/ci_signoff.md.
 .PHONY: signoff
 signoff:
 	@./scripts/signoff
 
 # Remote sign-off for the current branch: probe lab SSH hosts (192.168.1.100,
-# 192.168.1.101) for ~/dev/spice2 and run scripts/signoff there when available;
-# otherwise dispatch the self-hosted GitHub Actions signoff.yml workflow.
-# Supports Git and JJ via scripts/signoff remote. Skips Rust lint/build/tests
-# when the branch has no changed .rs files vs trunk (same as local signoff).
+# 192.168.1.101) for a Git checkout at $HOME/dev/spice2 and run scripts/signoff
+# there when available; otherwise dispatch the self-hosted GitHub Actions
+# signoff.yml workflow. Supports Git and JJ via scripts/signoff remote. Skips
+# Rust lint/build/tests when the branch has no Rust-affecting files vs trunk
+# (same as local signoff).
 .PHONY: signoff-remote
 signoff-remote:
 	@./scripts/signoff remote

--- a/Makefile
+++ b/Makefile
@@ -61,16 +61,19 @@ ci:
 	make -C bin/spice
 	make -C bin/spiced
 
-# Local CI attestation ("developer sign-off"). Target-lints changed crates,
-# then full lint + unit tests, then posts a `signoff` commit status on HEAD so
-# the PR can enter the merge queue. See scripts/signoff and docs/dev/ci_signoff.md.
+# Local CI attestation ("developer sign-off"). Skips Rust lint/build/tests when
+# the branch has no changed .rs files vs trunk; otherwise target-lints changed
+# crates, then full lint + unit tests. Posts a `signoff` commit status on HEAD
+# so the PR can enter the merge queue. See scripts/signoff and docs/dev/ci_signoff.md.
 .PHONY: signoff
 signoff:
 	@./scripts/signoff
 
-# Dispatch the Remote Sign-off workflow for the current branch (self-hosted).
-# Supports Git and JJ via scripts/signoff remote. Targeted pre-lint always
-# diffs against trunk.
+# Remote sign-off for the current branch: probe lab SSH hosts (192.168.1.100,
+# 192.168.1.101) for ~/dev/spice2 and run scripts/signoff there when available;
+# otherwise dispatch the self-hosted GitHub Actions signoff.yml workflow.
+# Supports Git and JJ via scripts/signoff remote. Skips Rust lint/build/tests
+# when the branch has no changed .rs files vs trunk (same as local signoff).
 .PHONY: signoff-remote
 signoff-remote:
 	@./scripts/signoff remote

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -55,11 +55,12 @@ and up to date:
 make signoff          # targeted crate lint → full lint + unit tests, then attests
 ```
 
-`make signoff` first diffs the branch against `trunk`, maps changed files to
-workspace crates, and runs `make lint-rust PACKAGES="…"` for fast fail-first
-feedback. It then always runs the full `make lint-rust` and
-`make build-cli nextest` gate. Set `SIGNOFF_SKIP_TARGETED_LINT=1` to skip the
-scoped pre-lint.
+`make signoff` first diffs the branch against `trunk`. If that diff contains no
+`.rs` files, Rust lint/build/unit tests are skipped and the sign-off status is
+still posted (docs/YAML/script-only changes). Otherwise it maps changed files to
+workspace crates, runs `make lint-rust PACKAGES="…"` for fast fail-first
+feedback, then the full `make lint-rust` and `make build-cli nextest` gate. Set
+`SIGNOFF_SKIP_TARGETED_LINT=1` to skip the scoped pre-lint.
 
 On success it posts a `signoff` commit status on your current `HEAD`. If the
 **Attestation** check already ran and failed before the sign-off existed, the
@@ -114,30 +115,42 @@ scripts/signoff status        # does HEAD have its own sign-off?
 scripts/signoff --help        # full usage
 ```
 
-### Remote sign-off (self-hosted runner)
+### Remote sign-off (lab SSH host or self-hosted runner)
 
-When you can't (or don't want to) run the checks on your machine, dispatch the
-**Remote Sign-off** workflow. It runs the same fail-fast sequence as local
-`make signoff` on a self-hosted runner, then posts the `signoff` status
-attributed to you:
+When you can't (or don't want to) run the checks on your machine:
 
 ```bash
 make signoff-remote                 # current branch
+```
+
+`make signoff-remote` first probes lab hosts over SSH (`192.168.1.100`,
+`192.168.1.101` by default; override with `SIGNOFF_SSH_HOSTS`). The first host
+that answers and has a `~/dev/spice2` checkout is used: it fetches your pushed
+branch into that clone and runs `scripts/signoff -f` there (same checks and
+skip-if-no-`.rs` behavior as local). Override the remote path with
+`SIGNOFF_SSH_REPO=/absolute/path`.
+
+If no SSH host is usable, it falls back to dispatching the **Remote Sign-off**
+GitHub Actions workflow on a self-hosted runner:
+
+```bash
 gh workflow run signoff.yml -f branch=<your-branch>
 gh run watch --workflow signoff.yml
 ```
 
-The workflow:
+The Actions workflow:
 
 1. Checks out your branch (full history) and fetches `trunk`
 2. Target-lints crates touched by the branch vs `trunk` (GitHub compare API as a
-   fallback when merge-base isn't available)
-3. Runs full `make lint-rust` + `make build-cli nextest`
+   fallback when merge-base isn't available), or skips Rust checks when the
+   branch has no changed `.rs` files
+3. Runs full `make lint-rust` + `make build-cli nextest` when Rust changed
 4. Posts pending → success/failure `signoff` statuses, then re-runs
    **Attestation** if needed
 
 Requires write access to the repository (same as local sign-off — fork
-contributors still need a maintainer to sign off).
+contributors still need a maintainer to sign off). The lab SSH path also needs
+SSH key access to the host and `gh` auth on that machine.
 
 ### Jujutsu workspaces
 
@@ -184,8 +197,8 @@ merge queue is still the real gate.
 
 | Stage | Trigger | Checks |
 | --- | --- | --- |
-| Local | `make signoff` | targeted `make lint-rust PACKAGES=…` (changed crates), then full `make lint-rust`, `make build-cli nextest` |
-| Remote | `make signoff-remote` / `signoff.yml` | same checks as local on a self-hosted runner; posts `signoff` as the dispatcher |
+| Local | `make signoff` | skip Rust if no `.rs` in the branch diff; else targeted `make lint-rust PACKAGES=…`, full `make lint-rust`, `make build-cli nextest` |
+| Remote | `make signoff-remote` | same checks via lab SSH (`~/dev/spice2` on 192.168.1.100/101) if reachable, else self-hosted `signoff.yml`; posts `signoff` |
 | Pull request | `pull_request` | **Attestation** (validates the sign-off, or auto-passes a pure revert) + PR hygiene; merge-queue check names report lightweight skipped/passthrough results |
 | Merge queue | `merge_group` | the full required suite (below) + advisory niche checks |
 

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -55,8 +55,9 @@ and up to date:
 make signoff          # targeted crate lint → full lint + unit tests, then attests
 ```
 
-`make signoff` first diffs the branch against `trunk`. If that diff contains no
-`.rs` files, Rust lint/build/unit tests are skipped and the sign-off status is
+`make signoff` first diffs the branch against `trunk`. If that diff has no
+Rust-affecting files (`.rs`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain*`,
+`.cargo/*`), Rust lint/build/unit tests are skipped and the sign-off status is
 still posted (docs/YAML/script-only changes). Otherwise it maps changed files to
 workspace crates, runs `make lint-rust PACKAGES="…"` for fast fail-first
 feedback, then the full `make lint-rust` and `make build-cli nextest` gate. Set
@@ -125,10 +126,10 @@ make signoff-remote                 # current branch
 
 `make signoff-remote` first probes lab hosts over SSH (`192.168.1.100`,
 `192.168.1.101` by default; override with `SIGNOFF_SSH_HOSTS`). The first host
-that answers and has a `~/dev/spice2` checkout is used: it fetches your pushed
-branch into that clone and runs `scripts/signoff -f` there (same checks and
-skip-if-no-`.rs` behavior as local). Override the remote path with
-`SIGNOFF_SSH_REPO=/absolute/path`.
+that answers and has a Git checkout at `$HOME/dev/spice2` is used: it fetches
+your pushed branch into that clone and runs `scripts/signoff -f` there (same
+checks and Rust-skip behavior as local). Override the remote path with an
+absolute path only: `SIGNOFF_SSH_REPO=/absolute/path` (`~` is not expanded).
 
 If no SSH host is usable, it falls back to dispatching the **Remote Sign-off**
 GitHub Actions workflow on a self-hosted runner:
@@ -143,8 +144,8 @@ The Actions workflow:
 1. Checks out your branch (full history) and fetches `trunk`
 2. Target-lints crates touched by the branch vs `trunk` (GitHub compare API as a
    fallback when merge-base isn't available), or skips Rust checks when the
-   branch has no changed `.rs` files
-3. Runs full `make lint-rust` + `make build-cli nextest` when Rust changed
+   branch has no Rust-affecting files
+3. Runs full `make lint-rust` + `make build-cli nextest` when Rust is affected
 4. Posts pending → success/failure `signoff` statuses, then re-runs
    **Attestation** if needed
 
@@ -197,8 +198,8 @@ merge queue is still the real gate.
 
 | Stage | Trigger | Checks |
 | --- | --- | --- |
-| Local | `make signoff` | skip Rust if no `.rs` in the branch diff; else targeted `make lint-rust PACKAGES=…`, full `make lint-rust`, `make build-cli nextest` |
-| Remote | `make signoff-remote` | same checks via lab SSH (`~/dev/spice2` on 192.168.1.100/101) if reachable, else self-hosted `signoff.yml`; posts `signoff` |
+| Local | `make signoff` | skip Rust if no Rust-affecting files in the branch diff; else targeted `make lint-rust PACKAGES=…`, full `make lint-rust`, `make build-cli nextest` |
+| Remote | `make signoff-remote` | same checks via lab SSH (`$HOME/dev/spice2` on 192.168.1.100/101) if reachable, else self-hosted `signoff.yml`; posts `signoff` |
 | Pull request | `pull_request` | **Attestation** (validates the sign-off, or auto-passes a pure revert) + PR hygiene; merge-queue check names report lightweight skipped/passthrough results |
 | Merge queue | `merge_group` | the full required suite (below) + advisory niche checks |
 

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -39,14 +39,16 @@
 #   SIGNOFF_SKIP_TARGETED_LINT  Set to any value to skip the branch-scoped pre-lint
 #   SIGNOFF_SSH_HOSTS Space-separated hosts for make signoff-remote (default:
 #                     192.168.1.100 192.168.1.101). First host that answers SSH
-#                     and has ~/dev/spice2 is used; otherwise falls back to GHA.
-#   SIGNOFF_SSH_REPO  Path to the spice2 checkout on the SSH host (default:
-#                     $HOME/dev/spice2 on the remote). Relative paths are not
-#                     supported — use an absolute path or ~/….
+#                     and has a Git checkout at $HOME/dev/spice2 is used;
+#                     otherwise falls back to GHA.
+#   SIGNOFF_SSH_REPO  Absolute path to the spice2 Git checkout on the SSH host
+#                     (default: $HOME/dev/spice2 on the remote). Must start with
+#                     / — ~ and relative paths are not expanded through SSH argv.
 #
 # Targeted pre-lint always diffs against trunk (not configurable).
-# When the branch has no changed .rs files vs trunk, Rust lint/build/tests are
-# skipped (both local and remote); the sign-off status is still posted.
+# When the branch has no Rust-affecting changes vs trunk (.rs, Cargo.toml,
+# Cargo.lock, rust-toolchain*, .cargo/*), Rust lint/build/tests are skipped
+# (both local and remote); the sign-off status is still posted.
 #
 # Remote alternative to local `make signoff`:
 #   make signoff-remote                  # SSH to a lab host if available, else GHA
@@ -475,9 +477,11 @@ post_commit_status() {
 
 # --- commands ----------------------------------------------------------------
 
-# True when the branch delta vs trunk includes at least one `.rs` file.
-# Prints nothing. Exit 0 = has Rust changes (or unknown — run checks).
-# Exit 1 = definitively no `.rs` files in the changed set → safe to skip.
+# True when the branch delta vs trunk can affect Rust lint/build/tests.
+# Matches .rs sources plus Cargo/toolchain config that can break those gates:
+#   *.rs, Cargo.toml, Cargo.lock, rust-toolchain[.toml], .cargo/*
+# Prints nothing. Exit 0 = has Rust-affecting changes (or unknown — run checks).
+# Exit 1 = no such paths in the changed set → safe to skip.
 # Unknown (diff unavailable) returns 0 so we never skip when we can't tell.
 branch_has_rust_changes() {
   local revision="$1"
@@ -491,12 +495,13 @@ branch_has_rust_changes() {
     debug "no changed files vs ${LINT_BASE_BRANCH} — no Rust changes"
     return 1
   fi
-  # Match paths ending in .rs (case-sensitive; Rust sources are always .rs).
-  if printf '%s\n' "$files" | grep -qE '\.rs$'; then
-    debug "changed .rs files present — will run Rust checks"
+  # Paths that can change what cargo/clippy/fmt/nextest do (not docs/scripts alone).
+  if printf '%s\n' "$files" | grep -qE \
+      '(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/)'; then
+    debug "Rust-affecting files present — will run Rust checks"
     return 0
   fi
-  debug "no .rs files in changed set — can skip Rust lint/build/tests"
+  debug "no Rust-affecting files in changed set — can skip Rust lint/build/tests"
   return 1
 }
 
@@ -505,7 +510,7 @@ branch_has_rust_changes() {
 # queue, so it deliberately isn't part of the local sign-off.
 #
 # Fail-fast order:
-#   0. Skip all Rust work when the branch has no changed .rs files vs trunk
+#   0. Skip all Rust work when the branch has no Rust-affecting files vs trunk
 #   1. Targeted lint on packages touched by the branch (fast feedback)
 #   2. Full workspace lint (the real gate)
 #   3. CLI build + unit tests
@@ -520,8 +525,8 @@ run_checks() {
   # Non-Rust-only changes (docs, YAML, scripts, …): still attest, but skip the
   # expensive lint/build/test gate. Unknown diffs fall through and run checks.
   if [[ -n "$revision" ]] && ! branch_has_rust_changes "$revision"; then
-    info "No .rs files changed vs ${LINT_BASE_BRANCH} — skipping Rust lint, build, and unit tests"
-    append_step_summary "### Rust checks"$'\n'"Skipped (no \`.rs\` files in the branch diff vs \`${LINT_BASE_BRANCH}\`)."$'\n'
+    info "No Rust-affecting files changed vs ${LINT_BASE_BRANCH} — skipping Rust lint, build, and unit tests"
+    append_step_summary "### Rust checks"$'\n'"Skipped (no \`.rs\` / Cargo / rust-toolchain / \`.cargo/\` files in the branch diff vs \`${LINT_BASE_BRANCH}\`)."$'\n'
     SIGNOFF_CHECK_SUMMARY="no Rust changes (lint/test skipped)"
     return 0
   fi
@@ -809,8 +814,9 @@ cmd_install() {
   echo "${OK} '${TARGET_BRANCH}' now requires developer sign-off + the full merge-queue suite."
 }
 
-# Validate SIGNOFF_SSH_REPO (optional override). Empty → default ~/dev/spice2
-# on the remote. Absolute path only; tight charset so it is safe in ssh argv.
+# Validate SIGNOFF_SSH_REPO (optional override). Empty → default $HOME/dev/spice2
+# on the remote. Absolute path only (/…); tight charset so it is safe in ssh argv.
+# ~ and relative paths are rejected — they are not expanded through SSH argv.
 signoff_ssh_repo_or_default() {
   local remote_repo="${SIGNOFF_SSH_REPO:-}"
   if [[ -z "$remote_repo" ]]; then
@@ -818,13 +824,15 @@ signoff_ssh_repo_or_default() {
     return 0
   fi
   [[ "$remote_repo" == /* ]] \
-    || fail "SIGNOFF_SSH_REPO must be an absolute path (got: '${remote_repo}')"
+    || fail "SIGNOFF_SSH_REPO must be an absolute path starting with / (got: '${remote_repo}')"
   [[ "$remote_repo" =~ ^[A-Za-z0-9._/-]+$ ]] \
     || fail "SIGNOFF_SSH_REPO contains unsafe characters: '${remote_repo}'"
   echo "$remote_repo"
 }
 
-# Probe SIGNOFF_SSH_HOSTS (default lab IPs) for BatchMode SSH + a spice2 checkout.
+# Probe SIGNOFF_SSH_HOSTS (default lab IPs) for BatchMode SSH + a spice2 Git checkout.
+# Only Git is accepted (run_signoff_via_ssh requires git); a bare .jj workspace
+# would pass a looser probe and then fail the sign-off itself.
 # Prints the first usable host to stdout; status messages go to stderr via info.
 # Exit 0 with a host, or 1 if none are usable.
 find_signoff_ssh_host() {
@@ -834,9 +842,10 @@ find_signoff_ssh_host() {
 
   if [[ -n "$remote_repo" ]]; then
     # Path already charset-validated; embed as a single-quoted remote literal.
-    probe_cmd="repo='${remote_repo}'; test -d \"\$repo\" && { test -e \"\$repo/.git\" || test -d \"\$repo/.jj\"; }"
+    # Require .git (file or dir) — matches run_signoff_via_ssh Git-only support.
+    probe_cmd="repo='${remote_repo}'; test -d \"\$repo\" && test -e \"\$repo/.git\""
   else
-    probe_cmd='repo="$HOME/dev/spice2"; test -d "$repo" && { test -e "$repo/.git" || test -d "$repo/.jj"; }'
+    probe_cmd='repo="$HOME/dev/spice2"; test -d "$repo" && test -e "$repo/.git"'
   fi
 
   for host in $hosts; do
@@ -869,7 +878,7 @@ run_signoff_via_ssh() {
   local remote_repo
   remote_repo=$(signoff_ssh_repo_or_default)
 
-  info "Running sign-off via SSH on ${host}:${remote_repo:-~/dev/spice2} (branch ${branch})…"
+  info "Running sign-off via SSH on ${host}:${remote_repo:-\$HOME/dev/spice2} (branch ${branch})…"
   # Remote command is `bash -s -- <branch> <repo-or-empty>`; the heredoc is
   # stdin for bash -s. Branch is charset-validated in cmd_remote; repo is an
   # absolute path or empty (→ $HOME/dev/spice2 on the remote).
@@ -981,8 +990,8 @@ Maintainers:
   scripts/signoff install --yes  Apply it (needs admin on the repo)
 
 Checks (when verify is on):
-  0. If the branch has no changed .rs files vs trunk → skip Rust lint/build/tests
-     (still posts the sign-off status)
+  0. If the branch has no Rust-affecting files vs trunk (.rs, Cargo.toml/lock,
+     rust-toolchain*, .cargo/*) → skip Rust lint/build/tests (still posts status)
   1. Targeted lint of crates touched by this branch vs trunk
      (make lint-rust PACKAGES="…") — fail-fast feedback
   2. Full workspace lint (make lint-rust)
@@ -993,8 +1002,9 @@ Checks (when verify is on):
   the GitHub compare API when the clone is too shallow for merge-base.
 
   make signoff-remote probes SIGNOFF_SSH_HOSTS (default: ${DEFAULT_SIGNOFF_SSH_HOSTS})
-  for SSH + ~/dev/spice2, checks out the pushed branch there, and runs signoff.
-  If no host is usable, it falls back to dispatching signoff.yml on GitHub Actions.
+  for SSH + a Git checkout at \$HOME/dev/spice2, checks out the pushed branch
+  there, and runs signoff. If no host is usable, it falls back to dispatching
+  signoff.yml on GitHub Actions.
 
 The sign-off is a '${STATUS_CONTEXT}' commit status bound to the exact commit you
 pushed. Sign off again after any code change or manual conflict resolution. The

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -37,16 +37,26 @@
 #                     statuses, "via remote" description, GitHub step summary
 #   SIGNOFF_DEBUG     Set to any value for verbose debug logging
 #   SIGNOFF_SKIP_TARGETED_LINT  Set to any value to skip the branch-scoped pre-lint
+#   SIGNOFF_SSH_HOSTS Space-separated hosts for make signoff-remote (default:
+#                     192.168.1.100 192.168.1.101). First host that answers SSH
+#                     and has ~/dev/spice2 is used; otherwise falls back to GHA.
+#   SIGNOFF_SSH_REPO  Path to the spice2 checkout on the SSH host (default:
+#                     $HOME/dev/spice2 on the remote). Relative paths are not
+#                     supported — use an absolute path or ~/….
 #
 # Targeted pre-lint always diffs against trunk (not configurable).
+# When the branch has no changed .rs files vs trunk, Rust lint/build/tests are
+# skipped (both local and remote); the sign-off status is still posted.
 #
-# Remote (self-hosted runner) alternative to local `make signoff`:
-#   make signoff-remote                  # gh workflow run signoff.yml for HEAD branch
+# Remote alternative to local `make signoff`:
+#   make signoff-remote                  # SSH to a lab host if available, else GHA
 #   gh workflow run signoff.yml -f branch=<branch>
 
 set -euo pipefail
 
-readonly VERSION="1.2.0"
+readonly VERSION="1.3.0"
+# Default LAN lab hosts for `signoff remote` (SSH path). Overridable via env.
+readonly DEFAULT_SIGNOFF_SSH_HOSTS="192.168.1.100 192.168.1.101"
 # Fixed, not configurable: it must match the hardcoded context the Attestation
 # workflow (pr.yml) looks for, so an env override would silently break the gate.
 readonly STATUS_CONTEXT="signoff"
@@ -465,20 +475,56 @@ post_commit_status() {
 
 # --- commands ----------------------------------------------------------------
 
+# True when the branch delta vs trunk includes at least one `.rs` file.
+# Prints nothing. Exit 0 = has Rust changes (or unknown — run checks).
+# Exit 1 = definitively no `.rs` files in the changed set → safe to skip.
+# Unknown (diff unavailable) returns 0 so we never skip when we can't tell.
+branch_has_rust_changes() {
+  local revision="$1"
+  local files
+
+  if ! files=$(changed_files_vs_trunk "$revision"); then
+    debug "could not list changed files — assuming Rust changes (will run checks)"
+    return 0
+  fi
+  if [[ -z "${files//[$'\t\n\r ']/}" ]]; then
+    debug "no changed files vs ${LINT_BASE_BRANCH} — no Rust changes"
+    return 1
+  fi
+  # Match paths ending in .rs (case-sensitive; Rust sources are always .rs).
+  if printf '%s\n' "$files" | grep -qE '\.rs$'; then
+    debug "changed .rs files present — will run Rust checks"
+    return 0
+  fi
+  debug "no .rs files in changed set — can skip Rust lint/build/tests"
+  return 1
+}
+
 # Run the same fast checks the old PR build ran: lint + build + unit tests.
 # The heavier suite (release build, integration, e2e, ...) runs in the merge
 # queue, so it deliberately isn't part of the local sign-off.
 #
 # Fail-fast order:
+#   0. Skip all Rust work when the branch has no changed .rs files vs trunk
 #   1. Targeted lint on packages touched by the branch (fast feedback)
 #   2. Full workspace lint (the real gate)
 #   3. CLI build + unit tests
 #
+# Sets SIGNOFF_CHECK_SUMMARY (short phrase for the commit-status description).
 # Output streams straight to the terminal — call this bare, never `$(run_checks)`,
 # which would capture make's stdout.
 run_checks() {
   local revision="${1:-}"
   local packages=""
+
+  # Non-Rust-only changes (docs, YAML, scripts, …): still attest, but skip the
+  # expensive lint/build/test gate. Unknown diffs fall through and run checks.
+  if [[ -n "$revision" ]] && ! branch_has_rust_changes "$revision"; then
+    info "No .rs files changed vs ${LINT_BASE_BRANCH} — skipping Rust lint, build, and unit tests"
+    append_step_summary "### Rust checks"$'\n'"Skipped (no \`.rs\` files in the branch diff vs \`${LINT_BASE_BRANCH}\`)."$'\n'
+    SIGNOFF_CHECK_SUMMARY="no Rust changes (lint/test skipped)"
+    return 0
+  fi
 
   if [[ -z "${SIGNOFF_SKIP_TARGETED_LINT:-}" && -n "$revision" ]]; then
     packages=$(changed_workspace_packages "$revision" || true)
@@ -507,6 +553,8 @@ run_checks() {
 
   info "Building the CLI and running unit tests (make build-cli nextest)…"
   make build-cli nextest || return $?
+
+  SIGNOFF_CHECK_SUMMARY="lint+test passed"
 }
 
 # After a successful sign-off, the PR's `Attestation` job (pr.yml) only
@@ -597,6 +645,8 @@ cmd_signoff() {
 
   if $verify; then
     local check_status=0
+    # Default summary; run_checks overwrites on success (incl. Rust-skip path).
+    SIGNOFF_CHECK_SUMMARY="lint+test passed"
     start=$(date +%s)
     if is_remote_run; then
       post_commit_status "$repo" "$sha" pending \
@@ -621,7 +671,7 @@ cmd_signoff() {
       fail "sign-off checks failed"
     fi
     elapsed=$(( $(date +%s) - start ))
-    description="Signed off by ${user}${via} — lint+test passed in ${elapsed}s"
+    description="Signed off by ${user}${via} — ${SIGNOFF_CHECK_SUMMARY} in ${elapsed}s"
   else
     description="Signed off by ${user}${via} (checks not verified locally)"
   fi
@@ -759,9 +809,107 @@ cmd_install() {
   echo "${OK} '${TARGET_BRANCH}' now requires developer sign-off + the full merge-queue suite."
 }
 
-# Dispatch .github/workflows/signoff.yml for the current branch (Git or JJ).
+# Validate SIGNOFF_SSH_REPO (optional override). Empty → default ~/dev/spice2
+# on the remote. Absolute path only; tight charset so it is safe in ssh argv.
+signoff_ssh_repo_or_default() {
+  local remote_repo="${SIGNOFF_SSH_REPO:-}"
+  if [[ -z "$remote_repo" ]]; then
+    echo ""
+    return 0
+  fi
+  [[ "$remote_repo" == /* ]] \
+    || fail "SIGNOFF_SSH_REPO must be an absolute path (got: '${remote_repo}')"
+  [[ "$remote_repo" =~ ^[A-Za-z0-9._/-]+$ ]] \
+    || fail "SIGNOFF_SSH_REPO contains unsafe characters: '${remote_repo}'"
+  echo "$remote_repo"
+}
+
+# Probe SIGNOFF_SSH_HOSTS (default lab IPs) for BatchMode SSH + a spice2 checkout.
+# Prints the first usable host to stdout; status messages go to stderr via info.
+# Exit 0 with a host, or 1 if none are usable.
+find_signoff_ssh_host() {
+  local hosts host remote_repo probe_cmd
+  hosts="${SIGNOFF_SSH_HOSTS:-$DEFAULT_SIGNOFF_SSH_HOSTS}"
+  remote_repo=$(signoff_ssh_repo_or_default)
+
+  if [[ -n "$remote_repo" ]]; then
+    # Path already charset-validated; embed as a single-quoted remote literal.
+    probe_cmd="repo='${remote_repo}'; test -d \"\$repo\" && { test -e \"\$repo/.git\" || test -d \"\$repo/.jj\"; }"
+  else
+    probe_cmd='repo="$HOME/dev/spice2"; test -d "$repo" && { test -e "$repo/.git" || test -d "$repo/.jj"; }'
+  fi
+
+  for host in $hosts; do
+    # Hostnames/IPs only — keep the charset tight so ssh argv stays safe.
+    if [[ ! "$host" =~ ^[A-Za-z0-9._-]+$ ]]; then
+      info "  ${NO} skipping invalid SSH host name: '${host}'"
+      continue
+    fi
+    info "Probing SSH connectivity to ${host}…"
+    # BatchMode: never prompt for a password. Short connect timeout so offline
+    # hosts don't stall the developer. stdin from /dev/null so ssh can't eat
+    # a surrounding heredoc or pipe.
+    if ssh -o BatchMode=yes -o ConnectTimeout=1 -o ConnectionAttempts=1 \
+        -o StrictHostKeyChecking=accept-new \
+        "$host" "$probe_cmd" </dev/null 2>/dev/null; then
+      info "  ${OK} ${host} reachable and spice2 repo present"
+      echo "$host"
+      return 0
+    fi
+    info "  ${NO} ${host} unavailable or missing spice2 repo"
+  done
+  return 1
+}
+
+# SSH into a lab host, check out the pushed branch in its spice2 clone, and run
+# scripts/signoff -f there (same attestation as local; -f because checkout -B
+# leaves no @{push} tracking). Branch must already be on origin.
+run_signoff_via_ssh() {
+  local host="$1" branch="$2"
+  local remote_repo
+  remote_repo=$(signoff_ssh_repo_or_default)
+
+  info "Running sign-off via SSH on ${host}:${remote_repo:-~/dev/spice2} (branch ${branch})…"
+  # Remote command is `bash -s -- <branch> <repo-or-empty>`; the heredoc is
+  # stdin for bash -s. Branch is charset-validated in cmd_remote; repo is an
+  # absolute path or empty (→ $HOME/dev/spice2 on the remote).
+  # shellcheck disable=SC2029 # intentional: host/branch/repo are validated
+  ssh -o BatchMode=yes -o ConnectTimeout=1 -o ConnectionAttempts=1 \
+    -o StrictHostKeyChecking=accept-new \
+    -o ServerAliveInterval=30 -o ServerAliveCountMax=120 \
+    "$host" bash -s -- "$branch" "$remote_repo" <<'REMOTE'
+set -euo pipefail
+branch="$1"
+# Empty $2 → default lab checkout path on this host.
+if [[ -n "${2:-}" ]]; then
+  repo="$2"
+else
+  repo="${HOME}/dev/spice2"
+fi
+cd "$repo" || { echo "✗ cannot cd to ${repo}" >&2; exit 1; }
+
+if command -v git >/dev/null 2>&1 && git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "Fetching origin/${branch} into ${repo}…"
+  git fetch --no-tags origin "+refs/heads/${branch}:refs/remotes/origin/${branch}" \
+    || { echo "✗ fetch failed — is '${branch}' pushed to origin?" >&2; exit 1; }
+  # -f discards any dirty local state on the lab machine; HEAD matches origin.
+  git checkout -f -B "$branch" "origin/${branch}"
+  git reset --hard "origin/${branch}"
+  echo "HEAD is now $(git rev-parse --short HEAD) on ${branch}"
+  # -f: no @{push} after checkout -B; tree matches origin tip we just fetched.
+  exec ./scripts/signoff -f
+fi
+
+echo "✗ ${repo} is not a Git checkout (SSH remote sign-off requires Git)" >&2
+exit 1
+REMOTE
+}
+
+# Dispatch remote sign-off for the current branch (Git or JJ).
+# Prefer a LAN SSH host with ~/dev/spice2 (lab machines); fall back to the
+# GitHub Actions Remote Sign-off workflow when no host is reachable.
 # Branch names are validated to a safe charset so they cannot break shell
-# quoting or the workflow input parser.
+# quoting, the SSH remote script, or the workflow input parser.
 cmd_remote() {
   require_tools
 
@@ -798,10 +946,16 @@ cmd_remote() {
     fail "refusing to dispatch Remote Sign-off for invalid branch name: '${branch}'"
   fi
 
+  local host
+  if host=$(find_signoff_ssh_host); then
+    run_signoff_via_ssh "$host" "$branch"
+    return
+  fi
+
   local repo
   repo=$(repo_slug) || fail "could not resolve GitHub repo for workflow dispatch"
 
-  info "Dispatching Remote Sign-off for ${branch} on ${repo}…"
+  info "No SSH sign-off host available — dispatching GitHub Actions Remote Sign-off for ${branch} on ${repo}…"
   # --repo so non-colocated JJ workspaces (no .git) still resolve the remote;
   # --raw-field avoids shell re-quoting pitfalls; the branch was validated above.
   gh workflow run signoff.yml --repo "$repo" --raw-field "branch=${branch}" \
@@ -815,7 +969,7 @@ scripts/signoff ${VERSION} — local CI attestation for Spice.ai
 
 Developers:
   make signoff                 Run lint + unit tests, then sign off on HEAD
-  make signoff-remote          Dispatch Remote Sign-off for the current branch
+  make signoff-remote          SSH lab host if available, else GHA Remote Sign-off
   scripts/signoff remote       Same as make signoff-remote (Git + JJ)
   scripts/signoff -f           Sign off even with a dirty/unpushed tree
   scripts/signoff --no-verify  Sign off without running checks (honor system)
@@ -827,6 +981,8 @@ Maintainers:
   scripts/signoff install --yes  Apply it (needs admin on the repo)
 
 Checks (when verify is on):
+  0. If the branch has no changed .rs files vs trunk → skip Rust lint/build/tests
+     (still posts the sign-off status)
   1. Targeted lint of crates touched by this branch vs trunk
      (make lint-rust PACKAGES="…") — fail-fast feedback
   2. Full workspace lint (make lint-rust)
@@ -835,6 +991,10 @@ Checks (when verify is on):
   Set SIGNOFF_SKIP_TARGETED_LINT=1 to skip step 1.
   Remote runs (.github/workflows/signoff.yml) set SIGNOFF_REMOTE_RUN and use
   the GitHub compare API when the clone is too shallow for merge-base.
+
+  make signoff-remote probes SIGNOFF_SSH_HOSTS (default: ${DEFAULT_SIGNOFF_SSH_HOSTS})
+  for SSH + ~/dev/spice2, checks out the pushed branch there, and runs signoff.
+  If no host is usable, it falls back to dispatching signoff.yml on GitHub Actions.
 
 The sign-off is a '${STATUS_CONTEXT}' commit status bound to the exact commit you
 pushed. Sign off again after any code change or manual conflict resolution. The


### PR DESCRIPTION
## Summary

- **`make signoff-remote`** first probes lab hosts over SSH (`192.168.1.100`, `192.168.1.101`; 1s `ConnectTimeout`) for a `~/dev/spice2` checkout, checks out the pushed branch there, and runs `scripts/signoff -f`. Falls back to the existing GitHub Actions `signoff.yml` workflow when no host is usable.
- **Local and remote sign-off** skip Rust lint/build/unit tests when the branch diff vs `trunk` has no changed `.rs` files (docs/YAML/script-only changes still get a `signoff` status).
- Overrides: `SIGNOFF_SSH_HOSTS`, `SIGNOFF_SSH_REPO`. Docs updated in `docs/dev/ci_signoff.md` and `CONTRIBUTING.md`.

## Test plan

- [x] `bash -n scripts/signoff`
- [x] Probe hosts: `.100` fails fast (auth), `.101` selected with `~/dev/spice2`; unreachable host times out at ~1s
- [x] Controlled unit tests: no `.rs` → skip; with `.rs` / unknown diff → run checks
- [ ] `make signoff` on a docs-only branch skips Rust checks and posts status
- [ ] `make signoff-remote` uses SSH when on the lab network, GHA fallback when not