### PR TITLE
fix(mysql-cdc): detect source reset on GTID resume

### DIFF
--- a/crates/data_components/src/mysql_replication/gtid.rs
+++ b/crates/data_components/src/mysql_replication/gtid.rs
@@ -198,6 +198,41 @@ impl GtidSet {
         }
         out
     }
+
+    /// Whether `self` is a subset of `other`: every transaction in `self` is
+    /// also in `other`.
+    ///
+    /// This is the GTID analog of "is the persisted binlog file still present
+    /// on the source": a resume checkpoint's executed set must be a subset of
+    /// the source's current `@@gtid_executed`. When it is not — a `RESET
+    /// MASTER`, a rebuilt server with a fresh `server_uuid`, or a different
+    /// source entirely — the source no longer contains the checkpoint's
+    /// transactions, so resuming from it would position `COM_BINLOG_DUMP_GTID`
+    /// from a set the server cannot honor and silently stream against a
+    /// diverged history. The empty set is a subset of anything (`gtid_mode =
+    /// ON` with no transactions applied is always resumable).
+    #[must_use]
+    pub fn is_subset_of(&self, other: &Self) -> bool {
+        self.intervals.iter().all(|(uuid, ranges)| {
+            if ranges.is_empty() {
+                return true;
+            }
+            let Some(other_ranges) = other.intervals.get(uuid) else {
+                return false;
+            };
+            // Both sides are sorted, coalesced, disjoint inclusive ranges, so a
+            // single forward sweep suffices: each `self` interval must fall
+            // entirely within one `other` interval. `j` only advances (both
+            // ascending), so cover-checking is linear.
+            let mut j = 0usize;
+            ranges.iter().all(|&(start, end)| {
+                while j < other_ranges.len() && other_ranges[j].1 < start {
+                    j += 1;
+                }
+                j < other_ranges.len() && other_ranges[j].0 <= start && end <= other_ranges[j].1
+            })
+        })
+    }
 }
 
 impl std::fmt::Display for GtidSet {
@@ -325,6 +360,63 @@ mod tests {
         // Disjoint UUIDs share nothing.
         let other = GtidSet::parse(&format!("{U2}:1-10")).expect("parse other");
         assert!(a.intersect(&other).is_empty());
+    }
+
+    #[test]
+    fn subset_of_covers_reset_and_divergence() {
+        let checkpoint = GtidSet::parse(&format!("{U1}:1-100")).expect("parse checkpoint");
+
+        // Normal restart: the source has advanced past the checkpoint.
+        let advanced = GtidSet::parse(&format!("{U1}:1-150")).expect("parse advanced");
+        assert!(
+            checkpoint.is_subset_of(&advanced),
+            "a checkpoint the source has kept and grown past is resumable"
+        );
+
+        // Exact match resumes (subset is reflexive).
+        assert!(checkpoint.is_subset_of(&checkpoint));
+
+        // RESET MASTER / rebuilt server: the source's executed set is under a
+        // brand-new server_uuid, so the checkpoint's UUID is absent entirely.
+        let reset = GtidSet::parse(&format!("{U2}:1-3")).expect("parse reset");
+        assert!(
+            !checkpoint.is_subset_of(&reset),
+            "a source whose executed set no longer contains the checkpoint UUID is not resumable"
+        );
+
+        // Divergence / restore-from-older-backup: same UUID, but the source has
+        // fewer transactions than the checkpoint claims were applied.
+        let rolled_back = GtidSet::parse(&format!("{U1}:1-50")).expect("parse rolled_back");
+        assert!(
+            !checkpoint.is_subset_of(&rolled_back),
+            "a source missing transactions the checkpoint already applied is not resumable"
+        );
+
+        // A hole inside the covered range is not a subset either.
+        let holed = GtidSet::parse(&format!("{U1}:1-40:60-150")).expect("parse holed");
+        assert!(
+            !checkpoint.is_subset_of(&holed),
+            "a gap inside the source's set breaks coverage of the checkpoint range"
+        );
+    }
+
+    #[test]
+    fn empty_subset_of_anything_and_multi_uuid() {
+        let empty = GtidSet::new();
+        let any = GtidSet::parse(&format!("{U1}:1-10")).expect("parse");
+        // gtid_mode = ON with zero applied transactions is always resumable.
+        assert!(empty.is_subset_of(&any));
+        assert!(empty.is_subset_of(&empty));
+        // A non-empty set is never a subset of the empty set.
+        assert!(!any.is_subset_of(&empty));
+
+        // Every UUID block must be covered: one missing block fails the whole
+        // check even when the other is present.
+        let two = GtidSet::parse(&format!("{U1}:1-5,{U2}:1-5")).expect("parse two");
+        let only_one = GtidSet::parse(&format!("{U1}:1-9")).expect("parse only_one");
+        assert!(!two.is_subset_of(&only_one));
+        let both = GtidSet::parse(&format!("{U1}:1-9,{U2}:1-9")).expect("parse both");
+        assert!(two.is_subset_of(&both));
     }
 
     #[test]

--- a/crates/data_components/src/mysql_replication/setup.rs
+++ b/crates/data_components/src/mysql_replication/setup.rs
@@ -369,6 +369,28 @@ pub async fn fetch_head_and_gtid(conn: &mut Conn) -> Result<(BinlogPosition, Gti
     }
 }
 
