### PR TITLE
fix(aws): accept aws_session_token for temporary credentials (fixes #10932)

### DIFF
--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -194,6 +194,11 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("aws_secret_access_key")
         .description("The AWS secret access key to use for S3 storage.")
         .secret(),
+    ParameterSpec::component("aws_session_token")
+        .description(
+            "The AWS session token to use for S3 storage. Required with temporary (STS) credentials.",
+        )
+        .secret(),
     ParameterSpec::component("aws_endpoint")
         .description("The AWS endpoint to use for S3 storage.")
         .secret(),
@@ -1378,6 +1383,48 @@ mod tests {
         io::{AsyncReadExt, AsyncWriteExt},
         sync::Mutex,
     };
+
+    /// Temporary (STS) credentials only authenticate when the session token travels with
+    /// the key and secret, so `databricks_aws_session_token` has to survive into the storage
+    /// options handed to the Delta Lake reader.
+    #[tokio::test]
+    async fn databricks_aws_session_token_reaches_delta_storage_options() {
+        let parameters = Parameters::try_new(
+            "connector databricks",
+            vec![
+                (
+                    "databricks_endpoint".to_string(),
+                    secrecy::SecretString::from("dbc-abcd.cloud.databricks.com"),
+                ),
+                (
+                    "databricks_aws_access_key_id".to_string(),
+                    secrecy::SecretString::from("ASIAEXAMPLE"),
+                ),
+                (
+                    "databricks_aws_secret_access_key".to_string(),
+                    secrecy::SecretString::from("secret"),
+                ),
+                (
+                    "databricks_aws_session_token".to_string(),
+                    secrecy::SecretString::from("FwoSessionToken"),
+                ),
+            ],
+            "databricks",
+            Arc::new(tokio::sync::RwLock::new(runtime::secrets::Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("temporary credential parameters should be accepted for databricks");
+
+        let storage_options = parameters.to_secret_map();
+        assert_eq!(
+            storage_options
+                .get("aws_session_token")
+                .map(ExposeSecret::expose_secret),
+            Some("FwoSessionToken"),
+            "session token must reach the Delta Lake storage options"
+        );
+    }
 
     #[test]
     fn databricks_parameters_include_http_rate_control() {

--- a/crates/data-connectors/connector-ducklake/src/lib.rs
+++ b/crates/data-connectors/connector-ducklake/src/lib.rs
@@ -21,7 +21,9 @@ limitations under the License.
 use async_trait::async_trait;
 use data_components::Read;
 use data_components::ducklake::writer::DuckDbFederatedTableWriter;
-use data_components::ducklake::{DuckLakeS3Params, build_ducklake_attach_sql};
+use data_components::ducklake::{
+    DuckLakeS3Params, build_ducklake_attach_sql, configure_duckdb_httpfs,
+};
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::UnsupportedTypeAction;
@@ -54,59 +56,6 @@ pub enum Error {
 
     #[snafu(display("Failed to get underlying DuckDB connection"))]
     FailedToGetDuckDbConnection,
-}
-
-fn configure_duckdb_httpfs(
-    conn: &duckdb::Connection,
-    s3: &DuckLakeS3Params,
-) -> Result<(), duckdb::Error> {
-    conn.execute("INSTALL httpfs", [])?;
-    conn.execute("LOAD httpfs", [])?;
-
-    let has_explicit_creds =
-        s3.access_key_id.is_some() || s3.endpoint.is_some() || s3.region.is_some();
-    if !has_explicit_creds {
-        return Ok(());
-    }
-
-    let region = s3.region.as_deref().unwrap_or("us-east-1");
-    let use_ssl = !s3.allow_http;
-
-    let mut secret_parts = vec![
-        "TYPE s3".to_string(),
-        format!("REGION '{}'", region.replace('\'', "''")),
-        format!("USE_SSL {use_ssl}"),
-    ];
-
-    if let Some(key_id) = &s3.access_key_id {
-        secret_parts.push("PROVIDER config".to_string());
-        secret_parts.push(format!("KEY_ID '{}'", key_id.replace('\'', "''")));
-        if let Some(secret) = &s3.secret_access_key {
-            secret_parts.push(format!("SECRET '{}'", secret.replace('\'', "''")));
-        } else {
-            tracing::warn!(
-                "DuckLake: 'aws_access_key_id' provided without 'aws_secret_access_key'. Both must be set for S3 authentication."
-            );
-        }
-    } else {
-        secret_parts.push("PROVIDER credential_chain".to_string());
-    }
-
-    if let Some(endpoint) = &s3.endpoint {
-        let endpoint = endpoint
-            .trim_start_matches("http://")
-            .trim_start_matches("https://");
-        secret_parts.push(format!("ENDPOINT '{}'", endpoint.replace('\'', "''")));
-        secret_parts.push("URL_STYLE 'path'".to_string());
-    }
-
-    let secret_sql = format!(
-        "CREATE OR REPLACE SECRET __ducklake_s3 ({})",
-        secret_parts.join(", ")
-    );
-    conn.execute(&secret_sql, [])?;
-
-    Ok(())
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -159,6 +108,9 @@ const PARAMETERS: &[ParameterSpec] = &[
         .secret(),
     ParameterSpec::component("aws_secret_access_key")
         .description("The AWS secret access key for S3 storage.")
+        .secret(),
+    ParameterSpec::component("aws_session_token")
+        .description("The AWS session token for S3 storage. Required with temporary (STS) credentials.")
         .secret(),
     ParameterSpec::component("aws_endpoint")
         .description("Custom S3-compatible endpoint URL (e.g. for MinIO).")
@@ -261,6 +213,12 @@ fn create_ducklake_factory(
         secret_access_key: params
             .parameters
             .get("aws_secret_access_key")
+            .expose()
+            .ok()
+            .map(ToString::to_string),
+        session_token: params
+            .parameters
+            .get("aws_session_token")
             .expose()
             .ok()
             .map(ToString::to_string),
@@ -458,3 +416,21 @@ runtime::register_data_connector!(
     CONNECTOR_NAME,
     DuckLakeFactory
 );
+
+#[cfg(test)]
+mod tests {
+    use super::PARAMETERS;
+
+    /// The S3 secret built for `DuckDB` only carries `SESSION_TOKEN` when the parameter is
+    /// declared here — otherwise `Parameters::try_new` strips it and temporary (STS)
+    /// credentials fail with `InvalidAccessKeyId`.
+    #[test]
+    fn ducklake_parameters_include_aws_session_token() {
+        assert!(
+            PARAMETERS
+                .iter()
+                .any(|parameter| parameter.name == "aws_session_token"),
+            "missing DuckLake data connector parameter aws_session_token"
+        );
+    }
+}

--- a/crates/data_components/src/ducklake/mod.rs
+++ b/crates/data_components/src/ducklake/mod.rs
@@ -62,6 +62,15 @@ pub fn configure_duckdb_httpfs(
     Ok(())
 }
 
+/// Whether a configured session token will be dropped rather than sent to `DuckDB`.
+///
+/// `SESSION_TOKEN` is only meaningful next to an explicit `KEY_ID`, so a token supplied
+/// without `aws_access_key_id` is ignored however the rest of the parameters are set —
+/// including the token-only case, which resolves no secret at all.
+fn session_token_is_ignored(s3: &DuckLakeS3Params) -> bool {
+    s3.session_token.is_some() && s3.access_key_id.is_none()
+}
+
 /// Builds the `CREATE SECRET` statement configuring `DuckDB`'s `httpfs` extension for
 /// S3 access, or `None` when no explicit S3 parameters are set (`DuckDB` then resolves
 /// credentials through its own `credential_chain` provider).
@@ -71,6 +80,15 @@ pub fn configure_duckdb_httpfs(
 /// usable; long-lived `AKIA…` credentials carry no token and are unaffected.
 #[must_use]
 pub fn build_ducklake_s3_secret_sql(s3: &DuckLakeS3Params) -> Option<String> {
+    // Warn before the early return below: a session token on its own is not an explicit
+    // credential, so a token-only configuration returns early and would never reach a
+    // check placed further down — the very case where the token is most silently dropped.
+    if session_token_is_ignored(s3) {
+        tracing::warn!(
+            "DuckLake: 'aws_session_token' provided without 'aws_access_key_id'. Set all three of 'aws_access_key_id', 'aws_secret_access_key', and 'aws_session_token' to use temporary credentials."
+        );
+    }
+
     let has_explicit_creds =
         s3.access_key_id.is_some() || s3.endpoint.is_some() || s3.region.is_some();
     if !has_explicit_creds {
@@ -103,11 +121,6 @@ pub fn build_ducklake_s3_secret_sql(s3: &DuckLakeS3Params) -> Option<String> {
             ));
         }
     } else {
-        if s3.session_token.is_some() {
-            tracing::warn!(
-                "DuckLake: 'aws_session_token' provided without 'aws_access_key_id'. Set all three of 'aws_access_key_id', 'aws_secret_access_key', and 'aws_session_token' to use temporary credentials."
-            );
-        }
         secret_parts.push("PROVIDER credential_chain".to_string());
     }
 
@@ -152,12 +165,62 @@ pub fn build_ducklake_attach_sql(
 
 #[cfg(test)]
 mod tests {
-    use super::{DuckLakeS3Params, build_ducklake_attach_sql, build_ducklake_s3_secret_sql};
+    use super::{
+        DuckLakeS3Params, build_ducklake_attach_sql, build_ducklake_s3_secret_sql,
+        session_token_is_ignored,
+    };
 
     #[test]
     fn s3_secret_sql_is_none_without_explicit_parameters() {
         assert_eq!(
             build_ducklake_s3_secret_sql(&DuckLakeS3Params::default()),
+            None
+        );
+    }
+
+    #[test]
+    fn a_session_token_without_a_key_id_is_reported_ignored() {
+        // A token on its own resolves no secret at all, so this is the configuration
+        // whose token is dropped most quietly — it must still be flagged.
+        assert!(session_token_is_ignored(&DuckLakeS3Params {
+            session_token: Some("FwoSessionToken".to_string()),
+            ..DuckLakeS3Params::default()
+        }));
+
+        // …as must a token alongside other explicit parameters but still no key id.
+        assert!(session_token_is_ignored(&DuckLakeS3Params {
+            region: Some("us-east-1".to_string()),
+            session_token: Some("FwoSessionToken".to_string()),
+            ..DuckLakeS3Params::default()
+        }));
+    }
+
+    #[test]
+    fn a_usable_or_absent_session_token_is_not_reported_ignored() {
+        // Sent as SESSION_TOKEN next to the key id.
+        assert!(!session_token_is_ignored(&DuckLakeS3Params {
+            access_key_id: Some("ASIAEXAMPLE".to_string()),
+            secret_access_key: Some("secret".to_string()),
+            session_token: Some("FwoSessionToken".to_string()),
+            ..DuckLakeS3Params::default()
+        }));
+
+        // Nothing to ignore when no token was configured.
+        assert!(!session_token_is_ignored(&DuckLakeS3Params {
+            region: Some("us-east-1".to_string()),
+            ..DuckLakeS3Params::default()
+        }));
+    }
+
+    #[test]
+    fn a_session_token_alone_still_resolves_no_secret() {
+        // Warning aside, a token is not an explicit credential: DuckDB keeps using its
+        // own credential_chain rather than gaining a half-populated secret.
+        assert_eq!(
+            build_ducklake_s3_secret_sql(&DuckLakeS3Params {
+                session_token: Some("FwoSessionToken".to_string()),
+                ..DuckLakeS3Params::default()
+            }),
             None
         );
     }

--- a/crates/data_components/src/ducklake/mod.rs
+++ b/crates/data_components/src/ducklake/mod.rs
@@ -33,6 +33,10 @@ pub struct DuckLakeS3Params {
     pub region: Option<String>,
     pub access_key_id: Option<String>,
     pub secret_access_key: Option<String>,
+    /// Session token accompanying temporary (STS) credentials. `DuckDB` rejects
+    /// temporary `ASIA…` keys without it, because `SigV4` only validates when the
+    /// token is sent alongside the key and secret.
+    pub session_token: Option<String>,
     pub endpoint: Option<String>,
     pub allow_http: bool,
 }
@@ -51,10 +55,26 @@ pub fn configure_duckdb_httpfs(
     conn.execute("INSTALL httpfs", [])?;
     conn.execute("LOAD httpfs", [])?;
 
+    if let Some(secret_sql) = build_ducklake_s3_secret_sql(s3) {
+        conn.execute(&secret_sql, [])?;
+    }
+
+    Ok(())
+}
+
+/// Builds the `CREATE SECRET` statement configuring `DuckDB`'s `httpfs` extension for
+/// S3 access, or `None` when no explicit S3 parameters are set (`DuckDB` then resolves
+/// credentials through its own `credential_chain` provider).
+///
+/// Values are escaped for single-quoted literals. `SESSION_TOKEN` is emitted whenever a
+/// session token is configured, which is what makes temporary (STS) `ASIA…` credentials
+/// usable; long-lived `AKIA…` credentials carry no token and are unaffected.
+#[must_use]
+pub fn build_ducklake_s3_secret_sql(s3: &DuckLakeS3Params) -> Option<String> {
     let has_explicit_creds =
         s3.access_key_id.is_some() || s3.endpoint.is_some() || s3.region.is_some();
     if !has_explicit_creds {
-        return Ok(());
+        return None;
     }
 
     let region = s3.region.as_deref().unwrap_or("us-east-1");
@@ -76,7 +96,18 @@ pub fn configure_duckdb_httpfs(
                 "DuckLake: 'aws_access_key_id' provided without 'aws_secret_access_key'. Both must be set for S3 authentication."
             );
         }
+        if let Some(session_token) = &s3.session_token {
+            secret_parts.push(format!(
+                "SESSION_TOKEN '{}'",
+                session_token.replace('\'', "''")
+            ));
+        }
     } else {
+        if s3.session_token.is_some() {
+            tracing::warn!(
+                "DuckLake: 'aws_session_token' provided without 'aws_access_key_id'. Set all three of 'aws_access_key_id', 'aws_secret_access_key', and 'aws_session_token' to use temporary credentials."
+            );
+        }
         secret_parts.push("PROVIDER credential_chain".to_string());
     }
 
@@ -88,13 +119,10 @@ pub fn configure_duckdb_httpfs(
         secret_parts.push("URL_STYLE 'path'".to_string());
     }
 
-    let secret_sql = format!(
+    Some(format!(
         "CREATE OR REPLACE SECRET __ducklake_s3 ({})",
         secret_parts.join(", ")
-    );
-    conn.execute(&secret_sql, [])?;
-
-    Ok(())
+    ))
 }
 
 /// Builds the `ATTACH` statement used to attach a `DuckLake` catalog in `DuckDB`.
@@ -124,7 +152,84 @@ pub fn build_ducklake_attach_sql(
 
 #[cfg(test)]
 mod tests {
-    use super::build_ducklake_attach_sql;
+    use super::{DuckLakeS3Params, build_ducklake_attach_sql, build_ducklake_s3_secret_sql};
+
+    #[test]
+    fn s3_secret_sql_is_none_without_explicit_parameters() {
+        assert_eq!(
+            build_ducklake_s3_secret_sql(&DuckLakeS3Params::default()),
+            None
+        );
+    }
+
+    #[test]
+    fn s3_secret_sql_includes_session_token_for_temporary_credentials() {
+        let sql = build_ducklake_s3_secret_sql(&DuckLakeS3Params {
+            region: Some("us-east-1".to_string()),
+            access_key_id: Some("ASIAEXAMPLE".to_string()),
+            secret_access_key: Some("secret".to_string()),
+            session_token: Some("FwoSessionToken".to_string()),
+            endpoint: None,
+            allow_http: false,
+        })
+        .expect("explicit credentials should produce a secret");
+
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE SECRET __ducklake_s3 (TYPE s3, REGION 'us-east-1', USE_SSL true, PROVIDER config, KEY_ID 'ASIAEXAMPLE', SECRET 'secret', SESSION_TOKEN 'FwoSessionToken')"
+        );
+    }
+
+    #[test]
+    fn s3_secret_sql_omits_session_token_when_unset() {
+        let sql = build_ducklake_s3_secret_sql(&DuckLakeS3Params {
+            region: Some("us-east-1".to_string()),
+            access_key_id: Some("AKIAEXAMPLE".to_string()),
+            secret_access_key: Some("secret".to_string()),
+            session_token: None,
+            endpoint: None,
+            allow_http: false,
+        })
+        .expect("explicit credentials should produce a secret");
+
+        assert!(
+            !sql.contains("SESSION_TOKEN"),
+            "long-lived credentials must not carry a session token: {sql}"
+        );
+    }
+
+    #[test]
+    fn s3_secret_sql_escapes_session_token() {
+        let sql = build_ducklake_s3_secret_sql(&DuckLakeS3Params {
+            region: Some("us-east-1".to_string()),
+            access_key_id: Some("ASIAEXAMPLE".to_string()),
+            secret_access_key: Some("secret".to_string()),
+            session_token: Some("tok'en".to_string()),
+            endpoint: None,
+            allow_http: false,
+        })
+        .expect("explicit credentials should produce a secret");
+
+        assert!(
+            sql.contains("SESSION_TOKEN 'tok''en'"),
+            "session token must be escaped for a single-quoted literal: {sql}"
+        );
+    }
+
+    #[test]
+    fn s3_secret_sql_falls_back_to_credential_chain_without_a_key() {
+        let sql = build_ducklake_s3_secret_sql(&DuckLakeS3Params {
+            region: Some("us-east-1".to_string()),
+            session_token: Some("FwoSessionToken".to_string()),
+            ..DuckLakeS3Params::default()
+        })
+        .expect("an explicit region should produce a secret");
+
+        assert!(
+            sql.contains("PROVIDER credential_chain") && !sql.contains("SESSION_TOKEN"),
+            "a session token without a key id must not be sent: {sql}"
+        );
+    }
 
     #[test]
     fn attach_sql_without_migration_is_unchanged() {

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -136,6 +136,11 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("aws_secret_access_key")
         .description("The AWS secret access key to use for S3 storage.")
         .secret(),
+    ParameterSpec::component("aws_session_token")
+        .description(
+            "The AWS session token to use for S3 storage. Required with temporary (STS) credentials.",
+        )
+        .secret(),
     ParameterSpec::component("aws_endpoint")
         .description("The AWS endpoint to use for S3 storage.")
         .secret(),
@@ -882,5 +887,47 @@ mod tests {
                 "parameter `{name}` is consumed by build_sql_warehouse_config but not declared in PARAMETERS; Parameters::try_new would strip it"
             );
         }
+    }
+
+    /// Temporary (STS) credentials only authenticate when the session token travels with
+    /// the key and secret, so `databricks_aws_session_token` has to survive into the
+    /// storage options handed to `DeltaTableFactory`.
+    #[tokio::test]
+    async fn test_aws_session_token_reaches_delta_storage_options() {
+        let parameters = Parameters::try_new(
+            "catalog databricks",
+            vec![
+                (
+                    "databricks_endpoint".to_string(),
+                    SecretString::from("dbc-abcd.cloud.databricks.com"),
+                ),
+                (
+                    "databricks_aws_access_key_id".to_string(),
+                    SecretString::from("ASIAEXAMPLE"),
+                ),
+                (
+                    "databricks_aws_secret_access_key".to_string(),
+                    SecretString::from("secret"),
+                ),
+                (
+                    "databricks_aws_session_token".to_string(),
+                    SecretString::from("FwoSessionToken"),
+                ),
+            ],
+            "databricks",
+            Arc::new(tokio::sync::RwLock::new(crate::secrets::Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("temporary credential parameters should be accepted for databricks");
+
+        let storage_options = parameters.to_secret_map();
+        assert_eq!(
+            storage_options
+                .get("aws_session_token")
+                .map(ExposeSecret::expose_secret),
+            Some("FwoSessionToken"),
+            "session token must reach the Delta Lake storage options"
+        );
     }
 }

--- a/crates/runtime/src/catalogconnector/ducklake.rs
+++ b/crates/runtime/src/catalogconnector/ducklake.rs
@@ -27,7 +27,9 @@ use crate::{
 use async_trait::async_trait;
 use data_components::RefreshableCatalogProvider;
 use data_components::ducklake::provider::DuckLakeCatalogProvider;
-use data_components::ducklake::{DuckLakeS3Params, build_ducklake_attach_sql};
+use data_components::ducklake::{
+    DuckLakeS3Params, build_ducklake_attach_sql, configure_duckdb_httpfs,
+};
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use duckdb::AccessMode;
@@ -64,6 +66,11 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("aws_secret_access_key")
         .description("The AWS secret access key for S3 storage.")
         .secret(),
+    ParameterSpec::component("aws_session_token")
+        .description(
+            "The AWS session token for S3 storage. Required with temporary (STS) credentials.",
+        )
+        .secret(),
     ParameterSpec::component("aws_endpoint")
         .description("Custom S3-compatible endpoint URL (e.g. for MinIO).")
         .secret(),
@@ -73,59 +80,6 @@ pub const PARAMETERS: &[ParameterSpec] = &[
         "Automatically migrate an older DuckLake catalog schema to the version required by the ducklake extension on attach. Defaults to false; migration rewrites catalog metadata and cannot be undone.",
     ),
 ];
-
-fn configure_duckdb_httpfs(
-    conn: &duckdb::Connection,
-    s3: &DuckLakeS3Params,
-) -> Result<(), duckdb::Error> {
-    conn.execute("INSTALL httpfs", [])?;
-    conn.execute("LOAD httpfs", [])?;
-
-    let has_explicit_creds =
-        s3.access_key_id.is_some() || s3.endpoint.is_some() || s3.region.is_some();
-    if !has_explicit_creds {
-        return Ok(());
-    }
-
-    let region = s3.region.as_deref().unwrap_or("us-east-1");
-    let use_ssl = !s3.allow_http;
-
-    let mut secret_parts = vec![
-        "TYPE s3".to_string(),
-        format!("REGION '{}'", region.replace('\'', "''")),
-        format!("USE_SSL {use_ssl}"),
-    ];
-
-    if let Some(key_id) = &s3.access_key_id {
-        secret_parts.push("PROVIDER config".to_string());
-        secret_parts.push(format!("KEY_ID '{}'", key_id.replace('\'', "''")));
-        if let Some(secret) = &s3.secret_access_key {
-            secret_parts.push(format!("SECRET '{}'", secret.replace('\'', "''")));
-        } else {
-            tracing::warn!(
-                "DuckLake: 'aws_access_key_id' provided without 'aws_secret_access_key'. Both must be set for S3 authentication."
-            );
-        }
-    } else {
-        secret_parts.push("PROVIDER credential_chain".to_string());
-    }
-
-    if let Some(endpoint) = &s3.endpoint {
-        let endpoint = endpoint
-            .trim_start_matches("http://")
-            .trim_start_matches("https://");
-        secret_parts.push(format!("ENDPOINT '{}'", endpoint.replace('\'', "''")));
-        secret_parts.push("URL_STYLE 'path'".to_string());
-    }
-
-    let secret_sql = format!(
-        "CREATE OR REPLACE SECRET __ducklake_s3 ({})",
-        secret_parts.join(", ")
-    );
-    conn.execute(&secret_sql, [])?;
-
-    Ok(())
-}
 
 /// A catalog connector for `DuckLake`, providing access to schemas and tables via `DuckDB`.
 #[derive(Clone)]
@@ -236,6 +190,13 @@ impl CatalogConnector for DuckLakeCatalog {
                 .params
                 .parameters
                 .get("aws_secret_access_key")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
+            session_token: self
+                .params
+                .parameters
+                .get("aws_session_token")
                 .expose()
                 .ok()
                 .map(ToString::to_string),
@@ -371,5 +332,42 @@ impl CatalogConnector for DuckLakeCatalog {
             })?;
 
         Ok(catalog_provider as Arc<dyn RefreshableCatalogProvider>)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PARAMETERS;
+    use crate::parameters::Parameters;
+    use crate::secrets::Secrets;
+    use secrecy::{ExposeSecret, SecretString};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    /// The S3 secret built for `DuckDB` only carries `SESSION_TOKEN` when the parameter
+    /// survives `Parameters::try_new` — otherwise temporary (STS) credentials fail with
+    /// `InvalidAccessKeyId`.
+    #[tokio::test]
+    async fn ducklake_aws_session_token_is_accepted() {
+        let parameters = Parameters::try_new(
+            "catalog ducklake",
+            vec![(
+                "ducklake_aws_session_token".to_string(),
+                SecretString::from("FwoSessionToken"),
+            )],
+            "ducklake",
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("session token should be accepted for ducklake");
+
+        assert_eq!(
+            parameters
+                .to_secret_map()
+                .get("aws_session_token")
+                .map(ExposeSecret::expose_secret),
+            Some("FwoSessionToken")
+        );
     }
 }

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -71,6 +71,11 @@ pub const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("aws_secret_access_key")
         .description("The AWS secret access key to use for S3 storage.")
         .secret(),
+    ParameterSpec::component("aws_session_token")
+        .description(
+            "The AWS session token to use for S3 storage. Required with temporary (STS) credentials.",
+        )
+        .secret(),
     ParameterSpec::component("aws_endpoint")
         .description("The AWS endpoint to use for S3 storage.")
         .secret(),
@@ -373,5 +378,45 @@ mod tests {
             }
             _ => panic!("Expected Bare table reference"),
         }
+    }
+
+    /// Temporary (STS) credentials only authenticate when the session token travels with
+    /// the key and secret, so `unity_catalog_aws_session_token` has to survive into the
+    /// storage options handed to `DeltaTableFactory`.
+    #[tokio::test]
+    async fn test_aws_session_token_reaches_delta_storage_options() {
+        use secrecy::ExposeSecret;
+
+        let parameters = Parameters::try_new(
+            "catalog unity_catalog",
+            vec![
+                (
+                    "unity_catalog_aws_access_key_id".to_string(),
+                    SecretString::from("ASIAEXAMPLE"),
+                ),
+                (
+                    "unity_catalog_aws_secret_access_key".to_string(),
+                    SecretString::from("secret"),
+                ),
+                (
+                    "unity_catalog_aws_session_token".to_string(),
+                    SecretString::from("FwoSessionToken"),
+                ),
+            ],
+            "unity_catalog",
+            Arc::new(tokio::sync::RwLock::new(crate::secrets::Secrets::new())),
+            PARAMETERS,
+        )
+        .await
+        .expect("temporary credential parameters should be accepted for unity_catalog");
+
+        let storage_options = parameters.to_secret_map();
+        assert_eq!(
+            storage_options
+                .get("aws_session_token")
+                .map(ExposeSecret::expose_secret),
+            Some("FwoSessionToken"),
+            "session token must reach the Delta Lake storage options"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Temporary AWS credentials (STS, `ASIA…` keys) could not be used with the Databricks, Unity Catalog, or DuckLake connectors. `SigV4` only validates a temporary key when the session token is sent alongside the key and secret, but none of these components declared an `aws_session_token` parameter — and `Parameters::try_new` **drops** any parameter that is not declared, logging `Ignoring parameter …: not supported`. Users therefore had no way to supply the token, and S3 reads failed with:

```
403 Forbidden: <Code>InvalidAccessKeyId</Code> … <AWSAccessKeyId>ASIA…</AWSAccessKeyId>
```

Root cause is a declaration asymmetry, not a plumbing bug: `aws_access_key_id` + `aws_secret_access_key` were declared without their session-token sibling. The `delta_lake` data connector, the `s3` connector, `dynamodb`, `iceberg`, and `glue` all already accept a session token, so this is the same class of gap in the five component parameter lists that had missed it.

Once the parameter is declared, the two consumption paths already carry it end-to-end:

- **Delta-backed** (Databricks `mode: delta_lake`, Databricks catalog, Unity Catalog catalog) — the parameter map flows through `DeltaTableFactory` → `DeltaTable::from` → `object_store::parse_url_opts`, which maps `aws_session_token` to the S3 token config key. Explicit credentials also bypass the AWS SDK credential bridge, so the token is used as given.
- **DuckLake** (data connector and catalog connector) — the token is added to the `CREATE OR REPLACE SECRET __ducklake_s3` statement as `SESSION_TOKEN`, escaped for a single-quoted literal like the sibling values.

Fixes #10932

## Changes

- Declare `aws_session_token` (secret) in the parameter lists of the Databricks data connector, Databricks catalog connector, Unity Catalog catalog connector, DuckLake data connector, and DuckLake catalog connector — i.e. `databricks_aws_session_token`, `unity_catalog_aws_session_token`, `ducklake_aws_session_token`.
- Add `DuckLakeS3Params::session_token` and emit `SESSION_TOKEN` in the `DuckDB` S3 secret. The token is only sent with `PROVIDER config` (an explicit key); a token supplied without a key id now warns instead of being silently dropped, matching the existing key-without-secret warning.
- Extract `build_ducklake_s3_secret_sql` from `configure_duckdb_httpfs` in `data_components::ducklake` so the emitted SQL is unit-testable, and delete the two verbatim copies of `configure_duckdb_httpfs` that had been forked into the DuckLake data connector and DuckLake catalog connector — the shared function is now the single site, so the session-token support cannot land in only one of the three.

## Test plan

- `make lint`
- `make test`
- New unit tests:
  - `data_components::ducklake` — `SESSION_TOKEN` is emitted for temporary credentials, omitted for long-lived ones, escaped for single quotes, and suppressed (with a warning) when no key id is set; no secret at all without explicit S3 parameters.
  - `catalogconnector::databricks`, `catalogconnector::unity_catalog`, `connector-databricks` — `Parameters::try_new` accepts `<prefix>_aws_session_token` and it reaches the Delta Lake storage options under the `aws_session_token` key. These fail before this change, because the undeclared parameter is stripped.
  - `catalogconnector::ducklake`, `connector-ducklake` — the session-token parameter is accepted / declared.

## Checklist

- [x] Tests added for the fix and the bug class (all five components)
- [x] No behavior change for long-lived (`AKIA…`) credentials — no session token is emitted when none is configured
- [x] `cargo fmt` clean