### PR TITLE
fix(mysql): take the binlog rotate target from the ROTATE event, not its header offset (fixes #12042)

### DIFF
--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -94,7 +94,7 @@ use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use futures::{StreamExt, stream};
 use mysql_async::Conn;
-use mysql_async::binlog::events::{EventData, RowsEventData, TableMapEvent};
+use mysql_async::binlog::events::{EventData, RotateEvent, RowsEventData, TableMapEvent};
 use rustc_hash::FxHashMap;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -1492,7 +1492,9 @@ async fn run_pump(source: Arc<SharedSource>) {
             };
 
             let header = event.header();
-            let event_end_pos = u64::from(header.log_pos());
+            // Offset within `current_file` this event advances the stream to. A
+            // real `ROTATE` rewrites both together (see [`rotate_target`]).
+            let mut event_end_pos = u64::from(header.log_pos());
             let event_timestamp = header.timestamp();
             let data = match event.read_data() {
                 Ok(data) => data,
@@ -1505,8 +1507,14 @@ async fn run_pump(source: Arc<SharedSource>) {
 
             match data {
                 Some(EventData::RotateEvent(rotate)) => {
-                    if !rotate.is_fake() {
-                        current_file = rotate.name().into_owned();
+                    // Take BOTH the file and the offset from the event: its
+                    // header offset belongs to the file being closed, so keeping
+                    // `event_end_pos` here would credit idle members a position
+                    // the newly opened file will not reach for a long time. See
+                    // [`rotate_target`].
+                    if let Some(target) = rotate_target(&rotate) {
+                        current_file = target.file;
+                        event_end_pos = target.pos;
                     }
                 }
                 Some(EventData::TableMapEvent(tme)) => {
@@ -1754,6 +1762,21 @@ async fn run_pump(source: Arc<SharedSource>) {
 
 fn current_file_pos(file: &str) -> BinlogPosition {
     BinlogPosition::new(file.to_string(), 0)
+}
+
+/// Where a `ROTATE` event repositions the shared stream, or `None` for the fake
+/// rotate the server sends at the head of a dump (which opens no new file).
+///
+/// `ROTATE` is the one event whose header offset does **not** belong to the file
+/// it names: `log_pos` is the end of the event in the file being *closed*, while
+/// the payload names the file being *opened* and the offset to resume reading at
+/// (normally 4, just past the magic number). Pairing the new name with the
+/// closing file's offset yields a coordinate far beyond anything the new file
+/// holds — an idle member credited there has every later commit in that file
+/// suppressed by [`AckSlot::already_committed`], silently and for as long as the
+/// new file stays smaller than the old one (#12042).
+fn rotate_target(rotate: &RotateEvent<'_>) -> Option<BinlogPosition> {
+    (!rotate.is_fake()).then(|| BinlogPosition::new(rotate.name(), rotate.position()))
 }
 
 /// Deliver a committed transaction's buffered rows to their members, then
@@ -2358,6 +2381,61 @@ mod tests {
             file_checkpoint_verdict(false),
             CheckpointVerdict::Unresumable(_)
         ));
+    }
+
+    /// A real `ROTATE` closing `binlog.000041` at ~1 GiB and opening
+    /// `binlog.000042`: the stream continues at offset 4 of the *new* file, not
+    /// at the *closed* file's end offset (which the event header carries).
+    #[test]
+    fn rotate_targets_the_new_files_resume_offset() {
+        let rotate = RotateEvent::new(4, &b"binlog.000042"[..]);
+        assert_eq!(
+            rotate_target(&rotate),
+            Some(pos("binlog.000042", 4)),
+            "a rotate must reposition to the offset its payload names"
+        );
+    }
+
+    #[test]
+    fn a_fake_rotate_does_not_reposition_the_stream() {
+        // The artificial rotate at the head of a dump opens no new file.
+        let rotate = RotateEvent::new(0, &b"binlog.000042"[..]);
+        assert_eq!(rotate_target(&rotate), None);
+    }
+
+    /// Regression test for #12042.
+    ///
+    /// The pump credits idle streaming members the coordinate each event
+    /// advances the stream to. When a `ROTATE` contributed the *closing* file's
+    /// end offset under the *opening* file's name, an idle member's committed
+    /// floor jumped ~1 GiB past the new file's real offsets and `deliver_commit`
+    /// then dropped every following transaction as `already_committed` — with no
+    /// error, no detach, and no backpressure warning, for the rest of the run.
+    #[test]
+    fn a_rotate_credit_does_not_suppress_the_new_files_commits() {
+        let ack = AckTable::default();
+        let member = key("tpcc", "warehouse");
+        // An idle member caught up to the end of the file about to be closed.
+        ack.register(&member, pos("binlog.000041", 1_073_741_800), false);
+        ack.promote_ready_members();
+
+        let rotate = RotateEvent::new(4, &b"binlog.000042"[..]);
+        let target = rotate_target(&rotate).expect("a real rotate repositions the stream");
+        ack.credit_idle(&target, None);
+
+        assert_eq!(
+            ack.committed(&member),
+            Some(pos("binlog.000042", 4)),
+            "the credit must land at the new file's start"
+        );
+
+        // The first transaction of the newly opened file must still be delivered.
+        let next_commit = pos("binlog.000042", 1_182);
+        let slot = ack.slot(&member).expect("registered member has a slot");
+        assert!(
+            !slot.already_committed(&next_commit),
+            "commit at {next_commit} was suppressed as already-applied, so its rows are lost"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

MySQL CDC datasets silently stopped receiving changes partway through a run — rows permanently missing after a full drain, replication-lag p99 climbing from ~1 s to 300–620 s, and no error, detach, or backpressure warning anywhere in the logs.

A real `ROTATE` event is the one binlog event whose header offset does **not** belong to the file it names: `log_pos` is the end of the event in the file being *closed*, while the payload names the file being *opened* and the offset to resume reading at (normally 4). The shared pump updated `current_file` from the payload but kept `event_end_pos` from the header, then fell through to the idle safe-advance and credited idle members `BinlogPosition { file: <new file>, pos: <closed file's end> }`.

`AckSlot::commit` is a monotonic max, so that coordinate stuck. Every subsequent transaction in the new file has a smaller offset, so `deliver_commit`'s `slot.already_committed(commit_pos)` guard returned true and skipped delivery at an unlogged `continue` — for as long as the new file stayed smaller than the old one, i.e. the rest of the run.

This also matches the reported fingerprint exactly: `poll_head_and_heartbeat` reports `lag = head.pos.saturating_sub(resume.pos)`, which saturates to **0** once a member's committed offset is past the head — the stalled datasets all reported `lag_bytes=0` while frozen. Members with an in-flight envelope at the moment of the rotate are skipped by `credit_idle`, which is why high-traffic tables kept flowing while quiet ones froze one by one.

The same poisoned coordinate is what `persist_all` writes to the durable sidecar, so a restart would have resumed from an offset that does not exist in that file.

Fixes #12042

## Changes

- `rotate_target()` — a small helper returning where a `ROTATE` repositions the stream (`None` for the fake rotate at the head of a dump), taking **both** the file name and the offset from the event payload.
- The pump's rotate arm now sets `current_file` and `event_end_pos` together from that helper, so the idle safe-advance, the checkpoint, and any later commit comparison all agree on one file.

No behavior change outside the rotate boundary; every other event's header offset genuinely belongs to `current_file`.

## Test plan

- `make lint`
- `make test`

New unit tests in `crates/data_components/src/mysql_replication/shared.rs`:

- `rotate_targets_the_new_files_resume_offset` — a rotate closing `binlog.000041` at ~1 GiB and opening `binlog.000042` repositions to `binlog.000042:4`.
- `a_fake_rotate_does_not_reposition_the_stream` — the artificial rotate at the head of a dump opens no new file.
- `a_rotate_credit_does_not_suppress_the_new_files_commits` — regression test: after the rotate credit, the first transaction of the newly opened file is **not** reported as already-applied.

Verified the two rotate tests **fail** when the helper is reverted to the pre-fix pairing and **pass** with the fix; the other 14 tests in the module are unaffected either way.

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] Existing tests in the module still pass
- [x] Both CI clippy passes (lib and tests) and `cargo fmt` clean
- [x] No sibling instances — `shared.rs` is the only `RotateEvent` handler in the repo