### PR TITLE
feat(catalog): fail-loud + metrics + by-kind reporting for PostgreSQL catalog CDC (#11850)

### DIFF
--- a/crates/data-connectors/connector-postgres-common/src/lib.rs
+++ b/crates/data-connectors/connector-postgres-common/src/lib.rs
@@ -535,7 +535,7 @@ pub fn classify_replica_identity(identity: &ReplicaIdentity) -> ReplicaIdentityO
 #[cfg(test)]
 mod tests {
     use super::{
-        ReplicaIdentity, ReplicaIdentityMode, ReplicaIdentityOutcome, SkipReason,
+        Error, ReplicaIdentity, ReplicaIdentityMode, ReplicaIdentityOutcome, SkipReason,
         accumulate_replica_identity, classify_replica_identity,
     };
 
@@ -683,5 +683,55 @@ mod tests {
             accumulate_replica_identity(ReplicaIdentityMode::Default, vec![(None, None, None)]);
         assert!(id.primary_key.is_empty());
         assert!(id.identity_index.is_empty());
+    }
+
+    #[test]
+    fn skip_reason_explanations_are_actionable() {
+        // Every skip reason drives a per-table warning, so each must name the
+        // property at fault (REPLICA IDENTITY) and a concrete fix the operator
+        // can apply.
+        for reason in [
+            SkipReason::NoReplicaIdentity,
+            SkipReason::KeylessDefault,
+            SkipReason::UnusableIdentityIndex,
+            SkipReason::FullWithoutKey,
+            SkipReason::UnknownMode,
+        ] {
+            let explanation = reason.explanation();
+            assert!(
+                explanation.contains("REPLICA IDENTITY"),
+                "{reason:?} explanation should name REPLICA IDENTITY: {explanation}"
+            );
+            assert!(
+                explanation.contains("primary key")
+                    || explanation.contains("USING INDEX")
+                    || explanation.contains("unique"),
+                "{reason:?} explanation should name a concrete fix: {explanation}"
+            );
+        }
+    }
+
+    #[test]
+    fn cdc_prerequisite_errors_are_actionable_with_docs_links() {
+        // The wal_level and replication-privilege errors are the first thing an
+        // operator hits when a source can't do CDC -- each must name the exact
+        // problem, the exact fix, and a docs link.
+        let wal = Error::WalLevelNotLogical {
+            wal_level: "replica".to_string(),
+        }
+        .to_string();
+        assert!(wal.contains("wal_level"), "{wal}");
+        assert!(wal.contains("logical"), "{wal}");
+        assert!(wal.contains("ALTER SYSTEM SET wal_level"), "{wal}");
+        assert!(wal.contains("https://spiceai.org/docs"), "{wal}");
+
+        let role = Error::MissingReplicationPrivilege {
+            role: "app_ro".to_string(),
+        }
+        .to_string();
+        assert!(role.contains("app_ro"), "{role}");
+        assert!(role.contains("replication"), "{role}");
+        assert!(role.contains("ALTER ROLE"), "{role}");
+        assert!(role.contains("https://spiceai.org/docs"), "{role}");
     }
 }

--- a/crates/data_components/src/postgres_replication/config.rs
+++ b/crates/data_components/src/postgres_replication/config.rs
@@ -276,16 +276,21 @@ pub fn default_slot_name(dataset_name: &str) -> String {
 /// that distinguishes one spiced instance from another sharing the same source
 /// database). Factored out as a pure function — the instance identity is passed
 /// in rather than read from the environment — so its determinism and
-/// uniqueness properties can be unit-tested without mutating process-global env
-/// vars. Guarantees, for the resulting slot name:
+/// distinctness properties can be unit-tested without mutating process-global
+/// env vars. For the resulting slot name:
 ///
-///   - deterministic/stable: identical `(dataset_name, instance_id)` always
-///     produces the identical name, so a restart of the same instance resumes
-///     its existing replication slot rather than orphaning one;
-///   - unique per instance: two instances (distinct `instance_id`) pointed at
-///     the same catalog get distinct names, so they never collide on one
-///     physical Postgres slot (which permits a single consumer);
-///   - unique per dataset/catalog: distinct `dataset_name`s get distinct names.
+///   - deterministic/stable (a strict guarantee): identical `(dataset_name,
+///     instance_id)` always produces the identical name, so a restart of the
+///     same instance resumes its existing replication slot rather than
+///     orphaning one;
+///   - distinct per instance (in practice, not a strict guarantee): two
+///     instances (distinct `instance_id`) pointed at the same catalog get
+///     different names, so they don't share one physical Postgres slot (which
+///     permits a single consumer). The instance identity is folded into a short
+///     8-hex hash, so a collision is possible but astronomically unlikely;
+///   - distinct per dataset/catalog (same caveat): distinct `dataset_name`s get
+///     different names, disambiguated by a 6-hex hash of the full name so that
+///     names sharing a truncated prefix still differ.
 fn slot_name_for(dataset_name: &str, instance_id: &str) -> String {
     let instance_hash = xxh3_short_hash(instance_id);
     let dataset_hash = xxh3_short_hash_prefix(dataset_name, DATASET_HASH_LEN);

--- a/crates/data_components/src/postgres_replication/config.rs
+++ b/crates/data_components/src/postgres_replication/config.rs
@@ -269,7 +269,25 @@ const PUB_DATASET_PORTION_MAX: usize =
 /// within Postgres' 63-byte limit.
 #[must_use]
 pub fn default_slot_name(dataset_name: &str) -> String {
-    let instance_hash = instance_hash();
+    slot_name_for(dataset_name, &resolve_instance_id())
+}
+
+/// Build the slot name for `dataset_name` scoped to `instance_id` (the value
+/// that distinguishes one spiced instance from another sharing the same source
+/// database). Factored out as a pure function — the instance identity is passed
+/// in rather than read from the environment — so its determinism and
+/// uniqueness properties can be unit-tested without mutating process-global env
+/// vars. Guarantees, for the resulting slot name:
+///
+///   - deterministic/stable: identical `(dataset_name, instance_id)` always
+///     produces the identical name, so a restart of the same instance resumes
+///     its existing replication slot rather than orphaning one;
+///   - unique per instance: two instances (distinct `instance_id`) pointed at
+///     the same catalog get distinct names, so they never collide on one
+///     physical Postgres slot (which permits a single consumer);
+///   - unique per dataset/catalog: distinct `dataset_name`s get distinct names.
+fn slot_name_for(dataset_name: &str, instance_id: &str) -> String {
+    let instance_hash = xxh3_short_hash(instance_id);
     let dataset_hash = xxh3_short_hash_prefix(dataset_name, DATASET_HASH_LEN);
     let dataset = truncate_to_bytes(&sanitize(dataset_name), SLOT_DATASET_PORTION_MAX);
     format!("{SLOT_PREFIX}{dataset}_{dataset_hash}_{instance_hash}")
@@ -289,15 +307,15 @@ pub fn publication_name_for_slot(slot_name: &str) -> String {
     format!("{base}_pub")
 }
 
-/// 8-hex-char hash identifying this spiced instance, derived from
-/// `SPICE_INSTANCE_ID` (falling back to the machine hostname). Deterministic
-/// across restarts of the same instance.
-fn instance_hash() -> String {
-    let instance = std::env::var("SPICE_INSTANCE_ID")
+/// The identity distinguishing this spiced instance from another sharing the
+/// same source database: `SPICE_INSTANCE_ID` if set, else the machine hostname,
+/// else `"unknown"`. Stable across restarts of the same instance, which is what
+/// keeps [`slot_name_for`] resuming the same replication slot on restart.
+fn resolve_instance_id() -> String {
+    std::env::var("SPICE_INSTANCE_ID")
         .ok()
         .or_else(|| hostname::get().ok().and_then(|h| h.into_string().ok()))
-        .unwrap_or_else(|| "unknown".to_string());
-    xxh3_short_hash(&instance)
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// Default publication is shared across replicas:
@@ -590,6 +608,50 @@ mod tests {
         let a2 = default_slot_name("users");
         assert_eq!(a1, a2);
         assert!(a1.starts_with("spice_users_"));
+    }
+
+    #[test]
+    fn slot_name_is_stable_across_restarts_of_the_same_instance() {
+        // A restart of the same spiced instance (same catalog name, same
+        // instance id) must resolve to the identical slot name, so CDC resumes
+        // the existing replication slot instead of orphaning it and forcing a
+        // fresh snapshot.
+        let before_restart = slot_name_for("my_catalog", "instance-a");
+        let after_restart = slot_name_for("my_catalog", "instance-a");
+        assert_eq!(before_restart, after_restart);
+    }
+
+    #[test]
+    fn slot_name_is_unique_per_instance_for_the_same_catalog() {
+        // Two spiced instances pointed at the SAME catalog on the same database
+        // must not collide on one physical replication slot -- Postgres permits
+        // a single consumer per slot, so a collision would have one instance
+        // steal the other's stream. Distinct instance ids => distinct slots.
+        let instance_a = slot_name_for("my_catalog", "instance-a");
+        let instance_b = slot_name_for("my_catalog", "instance-b");
+        assert_ne!(instance_a, instance_b);
+    }
+
+    #[test]
+    fn slot_name_is_unique_per_catalog_for_the_same_instance() {
+        // One spiced instance accelerating two different catalogs must give each
+        // its own slot.
+        let catalog_one = slot_name_for("catalog_one", "instance-a");
+        let catalog_two = slot_name_for("catalog_two", "instance-a");
+        assert_ne!(catalog_one, catalog_two);
+    }
+
+    #[test]
+    fn slot_name_stays_within_postgres_limit_for_any_instance_id() {
+        // The instance id is hashed to a fixed 8 chars, so even a pathologically
+        // long id can't push the slot name past Postgres' identifier limit.
+        let long_instance = "i".repeat(300);
+        let slot = slot_name_for("catalog", &long_instance);
+        assert!(
+            slot.len() <= PG_IDENTIFIER_MAX_BYTES,
+            "slot `{slot}` exceeds {PG_IDENTIFIER_MAX_BYTES} bytes: {}",
+            slot.len()
+        );
     }
 
     #[test]

--- a/crates/runtime-metrics/src/catalogs/mod.rs
+++ b/crates/runtime-metrics/src/catalogs/mod.rs
@@ -31,3 +31,28 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
             .with_description("Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.")
             .build()
 });
+
+/// Number of tables a CDC-accelerated catalog resolved into each disposition,
+/// labeled by `catalog` and `category` (`accelerated`, `skipped`, `excluded`).
+/// A gauge, not a counter: it reflects the current disposition after each
+/// catalog refresh re-plans the whole namespace, so it can rise or fall.
+pub static ACCELERATION_TABLES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    CATALOGS_METER
+        .u64_gauge("catalog_acceleration_tables")
+        .with_description(
+            "Tables resolved by a CDC-accelerated catalog, labeled by catalog and category (accelerated, skipped, excluded).",
+        )
+        .build()
+});
+
+/// Number of accelerated tables broken down by the CDC key that accelerates
+/// them, labeled by `catalog` and `kind` (`primary_key`, `unique_index`,
+/// `full`). A gauge for the same reason as [`ACCELERATION_TABLES`].
+pub static ACCELERATION_TABLES_BY_KIND: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    CATALOGS_METER
+        .u64_gauge("catalog_acceleration_accelerated_tables")
+        .with_description(
+            "Accelerated tables in a CDC-accelerated catalog, labeled by catalog and acceleration kind (primary_key, unique_index, full).",
+        )
+        .build()
+});

