### PR TITLE
fix(cayenne): keep protected snapshots a position-delete rewrite never folded in (fixes #11477)

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -8131,6 +8131,105 @@ mod tests {
         let _ = std::fs::remove_file(format!("{db_path}-wal"));
     }
 
+    /// Issue #11477 — at an unbounded cutoff, `commit_compaction_fenced_in_txn`
+    /// clears every tombstone (matching the wholesale
+    /// [`CayenneCatalog::commit_compaction_in_txn`]) while still clearing ONLY
+    /// the named protected snapshots.
+    ///
+    /// This is the shape the position-delete full rewrite commits with: it holds
+    /// `write_lock` for its whole pass so no tombstone can survive it, but the
+    /// mem-tier checkpoint can still publish a protected snapshot the scan never
+    /// folded in — and deleting that row here loses its rows durably.
+    #[tokio::test]
+    async fn test_commit_compaction_fenced_unbounded_cutoff_retains_unfolded_snapshots() {
+        let test_db = format!(
+            "sqlite://./.test_fenced_unbounded_{}.db",
+            uuid::Uuid::now_v7()
+        );
+        let catalog = CayenneCatalog::new(&test_db).expect("Failed to create catalog");
+        catalog.init().await.expect("Failed to initialize catalog");
+
+        let table_id =
+            setup_table_with_delete_file(&catalog, "fenced_unbounded", "/tmp/fenced_unbounded")
+                .await;
+
+        // Two protected snapshots the rewrite folded in, and one published after
+        // its scan (the racing checkpoint).
+        let folded: Vec<String> = vec![
+            uuid::Uuid::now_v7().to_string(),
+            uuid::Uuid::now_v7().to_string(),
+        ];
+        let late = uuid::Uuid::now_v7().to_string();
+        for (idx, id) in folded.iter().chain(std::iter::once(&late)).enumerate() {
+            let seq = i64::try_from(idx).expect("test index fits in i64") + 1;
+            catalog
+                .set_snapshot_sequence(&table_id, id, seq)
+                .await
+                .expect("Failed to register protected snapshot");
+        }
+
+        let new_snapshot_id = uuid::Uuid::now_v7().to_string();
+        let mut tx = catalog
+            .begin_transaction()
+            .await
+            .expect("Failed to begin transaction");
+        catalog
+            .commit_compaction_fenced_in_txn(
+                &mut *tx,
+                &table_id,
+                &new_snapshot_id,
+                i64::MAX,
+                &folded,
+            )
+            .await
+            .expect("commit_compaction_fenced_in_txn failed");
+        tx.commit()
+            .await
+            .expect("Failed to commit caller transaction");
+
+        // An unbounded cutoff clears every tombstone, exactly as the wholesale
+        // variant does.
+        let delete_files = catalog
+            .get_table_delete_files(&table_id)
+            .await
+            .expect("Failed to get delete files after commit");
+        assert!(
+            delete_files.is_empty(),
+            "an unbounded cutoff must clear every delete file"
+        );
+
+        // Only the folded protected snapshots are cleared.
+        let sequences = catalog
+            .get_all_snapshot_sequences(&table_id)
+            .await
+            .expect("Failed to read snapshot sequences");
+        assert!(
+            sequences.contains_key(&late),
+            "DATA LOSS: the protected snapshot published after the scan was cleared; \
+             remaining ids: {:?}",
+            sequences.keys().collect::<Vec<_>>()
+        );
+        for id in &folded {
+            assert!(
+                !sequences.contains_key(id),
+                "folded snapshot {id} must be cleared"
+            );
+        }
+
+        // Snapshot pointer advanced.
+        let table = catalog
+            .get_table("fenced_unbounded")
+            .await
+            .expect("Failed to get table after commit");
+        assert_eq!(table.current_snapshot_id, new_snapshot_id);
+
+        // Cleanup.
+        let db_path = test_db.strip_prefix("sqlite://").unwrap_or(&test_db);
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(format!("{db_path}-shm"));
+        let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    }
+
     /// Issue #10125 — two `commit_compaction_in_txn` calls inside one
     /// transaction commit atomically: after `tx.commit()`, both partitions'
     /// pointers have advanced together.

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1732,6 +1732,44 @@ pub struct PreparedAppendSnapshotPublish {
     listing_table: Arc<ListingTable>,
 }
 
+/// What a full-snapshot rewrite materialized, and therefore exactly what its
+/// commit may clear.
+///
+/// A rewrite scans the live rows, re-encodes them off-lock (slow), then drops
+/// the state it folded in. Clearing state the scan did NOT fold loses its rows;
+/// failing to clear state it DID fold duplicates them — so the commit is only as
+/// correct as this scope.
+///
+/// The two producers a rewrite races are tracked separately because they are
+/// excluded by different locks:
+///
+/// * **Tombstones** (delete files / insert records) are produced by writers,
+///   which `write_lock` excludes.
+/// * **Protected snapshots** are also published by the mem-tier checkpoint,
+///   which takes `write_lock` only for its capture and publishes under
+///   `listing_fence.write()` alone — so `write_lock` does NOT exclude it, and a
+///   rewrite must name the protected snapshots it folded even when it held
+///   `write_lock` throughout.
+pub(crate) enum RewriteScope {
+    /// Clear everything. Only correct when neither producer could have run —
+    /// i.e. the caller guarantees no concurrent writer *and* no concurrent
+    /// checkpoint (`sort_and_rewrite_data`, which must not run alongside CDC).
+    All,
+    /// Writers were excluded for the whole rewrite (position-delete tables), so
+    /// every tombstone is materialized and cleared; but a mem-tier checkpoint
+    /// may still have published a protected snapshot during the re-encode, so
+    /// clear only `folded`.
+    AllTombstonesFoldedSnapshots {
+        folded: std::collections::HashSet<String>,
+    },
+    /// Writers ran concurrently (key-delete tables): clear only tombstones at or
+    /// below `cutoff` and only the `folded` protected snapshots.
+    Fenced {
+        cutoff: i64,
+        folded: std::collections::HashSet<String>,
+    },
+}
+
 /// Builder for constructing a `CayenneTableProvider` with optional configuration.
 ///
 /// Use this builder to configure optional parameters before opening an existing table
@@ -2713,32 +2751,37 @@ impl CayenneTableProvider {
         )
     }
 
