### PR TITLE
fix(e2e): report a REPL that exits mid-script instead of passing the step (fixes #12057)

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -258,6 +258,10 @@ jobs:
             HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install expect
           fi
 
+      - name: Test the expect scripts driving the REPLs
+        run: |
+          ./test/models/expect_test.sh
+
       - name: Test vector search
         run: |
           ./test/models/search_01.exp
@@ -343,6 +347,10 @@ jobs:
           else
             HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install expect
           fi
+
+      - name: Test the expect scripts driving the REPLs
+        run: |
+          ./test/models/expect_test.sh
 
       - name: Test vector search
         run: |

--- a/test/models/chat_01.exp
+++ b/test/models/chat_01.exp
@@ -1,5 +1,7 @@
 #!/usr/bin/expect -f
 
+source [file join [file dirname [info script]] repl_helpers.exp]
+
 # Runtime response timeout
 set timeout 30
 
@@ -12,7 +14,7 @@ proc verify_datasets_access {} {
     set gh_issues_available 0
     set catalog_page_available 0
 
-    send "What datasets you have access to\r"
+    repl_send "What datasets you have access to\r"
 
     expect {
         -re "(?i)taxi_trips|taxi trips" {
@@ -36,6 +38,9 @@ proc verify_datasets_access {} {
         "chat> " {
             # end of model response
         }
+        eof {
+            repl_died "Waiting for the list of datasets"
+        }
         timeout {
             send_user "Timeout waiting for expected response\n"
             exit 1
@@ -53,7 +58,7 @@ proc verify_datasets_access {} {
 proc verify_num_issues {} {
     global timeout
 
-    send "How many issues stored in database?\r"
+    repl_send "How many issues stored in database?\r"
 
     expect {
         " ERROR " {
@@ -64,6 +69,9 @@ proc verify_num_issues {} {
         }
         "chat> " {
             # end of model response
+        }
+        eof {
+            repl_died "Waiting for the issue count"
         }
         timeout {
             send_user "Timeout waiting for expected response\n"
@@ -80,7 +88,7 @@ proc verify_catalog_page {} {
     set original_timeout $timeout
     set timeout 60
 
-    send "find top 3 exclusive deals in catalog pages. Respond with a short bullet list.\r"
+    repl_send "find top 3 exclusive deals in catalog pages. Respond with a short bullet list.\r"
 
     expect {
         " ERROR " {
@@ -91,6 +99,9 @@ proc verify_catalog_page {} {
         }
         "chat> " {
             # end of model response
+        }
+        eof {
+            repl_died "Waiting for the catalog page deals"
         }
         timeout {
             send_user "Timeout waiting for expected response\n"
@@ -103,7 +114,18 @@ proc verify_catalog_page {} {
     send_user "Model returned expected response\n"
 }
 
-expect "chat>"
+expect {
+    "chat>" {
+        # runtime is ready for input
+    }
+    eof {
+        repl_died "Waiting for the initial chat prompt"
+    }
+    timeout {
+        send_user "Timeout waiting for initial chat prompt\n"
+        exit 1
+    }
+}
 
 verify_datasets_access
 sleep 1
@@ -113,7 +135,10 @@ sleep 1
 
 verify_catalog_page
 
+# Every verification passed, so the REPL must still be sitting at its prompt.
+repl_assert_running "Checking the chat REPL is still running"
+
 # Signal to exit (Ctrl+C)
-send \x03
+repl_send \x03
 
 exit 0

--- a/test/models/chat_01_simple.exp
+++ b/test/models/chat_01_simple.exp
@@ -1,5 +1,7 @@
 #!/usr/bin/expect -f
 
+source [file join [file dirname [info script]] repl_helpers.exp]
+
 # Runtime response timeout
 set timeout 30
 
@@ -8,7 +10,7 @@ spawn spice chat
 proc chat {message}  {
     global timeout
 
-    send "$message\r"
+    repl_send "$message\r"
 
     expect {
         " ERROR " {
@@ -21,8 +23,7 @@ proc chat {message}  {
             # end of model response
         }
         eof {
-            send_user "Chat process exited before returning a response\n"
-            exit 1
+            repl_died "Waiting for the response to \"$message\""
         }
         timeout {
             send_user "Timeout waiting for expected response\n"
@@ -39,8 +40,7 @@ proc chat {message}  {
 expect {
     "chat> " {}
     eof {
-        send_user "Chat process exited before showing the initial prompt\n"
-        exit 1
+        repl_died "Waiting for the initial chat prompt"
     }
     timeout {
         send_user "Timeout waiting for initial chat prompt\n"
@@ -52,7 +52,10 @@ chat "What datasets you have access to?"
 
 chat "How many issues stored in database?"
 
+# Every verification passed, so the REPL must still be sitting at its prompt.
+repl_assert_running "Checking the chat REPL is still running"
+
 # Signal to exit (Ctrl+C)
-send \x03
+repl_send \x03
 
 exit 0

--- a/test/models/expect_test.sh
+++ b/test/models/expect_test.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+#
+# Tests for the expect scripts that drive the Spice REPLs in E2E Test CI, and for
+# the helpers in repl_helpers.exp that they share.
+#
+# A REPL that exits part-way through a script must be reported as a crash — with
+# the exit status, or the signal that ended it — rather than as a step that passed
+# or as expect's "spawn id expN not open".
+#
+# Drives stand-in processes instead of the real `spice` binary, so it needs only
+# `expect`: no Spice runtime, no model provider, no network.
+#
+#   ./test/models/expect_test.sh
+
+set -u
+
+script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+failures=0
+case_output=""
+case_status=0
+
+pass() {
+  printf '  ok    %s\n' "$1"
+}
+
+fail() {
+  printf '  FAIL  %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+assert_status() {
+  if [ "$case_status" = "$1" ]; then
+    pass "exits $1"
+  else
+    fail "expected exit $1, got $case_status"
+    printf '%s\n' "$case_output" | sed 's/^/        | /'
+  fi
+}
+
+assert_reports() {
+  case $case_output in
+  *"$1"*) pass "reports \"$1\"" ;;
+  *)
+    fail "output does not mention \"$1\""
+    printf '%s\n' "$case_output" | sed 's/^/        | /'
+    ;;
+  esac
+}
+
+assert_silent_about() {
+  case $case_output in
+  *"$1"*)
+    fail "output still mentions \"$1\""
+    printf '%s\n' "$case_output" | sed 's/^/        | /'
+    ;;
+  *) pass "does not mention \"$1\"" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# repl_helpers.exp, driven against stand-in processes
+# ---------------------------------------------------------------------------
+
+# helper_case <name> <expect-script-body> — writes the body to a script that
+# sources the helpers, runs it, and leaves the result in $case_status/$case_output.
+helper_case() {
+  local script="$work_dir/helper_case.exp"
+
+  printf 'case: %s\n' "$1"
+  {
+    printf 'source %s\n' "$script_dir/repl_helpers.exp"
+    printf 'log_user 0\n'
+    printf '%s\n' "$2"
+  } >"$script"
+
+  case_output=$(expect -f "$script" 2>&1)
+  case_status=$?
+}
+
+# A REPL that exits while sitting idle at its prompt. Writing to the pty of an
+# exited process succeeds silently, so without repl_assert_running the script
+# would send its next line into the void and finish reporting success.
+helper_case 'exits while idle at the prompt' '
+spawn sh -c {printf "ready> "; exit 42}
+set timeout 5
+expect "ready> "
+sleep 1
+repl_assert_running "Idle check"
+send_user "REACHED THE END\n"
+exit 0
+'
+assert_status 1
+assert_reports 'exited with status 42'
+assert_silent_about 'REACHED THE END'
+assert_silent_about 'spawn id'
+
+# A REPL that exits instead of answering. An expect block with no eof branch ends
+# without running a body, so the script would carry on and report the answer it
+# never received.
+helper_case 'exits instead of answering' '
+spawn sh -c {printf "ready> "; read -r line; exit 7}
+set timeout 5
+expect "ready> "
+repl_send "how many issues?\r"
+expect {
+    "answer" {
+        send_user "MODEL ANSWERED\n"
+    }
+    eof {
+        repl_died "Waiting for the answer"
+    }
+    timeout {
+        send_user "TIMED OUT\n"
+        exit 1
+    }
+}
+exit 0
+'
+assert_status 1
+assert_reports 'Waiting for the answer'
+assert_reports 'exited with status 7'
+assert_silent_about 'MODEL ANSWERED'
+
+# A REPL killed by a signal — an out-of-memory kill looks like this, and the
+# signal is the whole diagnosis.
+helper_case 'killed by a signal' '
+spawn sh -c {printf "ready> "; read -r line; kill -9 $$}
+set timeout 5
+expect "ready> "
+repl_send "how many issues?\r"
+expect {
+    "answer" {
+        send_user "MODEL ANSWERED\n"
+    }
+    eof {
+        repl_died "Waiting for the answer"
+    }
+    timeout {
+        send_user "TIMED OUT\n"
+        exit 1
+    }
+}
+exit 0
+'
+assert_status 1
+assert_reports 'was terminated abnormally'
+assert_reports 'SIGKILL'
+
+# A REPL that has already gone away when the script sends to it. expect reports
+# this as "spawn id expN not open", which names the script line rather than the
+# process that left.
+helper_case 'has gone away by the time the script sends' '
+spawn sh -c {printf "ready> "; exit 3}
+set timeout 5
+expect "ready> "
+expect {
+    eof {}
+    timeout {}
+}
+repl_send "how many issues?\r"
+send_user "REACHED THE END\n"
+exit 0
+'
+assert_status 1
+assert_reports 'Sending "how many issues?"'
+assert_reports 'exited with status 3'
+assert_silent_about 'REACHED THE END'
+
+# A healthy exchange still runs to completion: the helpers must not turn a
+# working interaction into a failure.
+helper_case 'healthy exchange' '
+spawn sh -c {printf "ready> "; while read -r line; do printf "answer\r\nready> "; done}
+set timeout 5
+expect "ready> "
+repl_send "how many issues?\r"
+expect {
+    "answer" {}
+    eof {
+        repl_died "Waiting for the answer"
+    }
+    timeout {
+        send_user "TIMED OUT\n"
+        exit 1
+    }
+}
+expect {
+    "ready> " {}
+    eof {
+        repl_died "Waiting for the next prompt"
+    }
+    timeout {
+        send_user "TIMED OUT\n"
+        exit 1
+    }
+}
+repl_assert_running "Idle check"
+repl_send \x03
+send_user "REACHED THE END\n"
+exit 0
+'
+assert_status 0
+assert_reports 'REACHED THE END'
+assert_silent_about 'no longer running'
+
+# ---------------------------------------------------------------------------
+# The E2E scripts themselves, driven against a stand-in `spice`
+# ---------------------------------------------------------------------------
+
+# A stand-in for the `spice` CLI that emulates just enough of the `chat` and
+# `search` REPLs for the scripts to run, and that can be told to exit part-way
+# through so the crash paths are exercised.
+mkdir -p "$work_dir/bin"
+cat >"$work_dir/bin/spice" <<'STAND_IN'
+#!/usr/bin/env bash
+set -u
+mode=$1
+exit_before=${SPICE_FAKE_EXIT_BEFORE_TURN:-0}
+exit_after=${SPICE_FAKE_EXIT_AFTER_TURN:-0}
+
+prompt='chat> '
+if [ "$mode" = 'search' ]; then
+  prompt='search> '
+fi
+
+turn=0
+printf '%s' "$prompt"
+
+while IFS= read -r line; do
+  turn=$((turn + 1))
+
+  if [ "$exit_before" -ne 0 ] && [ "$turn" -ge "$exit_before" ]; then
+    exit 44
+  fi
+
+  if [ "$mode" = 'search' ]; then
+    case $line in
+    *error*) printf '1  a1b2  a spice runtime error occurred  0.75  spice.public.issues\r\n' ;;
+    *) printf '1  c3d4  deals for friends of spice  0.66  spice.public.catalog_page\r\n' ;;
+    esac
+  else
+    case $line in
+    *datasets*) printf 'taxi_trips, github_issues and catalog_page\r\n' ;;
+    *) printf -- '- 42 of them\r\n' ;;
+    esac
+  fi
+
+  printf '%s' "$prompt"
+
+  # Leaving after the prompt is written is how a REPL that dies while sitting
+  # idle looks to the script driving it.
+  if [ "$exit_after" -ne 0 ] && [ "$turn" -ge "$exit_after" ]; then
+    exit 44
+  fi
+done
+STAND_IN
+chmod +x "$work_dir/bin/spice"
+
+# script_case <name> <script> [env assignments...] — runs one of the E2E scripts
+# against the stand-in `spice`.
+script_case() {
+  local name=$1
+  local script=$2
+  shift 2
+
+  printf 'case: %s\n' "$name"
+  case_output=$(PATH="$work_dir/bin:$PATH" env "$@" "$script_dir/$script" 2>&1)
+  case_status=$?
+}
+
+for script in chat_01.exp chat_01_simple.exp search_01.exp; do
+  script_case "$script against a healthy REPL" "$script"
+  assert_status 0
+  assert_silent_about 'no longer running'
+  assert_silent_about 'Timeout waiting'
+done
+
+script_case 'chat_01.exp when the REPL exits before answering' chat_01.exp \
+  SPICE_FAKE_EXIT_BEFORE_TURN=2
+assert_status 1
+assert_reports 'Waiting for the issue count'
+assert_reports 'exited with status 44'
+assert_silent_about 'spawn id'
+
+script_case 'chat_01_simple.exp when the REPL exits before answering' chat_01_simple.exp \
+  SPICE_FAKE_EXIT_BEFORE_TURN=1
+assert_status 1
+assert_reports 'Waiting for the response to'
+assert_reports 'exited with status 44'
+assert_silent_about 'Model returned expected response'
+
+script_case 'search_01.exp when the REPL exits before answering' search_01.exp \
+  SPICE_FAKE_EXIT_BEFORE_TURN=1
+assert_status 1
+assert_reports 'Searching for "Spice runtime error"'
+assert_reports 'exited with status 44'
+assert_silent_about 'Search returned expected result'
+
+script_case 'chat_01.exp when the REPL exits while idle' chat_01.exp \
+  SPICE_FAKE_EXIT_AFTER_TURN=3
+assert_status 1
+assert_reports 'Checking the chat REPL is still running'
+assert_reports 'exited with status 44'
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%s check(s) failed\n' "$failures"
+  exit 1
+fi
+
+printf '\nAll checks passed\n'

--- a/test/models/repl_helpers.exp
+++ b/test/models/repl_helpers.exp
@@ -1,0 +1,85 @@
+# Shared helpers for the expect scripts that drive an interactive Spice REPL
+# (`spice chat`, `spice search`) over a pty.
+#
+# expect treats a spawned process going away as an ordinary end of input: when an
+# `expect` block has no `eof` pattern, the eof ends the block without running any
+# body, so the script continues as if the pattern had matched and reports success
+# for a response that never arrived. The dead process then only surfaces at the
+# next `send`, as "spawn id expN not open" — naming a line in the script instead
+# of the exit status of the process that died. See #12057.
+#
+# Every `expect` block in these scripts therefore needs an `eof` branch calling
+# `repl_died`, and every `send` goes through `repl_send`.
+
+# Renders text passed to `repl_send` for a diagnostic message.
+proc repl_render {text} {
+    return [string map [list "\r" "" "\x03" "<Ctrl-C>"] $text]
+}
+
+# Describes how the spawned process terminated, reaping it in the process.
+proc repl_termination_description {} {
+    if {[catch {wait} status]} {
+        return "could not be waited for ($status)"
+    }
+
+    # `wait` returns {pid spawn_id os_error_flag value}, where a non-zero
+    # os_error_flag makes `value` an errno message rather than an exit status,
+    # optionally followed by {CHILDKILLED signal description}.
+    if {[lindex $status 2] != 0} {
+        return "could not be reaped: [lindex $status 3]"
+    }
+
+    set signal [lrange $status 4 end]
+    if {[llength $signal] > 0} {
+        return "was terminated abnormally: $signal"
+    }
+
+    return "exited with status [lindex $status 3]"
+}
+
+# Reports a spawned process that is no longer running, then fails the script.
+# `context` says what the script was doing when it noticed.
+proc repl_died {context {detail ""}} {
+    send_user "\n$context: the spawned process is no longer running.\n"
+
+    if {$detail ne ""} {
+        send_user "expect reported: $detail\n"
+    }
+
+    # Read anything the process printed on its way out — with `log_user` on that
+    # output is echoed as it arrives, and it is usually the only record of why
+    # the process left. The connection is already closed once an `expect` block
+    # has matched eof, which makes this a no-op.
+    catch {
+        set timeout 5
+        expect {
+            eof {}
+            timeout {}
+        }
+    }
+
+    send_user "Spawned process [repl_termination_description].\n"
+    exit 1
+}
+
+# `send`, reporting a process that has already gone away instead of raising
+# "spawn id expN not open".
+proc repl_send {text} {
+    if {[catch {send -- $text} send_error]} {
+        repl_died "Sending \"[repl_render $text]\"" $send_error
+    }
+}
+
+# Fails the script if the spawned process has exited. Writing to the pty of an
+# exited process succeeds silently, so a REPL that crashes while sitting idle at
+# its prompt is invisible to `repl_send` alone; reading finds the eof. Output
+# already buffered stays available to the next `expect`.
+proc repl_assert_running {context} {
+    set timeout 1
+    expect {
+        eof {
+            repl_died $context
+        }
+        timeout {}
+    }
+}

--- a/test/models/search_01.exp
+++ b/test/models/search_01.exp
@@ -1,5 +1,7 @@
 #!/usr/bin/expect -f
 
+source [file join [file dirname [info script]] repl_helpers.exp]
+
 # spiced runtime response timeout
 set timeout 5
 
@@ -8,7 +10,7 @@ spawn spice search
 proc perform_search {search_term expected_term} {
     global timeout
 
-    send "$search_term\r"
+    repl_send "$search_term\r"
 
     expect {
         -re $expected_term {
@@ -23,19 +25,44 @@ proc perform_search {search_term expected_term} {
             send_user "Error detected\n"
             exit 1
         }
+        eof {
+            repl_died "Searching for \"$search_term\""
+        }
         timeout {
             send_user "Timeout waiting for expected response\n"
             exit 1
         }
     }
 }
-expect "search>"
+
+proc expect_search_prompt {} {
+    global timeout
+
+    expect {
+        "search>" {
+            # runtime is ready for input
+        }
+        eof {
+            repl_died "Waiting for the search prompt"
+        }
+        timeout {
+            send_user "Timeout waiting for search prompt\n"
+            exit 1
+        }
+    }
+}
+
+expect_search_prompt
 perform_search "Spice runtime error" {1 +\S+ +.* +[0-9]+\.[0-9]+ +spice\.public\.issues}
 
-expect "search>"
+expect_search_prompt
 perform_search "friends" {1 +\S+ +.* +[0-9]+\.[0-9]+ +spice\.public\.catalog_page}
 
+# Every search returned its expected result, so the REPL must still be sitting at
+# its prompt.
+repl_assert_running "Checking the search REPL is still running"
+
 # Signal to exit (Ctrl+C)
-send \x03
+repl_send \x03
 
 exit 0


### PR DESCRIPTION
## Summary

`E2E Test CI` drives `spice chat` and `spice search` over a pty with `expect`. When one of those REPLs went away mid-script, the failure was reported as `send: spawn id exp5 not open` — naming a line in the script rather than the exit status of the process that died, which was recorded nowhere.

Tracing the reported run showed the reporting gap is the smaller half of the problem. An `expect` block with **no `eof` pattern** ends *without running any body* when the spawned process goes away, and the script then carries on as if the pattern had matched:

- In [run 30186823353](https://github.com/spiceai/spiceai/actions/runs/30186823353), `spice chat` exited immediately after receiving the second prompt. `verify_num_issues` matched the resulting eof 90 ms after sending (`05:14:31.851` → `05:14:31.944`) and printed **`Model returned expected response`**. The run's "first two prompts succeeded" reading is wrong: prompt 2 was never answered. The dead process only surfaced at the *next* `send`, because the eof had closed the spawn id by then.
- A REPL that exits while sitting **idle at its prompt** was invisible: writing to the pty of an exited process succeeds silently, so `send \x03` returned success and the script exited **0**. Reduced to the pre-fix shape, a stand-in REPL that dies without answering produces:

  ```
  chat> How many issues stored in database?
  Model returned expected response
  PRE-FIX EXIT=0
  ```

So a crashed REPL could be reported as a passing step in a gate that runs on `merge_group`.

Fixes #12057

## Changes

- **`test/models/repl_helpers.exp`** (new) — shared helpers: `repl_died` reports how the process terminated (its exit status, or `CHILDKILLED` plus the signal name — an OOM kill looks like this) after draining whatever it printed on the way out; `repl_send` reports a process that has already gone away instead of raising `spawn id expN not open`; `repl_assert_running` reads for a pending eof, which is the only way to notice a REPL that died while idle.
- **`chat_01.exp`, `chat_01_simple.exp`, `search_01.exp`** — every `expect` block gained an `eof` branch, every `send` goes through `repl_send`, and each script checks the REPL is still running before sending Ctrl+C. The two bare prompt waits (`expect "chat>"`, `expect "search>"`) gained `eof` *and* `timeout` branches; previously a timeout there let the script continue in an unknown state, matching what `chat_01_simple.exp` already did.
- **`test/models/expect_test.sh`** (new) — drives stand-in processes instead of `spice`, so every crash path runs with no runtime, model provider, or network. Wired into both model jobs in `e2e_test_ci.yml`, next to the scripts it tests.

Deliberately **not** changed:

- No retry around the failing step. The issue asks for the opposite, and a retry would keep the process exit invisible.
- No new artifact upload for the runtime log: the existing `Stop spice and check logs` step already runs `if: always()` and `cat spice.log`, and `spice chat`'s own output reaches the job log through the pty.
- The **flake rate itself** is untouched — this makes each failure diagnosable and unable to masquerade as a pass. The recurring offenders (`Test Dremio quickstart`, the model-download jobs) need their own reliability pass, tracked separately in #12058.

## Test plan

- [x] Added regression test for a REPL that exits without answering, one that exits while idle at its prompt, one that has already gone when the script sends, and one killed by a signal — at the helper level and through `chat_01.exp` / `chat_01_simple.exp` / `search_01.exp` themselves
- [x] Added edge case tests for a healthy exchange through all three scripts (the helpers must not turn a working interaction into a failure), and for the signal-kill path reporting `SIGKILL`
- [x] Verified by neutering: with the helpers reduced to their pre-fix behaviour, 14 checks fail across 7 cases — including `chat_01.exp` exiting **0** on a REPL that died while idle — while all three healthy cases still pass
- [x] `test/models/expect_test.sh` passes (40 checks), 3 consecutive runs, under both `/usr/bin/env bash` and macOS `/bin/bash` 3.2
- [x] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy — not a per-crate `cargo clippy -p <crate>`)
- [x] `make test` passes
- [x] `make signoff` run after the final push (`Attestation` check is green)

## Checklist

- [x] No behaviour change for a healthy run: the same prompts, patterns and success messages, plus a one-second liveness check before the REPL is asked to exit
- [x] No Rust, config, or runtime code touched — CI test scripts only
- [x] The new CI step is deterministic: no network, no model provider, no `spice` binary