### PR TITLE
Update signoff.yml. 

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -154,7 +154,7 @@ jobs:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          SIGNOFF_SKIP_TARGETED_LINT: ${{ inputs.skip_targeted_lint }}
+          SIGNOFF_SKIP_TARGETED_LINT: "${{ inputs.skip_targeted_lint && '1' || '' }}"
 
       - name: Show sccache stats
         if: env.SCCACHE_SETUP == 'true'

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -9,7 +9,7 @@
 #   0. Skip Rust lint/build/tests when the branch has no Rust-affecting files
 #      vs trunk (.rs, Cargo.toml/lock, rust-toolchain*, .cargo/*)
 #   1. Targeted lint of crates touched by the branch vs trunk (off by default —
-#      see the run_targeted_lint input)
+#      see the skip_targeted_lint input)
 #   2. Full workspace lint (make lint-rust)
 #   3. CLI build + unit tests (make build-cli nextest)
 #   4. Post signoff status + re-run Attestation if needed
@@ -19,7 +19,7 @@
 # host works:
 #   make signoff-remote
 #   gh workflow run signoff.yml -f branch=<your-branch>
-#   gh workflow run signoff.yml -f branch=<your-branch> -f run_targeted_lint=true
+#   gh workflow run signoff.yml -f branch=<your-branch> -f skip_targeted_lint=true
 name: Remote Sign-off
 
 run-name: Remote Sign-off (${{ inputs.branch }})

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -147,6 +147,7 @@ jobs:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          SIGNOFF_SKIP_TARGETED_LINT: 1
 
       - name: Show sccache stats
         if: env.SCCACHE_SETUP == 'true'

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -30,11 +30,11 @@ on:
         description: 'Branch to sign off (must be pushed to origin)'
         required: true
         type: string
-      run_targeted_lint:
-        description: 'Run the branch-scoped targeted pre-lint (currently unreliable on this runner; leave off unless debugging it)'
+      skip_targeted_lint:
+        description: 'Skip the branch-scoped targeted pre-lint'
         required: false
         type: boolean
-        default: true
+        default: false
 
 concurrency:
   group: signoff-${{ github.event.inputs.branch }}
@@ -154,9 +154,7 @@ jobs:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          # Targeted lint currently breaks signoffs on this runner; keep it off
-          # by default and let a dispatcher opt in via the run_targeted_lint input.
-          SIGNOFF_SKIP_TARGETED_LINT: ${{ inputs.run_targeted_lint && '' || '1' }}
+          SIGNOFF_SKIP_TARGETED_LINT: ${{ inputs.skip_targeted_lint }}
 
       - name: Show sccache stats
         if: env.SCCACHE_SETUP == 'true'

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -8,7 +8,8 @@
 # Same fail-fast order as local sign-off:
 #   0. Skip Rust lint/build/tests when the branch has no Rust-affecting files
 #      vs trunk (.rs, Cargo.toml/lock, rust-toolchain*, .cargo/*)
-#   1. Targeted lint of crates touched by the branch vs trunk
+#   1. Targeted lint of crates touched by the branch vs trunk (off by default —
+#      see the run_targeted_lint input)
 #   2. Full workspace lint (make lint-rust)
 #   3. CLI build + unit tests (make build-cli nextest)
 #   4. Post signoff status + re-run Attestation if needed
@@ -18,6 +19,7 @@
 # host works:
 #   make signoff-remote
 #   gh workflow run signoff.yml -f branch=<your-branch>
+#   gh workflow run signoff.yml -f branch=<your-branch> -f run_targeted_lint=true
 name: Remote Sign-off
 
 run-name: Remote Sign-off (${{ inputs.branch }})
@@ -28,6 +30,11 @@ on:
         description: 'Branch to sign off (must be pushed to origin)'
         required: true
         type: string
+      run_targeted_lint:
+        description: 'Run the branch-scoped targeted pre-lint (currently unreliable on this runner; leave off unless debugging it)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: signoff-${{ github.event.inputs.branch }}
@@ -147,7 +154,9 @@ jobs:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-          SIGNOFF_SKIP_TARGETED_LINT: 1
+          # Targeted lint currently breaks signoffs on this runner; keep it off
+          # by default and let a dispatcher opt in via the run_targeted_lint input.
+          SIGNOFF_SKIP_TARGETED_LINT: ${{ inputs.run_targeted_lint && '' || '1' }}
 
       - name: Show sccache stats
         if: env.SCCACHE_SETUP == 'true'

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -34,7 +34,7 @@ on:
         description: 'Run the branch-scoped targeted pre-lint (currently unreliable on this runner; leave off unless debugging it)'
         required: false
         type: boolean
-        default: false
+        default: true
 
 concurrency:
   group: signoff-${{ github.event.inputs.branch }}


### PR DESCRIPTION
## 📝 Summary
Targeted lints usually break `signoff.yml`. Add input that allows users to skip it.  