### PR TITLE
fix(write-back): gate durable write-back on a safe source delivery primitive (fixes #11915)

### DIFF
--- a/crates/runtime-acceleration/src/acceleration.rs
+++ b/crates/runtime-acceleration/src/acceleration.rs
@@ -444,6 +444,28 @@ impl Acceleration {
         self
     }
 
+    /// Returns whether this configuration resolves to durable federated
+    /// write-back: a Cayenne `write_mode: write_back` dataset that declares an
+    /// `on_conflict` key and is CDC-fed (`refresh_mode: changes`).
+    ///
+    /// Such a dataset marks every committed write's primary keys so a delivery
+    /// worker can reconcile them to the federated source. Delivery mutates the
+    /// source, so the source connector must advertise a delivery primitive that
+    /// cannot lose the write; callers gate on
+    /// `DataConnector::supports_durable_write_back_delivery` and reject the
+    /// dataset at registration otherwise.
+    ///
+    /// This is the single source of truth for the condition: both the
+    /// registration gate and the Cayenne provider that turns the marking on
+    /// call it, so the check and the behavior cannot drift apart.
+    #[must_use]
+    pub fn resolves_to_durable_write_back(&self) -> bool {
+        self.engine == Engine::Cayenne
+            && self.write_mode == spicepod_acceleration::WriteMode::WriteBack
+            && !self.on_conflict.is_empty()
+            && self.refresh_mode == Some(RefreshMode::Changes)
+    }
+
     /// Returns whether Arrow `hash_index` is enabled for primary key upserts or indexes.
     #[must_use]
     pub fn is_hash_index_enabled(&self) -> bool {
@@ -1176,5 +1198,93 @@ mod tests {
         acceleration
             .validate_primary_key(&schema_with(&["marker_id", "value"]))
             .expect("primary key column present, so validation passes");
+    }
+
+    /// The exact configuration that turns durable federated write-back on.
+    fn durable_write_back_acceleration() -> Acceleration {
+        let mut on_conflict = HashMap::new();
+        on_conflict.insert(
+            ColumnReference::try_from("id").expect("valid column reference"),
+            OnConflictBehavior::Upsert(UpsertOptions::default()),
+        );
+        Acceleration {
+            engine: Engine::Cayenne,
+            write_mode: spicepod_acceleration::WriteMode::WriteBack,
+            on_conflict,
+            refresh_mode: Some(RefreshMode::Changes),
+            ..Acceleration::default()
+        }
+    }
+
+    #[test]
+    fn durable_write_back_is_recognized() {
+        assert!(durable_write_back_acceleration().resolves_to_durable_write_back());
+    }
+
+    /// Every conjunct must be load-bearing: if dropping one still reports
+    /// durable write-back, the registration gate would fire on datasets that
+    /// never mark keys (or, worse, stay silent on ones that do).
+    #[test]
+    fn every_condition_is_required_for_durable_write_back() {
+        let not_cayenne = Acceleration {
+            engine: Engine::DuckDB,
+            ..durable_write_back_acceleration()
+        };
+        assert!(
+            !not_cayenne.resolves_to_durable_write_back(),
+            "only the Cayenne provider marks dirty keys for delivery"
+        );
+
+        let not_write_back = Acceleration {
+            write_mode: spicepod_acceleration::WriteMode::WriteThrough,
+            ..durable_write_back_acceleration()
+        };
+        assert!(
+            !not_write_back.resolves_to_durable_write_back(),
+            "write-through commits to the source directly, with no delivery worker"
+        );
+
+        let no_on_conflict = Acceleration {
+            on_conflict: HashMap::new(),
+            ..durable_write_back_acceleration()
+        };
+        assert!(
+            !no_on_conflict.resolves_to_durable_write_back(),
+            "without on_conflict there is no key to reconcile"
+        );
+
+        for refresh_mode in [
+            RefreshMode::Disabled,
+            RefreshMode::Full,
+            RefreshMode::Append,
+            RefreshMode::Caching,
+            RefreshMode::Snapshot,
+        ] {
+            let not_changes = Acceleration {
+                refresh_mode: Some(refresh_mode),
+                ..durable_write_back_acceleration()
+            };
+            assert!(
+                !not_changes.resolves_to_durable_write_back(),
+                "{refresh_mode:?} is not CDC-fed, so no delivery worker runs"
+            );
+        }
+
+        let unset_refresh_mode = Acceleration {
+            refresh_mode: None,
+            ..durable_write_back_acceleration()
+        };
+        assert!(
+            !unset_refresh_mode.resolves_to_durable_write_back(),
+            "an unset refresh_mode is not 'changes'"
+        );
+    }
+
+    #[test]
+    fn a_default_acceleration_is_not_durable_write_back() {
+        assert!(
+            !Acceleration::default().resolves_to_durable_write_back(),
+            "the gate must not fire on ordinary datasets"
+        );
     }
 }

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -67,7 +67,6 @@ use runtime_acceleration::snapshot::{AccelerationEngine, AccelerationLayout};
 use runtime_datafusion_index::{Index, IndexedTableProvider};
 use search::index::native_vector::NativeVectorIndex;
 use spicepod::acceleration as spicepod_acceleration;
-use spicepod::acceleration::WriteMode;
 
 /// Metadata key to identify the accelerator type in the schema metadata.
 const SPICE_ACCELERATOR_METADATA_KEY: &str = "spice.accelerator";
@@ -2072,11 +2071,13 @@ impl CayenneAccelerator {
         // (on_conflict with a non-`changes` refresh forces AcceleratorOnly). When
         // so configured, every committed write durably marks its PKs so the
         // delivery worker reconciles them to the federated source.
-        let durable_write_back = source.acceleration().is_some_and(|acceleration| {
-            acceleration.write_mode == WriteMode::WriteBack
-                && !acceleration.on_conflict.is_empty()
-                && acceleration.refresh_mode == Some(RefreshMode::Changes)
-        });
+        // `resolves_to_durable_write_back` is shared with the registration gate
+        // that requires the source connector to advertise a safe delivery
+        // primitive, so marking can never be switched on for a dataset the gate
+        // would have rejected.
+        let durable_write_back = source
+            .acceleration()
+            .is_some_and(Acceleration::resolves_to_durable_write_back);
 
         // Create CayenneTableProvider with object store for S3 Express One Zone
         let mut builder = CayenneTableProviderBuilder::new(catalog, runtime_env)

--- a/crates/runtime/src/dataconnector/deferred.rs
+++ b/crates/runtime/src/dataconnector/deferred.rs
@@ -93,6 +93,15 @@ impl DataConnector for DeferredConnector {
         false
     }
 
+    // Unlike the stream capabilities above, this is a static property of the
+    // source the deferred dataset will eventually load from, not of the
+    // placeholder — so it forwards, matching `resolve_refresh_mode`. Answering
+    // `false` here would reject a durable-write-back dataset whose real source
+    // is perfectly safe.
+    fn supports_durable_write_back_delivery(&self) -> bool {
+        self.inner.supports_durable_write_back_delivery()
+    }
+
     fn changes_stream(
         &self,
         _federated_table: Arc<crate::federated_table::FederatedTable>,

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -646,6 +646,33 @@ pub trait DataConnector: Debug + Send + Sync + 'static {
         None
     }
 
+    /// Whether this connector can accept durable federated write-back delivery
+    /// without risking the silent loss of a committed write.
+    ///
+    /// Delivery reconciles a committed accelerator row to the source. Emulating
+    /// an upsert as a standalone `DELETE` followed by a separate `INSERT` is
+    /// **not** safe for a CDC-fed accelerator: the two are distinct source
+    /// commits, so the source echoes the `DELETE` back over CDC and erases the
+    /// committed row from the accelerator. If the follow-up `INSERT` then fails,
+    /// the next delivery pass sees the key as absent, treats the delete as
+    /// complete, and clears the marker — the write is gone from both sides with
+    /// no error raised.
+    ///
+    /// Returning `true` therefore asserts that delivery is atomic from the
+    /// source's point of view: either a single transaction covering both legs,
+    /// or a native conditional upsert (`INSERT … ON CONFLICT DO UPDATE`) that
+    /// removes the delete leg entirely for present keys.
+    ///
+    /// Defaults to `false` — the conservative answer. A connector that has not
+    /// been audited for this makes the dataset fail registration with an
+    /// actionable error rather than silently risk losing writes.
+    ///
+    /// **Wrappers must forward this.** Inheriting the default would report a
+    /// perfectly safe inner connector as unsafe and reject a valid dataset.
+    fn supports_durable_write_back_delivery(&self) -> bool {
+        false
+    }
+
     async fn metadata_provider(
         &self,
         _dataset: &Dataset,
@@ -1135,6 +1162,70 @@ mod tests {
         assert!(
             result_two.expect("second factory should exist").is_ok(),
             "second connector should initialize successfully"
+        );
+    }
+
+    /// A source that advertises safe durable write-back delivery, so a wrapper
+    /// that silently inherits the trait default is visible as `false`.
+    #[derive(Debug)]
+    struct SafeDeliveryConnector;
+
+    #[async_trait]
+    impl DataConnector for SafeDeliveryConnector {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        async fn read_provider(
+            &self,
+            _dataset: &Dataset,
+        ) -> DataConnectorResult<Arc<dyn TableProvider>> {
+            unimplemented!("capability-forwarding test never reads")
+        }
+
+        fn supports_durable_write_back_delivery(&self) -> bool {
+            true
+        }
+    }
+
+    /// `supports_durable_write_back_delivery` has a `false` default, so any
+    /// wrapper that forgets to forward it silently reports a safe source as
+    /// unsafe and the registration gate rejects a valid dataset. That is the
+    /// defaulted-no-op wrapper bug (#10460) applied to this capability, and it
+    /// compiles cleanly — only a test catches it.
+    ///
+    /// `ElasticsearchFullTextConnector` forwards the same one-liner but is
+    /// behind the `elasticsearch` feature and needs a params-bearing dataset to
+    /// construct, so it is not exercised here.
+    #[test]
+    fn every_wrapper_forwards_durable_write_back_delivery_support() {
+        let inner: Arc<dyn DataConnector> = Arc::new(SafeDeliveryConnector);
+        assert!(
+            inner.supports_durable_write_back_delivery(),
+            "precondition: the wrapped source advertises safe delivery"
+        );
+
+        let deferred = crate::dataconnector::deferred::DeferredConnector::new(Arc::clone(&inner));
+        assert!(
+            deferred.supports_durable_write_back_delivery(),
+            "DeferredConnector must forward the source's delivery capability"
+        );
+
+        let full_text =
+            crate::search::full_text::connector::FullTextConnector::new(Arc::clone(&inner));
+        assert!(
+            full_text.supports_durable_write_back_delivery(),
+            "FullTextConnector must forward the source's delivery capability"
+        );
+
+        let embedding = crate::embeddings::connector::EmbeddingConnector::new(
+            Arc::clone(&inner),
+            Arc::new(RwLock::new(std::collections::HashMap::new())),
+            Arc::new(RwLock::new(Secrets::default())),
+        );
+        assert!(
+            embedding.supports_durable_write_back_delivery(),
+            "EmbeddingConnector must forward the source's delivery capability"
         );
     }
 }

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -330,6 +330,10 @@ impl DataConnector for EmbeddingConnector {
         self.inner_connector.supports_changes_stream()
     }
 
+    fn supports_durable_write_back_delivery(&self) -> bool {
+        self.inner_connector.supports_durable_write_back_delivery()
+    }
+
     fn changes_stream(
         &self,
         federated_table: Arc<FederatedTable>,

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -23,11 +23,12 @@ use crate::dataaccelerator::spice_sys::caching_engine::CachingEngineSys;
 use crate::init::dataset_initialization::DatasetInitialization;
 use crate::{
     AcceleratedTableInvalidChangesSnafu, AcceleratorEngineNotAvailableSnafu,
-    AcceleratorInitializationFailedSnafu, Error, FullTextSearchRequiresAccelerationSnafu,
-    LogErrors, OdbcNotInstalledSnafu, PermanentDatasetFailureSnafu, Result, Runtime,
-    UnableToAttachDataConnectorSnafu, UnableToBuildDatasetSnafu,
-    UnableToCreateAcceleratedTableSnafu, UnableToInitializeDataConnectorSnafu,
-    UnableToLoadDatasetConnectorSnafu, UnknownDataConnectorSnafu,
+    AcceleratorInitializationFailedSnafu, DurableWriteBackUnsupportedBySourceSnafu, Error,
+    FullTextSearchRequiresAccelerationSnafu, LogErrors, OdbcNotInstalledSnafu,
+    PermanentDatasetFailureSnafu, Result, Runtime, UnableToAttachDataConnectorSnafu,
+    UnableToBuildDatasetSnafu, UnableToCreateAcceleratedTableSnafu,
+    UnableToInitializeDataConnectorSnafu, UnableToLoadDatasetConnectorSnafu,
+    UnknownDataConnectorSnafu,
     accelerated_table::AcceleratedTable,
     component::dataset::{
         Dataset,
@@ -766,6 +767,26 @@ impl Runtime {
         {
             let err = AcceleratedTableInvalidChangesSnafu {
                 dataset_name: ds.name.to_string(),
+            }
+            .build();
+            warn_spaced!(spaced_tracer, "{}{err}", "");
+            return Err(err);
+        }
+
+        // Durable write-back delivers each committed row to the source. Unless
+        // the connector can do that atomically, delivery has to emulate an
+        // upsert as a standalone delete plus a separate insert — and because the
+        // accelerator is CDC-fed from that same source, the delete echoes back
+        // and erases the committed row. A failure between the two legs then
+        // leaves the write gone from both sides with nothing reported. Refuse
+        // the dataset instead of accepting a config that can lose data.
+        if let Some(acceleration) = &ds.acceleration
+            && acceleration.resolves_to_durable_write_back()
+            && !data_connector.supports_durable_write_back_delivery()
+        {
+            let err = DurableWriteBackUnsupportedBySourceSnafu {
+                dataset_name: ds.name.to_string(),
+                connector: source.clone(),
             }
             .build();
             warn_spaced!(spaced_tracer, "{}{err}", "");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -306,6 +306,14 @@ pub enum Error {
     AcceleratedTableInvalidChanges { dataset_name: String },
 
     #[snafu(display(
+        "Failed to register dataset {dataset_name} ({connector}): durable write-back needs a source that can apply a delivered row in one atomic step, and the {connector} connector cannot yet. Delivering as a separate delete and insert lets the deleted state echo back over CDC, which can silently drop a committed write. Remove 'on_conflict' to keep writes on the accelerator, or use a different 'acceleration.write_mode'. See: https://spiceai.org/docs/reference/spicepod/datasets#acceleration"
+    ))]
+    DurableWriteBackUnsupportedBySource {
+        dataset_name: String,
+        connector: String,
+    },
+
+    #[snafu(display(
         "An accelerated table has invalid configuration: {source}. Update the configuration and retry. For details, visit: https://spiceai.org/docs/reference/spicepod/datasets#acceleration"
     ))]
     InvalidAccelerationConfiguration {

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -166,6 +166,10 @@ impl DataConnector for FullTextConnector {
         self.inner_connector.supports_changes_stream()
     }
 
+    fn supports_durable_write_back_delivery(&self) -> bool {
+        self.inner_connector.supports_durable_write_back_delivery()
+    }
+
     fn changes_stream(
         &self,
         federated_table: Arc<FederatedTable>,

--- a/crates/runtime/src/search/full_text/elasticsearch.rs
+++ b/crates/runtime/src/search/full_text/elasticsearch.rs
@@ -255,6 +255,10 @@ impl DataConnector for ElasticsearchFullTextConnector {
         self.inner_connector.supports_changes_stream()
     }
 
+    fn supports_durable_write_back_delivery(&self) -> bool {
+        self.inner_connector.supports_durable_write_back_delivery()
+    }
+
     fn changes_stream(
         &self,
         federated_table: Arc<FederatedTable>,


### PR DESCRIPTION
Fixes #11915

## Summary

Durable federated write-back could silently and permanently lose a committed write. No crash was required — a transient source error was enough.

Delivery reconciles a committed accelerator row to the source as **two separate source commits**: `delete_from(pk)`, then `insert(present rows, InsertOp::Append)`. Because the accelerator is CDC-fed from that same source and has no self-echo suppression, the standalone `DELETE` echoes back and erases the committed row from the accelerator. If the follow-up `INSERT` then fails:

1. Pass 1 deletes at the source; the insert fails, so markers are correctly left in place.
2. During the backoff the source's CDC stream delivers the `DELETE` echo, removing `K = v` from the accelerator.
3. Pass 2 reads `K` as **absent** → the source delete is a no-op → nothing to insert → `clear_dirty_keys` succeeds.

The row is now gone from the source *and* the accelerator, the marker is gone, and nothing was reported. The same shape occurs on a worker crash between the two commits.

There is no primitive-preserving small fix: source delivery uses `InsertOp::Append` and the write-back path rejects `Replace`/upsert, so present keys must be delete-first-then-insert, and that standalone delete's echo is the loss. Closing it properly requires an atomic delete+insert, a native conditional upsert, or replication-origin tagging — all connector-capability-dependent.

This PR implements the first step the issue scopes: **gate the configuration on the connector advertising a safe delivery primitive, and fail registration otherwise**, rather than accepting a config that can lose data.

## Changes

- **`Acceleration::resolves_to_durable_write_back()`** (`runtime-acceleration`) — one predicate for "this config turns durable write-back on" (Cayenne + `write_mode: write_back` + non-empty `on_conflict` + `refresh_mode: changes`). The Cayenne provider previously inlined these conditions; it now calls this, so the gate and the behavior it guards cannot drift apart.
- **`DataConnector::supports_durable_write_back_delivery()`** — new capability, defaulting to `false`. Modeled on the existing `supports_changes_stream` precedent. Returning `true` asserts delivery is atomic from the source's point of view (one transaction covering both legs, or a native `INSERT … ON CONFLICT DO UPDATE` that removes the delete leg).
- **Forwarded in every wrapper** — `EmbeddingConnector`, `FullTextConnector`, `ElasticsearchFullTextConnector`, `DeferredConnector`. `DeferredConnector` forwards this even though it hard-returns `false` for the stream capabilities: this is a static property of the source it will eventually load from, not of the placeholder (matching how it already treats `resolve_refresh_mode`).
- **Registration gate** in `register_loaded_dataset`, beside the existing `refresh_mode: changes` gate and before `read_provider`, so an unsafe dataset fails fast without touching the network. New `Error::DurableWriteBackUnsupportedBySource` names the dataset and connector and gives the actionable alternatives.

No connector opts in yet, so this disables durable write-back until per-connector safe delivery lands — which is the intended sequencing in the issue ("gate … and fail registration otherwise, then implement transactional/upsert delivery per-connector").

## Scope note

This does **not** yet satisfy the issue's literal acceptance bullets — a committed write surviving a transient insert failure and a worker crash still needs the per-connector atomic/upsert delivery the issue scopes as the follow-up (Postgres/MySQL first). This PR closes the data-loss window by refusing the unsafe configuration instead of silently accepting it. Happy to split differently if a reviewer would rather see delivery land first.

## Test plan

- `make lint`
- `make test`

New tests:

- `durable_write_back_is_recognized` — the exact enabling config is detected.
- `every_condition_is_required_for_durable_write_back` — flips each conjunct independently (including all five non-`changes` `RefreshMode`s and an unset one) so no condition can silently stop being load-bearing.
- `a_default_acceleration_is_not_durable_write_back` — the gate cannot fire on ordinary datasets.
- `every_wrapper_forwards_durable_write_back_delivery_support` — a wrapper that inherits the `false` default would report a safe source as unsafe and reject a valid dataset. That is the defaulted-no-op wrapper bug (#10460) applied to this capability; it compiles cleanly, so only a test catches it. (`ElasticsearchFullTextConnector` is excluded — it is feature-gated and needs a params-bearing dataset to construct.)

## Checklist

- [x] Root cause identified and stated
- [x] Fix is minimal and in scope
- [x] Tests added, including a guard for the wrapper-forwarding regression class
- [x] Capability defaults to the conservative value; config validated against it with a structured error
- [x] No `.unwrap()`; `cargo fmt` clean
