### PR TITLE
fix(cdc): don't force the durable path on zero-row readiness heartbeats (fixes #12007)

### DIFF
--- a/crates/data-connectors/connector-dynamodb/src/connector.rs
+++ b/crates/data-connectors/connector-dynamodb/src/connector.rs
@@ -20,7 +20,7 @@ use crate::stream::StreamError as DynamoDBStreamError;
 use async_trait::async_trait;
 use data_components::cdc::{
     ChangeEnvelope, ChangesStream, CommitChange, CommitError, InitialSnapshotMode,
-    InvalidCheckpointBehavior,
+    InvalidCheckpointBehavior, NoOpCommitter,
 };
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
@@ -1106,14 +1106,6 @@ impl MetricsProvider for DynamoDBMetricsProvider {
             }
             _ => None,
         }
-    }
-}
-
-struct NoOpCommitter;
-#[async_trait]
-impl CommitChange for NoOpCommitter {
-    async fn commit(&self) -> Result<(), CommitError> {
-        Ok(())
     }
 }
 

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -211,6 +211,19 @@ pub trait CommitChange {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         None
     }
+
+    /// Whether [`Self::commit`] is statically known to do nothing — there is no
+    /// source position, token, or checkpoint to acknowledge. Consumers may run
+    /// or drop such a committer at any point without ordering or durability
+    /// constraints; the runtime relies on this to keep zero-row readiness
+    /// heartbeats out of the CDC write/durability path (see
+    /// [`ChangeEnvelope::is_no_op_heartbeat`]). Defaults to `false`
+    /// (conservative: assume the commit has effects, preserving ordering); only
+    /// genuinely effect-free committers such as [`NoOpCommitter`] should
+    /// override this to `true`.
+    fn is_no_op(&self) -> bool {
+        false
+    }
 }
 
 /// Destination-passing-style source of the change rows carried by a
@@ -502,6 +515,23 @@ impl ChangeEnvelope {
         self.change_batch.is_heartbeat()
     }
 
+    /// Whether this envelope is a pure readiness heartbeat: a zero-row change
+    /// batch whose committer is a no-op ([`CommitChange::is_no_op`]).
+    ///
+    /// CDC connectors emit these ([`build_heartbeat_envelope`],
+    /// [`build_ready_signal_envelope`]) only to carry `is_dataset_ready` and a
+    /// source freshness timestamp; they hold no data and acknowledge no source
+    /// position, so a consumer may honor the ready flag and drop the envelope
+    /// without writing, committing, or forcing any durability transition. A
+    /// zero-row envelope whose committer has real effects (e.g. a `MySQL`
+    /// snapshot-boundary envelope that persists the initial resume token) is
+    /// NOT a heartbeat under this predicate and must keep normal
+    /// durability-then-commit ordering.
+    #[must_use]
+    pub fn is_no_op_heartbeat(&self) -> bool {
+        self.change_committer.is_no_op() && self.is_heartbeat()
+    }
+
     pub async fn commit(self) -> Result<(), CommitError> {
         self.change_committer.commit().await
     }
@@ -582,6 +612,10 @@ pub struct NoOpCommitter;
 impl CommitChange for NoOpCommitter {
     async fn commit(&self) -> Result<(), CommitError> {
         Ok(())
+    }
+
+    fn is_no_op(&self) -> bool {
+        true
     }
 }
 
