### PR TITLE
fix(mysql): verify an adopted layout against the event's own column types (fixes #11764)

### DIFF
--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -29,7 +29,8 @@ limitations under the License.
 //!   - [`readiness_heartbeat`] / [`record_watermark`] / [`commit_ts_ms`] for
 //!     lag-based readiness and freshness metrics,
 //!   - [`adopt_current_layout`] + [`compute_pk_source_indexes`] for compatible
-//!     mid-stream `ALTER` adoption,
+//!     mid-stream `ALTER` adoption, and [`layout_event_mismatch`] to check an
+//!     adopted layout against the row images it will actually decode,
 //!   - [`classify_query`] / [`classify_statement`] for the transaction and DDL
 //!     boundaries in the event stream.
 //!
@@ -46,6 +47,7 @@ use std::time::{Duration, SystemTime};
 use arrow::datatypes::SchemaRef;
 use mysql_async::binlog::events::{RowsEventData, TableMapEvent};
 use mysql_async::binlog::row::BinlogRow;
+use mysql_async::consts::ColumnType;
 use mysql_async::{BinlogStream, BinlogStreamRequest, Conn, Value};
 
 use super::config::{BinlogPosition, ReplicationParams};
@@ -341,6 +343,156 @@ pub(super) async fn adopt_current_layout(
     })
 }
 
