### PR TITLE
fix(accelerator): let an index declare a finalize failure fatal so a stale index can't report a successful refresh (fixes #12038)

### DIFF
--- a/crates/runtime-datafusion-index/src/lib.rs
+++ b/crates/runtime-datafusion-index/src/lib.rs
@@ -78,5 +78,19 @@ pub trait Index: Debug + Send + Sync + 'static {
         Ok(())
     }
 
+    /// Whether a failure in [`Index::on_write_complete`] must fail the write.
+    ///
+    /// Defaults to `false` (best-effort), matching indexes whose finalize step has
+    /// `IF NOT EXISTS` semantics and is simply redone on the next refresh. An index
+    /// that finalizes durable state the written data depends on returns `true`: for
+    /// those, a failed finalize leaves the index stale while the write reports
+    /// success, so the sink reports the write as failed instead.
+    ///
+    /// Wrapper implementations MUST forward this to the index they wrap — inheriting
+    /// the default silently downgrades a fatal inner index to best-effort.
+    fn write_complete_failure_is_fatal(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> &dyn Any;
 }

--- a/crates/runtime/src/accelerated_table/sink/mod.rs
+++ b/crates/runtime/src/accelerated_table/sink/mod.rs
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 use datafusion::{
-    catalog::TableProvider, logical_expr::dml::InsertOp, physical_plan::RecordBatchStream,
+    catalog::TableProvider, error::DataFusionError, logical_expr::dml::InsertOp,
+    physical_plan::RecordBatchStream,
 };
 use multi::MultiSink;
 use runtime_datafusion_index::Index;
@@ -80,5 +81,250 @@ impl AccelerationSink {
             AccelerationSink::Table(sink) => sink.insert_into(record_batch_stream, overwrite).await,
             AccelerationSink::Multi(sink) => sink.insert_into(record_batch_stream, overwrite).await,
         }