@@ -1375,5 +1409,63 @@ mod deferred_tests {
         let env = build_heartbeat_envelope(&schema, None, false)
             .expect("heartbeat builds with non-null columns");
         assert_eq!(env.change_batch().expect("built").record.num_rows(), 0);
+    }
+
+    /// A committer whose `commit` happens to do nothing here but does NOT
+    /// override `is_no_op` — modeling a real committer (resume-token persist,
+    /// snapshot-boundary ack) attached to a zero-row envelope.
+    struct PositionCommitter;
+
+    #[async_trait]
+    impl CommitChange for PositionCommitter {
+        async fn commit(&self) -> Result<(), CommitError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn no_op_heartbeat_predicate_identifies_strippable_readiness_envelopes() {
+        assert!(NoOpCommitter.is_no_op());
+        assert!(
+            !PositionCommitter.is_no_op(),
+            "is_no_op must default to false: assume a commit has effects"
+        );
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+
+        // Connector idle heartbeats and ready signals: zero rows + no-op
+        // committer -> safe to drop from the write/durability path (#12007).
+        let heartbeat = build_heartbeat_envelope(&schema, now_unix_ms(), true)
+            .expect("heartbeat envelope builds");
+        assert!(heartbeat.is_no_op_heartbeat());
+        let ready = build_ready_signal_envelope(&schema).expect("ready envelope builds");
+        assert!(ready.is_no_op_heartbeat());
+
+        // A zero-row envelope re-wrapped with a REAL committer (the MySQL
+        // snapshot-boundary pattern) must NOT be treated as a heartbeat: its
+        // commit persists source progress and needs durability-then-commit
+        // ordering.
+        let (_, boundary_batch, _) = build_heartbeat_envelope(&schema, None, false)
+            .expect("boundary batch builds")
+            .into_parts()
+            .expect("already built");
+        let boundary = ChangeEnvelope::new(Box::new(PositionCommitter), boundary_batch, false);
+        assert!(boundary.is_heartbeat(), "zero-row batch");
+        assert!(
+            !boundary.is_no_op_heartbeat(),
+            "a real committer disqualifies the envelope from heartbeat stripping"
+        );
+
+        // A row-bearing (deferred, not yet built) envelope with a no-op
+        // committer is not a heartbeat either.
+        let rows = MockRows {
+            result: None,
+            builds: Arc::new(AtomicUsize::new(0)),
+            rows_hint: 1,
+            empty: false,
+            ts: None,
+        };
+        let data_bearing = deferred(rows, false);
+        assert!(!data_bearing.is_no_op_heartbeat());
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1773,6 +1773,22 @@ impl RefreshTask {
     /// finalize task itself (and surfacing any finalize error) before calling
     /// this; here the finalize is known to have succeeded. Returns `false` when
     /// a fatal commit error was surfaced and the stream should stop.
+    /// Signal the dataset Ready: flip `initial_load_completed`, wake readiness
+    /// waiters, then publish the `Ready` component status — in that order, so a
+    /// waiter woken by the notify observes the completed flag. The single
+    /// definition of the readiness side effect for every apply path (write,
+    /// post-finalize, and readiness-only heartbeat runs).
+    async fn signal_dataset_ready(&self, context: &ApplyContext<'_>) {
+        context
+            .initial_load_completed
+            .store(true, Ordering::Relaxed);
+        if let Some(sender) = context.ready_sender {
+            sender.notify_waiters();
+        }
+        self.update_component_status(status::ComponentStatus::Ready)
+            .await;
+    }
+
     async fn run_finalize_side_effects(
         &self,
         context: &mut ApplyContext<'_>,
@@ -1780,14 +1796,7 @@ impl RefreshTask {
         ready_after_finalize: bool,
     ) -> bool {
         if ready_after_finalize {
-            context
-                .initial_load_completed
-                .store(true, Ordering::Relaxed);
-            if let Some(sender) = context.ready_sender {
-                sender.notify_waiters();
-            }
-            self.update_component_status(status::ComponentStatus::Ready)
-                .await;
+            self.signal_dataset_ready(context).await;
         }
 
         if let Some(cache_provider_ref) = context.caching
@@ -1855,7 +1864,7 @@ impl RefreshTask {
     async fn apply_envelope_run(
         &self,
         context: &mut ApplyContext<'_>,
-        envelopes: Vec<cdc::ChangeEnvelope>,
+        mut envelopes: Vec<cdc::ChangeEnvelope>,
     ) -> bool {
         debug_assert!(
             !envelopes.is_empty(),
@@ -1868,6 +1877,41 @@ impl RefreshTask {
         // Status Update` carrying the latest LSN, Kafka per-partition
         // offsets) require this ordering.
         let any_ready = envelopes.iter().any(cdc::ChangeEnvelope::is_dataset_ready);
+
+        // Strip zero-row readiness heartbeats from the write/durability path
+        // (#12007). Lag-based readiness (#11777) makes CDC connectors emit a
+        // heartbeat roughly every second on a caught-up source; the heartbeat's
+        // committer is a no-op by construction, but a no-op committer does not
+        // support deferral, so leaving heartbeats in the burst forced
+        // `requires_durable_cdc_path` — a mem-tier checkpoint plus a durable
+        // write transition per heartbeat. Under load those once-a-second forced
+        // checkpoints raced Cayenne's pipelined Stage-B staged-append finalize,
+        // and its staged-WAL crash recovery "recovered" (double-published or
+        // rolled back) in-flight appends — duplicating rows. A heartbeat's only
+        // observable effect is its ready flag, already folded into `any_ready`
+        // above; dropping its committer is exact because `is_no_op_heartbeat`
+        // requires `CommitChange::is_no_op` (nothing to acknowledge). Zero-row
+        // envelopes carrying a REAL committer (e.g. the MySQL snapshot-boundary
+        // envelope persisting the initial resume token) are not heartbeats
+        // under that predicate and keep durability-then-commit ordering.
+        envelopes.retain(|env| !env.is_no_op_heartbeat());
+
+        // Readiness-only run: every envelope was a heartbeat. Honor the ready
+        // flag and stop — there is nothing to write and nothing to commit, so
+        // the run must not touch the write path or force a checkpoint.
+        if envelopes.is_empty() {
+            if any_ready {
+                if let Some(pending) = context.pending_finalize.as_mut() {
+                    // A previous durable burst's Stage-B publish is still
+                    // pending; readiness follows its completion, mirroring the
+                    // `!current_finalize_pending` gate on the write path.
+                    pending.ready_after_finalize = true;
+                } else {
+                    self.signal_dataset_ready(context).await;
+                }
+            }
+            return true;
+        }
         let mut committers: Vec<Box<dyn cdc::CommitChange + Send + Sync>> =
             Vec::with_capacity(envelopes.len());
         let mut batches: Vec<ChangeBatch> = Vec::with_capacity(envelopes.len());
@@ -2084,14 +2128,7 @@ impl RefreshTask {
 
                 let current_finalize_pending = write_outcome.pending_finalize.is_some();
                 if mark_ready && !current_finalize_pending {
-                    context
-                        .initial_load_completed
-                        .store(true, Ordering::Relaxed);
-                    if let Some(sender) = context.ready_sender {
-                        sender.notify_waiters();
-                    }
-                    self.update_component_status(status::ComponentStatus::Ready)
-                        .await;
+                    self.signal_dataset_ready(context).await;
                 }
                 if write_outcome.result == WriteChangeResult::DataWritten
                     && !current_finalize_pending
@@ -6518,6 +6555,101 @@ mod tests {
         assert!(
             notified.await.expect("ready notifier task must finish"),
             "ready_sender.notify_waiters() must fire when a ready envelope is processed"
+        );
+    }
+
+    // -- Correctness: readiness heartbeats bypass the write/durability path ---
+
+    /// Build a zero-row readiness heartbeat envelope over the unit-test data
+    /// schema, as CDC connectors emit (#11777) roughly once a second on a
+    /// caught-up source.
+    fn make_heartbeat_envelope(is_ready: bool) -> ChangeEnvelope {
+        let schema = Arc::new(create_test_data_schema());
+        cdc::build_heartbeat_envelope(&schema, cdc::now_unix_ms(), is_ready)
+            .expect("heartbeat envelope builds")
+    }
+
+    /// A run of pure readiness heartbeats must flip the dataset Ready without
+    /// ever reaching the accelerator write path — no insert plan is built and
+    /// no write executes (#12007: heartbeats forcing the durable CDC path per
+    /// beat made Cayenne duplicate rows).
+    #[tokio::test]
+    async fn test_heartbeat_only_stream_signals_ready_without_touching_the_accelerator() {
+        let insert_plan_calls = Arc::new(AtomicUsize::new(0));
+        let insert_execution_calls = Arc::new(AtomicUsize::new(0));
+        let provider = Arc::new(CountingInsertProvider {
+            inner: make_mem_table() as Arc<dyn TableProvider>,
+            insert_plan_calls: Arc::clone(&insert_plan_calls),
+            insert_execution_calls: Arc::clone(&insert_execution_calls),
+        });
+        let task = make_refresh_task(provider as Arc<dyn TableProvider>);
+        let initial_load = Arc::new(AtomicBool::new(false));
+        let notify = Arc::new(Notify::new());
+
+        let stream = make_changes_stream(vec![
+            Ok(make_heartbeat_envelope(false)),
+            Ok(make_heartbeat_envelope(true)),
+            Ok(make_heartbeat_envelope(false)),
+        ]);
+        run_changes_stream(
+            &task,
+            stream,
+            Some(Arc::clone(&notify)),
+            Arc::clone(&initial_load),
+        )
+        .await
+        .expect("heartbeat-only stream should succeed");
+
+        assert!(
+            initial_load.load(Ordering::Relaxed),
+            "a ready heartbeat must still flip initial_load_completed"
+        );
+        assert_eq!(
+            insert_plan_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "readiness heartbeats must never reach the accelerator write path"
+        );
+        assert_eq!(
+            insert_execution_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "readiness heartbeats must never execute a write"
+        );
+    }
+
+    /// Heartbeats interleaved with real change envelopes must not disturb the
+    /// data path: every row lands, every real committer commits in stream
+    /// order, and the ready flag carried by a heartbeat is honored.
+    #[tokio::test]
+    async fn test_heartbeats_interleaved_with_data_preserve_apply_and_commit_order() {
+        let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
+        let log = CommitLog::new();
+        let initial_load = Arc::new(AtomicBool::new(false));
+        let notify = Arc::new(Notify::new());
+
+        let stream = make_changes_stream(vec![
+            Ok(make_tracked_envelope(1, Arc::clone(&log), false)),
+            Ok(make_heartbeat_envelope(false)),
+            Ok(make_tracked_envelope(2, Arc::clone(&log), false)),
+            Ok(make_heartbeat_envelope(true)),
+            Ok(make_tracked_envelope(3, Arc::clone(&log), false)),
+        ]);
+        run_changes_stream(
+            &task,
+            stream,
+            Some(Arc::clone(&notify)),
+            Arc::clone(&initial_load),
+        )
+        .await
+        .expect("mixed stream should succeed");
+
+        assert_eq!(
+            log.ids().await,
+            vec![1, 2, 3],
+            "real committers must commit exactly once, in stream order, with heartbeats stripped"
+        );
+        assert!(
+            initial_load.load(Ordering::Relaxed),
+            "the ready flag carried by a heartbeat must be honored"
         );
     }
 

--- a/crates/runtime/tests/cdc_cayenne_heartbeat.rs
+++ b/crates/runtime/tests/cdc_cayenne_heartbeat.rs
@@ -1,0 +1,321 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Regression test for #12007: zero-row CDC readiness heartbeats (#11777)
+//! must not force the durable CDC path on a memory-durability Cayenne table.
+//!
+//! Lag-based readiness makes CDC connectors emit a zero-row heartbeat
+//! envelope roughly every second on a caught-up source. The heartbeat's
+//! committer is a no-op, but a no-op committer does not support deferral, so
+//! before the fix every heartbeat flipped the coalesced burst to
+//! `requires_durable_cdc_path` — forcing a mem-tier checkpoint (which acks
+//! the deferred source committers) once per heartbeat. Under load those
+//! forced checkpoints raced Cayenne's pipelined Stage-B staged-append
+//! finalize and its staged-WAL crash recovery, duplicating rows.
+//!
+//! The invariant verified here: applying a readiness heartbeat marks the
+//! dataset Ready but does NOT drain (ack) the deferred commit queue — the
+//! source slot advances only when a real durability event covers the RAM
+//! tier, never because a heartbeat arrived.
+
+#![cfg(not(windows))]
+#![allow(clippy::expect_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::{Duration, Instant};
+
+use arrow::array::{ArrayRef, Int64Array, ListArray, RecordBatch, StringArray, StructArray};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{DataType, Field, Schema};
+use async_trait::async_trait;
+use cayenne::metadata::{CdcDurability, CreateTableOptions, DeletionMode, VortexConfig};
+use cayenne::{CayenneCatalog, CayenneTableProvider, MetadataCatalog};
+use data_components::cdc::{
+    ChangeBatch, ChangeEnvelope, CommitChange, CommitError, StreamError, build_heartbeat_envelope,
+    changes_schema, now_unix_ms,
+};
+use datafusion::datasource::TableProvider;
+use datafusion::physical_plan::collect;
+use datafusion::prelude::SessionContext;
+use datafusion::sql::TableReference;
+use datafusion_table_providers::util::{
+    column_reference::ColumnReference, on_conflict::OnConflict,
+};
+use futures::StreamExt;
+use runtime::accelerated_table::refresh::Refresh;
+use runtime::accelerated_table::refresh_task::RefreshTaskBuilder;
+use runtime::federated_table::FederatedTable;
+use runtime::status::RuntimeStatus;
+use tempfile::TempDir;
+use tokio::runtime::Handle;
+use tokio::sync::{Mutex as TokioMutex, Notify, RwLock};
+
+/// All-nullable data schema, matching what CDC sources produce (and what the
+/// heartbeat envelope normalizes to), so heartbeats and change batches share
+/// one schema.
+fn data_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, true),
+        Field::new("name", DataType::Utf8, true),
+    ]))
+}
+
+/// Records committed envelope ids; supports deferral like a real replayable
+/// source committer (a Postgres replication slot LSN ack), so memory-mode
+/// Cayenne defers it behind the covering checkpoint.
+struct DeferrableRecordingCommitter {
+    id: i64,
+    commits: Arc<TokioMutex<Vec<i64>>>,
+}
+
+#[async_trait]
+impl CommitChange for DeferrableRecordingCommitter {
+    async fn commit(&self) -> Result<(), CommitError> {
+        self.commits.lock().await.push(self.id);
+        Ok(())
+    }
+
+    fn supports_deferral(&self) -> bool {
+        true
+    }
+}
+
+/// Build a single-row create-op `ChangeEnvelope` for `(id, name)`.
+fn make_create_envelope(id: i64, name: &str, commits: Arc<TokioMutex<Vec<i64>>>) -> ChangeEnvelope {
+    let data = data_schema();
+    let wrapper = changes_schema(&data);
+
+    let op_array: ArrayRef = Arc::new(StringArray::from(vec!["c"]));
+
+    let pk_field = Arc::new(Field::new("item", DataType::Utf8, false));
+    let pk_values = StringArray::from(vec!["id"]);
+    let pk_array: ArrayRef = Arc::new(
+        ListArray::try_new(
+            pk_field,
+            OffsetBuffer::new(vec![0i32, 1].into()),
+            Arc::new(pk_values),
+            None,
+        )
+        .expect("ListArray"),
+    );
+
+    let id_array: ArrayRef = Arc::new(Int64Array::from(vec![id]));
+    let name_array: ArrayRef = Arc::new(StringArray::from(vec![Some(name)]));
+    let data_array: ArrayRef = Arc::new(StructArray::from(vec![
+        (Arc::new(Field::new("id", DataType::Int64, true)), id_array),
+        (
+            Arc::new(Field::new("name", DataType::Utf8, true)),
+            name_array,
+        ),
+    ]));
+
+    let record = RecordBatch::try_new(Arc::new(wrapper), vec![op_array, pk_array, data_array])
+        .expect("wrapper RecordBatch");
+    let batch = ChangeBatch::try_new(record).expect("ChangeBatch");
+
+    ChangeEnvelope::new(
+        Box::new(DeferrableRecordingCommitter { id, commits }),
+        batch,
+        false,
+    )
+}
+
+/// Construct a memory-durability (CDC mem-tier) Cayenne table provider backed
+/// by a temp `SQLite` metastore and temp data directory, mirroring the
+/// production `cdc_durability: memory` chbench configuration.
+async fn setup_memory_mode_cayenne(table_name: &str) -> (TempDir, Arc<CayenneTableProvider>) {
+    let temp = TempDir::new().expect("temp dir");
+    let data_path = temp.path().join("data");
+    tokio::fs::create_dir_all(&data_path)
+        .await
+        .expect("data dir");
+    let db_path = temp.path().join("test.db");
+    let conn = format!("sqlite://{}", db_path.to_string_lossy());
+
+    let catalog = Arc::new(CayenneCatalog::new(conn).expect("CayenneCatalog::new"));
+    catalog.init().await.expect("catalog init");
+
+    let ctx = SessionContext::new();
+    let table = CayenneTableProvider::create_table(
+        Arc::clone(&catalog) as Arc<dyn MetadataCatalog>,
+        CreateTableOptions {
+            table_name: table_name.to_string(),
+            schema: data_schema(),
+            primary_key: vec!["id".to_string()],
+            on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+                "id".to_string(),
+            ]))),
+            base_path: data_path.to_string_lossy().to_string(),
+            partition_column: None,
+            vortex_config: VortexConfig {
+                cdc_durability: CdcDurability::Memory,
+                deletion_mode: DeletionMode::Key,
+                ..VortexConfig::default()
+            },
+        },
+        ctx.runtime_env(),
+    )
+    .await
+    .expect("create_table");
+
+    assert!(
+        table.is_cdc_memory_mode(),
+        "test requires a memory-durability CDC tier"
+    );
+    (temp, Arc::new(table))
+}
+
+fn make_refresh_task(
+    accelerator: Arc<dyn TableProvider>,
+    table_name: &str,
+) -> runtime::accelerated_table::refresh_task::RefreshTask {
+    let federated = Arc::new(FederatedTable::new_unchecked(Arc::clone(&accelerator)));
+    RefreshTaskBuilder::new(
+        RuntimeStatus::new(),
+        TableReference::bare(table_name),
+        federated,
+        None,
+        accelerator,
+        Handle::current(),
+        Arc::new(tokio::sync::Mutex::new(())),
+    )
+    .build()
+}
+
+/// Count the rows currently visible via `TableProvider::scan`.
+async fn count_rows(provider: &Arc<CayenneTableProvider>) -> usize {
+    let ctx = SessionContext::new();
+    let plan = provider
+        .scan(&ctx.state(), None, &[], None)
+        .await
+        .expect("scan");
+    let batches = collect(plan, ctx.task_ctx()).await.expect("collect");
+    batches.iter().map(RecordBatch::num_rows).sum()
+}
+
+/// Poll `condition` until it returns true or `timeout` elapses; returns
+/// whether the condition was met. Bounded wait — no fixed sleeps as readiness
+/// gates.
+async fn wait_until<F, Fut>(timeout: Duration, mut condition: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        if condition().await {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn heartbeat_must_not_force_mem_tier_checkpoint_or_ack_deferred_commits() {
+    let (_temp, table) = setup_memory_mode_cayenne("cdc_heartbeat_no_checkpoint").await;
+    let task = make_refresh_task(
+        Arc::clone(&table) as Arc<dyn TableProvider>,
+        "cdc_heartbeat_no_checkpoint",
+    );
+
+    let commits: Arc<TokioMutex<Vec<i64>>> = Arc::new(TokioMutex::new(Vec::new()));
+    let initial_load = Arc::new(AtomicBool::new(false));
+    let ready_notify = Arc::new(Notify::new());
+
+    // Channel-driven stream so envelope timing is under test control.
+    let (tx, rx) = futures::channel::mpsc::unbounded::<Result<ChangeEnvelope, StreamError>>();
+
+    let stream_task = {
+        let notify = Arc::clone(&ready_notify);
+        let load = Arc::clone(&initial_load);
+        let refresh = Arc::new(RwLock::new(Refresh::default()));
+        tokio::spawn(async move {
+            task.start_changes_stream(refresh, rx.boxed(), None, Some(notify), load)
+                .await
+        })
+    };
+
+    // Subscribe to the ready notification BEFORE the heartbeat is sent so the
+    // notify_waiters signal cannot be missed.
+    let ready_seen = {
+        let notify = Arc::clone(&ready_notify);
+        tokio::spawn(async move {
+            let waiter = notify.notified();
+            tokio::pin!(waiter);
+            tokio::time::timeout(Duration::from_secs(10), &mut waiter)
+                .await
+                .is_ok()
+        })
+    };
+    tokio::task::yield_now().await;
+
+    // 1. A real change lands in the mem tier; its committer is DEFERRED
+    //    behind the covering checkpoint (memory durability), so it must not
+    //    have committed yet.
+    tx.unbounded_send(Ok(make_create_envelope(1, "row-1", Arc::clone(&commits))))
+        .expect("send row envelope");
+    assert!(
+        wait_until(Duration::from_secs(10), || async {
+            count_rows(&table).await == 1
+        })
+        .await,
+        "the CDC row must become visible via the mem tier"
+    );
+    assert!(
+        commits.lock().await.is_empty(),
+        "premise: a memory-durability write defers its source committer behind \
+         the covering checkpoint (nothing durable happened yet)"
+    );
+
+    // 2. A readiness heartbeat arrives (as connectors emit every ~1s on a
+    //    caught-up source). It must mark the dataset Ready...
+    let heartbeat = build_heartbeat_envelope(&data_schema(), now_unix_ms(), true)
+        .expect("heartbeat envelope builds");
+    tx.unbounded_send(Ok(heartbeat)).expect("send heartbeat");
+
+    assert!(
+        ready_seen.await.expect("ready waiter task must finish"),
+        "the heartbeat's ready flag must flip the dataset Ready"
+    );
+
+    // 3. ...but it must NOT force a mem-tier checkpoint: the deferred source
+    //    committer stays queued (un-acked). Before the #12007 fix, the
+    //    heartbeat's non-deferrable no-op committer forced
+    //    `requires_durable_cdc_path`, checkpointing the mem tier and acking
+    //    the deferred committer right here.
+    assert!(
+        commits.lock().await.is_empty(),
+        "a readiness heartbeat must not force a mem-tier checkpoint that acks \
+         deferred source commits (#12007)"
+    );
+
+    // The row remains visible; the heartbeat wrote nothing.
+    assert_eq!(
+        count_rows(&table).await,
+        1,
+        "heartbeat must not change data"
+    );
+
+    drop(tx);
+    stream_task
+        .await
+        .expect("changes stream task join")
+        .expect("changes stream should end cleanly");
+}


### PR DESCRIPTION
Fixes #12007

## Summary

Since #11777 (Unified CDC config), the two scheduled HTAP SF1 `postgres-cayenne` configs fail the data-correctness gate with **duplicate rows** in Cayenne-accelerated CDC tables (`oorder` +21,000; `customer`/`stock` +5/+20) that never converge.

**Root cause:** #11777's lag-based readiness makes CDC connectors emit a zero-row heartbeat envelope roughly every second on a caught-up source. The heartbeat's committer is a `NoOpCommitter`, which reports `supports_deferral() == false`, so in the CDC apply loop every heartbeat-bearing burst flipped `requires_durable_cdc_path` — forcing a Cayenne mem-tier checkpoint (and, for heartbeat-only bursts, a second post-write checkpoint via the epoch-less commit path) once per heartbeat. Under TPC-C load those once-a-second forced checkpoints raced the pipelined Stage-B staged-append finalize, and Cayenne's staged-WAL crash recovery "recovered" (double-published or rolled back) in-flight appends — duplicating rows. Log evidence: the failing adaptive run ([29986755766](https://github.com/spiceai/spiceai/actions/runs/29986755766)) has **1,234** `Incomplete staged append detected — attempting automated recovery` events and **527** `Rolling back an uncommitted deferred snapshot append` events; the last passing run before #11777 ([29898895414](https://github.com/spiceai/spiceai/actions/runs/29898895414)) has **0**.

## Changes

- `data_components/src/cdc.rs`: add `CommitChange::is_no_op()` (default `false`; only `NoOpCommitter` overrides to `true`) and `ChangeEnvelope::is_no_op_heartbeat()` — a pure readiness heartbeat is a **zero-row** batch with a **no-op** committer. Zero-row envelopes carrying a real committer (e.g. the MySQL snapshot-boundary envelope that persists the initial resume token) are deliberately excluded and keep durability-then-commit ordering.
- `runtime/src/accelerated_table/refresh_task/changes.rs`: `apply_envelope_run` strips no-op heartbeats from the burst before write/durability classification. Their only observable effect — the `is_dataset_ready` flag — is honored: a heartbeat-only run marks the dataset Ready (deferred behind a still-pending Stage-B finalize, mirroring the write path's gate) and touches neither the write path nor the checkpoint machinery. Extracted the previously-triplicated mark-ready side effect into one `signal_dataset_ready` helper used by all three ready paths.
- `data-connectors/connector-dynamodb`: drop the connector's duplicate local `NoOpCommitter` in favor of the shared `cdc::NoOpCommitter`, so the "effect-free committer" contract has a single definition.

## Test plan

- [x] New integration regression test `runtime/tests/cdc_cayenne_heartbeat.rs`: memory-durability Cayenne table; a deferred source committer must **not** be acked when a readiness heartbeat arrives (it was, before the fix — the test fails on pre-fix code at exactly that assertion) while the ready flag still flips.
- [x] New unit tests: heartbeat-only stream signals Ready without ever reaching the accelerator write path; heartbeats interleaved with data preserve apply/commit order; `is_no_op_heartbeat` predicate accepts connector heartbeats/ready signals and rejects zero-row envelopes with real committers and row-bearing envelopes.
- [x] `make lint`
- [x] `make test` / `make nextest` (via `make signoff`)

## Performance impact

Heartbeat envelopes no longer trigger a durable mem-tier checkpoint per beat, restoring the pre-#11777 checkpoint cadence for `cdc_durability: memory` tables. Per-burst cost of the strip is one virtual call per envelope (short-circuits before any batch access for real committers).

## Checklist

- [x] Fix targets the root cause, gated to exactly the heartbeat envelopes (`zero rows && no-op committer`)
- [x] Regression test fails on pre-fix code, passes on the fix
- [x] No behavior change for zero-row envelopes with real committers (MySQL boundary/resume-token path)
- [x] Lint green; signoff to follow after push