--- a/crates/runtime/src/catalogconnector/postgres.rs
+++ b/crates/runtime/src/catalogconnector/postgres.rs
@@ -20,7 +20,9 @@ limitations under the License.
 //! discovery via `information_schema` queries.
 
 use super::{CatalogConnector, ConnectorComponent, ParameterSpec};
-use crate::catalogconnector::postgres_accelerated::AcceleratedCatalogProvider;
+use crate::catalogconnector::postgres_accelerated::{
+    AcceleratedCatalogProvider, NoEligibleTablesError,
+};
 use crate::{Runtime, component::catalog::Catalog, dataconnector::parameters::ConnectorParams};
 use async_trait::async_trait;
 use data_components::RefreshableCatalogProvider;
@@ -136,14 +138,26 @@ impl CatalogConnector for PostgresCatalog {
                 ))
             };
 
-        catalog_provider
-            .refresh()
-            .await
-            .map_err(|e| super::Error::UnableToGetCatalogProvider {
-                connector: PREFIX.to_string(),
-                connector_component,
-                source: e,
-            })?;
+        catalog_provider.refresh().await.map_err(|e| {
+            // A catalog with zero eligible tables is a configuration problem
+            // that retrying can't resolve (discovery is one-shot), so surface it
+            // as a permanent configuration error -- catalog load stops with an
+            // ERROR status instead of retrying the empty discovery forever.
+            if e.downcast_ref::<NoEligibleTablesError>().is_some() {
+                super::Error::InvalidConfiguration {
+                    connector: PREFIX.to_string(),
+                    connector_component: connector_component.clone(),
+                    message: e.to_string(),
+                    source: e,
+                }
+            } else {
+                super::Error::UnableToGetCatalogProvider {
+                    connector: PREFIX.to_string(),
+                    connector_component: connector_component.clone(),
+                    source: e,
+                }
+            }
+        })?;
 
         Ok(catalog_provider)
     }

