### PR TITLE
perf: remove three unnecessary allocations on the query hot path

### DIFF
--- a/crates/datafusion-optimizer-rules/src/physical_plan/http_subquery_pushdown.rs
+++ b/crates/datafusion-optimizer-rules/src/physical_plan/http_subquery_pushdown.rs
@@ -572,7 +572,7 @@ async fn materialize_string_values(
 ) -> Result<Vec<String>, DataFusionError> {
     let batches = datafusion::physical_plan::collect(Arc::clone(plan), Arc::clone(context)).await?;
 
-    let mut seen = HashSet::new();
+    let mut seen: HashSet<&str> = HashSet::new();
     let mut values = Vec::new();
     for (batch_index, batch) in batches.iter().enumerate() {
         if batch.num_columns() <= col_index {
@@ -598,7 +598,7 @@ async fn materialize_string_values(
             };
 
         for val in string_iter.flatten() {
-            if seen.insert(val.to_string()) {
+            if seen.insert(val) {
                 if values.len() >= MAX_MATERIALIZED_VALUES {
                     return Err(DataFusionError::Plan(format!(
                         "HttpWithDeferredParamsExec: subquery produced more than {MAX_MATERIALIZED_VALUES} unique values, aborting pushdown"

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -859,7 +859,7 @@ impl Query {
         }
 
         // Get the schema from the logical plan
-        let schema = Arc::new(plan.schema().as_arrow().clone());
+        let schema = Arc::clone(plan.schema().inner());
 
         let input_tables = get_logical_plan_input_tables(&plan);
         if input_tables
@@ -1444,8 +1444,10 @@ impl Query {
                         }
                     };
 
-                    let mut execution_session = session.clone();
-                    if let Some(batch_size) =
+                    // Only clone SessionState when adaptive Flight batch sizing
+                    // rebuilds the physical plan; otherwise TaskContext can borrow
+                    // the existing session.
+                    let task_ctx = if let Some(batch_size) =
                         Self::adaptive_flight_batch_size(&session, &request_context, &physical_plan)
                     {
                         Self::ensure_not_cancelled(
@@ -1468,11 +1470,12 @@ impl Query {
                                 )
                             }
                         };
-                        execution_session = adaptive_session;
-                    }
+                        Arc::new(TaskContext::from(&adaptive_session))
+                    } else {
+                        Arc::new(TaskContext::from(&session))
+                    };
 
                     Self::ensure_not_cancelled(&query_cancel_token, &query_id_str, &timeout_state)?;
-                    let task_ctx = Arc::new(TaskContext::from(&execution_session));
 
                     let stream = match execute_stream_preserving_output_order(
                         Arc::clone(&physical_plan),


### PR DESCRIPTION
## Summary

No-behavior-change refactor that removes three unnecessary heap allocations on the SQL query hot path (request → plan → execute → results).

### 1. Guard `SessionState` clone behind adaptive Flight batch sizing

**Where:** `crates/runtime/src/datafusion/query.rs` (~1447)

**What changed:** Only builds an adaptive `SessionState` (and `TaskContext` from it) when `adaptive_flight_batch_size` returns `Some`. Otherwise `TaskContext::from(&session)` borrows the existing session — the same pattern already used for Statement plans in this function.

**Why hot:** Every non-Statement local query (`/v1/sql`, Flight DoGet, FlightSQL) goes through this execute path. Adaptive batch sizing applies only to Flight/FlightSQL with `FlightBatchSize::Adaptive` and large enough estimates; HTTP and most Flight traffic previously cloned `SessionState` unconditionally first.

**Why unchanged:** When adaptive sizing is off, `TaskContext` is built from the same session as before. When it is on, the adaptive rebuild path is identical.

### 2. Reuse plan `SchemaRef` on distributed submit

**Where:** `crates/runtime/src/datafusion/query.rs:862`

**What changed:** Replaced `Arc::new(plan.schema().as_arrow().clone())` with `Arc::clone(plan.schema().inner())`.

**Why hot:** Distributed job submit builds a `QueryHandle` schema on every distributed query. `as_arrow().clone()` deep-copies all fields/metadata; `inner()` is already the `SchemaRef` owned by the `DFSchema`. Nearby call sites in the same file already use `Arc::clone(...inner())`.

**Why unchanged:** Same schema bytes/content; only the Arc refcount is bumped instead of allocating a new `Schema`.

### 3. Single string allocation when materializing HTTP subquery values

**Where:** `crates/datafusion-optimizer-rules/src/physical_plan/http_subquery_pushdown.rs:575`

**What changed:** Dedup set is `HashSet<&str>` (batches outlive the loop) so each unique value is `to_string()`'d once into `values`, not twice (HashSet insert + Vec push).

**Why hot:** `HttpWithDeferredParamsExec::execute` materializes build-side string keys on the query path (up to 20k unique values). Duplicates previously allocated a throwaway `String` on every `HashSet::insert` check.

**Why unchanged:** Same unique set, insertion order, null/empty handling, and `MAX_MATERIALIZED_VALUES` error threshold.

## Test plan

- [x] `cargo test -p datafusion-optimizer-rules`
- [x] `cargo test -p runtime --lib datafusion::query` (63 passed)
- [x] `make lint-rust` (fmt + crate-layering + clippy lib/bins + clippy tests)