### PR TITLE
fix(ci): stop rebasing snapshot-update commits backwards onto stale branches

### DIFF
--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -74,14 +74,22 @@ runs:
           echo "No changes to commit"
         else
           git commit -m "${PR_TITLE}"
-          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}"; then
-            if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
-              git fetch --unshallow origin
-            fi
-            git fetch origin "${BRANCH_NAME}"
-            git rebase -X theirs "origin/${BRANCH_NAME}"
+          # HEAD is already branched off the current trunk checkout (see `git checkout -b` above),
+          # and cargo test regenerates .snap files from scratch each run, so this commit is a
+          # complete, up-to-date replacement for whatever the existing branch (if any) held —
+          # there's nothing in the old branch worth preserving or rebasing onto. Reset the
+          # remote branch to point here instead of rebasing this commit backwards onto the old
+          # (possibly weeks-stale) branch tip, which previously forced trunk's entire commit
+          # history since the branch's fork point to be replayed nightly.
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" > /dev/null; then
+            # Explicit refspec so the remote-tracking ref is populated even though this is a
+            # shallow, single-ref checkout without a wildcard `origin/*` fetch config —
+            # `--force-with-lease` needs it to verify no one else pushed to the branch first.
+            git fetch origin "${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
+            git push --force-with-lease origin "HEAD:${BRANCH_NAME}"
+          else
+            git push origin "HEAD:${BRANCH_NAME}"
           fi
-          git push origin "HEAD:${BRANCH_NAME}"
 
           if [[ -n "${EXISTING_PR_NUMBER}" ]]; then
             PR_URL="$(gh pr view "${EXISTING_PR_NUMBER}" --json url --jq .url)"


### PR DESCRIPTION
## Summary
- `push-snap-changes` (used by `integration_search.yml` and similar snapshot-update workflows) reused an existing open snapshot-update PR indefinitely, but rebased the *fresh trunk checkout + new commit* onto the *old, stale branch tip* — the wrong direction. Since the branch never advanced, every nightly run had to replay all of trunk's commits since the branch's original fork point on top of it.
- Concretely, spiceai/spiceai#11687's branch was forked on 2026-06-29 and, three weeks later, had accumulated 629 commits and an 8k+ file diff against trunk, purely from this replay — not from any real snapshot changes.
- Since `INSTA_UPDATE=always` regenerates `.snap` files from scratch every run, the new commit (already based on current trunk, via the checkout step's `ref: ${{ github.sha }}`) is a complete, up-to-date replacement for whatever the existing branch held. There's nothing worth preserving from the old branch, so this now force-pushes the fresh commit to the branch instead of rebasing backwards onto it.

## Test plan
- [ ] Validated the embedded shell block parses (`bash -n`) after the edit
- [ ] Manually trigger `integration tests (search)` via `workflow_dispatch` with `update_snapshots: always` against a branch with an existing stale snapshot-update PR, confirm the PR updates to a single fresh commit against current trunk instead of growing
- [ ] Confirm `#11687` gets superseded/cleaned up (closed or force-updated to a clean single-commit diff) after this lands