### PR TITLE
fix(search): expunge superseded documents from full-text BM25 statistics (fixes #12053)

### DIFF
--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -49,27 +49,14 @@ use crate::index::SearchIndex;
 pub static MEMORY_BUDGET_FOR_INDEX_WRITER: usize = 150 * 1024 * 1024;
 pub static INDEX_UNIQUE_FIELD_NAME: &str = "__spice.unique_field";
 
-/// The fraction of a tantivy segment's documents that may be superseded — deleted, but
-/// still physically present — before the segment is rewritten by a merge.
+/// The fraction of a tantivy segment's documents that may be superseded/deleted, but
+/// still physically present, before the segment is rewritten by a merge.
 ///
-/// This bounds a relevance-scoring error. tantivy derives BM25's collection size from
-/// each segment's `max_doc`, which counts superseded documents, so every term's inverse
-/// document frequency is computed against a collection that still contains rows the
-/// index has already replaced. A single-term query is scaled uniformly and keeps its
-/// order, but a multi-term query weights its terms by their individual IDFs, so the
-/// ranking itself can differ from the one the live rows imply.
+/// Tantivy BM25 collection size statistics includes these superseded documents. A merge
+/// is the only mechanism to expunge documents. The default, [`LogMergePolicy`], does
+/// not merge on deletions, only when the ratio of deleted to collected documents is above a threshold.
 ///
-/// A merge is the only thing that expunges those documents, and tantivy's default
-/// [`LogMergePolicy`] never merges on deletions alone: `del_docs_ratio_before_merge`
-/// defaults to `1.0`, a ratio no segment can exceed. Its own documentation calls that
-/// default "not a very sensible default". Left at `1.0`, a segment that has grown large
-/// enough to sit alone at its size level — where the policy's segment-count rule can
-/// never apply either — keeps its superseded documents forever. Because `update_index`
-/// writes every incoming primary key as a deletion followed by an insertion, a
-/// repeatedly refreshed index reaches exactly that state as a matter of course.
-///
-/// Capping the ratio bounds the over-count instead: once merges settle, the collection
-/// size exceeds the live document count by at most `1 / (1 - RATIO)`.
+/// [`MAX_SUPERSEDED_DOCS_RATIO_PER_SEGMENT`] is the ratio to use in [`LogMergePolicy`]/
 const MAX_SUPERSEDED_DOCS_RATIO_PER_SEGMENT: f32 = 0.25;
 
 /// The merge policy for the index writer, which differs from tantivy's default only in
@@ -81,13 +68,9 @@ fn index_merge_policy() -> LogMergePolicy {
     policy
 }
 
-/// Discard everything staged in the writer since the last commit.
+/// Perform a [`tantivy::IndexWriter::rollback`] and preserve the [`MergePolicy`] from `index_merge_policy`.
 ///
-/// [`tantivy::IndexWriter::rollback`] does not reset the existing writer, it replaces it
-/// with a freshly constructed one — and a fresh writer carries tantivy's default merge
-/// policy. Every rollback therefore has to reinstate [`index_merge_policy`], or the first
-/// rolled-back write window silently reverts the index to never expunging superseded
-/// documents.
+/// [`tantivy::IndexWriter::rollback`] overwrites any custom [`MergePolicy`] with the default.
 fn rollback_writer(writer: &mut tantivy::IndexWriter) -> Result<(), TantivyError> {
     writer.rollback()?;
     writer.set_merge_policy(Box::new(index_merge_policy()));

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -28,6 +28,7 @@ use datafusion::error::DataFusionError;
 use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder};
 use runtime_datafusion_index::Index;
 use snafu::ResultExt;
+use tantivy::merge_policy::LogMergePolicy;
 use tantivy::schema::{DocParsingError, SchemaBuilder};
 use tantivy::{TantivyDocument, TantivyError};
 use tokio::sync::Mutex;
@@ -47,6 +48,51 @@ use crate::index::SearchIndex;
 /// significantly improving bulk-indexing throughput.
 pub static MEMORY_BUDGET_FOR_INDEX_WRITER: usize = 150 * 1024 * 1024;
 pub static INDEX_UNIQUE_FIELD_NAME: &str = "__spice.unique_field";
+
+/// The fraction of a tantivy segment's documents that may be superseded — deleted, but
+/// still physically present — before the segment is rewritten by a merge.
+///
+/// This bounds a relevance-scoring error. tantivy derives BM25's collection size from
+/// each segment's `max_doc`, which counts superseded documents, so every term's inverse
+/// document frequency is computed against a collection that still contains rows the
+/// index has already replaced. A single-term query is scaled uniformly and keeps its
+/// order, but a multi-term query weights its terms by their individual IDFs, so the
+/// ranking itself can differ from the one the live rows imply.
+///
+/// A merge is the only thing that expunges those documents, and tantivy's default
+/// [`LogMergePolicy`] never merges on deletions alone: `del_docs_ratio_before_merge`
+/// defaults to `1.0`, a ratio no segment can exceed. Its own documentation calls that
+/// default "not a very sensible default". Left at `1.0`, a segment that has grown large
+/// enough to sit alone at its size level — where the policy's segment-count rule can
+/// never apply either — keeps its superseded documents forever. Because `update_index`
+/// writes every incoming primary key as a deletion followed by an insertion, a
+/// repeatedly refreshed index reaches exactly that state as a matter of course.
+///
+/// Capping the ratio bounds the over-count instead: once merges settle, the collection
+/// size exceeds the live document count by at most `1 / (1 - RATIO)`.
+const MAX_SUPERSEDED_DOCS_RATIO_PER_SEGMENT: f32 = 0.25;
+
+/// The merge policy for the index writer, which differs from tantivy's default only in
+/// capping superseded documents per segment — see
+/// [`MAX_SUPERSEDED_DOCS_RATIO_PER_SEGMENT`].
+fn index_merge_policy() -> LogMergePolicy {
+    let mut policy = LogMergePolicy::default();
+    policy.set_del_docs_ratio_before_merge(MAX_SUPERSEDED_DOCS_RATIO_PER_SEGMENT);
+    policy
+}
+
+/// Discard everything staged in the writer since the last commit.
+///
+/// [`tantivy::IndexWriter::rollback`] does not reset the existing writer, it replaces it
+/// with a freshly constructed one — and a fresh writer carries tantivy's default merge
+/// policy. Every rollback therefore has to reinstate [`index_merge_policy`], or the first
+/// rolled-back write window silently reverts the index to never expunging superseded
+/// documents.
+fn rollback_writer(writer: &mut tantivy::IndexWriter) -> Result<(), TantivyError> {
+    writer.rollback()?;
+    writer.set_merge_policy(Box::new(index_merge_policy()));
+    Ok(())
+}
 
 #[derive(Clone)]
 pub struct FullTextDatabaseIndex {
@@ -136,9 +182,7 @@ impl Index for FullTextDatabaseIndex {
         // writer keeps its per-write commit behavior rather than deferring on a
         // writer in an unknown state).
         let mut index_writer = self.writer.lock().await;
-        index_writer
-            .rollback()
-            .map(|_| ())
+        rollback_writer(&mut index_writer)
             .context(TextSearchIndexingSnafu)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
         self.defer_commit.store(true, Ordering::Release);
@@ -161,7 +205,7 @@ impl Index for FullTextDatabaseIndex {
             .context(FailedToInsertDataIntoIndexSnafu);
         if let Err(e) = &commit_result {
             tracing::warn!("Rolling back full-text index writer after failed commit: {e}");
-            if let Err(rb_err) = index_writer.rollback() {
+            if let Err(rb_err) = rollback_writer(&mut index_writer) {
                 tracing::error!("Failed to rollback full-text index writer: {rb_err}");
             }
         }
@@ -189,9 +233,7 @@ impl Index for FullTextDatabaseIndex {
         // A rollback failure must reach the caller: staged operations that could not
         // be discarded may leak into a later commit and make a partial refresh
         // visible.
-        index_writer
-            .rollback()
-            .map(|_| ())
+        rollback_writer(&mut index_writer)
             .context(TextSearchIndexingSnafu)
             .map_err(|e| DataFusionError::External(Box::new(e)))
     }
@@ -228,6 +270,7 @@ impl FullTextDatabaseIndex {
         let writer = index
             .writer(MEMORY_BUDGET_FOR_INDEX_WRITER)
             .context(IndexCreationSnafu)?;
+        writer.set_merge_policy(Box::new(index_merge_policy()));
 
         Ok(Self {
             base_table: inner,
@@ -379,7 +422,7 @@ impl FullTextDatabaseIndex {
         })();
         if let Err(e) = &write_result {
             tracing::warn!("Rolling back index writer after failed write: {e}");
-            if let Err(rb_err) = index_writer.rollback() {
+            if let Err(rb_err) = rollback_writer(&mut index_writer) {
                 tracing::error!("Failed to rollback index writer: {rb_err}");
             }
         }
@@ -621,6 +664,7 @@ mod tests {
     use datafusion::datasource::{MemTable, TableProvider};
     use futures::{StreamExt, TryStreamExt};
     use runtime_datafusion_index::Index;
+    use std::time::Duration;
 
     /// Create a basic [`MemTable`] with fields: `id`, `content`.
     fn create_test_table() -> Arc<dyn TableProvider> {
@@ -666,6 +710,146 @@ mod tests {
                 .map(|(original_idx, _)| Arc::clone(batch.column(*original_idx)))
                 .collect::<Vec<_>>(),
         )
+    }
+
+    /// The collection size tantivy uses for BM25: the sum of every segment's `max_doc`,
+    /// which counts superseded documents until a merge expunges them.
+    fn bm25_collection_size(index: &FullTextDatabaseIndex) -> u32 {
+        index
+            .reader
+            .searcher()
+            .segment_readers()
+            .iter()
+            .map(tantivy::SegmentReader::max_doc)
+            .sum()
+    }
+
+    /// Poll the index's segment set until `reached` holds, reloading the reader each
+    /// time. Merges run on their own threads, so a caller that depends on their outcome
+    /// has to wait for it rather than assume it has already happened.
+    async fn wait_for_segments(
+        index: &FullTextDatabaseIndex,
+        expectation: &str,
+        reached: impl Fn(&[tantivy::SegmentReader]) -> bool,
+    ) {
+        const ATTEMPTS: usize = 150;
+        const INTERVAL: Duration = Duration::from_millis(20);
+
+        let mut observed = "<never sampled>".to_string();
+        for _ in 0..ATTEMPTS {
+            index
+                .reader
+                .reload()
+                .expect("failed to reload the full-text index reader");
+            let searcher = index.reader.searcher();
+            if reached(searcher.segment_readers()) {
+                return;
+            }
+            observed = searcher
+                .segment_readers()
+                .iter()
+                .map(|reader| format!("max_doc={} live={}", reader.max_doc(), reader.num_docs()))
+                .collect::<Vec<_>>()
+                .join(" | ");
+            tokio::time::sleep(INTERVAL).await;
+        }
+        panic!("timed out waiting for {expectation}; last observed segments [{observed}]");
+    }
+
+    /// Wait until no segment still holds a superseded document, which is when BM25's
+    /// collection size finally matches the live rows.
+    async fn wait_for_superseded_docs_expunged(index: &FullTextDatabaseIndex) {
+        wait_for_segments(index, "superseded documents to be expunged", |segments| {
+            segments
+                .iter()
+                .all(|reader| reader.max_doc() == reader.num_docs())
+        })
+        .await;
+    }
+
+    /// A full-text index over [`create_test_table`], keyed on `id` and searching `content`.
+    fn new_test_index() -> FullTextDatabaseIndex {
+        FullTextDatabaseIndex::try_new(
+            create_test_table(),
+            vec!["content".to_string()],
+            Some(vec!["id".to_string()]),
+            None,
+            &["content".to_string()],
+        )
+        .expect("Failed to create FullTextDatabaseIndex")
+    }
+
+    const EXPUNGE_FIXTURE_IDS: [i32; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    /// Drive an index into the one state in which superseded documents can linger — a
+    /// single consolidated segment, half of whose documents have been replaced — and
+    /// assert they leave BM25's collection size.
+    async fn supersede_half_of_a_consolidated_segment(index: &FullTextDatabaseIndex) {
+        // Every document is two tokens long, so its field length equals the collection
+        // average and BM25's term-frequency factor cancels to exactly 1. A score is then
+        // purely the term's inverse document frequency, and so a direct reading of the
+        // collection size the index scored against.
+        //
+        // One commit per row leaves eight single-document segments, which the merge
+        // policy's segment-count rule consolidates into one. That is the shape a
+        // long-lived index settles into, and the only shape in which a superseded
+        // document has nowhere to go but a segment it shares with live documents: alone
+        // in its own segment it is dropped outright at commit and never reaches the
+        // statistics at all.
+        for id in EXPUNGE_FIXTURE_IDS {
+            index
+                .compute_index(vec![batch(&[id], &[&format!("term{id} shared")])])
+                .await
+                .expect("failed to compute_index");
+        }
+        wait_for_segments(
+            index,
+            "the single-document segments to consolidate",
+            |segments| segments.len() == 1,
+        )
+        .await;
+        assert_eq!(
+            bm25_collection_size(index),
+            8,
+            "the eight rows should have consolidated into one eight-document segment"
+        );
+
+        // Supersede half of them: the consolidated segment is now half superseded, and is
+        // still the only segment at its size level, so nothing but the deleted-document
+        // ratio can select it for a merge.
+        index
+            .compute_index(vec![batch(
+                &[1, 2, 3, 4],
+                &[
+                    "replaced1 shared",
+                    "replaced2 shared",
+                    "replaced3 shared",
+                    "replaced4 shared",
+                ],
+            )])
+            .await
+            .expect("failed to compute_index");
+
+        wait_for_superseded_docs_expunged(index).await;
+        assert_eq!(
+            bm25_collection_size(index),
+            8,
+            "the four superseded documents must not be counted in the collection size"
+        );
+    }
+
+    fn batch(ids: &[i32], contents: &[&str]) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new("content", DataType::Utf8, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(ids.to_vec())),
+                Arc::new(arrow::array::StringArray::from(contents.to_vec())),
+            ],
+        )
+        .expect("Failed to create test batch")
     }
 
     async fn search_and_format(idx: &FullTextSearchFieldIndex, query: impl Into<String>) -> String {
@@ -752,6 +936,10 @@ mod tests {
                 ])
                 .await
                 .expect("failed to compute_index");
+
+            // The `_score` column below is a BM25 score, so it is only stable once the
+            // superseded documents have left the collection statistics.
+            wait_for_superseded_docs_expunged(&index).await;
 
             let search_index = index
                 .full_text_search_field_index("content")
@@ -858,6 +1046,10 @@ mod tests {
                 .await
                 .expect("failed to compute_index");
 
+            // See `test_updates_overwrites_on_compute_index`: BM25 scores are only
+            // stable once the superseded documents have left the collection statistics.
+            wait_for_superseded_docs_expunged(&index).await;
+
             let search_index = index
                 .full_text_search_field_index("content")
                 .expect("Failed to create FullTextSearchFieldIndex");
@@ -888,6 +1080,68 @@ mod tests {
                 search_and_format(&search_index, "piano").await
             );
         }
+    }
+
+    /// A segment big enough to sit alone at its size level still has to be rewritten once
+    /// most of its documents have been superseded. Otherwise tantivy keeps counting those
+    /// documents in BM25's collection size and the index scores every query against rows
+    /// it has already replaced.
+    ///
+    /// Regression test for #12053.
+    #[tokio::test]
+    async fn test_superseded_documents_leave_the_bm25_collection_size() {
+        let index = new_test_index();
+        supersede_half_of_a_consolidated_segment(&index).await;
+
+        // An index updated in place must score exactly as one rebuilt from the same final
+        // rows — the comparison a user makes when they check a refreshed dataset against a
+        // freshly loaded one.
+        let rebuilt = new_test_index();
+        rebuilt
+            .compute_index(vec![batch(
+                &EXPUNGE_FIXTURE_IDS,
+                &[
+                    "replaced1 shared",
+                    "replaced2 shared",
+                    "replaced3 shared",
+                    "replaced4 shared",
+                    "term5 shared",
+                    "term6 shared",
+                    "term7 shared",
+                    "term8 shared",
+                ],
+            )])
+            .await
+            .expect("failed to compute_index");
+
+        let updated_search = index
+            .full_text_search_field_index("content")
+            .expect("Failed to create FullTextSearchFieldIndex");
+        let rebuilt_search = rebuilt
+            .full_text_search_field_index("content")
+            .expect("Failed to create FullTextSearchFieldIndex");
+        assert_eq!(
+            search_and_format(&updated_search, "term8").await,
+            search_and_format(&rebuilt_search, "term8").await,
+            "an updated index must score identically to one rebuilt from the same rows"
+        );
+    }
+
+    /// `on_write_start` and `on_write_failed` both roll the writer back, and a tantivy
+    /// rollback swaps in a freshly built writer carrying the default merge policy. If the
+    /// policy is not reinstated, an index stops expunging superseded documents the moment
+    /// its first write window opens — which is every refresh.
+    #[tokio::test]
+    async fn test_merge_policy_survives_a_writer_rollback() {
+        let index = new_test_index();
+        index.on_write_start().await.expect("on_write_start failed");
+        index
+            .on_write_failed()
+            .await
+            .expect("on_write_failed failed");
+
+        // Re-run the whole expunge fixture on the rolled-back writer.
+        supersede_half_of_a_consolidated_segment(&index).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Full-text relevance scores were computed against documents the index had already replaced.

tantivy derives BM25's collection size from each segment's `max_doc`, which counts documents that have been deleted but not yet physically expunged. Only a merge expunges them, and `FullTextDatabaseIndex` kept tantivy's default `LogMergePolicy`, whose `del_docs_ratio_before_merge` is `1.0` — a ratio no segment can exceed, so deletions never trigger a merge at all. (tantivy's own source calls that default "not a very sensible default", kept for backward compatibility.)

Because `update_index` writes every incoming primary key as a deletion followed by an insertion, every refresh and every CDC change supersedes rows. Once a segment has grown large enough to sit alone at its size level — where the policy's other rule, a minimum of eight segments per level, can never apply either — its superseded documents stay in the collection statistics permanently. A single-term query is scaled uniformly and keeps its order, but a multi-term query weights its terms by their individual inverse document frequencies, so the ranking itself drifts from the one the live rows imply.

Measured on `trunk` with three documents, two of which are then replaced: the surviving document scores `1.3862944` (the IDF at five documents) instead of `0.9808292` (the IDF at three), and never converges.

This is also why `test_updates_overwrites_on_compute_index` and its composite-key twin failed intermittently. Whether the superseded documents were counted depended on whether they happened to land in a segment of their own — dropped whole at commit, never reaching the statistics — or shared one with a live document, in which case the segment was retained.

## Changes

- Cap superseded documents per segment at 25% (`MAX_SUPERSEDED_DOCS_RATIO_PER_SEGMENT`), so a mostly-replaced segment is rewritten and its documents leave the statistics. Once merges settle, the collection size exceeds the live document count by at most `1 / (1 - ratio)`.
- Reinstate the policy after every rollback. `tantivy::IndexWriter::rollback` does not reset the writer, it replaces it with a freshly constructed one carrying the default policy — and `on_write_start` rolls back before every write window, so without this the fix would have lasted exactly until the first refresh. All four rollback sites now go through `rollback_writer`.
- The two snapshot tests wait for the superseded documents to be expunged before asserting a score, since merges are asynchronous. Their snapshots are unchanged.

## Test plan

- `make lint`
- `make test`

Two new tests, each verified to fail with its corresponding guard removed:

- `test_superseded_documents_leave_the_bm25_collection_size` — drives an index into the only state in which superseded documents can linger (one consolidated segment, half of it replaced), asserts they leave the collection size, and asserts that an index updated in place scores identically to one rebuilt from the same final rows. Without the merge-policy cap it times out at `max_doc=8 live=4`.
- `test_merge_policy_survives_a_writer_rollback` — the same fixture after `on_write_start`/`on_write_failed`. Without the reinstatement it times out the same way.

Removing the cap also makes the originally reported `test_updates_overwrites_on_compute_index` fail deterministically, at `max_doc=3 live=1`.

Verified locally: `cargo test -p search --lib` (75 passed), both CI clippy passes, `cargo fmt`.

## Performance impact

Merges now also trigger on superseded documents, which is additional background work for an index that is updated in place. It is bounded and amortized: a segment is rewritten once per 25% of its documents being replaced, which is the same work that reclaims their storage. An index that is only ever loaded, with no deletions, is unaffected — `deletes_ratio` is zero for every segment, so no merge is scheduled that would not already have happened, and no score changes. That is why no existing snapshot needed regenerating, including the search integration snapshots that assert `_score`.

## Checklist

- [x] Root cause confirmed against the tantivy source and reproduced end to end
- [x] Regression tests verified failing without each guard
- [x] No behavior change for indexes without superseded documents
- [x] `cargo fmt` + both CI clippy passes clean

Fixes #12053
