### PR TITLE
fix(cli): avoid escaped ANSI version notification

### DIFF
--- a/bin/spice/src/commands/version.rs
+++ b/bin/spice/src/commands/version.rs
@@ -148,10 +148,8 @@ async fn check_and_notify_upgrade(ctx: &RuntimeContext) {
     };
 
     if is_newer_version(&current, &latest) {
-        // Use green color for the version
-        let green_version = format!("\x1b[92m{latest}\x1b[0m");
         println!();
-        tracing::info!("CLI version {green_version} is now available!");
+        tracing::info!("CLI version {latest} is now available!");
         tracing::info!("To upgrade, run \"spice upgrade\".");
     }
 }


### PR DESCRIPTION
## What
Remove manual ANSI escape sequences from the `spice version` update notification.

## Why
`tracing` escapes embedded terminal control characters, causing users to see literal `\x1b` sequences rather than a readable version. Logging the version as plain text keeps the notification clean.

## Example Output

Before:
```text
➜ spice version
CLI version:     v2.1.0-unstable (8ef599d5d8)
Runtime version: v2.1.0+models.metal

 INFO CLI version \x1b[92mv2.1.1\x1b[0m is now available!
 INFO To upgrade, run "spice upgrade".
```

After:
```text
❯ spice version
CLI version:     v2.1.0-unstable (acd88d18e6)
Runtime version: v2.1.0-build.1fcf9b5a7a+models

 INFO CLI version v2.1.1 is now available!
 INFO To upgrade, run "spice upgrade".
```

## Validation
`make install-cli-dev`

Closes #11995