--- a/crates/runtime/src/catalogconnector/postgres_accelerated.rs
+++ b/crates/runtime/src/catalogconnector/postgres_accelerated.rs
@@ -294,7 +294,7 @@ struct SpawnedTable {
 /// configuration error.
 #[derive(Debug, Snafu)]
 #[snafu(display(
-    "Catalog '{catalog}': no tables are eligible for CDC acceleration ({excluded} excluded by include/exclude filters, {skipped} skipped for lacking a usable REPLICA IDENTITY). Ensure the target schema(s) contain tables with a primary key, a UNIQUE NOT NULL index set as REPLICA IDENTITY USING INDEX, or REPLICA IDENTITY FULL, and that the catalog's `include`/`exclude` patterns match them. Docs: https://spiceai.org/docs/components/data-connectors/postgres"
+    "Catalog '{catalog}': no tables are eligible for CDC acceleration ({excluded} excluded by include/exclude filters, {skipped} skipped for lacking a usable REPLICA IDENTITY). Give each table a usable CDC key -- a primary key (which REPLICA IDENTITY DEFAULT or FULL then keys on), or a UNIQUE NOT NULL index set as REPLICA IDENTITY USING INDEX -- and ensure the catalog's `include`/`exclude` patterns match them. Note that REPLICA IDENTITY FULL without a primary key is still skipped. Docs: https://spiceai.org/docs/components/data-connectors/postgres"
 ))]
 pub(crate) struct NoEligibleTablesError {
     catalog: String,

--- a/crates/runtime/src/catalogconnector/postgres_accelerated.rs
+++ b/crates/runtime/src/catalogconnector/postgres_accelerated.rs
@@ -148,6 +148,160 @@ fn column_reference_string(key: &[String]) -> String {
     }
 }
 
+/// How a table's `REPLICA IDENTITY` lets it be CDC-accelerated -- the reporting
+/// counterpart of the eligible [`ReplicaIdentityOutcome`] variants. Carried so
+/// the startup summary and metrics can break accelerated tables down by the key
+/// that drives their upsert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AccelerationKind {
+    /// `DEFAULT` + primary key.
+    PrimaryKey,
+    /// `USING INDEX`, keyed by the nominated unique index.
+    UniqueIndex,
+    /// `FULL` + primary key.
+    Full,
+}
+
+impl AccelerationKind {
+    /// The eligible outcome's kind, or `None` for `Skip`.
+    fn from_outcome(outcome: &ReplicaIdentityOutcome) -> Option<Self> {
+        match outcome {
+            ReplicaIdentityOutcome::AccelerateViaPrimaryKey { .. } => Some(Self::PrimaryKey),
+            ReplicaIdentityOutcome::AccelerateViaUniqueIndex { .. } => Some(Self::UniqueIndex),
+            ReplicaIdentityOutcome::AccelerateFullReplicaIdentity { .. } => Some(Self::Full),
+            ReplicaIdentityOutcome::Skip { .. } => None,
+        }
+    }
+
+    /// Stable metric-attribute value (never a display string).
+    fn metric_label(self) -> &'static str {
+        match self {
+            Self::PrimaryKey => "primary_key",
+            Self::UniqueIndex => "unique_index",
+            Self::Full => "full",
+        }
+    }
+}
+
+/// Widen a table count to the `u64` the metrics API takes, saturating rather
+/// than panicking (counts never approach `u64::MAX`; this only satisfies the
+/// no-`unwrap` lint without an `as` cast).
+fn count_as_u64(count: usize) -> u64 {
+    u64::try_from(count).unwrap_or(u64::MAX)
+}
+
+/// The per-catalog tally of how discovery resolved every table it looked at:
+/// accelerated (broken down by [`AccelerationKind`]), skipped for lacking a
+/// usable `REPLICA IDENTITY`, or excluded by `include`/`exclude`. Accumulated
+/// across schemas (see [`AccelerationSummary::add`]) into the startup summary
+/// log line and the catalog acceleration metrics, and used to fail loudly when
+/// nothing is eligible.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct AccelerationSummary {
+    primary_key: usize,
+    unique_index: usize,
+    full: usize,
+    skipped: usize,
+    excluded: usize,
+}
+
+impl AccelerationSummary {
+    fn record_accelerated(&mut self, kind: AccelerationKind) {
+        match kind {
+            AccelerationKind::PrimaryKey => self.primary_key += 1,
+            AccelerationKind::UniqueIndex => self.unique_index += 1,
+            AccelerationKind::Full => self.full += 1,
+        }
+    }
+
+    /// Total tables that will be CDC-accelerated (across all kinds).
+    fn accelerated_total(&self) -> usize {
+        self.primary_key + self.unique_index + self.full
+    }
+
+    /// Fold another schema's summary into this one.
+    fn add(&mut self, other: &Self) {
+        self.primary_key += other.primary_key;
+        self.unique_index += other.unique_index;
+        self.full += other.full;
+        self.skipped += other.skipped;
+        self.excluded += other.excluded;
+    }
+
+    /// The single startup summary line, naming the shared slot and breaking the
+    /// accelerated count down by acceleration kind.
+    fn summary_message(&self, catalog_name: &str, slot_name: &str) -> String {
+        format!(
+            "Catalog '{catalog_name}': accelerating {} table(s) via CDC ({} via primary key, {} via REPLICA IDENTITY USING INDEX, {} via REPLICA IDENTITY FULL; shared replication slot '{slot_name}'); {} table(s) excluded by include/exclude filters; {} table(s) skipped (no usable replica identity -- see warnings).",
+            self.accelerated_total(),
+            self.primary_key,
+            self.unique_index,
+            self.full,
+            self.excluded,
+            self.skipped,
+        )
+    }
+
+    /// Emit the catalog acceleration gauges (accelerated/skipped/excluded counts
+    /// and the by-kind breakdown) for `catalog_name`.
+    fn emit_metrics(&self, catalog_name: &str) {
+        use opentelemetry::KeyValue;
+        let category = |value: &'static str| {
+            [
+                KeyValue::new("catalog", catalog_name.to_string()),
+                KeyValue::new("category", value),
+            ]
+        };
+        runtime_metrics::catalogs::ACCELERATION_TABLES.record(
+            count_as_u64(self.accelerated_total()),
+            &category("accelerated"),
+        );
+        runtime_metrics::catalogs::ACCELERATION_TABLES
+            .record(count_as_u64(self.skipped), &category("skipped"));
+        runtime_metrics::catalogs::ACCELERATION_TABLES
+            .record(count_as_u64(self.excluded), &category("excluded"));
+
+        let kind = |k: AccelerationKind, n: usize| {
+            runtime_metrics::catalogs::ACCELERATION_TABLES_BY_KIND.record(
+                count_as_u64(n),
+                &[
+                    KeyValue::new("catalog", catalog_name.to_string()),
+                    KeyValue::new("kind", k.metric_label()),
+                ],
+            );
+        };
+        kind(AccelerationKind::PrimaryKey, self.primary_key);
+        kind(AccelerationKind::UniqueIndex, self.unique_index);
+        kind(AccelerationKind::Full, self.full);
+    }
+}
+
+/// A table already handed off to a background bootstrap/CDC task, tracked across
+/// refreshes: the dataset name it was registered under and how it is
+/// accelerated (so re-plans re-report its [`AccelerationKind`] without
+/// re-querying its replica identity).
+#[derive(Debug, Clone)]
+struct SpawnedTable {
+    dataset_name: String,
+    kind: AccelerationKind,
+}
+
+/// Discovery found no CDC-eligible table in the catalog. A hard, actionable
+/// startup error (see [`AcceleratedCatalogProvider::refresh`]): catalog
+/// discovery is one-shot (tables added after startup are a documented non-goal),
+/// so an empty result is a configuration problem to surface, not an empty
+/// catalog to register silently. `postgres.rs` maps this to a permanent
+/// configuration error.
+#[derive(Debug, Snafu)]
+#[snafu(display(
+    "Catalog '{catalog}': no tables are eligible for CDC acceleration ({excluded} excluded by include/exclude filters, {skipped} skipped for lacking a usable REPLICA IDENTITY). Ensure the target schema(s) contain tables with a primary key, a UNIQUE NOT NULL index set as REPLICA IDENTITY USING INDEX, or REPLICA IDENTITY FULL, and that the catalog's `include`/`exclude` patterns match them. Docs: https://spiceai.org/docs/components/data-connectors/postgres"
+))]
+pub(crate) struct NoEligibleTablesError {
+    catalog: String,
+    excluded: usize,
+    skipped: usize,
+}
+
 /// A catalog provider that CDC-accelerates every table it discovers (subject
 /// to `include`/`exclude`), holding its own `PostgreSQL` connection directly
 /// rather than wrapping the plain federated catalog provider.