+/// A coarse binlog column-type class, used to compare a layout fetched from
+/// `information_schema` against the column types a `TableMap` event carries.
+///
+/// Deliberately coarse: families whose wire type depends on the server version
+/// or the column's charset/metadata are collapsed into one class (or left
+/// unmapped entirely) so that a class *disagreement* is always a real
+/// disagreement. See [`source_type_class`] for what is intentionally omitted —
+/// this comparison gates every decode, so a false positive would break a
+/// healthy stream, which is strictly worse than the rare scramble it detects.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BinlogTypeClass {
+    Int8,
+    Int16,
+    Int24,
+    Int32,
+    Int64,
+    Float,
+    Double,
+    Decimal,
+    Date,
+    Year,
+    Bit,
+    Json,
+    Geometry,
+    /// `CHAR` / `VARCHAR` / `BINARY` / `VARBINARY` / `ENUM` / `SET`. One class
+    /// because the wire type within this family depends on charset and on the
+    /// `MYSQL_TYPE_STRING` metadata that encodes the real type.
+    StringLike,
+}
+
+/// Classify an `information_schema.COLUMNS.COLUMN_TYPE` string, or `None` when
+/// the binlog wire type is not pinned by the declared type alone.
+///
+/// Unmapped on purpose: `DATETIME` / `TIMESTAMP` / `TIME` (`*2` variants since
+/// 5.6), `TEXT` / `BLOB` (all sent as `MYSQL_TYPE_BLOB`, distinguished only by
+/// a length byte in the metadata), and `REAL` (`REAL_AS_FLOAT` `sql_mode`).
+fn source_type_class(column_type: &str) -> Option<BinlogTypeClass> {
+    let base: String = column_type
+        .chars()
+        .take_while(char::is_ascii_alphabetic)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    match base.as_str() {
+        "tinyint" => Some(BinlogTypeClass::Int8),
+        "smallint" => Some(BinlogTypeClass::Int16),
+        "mediumint" => Some(BinlogTypeClass::Int24),
+        "int" | "integer" => Some(BinlogTypeClass::Int32),
+        "bigint" => Some(BinlogTypeClass::Int64),
+        "float" => Some(BinlogTypeClass::Float),
+        "double" => Some(BinlogTypeClass::Double),
+        "decimal" | "numeric" => Some(BinlogTypeClass::Decimal),
+        "date" => Some(BinlogTypeClass::Date),
+        "year" => Some(BinlogTypeClass::Year),
+        "bit" => Some(BinlogTypeClass::Bit),
+        "json" => Some(BinlogTypeClass::Json),
+        "geometry" | "point" | "linestring" | "polygon" | "multipoint" | "multilinestring"
+        | "multipolygon" | "geomcollection" | "geometrycollection" => {
+            Some(BinlogTypeClass::Geometry)
+        }
+        "char" | "varchar" | "binary" | "varbinary" | "enum" | "set" => {
+            Some(BinlogTypeClass::StringLike)
+        }
+        _ => None,
+    }
+}
+
+/// Classify a `TableMap` column type, or `None` when it carries no usable
+/// signal (see [`source_type_class`] for the omissions this mirrors).
+fn event_type_class(column_type: ColumnType) -> Option<BinlogTypeClass> {
+    match column_type {
+        ColumnType::MYSQL_TYPE_TINY => Some(BinlogTypeClass::Int8),
+        ColumnType::MYSQL_TYPE_SHORT => Some(BinlogTypeClass::Int16),
+        ColumnType::MYSQL_TYPE_INT24 => Some(BinlogTypeClass::Int24),
+        ColumnType::MYSQL_TYPE_LONG => Some(BinlogTypeClass::Int32),
+        ColumnType::MYSQL_TYPE_LONGLONG => Some(BinlogTypeClass::Int64),
+        ColumnType::MYSQL_TYPE_FLOAT => Some(BinlogTypeClass::Float),
+        ColumnType::MYSQL_TYPE_DOUBLE => Some(BinlogTypeClass::Double),
+        ColumnType::MYSQL_TYPE_NEWDECIMAL | ColumnType::MYSQL_TYPE_DECIMAL => {
+            Some(BinlogTypeClass::Decimal)
+        }
+        ColumnType::MYSQL_TYPE_DATE | ColumnType::MYSQL_TYPE_NEWDATE => Some(BinlogTypeClass::Date),
+        ColumnType::MYSQL_TYPE_YEAR => Some(BinlogTypeClass::Year),
+        ColumnType::MYSQL_TYPE_BIT => Some(BinlogTypeClass::Bit),
+        ColumnType::MYSQL_TYPE_JSON => Some(BinlogTypeClass::Json),
+        ColumnType::MYSQL_TYPE_GEOMETRY => Some(BinlogTypeClass::Geometry),
+        ColumnType::MYSQL_TYPE_VARCHAR
+        | ColumnType::MYSQL_TYPE_VAR_STRING
+        | ColumnType::MYSQL_TYPE_STRING
+        | ColumnType::MYSQL_TYPE_ENUM
+        | ColumnType::MYSQL_TYPE_SET => Some(BinlogTypeClass::StringLike),
+        _ => None,
+    }
+}
+
+/// A column position where the in-memory layout disagrees with the row images
+/// the `TableMap` event describes.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct LayoutEventMismatch {
+    pub(super) ordinal: usize,
+    pub(super) column: String,
+    pub(super) source_type: String,
+}
+
+/// Check the layout that will decode this table's row images against the
+/// column types the `TableMap` event itself carries.
+///
+/// [`adopt_current_layout`] re-reads `information_schema`, which reports the
+/// table's shape *now* — not its shape at the event being decoded. Under
+/// replication lag the source can apply a second, same-column-count `ALTER`
+/// (a reorder or a rename swap) before Spice reaches the first one, so the
+/// adopted layout maps ordinals that the row images in flight do not use, and
+/// values land in the wrong columns with nothing to fail on. The `TableMap`
+/// event is the one description of the row image that travels *with* it, so it
+/// is the authority here.
+///
+/// Returns the first position whose class disagrees, or `None` when the layout
+/// is consistent with the event (including when nothing could be compared
+/// confidently).
+pub(super) fn layout_event_mismatch(
+    layout: &TableLayout,
+    tme: &TableMapEvent<'_>,
+) -> Option<LayoutEventMismatch> {
+    // `get_column_type` resolves the real type behind `MYSQL_TYPE_STRING`. An
+    // out-of-range index, or a type this server build encodes in a way the
+    // client doesn't recognize, yields nothing to compare — not a mismatch.
+    layout_mismatch_against(layout, |ordinal| {
+        tme.get_column_type(ordinal).ok().flatten()
+    })
+}
+
+/// [`layout_event_mismatch`] over any source of per-ordinal column types.
+fn layout_mismatch_against(
+    layout: &TableLayout,
+    event_type: impl Fn(usize) -> Option<ColumnType>,
+) -> Option<LayoutEventMismatch> {
+    layout
+        .columns
+        .iter()
+        .enumerate()
+        .find_map(|(ordinal, column)| {
+            let source_class = source_type_class(&column.column_type)?;
+            let event_class = event_type(ordinal).and_then(event_type_class)?;
+            (source_class != event_class).then(|| LayoutEventMismatch {
+                ordinal,
+                column: column.name.clone(),
+                source_type: column.column_type.clone(),
+            })
+        })
+}
+
 pub(super) fn purged_position_error(resume: &BinlogPosition, dataset_name: &str) -> StreamError {
     StreamError::External(format!(
         "mysql binlog for {dataset_name}: the source no longer has binlog position {resume} \
@@ -620,6 +772,200 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::mysql_replication::setup::SourceColumn;
+
+    /// A layout of `(name, COLUMN_TYPE)` columns in ordinal order.
+    fn layout_of(columns: &[(&str, &str)]) -> TableLayout {
+        TableLayout {
+            columns: columns
+                .iter()
+                .map(|(name, column_type)| SourceColumn {
+                    name: (*name).to_string(),
+                    column_type: (*column_type).to_string(),
+                    enum_variants: None,
+                    set_variants: None,
+                    is_primary_key: false,
+                })
+                .collect(),
+        }
+    }
+
+    fn mismatch_against(
+        columns: &[(&str, &str)],
+        event: &[Option<ColumnType>],
+    ) -> Option<LayoutEventMismatch> {
+        layout_mismatch_against(&layout_of(columns), |ordinal| {
+            event.get(ordinal).copied().flatten()
+        })
+    }
+
+    #[test]
+    fn layout_agreeing_with_the_event_is_not_a_mismatch() {
+        assert_eq!(
+            mismatch_against(
+                &[("id", "int(11)"), ("name", "varchar(255)")],
+                &[
+                    Some(ColumnType::MYSQL_TYPE_LONG),
+                    Some(ColumnType::MYSQL_TYPE_VARCHAR),
+                ],
+            ),
+            None
+        );
+    }
+
+    /// The #11764 scramble: two same-column-count ALTERs land while replication
+    /// is behind, so the layout read for the first one is really the layout
+    /// after the second — here `(id int, name varchar)` reordered to
+    /// `(name varchar, id int)`. The row images in flight still use the old
+    /// order, so this must be caught rather than decoded.
+    #[test]
+    fn a_reorder_read_ahead_of_the_event_is_a_mismatch() {
+        let mismatch = mismatch_against(
+            &[("name", "varchar(255)"), ("id", "int(11)")],
+            &[
+                Some(ColumnType::MYSQL_TYPE_LONG),
+                Some(ColumnType::MYSQL_TYPE_VARCHAR),
+            ],
+        )
+        .expect("a reordered layout must not decode against the old row image");
+        assert_eq!(mismatch.ordinal, 0);
+        assert_eq!(mismatch.column, "name");
+        assert_eq!(mismatch.source_type, "varchar(255)");
+    }
+
+    /// The first disagreeing position is reported, not a later one.
+    #[test]
+    fn the_reported_mismatch_is_the_first_disagreeing_column() {
+        let mismatch = mismatch_against(
+            &[("a", "int"), ("b", "bigint"), ("c", "int")],
+            &[
+                Some(ColumnType::MYSQL_TYPE_LONG),
+                Some(ColumnType::MYSQL_TYPE_LONG),
+                Some(ColumnType::MYSQL_TYPE_LONG),
+            ],
+        )
+        .expect("bigint at position 1 disagrees with a 4-byte int");
+        assert_eq!(mismatch.ordinal, 1);
+        assert_eq!(mismatch.column, "b");
+    }
+
+    /// Widths within the integer family are distinct classes — a swap between
+    /// two integer columns of different widths still scrambles values.
+    #[test]
+    fn integer_widths_are_distinguished() {
+        for (declared, event) in [
+            ("tinyint(4)", ColumnType::MYSQL_TYPE_SHORT),
+            ("smallint(6)", ColumnType::MYSQL_TYPE_INT24),
+            ("mediumint(9)", ColumnType::MYSQL_TYPE_LONG),
+            ("bigint(20)", ColumnType::MYSQL_TYPE_LONG),
+        ] {
+            assert!(
+                mismatch_against(&[("n", declared)], &[Some(event)]).is_some(),
+                "{declared} must not be accepted against {event:?}"
+            );
+        }
+    }
+
+    /// A column the event says nothing usable about is skipped, not flagged —
+    /// the check only ever fails on a disagreement it is sure of.
+    #[test]
+    fn an_unreadable_event_type_is_skipped() {
+        assert_eq!(
+            mismatch_against(&[("id", "int(11)")], &[None]),
+            None,
+            "no event type to compare against is not a mismatch"
+        );
+        assert_eq!(
+            mismatch_against(&[("id", "int(11)")], &[]),
+            None,
+            "an out-of-range ordinal is not a mismatch"
+        );
+    }
+
+    /// Types whose wire encoding depends on the server version or the column's
+    /// charset are deliberately unmapped, so they can never produce a false
+    /// positive on a healthy stream. Guards the conservatism of the mapping.
+    #[test]
+    fn version_dependent_types_are_not_compared() {
+        for declared in [
+            "datetime(6)",
+            "timestamp",
+            "time(3)",
+            "text",
+            "longblob",
+            "tinytext",
+            "real",
+        ] {
+            assert_eq!(
+                source_type_class(declared),
+                None,
+                "{declared} must stay unmapped: its wire type is not pinned by the declared type"
+            );
+            // ...and therefore never reports a mismatch, whatever the event says.
+            assert_eq!(
+                mismatch_against(&[("c", declared)], &[Some(ColumnType::MYSQL_TYPE_LONG)]),
+                None
+            );
+        }
+    }
+
+    /// `CHAR`/`VARCHAR`/`BINARY`/`ENUM`/`SET` share one class: which wire type
+    /// the server picks within the family depends on charset and metadata, so
+    /// distinguishing them would fail healthy streams.
+    #[test]
+    fn the_string_family_is_one_class() {
+        for declared in [
+            "char(8)",
+            "varchar(64)",
+            "binary(16)",
+            "varbinary(16)",
+            "enum('a','b')",
+            "set('a','b')",
+        ] {
+            for event in [
+                ColumnType::MYSQL_TYPE_STRING,
+                ColumnType::MYSQL_TYPE_VARCHAR,
+                ColumnType::MYSQL_TYPE_VAR_STRING,
+                ColumnType::MYSQL_TYPE_ENUM,
+                ColumnType::MYSQL_TYPE_SET,
+            ] {
+                assert_eq!(
+                    mismatch_against(&[("c", declared)], &[Some(event)]),
+                    None,
+                    "{declared} vs {event:?} must not be reported"
+                );
+            }
+        }
+        // But a string column against a numeric event still is a mismatch.
+        assert!(
+            mismatch_against(
+                &[("c", "varchar(64)")],
+                &[Some(ColumnType::MYSQL_TYPE_LONG)]
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn source_types_are_parsed_from_their_base_name() {
+        assert_eq!(
+            source_type_class("int(10) unsigned zerofill"),
+            Some(BinlogTypeClass::Int32)
+        );
+        assert_eq!(
+            source_type_class("DECIMAL(10,2)"),
+            Some(BinlogTypeClass::Decimal)
+        );
+        assert_eq!(
+            source_type_class("numeric(5,0)"),
+            Some(BinlogTypeClass::Decimal)
+        );
+        assert_eq!(
+            source_type_class("bigint unsigned"),
+            Some(BinlogTypeClass::Int64)
+        );
+        assert_eq!(source_type_class(""), None);
+    }
 
     #[test]
     fn pk_source_indexes_follow_a_remapped_layout() {

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -73,8 +73,13 @@ limitations under the License.
 //! not classify) is adopted only if the freshly-fetched source layout matches
 //! the event's column count ([`super::binlog::adopt_current_layout`]), else
 //! member-fatal; the count-match guard makes replaying pre-change row images
-//! self-fatal rather than mis-decoded. A durable pre-adopt/replay-boundary
-//! checkpoint machinery is intentionally *not* implemented in v1. Instead,
+//! self-fatal rather than mis-decoded. Because a fetched layout describes the
+//! source *now* rather than the event being decoded, every routed `TableMap` is
+//! additionally checked against the column types the event itself carries
+//! ([`super::binlog::layout_event_mismatch`]), which is what catches a
+//! same-column-count reorder adopted from ahead of the stream. A durable
+//! pre-adopt/replay-boundary checkpoint machinery is intentionally *not*
+//! implemented in v1. Instead,
 //! safety across a detach/rejoin is guaranteed structurally: every (re)subscribe
 //! re-resolves the start position from the member's own sidecar and re-checks
 //! its persisted layout fingerprint against the current source layout, so a
@@ -102,8 +107,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use super::binlog::{
     AdoptedLayout, MIN_VALID_EVENT_POS, QueryKind, StatementKind, adopt_current_layout,
     classify_query, classify_statement, commit_ts_ms, compute_pk_source_indexes,
-    log_transient_reconnect, open_binlog_stream, purged_position_error, readiness_heartbeat,
-    record_watermark,
+    layout_event_mismatch, log_transient_reconnect, open_binlog_stream, purged_position_error,
+    readiness_heartbeat, record_watermark,
 };
 use super::changes::{MemberLayout, MysqlChangeRows};
 use super::config::{BinlogPosition, ReplicationParams};
@@ -1586,6 +1591,21 @@ async fn run_pump(source: Arc<SharedSource>) {
                         let g = lock(&member.layout);
                         Arc::clone(&g)
                     };
+                    // Every decode is routed from here, so this is the one place
+                    // that can check the layout against the event describing the
+                    // row images it will decode. A layout adopted from
+                    // `information_schema` reflects the source *now*, which under
+                    // lag can be a later DDL than the events in flight (#11764);
+                    // fail this member closed rather than scramble its columns.
+                    if let Some(mismatch) = layout_event_mismatch(&layout.layout, &tme) {
+                        member.metrics.inc_schema_mismatch_error();
+                        routes.remove(&table_id);
+                        member_fatal(&source, &mkey, format!(
+                            "source table {}.{} does not match the shape of the changes being replicated: column {} (position {}) is `{}` in the table definition but the change events carry a different type there. This happens when the source applies more than one ALTER TABLE while replication is behind, so the table definition read for the first one already reflects the second. Let replication catch up before the next schema change, then re-bootstrap by setting `mysql_replication_invalid_checkpoint_behavior: restart`.",
+                            mkey.0, mkey.1, mismatch.column, mismatch.ordinal, mismatch.source_type
+                        )).await;
+                        continue 'recv;
+                    }
                     let tme = Arc::new(tme.into_owned());
                     routes.insert(
                         table_id,


### PR DESCRIPTION
Fixes #11764

## Summary (root cause)

A compatible mid-stream `ALTER` is adopted by `adopt_current_layout`, which re-reads `information_schema`. That describes the source table **as it is now**, not as it was at the event being decoded.

While replication is behind, the source can apply a second same-column-count `ALTER` — a reorder (`MODIFY ... FIRST/AFTER`) or a rename swap — before Spice reaches the first one. The layout adopted for `ALTER₁` is then really the layout after `ALTER₂`, and it maps ordinals that the row images still in flight do not use. Values land in the wrong columns and **nothing fails**: the column counts agree, every name still resolves, and the types still convert. The durable fingerprint then advances to the final layout, so a restart sees a "compatible" table and the already-scrambled rows stand.

Count-changing composites already fail closed (the `TableMap` count guard), and name-breaking ones fail in `column_map`. What slipped through silently was exactly the same-count ordinal shuffle.

## Changes

The `TableMap` event is the one description of the row image that travels **with** it, so it is the authority on what the in-flight rows look like.

- `layout_event_mismatch` compares the layout that will decode a table's row images against the column types the `TableMap` event itself carries.
- It is called at the point every decode is routed from, so it gates both adopt paths (the `ALTER TABLE` statement path and the `TableMap` column-count path) and any other drift between the in-memory layout and the events. A disagreement is member-fatal — that one dataset detaches with an actionable error, the rest of the shared dump keeps running.
- The comparison is deliberately coarse, because this gate runs on every routed `TableMap` and a false positive would break a healthy stream — strictly worse than the rare scramble it detects:
  - `DATETIME`/`TIMESTAMP`/`TIME` (the `*2` variants since 5.6), `TEXT`/`BLOB` (all sent as `MYSQL_TYPE_BLOB`, distinguished only by a metadata length byte) and `REAL` (`REAL_AS_FLOAT` sql_mode) are **not compared at all**.
  - `CHAR`/`VARCHAR`/`BINARY`/`VARBINARY`/`ENUM`/`SET` are **one class**, since which wire type the server picks inside that family depends on charset and on the `MYSQL_TYPE_STRING` metadata.
  - Anything unmapped, out of range, or unrecognized is skipped rather than flagged.

  What remains is decisive: a reorder that moves columns of genuinely different types (int↔varchar, int↔bigint, decimal↔int).

This detects and fails rather than attempting event-time schema binding, per the direction in the issue discussion.

### Scope

The sibling Postgres CDC path is not affected: it reconciles against the in-stream `Relation` message, which travels with the events and is therefore already event-time correct. The MySQL resume path is separately guarded by the layout fingerprint check.

## Test plan

- 8 new unit tests in `mysql_replication::binlog` covering the reorder that motivated the issue, first-disagreement reporting, integer-width distinction, the skip-when-unreadable path, and two tests that pin the conservatism of the mapping (version-dependent types stay unmapped; the string family stays one class).
- The four detection tests were verified to **fail** with the comparison neutered to its pre-fix behavior, and pass with it restored.
- `make lint`
- `make test`

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] Both CI clippy passes (`--lib --bins`, then `--tests`) and `cargo fmt --check` clean
- [x] No new `.unwrap()`/`.expect()` in production code
- [x] Error message names the dataset/table and gives an actionable fix
- [x] Bug class checked across sibling connectors