+/// The source's current executed GTID set (`@@GLOBAL.gtid_executed`).
+///
+/// Used on resume to validate a GTID checkpoint against the live source: the
+/// persisted set must be a subset of this (see [`GtidSet::is_subset_of`]). A
+/// reset/rebuilt source reports a set that no longer contains the checkpoint,
+/// which is how a source reset is detected before blindly resuming. Only
+/// called when the source reports `gtid_mode = ON`, so the variable always
+/// exists; an empty value (a freshly-reset GTID server) parses to the empty
+/// set.
+pub async fn fetch_executed_gtid_set(conn: &mut Conn) -> Result<GtidSet> {
+    let raw: Option<String> = conn
+        .query_first("SELECT @@GLOBAL.gtid_executed")
+        .await
+        .context(SetupQuerySnafu {
+            context: "SELECT @@GLOBAL.gtid_executed",
+        })?;
+    match raw {
+        Some(raw) => GtidSet::parse(&raw).map_err(|message| Error::GtidParse { message }),
+        None => Ok(GtidSet::new()),
+    }
+}
+
 /// The source's current wall clock as Unix-epoch milliseconds, via `NOW(3)`
 /// (millisecond precision). Used to stamp idle readiness heartbeats with a
 /// source-attested time: a binlog HEARTBEAT event carries no usable clock, so

