### PR TITLE
fix(github): paginate issues and pull_requests on an immutable sort key so a row touched mid-scan isn't dropped (fixes #12067)

### DIFF
--- a/crates/data-connectors/connector-github/src/issues.rs
+++ b/crates/data-connectors/connector-github/src/issues.rs
@@ -121,10 +121,15 @@ impl GitHubTableArgs for IssuesTableArgs {
                 owner = self.owner,
                 name = self.repo
             ),
+            // `orderBy` must name an immutable field. A GitHub `after:` cursor is a value
+            // predicate on the sort key, so ordering by a mutable field (e.g. UPDATED_AT)
+            // lets an issue touched on the source mid-scan jump ahead of the cursor, where
+            // no remaining page will return it — silently dropping the row from the scan.
+            // CREATED_AT ASC is GitHub's own default order for this connection.
             GitHubQueryMode::Auto => format!(
                 r#"{{
                 repository(owner: "{owner}", name: "{name}") {{
-                    issues(first: 100, orderBy: {{field: UPDATED_AT, direction: DESC}}) {{
+                    issues(first: 100, orderBy: {{field: CREATED_AT, direction: ASC}}) {{
                         pageInfo {{
                             hasNextPage
                             endCursor
@@ -278,14 +283,30 @@ mod tests {
     }
 
     #[test]
-    fn auto_mode_query_orders_by_updated_at_desc() {
-        // Deterministic UPDATED_AT-descending order is the prerequisite for
-        // watermark-based early-exit pagination on append refreshes.
+    fn auto_mode_query_orders_by_created_at_asc() {
+        // Deterministic ordering on an immutable key: see
+        // `auto_mode_query_never_paginates_on_a_mutable_sort_key`.
         let params = auto_args().get_graphql_values();
         let query = params.query.as_ref();
         assert!(
-            query.contains("issues(first: 100, orderBy: {field: UPDATED_AT, direction: DESC})"),
-            "auto-mode issues query must order by UPDATED_AT DESC, got:\n{query}"
+            query.contains("issues(first: 100, orderBy: {field: CREATED_AT, direction: ASC})"),
+            "auto-mode issues query must order by CREATED_AT ASC, got:\n{query}"
+        );
+    }
+
+    /// Regression test for #12067. A GitHub `after:` cursor is a value predicate on the
+    /// sort key, so a connection paginated on a mutable field silently drops any row
+    /// that is touched on the source mid-scan: the row's key moves ahead of the cursor
+    /// and no remaining page returns it. Only immutable sort keys are safe here.
+    #[test]
+    fn auto_mode_query_never_paginates_on_a_mutable_sort_key() {
+        let params = auto_args().get_graphql_values();
+        let query = params.query.as_ref();
+        // The GraphQL enum is upper-case (`UPDATED_AT`), so this cannot collide with the
+        // `updated_at: updatedAt` field alias the query also selects.
+        assert!(
+            !query.contains("UPDATED_AT"),
+            "auto-mode issues query must not order by the mutable UPDATED_AT, got:\n{query}"
         );
     }
 }

--- a/crates/data-connectors/connector-github/src/pull_requests.rs
+++ b/crates/data-connectors/connector-github/src/pull_requests.rs
@@ -339,12 +339,17 @@ impl GitHubTableArgs for PullRequestTableArgs {
                     nodes = self.get_requested_nodes()
                 )
             }
+            // `orderBy` must name an immutable field. A GitHub `after:` cursor is a value
+            // predicate on the sort key, so ordering by a mutable field (e.g. UPDATED_AT)
+            // lets a pull request touched on the source mid-scan jump ahead of the cursor,
+            // where no remaining page will return it — silently dropping the row from the
+            // scan. CREATED_AT ASC is GitHub's own default order for this connection.
             GitHubQueryMode::Auto => {
                 format!(
                     r#"
             {{
                 repository(owner: "{owner}", name: "{name}") {{
-                    pullRequests(first: {page_size}, orderBy: {{field: UPDATED_AT, direction: DESC}}) {{
+                    pullRequests(first: {page_size}, orderBy: {{field: CREATED_AT, direction: ASC}}) {{
                         pageInfo {{
                             hasNextPage
                             endCursor
@@ -643,15 +648,32 @@ mod tests {
     }
 
     #[test]
-    fn auto_mode_query_orders_by_updated_at_desc() {
-        // Deterministic UPDATED_AT-descending order is the prerequisite for
-        // watermark-based early-exit pagination on append refreshes.
+    fn auto_mode_query_orders_by_created_at_asc() {
+        // Deterministic ordering on an immutable key: see
+        // `auto_mode_query_never_paginates_on_a_mutable_sort_key`.
         let a = args(PullRequestCommentType::None, 25);
         let params = a.get_graphql_values();
         let query = params.query.as_ref();
         assert!(
-            query.contains("orderBy: {field: UPDATED_AT, direction: DESC}"),
-            "auto-mode pull_requests query must order by UPDATED_AT DESC, got:\n{query}"
+            query.contains("orderBy: {field: CREATED_AT, direction: ASC}"),
+            "auto-mode pull_requests query must order by CREATED_AT ASC, got:\n{query}"
+        );
+    }
+
+    /// Regression test for #12067. A GitHub `after:` cursor is a value predicate on the
+    /// sort key, so a connection paginated on a mutable field silently drops any row
+    /// that is touched on the source mid-scan: the row's key moves ahead of the cursor
+    /// and no remaining page returns it. Only immutable sort keys are safe here.
+    #[test]
+    fn auto_mode_query_never_paginates_on_a_mutable_sort_key() {
+        let a = args(PullRequestCommentType::All, 25);
+        let params = a.get_graphql_values();
+        let query = params.query.as_ref();
+        // The GraphQL enum is upper-case (`UPDATED_AT`), so this cannot collide with the
+        // `updated_at: updatedAt` field alias the query also selects.
+        assert!(
+            !query.contains("UPDATED_AT"),
+            "auto-mode pull_requests query must not order by the mutable UPDATED_AT, got:\n{query}"
         );
     }
 }


### PR DESCRIPTION
## Summary

The GitHub connector's `issues` and `pull_requests` tables paginated their default (`github_query_mode: auto`) GraphQL queries with `orderBy: {field: UPDATED_AT, direction: DESC}`, which silently drops rows.

A GitHub `after:` cursor for an ordered connection is a **value predicate on the sort key**, not a position — the cursor literally carries the sort-key value (`base64("cursor:v2:" + msgpack([<sort key>, <node id>]))`). Because `updated_at` is **mutable**, a row that has not yet been fetched (its `updated_at` is older than the scan's current cursor) and that gets commented on, labelled, edited, assigned, or closed while the scan is in flight has its `updated_at` bumped to `now` — moving it to the *already-consumed* side of the cursor. No remaining page returns it. The scan completes normally, one row short, with no error and no warning.

Exposure is the full duration of a scan, and these scans are long: `issues` fetches 100 issues plus their labels, 25 comments and assignees per page (a declared cost of 226 points/page), so a repository with thousands of issues takes many pages and minutes of wall clock. With `refresh_mode: full` (the default) the accelerated table is replaced by each lossy scan, so queries return incomplete results and a different arbitrary subset goes missing every cycle.

Fixes #12067

## Root cause

`orderBy` named a mutable field. This was introduced as a prerequisite for future watermark-based early-exit pagination; the ordering itself is applied to every page (the shared paginator preserves non-pagination arguments when it appends `after:`), so the instability is live rather than page-1-only.

Ordering by an immutable key removes the failure mode entirely: a row's cursor key cannot change during the scan, so no row can cross the cursor. `CREATED_AT ASC` is verifiably GitHub's own default order for both connections — its cursors are byte-identical to those returned by the un-ordered query — so this restores the pagination guarantee that held before the ordering was added, while keeping the order explicit and deterministic.

Verified against the live GitHub GraphQL API:

- Re-encoding an observed cursor from its `(timestamp, node_id)` parts reproduces it byte-for-byte, confirming the cursor format rather than assuming it.
- With `orderBy: {field: UPDATED_AT, direction: DESC}`, the cursor carries `updatedAt`; a **forged** cursor holding `2026-07-01T00:00:00Z` returns only issues updated before that instant, excluding all 100 issues with a newer `updated_at`. That is the exclusion that loses rows.
- With `orderBy: {field: CREATED_AT, direction: ASC}` (and with no `orderBy` at all), the cursor carries the immutable `createdAt`, and both forms produce identical cursors for the same rows.

This does forgo the forward-looking purpose of the `UPDATED_AT` ordering. A watermark-based incremental scan needs `UPDATED_AT` ordering *and* tolerance for the reshuffling — it can accept the reshuffling because a row bumped mid-scan ends up newer than the stored watermark and is picked up on the following cycle. A full scan has no watermark to self-heal from, so it cannot. That incremental design is left to be decided on its own; #12067 records the reasoning.

## Changes

- `crates/data-connectors/connector-github/src/issues.rs` — Auto-mode `issues` connection orders by `CREATED_AT ASC`, with a comment recording why the sort key must be immutable.
- `crates/data-connectors/connector-github/src/pull_requests.rs` — same for the Auto-mode `pullRequests` connection.
- Tests: the two order-assertion tests now assert `CREATED_AT ASC`, plus a regression test per table asserting the generated query never orders by the mutable `UPDATED_AT`.

Scope check: these are the only two paginated connections in the connector that carry an `orderBy` at all. `commits` (`history`), `members` (`membersWithRole`), `projects` (`projectsV2`) and `stargazers` order by GitHub's default and are unaffected. The `search`-mode arms of both tables use the Search API, which takes no `orderBy` here.

## Performance impact

None on the query itself: same result set, same page size, same point cost, just a different sort key. Both orderings are index-backed on GitHub's side.

## Test plan

- [x] `make lint`
- [x] `make test`
- [x] Regression tests fail on the pre-fix queries (`UPDATED_AT DESC`) and pass on the fixed ones
- [x] Cursor semantics verified against the live GitHub GraphQL API (forged-cursor exclusion test, and cursor-key comparison between `UPDATED_AT DESC`, `CREATED_AT ASC` and the default order)

## Checklist

- [x] Root cause identified and stated
- [x] Whole bug class swept — every paginated connection in the connector checked for a mutable sort key
- [x] Regression tests added that fail on the old code
- [x] No behavior change beyond the pagination sort key
- [x] `cargo fmt` clean