-    /// Atomically commit a snapshot rewrite to the catalog.
-    ///
-    /// With `fence = None` this delegates to
-    /// [`MetadataCatalog::commit_compaction`], which advances the snapshot
-    /// pointer and clears ALL file-level delete/insert/protected-snapshot
-    /// tracking while preserving inlined rows. That wholesale clear is only
-    /// correct when no mutation can have interleaved the rewrite (the rewrite
-    /// held `write_lock` throughout, e.g. position-delete tables).
-    ///
-    /// With `fence = Some((cutoff, folded))` it delegates to the sequence-fenced
-    /// [`MetadataCatalog::commit_compaction_fenced`], which clears only delete
-    /// files / insert records with `sequence_number <= cutoff` and only the
-    /// `folded` protected snapshots — preserving deletes/upserts that committed
-    /// after the rewrite captured its cutoff (the concurrent key-delete path).
+    /// Atomically commit a snapshot rewrite to the catalog, clearing exactly the
+    /// state the rewrite materialized (see [`RewriteScope`]).
     pub(crate) async fn commit_snapshot_rewrite(
         &self,
         new_snapshot_id: &str,
-        fence: Option<&(i64, std::collections::HashSet<String>)>,
+        scope: &RewriteScope,
     ) -> CatalogResult<()> {
-        match fence {
-            None => {
+        match scope {
+            RewriteScope::All => {
                 self.catalog
                     .commit_compaction(&self.table_metadata.table_id, new_snapshot_id)
                     .await
             }
-            Some((cutoff, folded)) => {
+            RewriteScope::AllTombstonesFoldedSnapshots { folded } => {
+                let folded_ids: Vec<String> = folded.iter().cloned().collect();
+                self.catalog
+                    .commit_compaction_fenced(
+                        &self.table_metadata.table_id,
+                        new_snapshot_id,
+                        // Position tombstones are file-path scoped, not
+                        // sequence-tagged, so they cannot be carried past a
+                        // rewrite that rewrote their file away — an unbounded
+                        // cutoff clears every one, exactly as
+                        // `commit_compaction` does. Only the protected-snapshot
+                        // clear is narrowed to `folded`.
+                        i64::MAX,
+                        &folded_ids,
+                    )
+                    .await
+            }
+            RewriteScope::Fenced { cutoff, folded } => {
                 let folded_ids: Vec<String> = folded.iter().cloned().collect();
                 self.catalog
                     .commit_compaction_fenced(
@@ -11806,13 +11849,18 @@ impl CayenneTableProvider {
         )?;
 
         // Atomically update the catalog to point to the new sorted snapshot.
-        // `fence = None` => wholesale clear of delete files / insert records.
-        // This is only safe because `sort_and_rewrite_data` is documented as
-        // "must not run concurrently with CDC" (see its safety section) and
-        // defers while staged work is in flight. FOLLOW-UP: give this path the
-        // same sequence fence as `rewrite_current_snapshot_for_compaction` if it
-        // ever becomes reachable concurrently with writers.
-        if let Err(e) = self.commit_snapshot_rewrite(&new_snapshot_id, None).await {
+        // `RewriteScope::All` => wholesale clear of delete files / insert
+        // records / protected snapshots. This is only safe because
+        // `sort_and_rewrite_data` is documented as "must not run concurrently
+        // with CDC" (see its safety section) and defers while staged work is in
+        // flight — so neither a writer nor a mem-tier checkpoint can produce
+        // state this rewrite did not fold in. FOLLOW-UP: give this path the same
+        // scope tracking as `rewrite_current_snapshot_for_compaction` if it ever
+        // becomes reachable concurrently with writers.
+        if let Err(e) = self
+            .commit_snapshot_rewrite(&new_snapshot_id, &RewriteScope::All)
+            .await
+        {
             cleanup_failed_snapshot.await;
             return Err(Error::Catalog { source: e });
         }
@@ -14353,18 +14401,49 @@ impl CayenneTableProvider {
         // pass with inline data (after the explicit checkpoint the internal one is
         // a no-op since the memtable is already drained).
         //
-        // Position-delete tables already hold `write_lock` for the whole rewrite
-        // (above) and clear everything at the end, so they need no key-delete
-        // fence (their `fence` is `None`).
-        let (mut stream, fence, generation_before, snapshot_id_before): (
+        // Position-delete tables hold `write_lock` for the whole rewrite (above),
+        // so no tombstone can interleave and all of them are cleared at the end.
+        // They still need the folded-set bracket: `write_lock` does not exclude
+        // the mem-tier checkpoint's protected-snapshot publish (it takes
+        // `write_lock` only for its capture and publishes under `listing_fence`
+        // alone), so a blind protected-snapshot clear would drop rows the scan
+        // never folded in.
+        let (mut stream, scope, generation_before, snapshot_id_before): (
             SendableRecordBatchStream,
-            Option<(i64, std::collections::HashSet<String>)>,
+            RewriteScope,
             u64,
             String,
         ) = if uses_position_deletes {
             let snapshot_id_before = self.get_current_snapshot_id();
+            // Drain the inline memtable FIRST, for the same reason the
+            // key-delete arm does: `visible_file_stream_for_rewrite` also
+            // checkpoints inline data internally, which would publish a
+            // protected snapshot BETWEEN the two folded-set reads below and
+            // spuriously abort every pass on a table with inline data. After
+            // this the internal checkpoint is a no-op. Safe under the
+            // `write_lock` this arm already holds for the whole rewrite.
+            if self.cached_inlined_row_count() > 0 {
+                self.checkpoint_inlined_data().await?;
+            }
+            let folded_before = self.protected_snapshot_ids();
             let (stream, generation_before) = self.visible_file_stream_for_rewrite(&ctx).await?;
-            (stream, None, generation_before, snapshot_id_before)
+            if folded_before != self.protected_snapshot_ids() {
+                tracing::debug!(
+                    target: "cayenne::compaction",
+                    table = self.table_metadata.table_name.as_str(),
+                    "Aborting full rewrite: protected-snapshot set changed during scan \
+                     (concurrent checkpoint); will retry on the next trigger",
+                );
+                return Ok(false);
+            }
+            (
+                stream,
+                RewriteScope::AllTombstonesFoldedSnapshots {
+                    folded: folded_before,
+                },
+                generation_before,
+                snapshot_id_before,
+            )
         } else {
             let _capture_guard = self.write_lock_arc().lock_owned().await;
             // Defense-in-depth for table replacement while this pass encodes.
@@ -14375,20 +14454,10 @@ impl CayenneTableProvider {
             if self.cached_inlined_row_count() > 0 {
                 self.checkpoint_inlined_data().await?;
             }
-            let folded_before: std::collections::HashSet<String> = self
-                .protected_snapshots
-                .load_full()
-                .keys()
-                .cloned()
-                .collect();
+            let folded_before = self.protected_snapshot_ids();
             let (stream, generation_before) = self.visible_file_stream_for_rewrite(&ctx).await?;
             let cutoff = self.sequence_high_water().await;
-            let folded_after: std::collections::HashSet<String> = self
-                .protected_snapshots
-                .load_full()
-                .keys()
-                .cloned()
-                .collect();
+            let folded_after = self.protected_snapshot_ids();
             if folded_before != folded_after {
                 // A concurrent finalize published a protected snapshot during the
                 // scan; we can no longer tell which snapshots the scan folded.
@@ -14403,7 +14472,10 @@ impl CayenneTableProvider {
             }
             (
                 stream,
-                Some((cutoff, folded_before)),
+                RewriteScope::Fenced {
+                    cutoff,
+                    folded: folded_before,
+                },
                 generation_before,
                 snapshot_id_before,
             )
@@ -14494,8 +14566,8 @@ impl CayenneTableProvider {
 
         // Manifest snapshot model (phase 1c): record the new snapshot's COMPLETE
         // data-file set BEFORE the commit clears this table's tombstones.
-        // `commit_snapshot_rewrite` -> `commit_compaction` drops every delete
-        // file / insert record / snapshot-sequence row in one transaction, so
+        // `commit_snapshot_rewrite` drops the delete file / insert record /
+        // snapshot-sequence rows this rewrite folded in, in one transaction, so
         // the manifest must be durable first to honour the publish-before-clear
         // invariant (a new file set is published before the old deletions are
         // cleared). The prune (`prune_snapshot_manifest_to`) is deferred to
@@ -14651,10 +14723,7 @@ impl CayenneTableProvider {
                     .await;
                 return Ok(false);
             }
-            if let Err(e) = self
-                .commit_snapshot_rewrite(&new_snapshot_id, fence.as_ref())
-                .await
-            {
+            if let Err(e) = self.commit_snapshot_rewrite(&new_snapshot_id, &scope).await {
                 drop(listing_guard);
                 self.cleanup_failed_compaction_snapshot(&new_snapshot_id, is_s3)
                     .await;
@@ -14663,11 +14732,19 @@ impl CayenneTableProvider {
 
             self.listing_table.store(new_listing_table);
             self.update_current_snapshot_id(&new_snapshot_id);
-            match &fence {
+            match &scope {
+                // This rewrite always captures a folded set, so `All` is
+                // unreachable here; treat it as the conservative wholesale clear
+                // rather than silently skipping a clear it did materialize.
+                RewriteScope::All => self.clear_all_deletion_caches(),
                 // Position-delete tables held `write_lock` across the whole
-                // rewrite, so no mutation interleaved and clearing everything
-                // is exactly correct.
-                None => self.clear_all_deletion_caches(),
+                // rewrite, so no tombstone interleaved and clearing them all is
+                // exactly correct — but a mem-tier checkpoint can still have
+                // published a protected snapshot the scan never folded, so that
+                // half is narrowed to `folded`.
+                RewriteScope::AllTombstonesFoldedSnapshots { folded } => {
+                    self.clear_deletion_caches_retaining_unfolded_snapshots(folded);
+                }
                 // Key-delete tables ran the encode concurrently with writers.
                 // Drop only what the rewrite materialized (`seq <= cutoff` +
                 // the folded protected snapshots); deletes/upserts that raced
@@ -14676,7 +14753,7 @@ impl CayenneTableProvider {
                 // manifest's max sequence: this rewrite never touches cold
                 // objects, so tombstones masking cold-resident keys must
                 // survive until a promotion applies them.
-                Some((cutoff, folded)) => {
+                RewriteScope::Fenced { cutoff, folded } => {
                     let cold_cap = self.cold_tombstone_prune_cap().await;
                     let prune_cutoff = cold_cap.map_or(*cutoff, |cap| (*cutoff).min(cap));
                     self.prune_deletion_caches_after_full_rewrite(prune_cutoff, folded);
@@ -17701,9 +17778,79 @@ impl CayenneTableProvider {
     /// full-rewrite path) must NOT use this — it must carry forward post-cutoff
     /// mutations via [`Self::prune_deletion_caches_after_full_rewrite`] instead.
     pub(crate) fn clear_all_deletion_caches(&self) {
-        // Clear caches based on the current strategy.
-        // ArcSwap stores publish a fresh empty snapshot atomically; readers see either
-        // the old or new state and never block.
+        self.clear_tombstone_caches();
+
+        // Clear protected snapshots - after compaction all data is in the main snapshot
+        self.protected_snapshots.store(Arc::new(HashMap::new()));
+
+        self.clear_cached_pk_keyset();
+
+        // Compaction folded the deletions into rewritten files, so the in-memory
+        // key/position delete state is empty again — release its reservation.
+        // (clear_cached_pk_keyset already reset the keyset's reservation.)
+        self.table_memory.set_deletion_bytes(0);
+
+        tracing::debug!(
+            "Cleared all deletion and insert records caches for table {}",
+            self.table_metadata.table_name
+        );
+    }
+
+    /// In-memory counterpart of [`RewriteScope::AllTombstonesFoldedSnapshots`]:
+    /// clear every tombstone (writers were excluded, so the rewrite materialized
+    /// them all) but retain protected snapshots outside `folded`.
+    ///
+    /// A mem-tier checkpoint publishes its protected snapshot under
+    /// `listing_fence.write()` without `write_lock`, so it can land during the
+    /// rewrite's off-lock re-encode. Those rows are not in the new file, and
+    /// dropping the reference here would lose them (and, via the paired catalog
+    /// commit, lose them durably).
+    pub(crate) fn clear_deletion_caches_retaining_unfolded_snapshots(
+        &self,
+        folded: &std::collections::HashSet<String>,
+    ) {
+        self.clear_tombstone_caches();
+
+        // Copy-on-write removal of exactly the folded set, mirroring
+        // `prune_deletion_caches_after_full_rewrite`.
+        if !folded.is_empty() {
+            self.protected_snapshots.rcu(|current| {
+                let mut next = HashMap::clone(current);
+                next.retain(|id, _| !folded.contains(id));
+                Arc::new(next)
+            });
+        }
+
+        self.clear_cached_pk_keyset();
+        self.table_memory.set_deletion_bytes(0);
+
+        tracing::debug!(
+            target: "cayenne::compaction",
+            table = self.table_metadata.table_name.as_str(),
+            folded_protected = folded.len(),
+            "Cleared deletion caches after position-delete full rewrite, retaining unfolded protected snapshots"
+        );
+    }
+
+    /// The ids of every protected snapshot currently registered on this table.
+    ///
+    /// Read twice around a rewrite's scan to detect a concurrent publish (see
+    /// [`RewriteScope`]), so both reads must observe the same map shape — hence
+    /// a single `load_full()` per call.
+    fn protected_snapshot_ids(&self) -> std::collections::HashSet<String> {
+        self.protected_snapshots
+            .load_full()
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    /// Drop every file-level deletion/insert cache for this table's strategy,
+    /// leaving protected snapshots and the PK keyset to the caller.
+    ///
+    /// `ArcSwap` stores publish a fresh empty snapshot atomically; readers see
+    /// either the old or the new state and never block.
+    fn clear_tombstone_caches(&self) {
         match &self.pk_deletion_strategy {
             PkDeletionStrategyWithCache::PositionBased {
                 cached_deleted_row_ids,
@@ -17725,21 +17872,6 @@ impl CayenneTableProvider {
                 position_deletions.store(Arc::new(PositionBitmap::new()));
             }
         }
-
-        // Clear protected snapshots - after compaction all data is in the main snapshot
-        self.protected_snapshots.store(Arc::new(HashMap::new()));
-
-        self.clear_cached_pk_keyset();
-
-        // Compaction folded the deletions into rewritten files, so the in-memory
-        // key/position delete state is empty again — release its reservation.
-        // (clear_cached_pk_keyset already reset the keyset's reservation.)
-        self.table_memory.set_deletion_bytes(0);
-
-        tracing::debug!(
-            "Cleared all deletion and insert records caches for table {}",
-            self.table_metadata.table_name
-        );
     }
 
     /// Sequence-fenced counterpart of [`Self::clear_all_deletion_caches`] for the
@@ -17761,8 +17893,10 @@ impl CayenneTableProvider {
     ///   and is retained (its data is NOT in the new file).
     ///
     /// Position deletions are untouched: this path is only taken for key-delete
-    /// tables (position-delete tables hold `write_lock` across the whole rewrite
-    /// and use [`Self::clear_all_deletion_caches`] instead).
+    /// tables. Position-delete tables hold `write_lock` across the whole rewrite
+    /// and use [`Self::clear_deletion_caches_retaining_unfolded_snapshots`],
+    /// which clears every tombstone but narrows the protected-snapshot clear the
+    /// same way this method does.
     pub(crate) fn prune_deletion_caches_after_full_rewrite(
         &self,
         cutoff: i64,
@@ -28176,6 +28310,181 @@ mod tests {
                 persisted.get(id),
             );
         }
+    }
+
+    /// Build a position-delete CDC upsert table whose every insert publishes its
+    /// own protected snapshot, with the background compactor pinned far out so
+    /// only explicit calls run.
+    async fn create_position_delete_protected_snapshot_table(
+        table_name: &str,
+        runtime_env: Arc<RuntimeEnv>,
+    ) -> (CayenneTableProvider, Arc<dyn MetadataCatalog>, TempDir) {
+        create_cdc_upsert_table_with_vortex_config(
+            table_name,
+            runtime_env,
+            VortexConfig {
+                deletion_mode: crate::metadata::DeletionMode::Position,
+                // Disable the inline memtable so each write lands in a
+                // file-backed protected snapshot.
+                inline_max_rows: 0,
+                compaction_background_interval_ms: 3_600_000,
+                ..VortexConfig::default()
+            },
+        )
+        .await
+    }
+
+    /// Publish one more protected snapshot and return its id — standing in for
+    /// the mem-tier checkpoint that lands during a rewrite's off-lock re-encode.
+    async fn publish_one_more_protected_snapshot(
+        provider: &CayenneTableProvider,
+        before: &std::collections::HashSet<String>,
+        id: i64,
+    ) -> String {
+        let schema = provider.table_schema();
+        insert_batch(provider, id_value_batch(schema, &[id], &[id * 10])).await;
+        let mut added = provider
+            .protected_snapshot_ids()
+            .difference(before)
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            added.len(),
+            1,
+            "expected exactly one protected snapshot to be published"
+        );
+        added.pop().expect("the one added snapshot id")
+    }
+
+    /// Regression for issue #11477: a full rewrite's commit must not drop a
+    /// protected snapshot its scan never folded in.
+    ///
+    /// A position-delete rewrite holds `write_lock` across the whole pass, which
+    /// excludes writers — but NOT the mem-tier checkpoint, which takes
+    /// `write_lock` only for its capture and publishes its protected snapshot
+    /// under `listing_fence.write()` alone. Such a snapshot lands after the scan,
+    /// so its rows are absent from the consolidated output; clearing its
+    /// reference (durably via `cayenne_snapshot_sequence`, and in memory) loses
+    /// those rows permanently, and the durable half survives a restart.
+    ///
+    /// This drives both commit halves with a `folded` set captured BEFORE a later
+    /// snapshot is published — exactly the shape the rewrite produces when a
+    /// checkpoint interleaves.
+    #[tokio::test]
+    async fn position_rewrite_commit_retains_a_snapshot_published_after_the_scan() {
+        let ctx = SessionContext::new();
+        let (provider, catalog, _tmp) = create_position_delete_protected_snapshot_table(
+            "position_rewrite_late_snapshot",
+            ctx.runtime_env(),
+        )
+        .await;
+        let schema = provider.table_schema();
+
+        // Protected snapshots visible to the rewrite's scan.
+        for i in 0..2i64 {
+            insert_batch(
+                &provider,
+                id_value_batch(Arc::clone(&schema), &[i], &[i * 10]),
+            )
+            .await;
+        }
+        let folded = provider.protected_snapshot_ids();
+        assert!(
+            !folded.is_empty(),
+            "the scan must observe at least one protected snapshot"
+        );
+
+        let late = publish_one_more_protected_snapshot(&provider, &folded, 99).await;
+
+        let new_snapshot_id = uuid::Uuid::now_v7().to_string();
+        provider
+            .commit_snapshot_rewrite(
+                &new_snapshot_id,
+                &RewriteScope::AllTombstonesFoldedSnapshots {
+                    folded: folded.clone(),
+                },
+            )
+            .await
+            .expect("fenced compaction commit succeeds");
+        provider.clear_deletion_caches_retaining_unfolded_snapshots(&folded);
+
+        // Durable half: the late snapshot's sequence row must survive, or its
+        // rows are gone after a restart.
+        let persisted = catalog
+            .get_all_snapshot_sequences(&provider.table_metadata.table_id)
+            .await
+            .expect("persisted snapshot sequences");
+        assert!(
+            persisted.contains_key(&late),
+            "DATA LOSS: the protected snapshot published after the scan was cleared \
+             from the catalog; persisted ids: {:?}",
+            persisted.keys().collect::<Vec<_>>()
+        );
+        for id in &folded {
+            assert!(
+                !persisted.contains_key(id),
+                "folded snapshot {id} was materialized by the rewrite and must be cleared"
+            );
+        }
+
+        // In-memory half: same subset semantics, or scans stop reading its rows
+        // until a restart reloads the catalog.
+        let in_mem = provider.protected_snapshots.load_full();
+        assert!(
+            in_mem.contains_key(&late),
+            "DATA LOSS: the protected snapshot published after the scan was cleared \
+             from the in-memory map; retained ids: {:?}",
+            in_mem.keys().collect::<Vec<_>>()
+        );
+        for id in &folded {
+            assert!(
+                !in_mem.contains_key(id),
+                "folded snapshot {id} must be dropped from the in-memory map"
+            );
+        }
+    }
+
+    /// The contrast that makes the test above load-bearing: [`RewriteScope::All`]
+    /// clears EVERY protected snapshot, including one published after the scan.
+    ///
+    /// That is the behaviour the position-delete arm used to have, and it is why
+    /// `All` is only correct for a caller that guarantees no concurrent writer
+    /// *and* no concurrent checkpoint (`sort_and_rewrite_data`). Pinning it here
+    /// means routing the position arm back to `All` fails a test rather than
+    /// silently losing rows again.
+    #[tokio::test]
+    async fn wholesale_rewrite_commit_drops_every_protected_snapshot() {
+        let ctx = SessionContext::new();
+        let (provider, catalog, _tmp) = create_position_delete_protected_snapshot_table(
+            "wholesale_rewrite_clears_all",
+            ctx.runtime_env(),
+        )
+        .await;
+        let schema = provider.table_schema();
+
+        insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[0], &[0])).await;
+        let scanned = provider.protected_snapshot_ids();
+        let late = publish_one_more_protected_snapshot(&provider, &scanned, 99).await;
+
+        let new_snapshot_id = uuid::Uuid::now_v7().to_string();
+        provider
+            .commit_snapshot_rewrite(&new_snapshot_id, &RewriteScope::All)
+            .await
+            .expect("wholesale compaction commit succeeds");
+        provider.clear_all_deletion_caches();
+
+        let persisted = catalog
+            .get_all_snapshot_sequences(&provider.table_metadata.table_id)
+            .await
+            .expect("persisted snapshot sequences");
+        assert!(
+            persisted.is_empty(),
+            "`All` clears every snapshot-sequence row, including {late}"
+        );
+        assert!(
+            provider.protected_snapshots.load_full().is_empty(),
+            "`All` clears the whole in-memory protected map"
+        );
     }
 
     /// OVERWRITE-GUARD regression (issue #11823): an overwrite that commits


### PR DESCRIPTION
## Summary

A full-snapshot compaction rewrite (`rewrite_current_snapshot_for_compaction`) scans the live rows, re-encodes them off-lock, then clears the state it folded in. The **position-delete arm** cleared *every* protected snapshot wholesale — durably (`DELETE FROM cayenne_snapshot_sequence WHERE table_id = …`) and in memory (`protected_snapshots.store(empty)`) — on the premise that holding `write_lock` for the whole rewrite excludes anything that could publish one.

It does not. The mem-tier checkpoint takes `write_lock` only for its **capture**, then encodes off-lock and publishes its protected snapshot under `listing_fence.write()` alone. That is the same fact the sibling key-delete arm was already hardened against in #11465 ("a pipelined CDC finalize publishes a protected snapshot under `listing_fence.write()` WITHOUT `write_lock`") — the position arm kept the unsafe assumption, and its comment asserted a protection that does not hold.

A checkpoint landing during the re-encode creates a snapshot whose rows are absent from the consolidated output; the commit then deletes its reference. Those rows disappear from every future query, and because the metastore row is gone, the loss survives a restart.

Reachable on a `refresh_mode: changes` table with memory durability, a primary key, and `cayenne_deletion_mode: position` — the documented opt-out from the `auto` → `key` resolution. (`is_cdc_memory_mode()` gates the mem-tier checkpoint and requires a non-position-based PK strategy; `should_capture_positions()` selects this arm.)

Fixes #11477

## Changes

- **`RewriteScope` replaces the `Option<(cutoff, folded)>` fence**, so each arm states exactly what it materialized instead of encoding it in a `None`: `All` (no producer could have run), `AllTombstonesFoldedSnapshots` (writers excluded, checkpoints not), `Fenced` (writers ran concurrently). The two producers are tracked separately because different locks exclude them.
- **The position arm brackets its scan** with a folded-set read and aborts the pass if a checkpoint interleaves, then commits with an unbounded cutoff plus that folded set — every tombstone is still cleared (position tombstones are file-path scoped and cannot be carried forward), while a protected snapshot the scan never folded survives both halves of the commit.
- **The position arm drains the inline memtable before its first read**, for the same reason the key-delete arm does: `visible_file_stream_for_rewrite` checkpoints inline data internally, which would otherwise publish a snapshot between the two reads and trip the bracket on every pass with inline data.
- `clear_all_deletion_caches` and the new `clear_deletion_caches_retaining_unfolded_snapshots` share a `clear_tombstone_caches` helper; `protected_snapshot_ids()` replaces three copies of the same `load_full().keys().cloned().collect()`.
- `sort_and_rewrite_data` now passes `RewriteScope::All` explicitly, with its existing "must not run concurrently with CDC" justification extended to cover checkpoints.

No behaviour change for key-delete tables (the default for CDC PK tables) or for `sort_and_rewrite_data`.

## Test plan

- `position_rewrite_commit_retains_a_snapshot_published_after_the_scan` — the regression test. Drives both commit halves with a `folded` set captured before a later snapshot is published, and asserts that snapshot survives in the catalog *and* in the in-memory map. **Verified to fail on the pre-fix behaviour** (`DATA LOSS: the protected snapshot published after the scan was cleared from the catalog; persisted ids: []`) and pass with the fix.
- `wholesale_rewrite_commit_drops_every_protected_snapshot` — pins the contrast, so routing the position arm back to `RewriteScope::All` fails a test rather than silently losing rows again.
- `test_commit_compaction_fenced_unbounded_cutoff_retains_unfolded_snapshots` — catalog-level: an unbounded cutoff clears every delete file (matching the wholesale variant) while clearing only the named protected snapshots. First coverage of `commit_compaction_fenced_in_txn`.
- Caught and fixed one regression this change introduced along the way: without the inline-memtable drain, `current_snapshot_compaction_casts_force_view_scan_to_write_schema` failed because the bracket aborted every pass.
- `make lint` and `make test` via `make signoff`.

Note: 5 pre-existing `cayenne_catalog` test failures on this box (`PermissionDenied` on hardcoded `/tmp/...` base paths) are unrelated — confirmed identical on unmodified `trunk`.

## Checklist

- [x] Root cause identified and stated
- [x] Regression test verified to fail before the fix
- [x] Sibling arms audited (the key-delete arm was already correct; `sort_and_rewrite_data` is guarded by its non-concurrency contract)
- [x] `cargo fmt` + both CI clippy passes clean
- [ ] `make signoff` green