### PR TITLE
fix(imap): narrow scans with IMAP SEARCH instead of refetching the mailbox (fixes #11548)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4498,6 +4498,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "charset",
+ "chrono",
  "data_components",
  "datafusion",
  "imap",

--- a/crates/data-connectors/connector-imap/Cargo.toml
+++ b/crates/data-connectors/connector-imap/Cargo.toml
@@ -10,6 +10,7 @@ description = "IMAP data connector for Spice.ai runtime"
 arrow.workspace = true
 async-trait.workspace = true
 charset.workspace = true
+chrono.workspace = true
 data_components = { path = "../../data_components" }
 datafusion.workspace = true
 imap.workspace = true

--- a/crates/data-connectors/connector-imap/src/imap/mod.rs
+++ b/crates/data-connectors/connector-imap/src/imap/mod.rs
@@ -28,12 +28,21 @@ use session::ImapSession;
 use snafu::prelude::*;
 
 pub mod provider;
+pub(crate) mod search;
 pub mod session;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to fetch messages from IMAP mailbox: {source}"))]
     FetchMessages { source: imap::Error },
+    // `source` is boxed so carrying the criteria alongside it does not make this
+    // the largest variant — every `Result<_, Error>` in the crate pays for that.
+    #[snafu(display("Failed to search the IMAP mailbox with '{criteria}': {source}"))]
+    SearchMessages {
+        criteria: String,
+        #[snafu(source(from(imap::Error, Box::new)))]
+        source: Box<imap::Error>,
+    },
     #[snafu(display("Failed to open IMAP mailbox for reading: {source}"))]
     ExamineMailbox { source: imap::Error },
     #[snafu(display("Failed to get IMAP mailbox status: {source}"))]

--- a/crates/data-connectors/connector-imap/src/imap/provider.rs
+++ b/crates/data-connectors/connector-imap/src/imap/provider.rs
@@ -22,7 +22,7 @@ use datafusion::{
     catalog::{Session, TableProvider},
     datasource::TableType,
     error::Result as DataFusionResult,
-    logical_expr::Expr,
+    logical_expr::{Expr, TableProviderFilterPushDown},
     physical_plan::ExecutionPlan,
 };
 use mailparse::{ParsedMail, dateparse, parse_mail};
@@ -32,8 +32,28 @@ use data_components::arrow::write::MemTable;
 
 use super::{
     EmailMessage, Error, FailedToLogoutSnafu, FailedToParseHeaderSnafu, FetchMessagesSnafu,
-    GetMailboxStatusSnafu, ImapTableProvider,
+    GetMailboxStatusSnafu, ImapTableProvider, SearchMessagesSnafu, search,
 };
+
+/// Longest identifier set to send in a single fetch.
+///
+/// A match set that alternates rather than running contiguously can compact into
+/// an identifier set past a server's command-line limit. Fetching the whole
+/// mailbox instead is slower but always valid, and the filters are re-applied
+/// above the scan either way.
+const MAX_ID_SET_LEN: usize = 8 * 1024;
+
+/// The message attributes every scan needs: the envelope for the header columns,
+/// and the raw body when `content` is part of the table.
+const FETCH_QUERY: &str = "(ENVELOPE BODY.PEEK[HEADER] BODY.PEEK[])";
+
+/// Which messages a scan asks the server for.
+enum FetchSet {
+    /// UIDs, used whenever a subset was resolved by `UID SEARCH`.
+    Uid(String),
+    /// Sequence numbers, used for the unnarrowed `1:N` fetch of the mailbox.
+    Sequence(String),
+}
 
 fn decode(value: &[u8]) -> String {
     match String::from_utf8(value.to_vec()) {
@@ -183,6 +203,27 @@ impl TableProvider for ImapTableProvider {
         TableType::Base
     }
 
+    /// Report the filters the mailbox can narrow with `SEARCH`.
+    ///
+    /// Always `Inexact`: `SEARCH` matches on the calendar day of the `Date:`
+    /// header, so the server returns a superset of the rows the filter keeps and
+    /// `DataFusion` has to apply it exactly on top.
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|filter| {
+                if search::search_criteria([*filter]).is_some() {
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
     async fn scan(
         &self,
         state: &dyn Session,
@@ -192,60 +233,97 @@ impl TableProvider for ImapTableProvider {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let mut session = self.session.connect()?;
 
-        let status = session
-            .status(self.session.mailbox(), "(MESSAGES)")
-            .context(GetMailboxStatusSnafu)?;
-        let message_count = if let Some(limit) = limit {
-            limit.min(status.exists as usize)
+        // Let the server pick the candidate messages where the filters allow it,
+        // so refresh cost tracks new mail rather than mailbox size (#11548).
+        //
+        // The narrowed path addresses messages by UID: a concurrent `EXPUNGE`
+        // renumbers sequence numbers, so a set resolved by `SEARCH` could name
+        // different messages by the time the fetch runs. UIDs never change.
+        let fetch = if let Some(criteria) = search::search_criteria(filters) {
+            // `limit` is deliberately ignored here. Reporting the filters as
+            // `Inexact` leaves a filter above this scan, so some of the messages
+            // fetched will be discarded — capping the fetch at `limit` could then
+            // yield fewer rows than the query asked for while matching messages
+            // were left in the mailbox. Returning more rows than `limit` is
+            // always allowed; returning fewer than are available is not.
+            let mut uids: Vec<u32> = session
+                .uid_search(&criteria)
+                .context(SearchMessagesSnafu { criteria })?
+                .into_iter()
+                .collect();
+            uids.sort_unstable();
+
+            search::id_set(&uids)
+                .map(|set| {
+                    if set.len() > MAX_ID_SET_LEN {
+                        search::ALL_MESSAGES.to_string()
+                    } else {
+                        set
+                    }
+                })
+                .map(FetchSet::Uid)
         } else {
-            status.exists as usize
-        };
-
-        let fetch_messages = session
-            .fetch(
-                format!("1:{message_count}"),
-                "(ENVELOPE BODY.PEEK[HEADER] BODY.PEEK[])",
-            )
-            .context(FetchMessagesSnafu)?;
-        let mut messages = vec![];
-
-        for i in 0..fetch_messages.len() {
-            let message = fetch_messages.get(i).ok_or(Error::MessageNotFound {})?;
-            let envelope = message.envelope().ok_or(Error::EnvelopeNotFound {
-                segment: "envelope".to_string(),
-            })?;
-            let subject = envelope.subject.as_ref().map(|v| decode(v));
-            let date = parse_date_millis(&decode(envelope.date.as_ref().ok_or(
-                Error::EnvelopeNotFound {
-                    segment: "date".to_string(),
-                },
-            )?))
-            .context(FailedToParseHeaderSnafu)?;
-            let message_id = envelope.message_id.as_ref().map(|v| decode(v));
-            let in_reply_to = envelope.in_reply_to.as_ref().map(|v| decode(v));
-            let message_froms = parse_addreses_from_envelope!(envelope, from);
-            let message_tos = parse_addreses_from_envelope!(envelope, to);
-            let message_ccs = parse_addreses_from_envelope!(envelope, cc);
-            let message_blind_ccs = parse_addreses_from_envelope!(envelope, bcc);
-            let message_reply_tos = parse_addreses_from_envelope!(envelope, reply_to);
-            let body = if self.fetch_content {
-                message.body().as_ref().map(|v| extract_text_body(v))
+            let status = session
+                .status(self.session.mailbox(), "(MESSAGES)")
+                .context(GetMailboxStatusSnafu)?;
+            let message_count = if let Some(limit) = limit {
+                limit.min(status.exists as usize)
             } else {
-                None
+                status.exists as usize
             };
 
-            messages.push(EmailMessage {
-                date,
-                subject,
-                from: message_froms,
-                to: message_tos,
-                cc: message_ccs,
-                bcc: message_blind_ccs,
-                reply_to: message_reply_tos,
-                message_id,
-                in_reply_to,
-                body,
-            });
+            (message_count > 0).then(|| FetchSet::Sequence(format!("1:{message_count}")))
+        };
+
+        let mut messages = vec![];
+
+        // An empty mailbox, or no message matching the filters, means there is
+        // nothing to ask for — and `1:0` is not a valid identifier set.
+        if let Some(fetch) = fetch {
+            let fetch_messages = match fetch {
+                FetchSet::Uid(uids) => session.uid_fetch(uids, FETCH_QUERY),
+                FetchSet::Sequence(sequence_set) => session.fetch(sequence_set, FETCH_QUERY),
+            }
+            .context(FetchMessagesSnafu)?;
+
+            for i in 0..fetch_messages.len() {
+                let message = fetch_messages.get(i).ok_or(Error::MessageNotFound {})?;
+                let envelope = message.envelope().ok_or(Error::EnvelopeNotFound {
+                    segment: "envelope".to_string(),
+                })?;
+                let subject = envelope.subject.as_ref().map(|v| decode(v));
+                let date = parse_date_millis(&decode(envelope.date.as_ref().ok_or(
+                    Error::EnvelopeNotFound {
+                        segment: "date".to_string(),
+                    },
+                )?))
+                .context(FailedToParseHeaderSnafu)?;
+                let message_id = envelope.message_id.as_ref().map(|v| decode(v));
+                let in_reply_to = envelope.in_reply_to.as_ref().map(|v| decode(v));
+                let message_froms = parse_addreses_from_envelope!(envelope, from);
+                let message_tos = parse_addreses_from_envelope!(envelope, to);
+                let message_ccs = parse_addreses_from_envelope!(envelope, cc);
+                let message_blind_ccs = parse_addreses_from_envelope!(envelope, bcc);
+                let message_reply_tos = parse_addreses_from_envelope!(envelope, reply_to);
+                let body = if self.fetch_content {
+                    message.body().as_ref().map(|v| extract_text_body(v))
+                } else {
+                    None
+                };
+
+                messages.push(EmailMessage {
+                    date,
+                    subject,
+                    from: message_froms,
+                    to: message_tos,
+                    cc: message_ccs,
+                    bcc: message_blind_ccs,
+                    reply_to: message_reply_tos,
+                    message_id,
+                    in_reply_to,
+                    body,
+                });
+            }
         }
 
         session.logout().context(FailedToLogoutSnafu)?; // good IMAP etiquette to not leave the session open

--- a/crates/data-connectors/connector-imap/src/imap/provider.rs
+++ b/crates/data-connectors/connector-imap/src/imap/provider.rs
@@ -43,16 +43,44 @@ use super::{
 /// above the scan either way.
 const MAX_ID_SET_LEN: usize = 8 * 1024;
 
-/// The message attributes every scan needs: the envelope for the header columns,
-/// and the raw body when `content` is part of the table.
+/// The message attributes every scan asks for: the envelope backing the header
+/// columns, and the raw message backing `content`.
+///
+/// The raw message is requested for every scan, including one whose table has no
+/// `content` column and therefore discards it — see #12046.
 const FETCH_QUERY: &str = "(ENVELOPE BODY.PEEK[HEADER] BODY.PEEK[])";
 
 /// Which messages a scan asks the server for.
+#[derive(Debug, PartialEq, Eq)]
 enum FetchSet {
     /// UIDs, used whenever a subset was resolved by `UID SEARCH`.
     Uid(String),
     /// Sequence numbers, used for the unnarrowed `1:N` fetch of the mailbox.
     Sequence(String),
+}
+
+/// The identifier set covering the messages `UID SEARCH` matched, or `None` when
+/// it matched nothing — there is then nothing to ask the server for, and an empty
+/// identifier set is not valid syntax.
+///
+/// `uids` must be ascending. A set too long to send falls back to the whole
+/// mailbox, which is slower but always valid.
+fn narrowed_fetch_set(uids: &[u32]) -> Option<FetchSet> {
+    search::id_set(uids).map(|set| {
+        if set.len() > MAX_ID_SET_LEN {
+            FetchSet::Uid(search::ALL_MESSAGES.to_string())
+        } else {
+            FetchSet::Uid(set)
+        }
+    })
+}
+
+/// The sequence set covering the whole mailbox, capped at `limit` when the query
+/// set one, or `None` for an empty mailbox — `1:0` is not a valid identifier set.
+fn full_fetch_set(exists: usize, limit: Option<usize>) -> Option<FetchSet> {
+    let message_count = limit.map_or(exists, |limit| limit.min(exists));
+
+    (message_count > 0).then(|| FetchSet::Sequence(format!("1:{message_count}")))
 }
 
 fn decode(value: &[u8]) -> String {
@@ -253,26 +281,13 @@ impl TableProvider for ImapTableProvider {
                 .collect();
             uids.sort_unstable();
 
-            search::id_set(&uids)
-                .map(|set| {
-                    if set.len() > MAX_ID_SET_LEN {
-                        search::ALL_MESSAGES.to_string()
-                    } else {
-                        set
-                    }
-                })
-                .map(FetchSet::Uid)
+            narrowed_fetch_set(&uids)
         } else {
             let status = session
                 .status(self.session.mailbox(), "(MESSAGES)")
                 .context(GetMailboxStatusSnafu)?;
-            let message_count = if let Some(limit) = limit {
-                limit.min(status.exists as usize)
-            } else {
-                status.exists as usize
-            };
 
-            (message_count > 0).then(|| FetchSet::Sequence(format!("1:{message_count}")))
+            full_fetch_set(status.exists as usize, limit)
         };
 
         let mut messages = vec![];
@@ -484,5 +499,87 @@ mod tests {
         // A simple non-multipart message decodes to its body.
         let raw = b"Content-Type: text/plain\r\n\r\njust some text\r\n";
         assert_eq!(extract_text_body(raw).trim(), "just some text");
+    }
+
+    #[test]
+    fn narrowed_fetch_set_addresses_matches_by_uid() {
+        // The messages `SEARCH` matched are fetched by UID — a concurrent
+        // `EXPUNGE` renumbers sequence numbers but never UIDs — and contiguous
+        // runs collapse so the command stays short.
+        assert_eq!(
+            narrowed_fetch_set(&[4, 5, 6, 9]),
+            Some(FetchSet::Uid("4:6,9".to_string()))
+        );
+    }
+
+    #[test]
+    fn narrowed_fetch_set_of_no_matches_is_nothing_to_fetch() {
+        // Regression for #11548: a filter matching nothing must fetch nothing
+        // rather than falling back to the whole mailbox. An empty identifier set
+        // is also not valid syntax, so there is no set to send either.
+        assert_eq!(narrowed_fetch_set(&[]), None);
+    }
+
+    #[test]
+    fn narrowed_fetch_set_falls_back_to_the_mailbox_when_the_set_is_too_long() {
+        // An alternating match set collapses into no runs, so its identifier set
+        // grows past what a server will accept on one command line. Fetching the
+        // whole mailbox is slower but valid, and the filters are re-applied above
+        // the scan, so the rows are the same either way.
+        let alternating: Vec<u32> = (1..=5_000).map(|id| id * 2).collect();
+        assert!(
+            search::id_set(&alternating).is_some_and(|set| set.len() > MAX_ID_SET_LEN),
+            "the alternating set should exceed the fetch limit"
+        );
+
+        assert_eq!(
+            narrowed_fetch_set(&alternating),
+            Some(FetchSet::Uid(search::ALL_MESSAGES.to_string()))
+        );
+    }
+
+    #[test]
+    fn narrowed_fetch_set_keeps_a_long_run_that_compacts_short() {
+        // The fallback keys on the length of the identifier *set*, not the number
+        // of messages: a contiguous run of far more UIDs than the limit still
+        // compacts to one short range and is fetched as the narrowed set.
+        let limit = u32::try_from(MAX_ID_SET_LEN).expect("the fetch limit fits in a u32");
+        let ids: Vec<u32> = (1..=limit).collect();
+
+        assert_eq!(
+            narrowed_fetch_set(&ids),
+            Some(FetchSet::Uid(format!("1:{limit}")))
+        );
+    }
+
+    #[test]
+    fn full_fetch_set_covers_the_whole_mailbox() {
+        assert_eq!(
+            full_fetch_set(42, None),
+            Some(FetchSet::Sequence("1:42".to_string()))
+        );
+    }
+
+    #[test]
+    fn full_fetch_set_of_an_empty_mailbox_is_nothing_to_fetch() {
+        // `1:0` is not a valid identifier set, so an empty mailbox must fetch
+        // nothing at all.
+        assert_eq!(full_fetch_set(0, None), None);
+        assert_eq!(full_fetch_set(0, Some(10)), None);
+    }
+
+    #[test]
+    fn full_fetch_set_caps_at_the_limit() {
+        // Without filters no row is discarded above the scan, so a `LIMIT` can
+        // cap the fetch — but never above what the mailbox holds.
+        assert_eq!(
+            full_fetch_set(42, Some(10)),
+            Some(FetchSet::Sequence("1:10".to_string()))
+        );
+        assert_eq!(
+            full_fetch_set(5, Some(10)),
+            Some(FetchSet::Sequence("1:5".to_string()))
+        );
+        assert_eq!(full_fetch_set(42, Some(0)), None);
     }
 }

--- a/crates/data-connectors/connector-imap/src/imap/provider.rs
+++ b/crates/data-connectors/connector-imap/src/imap/provider.rs
@@ -47,7 +47,7 @@ const MAX_ID_SET_LEN: usize = 8 * 1024;
 /// columns, and the raw message backing `content`.
 ///
 /// The raw message is requested for every scan, including one whose table has no
-/// `content` column and therefore discards it — see #12046.
+/// `content` column and therefore discards it — see #12045.
 const FETCH_QUERY: &str = "(ENVELOPE BODY.PEEK[HEADER] BODY.PEEK[])";
 
 /// Which messages a scan asks the server for.

--- a/crates/data-connectors/connector-imap/src/imap/search.rs
+++ b/crates/data-connectors/connector-imap/src/imap/search.rs
@@ -1,0 +1,402 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Translation of `date` column filters into IMAP `SEARCH` criteria.
+//!
+//! A scan that cannot narrow server-side has to fetch every message in the
+//! mailbox, so an acceleration refresh costs the whole mailbox each cycle rather
+//! than the new mail since the last one (see #11548). Translating the filters
+//! into `SEARCH` criteria lets the server pick the candidate messages, which is
+//! what makes `refresh_mode: append` and `refresh_data_window` incremental for
+//! this connector.
+
+use chrono::{DateTime, Days, NaiveDate, Utc};
+use datafusion::{
+    logical_expr::{BinaryExpr, Expr, Operator},
+    scalar::ScalarValue,
+};
+
+/// The message send-time column, parsed from the RFC822 `Date:` header.
+const DATE_COLUMN: &str = "date";
+
+/// Days of slack applied to every bound.
+///
+/// The IMAP `SENTSINCE`/`SENTBEFORE` keys compare the `Date:` header
+/// "disregarding time and timezone" (RFC 3501 §6.4.4), while the `date` column
+/// holds an absolute UTC instant. A header offset as far as ±14:00 from UTC puts
+/// the header's own calendar day one day either side of the UTC day of the same
+/// instant, so widening by a day keeps the server-side result a superset of the
+/// predicate — never dropping a row the filter would have kept.
+const SKEW_DAYS: u64 = 1;
+
+/// Every message in the mailbox, as an IMAP identifier set.
+pub(crate) const ALL_MESSAGES: &str = "1:*";
+
+/// The IMAP `SEARCH` criteria matching a superset of the messages that satisfy
+/// `filters`, or `None` when nothing could be translated and the whole mailbox
+/// has to be fetched.
+pub(crate) fn search_criteria<'a>(filters: impl IntoIterator<Item = &'a Expr>) -> Option<String> {
+    let mut keys = Vec::new();
+    for filter in filters {
+        collect_keys(filter, &mut keys);
+    }
+
+    (!keys.is_empty()).then(|| keys.join(" "))
+}
+
+/// Collect the `SEARCH` keys implied by `expr`.
+///
+/// An expression shape that isn't understood contributes no key, which only
+/// widens the fetch. Narrowing it wrongly would drop rows, so anything but a
+/// conjunction of recognized `date` comparisons is left to the caller's filter.
+fn collect_keys(expr: &Expr, keys: &mut Vec<String>) {
+    match expr {
+        // `SEARCH` ANDs its keys together, so each side of a conjunction can
+        // contribute independently.
+        Expr::BinaryExpr(BinaryExpr {
+            left,
+            op: Operator::And,
+            right,
+        }) => {
+            collect_keys(left, keys);
+            collect_keys(right, keys);
+        }
+        Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
+            collect_date_keys(left, *op, right, keys);
+        }
+        _ => {}
+    }
+}
+
+/// Collect the keys bounding `date` for a `date <op> <timestamp>` comparison
+/// (or its mirror image, `<timestamp> <op> date`).
+fn collect_date_keys(left: &Expr, op: Operator, right: &Expr, keys: &mut Vec<String>) {
+    let (value, op) = match (left, right) {
+        (Expr::Column(column), Expr::Literal(value, _)) if column.name == DATE_COLUMN => {
+            (value, op)
+        }
+        (Expr::Literal(value, _), Expr::Column(column)) if column.name == DATE_COLUMN => {
+            (value, mirror(op))
+        }
+        _ => return,
+    };
+
+    let Some(day) = epoch_millis(value).and_then(utc_day) else {
+        return;
+    };
+
+    // A lower bound becomes `SENTSINCE`, an upper bound `SENTBEFORE`, and an
+    // equality bounds the day from both sides.
+    if matches!(op, Operator::Gt | Operator::GtEq | Operator::Eq) {
+        keys.extend(
+            day.checked_sub_days(Days::new(SKEW_DAYS))
+                .map(|since| format!("SENTSINCE {}", imap_date(since))),
+        );
+    }
+    if matches!(op, Operator::Lt | Operator::LtEq | Operator::Eq) {
+        // `SENTBEFORE` is exclusive, so the day itself needs one more day on top
+        // of the skew allowance to stay included.
+        keys.extend(
+            day.checked_add_days(Days::new(SKEW_DAYS + 1))
+                .map(|before| format!("SENTBEFORE {}", imap_date(before))),
+        );
+    }
+}
+
+/// The operator with its operands swapped: `5 < date` is `date > 5`.
+fn mirror(op: Operator) -> Operator {
+    match op {
+        Operator::Lt => Operator::Gt,
+        Operator::LtEq => Operator::GtEq,
+        Operator::Gt => Operator::Lt,
+        Operator::GtEq => Operator::LtEq,
+        other => other,
+    }
+}
+
+/// A timestamp or date literal as milliseconds since the Unix epoch.
+///
+/// Sub-millisecond units floor towards negative infinity so that instants before
+/// 1970 land on the calendar day that contains them rather than the one after.
+fn epoch_millis(value: &ScalarValue) -> Option<i64> {
+    match value {
+        ScalarValue::TimestampSecond(Some(seconds), _) => seconds.checked_mul(1_000),
+        // `Date64` also counts milliseconds since the epoch.
+        ScalarValue::TimestampMillisecond(Some(millis), _) | ScalarValue::Date64(Some(millis)) => {
+            Some(*millis)
+        }
+        ScalarValue::TimestampMicrosecond(Some(micros), _) => Some(micros.div_euclid(1_000)),
+        ScalarValue::TimestampNanosecond(Some(nanos), _) => Some(nanos.div_euclid(1_000_000)),
+        ScalarValue::Date32(Some(days)) => i64::from(*days).checked_mul(86_400_000),
+        _ => None,
+    }
+}
+
+/// The UTC calendar day containing `millis`.
+fn utc_day(millis: i64) -> Option<NaiveDate> {
+    DateTime::<Utc>::from_timestamp_millis(millis).map(|instant| instant.date_naive())
+}
+
+/// Format as the RFC 3501 `date-text` a `SEARCH` key expects, e.g. `01-Jul-2026`.
+fn imap_date(date: NaiveDate) -> String {
+    date.format("%d-%b-%Y").to_string()
+}
+
+/// Collapse ascending message identifiers into an IMAP identifier set such as
+/// `2,5:7,9`, or `None` when there are none to fetch.
+///
+/// Contiguous runs collapse into ranges, which keeps the `UID FETCH` command
+/// short for the usual case of matching a recent stretch of the mailbox.
+pub(crate) fn id_set(ids: &[u32]) -> Option<String> {
+    let mut runs: Vec<String> = Vec::new();
+    let mut ids = ids.iter().copied();
+    let mut start = ids.next()?;
+    let mut end = start;
+
+    for id in ids {
+        if id == end || id == end.saturating_add(1) {
+            end = id;
+            continue;
+        }
+
+        runs.push(run(start, end));
+        start = id;
+        end = id;
+    }
+    runs.push(run(start, end));
+
+    Some(runs.join(","))
+}
+
+fn run(start: u32, end: u32) -> String {
+    if start == end {
+        start.to_string()
+    } else {
+        format!("{start}:{end}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::logical_expr::{col, lit};
+
+    /// `2026-07-01T12:00:00Z`, midday so a day's widening is unambiguous.
+    const JULY_FIRST: i64 = 1_782_907_200_000;
+
+    /// The same day as [`JULY_FIRST`], as days since the epoch.
+    const JULY_FIRST_DAY32: i32 = 20_635;
+
+    fn timestamp(millis: i64) -> Expr {
+        lit(ScalarValue::TimestampMillisecond(Some(millis), None))
+    }
+
+    #[test]
+    fn lower_bound_becomes_a_widened_sentsince() {
+        // `SENTSINCE` compares the `Date:` header's own calendar day, which can
+        // trail the UTC day by one for a far-west timezone offset, so the bound
+        // is the day before — a superset the caller then filters exactly.
+        for op in [Operator::Gt, Operator::GtEq] {
+            let filter = Expr::BinaryExpr(BinaryExpr::new(
+                Box::new(col("date")),
+                op,
+                Box::new(timestamp(JULY_FIRST)),
+            ));
+            assert_eq!(
+                search_criteria([&filter]).as_deref(),
+                Some("SENTSINCE 30-Jun-2026"),
+                "unexpected criteria for {op}"
+            );
+        }
+    }
+
+    #[test]
+    fn upper_bound_becomes_a_widened_sentbefore() {
+        // `SENTBEFORE` is exclusive, so covering all of 1 July needs 2 July, plus
+        // one more day of timezone slack.
+        for op in [Operator::Lt, Operator::LtEq] {
+            let filter = Expr::BinaryExpr(BinaryExpr::new(
+                Box::new(col("date")),
+                op,
+                Box::new(timestamp(JULY_FIRST)),
+            ));
+            assert_eq!(
+                search_criteria([&filter]).as_deref(),
+                Some("SENTBEFORE 03-Jul-2026"),
+                "unexpected criteria for {op}"
+            );
+        }
+    }
+
+    #[test]
+    fn equality_bounds_the_day_from_both_sides() {
+        let filter = col("date").eq(timestamp(JULY_FIRST));
+        assert_eq!(
+            search_criteria([&filter]).as_deref(),
+            Some("SENTSINCE 30-Jun-2026 SENTBEFORE 03-Jul-2026")
+        );
+    }
+
+    #[test]
+    fn literal_on_the_left_mirrors_the_operator() {
+        // `'2026-07-01' < date` is the same lower bound as `date > '2026-07-01'`.
+        let filter = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(timestamp(JULY_FIRST)),
+            Operator::Lt,
+            Box::new(col("date")),
+        ));
+        assert_eq!(
+            search_criteria([&filter]).as_deref(),
+            Some("SENTSINCE 30-Jun-2026")
+        );
+    }
+
+    #[test]
+    fn conjunction_contributes_both_bounds() {
+        // The window an append refresh with `refresh_data_window` produces.
+        let filter = col("date")
+            .gt(timestamp(JULY_FIRST))
+            .and(col("date").lt(timestamp(JULY_FIRST + 86_400_000)));
+        assert_eq!(
+            search_criteria([&filter]).as_deref(),
+            Some("SENTSINCE 30-Jun-2026 SENTBEFORE 04-Jul-2026")
+        );
+    }
+
+    #[test]
+    fn separate_filters_are_all_applied() {
+        let lower = col("date").gt(timestamp(JULY_FIRST));
+        let upper = col("date").lt(timestamp(JULY_FIRST));
+        assert_eq!(
+            search_criteria([&lower, &upper]).as_deref(),
+            Some("SENTSINCE 30-Jun-2026 SENTBEFORE 03-Jul-2026")
+        );
+    }
+
+    #[test]
+    fn every_timestamp_unit_resolves_to_the_same_day() {
+        let seconds = JULY_FIRST / 1_000;
+        for value in [
+            ScalarValue::TimestampSecond(Some(seconds), None),
+            ScalarValue::TimestampMillisecond(Some(JULY_FIRST), None),
+            ScalarValue::TimestampMicrosecond(Some(JULY_FIRST * 1_000), None),
+            ScalarValue::TimestampNanosecond(Some(JULY_FIRST * 1_000_000), None),
+            ScalarValue::Date64(Some(JULY_FIRST)),
+            ScalarValue::Date32(Some(JULY_FIRST_DAY32)),
+        ] {
+            let filter = col("date").gt(lit(value.clone()));
+            assert_eq!(
+                search_criteria([&filter]).as_deref(),
+                Some("SENTSINCE 30-Jun-2026"),
+                "unexpected criteria for {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn timezone_carrying_timestamp_is_still_an_absolute_instant() {
+        // A `Timestamp(_, Some(tz))` literal still counts epoch milliseconds, so
+        // the bound must match the timezone-less case rather than be skipped.
+        let filter = col("date").gt(lit(ScalarValue::TimestampMillisecond(
+            Some(JULY_FIRST),
+            Some("America/New_York".into()),
+        )));
+        assert_eq!(
+            search_criteria([&filter]).as_deref(),
+            Some("SENTSINCE 30-Jun-2026")
+        );
+    }
+
+    #[test]
+    fn instants_before_the_epoch_land_on_the_containing_day() {
+        // Flooring matters here: truncating towards zero would report 1 January
+        // 1970 and wrongly exclude the last day of 1969.
+        let filter = col("date").gt(lit(ScalarValue::TimestampNanosecond(
+            Some(-1_000_000),
+            None,
+        )));
+        assert_eq!(
+            search_criteria([&filter]).as_deref(),
+            Some("SENTSINCE 30-Dec-1969")
+        );
+    }
+
+    #[test]
+    fn untranslatable_filters_yield_no_criteria() {
+        // Each of these must fetch wide and let the caller filter, rather than
+        // narrow on a guess: a disjunction, another column, a null bound, a
+        // non-temporal literal, an inequality, and a bare column reference.
+        let disjunction = col("date")
+            .gt(timestamp(JULY_FIRST))
+            .or(col("date").lt(timestamp(0)));
+        let other_column = col("subject").eq(lit("hello"));
+        let null_bound = col("date").gt(lit(ScalarValue::TimestampMillisecond(None, None)));
+        let not_a_timestamp = col("date").gt(lit(7_i64));
+        let not_equal = col("date").not_eq(timestamp(JULY_FIRST));
+        let bare_column = col("date");
+
+        for filter in [
+            disjunction,
+            other_column,
+            null_bound,
+            not_a_timestamp,
+            not_equal,
+            bare_column,
+        ] {
+            assert_eq!(
+                search_criteria([&filter]),
+                None,
+                "unexpectedly narrowed on {filter}"
+            );
+        }
+    }
+
+    #[test]
+    fn conjunction_keeps_the_translatable_half() {
+        // A conjunction is safe to narrow on one side alone: the caller still
+        // applies both predicates.
+        let filter = col("date")
+            .gt(timestamp(JULY_FIRST))
+            .and(col("subject").eq(lit("hello")));
+        assert_eq!(
+            search_criteria([&filter]).as_deref(),
+            Some("SENTSINCE 30-Jun-2026")
+        );
+    }
+
+    #[test]
+    fn id_set_collapses_runs() {
+        assert_eq!(id_set(&[1, 2, 3]).as_deref(), Some("1:3"));
+        assert_eq!(id_set(&[7]).as_deref(), Some("7"));
+        assert_eq!(id_set(&[1, 2, 3, 5, 8, 9]).as_deref(), Some("1:3,5,8:9"));
+        assert_eq!(id_set(&[2, 4, 6]).as_deref(), Some("2,4,6"));
+    }
+
+    #[test]
+    fn id_set_of_nothing_is_none() {
+        // No match must mean no fetch at all — `1:0` is not a valid identifier set.
+        assert_eq!(id_set(&[]), None);
+    }
+
+    #[test]
+    fn id_set_handles_the_largest_representable_id() {
+        // `end + 1` must not overflow when a UID reaches `u32::MAX`.
+        assert_eq!(
+            id_set(&[u32::MAX - 1, u32::MAX]).as_deref(),
+            Some("4294967294:4294967295")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The IMAP connector fetched the whole mailbox on every scan, so an acceleration refresh cost the entire mailbox each cycle instead of the new mail since the last one.

`ImapTableProvider` never implemented `supports_filters_pushdown`, so it inherited the `Unsupported` default. Every predicate was applied in a `FilterExec` above the scan, and `scan()` unconditionally ran `STATUS (MESSAGES)` followed by `FETCH 1:N (ENVELOPE BODY.PEEK[HEADER] BODY.PEEK[])` across the full message count — pulling envelopes and full bodies for every message, every time.

That also silently defeated the two mechanisms meant to bound refresh cost, because both express themselves as a filter the connector then discarded: an append-mode refresh builds `date > <last watermark>` and `refresh_data_window` builds `date > now - window` (`accelerated_table/refresh_task.rs`). The reporter measured 6m19s of IMAP fetch for ~1,100 messages, paid in full on every refresh.

Fixes #11548

## Changes

- **`supports_filters_pushdown`** reports `Inexact` for the `date` predicates the mailbox can narrow with `SEARCH`, and `Unsupported` for everything else. `Inexact` is deliberate: `SENTSINCE`/`SENTBEFORE` match on the calendar day of the `Date:` header "disregarding time and timezone" (RFC 3501 §6.4.4), so the server returns a superset and the engine still applies the predicate exactly.
- **New `imap::search` module** translates filters into `SEARCH` criteria. It handles `date` compared against a timestamp/date literal (`>`, `>=`, `<`, `<=`, `=`, either operand order) and conjunctions of those. Every bound is widened by a day, because a `Date:` header offset as far as ±14:00 from UTC puts the header's own calendar day one day either side of the UTC day of the same instant — so the server-side result stays a superset and no row the filter would keep is ever dropped. Any shape that isn't recognized (a disjunction, another column, a null or non-temporal literal, `!=`) contributes no criteria and simply fetches wide, since narrowing on a guess would drop rows.
- **The narrowed path addresses messages by UID** (`UID SEARCH` + `UID FETCH`). A concurrent `EXPUNGE` renumbers sequence numbers, so a set resolved by `SEARCH` could name different messages by the time the fetch ran; UIDs are stable. Matching identifiers are collapsed into ranges (`1:3,5,8:9`) to keep the command short.
- **An empty result now skips the fetch entirely.** Previously an empty mailbox produced `FETCH 1:0`, which is not a valid identifier set.
- A pathological match set that compacts past 8 KiB falls back to fetching the whole mailbox — slower, but always valid, and the filters are re-applied above the scan either way.
- The narrowed path deliberately ignores the `limit` hint. `Inexact` leaves a filter above the scan, so some fetched messages are discarded; capping the fetch at `limit` could then yield fewer rows than the query asked for while matching messages sat in the mailbox. Returning more rows than `limit` is always allowed, returning fewer than are available is not. (In practice DataFusion does not push a limit through a filter, so this is defensive.) The unfiltered path honors `limit` exactly as before.

The unfiltered scan is unchanged: same `STATUS` + `1:N` sequence fetch as before, so a query with no usable `date` predicate behaves exactly as it does today.

## Performance impact

Strictly narrowing. A scan with a usable `date` predicate replaces one full-mailbox `FETCH` with a `UID SEARCH` plus a `UID FETCH` of the matching messages, so an append-mode refresh (or one bounded by `refresh_data_window`) now transfers new mail rather than the whole mailbox. A scan without such a predicate issues exactly the commands it issued before.

## Test plan
- [x] Added regression test for the reported bug: a `date >` filter is translated to a `SENTSINCE` bound rather than being dropped, and a conjunction produces the two-sided window an append refresh with `refresh_data_window` generates
- [x] Added edge case tests for both operand orders, all four timestamp units plus `Date32`/`Date64`, a timezone-carrying timestamp, a pre-epoch instant (flooring, not truncation, so the containing day is not skipped), untranslatable shapes (disjunction, other column, null bound, non-temporal literal, `!=`, bare column) yielding no criteria, a conjunction where only one side is translatable, identifier-set run collapsing, the empty set, and a UID at `u32::MAX`
- [x] 23 unit tests pass in the connector crate (16 new), and the crate is clippy-clean at the workspace lint levels
- [ ] `make lint` passes (workspace-wide fmt check + full clippy)
- [ ] `make test` passes
- [ ] `make signoff` run after the final push (`Attestation` check is green)

The last three run together as `make signoff`, which is the workspace gate on this repo — it is queued against the pushed HEAD and these boxes will be checked once it reports. Local iteration used crate-scoped commands for speed; they are not a substitute for the gate.