@@ -179,7 +333,7 @@ pub struct AcceleratedCatalogProvider {
     /// table `"c"` vs. schema `"a"`, table `"b.c"`), which would make one
     /// table reuse another's dataset name and silently route queries to the
     /// wrong accelerated table.
-    spawned: RwLock<HashMap<(String, String), String>>,
+    spawned: RwLock<HashMap<(String, String), SpawnedTable>>,
 }
 
 impl std::fmt::Debug for AcceleratedCatalogProvider {
@@ -300,8 +454,7 @@ impl AcceleratedCatalogProvider {
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         let mut tables = HashMap::new();
-        let mut excluded = 0usize;
-        let mut skipped = 0usize;
+        let mut summary = AccelerationSummary::default();
         let mut to_spawn = Vec::new();
         for table_name in table_names {
             if !table_is_selected(
@@ -310,21 +463,24 @@ impl AcceleratedCatalogProvider {
                 self.include.as_deref(),
                 self.exclude.as_deref(),
             ) {
-                excluded += 1;
+                summary.excluded += 1;
                 continue;
             }
 
             // Already running from a previous refresh -- reuse it rather
             // than re-classifying and re-spawning a duplicate bootstrap/CDC
-            // task for a table `refresh()` already knows about.
+            // task for a table `refresh()` already knows about. Its stored
+            // acceleration kind is re-counted so re-plans keep the by-kind
+            // summary/metrics accurate without re-querying its replica identity.
             let spawn_key = (schema_name.to_string(), table_name.clone());
             let already_spawned = {
                 let guard = self.spawned.read();
                 guard.get(&spawn_key).cloned()
             };
 
-            let dataset_name = if let Some(dataset_name) = already_spawned {
-                dataset_name
+            let dataset_name = if let Some(spawned) = already_spawned {
+                summary.record_accelerated(spawned.kind);
+                spawned.dataset_name
             } else {
                 // Quote each component (only when required) so the per-table
                 // warnings below unambiguously identify the table and round-trip
@@ -346,9 +502,10 @@ impl AcceleratedCatalogProvider {
                 // the catalog still replicates. `DEFAULT` + primary key is the
                 // normal case and logs nothing (counted in the summary); the
                 // notable cases each get one line.
-                let key = match classify_replica_identity(&identity) {
+                let outcome = classify_replica_identity(&identity);
+                let key = match &outcome {
                     ReplicaIdentityOutcome::Skip { reason } => {
-                        skipped += 1;
+                        summary.skipped += 1;
                         tracing::warn!(
                             "Catalog '{}': skipping table {table_path}: {}. Exclude it via the catalog's `include`/`exclude` patterns to suppress this warning.",
                             self.catalog_name,
@@ -356,14 +513,14 @@ impl AcceleratedCatalogProvider {
                         );
                         continue;
                     }
-                    ReplicaIdentityOutcome::AccelerateViaPrimaryKey { key } => key,
+                    ReplicaIdentityOutcome::AccelerateViaPrimaryKey { key } => key.clone(),
                     ReplicaIdentityOutcome::AccelerateViaUniqueIndex { key } => {
                         tracing::info!(
                             "Catalog '{}': accelerating table {table_path} via its REPLICA IDENTITY unique index ({}).",
                             self.catalog_name,
                             key.join(", "),
                         );
-                        key
+                        key.clone()
                     }
                     ReplicaIdentityOutcome::AccelerateFullReplicaIdentity { key } => {
                         tracing::warn!(
@@ -371,16 +528,21 @@ impl AcceleratedCatalogProvider {
                             self.catalog_name,
                             key.join(", "),
                         );
-                        key
+                        key.clone()
                     }
                 };
+                // Skip returned above; every remaining outcome has a kind.
+                let Some(kind) = AccelerationKind::from_outcome(&outcome) else {
+                    continue;
+                };
+                summary.record_accelerated(kind);
 
                 // Build (validate) now; defer spawning to `refresh` so a later
                 // unbuildable table can't leave this one orphaned.
                 let (dataset_name, dataset) = self
                     .build_accelerated_dataset(schema_name, &table_name, &key)
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
-                to_spawn.push((table_name.clone(), dataset_name.clone(), dataset));
+                to_spawn.push((table_name.clone(), dataset_name.clone(), kind, dataset));
                 dataset_name
             };
 
@@ -389,8 +551,7 @@ impl AcceleratedCatalogProvider {
 
         Ok(SchemaPlan {
             tables,
-            excluded,
-            skipped,
+            summary,
             to_spawn,
         })
     }
@@ -398,18 +559,23 @@ impl AcceleratedCatalogProvider {
 
 /// A validated, not-yet-spawned plan for one schema (see
 /// [`AcceleratedCatalogProvider::refresh`]): the `table_name -> dataset
-/// registration name` map for the schema provider, the number of tables
-/// `include`/`exclude` excluded, the number skipped for having no usable replica
-/// identity, and the datasets that are new this refresh and still need spawning.
+/// registration name` map for the schema provider, the schema's
+/// [`AccelerationSummary`] (accelerated-by-kind / skipped / excluded counts),
+/// and the datasets that are new this refresh and still need spawning.
 /// Classification + build completes for the whole catalog before any dataset is
 /// spawned, so a later unbuildable table can't leave earlier tables' bootstrap/
 /// CDC tasks running orphaned against a catalog that never registers.
 struct SchemaPlan {
     tables: HashMap<String, String>,
-    excluded: usize,
-    skipped: usize,
-    /// `(table_name, dataset_name, built dataset)` for each new table.
-    to_spawn: Vec<(String, String, crate::component::dataset::Dataset)>,
+    summary: AccelerationSummary,
+    /// `(table_name, dataset_name, acceleration kind, built dataset)` for each
+    /// new table.
+    to_spawn: Vec<(
+        String,
+        String,
+        AccelerationKind,
+        crate::component::dataset::Dataset,
+    )>,
 }
 
 #[async_trait]
@@ -434,15 +600,26 @@ impl RefreshableCatalogProvider for AcceleratedCatalogProvider {
         // has been spawned, so it can't leave earlier tables' bootstrap/CDC tasks
         // running orphaned against a catalog that then never registers.
         let mut plans = Vec::new();
-        let mut included_tables = 0usize;
-        let mut excluded_tables = 0usize;
-        let mut skipped_tables = 0usize;
+        let mut summary = AccelerationSummary::default();
         for schema_name in &schema_names {
             let plan = self.plan_schema_provider(schema_name).await?;
-            included_tables += plan.tables.len();
-            excluded_tables += plan.excluded;
-            skipped_tables += plan.skipped;
+            summary.add(&plan.summary);
             plans.push((schema_name.clone(), plan));
+        }
+
+        // Fail loudly when nothing is eligible: catalog discovery is one-shot
+        // (auto-detecting tables added after startup is a documented non-goal),
+        // so an empty result is a configuration problem to surface -- not an
+        // empty catalog to register silently. Returned before spawning or
+        // swapping `self.schemas`, so a later refresh that transiently sees zero
+        // leaves any previously-registered schemas intact. `postgres.rs` maps
+        // this to a permanent configuration error (ERROR status, no retry loop).
+        if summary.accelerated_total() == 0 {
+            return Err(Box::new(NoEligibleTablesError {
+                catalog: self.catalog_name.clone(),
+                excluded: summary.excluded,
+                skipped: summary.skipped,
+            }));
         }
 
         // Phase 2: the whole catalog validated -- now spawn the new datasets
@@ -451,10 +628,11 @@ impl RefreshableCatalogProvider for AcceleratedCatalogProvider {
         // registration can no longer be left partially applied.
         let mut schemas = HashMap::new();
         for (schema_name, plan) in plans {
-            for (table_name, dataset_name, dataset) in plan.to_spawn {
-                self.spawned
-                    .write()
-                    .insert((schema_name.clone(), table_name), dataset_name);
+            for (table_name, dataset_name, kind, dataset) in plan.to_spawn {
+                self.spawned.write().insert(
+                    (schema_name.clone(), table_name),
+                    SpawnedTable { dataset_name, kind },
+                );
                 tokio::spawn(Arc::clone(&self.runtime).load_synthesized_dataset(Arc::new(dataset)));
             }
             schemas.insert(
@@ -471,13 +649,10 @@ impl RefreshableCatalogProvider for AcceleratedCatalogProvider {
             *guard = schemas;
         }
 
+        summary.emit_metrics(&self.catalog_name);
         tracing::info!(
-            "Catalog '{}': accelerating {included_tables} table{} via CDC (shared replication slot '{}'); {excluded_tables} table{} excluded by include/exclude filters; {skipped_tables} table{} skipped (no usable replica identity -- see warnings).",
-            self.catalog_name,
-            if included_tables == 1 { "" } else { "s" },
-            self.slot_name,
-            if excluded_tables == 1 { "" } else { "s" },
-            if skipped_tables == 1 { "" } else { "s" },
+            "{}",
+            summary.summary_message(&self.catalog_name, &self.slot_name)
         );
 
         Ok(())
@@ -604,5 +779,186 @@ mod tests {
         let shifted_left = synthesized_dataset_name("cat", "a_b", "c");
         let shifted_right = synthesized_dataset_name("cat", "a", "b_c");
         assert_ne!(shifted_left, shifted_right);
+    }
+
+    fn globset(patterns: &[&str]) -> GlobSet {
+        let mut builder = globset::GlobSetBuilder::new();
+        for pattern in patterns {
+            builder.add(globset::Glob::new(pattern).expect("valid glob"));
+        }
+        builder.build().expect("valid globset")
+    }
+
+    #[test]
+    fn table_is_selected_with_no_filters_selects_everything() {
+        assert!(table_is_selected("public", "orders", None, None));
+    }
+
+    #[test]
+    fn table_is_selected_honors_include() {
+        let include = globset(&["public.*"]);
+        assert!(table_is_selected("public", "orders", Some(&include), None));
+        // A table outside the include set is not selected.
+        assert!(!table_is_selected(
+            "reporting",
+            "orders",
+            Some(&include),
+            None
+        ));
+    }
+
+    #[test]
+    fn table_is_selected_honors_exclude() {
+        let exclude = globset(&["public.audit"]);
+        assert!(table_is_selected("public", "orders", None, Some(&exclude)));
+        assert!(!table_is_selected("public", "audit", None, Some(&exclude)));
+    }
+
+    #[test]
+    fn table_is_selected_exclude_wins_over_include() {
+        // A table matched by BOTH include and exclude is excluded -- exclude is
+        // the veto.
+        let include = globset(&["public.*"]);
+        let exclude = globset(&["public.audit"]);
+        assert!(table_is_selected(
+            "public",
+            "orders",
+            Some(&include),
+            Some(&exclude)
+        ));
+        assert!(!table_is_selected(
+            "public",
+            "audit",
+            Some(&include),
+            Some(&exclude)
+        ));
+    }
+
+    #[test]
+    fn acceleration_kind_maps_from_eligible_outcomes_only() {
+        use data_components::postgres::provider::SkipReason;
+        assert_eq!(
+            AccelerationKind::from_outcome(&ReplicaIdentityOutcome::AccelerateViaPrimaryKey {
+                key: vec!["id".to_string()],
+            }),
+            Some(AccelerationKind::PrimaryKey)
+        );
+        assert_eq!(
+            AccelerationKind::from_outcome(&ReplicaIdentityOutcome::AccelerateViaUniqueIndex {
+                key: vec!["uid".to_string()],
+            }),
+            Some(AccelerationKind::UniqueIndex)
+        );
+        assert_eq!(
+            AccelerationKind::from_outcome(
+                &ReplicaIdentityOutcome::AccelerateFullReplicaIdentity {
+                    key: vec!["id".to_string()],
+                }
+            ),
+            Some(AccelerationKind::Full)
+        );
+        assert_eq!(
+            AccelerationKind::from_outcome(&ReplicaIdentityOutcome::Skip {
+                reason: SkipReason::KeylessDefault,
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn acceleration_summary_counts_by_kind_and_total() {
+        let mut summary = AccelerationSummary::default();
+        summary.record_accelerated(AccelerationKind::PrimaryKey);
+        summary.record_accelerated(AccelerationKind::PrimaryKey);
+        summary.record_accelerated(AccelerationKind::UniqueIndex);
+        summary.record_accelerated(AccelerationKind::Full);
+        summary.skipped = 2;
+        summary.excluded = 1;
+
+        assert_eq!(summary.primary_key, 2);
+        assert_eq!(summary.unique_index, 1);
+        assert_eq!(summary.full, 1);
+        // Skipped/excluded do not count toward accelerated total.
+        assert_eq!(summary.accelerated_total(), 4);
+    }
+
+    #[test]
+    fn acceleration_summary_add_folds_every_field() {
+        let mut a = AccelerationSummary {
+            primary_key: 1,
+            unique_index: 2,
+            full: 3,
+            skipped: 4,
+            excluded: 5,
+        };
+        let b = AccelerationSummary {
+            primary_key: 10,
+            unique_index: 20,
+            full: 30,
+            skipped: 40,
+            excluded: 50,
+        };
+        a.add(&b);
+        assert_eq!(
+            a,
+            AccelerationSummary {
+                primary_key: 11,
+                unique_index: 22,
+                full: 33,
+                skipped: 44,
+                excluded: 55,
+            }
+        );
+    }
+
+    #[test]
+    fn acceleration_summary_detects_zero_eligible() {
+        // Only skipped/excluded tables => nothing eligible => the fail-loud path.
+        let summary = AccelerationSummary {
+            skipped: 3,
+            excluded: 2,
+            ..AccelerationSummary::default()
+        };
+        assert_eq!(summary.accelerated_total(), 0);
+    }
+
+    #[test]
+    fn acceleration_summary_message_reports_counts_and_slot() {
+        let summary = AccelerationSummary {
+            primary_key: 2,
+            unique_index: 1,
+            full: 1,
+            skipped: 2,
+            excluded: 3,
+        };
+        let message = summary.summary_message("my_pg", "spice_my_pg_slot");
+        assert!(message.contains("my_pg"), "{message}");
+        assert!(message.contains("spice_my_pg_slot"), "{message}");
+        assert!(
+            message.contains("4 table(s)"),
+            "accelerated total: {message}"
+        );
+        assert!(message.contains("2 via primary key"), "{message}");
+        assert!(
+            message.contains("1 via REPLICA IDENTITY USING INDEX"),
+            "{message}"
+        );
+        assert!(message.contains("1 via REPLICA IDENTITY FULL"), "{message}");
+        assert!(message.contains("3 table(s) excluded"), "{message}");
+        assert!(message.contains("2 table(s) skipped"), "{message}");
+    }
+
+    #[test]
+    fn no_eligible_tables_error_is_actionable_with_docs_link() {
+        let err = NoEligibleTablesError {
+            catalog: "my_pg".to_string(),
+            excluded: 3,
+            skipped: 2,
+        }
+        .to_string();
+        assert!(err.contains("my_pg"), "{err}");
+        assert!(err.contains("no tables are eligible"), "{err}");
+        assert!(err.contains("REPLICA IDENTITY"), "{err}");
+        assert!(err.contains("https://spiceai.org/docs"), "{err}");
     }
 }

--- a/crates/runtime/tests/postgres/catalog_changes.rs
+++ b/crates/runtime/tests/postgres/catalog_changes.rs
@@ -731,14 +731,20 @@ async fn test_catalog_acceleration_fails_loudly_when_no_tables_eligible()
                 rt.status().get_catalog_statuses().get(CATALOG_NAME)
             );
 
-            // And the error must name the problem actionably.
-            if let Some(ComponentStatus::Error(Some(message))) =
-                rt.status().get_catalog_statuses().get(CATALOG_NAME)
-            {
-                anyhow::ensure!(
-                    message.contains("no tables are eligible"),
-                    "error message should be actionable, got: {message}"
-                );
+            // And the error must carry an actionable message. An `Error(None)`
+            // (message-less) or any non-`Error` status is a failure here, not a
+            // case to skip -- the whole point is that the failure is loud AND
+            // explains itself.
+            match rt.status().get_catalog_statuses().get(CATALOG_NAME) {
+                Some(ComponentStatus::Error(Some(message))) => {
+                    anyhow::ensure!(
+                        message.contains("no tables are eligible"),
+                        "error message should be actionable, got: {message}"
+                    );
+                }
+                other => anyhow::bail!(
+                    "catalog should be in an Error state with an actionable message, got {other:?}"
+                ),
             }
 
             // The catalog's tables must not be queryable.

--- a/crates/runtime/tests/postgres/catalog_changes.rs
+++ b/crates/runtime/tests/postgres/catalog_changes.rs
@@ -45,8 +45,10 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use app::AppBuilder;
 use data_components::postgres::provider::check_cdc_prerequisites;
 use datafusion::assert_batches_eq;
+use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 use runtime::Runtime;
-use secrecy::ExposeSecret;
+use runtime::status::ComponentStatus;
+use secrecy::{ExposeSecret, SecretString};
 use spicepod::{
     component::catalog::{
         Catalog, CatalogAcceleration, CatalogAccelerationEngine, CatalogRefreshMode,
@@ -171,7 +173,72 @@ fn accelerated_pg_catalog_excluding_items(port: usize) -> Catalog {
     catalog
 }
 
-async fn start_runtime(catalog: Catalog) -> Result<Arc<Runtime>, anyhow::Error> {
+/// Same as [`accelerated_pg_catalog`], but including only `orders` -- validates
+/// the `include` filter's positive form: a table that doesn't match `include`
+/// is never synthesized (absent from the catalog's namespace), the mirror of
+/// [`accelerated_pg_catalog_excluding_items`].
+fn accelerated_pg_catalog_including_only_orders(port: usize) -> Catalog {
+    let mut catalog = accelerated_pg_catalog(port);
+    catalog.include = vec!["public.orders".to_string()];
+    catalog
+}
+
+/// Seed only tables that CANNOT be CDC-accelerated: `REPLICA IDENTITY NOTHING`
+/// and a keyless `DEFAULT` table. A catalog pointed here discovers tables but
+/// finds none eligible -- the fail-loud path
+/// (`test_catalog_acceleration_fails_loudly_when_no_tables_eligible`).
+async fn seed_only_ineligible_tables(port: usize) -> Result<(), anyhow::Error> {
+    let pool = common::get_postgres_connection_pool(port, None).await?;
+    let conn = pool
+        .connect_direct()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    conn.conn
+        .simple_query(
+            "CREATE TABLE ri_nothing (id INT PRIMARY KEY, name TEXT NOT NULL); \
+             ALTER TABLE ri_nothing REPLICA IDENTITY NOTHING; \
+             INSERT INTO ri_nothing VALUES (1, 'a'), (2, 'b'); \
+             CREATE TABLE ri_keyless (name TEXT NOT NULL); \
+             INSERT INTO ri_keyless VALUES ('a'), ('b');",
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Create a `LOGIN` role WITHOUT the `REPLICATION` privilege and return a
+/// connection pool authenticating as it, for exercising the
+/// replication-privilege prerequisite branch of `check_cdc_prerequisites`.
+async fn pool_for_non_replication_role(
+    port: usize,
+) -> Result<PostgresConnectionPool, anyhow::Error> {
+    let admin = common::get_postgres_connection_pool(port, None).await?;
+    let conn = admin
+        .connect_direct()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    // New roles default to NOREPLICATION NOSUPERUSER; make that explicit.
+    conn.conn
+        .simple_query("CREATE ROLE norepl LOGIN PASSWORD 'norepl_pw' NOSUPERUSER NOREPLICATION;")
+        .await?;
+
+    let mut params: HashMap<String, SecretString> = get_pg_params(port);
+    params.insert("pg_user".to_string(), SecretString::from("norepl"));
+    params.insert("pg_pass".to_string(), SecretString::from("norepl_pw"));
+
+    let pool = PostgresConnectionPool::new(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to build non-replication-role pool: {e}"))?;
+    Ok(pool)
+}
+
+/// Build a runtime with `catalog` and run component loading to completion, but
+/// WITHOUT asserting the runtime became ready. Used by the fail-loud test: a
+/// catalog that correctly fails to load leaves the runtime not-ready by design,
+/// so [`runtime_ready_check`] (which [`start_runtime`] runs) would panic before
+/// the test could observe the catalog's Error status.
+async fn build_and_load_runtime(catalog: Catalog) -> Result<Arc<Runtime>, anyhow::Error> {
     register_test_connectors().await;
     let app = AppBuilder::new("postgres_catalog_changes_test")
         .with_catalog(catalog)
@@ -186,6 +253,11 @@ async fn start_runtime(catalog: Catalog) -> Result<Arc<Runtime>, anyhow::Error> 
         () = Arc::clone(&rt).load_components() => {}
     }
 
+    Ok(rt)
+}
+
+async fn start_runtime(catalog: Catalog) -> Result<Arc<Runtime>, anyhow::Error> {
+    let rt = build_and_load_runtime(catalog).await?;
     runtime_ready_check(&rt).await;
     Ok(rt)
 }
@@ -574,6 +646,139 @@ async fn test_catalog_acceleration_using_index_cdc_converges() -> Result<(), any
                 "USING INDEX CDC never converged: count={:?} (expected 2), updated_name={:?} (expected \"x2\")",
                 query_i64(&rt, &count_sql).await,
                 query_string(&rt, &updated_sql).await,
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// The `include` filter's positive form: a catalog that includes only
+/// `public.orders` synthesizes that table and nothing else -- `items`, though
+/// eligible, is never synthesized and is absent from the catalog namespace.
+/// Mirror of `test_catalog_acceleration_respects_exclude_filter`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_catalog_acceleration_respects_include_filter() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,info,runtime::catalogconnector=debug",
+    ));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+
+            seed_tables(port).await?;
+
+            let rt = start_runtime(accelerated_pg_catalog_including_only_orders(port)).await?;
+
+            wait_for_table_ready(&rt, "orders").await?;
+
+            let items_result = run_query(
+                &rt,
+                &format!("SELECT COUNT(*) AS n FROM {CATALOG_NAME}.public.items"),
+            )
+            .await;
+            anyhow::ensure!(
+                items_result.is_err(),
+                "table {CATALOG_NAME}.public.items is not in the include set and should be \
+                absent, but the query succeeded"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// A catalog whose every discovered table is ineligible (`REPLICA IDENTITY
+/// NOTHING`, keyless `DEFAULT`) must fail loudly -- reaching an `Error` status
+/// with an actionable message -- rather than registering an empty catalog.
+/// Discovery is one-shot (auto-detecting tables added after startup is a
+/// non-goal), so zero eligible tables is a permanent configuration error.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_catalog_acceleration_fails_loudly_when_no_tables_eligible()
+-> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,info,runtime::catalogconnector=debug",
+    ));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+
+            seed_only_ineligible_tables(port).await?;
+
+            // NOT `start_runtime`: the catalog is expected to fail to load, which
+            // leaves the runtime not-ready by design, so a readiness assertion
+            // would fire before we can observe the catalog's Error status.
+            let rt = build_and_load_runtime(accelerated_pg_catalog(port)).await?;
+
+            // The catalog must reach Error state -- fail loud, not register empty.
+            let errored = wait_until_true(Duration::from_mins(1), || {
+                let rt = Arc::clone(&rt);
+                async move {
+                    rt.status()
+                        .get_catalog_statuses()
+                        .get(CATALOG_NAME)
+                        .is_some_and(|s| matches!(s, ComponentStatus::Error(_)))
+                }
+            })
+            .await;
+            anyhow::ensure!(
+                errored,
+                "catalog with no eligible tables should reach Error state, got {:?}",
+                rt.status().get_catalog_statuses().get(CATALOG_NAME)
+            );
+
+            // And the error must name the problem actionably.
+            if let Some(ComponentStatus::Error(Some(message))) =
+                rt.status().get_catalog_statuses().get(CATALOG_NAME)
+            {
+                anyhow::ensure!(
+                    message.contains("no tables are eligible"),
+                    "error message should be actionable, got: {message}"
+                );
+            }
+
+            // The catalog's tables must not be queryable.
+            let query_result = run_query(
+                &rt,
+                &format!("SELECT COUNT(*) AS n FROM {CATALOG_NAME}.public.ri_nothing"),
+            )
+            .await;
+            anyhow::ensure!(
+                query_result.is_err(),
+                "an ineligible-only catalog should register no queryable tables"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// `check_cdc_prerequisites` fails, naming the replication-privilege problem,
+/// when the connecting role lacks the `REPLICATION` attribute -- the second
+/// prerequisite branch, alongside the `wal_level` check.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_check_cdc_prerequisites_rejects_non_replication_role() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            // Needs wal_level=logical so the check gets PAST the wal_level gate
+            // and reaches the replication-privilege check.
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+
+            let pool = pool_for_non_replication_role(port).await?;
+
+            let result = check_cdc_prerequisites(&pool).await;
+            let err = result.expect_err("expected replication-privilege check to fail");
+            let message = err.to_string();
+            anyhow::ensure!(
+                message.contains("replication") && message.contains("norepl"),
+                "expected error naming the replication privilege and role, got: {message}"
             );
 
             Ok(())


### PR DESCRIPTION
Closes the remaining gaps for PostgreSQL catalog-level CDC acceleration (`refresh_mode: changes`), tracked in #11850. Builds on #11897 / #11951 / #11873 / #11777 (all merged).

## What & why

### 1. Fail loudly when zero tables are eligible
Previously a catalog that discovered no CDC-eligible tables registered empty and only logged an info summary. Now `refresh()` returns a typed, actionable `NoEligibleTablesError` (names the excluded/skipped counts, the fix, and a docs link) **before** spawning any dataset or swapping the schema map. `postgres.rs` downcasts it to a permanent `InvalidConfiguration`, so catalog load stops with an **ERROR** status rather than registering an empty catalog or retrying one-shot discovery forever. This matches the issue's "no auto-detecting tables added after startup" non-goal — discovery is startup-time, so an empty result is a configuration problem to surface.

### 2. Acceleration metrics
Two gauges (recorded each refresh):
- `catalog_acceleration_tables{catalog, category=accelerated|skipped|excluded}`
- `catalog_acceleration_accelerated_tables{catalog, kind=primary_key|unique_index|full}`

### 3. Acceleration-kind breakdown in the startup summary
A reusable `AccelerationSummary` now reports the PK / `USING INDEX` / `FULL` split. The resolved `AccelerationKind` is stored per spawned table so periodic re-plans keep the summary and metrics accurate without re-querying replica identity.

### 4. Test hardening
- **Slot naming** refactored to a pure `slot_name_for(name, instance_id)` with tests proving it is **stable across restarts** of the same instance (CDC resumes the same slot), **unique per instance** (two spiced instances pointed at the same catalog never collide on one physical replication slot), and unique per catalog.
- Unit tests for `table_is_selected` (include / exclude / exclude-veto), `SkipReason` explanations, the `wal_level` + replication-privilege prerequisite error messages, and `AccelerationSummary` aggregation.
- E2E tests (real Postgres/Docker): `include` filter, fail-loud-on-zero-eligible (asserts ERROR status + actionable message), and the replication-privilege prerequisite branch.

## Testing
- Unit/lib: `connector-postgres-common` 8/8, `data_components` slot-naming 11/11, `runtime` `postgres_accelerated` 12/12
- E2E `catalog_changes` suite **9/9** against real Postgres (3 new + 6 pre-existing — no regression)
- `cargo fmt` clean; clippy clean on the changed code (pedantic / `unwrap_used` / `clone_on_ref_ptr`)

## Docs
Cookbook recipe updated in spiceai/cookbook#542 (startup-log example → new by-kind format; added a "no eligible tables" troubleshooting entry).