### PR TITLE
fix(telemetry): validate runtime.telemetry.metric_prefix against OTel name syntax

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -991,9 +991,10 @@ fn init_metrics(
     // OpenTelemetry 0.31's SDK does not support per-reader name transforms.
     // Character/length validity is enforced at spicepod parse time via
     // `validate_metric_prefix` (OTel instrument name syntax).
-    if let Some(prefix) = metric_prefix.filter(|p| !p.is_empty()) {
+    if let Some(prefix) = metric_prefix {
         // Defense in depth: spicepod load already validates, but reject here
-        // if an invalid prefix reaches metrics init through another path.
+        // if an invalid (including empty) prefix reaches metrics init through
+        // another path. Do not skip empty strings — they are invalid.
         validate_metric_prefix(&prefix)
             .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
         tracing::info!(prefix = %prefix, "OTEL metrics name prefix enabled");

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -990,8 +990,7 @@ fn init_metrics(
     // telemetry level rather than under any single exporter because
     // OpenTelemetry 0.31's SDK does not support per-reader name transforms.
     // Character/length validity is enforced at spicepod parse time via
-    // `validate_metric_prefix` (OTel instrument name syntax). Empty prefixes
-    // are a no-op and are skipped here.
+    // `validate_metric_prefix` (OTel instrument name syntax).
     if let Some(prefix) = metric_prefix.filter(|p| !p.is_empty()) {
         validate_metric_prefix(&prefix)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -995,10 +995,8 @@ fn init_metrics(
         // Defense in depth: spicepod load already validates, but reject here
         // if an invalid (including empty) prefix reaches metrics init through
         // another path. Do not skip empty strings — they are invalid.
-        validate_metric_prefix(&prefix).map_err(|e| {
-            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
-                as Box<dyn std::error::Error>
-        })?;
+        validate_metric_prefix(&prefix)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
         tracing::info!(prefix = %prefix, "OTEL metrics name prefix enabled");
         provider_builder = provider_builder.with_view(
             move |instrument: &opentelemetry_sdk::metrics::Instrument| {

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -990,11 +990,9 @@ fn init_metrics(
     // telemetry level rather than under any single exporter because
     // OpenTelemetry 0.31's SDK does not support per-reader name transforms.
     // Character/length validity is enforced at spicepod parse time via
-    // `validate_metric_prefix` (OTel instrument name syntax).
-    if let Some(prefix) = metric_prefix {
-        // Defense in depth: spicepod load already validates, but reject here
-        // if an invalid (including empty) prefix reaches metrics init through
-        // another path. Do not skip empty strings — they are invalid.
+    // `validate_metric_prefix` (OTel instrument name syntax). Empty prefixes
+    // are a no-op and are skipped here.
+    if let Some(prefix) = metric_prefix.filter(|p| !p.is_empty()) {
         validate_metric_prefix(&prefix)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
         tracing::info!(prefix = %prefix, "OTEL metrics name prefix enabled");

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -995,8 +995,10 @@ fn init_metrics(
         // Defense in depth: spicepod load already validates, but reject here
         // if an invalid (including empty) prefix reaches metrics init through
         // another path. Do not skip empty strings — they are invalid.
-        validate_metric_prefix(&prefix)
-            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        validate_metric_prefix(&prefix).map_err(|e| {
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+                as Box<dyn std::error::Error>
+        })?;
         tracing::info!(prefix = %prefix, "OTEL metrics name prefix enabled");
         provider_builder = provider_builder.with_view(
             move |instrument: &opentelemetry_sdk::metrics::Instrument| {

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -27,6 +27,7 @@ use tokio::sync::SetOnce;
 
 use app::spicepod::component::runtime::{
     ClientAuthMode as SpicepodClientAuthMode, Runtime as SpicepodRuntime, TelemetryConfig,
+    validate_metric_prefix,
 };
 use app::{App, AppBuilder};
 use clap::{ArgAction, Parser, ValueEnum};
@@ -988,7 +989,13 @@ fn init_metrics(
     // on-demand OTLP, OTEL push). The prefix is intentionally placed at the
     // telemetry level rather than under any single exporter because
     // OpenTelemetry 0.31's SDK does not support per-reader name transforms.
+    // Character/length validity is enforced at spicepod parse time via
+    // `validate_metric_prefix` (OTel instrument name syntax).
     if let Some(prefix) = metric_prefix.filter(|p| !p.is_empty()) {
+        // Defense in depth: spicepod load already validates, but reject here
+        // if an invalid prefix reaches metrics init through another path.
+        validate_metric_prefix(&prefix)
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
         tracing::info!(prefix = %prefix, "OTEL metrics name prefix enabled");
         provider_builder = provider_builder.with_view(
             move |instrument: &opentelemetry_sdk::metrics::Instrument| {

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -2342,12 +2342,13 @@ datasets:
 
     #[test]
     fn test_validate_metric_prefix_accepts_otel_charset() {
+        let max_len = "a".repeat(METRIC_PREFIX_MAX_LEN);
         for valid in [
             "spiceai.",
             "spiceai_",
             "a",
             "A-B/c_d.e",
-            &"a".repeat(METRIC_PREFIX_MAX_LEN),
+            max_len.as_str(),
         ] {
             validate_metric_prefix(valid)
                 .unwrap_or_else(|e| panic!("expected '{valid}' to be valid: {e}"));

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -448,12 +448,32 @@ pub struct TelemetryConfig {
     /// `OpenTelemetry` 0.31's SDK does not support per-reader name transforms,
     /// so this knob is intentionally placed at the telemetry level rather
     /// than under any single exporter.
+    ///
+    /// Validated against the `OpenTelemetry` instrument name syntax so prefixed
+    /// names stay valid for OTLP backends and remain sanitizable to Prometheus
+    /// legacy names (`[a-zA-Z_:][a-zA-Z0-9_:]*`). Must be non-empty, start with
+    /// an ASCII letter, contain only ASCII letters, digits, `_`, `.`, `-`, or
+    /// `/`, and be at most [`METRIC_PREFIX_MAX_LEN`] characters. A trailing `.`
+    /// or `_` is recommended (e.g. `spiceai.`).
+    /// See: <https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metric_prefix: Option<String>,
     /// Optional configuration for pushing metrics to an OpenTelemetry collector
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub otel_exporter: Option<OtelExporterConfig>,
 }
+
+/// Maximum length for `runtime.telemetry.metric_prefix`.
+///
+/// `OpenTelemetry` instrument names are capped at 255 characters. Spice's
+/// longest instrument names are ~56 characters today; reserve 64 so a
+/// configured prefix cannot push current (or near-term) names over the limit.
+pub const METRIC_PREFIX_MAX_LEN: usize = 255 - 64;
+
+/// Non-alphanumeric characters allowed in `OpenTelemetry` instrument names
+/// (and therefore in `metric_prefix`). Matches the `OTel` Metrics API ABNF and
+/// the Rust SDK's `INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS`.
+const METRIC_PREFIX_ALLOWED_NON_ALPHANUMERIC: [char; 4] = ['_', '.', '-', '/'];
 
 impl Default for TelemetryConfig {
     fn default() -> Self {
@@ -465,6 +485,61 @@ impl Default for TelemetryConfig {
             otel_exporter: None,
         }
     }
+}
+
+/// Validate `runtime.telemetry.metric_prefix` against OpenTelemetry instrument
+/// name syntax so `{prefix}{instrument}` stays a valid metric name for OTLP
+/// and maps cleanly through Prometheus name sanitization.
+///
+/// Rules (mirroring the `OTel` Metrics API / SDK):
+/// - non-empty
+/// - starts with an ASCII alphabetic character
+/// - subsequent characters are ASCII alphanumeric, `_`, `.`, `-`, or `/`
+/// - length ≤ [`METRIC_PREFIX_MAX_LEN`] (leaves headroom under the 255-char
+///   `OTel` instrument name limit)
+///
+/// # Errors
+///
+/// Returns a user-facing error describing the violation and how to fix it.
+pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
+    if prefix.is_empty() {
+        return Err(
+            "Invalid 'runtime.telemetry.metric_prefix': value must not be empty. \
+             Omit the field for no prefix, or set a non-empty prefix such as 'spiceai.'. \
+             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+                .to_string(),
+        );
+    }
+
+    if prefix.len() > METRIC_PREFIX_MAX_LEN {
+        return Err(format!(
+            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': length {} exceeds the maximum of {METRIC_PREFIX_MAX_LEN} characters. \
+             Shorten the prefix so prefixed metric names stay within the OpenTelemetry 255-character instrument name limit. \
+             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix",
+            prefix.len()
+        ));
+    }
+
+    if prefix.starts_with(|c: char| !c.is_ascii_alphabetic()) {
+        return Err(format!(
+            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': must start with an ASCII letter (A-Z or a-z). \
+             Example: 'spiceai.'. \
+             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+        ));
+    }
+
+    if let Some(invalid) = prefix.chars().find(|c| {
+        !c.is_ascii_alphanumeric() && !METRIC_PREFIX_ALLOWED_NON_ALPHANUMERIC.contains(c)
+    }) {
+        return Err(format!(
+            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': contains invalid character {invalid:?}. \
+             Allowed characters are ASCII letters, digits, '_', '.', '-', and '/'. \
+             Example: 'spiceai.'. \
+             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+        ));
+    }
+
+    Ok(())
 }
 
 /// Configuration for the MCP (Model Context Protocol) HTTP endpoint.
@@ -1239,6 +1314,10 @@ impl TryFrom<RuntimeDeserializer> for Runtime {
             if !sql_results_explicit {
                 caching.sql_results = Some(results_cache.into());
             }
+        }
+
+        if let Some(prefix) = &deserializer.telemetry.metric_prefix {
+            validate_metric_prefix(prefix)?;
         }
 
         Ok(Runtime {
@@ -2164,6 +2243,104 @@ datasets:
         "#;
         let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
         assert_eq!(runtime.telemetry.metric_prefix.as_deref(), Some("spiceai."));
+    }
+
+    #[test]
+    fn test_metric_prefix_underscore_separator_accepted() {
+        let yaml = r#"
+            telemetry:
+                metric_prefix: "spiceai_"
+        "#;
+        let runtime: Runtime = yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.telemetry.metric_prefix.as_deref(), Some("spiceai_"));
+    }
+
+    #[test]
+    fn test_metric_prefix_empty_rejected() {
+        let yaml = r#"
+            telemetry:
+                metric_prefix: ""
+        "#;
+        let result: Result<Runtime, _> = yaml::from_str(yaml);
+        let err = result.expect_err("empty metric_prefix must fail to parse");
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_metric_prefix_leading_digit_rejected() {
+        let yaml = r#"
+            telemetry:
+                metric_prefix: "1spice."
+        "#;
+        let result: Result<Runtime, _> = yaml::from_str(yaml);
+        let err = result.expect_err("leading digit metric_prefix must fail to parse");
+        assert!(
+            err.to_string().contains("must start with an ASCII letter"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_metric_prefix_invalid_characters_rejected() {
+        for invalid in ["spice ai.", "spiceai:", "spiceai@", "spiceai🚀."] {
+            let yaml = format!(
+                r#"
+            telemetry:
+                metric_prefix: "{invalid}"
+        "#
+            );
+            let result: Result<Runtime, _> = yaml::from_str(&yaml);
+            let err = result
+                .expect_err("metric_prefix with invalid characters must fail to parse");
+            assert!(
+                err.to_string().contains("invalid character"),
+                "unexpected error for '{invalid}': {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_metric_prefix_too_long_rejected() {
+        let too_long = format!("{}{}", "a", "x".repeat(METRIC_PREFIX_MAX_LEN));
+        assert_eq!(too_long.len(), METRIC_PREFIX_MAX_LEN + 1);
+        let yaml = format!(
+            r#"
+            telemetry:
+                metric_prefix: "{too_long}"
+        "#
+        );
+        let result: Result<Runtime, _> = yaml::from_str(&yaml);
+        let err = result.expect_err("overlong metric_prefix must fail to parse");
+        assert!(
+            err.to_string().contains("exceeds the maximum"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_metric_prefix_accepts_otel_charset() {
+        for valid in [
+            "spiceai.",
+            "spiceai_",
+            "a",
+            "A-B/c_d.e",
+            &"a".repeat(METRIC_PREFIX_MAX_LEN),
+        ] {
+            validate_metric_prefix(valid)
+                .unwrap_or_else(|e| panic!("expected '{valid}' to be valid: {e}"));
+        }
+    }
+
+    #[test]
+    fn test_validate_metric_prefix_rejects_prometheus_colon() {
+        // Prometheus reserves ':' for recording rules; OTel instrument syntax
+        // also disallows it. Keep both backends happy by rejecting colons.
+        let err = validate_metric_prefix("spice:ai.")
+            .expect_err("colon in metric_prefix must be rejected");
+        assert!(err.contains("invalid character"));
     }
 
     #[test]

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -465,10 +465,10 @@ pub struct TelemetryConfig {
 
 /// Maximum length for `runtime.telemetry.metric_prefix`.
 ///
-/// `OpenTelemetry` instrument names are capped at 255 characters. Spice's
-/// longest instrument names are ~56 characters today; reserve 64 so a
-/// configured prefix cannot push current (or near-term) names over the limit.
-pub const METRIC_PREFIX_MAX_LEN: usize = 255 - 64;
+/// Cap at a round power of two so namespaces stay short while leaving room
+/// under the `OpenTelemetry` 255-character instrument name limit for the
+/// base metric name (`prefix` + instrument ≤ 255).
+pub const METRIC_PREFIX_MAX_LEN: usize = 128;
 
 /// Non-alphanumeric characters allowed in `OpenTelemetry` instrument names
 /// (and therefore in `metric_prefix`). Matches the `OTel` Metrics API ABNF and

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -510,7 +510,7 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
     // (UTF-8 byte length can exceed the limit even when char count does not).
     if !prefix.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
         return Err(format!(
-            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': must start with an ASCII letter (A-Z or a-z). Example: 'spiceai.'. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+            "Invalid 'runtime.telemetry.metric_prefix' value {prefix:?}: must start with an ASCII letter (A-Z or a-z). Example: 'spiceai.'. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
     }
 
@@ -518,7 +518,7 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
         !c.is_ascii_alphanumeric() && !METRIC_PREFIX_ALLOWED_NON_ALPHANUMERIC.contains(c)
     }) {
         return Err(format!(
-            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': contains invalid character {invalid:?}. Allowed characters are ASCII letters, digits, '_', '.', '-', and '/'. Example: 'spiceai.'. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+            "Invalid 'runtime.telemetry.metric_prefix' value {prefix:?}: contains invalid character {invalid:?}. Allowed characters are ASCII letters, digits, '_', '.', '-', and '/'. Example: 'spiceai.'. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
     }
 
@@ -526,7 +526,7 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
     let char_len = prefix.chars().count();
     if char_len > METRIC_PREFIX_MAX_LEN {
         return Err(format!(
-            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': length {char_len} exceeds the maximum of {METRIC_PREFIX_MAX_LEN} characters. Shorten the prefix so prefixed metric names stay within the OpenTelemetry 255-character instrument name limit. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+            "Invalid 'runtime.telemetry.metric_prefix' value {prefix:?}: length {char_len} exceeds the maximum of {METRIC_PREFIX_MAX_LEN} characters. Shorten the prefix so prefixed metric names stay within the OpenTelemetry 255-character instrument name limit. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
     }
 
@@ -2321,6 +2321,20 @@ datasets:
         assert!(
             !err.contains("exceeds the maximum"),
             "non-ASCII must not be reported as a length error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_metric_prefix_error_keeps_control_chars_on_one_line() {
+        let err = validate_metric_prefix("spice\nai.")
+            .expect_err("control characters in metric_prefix must be rejected");
+        assert!(
+            !err.contains('\n'),
+            "error must stay on one line when prefix contains newlines: {err:?}"
+        );
+        assert!(
+            err.contains("spice\\nai."),
+            "prefix must be debug-escaped in the error: {err}"
         );
     }
 

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -512,15 +512,20 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
     // Check character validity before length so non-ASCII input reports the
     // actionable "invalid character" error instead of a misleading length error
     // (UTF-8 byte length can exceed the limit even when char count does not).
-    if !prefix.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+    if !prefix
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+    {
         return Err(format!(
             "Invalid 'runtime.telemetry.metric_prefix' value {prefix:?}: must start with an ASCII letter (A-Z or a-z). Example: 'spiceai.'. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
     }
 
-    if let Some(invalid) = prefix.chars().find(|c| {
-        !c.is_ascii_alphanumeric() && !METRIC_PREFIX_ALLOWED_NON_ALPHANUMERIC.contains(c)
-    }) {
+    if let Some(invalid) = prefix
+        .chars()
+        .find(|c| !c.is_ascii_alphanumeric() && !METRIC_PREFIX_ALLOWED_NON_ALPHANUMERIC.contains(c))
+    {
         return Err(format!(
             "Invalid 'runtime.telemetry.metric_prefix' value {prefix:?}: contains invalid character {invalid:?}. Allowed characters are ASCII letters, digits, '_', '.', '-', and '/'. Example: 'spiceai.'. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
@@ -2285,8 +2290,7 @@ datasets:
         "#
             );
             let result: Result<Runtime, _> = yaml::from_str(&yaml);
-            let err = result
-                .expect_err("metric_prefix with invalid characters must fail to parse");
+            let err = result.expect_err("metric_prefix with invalid characters must fail to parse");
             assert!(
                 err.to_string().contains("invalid character"),
                 "unexpected error for '{invalid}': {err}"
@@ -2345,13 +2349,7 @@ datasets:
     #[test]
     fn test_validate_metric_prefix_accepts_otel_charset() {
         let max_len = "a".repeat(METRIC_PREFIX_MAX_LEN);
-        for valid in [
-            "spiceai.",
-            "spiceai_",
-            "a",
-            "A-B/c_d.e",
-            max_len.as_str(),
-        ] {
+        for valid in ["spiceai.", "spiceai_", "a", "A-B/c_d.e", max_len.as_str()] {
             validate_metric_prefix(valid)
                 .unwrap_or_else(|e| panic!("expected '{valid}' to be valid: {e}"));
         }

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -514,7 +514,7 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
     // Check character validity before length so non-ASCII input reports the
     // actionable "invalid character" error instead of a misleading length error
     // (UTF-8 byte length can exceed the limit even when char count does not).
-    if prefix.starts_with(|c: char| !c.is_ascii_alphabetic()) {
+    if !prefix.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
         return Err(format!(
             "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': must start with an ASCII letter (A-Z or a-z). \
              Example: 'spiceai.'. \

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -511,15 +511,9 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
         );
     }
 
-    if prefix.len() > METRIC_PREFIX_MAX_LEN {
-        return Err(format!(
-            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': length {} exceeds the maximum of {METRIC_PREFIX_MAX_LEN} characters. \
-             Shorten the prefix so prefixed metric names stay within the OpenTelemetry 255-character instrument name limit. \
-             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix",
-            prefix.len()
-        ));
-    }
-
+    // Check character validity before length so non-ASCII input reports the
+    // actionable "invalid character" error instead of a misleading length error
+    // (UTF-8 byte length can exceed the limit even when char count does not).
     if prefix.starts_with(|c: char| !c.is_ascii_alphabetic()) {
         return Err(format!(
             "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': must start with an ASCII letter (A-Z or a-z). \
@@ -535,6 +529,16 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
             "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': contains invalid character {invalid:?}. \
              Allowed characters are ASCII letters, digits, '_', '.', '-', and '/'. \
              Example: 'spiceai.'. \
+             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+        ));
+    }
+
+    // Character count (not UTF-8 bytes) matches the OpenTelemetry ABNF limit.
+    let char_len = prefix.chars().count();
+    if char_len > METRIC_PREFIX_MAX_LEN {
+        return Err(format!(
+            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': length {char_len} exceeds the maximum of {METRIC_PREFIX_MAX_LEN} characters. \
+             Shorten the prefix so prefixed metric names stay within the OpenTelemetry 255-character instrument name limit. \
              See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
     }
@@ -2305,7 +2309,7 @@ datasets:
     #[test]
     fn test_metric_prefix_too_long_rejected() {
         let too_long = format!("{}{}", "a", "x".repeat(METRIC_PREFIX_MAX_LEN));
-        assert_eq!(too_long.len(), METRIC_PREFIX_MAX_LEN + 1);
+        assert_eq!(too_long.chars().count(), METRIC_PREFIX_MAX_LEN + 1);
         let yaml = format!(
             r#"
             telemetry:
@@ -2317,6 +2321,22 @@ datasets:
         assert!(
             err.to_string().contains("exceeds the maximum"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_metric_prefix_non_ascii_reports_invalid_character_not_length() {
+        // Multi-byte UTF-8 must fail on character validity, not a misleading
+        // byte-length overflow (🚀 is 4 UTF-8 bytes).
+        let err = validate_metric_prefix("spiceai🚀.")
+            .expect_err("non-ASCII metric_prefix must be rejected");
+        assert!(
+            err.contains("invalid character"),
+            "expected invalid-character error, got: {err}"
+        );
+        assert!(
+            !err.contains("exceeds the maximum"),
+            "non-ASCII must not be reported as a length error: {err}"
         );
     }
 

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -451,11 +451,10 @@ pub struct TelemetryConfig {
     ///
     /// Validated against the `OpenTelemetry` instrument name syntax so prefixed
     /// names stay valid for OTLP backends and remain sanitizable to Prometheus
-    /// legacy names (`[a-zA-Z_:][a-zA-Z0-9_:]*`). An empty string is treated as
-    /// no prefix. Non-empty values must start with an ASCII letter, contain only
-    /// ASCII letters, digits, `_`, `.`, `-`, or `/`, and be at most
-    /// [`METRIC_PREFIX_MAX_LEN`] characters. A trailing `.` or `_` is
-    /// recommended (e.g. `spiceai.`).
+    /// legacy names (`[a-zA-Z_:][a-zA-Z0-9_:]*`). Must start with an ASCII
+    /// letter, contain only ASCII letters, digits, `_`, `.`, `-`, or `/`, and
+    /// be at most [`METRIC_PREFIX_MAX_LEN`] characters. A trailing `.` or `_`
+    /// is recommended (e.g. `spiceai.`).
     /// See: <https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metric_prefix: Option<String>,
@@ -492,7 +491,6 @@ impl Default for TelemetryConfig {
 /// name syntax so `{prefix}{instrument}` stays a valid metric name for OTLP
 /// and maps cleanly through Prometheus name sanitization.
 ///
-/// An empty prefix is accepted (no-op: instrument names are already non-empty).
 /// Non-empty prefixes must (mirroring the `OTel` Metrics API / SDK):
 /// - start with an ASCII alphabetic character
 /// - contain only ASCII alphanumeric characters, `_`, `.`, `-`, or `/`
@@ -503,7 +501,6 @@ impl Default for TelemetryConfig {
 ///
 /// Returns a user-facing error describing the violation and how to fix it.
 pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
-    // Empty prefix is a no-op — metric instrument names themselves are non-empty.
     if prefix.is_empty() {
         return Ok(());
     }
@@ -513,9 +510,7 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
     // (UTF-8 byte length can exceed the limit even when char count does not).
     if !prefix.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
         return Err(format!(
-            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': must start with an ASCII letter (A-Z or a-z). \
-             Example: 'spiceai.'. \
-             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': must start with an ASCII letter (A-Z or a-z). Example: 'spiceai.'. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
     }
 
@@ -523,10 +518,7 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
         !c.is_ascii_alphanumeric() && !METRIC_PREFIX_ALLOWED_NON_ALPHANUMERIC.contains(c)
     }) {
         return Err(format!(
-            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': contains invalid character {invalid:?}. \
-             Allowed characters are ASCII letters, digits, '_', '.', '-', and '/'. \
-             Example: 'spiceai.'. \
-             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': contains invalid character {invalid:?}. Allowed characters are ASCII letters, digits, '_', '.', '-', and '/'. Example: 'spiceai.'. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
     }
 
@@ -534,9 +526,7 @@ pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
     let char_len = prefix.chars().count();
     if char_len > METRIC_PREFIX_MAX_LEN {
         return Err(format!(
-            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': length {char_len} exceeds the maximum of {METRIC_PREFIX_MAX_LEN} characters. \
-             Shorten the prefix so prefixed metric names stay within the OpenTelemetry 255-character instrument name limit. \
-             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
+            "Invalid 'runtime.telemetry.metric_prefix' value '{prefix}': length {char_len} exceeds the maximum of {METRIC_PREFIX_MAX_LEN} characters. Shorten the prefix so prefixed metric names stay within the OpenTelemetry 255-character instrument name limit. See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
         ));
     }
 
@@ -2264,8 +2254,7 @@ datasets:
         "#;
         let runtime: Runtime = yaml::from_str(yaml).expect("empty metric_prefix must parse");
         assert_eq!(runtime.telemetry.metric_prefix.as_deref(), Some(""));
-        validate_metric_prefix("")
-            .expect("empty metric_prefix is a no-op and must be valid");
+        validate_metric_prefix("").expect("empty metric_prefix must be valid");
     }
 
     #[test]

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -453,8 +453,10 @@ pub struct TelemetryConfig {
     /// names stay valid for OTLP backends and remain sanitizable to Prometheus
     /// legacy names (`[a-zA-Z_:][a-zA-Z0-9_:]*`). Must start with an ASCII
     /// letter, contain only ASCII letters, digits, `_`, `.`, `-`, or `/`, and
-    /// be at most [`METRIC_PREFIX_MAX_LEN`] characters. A trailing `.` or `_`
-    /// is recommended (e.g. `spiceai.`).
+    /// be at most [`METRIC_PREFIX_MAX_LEN`] characters (128; ≥127 characters of
+    /// headroom remain under the 255-char `OpenTelemetry` instrument name
+    /// limit for the base metric name). A trailing `.` or `_` is recommended
+    /// (e.g. `spiceai.`).
     /// See: <https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metric_prefix: Option<String>,
@@ -465,9 +467,10 @@ pub struct TelemetryConfig {
 
 /// Maximum length for `runtime.telemetry.metric_prefix`.
 ///
-/// Cap at a round power of two so namespaces stay short while leaving room
-/// under the `OpenTelemetry` 255-character instrument name limit for the
-/// base metric name (`prefix` + instrument ≤ 255).
+/// Cap at a round power of two so namespaces stay short. Prefixed names must
+/// still fit the `OpenTelemetry` 255-character instrument name limit
+/// (`prefix` + base metric name ≤ 255), so 128 leaves ≥127 characters of
+/// headroom for the base name.
 pub const METRIC_PREFIX_MAX_LEN: usize = 128;
 
 /// Non-alphanumeric characters allowed in `OpenTelemetry` instrument names
@@ -494,8 +497,9 @@ impl Default for TelemetryConfig {
 /// Non-empty prefixes must (mirroring the `OTel` Metrics API / SDK):
 /// - start with an ASCII alphabetic character
 /// - contain only ASCII alphanumeric characters, `_`, `.`, `-`, or `/`
-/// - have length ≤ [`METRIC_PREFIX_MAX_LEN`] (leaves headroom under the
-///   255-char `OTel` instrument name limit)
+/// - have length ≤ [`METRIC_PREFIX_MAX_LEN`] (128; leaves ≥127 characters of
+///   headroom under the 255-char `OTel` instrument name limit for the base
+///   metric name)
 ///
 /// # Errors
 ///

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -451,10 +451,11 @@ pub struct TelemetryConfig {
     ///
     /// Validated against the `OpenTelemetry` instrument name syntax so prefixed
     /// names stay valid for OTLP backends and remain sanitizable to Prometheus
-    /// legacy names (`[a-zA-Z_:][a-zA-Z0-9_:]*`). Must be non-empty, start with
-    /// an ASCII letter, contain only ASCII letters, digits, `_`, `.`, `-`, or
-    /// `/`, and be at most [`METRIC_PREFIX_MAX_LEN`] characters. A trailing `.`
-    /// or `_` is recommended (e.g. `spiceai.`).
+    /// legacy names (`[a-zA-Z_:][a-zA-Z0-9_:]*`). An empty string is treated as
+    /// no prefix. Non-empty values must start with an ASCII letter, contain only
+    /// ASCII letters, digits, `_`, `.`, `-`, or `/`, and be at most
+    /// [`METRIC_PREFIX_MAX_LEN`] characters. A trailing `.` or `_` is
+    /// recommended (e.g. `spiceai.`).
     /// See: <https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metric_prefix: Option<String>,
@@ -491,24 +492,20 @@ impl Default for TelemetryConfig {
 /// name syntax so `{prefix}{instrument}` stays a valid metric name for OTLP
 /// and maps cleanly through Prometheus name sanitization.
 ///
-/// Rules (mirroring the `OTel` Metrics API / SDK):
-/// - non-empty
-/// - starts with an ASCII alphabetic character
-/// - subsequent characters are ASCII alphanumeric, `_`, `.`, `-`, or `/`
-/// - length ≤ [`METRIC_PREFIX_MAX_LEN`] (leaves headroom under the 255-char
-///   `OTel` instrument name limit)
+/// An empty prefix is accepted (no-op: instrument names are already non-empty).
+/// Non-empty prefixes must (mirroring the `OTel` Metrics API / SDK):
+/// - start with an ASCII alphabetic character
+/// - contain only ASCII alphanumeric characters, `_`, `.`, `-`, or `/`
+/// - have length ≤ [`METRIC_PREFIX_MAX_LEN`] (leaves headroom under the
+///   255-char `OTel` instrument name limit)
 ///
 /// # Errors
 ///
 /// Returns a user-facing error describing the violation and how to fix it.
 pub fn validate_metric_prefix(prefix: &str) -> Result<(), String> {
+    // Empty prefix is a no-op — metric instrument names themselves are non-empty.
     if prefix.is_empty() {
-        return Err(
-            "Invalid 'runtime.telemetry.metric_prefix': value must not be empty. \
-             Omit the field for no prefix, or set a non-empty prefix such as 'spiceai.'. \
-             See: https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix"
-                .to_string(),
-        );
+        return Ok(());
     }
 
     // Check character validity before length so non-ASCII input reports the
@@ -2260,17 +2257,15 @@ datasets:
     }
 
     #[test]
-    fn test_metric_prefix_empty_rejected() {
+    fn test_metric_prefix_empty_accepted() {
         let yaml = r#"
             telemetry:
                 metric_prefix: ""
         "#;
-        let result: Result<Runtime, _> = yaml::from_str(yaml);
-        let err = result.expect_err("empty metric_prefix must fail to parse");
-        assert!(
-            err.to_string().contains("must not be empty"),
-            "unexpected error: {err}"
-        );
+        let runtime: Runtime = yaml::from_str(yaml).expect("empty metric_prefix must parse");
+        assert_eq!(runtime.telemetry.metric_prefix.as_deref(), Some(""));
+        validate_metric_prefix("")
+            .expect("empty metric_prefix is a no-op and must be valid");
     }
 
     #[test]


### PR DESCRIPTION
## What
Adds base validation for `runtime.telemetry.metric_prefix` so invalid prefixes fail at spicepod load (and again at metrics init) instead of producing bad OTLP/Prometheus metric names.

Validated rules (aligned with the OpenTelemetry instrument name syntax):
- starts with an ASCII letter
- only ASCII letters, digits, `_`, `.`, `-`, `/`
- max length 128 (OpenTelemetry instrument names are capped at 255 characters; 128 leaves ≥127 characters of headroom for the base metric name after the prefix is applied)

## Why
`metric_prefix` is prepended to every exported metric via an OTel View on the shared `MeterProvider` (Prometheus scrape, cluster OTLP reader, and `otel_exporter` push). Without validation, overlong or illegal-character prefixes can yield names that violate OTel rules and only survive Prometheus export via sanitization (e.g. `.` → `_`). Fail fast with an actionable config error instead.

## Docs
- https://spiceai.org/docs/reference/spicepod/runtime#runtimetelemetrymetric_prefix
- https://spiceai.org/docs/features/observability
- OpenTelemetry instrument name syntax: https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax
- Prometheus metric name guidance: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

## Test plan
- [x] `cargo test -p spicepod --lib metric_prefix`
- [x] `cargo clippy -j 4 -p spicepod --lib --tests --no-deps -- -D warnings`
- [ ] Confirm valid prefixes like `spiceai.` / `spiceai_` still parse
- [ ] Confirm invalid prefixes (leading digit, `:`, spaces, emoji, overlong) fail spicepod load with a clear error