--- a/crates/data_components/src/mysql_replication/setup.rs
+++ b/crates/data_components/src/mysql_replication/setup.rs
@@ -385,9 +385,16 @@ pub async fn fetch_executed_gtid_set(conn: &mut Conn) -> Result<GtidSet> {
         .context(SetupQuerySnafu {
             context: "SELECT @@GLOBAL.gtid_executed",
         })?;
+    // `@@GLOBAL.gtid_executed` always returns exactly one row (an empty *string*
+    // for a fresh GTID server — parsed to the empty set below). A *missing row*
+    // is an unexpected server/driver anomaly, not a known-empty set: treating it
+    // as empty would make every non-empty checkpoint fail the subset check and
+    // force a spurious re-snapshot, masking the real problem. Surface it instead.
     match raw {
         Some(raw) => GtidSet::parse(&raw).map_err(|message| Error::GtidParse { message }),
-        None => Ok(GtidSet::new()),
+        None => Err(Error::Decode {
+            message: "SELECT @@GLOBAL.gtid_executed returned no row".to_string(),
+        }),
     }
 }
 

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -1176,11 +1176,14 @@ async fn apply_invalid_checkpoint(
 ) -> Result<()> {
     match params.invalid_position_behavior {
         InvalidCheckpointBehavior::Error => super::StalePositionSnafu {
+            // `reason` describes the actual condition (layout/schema drift, a
+            // purged binlog file, or a GTID-history divergence/reset) — surface
+            // it verbatim rather than a fixed explanation, since this helper now
+            // covers all three.
             message: format!(
-                "cannot resume mysql binlog for {dataset_name} ({reason}). Replaying against the \
-                 current source layout would mis-map columns. Set \
-                 `mysql_replication_invalid_checkpoint_behavior: restart` to drop the saved \
-                 position and re-snapshot the table."
+                "cannot resume mysql binlog for {dataset_name}: {reason}. Resuming could serve \
+                 incorrect data. Set `mysql_replication_invalid_checkpoint_behavior: restart` to \
+                 drop the saved position and re-snapshot the table."
             ),
         }
         .fail(),

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -1093,15 +1093,11 @@ async fn resolve_start_position(
                         }
                     }
                     CursorType::File => {
-                        let present = super::setup::binlog_file_exists(
-                            conn,
-                            &persisted.position.file,
-                        )
-                        .await?;
+                        let present =
+                            super::setup::binlog_file_exists(conn, &persisted.position.file)
+                                .await?;
                         match file_checkpoint_verdict(present) {
-                            CheckpointVerdict::Resume => {
-                                Some((persisted.position, GtidSet::new()))
-                            }
+                            CheckpointVerdict::Resume => Some((persisted.position, GtidSet::new())),
                             CheckpointVerdict::Unresumable(reason) => {
                                 apply_invalid_checkpoint(
                                     params,

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -940,6 +940,48 @@ async fn attach_member(
     Ok(Box::pin(head.chain(ReceiverStream::new(receiver))))
 }
 
+/// Whether a persisted checkpoint can be restored against the live source, or
+/// must be discarded because the source no longer contains it (a reset,
+/// purge, or a different/rebuilt server). Pure so the reset-detection decision
+/// is unit-testable without a live `MySQL` — the caller supplies the live
+/// source state it fetched.
+#[derive(Debug, PartialEq, Eq)]
+enum CheckpointVerdict {
+    /// The checkpoint is consistent with the current source; resume from it.
+    Resume,
+    /// The source no longer contains the checkpoint; apply
+    /// `invalid_checkpoint_behavior`. Carries the operator-facing reason.
+    Unresumable(&'static str),
+}
+
+/// GTID verdict: the persisted executed set must be a subset of the source's
+/// current `@@gtid_executed`. A `RESET MASTER`, a rebuilt server (fresh
+/// `server_uuid`), or a different source reports a set that no longer contains
+/// the checkpoint — resuming would position `COM_BINLOG_DUMP_GTID` from a set
+/// the server cannot honor and silently serve pre-reset data.
+fn gtid_checkpoint_verdict(persisted: &GtidSet, source_executed: &GtidSet) -> CheckpointVerdict {
+    if persisted.is_subset_of(source_executed) {
+        CheckpointVerdict::Resume
+    } else {
+        CheckpointVerdict::Unresumable(
+            "the source's GTID history diverged from the checkpoint (RESET MASTER, a rebuilt server, or a different source); its executed set no longer contains the persisted position",
+        )
+    }
+}
+
+/// File+offset verdict: the persisted binlog file must still be present in the
+/// source's binary log index. A purge, or a reset whose binlog numbering
+/// restarted below the checkpoint's file, drops it.
+fn file_checkpoint_verdict(persisted_file_present: bool) -> CheckpointVerdict {
+    if persisted_file_present {
+        CheckpointVerdict::Resume
+    } else {
+        CheckpointVerdict::Unresumable(
+            "the persisted binlog file is no longer present on the source (purged, or a reset restarted binlog numbering)",
+        )
+    }
+}
+
 /// Resolve a fresh (non-rejoin) member's start position, applying
 /// `invalid_checkpoint_behavior` per member. Returns
 /// `(floor, gtid_seed, snapshotting)`. `gtid_seed` is the executed GTID set to
@@ -1019,7 +1061,25 @@ async fn resolve_start_position(
                                          (corrupt or incomplete)"),
                         };
                         match parsed {
-                            Ok(set) => Some((persisted.position, set)),
+                            Ok(set) => {
+                                // Validate the checkpoint is still real on THIS source:
+                                // its executed set must be a subset of the source's current `@@gtid_executed`.
+                                let source_executed =
+                                    super::setup::fetch_executed_gtid_set(conn).await?;
+                                match gtid_checkpoint_verdict(&set, &source_executed) {
+                                    CheckpointVerdict::Resume => Some((persisted.position, set)),
+                                    CheckpointVerdict::Unresumable(reason) => {
+                                        apply_invalid_checkpoint(
+                                            params,
+                                            position_store,
+                                            dataset_name,
+                                            reason,
+                                        )
+                                        .await?;
+                                        None
+                                    }
+                                }
+                            }
                             Err(reason) => {
                                 apply_invalid_checkpoint(
                                     params,
@@ -1033,17 +1093,25 @@ async fn resolve_start_position(
                         }
                     }
                     CursorType::File => {
-                        if super::setup::binlog_file_exists(conn, &persisted.position.file).await? {
-                            Some((persisted.position, GtidSet::new()))
-                        } else {
-                            apply_invalid_checkpoint(
-                                params,
-                                position_store,
-                                dataset_name,
-                                "binlog purged",
-                            )
-                            .await?;
-                            None
+                        let present = super::setup::binlog_file_exists(
+                            conn,
+                            &persisted.position.file,
+                        )
+                        .await?;
+                        match file_checkpoint_verdict(present) {
+                            CheckpointVerdict::Resume => {
+                                Some((persisted.position, GtidSet::new()))
+                            }
+                            CheckpointVerdict::Unresumable(reason) => {
+                                apply_invalid_checkpoint(
+                                    params,
+                                    position_store,
+                                    dataset_name,
+                                    reason,
+                                )
+                                .await?;
+                                None
+                            }
                         }
                     }
                 }
@@ -1053,7 +1121,16 @@ async fn resolve_start_position(
     };
 
     if let Some((position, gtid_seed)) = resume {
-        tracing::info!(dataset = %dataset_name, position = %position, gtid = %use_gtid, "shared mysql binlog: resuming from persisted position");
+        // Report the cursor actually used. In GTID mode the pump ignores
+        // file+offset and positions purely from the executed set
+        // (`start_binlog_stream`), so logging `position=file:offset` there is
+        // misleading — surface the GTID set instead. File+offset positioning
+        // logs the file:offset it truly resumes from.
+        if use_gtid {
+            tracing::info!(dataset = %dataset_name, gtid_set = %gtid_seed, "shared mysql binlog: resuming from persisted GTID position");
+        } else {
+            tracing::info!(dataset = %dataset_name, position = %position, "shared mysql binlog: resuming from persisted file+offset position");
+        }
         return Ok((position, gtid_seed, false));
     }
 
@@ -1275,7 +1352,13 @@ async fn run_pump(source: Arc<SharedSource>) {
             Ok(stream) => {
                 backoff.reset();
                 if reconnect_attempts > 0 {
-                    tracing::info!(connection = %connection, attempts = reconnect_attempts, position = %resume, "shared mysql binlog connection resumed");
+                    // In GTID mode the dump repositions from the shared executed
+                    // set, not `resume` (the file+offset floor) — report the set.
+                    if use_gtid {
+                        tracing::info!(connection = %connection, attempts = reconnect_attempts, gtid_set = %resume_gtid, "shared mysql binlog connection resumed");
+                    } else {
+                        tracing::info!(connection = %connection, attempts = reconnect_attempts, position = %resume, "shared mysql binlog connection resumed");
+                    }
                     reconnect_attempts = 0;
                 }
                 // Connection starts at the shared min (<= every held member's
@@ -2217,6 +2300,65 @@ mod tests {
     }
     fn pos(file: &str, p: u64) -> BinlogPosition {
         BinlogPosition::new(file, p)
+    }
+
+    const SRC_A: &str = "3e11fa47-71ca-11e1-9e33-c80aa9429562";
+    const SRC_B: &str = "5d1c0d8c-71ca-11e1-9e33-c80aa9429999";
+
+    fn gtids(raw: &str) -> GtidSet {
+        GtidSet::parse(raw).expect("parse gtid set")
+    }
+
+    #[test]
+    fn gtid_checkpoint_resumes_when_subset_of_source() {
+        // Normal restart: the source kept the checkpoint's history and grew.
+        let checkpoint = gtids(&format!("{SRC_A}:1-100"));
+        let source = gtids(&format!("{SRC_A}:1-150"));
+        assert_eq!(
+            gtid_checkpoint_verdict(&checkpoint, &source),
+            CheckpointVerdict::Resume
+        );
+        // An empty checkpoint (gtid_mode = ON, zero txns applied) always resumes.
+        assert_eq!(
+            gtid_checkpoint_verdict(&GtidSet::new(), &source),
+            CheckpointVerdict::Resume
+        );
+    }
+
+    #[test]
+    fn gtid_checkpoint_unresumable_after_reset_or_divergence() {
+        let checkpoint = gtids(&format!("{SRC_A}:1-100"));
+
+        // RESET MASTER / rebuilt server: source executed set under a new UUID.
+        let rebuilt = gtids(&format!("{SRC_B}:1-3"));
+        assert!(matches!(
+            gtid_checkpoint_verdict(&checkpoint, &rebuilt),
+            CheckpointVerdict::Unresumable(_)
+        ));
+
+        // Freshly reset GTID server with zero transactions applied.
+        let empty_source = GtidSet::new();
+        assert!(matches!(
+            gtid_checkpoint_verdict(&checkpoint, &empty_source),
+            CheckpointVerdict::Unresumable(_)
+        ));
+
+        // Divergence: same UUID, but the source is behind the checkpoint.
+        let behind = gtids(&format!("{SRC_A}:1-50"));
+        assert!(matches!(
+            gtid_checkpoint_verdict(&checkpoint, &behind),
+            CheckpointVerdict::Unresumable(_)
+        ));
+    }
+
+    #[test]
+    fn file_checkpoint_verdict_tracks_presence() {
+        assert_eq!(file_checkpoint_verdict(true), CheckpointVerdict::Resume);
+        // Purged, or a reset that restarted binlog numbering below the file.
+        assert!(matches!(
+            file_checkpoint_verdict(false),
+            CheckpointVerdict::Unresumable(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #12020.

## Problem
On GTID resume, Spice trusted the persisted checkpoint without checking it against the live source. After a source reset/rebuild (new \`server_uuid\`, \`RESET MASTER\`), it resumed from a stale set and silently served pre-reset data — no error. The file+offset path was protected by \`binlog_file_exists\`; GTID had no equivalent guard.

## Fix
Require \`persisted_gtid_set ⊆ @@gtid_executed\` on GTID resume. On failure, honor \`invalid_checkpoint_behavior\` (re-snapshot or fail-loud) — the GTID analog of the file-existence check.

- \`GtidSet::is_subset_of\` + \`setup::fetch_executed_gtid_set\`
- Both cursors route through a pure \`CheckpointVerdict\` (unit-testable, no live server)
- Failover stays lossless: a promoted replica inherits the same global GTIDs, so the checkpoint remains a subset
- Tracing: GTID mode now logs the executed set on resume/reconnect, not the unused file:offset

## Tests
5 new unit tests (reset, divergence, empty/fresh server, failover-superset, file purge). \`cargo test -p data_components --features mysql\` → 85 passed; scoped clippy clean.