+    }
+}
+
+/// Runs [`Index::on_write_complete`] for every index after a successful write, and
+/// reports the first failure from an index that declares a finalize failure fatal.
+///
+/// Every index is finalized even once one has failed — stopping early would leave
+/// more indexes stale than the failure requires. A failure on an index with
+/// [`Index::write_complete_failure_is_fatal`] unset is best-effort: it is logged and
+/// the write still succeeds, because that index rebuilds on the next refresh. A fatal
+/// one fails the write, since reporting success would let the index serve stale or
+/// missing results for data the caller believes was indexed.
+pub(crate) async fn finalize_indexes<'a>(
+    sink: &str,
+    indexes: impl Iterator<Item = &'a Arc<dyn Index + Send + Sync>>,
+) -> Result<(), DataFusionError> {
+    let mut fatal: Option<DataFusionError> = None;
+
+    for index in indexes {
+        tracing::debug!(
+            "{sink}: running on_write_complete for index '{}'",
+            index.name()
+        );
+        let Err(e) = index.on_write_complete().await else {
+            continue;
+        };
+
+        if index.write_complete_failure_is_fatal() {
+            tracing::error!(
+                "{sink}: on_write_complete failed for index '{}': {e}. Failing the write - the index would otherwise be left stale while the write reported success.",
+                index.name()
+            );
+            // Carry the index name in the message rather than wrapping in
+            // `DataFusionError::Context`: `find_datafusion_root` unwraps `Context` and
+            // discards its description, so the name would never reach the caller.
+            fatal.get_or_insert_with(|| {
+                DataFusionError::Execution(format!(
+                    "Failed to finalize index '{}' after writing: {e}. The write was rejected because the index would otherwise be left stale.",
+                    index.name()
+                ))
+            });
+        } else {
+            tracing::warn!(
+                "{sink}: on_write_complete failed for index '{}': {e}. Index may be stale until next refresh.",
+                index.name()
+            );
+        }
+    }
+
+    fatal.map_or(Ok(()), Err)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        any::Any,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use crate::datafusion::error::find_datafusion_root;
+    use datafusion::error::{DataFusionError, Result as DataFusionResult};
+
+    use super::{Arc, Index, finalize_indexes};
+
+    /// An [`Index`] whose finalize outcome and fatality are configurable, recording how
+    /// many times it was finalized.
+    #[derive(Debug)]
+    struct FinalizeIndex {
+        name: &'static str,
+        fails: bool,
+        fatal: bool,
+        finalize_calls: AtomicUsize,
+    }
+
+    impl FinalizeIndex {
+        fn new(name: &'static str, fails: bool, fatal: bool) -> Arc<Self> {
+            Arc::new(Self {
+                name,
+                fails,
+                fatal,
+                finalize_calls: AtomicUsize::new(0),
+            })
+        }
+
+        fn finalize_calls(&self) -> usize {
+            self.finalize_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Index for FinalizeIndex {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        fn required_columns(&self) -> Vec<String> {
+            vec![]
+        }
+
+        async fn on_write_complete(&self) -> DataFusionResult<()> {
+            self.finalize_calls.fetch_add(1, Ordering::SeqCst);
+            if self.fails {
+                return Err(DataFusionError::Execution(format!(
+                    "{} could not finalize",
+                    self.name
+                )));
+            }
+            Ok(())
+        }
+
+        fn write_complete_failure_is_fatal(&self) -> bool {
+            self.fatal
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    fn erase(indexes: &[Arc<FinalizeIndex>]) -> Vec<Arc<dyn Index + Send + Sync>> {
+        indexes
+            .iter()
+            .map(|i| Arc::clone(i) as Arc<dyn Index + Send + Sync>)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn every_index_finalizes_when_none_fail() {
+        let indexes = vec![
+            FinalizeIndex::new("a", false, false),
+            FinalizeIndex::new("b", false, true),
+        ];
+        let erased = erase(&indexes);
+
+        finalize_indexes("TestSink", erased.iter())
+            .await
+            .expect("no index failed to finalize");
+
+        for index in &indexes {
+            assert_eq!(index.finalize_calls(), 1, "index '{}'", index.name);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_non_fatal_finalize_failure_leaves_the_write_successful() {
+        let indexes = vec![FinalizeIndex::new("best_effort", true, false)];
+        let erased = erase(&indexes);
+
+        finalize_indexes("TestSink", erased.iter())
+            .await
+            .expect("a best-effort finalize failure must not fail the write");
+        assert_eq!(indexes[0].finalize_calls(), 1);
+    }
+
+    /// Regression test for #12038: a fatal finalize failure must fail the write rather
+    /// than let a stale index report a successful refresh.
+    #[tokio::test]
+    async fn a_fatal_finalize_failure_fails_the_write() {
+        let indexes = vec![FinalizeIndex::new("full_text", true, true)];
+        let erased = erase(&indexes);
+
+        let err = finalize_indexes("TestSink", erased.iter())
+            .await
+            .expect_err("a fatal finalize failure must fail the write");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("Failed to finalize index 'full_text'"),
+            "error should name the index that failed: {message}"
+        );
+        assert!(
+            message.contains("full_text could not finalize"),
+            "error should keep the index's own message: {message}"
+        );
+    }
+
+    /// The reported error must survive `find_datafusion_root`, which the sinks apply via
+    /// `retry_from_df_error` — a `DataFusionError::Context` wrapper would have its
+    /// description discarded there, losing the index name before the caller sees it.
+    #[tokio::test]
+    async fn the_reported_error_keeps_the_index_name_through_find_datafusion_root() {
+        let indexes = vec![FinalizeIndex::new("full_text", true, true)];
+        let erased = erase(&indexes);
+
+        let err = finalize_indexes("TestSink", erased.iter())
+            .await
+            .expect_err("a fatal finalize failure must fail the write");
+
+        let rooted = find_datafusion_root(err).to_string();
+        assert!(
+            rooted.contains("Failed to finalize index 'full_text'"),
+            "the index name must survive root-cause unwrapping: {rooted}"
+        );
+    }
+
+    /// A fatal failure must not short-circuit the loop: the indexes after it still need
+    /// their finalize, or the failure leaves more indexes stale than it has to.
+    #[tokio::test]
+    async fn a_fatal_failure_still_finalizes_the_remaining_indexes() {
+        let indexes = vec![
+            FinalizeIndex::new("fatal_first", true, true),
+            FinalizeIndex::new("best_effort", true, false),
+            FinalizeIndex::new("healthy", false, false),
+        ];
+        let erased = erase(&indexes);
+
+        finalize_indexes("TestSink", erased.iter())
+            .await
+            .expect_err("a fatal finalize failure must fail the write");
+
+        for index in &indexes {
+            assert_eq!(index.finalize_calls(), 1, "index '{}'", index.name);
+        }
+    }
+
+    #[tokio::test]
+    async fn the_first_fatal_failure_is_the_reported_one() {
+        let indexes = vec![
+            FinalizeIndex::new("best_effort", true, false),
+            FinalizeIndex::new("fatal_first", true, true),
+            FinalizeIndex::new("fatal_second", true, true),
+        ];
+        let erased = erase(&indexes);
+
+        let err = finalize_indexes("TestSink", erased.iter())
+            .await
+            .expect_err("a fatal finalize failure must fail the write");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("fatal_first"),
+            "the first fatal failure should be reported: {message}"
+        );
+        assert!(
+            !message.contains("fatal_second"),
+            "a later fatal failure must not replace the first: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_indexes_is_a_successful_finalize() {
+        let erased: Vec<Arc<dyn Index + Send + Sync>> = vec![];
+        finalize_indexes("TestSink", erased.iter())
+            .await
+            .expect("an empty index set cannot fail");
     }
 }

--- a/crates/runtime/src/accelerated_table/sink/multi.rs
+++ b/crates/runtime/src/accelerated_table/sink/multi.rs
@@ -40,7 +40,10 @@ use data_components::index_maintenance::perform_index_maintenance;
 use runtime_datafusion_index::Index;
 
 use crate::{
-    accelerated_table::{refresh_task::retry_from_df_error, synchronized_table::SynchronizedTable},
+    accelerated_table::{
+        refresh_task::retry_from_df_error, sink::finalize_indexes,
+        synchronized_table::SynchronizedTable,
+    },
     datafusion::error::find_datafusion_root,
     dataupdate::StreamingDataUpdateExecutionPlan,
 };
@@ -252,18 +255,9 @@ impl MultiSink {
         }
 
         // Run on_write_complete for all sink_indexes.
-        for index in &self.sink_indexes {
-            tracing::debug!(
-                "MultiSink: running on_write_complete for index '{}'",
-                index.name()
-            );
-            if let Err(e) = index.on_write_complete().await {
-                tracing::warn!(
-                    "MultiSink: on_write_complete failed for index '{}': {e}. Index may be stale until next refresh.",
-                    index.name()
-                );
-            }
-        }
+        finalize_indexes("MultiSink", self.sink_indexes.iter())
+            .await
+            .map_err(retry_from_df_error)?;
 
         Ok(())
     }

--- a/crates/runtime/src/accelerated_table/sink/table.rs
+++ b/crates/runtime/src/accelerated_table/sink/table.rs
@@ -30,8 +30,10 @@ use runtime_table_partition::provider::PartitionTableProvider;
 use util::RetryError;
 
 use crate::{
-    accelerated_table::refresh_task::retry_from_df_error, datafusion::error::find_datafusion_root,
-    dataupdate::StreamingDataUpdateExecutionPlan, schema_evolution::SCHEMA_EVOLUTION_DETECTED,
+    accelerated_table::{refresh_task::retry_from_df_error, sink::finalize_indexes},
+    datafusion::error::find_datafusion_root,
+    dataupdate::StreamingDataUpdateExecutionPlan,
+    schema_evolution::SCHEMA_EVOLUTION_DETECTED,
 };
 
 /// Returns the (dropped columns, narrowed columns) that casting `input_schema` to
@@ -250,18 +252,14 @@ impl TableSink {
             .flat_map(IndexedTableProvider::get_all_indexes)
             .collect();
 
-        for index in provider_indexes_after
-            .iter()
-            .chain(self.sink_indexes.iter())
-        {
-            tracing::debug!("Running on_write_complete for index '{}'", index.name());
-            if let Err(e) = index.on_write_complete().await {
-                tracing::warn!(
-                    "TableSink: on_write_complete failed for index '{}': {e}. Index may be stale until next refresh.",
-                    index.name()
-                );
-            }
-        }
+        finalize_indexes(
+            "TableSink",
+            provider_indexes_after
+                .iter()
+                .chain(self.sink_indexes.iter()),
+        )
+        .await
+        .map_err(retry_from_df_error)?;
 
         tracing::debug!(
             "TableSink::insert_into completed in {:.2}s (collect phase: {:.2}s)",

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -95,6 +95,14 @@ impl Index for FullTextDatabaseIndex {
         }
         Ok(batches)
     }
+
+    fn write_complete_failure_is_fatal(&self) -> bool {
+        // Documents are only searchable once the tantivy writer commits them, and
+        // staged-but-uncommitted documents are discarded. A finalize that fails to
+        // commit therefore drops the write's documents while the underlying rows are
+        // already visible, so the write must not report success.
+        true
+    }
 }
 
 impl FullTextDatabaseIndex {

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -99,6 +99,10 @@ impl Index for ChunkedSearchIndex {
         self.inner.on_write_complete().await
     }
 
+    fn write_complete_failure_is_fatal(&self) -> bool {
+        self.inner.write_complete_failure_is_fatal()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -765,6 +769,10 @@ impl Index for ChunkedVectorIndex {
         self.inner.on_write_complete().await
     }
 
+    fn write_complete_failure_is_fatal(&self) -> bool {
+        self.inner.write_complete_failure_is_fatal()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -1019,6 +1027,8 @@ mod tests {
         search_column: String,
         calls: AtomicUsize,
         row_counts: std::sync::Mutex<Vec<usize>>,
+        /// What this mock reports from [`Index::write_complete_failure_is_fatal`].
+        write_complete_fatal: bool,
     }
 
     impl RecordingInner {
@@ -1027,6 +1037,14 @@ mod tests {
                 search_column: search_column.to_string(),
                 calls: AtomicUsize::new(0),
                 row_counts: std::sync::Mutex::new(Vec::new()),
+                write_complete_fatal: false,
+            }
+        }
+
+        fn with_fatal_write_complete(search_column: &str) -> Self {
+            Self {
+                write_complete_fatal: true,
+                ..Self::new(search_column)
             }
         }
     }
@@ -1039,8 +1057,24 @@ mod tests {
         fn required_columns(&self) -> Vec<String> {
             vec![self.search_column.clone()]
         }
+        fn write_complete_failure_is_fatal(&self) -> bool {
+            self.write_complete_fatal
+        }
         fn as_any(&self) -> &dyn Any {
             self
+        }
+    }
+
+    #[async_trait]
+    impl VectorIndex for RecordingInner {
+        fn list_table_provider(&self) -> Result<LogicalPlan, DataFusionError> {
+            Err(DataFusionError::NotImplemented(
+                "RecordingInner stores embeddings in the underlying table".to_string(),
+            ))
+        }
+
+        fn dimension(&self) -> i32 {
+            4
         }
     }
 
@@ -1134,6 +1168,43 @@ mod tests {
             ],
         )
         .expect("valid batch")
+    }
+
+    /// The chunking layer must not downgrade a fatal inner index to best-effort — a
+    /// wrapper inheriting the trait default is exactly the silent no-op #12038 fixes.
+    #[test]
+    fn chunked_search_index_forwards_write_complete_fatality() {
+        let chunker = || Arc::new(DelimChunker { delim: ' ' }) as Arc<dyn Chunker>;
+
+        let best_effort = ChunkedSearchIndex::new(
+            Arc::new(RecordingInner::new("content")) as Arc<dyn SearchIndex>,
+            chunker(),
+        );
+        assert!(!best_effort.write_complete_failure_is_fatal());
+
+        let fatal = ChunkedSearchIndex::new(
+            Arc::new(RecordingInner::with_fatal_write_complete("content")) as Arc<dyn SearchIndex>,
+            chunker(),
+        );
+        assert!(fatal.write_complete_failure_is_fatal());
+    }
+
+    #[test]
+    fn chunked_vector_index_forwards_write_complete_fatality() {
+        let chunker = || Arc::new(DelimChunker { delim: ' ' }) as Arc<dyn Chunker>;
+
+        let best_effort = ChunkedVectorIndex {
+            inner: Arc::new(RecordingInner::new("content")) as Arc<dyn VectorIndex>,
+            chunker: chunker(),
+        };
+        assert!(!best_effort.write_complete_failure_is_fatal());
+
+        let fatal = ChunkedVectorIndex {
+            inner: Arc::new(RecordingInner::with_fatal_write_complete("content"))
+                as Arc<dyn VectorIndex>,
+            chunker: chunker(),
+        };
+        assert!(fatal.write_complete_failure_is_fatal());
     }
 
     /// Smoke test: a tiny input that fits comfortably under the budget should result in exactly

--- a/crates/search/src/index/compound/search_index.rs
+++ b/crates/search/src/index/compound/search_index.rs
@@ -106,6 +106,12 @@ impl Index for CompoundSearchIndex {
         primary_result.and(secondary_result)
     }
 
+    fn write_complete_failure_is_fatal(&self) -> bool {
+        // Either half failing to finalize leaves this compound index stale.
+        self.primary.write_complete_failure_is_fatal()
+            || self.secondary.write_complete_failure_is_fatal()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/crates/search/src/index/compound/tests.rs
+++ b/crates/search/src/index/compound/tests.rs
@@ -53,6 +53,8 @@ struct MockIndex {
     write_output_rows: Option<usize>,
     fail_write: bool,
     fail_on_write_start: bool,
+    /// What this mock reports from `Index::write_complete_failure_is_fatal`.
+    write_complete_fatal: bool,
     events: Arc<Mutex<Vec<String>>>,
 }
 
@@ -69,6 +71,7 @@ impl MockIndex {
             write_output_rows: None,
             fail_write: false,
             fail_on_write_start: false,
+            write_complete_fatal: false,
             events: Arc::clone(events),
         }
     }
@@ -161,6 +164,10 @@ impl Index for MockIndex {
     async fn on_write_complete(&self) -> Result<(), DataFusionError> {
         self.record("on_write_complete");
         Ok(())
+    }
+
+    fn write_complete_failure_is_fatal(&self) -> bool {
+        self.write_complete_fatal
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -488,6 +495,64 @@ async fn lifecycle_hooks_forward_to_both_indexes() {
                 "missing {side}:{event} in {events:?}"
             );
         }
+    }
+}
+
+/// A compound index is stale if *either* half fails to finalize, so the fatality flag
+/// must be the union of both halves rather than the trait default (#12038).
+#[test]
+fn write_complete_fatality_is_the_union_of_both_search_halves() {
+    let events = Arc::new(Mutex::new(vec![]));
+
+    for (primary_fatal, secondary_fatal, expected) in [
+        (false, false, false),
+        (true, false, true),
+        (false, true, true),
+        (true, true, true),
+    ] {
+        let mut primary = MockIndex::new("primary", &events);
+        primary.write_complete_fatal = primary_fatal;
+        let mut secondary = MockIndex::new("secondary", &events);
+        secondary.write_complete_fatal = secondary_fatal;
+
+        let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
+        assert_eq!(
+            idx.write_complete_failure_is_fatal(),
+            expected,
+            "primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
+        );
+    }
+}
+
+#[test]
+fn write_complete_fatality_is_the_union_of_both_vector_halves() {
+    let events = Arc::new(Mutex::new(vec![]));
+
+    for (primary_fatal, secondary_fatal, expected) in [
+        (false, false, false),
+        (true, false, true),
+        (false, true, true),
+        (true, true, true),
+    ] {
+        let mut primary = MockIndex::new("primary", &events);
+        primary.dimension = Some(4);
+        primary.write_complete_fatal = primary_fatal;
+        let mut secondary = MockIndex::new("secondary", &events);
+        secondary.dimension = Some(4);
+        secondary.write_complete_fatal = secondary_fatal;
+
+        let idx = CompoundVectorIndex::try_new(
+            Arc::new(primary) as Arc<dyn VectorIndex>,
+            Arc::new(secondary) as Arc<dyn VectorIndex>,
+            CompoundReadMode::PrimaryOnly,
+        )
+        .expect("compatible vector indexes");
+
+        assert_eq!(
+            idx.write_complete_failure_is_fatal(),
+            expected,
+            "primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
+        );
     }
 }
 

--- a/crates/search/src/index/compound/vector_index.rs
+++ b/crates/search/src/index/compound/vector_index.rs
@@ -150,6 +150,12 @@ impl Index for CompoundVectorIndex {
         primary_result.and(secondary_result)
     }
 
+    fn write_complete_failure_is_fatal(&self) -> bool {
+        // Either half failing to finalize leaves this compound index stale.
+        self.primary.write_complete_failure_is_fatal()
+            || self.secondary.write_complete_failure_is_fatal()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }


### PR DESCRIPTION
## Summary

`TableSink` and `MultiSink` treated every `Index::on_write_complete` failure as best-effort — log a warning, let the write report success. For an index whose finalize step publishes durable state the written data depends on, that leaves the index **stale while the refresh or append reports success**, and search then serves results that silently omit the whole write with no error reaching the caller.

The root cause is that the finalize hook had no way to say whether its failure mattered. Creating an index with `IF NOT EXISTS` semantics genuinely is best-effort — the next refresh redoes it — but a finalize that *publishes* the write is not, and both went down the same warn-and-continue path, duplicated in two sinks.

## Changes

- **`Index::write_complete_failure_is_fatal()`** — new capability method defaulting to `false` (today's behavior, so nothing changes for an index that doesn't opt in). Its doc comment states the wrapper-forwarding requirement.
- **`finalize_indexes()`** in `accelerated_table::sink` — one implementation, now shared by `TableSink` and `MultiSink` in place of two copies of the same loop. It finalizes **every** index even after one has failed (stopping early would leave more indexes stale than the failure requires), logs non-fatal failures exactly as before, and returns the **first** fatal failure, wrapped with the failing index's name, so the sink reports the write as failed.
- **Wrapper forwarding** for all four wrapper indexes: `ChunkedSearchIndex` / `ChunkedVectorIndex` delegate to their inner index; `CompoundSearchIndex` / `CompoundVectorIndex` return the union of both halves, since either half failing to finalize leaves the compound index stale. Per the trait-evolution rule in `CLAUDE.md` these are precisely the impls where inheriting the default would silently no-op.
- **`FullTextDatabaseIndex` returns `true`** — its documents only become searchable once the tantivy writer commits, and staged-but-uncommitted documents are discarded.

### Scope decisions worth a reviewer's eye

- **Elasticsearch deliberately keeps the default (`false`).** `ElasticsearchWriteMaintenance::on_write_complete` restores `refresh_interval` and issues `_refresh`/`force_merge`; the documents were already bulk-written durably per batch, so a failure there delays visibility rather than losing the write, and the next write cycle re-applies the setting. Flagging rather than changing it — say the word and I'll make it fatal too.
- The `on_write_complete` call in `crates/runtime/src/embeddings/index/duckdb.rs` is untouched: it is an init-time index creation outside any write lifecycle, where "not created yet" is the expected outcome, not a stale index.
- On current `trunk`, `FullTextDatabaseIndex` commits per batch inside `compute_index` (a commit failure already aborts the write), so its finalize hook is a no-op and the new flag is not yet load-bearing. #12015 moves that commit into `on_write_complete`, which is what makes it so — this PR supplies the mechanism that change needs.

## Test plan

New unit tests, all failing against the old warn-and-continue behavior:

- `crates/runtime/src/accelerated_table/sink/mod.rs` — six tests over `finalize_indexes`: every index finalized when none fail; a non-fatal failure leaves the write successful; **a fatal failure fails the write** (regression test) and the error names both the index and its own message; a fatal failure still finalizes the indexes after it; the *first* fatal failure is the reported one; an empty index set succeeds.
- `crates/search/src/index/compound/tests.rs` — fatality is the union of both halves, over all four primary/secondary combinations, for both `CompoundSearchIndex` and `CompoundVectorIndex`.
- `crates/search/src/index/chunking.rs` — `ChunkedSearchIndex` and `ChunkedVectorIndex` each forward a fatal inner index rather than inheriting the default.

Verification:

- `make lint`
- `make test`

## Checklist

- [x] Root cause identified and stated
- [x] Regression test that fails on the old code
- [x] Every wrapper impl of the changed trait audited and explicitly forwarding
- [x] Default preserves existing behavior for indexes that don't opt in
- [x] `make lint`
- [x] `make test`

Fixes #12038