### PR TITLE
fix(accelerator): report PK equality pushdown Inexact so a point lookup can't return the whole table (fixes #12070)

### DIFF
--- a/crates/data_components/src/arrow/indexed.rs
+++ b/crates/data_components/src/arrow/indexed.rs
@@ -620,34 +620,26 @@ impl TableProvider for IndexedMemTable {
     ) -> Result<Vec<TableProviderFilterPushDown>> {
         let owned_filters: Vec<Expr> = filters.iter().map(|&e| e.clone()).collect();
 
-        // If we have a primary key index and the filter includes a PK equality,
-        // mark only the PK filter as Exact. Non-PK filters must be Inexact so
-        // DataFusion still applies them after the indexed lookup. Returning Exact
-        // for all filters would silently drop non-PK predicates (e.g.
-        // `WHERE id=10 AND version=101` would ignore `version=101` and return
-        // the row for id=10 regardless of its version).
+        // A primary-key equality lets `scan` serve the query from the hash index,
+        // but the pushdown is reported `Inexact` — never `Exact`.
+        //
+        // `Exact` is a promise that the scan applied the predicate, and this
+        // provider cannot keep it. Whether the index is usable is decided from the
+        // `dirty` flag, which is read here during logical optimization and read
+        // AGAIN in `scan` during physical planning. A write landing between those
+        // two reads (DML, retention eviction, or a refresh sink — all call
+        // `mark_dirty`) makes `scan` bypass the index and fall through to an
+        // unfiltered `MemTable` scan while the predicate has already been deleted
+        // from the plan, so the point lookup returns the whole table (#12070).
+        //
+        // `Inexact` still hands the filter to `scan`, so the `IndexedLookupExec`
+        // fast path is unchanged; DataFusion additionally keeps a `FilterExec`,
+        // which over a point-lookup result costs nothing and makes every path
+        // through `scan` correct — index hit, index miss, hash-collision miss, and
+        // the full-scan fallback alike. It also keeps non-PK predicates applied
+        // (`WHERE id=10 AND version=101` must not ignore `version=101`).
         if self.index.is_some() && self.extract_pk_equality_value(&owned_filters).is_some() {
-            // When the index is dirty (a DML/retention/synchronized write happened
-            // without a subsequent rebuild), it can no longer be trusted: report the
-            // PK filter as Inexact instead of Exact so DataFusion keeps a FilterExec
-            // and re-applies the predicate over the full-scan fallback in `scan`,
-            // rather than dropping the filter and trusting a stale index (#11262).
-            let pk_dirty = self.is_dirty();
-            let pk_column = &self.primary_key_columns[0];
-            return Ok(filters
-                .iter()
-                .map(|f| {
-                    if Self::extract_equality_value(f, pk_column).is_some() {
-                        if pk_dirty {
-                            TableProviderFilterPushDown::Inexact
-                        } else {
-                            TableProviderFilterPushDown::Exact
-                        }
-                    } else {
-                        TableProviderFilterPushDown::Inexact
-                    }
-                })
-                .collect());
+            return Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()]);
         }
 
         // Check if a secondary index can handle this filter
@@ -1296,12 +1288,14 @@ mod tests {
         )
         .expect("failed to create table");
 
-        // Equality on primary key should get Exact pushdown
+        // Equality on primary key gets Inexact pushdown: the index serves the
+        // lookup, but `scan` may bypass it, so DataFusion must re-apply the
+        // predicate (#12070).
         let filter_eq = col("id").eq(lit(1_i64));
         let pushdown = table
             .supports_filters_pushdown(&[&filter_eq])
             .expect("pushdown check failed");
-        assert_eq!(pushdown, vec![TableProviderFilterPushDown::Exact]);
+        assert_eq!(pushdown, vec![TableProviderFilterPushDown::Inexact]);
 
         // Non-equality should get Unsupported (MemTable doesn't support filter pushdown)
         let filter_gt = col("id").gt(lit(1_i64));
@@ -2739,14 +2733,14 @@ mod tests {
 
         let table_with_secondary = table.with_secondary_index(secondary);
 
-        // PK query should return Exact
+        // PK query should return Inexact (#12070)
         let pk_filter = datafusion::prelude::col("id").eq(datafusion::prelude::lit(1_i64));
         let result = table_with_secondary
             .supports_filters_pushdown(&[&pk_filter])
             .expect("pushdown check");
         assert_eq!(
             result,
-            vec![datafusion::logical_expr::TableProviderFilterPushDown::Exact]
+            vec![datafusion::logical_expr::TableProviderFilterPushDown::Inexact]
         );
 
         // Secondary index query should return Inexact (for unique secondary indexes)
@@ -3353,8 +3347,9 @@ mod tests {
         assert_eq!(name_col.value(0), "name_42");
     }
 
-    /// Test that `supports_filters_pushdown` returns per-filter pushdown types
-    /// when a PK equality is combined with other predicates.
+    /// Test that `supports_filters_pushdown` reports every filter `Inexact` when a
+    /// PK equality is combined with other predicates, so `DataFusion` re-applies
+    /// both the PK and the non-PK predicate over whatever `scan` returns.
     #[test]
     fn test_filter_pushdown_pk_and_non_pk_filters() {
         let batch = create_large_test_batch(300);
@@ -3377,10 +3372,12 @@ mod tests {
         assert_eq!(
             pushdown,
             vec![
-                TableProviderFilterPushDown::Exact,   // PK filter handled by index
+                // The index serves the lookup, but `scan` may still bypass it, so
+                // the PK predicate must be re-applied too (#12070).
+                TableProviderFilterPushDown::Inexact,
                 TableProviderFilterPushDown::Inexact, // non-PK filter must still be applied
             ],
-            "PK filter should be Exact, non-PK filter should be Inexact"
+            "both filters should be Inexact so DataFusion re-applies them"
         );
     }
 
@@ -3388,11 +3385,16 @@ mod tests {
     // Stale-index ("dirty") correctness tests (issue #11262)
     // =========================================================================
 
-    /// A dirty index must downgrade PK equality pushdown from Exact to Inexact so
-    /// `DataFusion` keeps a `FilterExec` and re-applies the predicate, instead of
-    /// trusting a stale index that could silently drop existing rows.
+    /// PK equality pushdown is `Inexact` whether or not the index is dirty, so
+    /// `DataFusion` always keeps a `FilterExec` and re-applies the predicate
+    /// instead of trusting a scan that may bypass the index.
+    ///
+    /// Regression test for #12070: reporting `Exact` while clean was unsound,
+    /// because `scan` re-reads the dirty flag during physical planning and a write
+    /// landing in between makes it serve an unfiltered full scan for a predicate
+    /// `DataFusion` has already deleted from the plan.
     #[test]
-    fn test_dirty_index_downgrades_pushdown_to_inexact() {
+    fn test_pk_pushdown_is_always_inexact() {
         let batch = create_large_test_batch(300);
         let schema = batch.schema();
         let table = create_test_indexed_table(schema, vec![vec![batch]], vec!["id".to_string()])
@@ -3400,12 +3402,13 @@ mod tests {
 
         let pk_filter = col("id").eq(lit(42_i64));
 
-        // Clean index: Exact.
+        // Clean index: still Inexact — `Exact` is a promise `scan` cannot keep.
         assert_eq!(
             table
                 .supports_filters_pushdown(&[&pk_filter])
                 .expect("pushdown check failed"),
-            vec![TableProviderFilterPushDown::Exact]
+            vec![TableProviderFilterPushDown::Inexact],
+            "a clean index must not report Exact (#12070)"
         );
 
         // After a DML marks the table dirty: Inexact.
@@ -3418,6 +3421,66 @@ mod tests {
             vec![TableProviderFilterPushDown::Inexact],
             "dirty index must report Inexact so the predicate is re-applied"
         );
+    }
+
+    /// A write that lands between logical optimization and physical planning must
+    /// not change the answer. Regression test for #12070: while PK equality was
+    /// reported `Exact`, `DataFusion` deleted the predicate during logical
+    /// optimization, then `scan` saw the now-dirty index, bypassed it, and served
+    /// an unfiltered `MemTable` scan — so the point lookup returned every row.
+    ///
+    /// The two planning stages are driven explicitly, with the write interleaved at
+    /// exactly the boundary the race straddles.
+    #[tokio::test]
+    async fn test_write_between_pushdown_and_scan_keeps_point_lookup_correct() {
+        let batch = create_test_batch(vec![1, 2, 3], vec!["alice", "bob", "charlie"]);
+        let schema = batch.schema();
+        let table = Arc::new(
+            create_test_indexed_table_force_index(
+                Arc::clone(&schema),
+                vec![vec![batch]],
+                vec!["id".to_string()],
+            )
+            .expect("failed to create table"),
+        );
+
+        let ctx = SessionContext::new();
+        ctx.register_table("test", Arc::clone(&table) as Arc<dyn TableProvider>)
+            .expect("failed to register");
+
+        // Stage 1 — logical optimization decides the pushdown (index is clean).
+        let optimized = ctx
+            .sql("SELECT id, name FROM test WHERE id = 1")
+            .await
+            .expect("failed to plan query")
+            .into_optimized_plan()
+            .expect("failed to optimize plan");
+
+        // A concurrent DML / retention eviction / refresh sink marks the index dirty.
+        table.mark_dirty();
+
+        // Stage 2 — physical planning now sees the dirty index and falls back to a
+        // full scan. The predicate must survive in the plan for that to be correct.
+        let physical = ctx
+            .state()
+            .create_physical_plan(&optimized)
+            .await
+            .expect("failed to create physical plan");
+        let batches = datafusion::physical_plan::collect(physical, ctx.task_ctx())
+            .await
+            .expect("failed to collect");
+
+        let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(
+            total_rows, 1,
+            "point lookup must return 1 row, not the whole table (#12070)"
+        );
+        let id_col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("expected int64");
+        assert_eq!(id_col.value(0), 1);
     }
 
     /// A dirty index must not be used in `scan` — the plan must NOT contain an
@@ -3521,8 +3584,8 @@ mod tests {
             table
                 .supports_filters_pushdown(&[&pk_filter])
                 .expect("pushdown check failed"),
-            vec![TableProviderFilterPushDown::Exact],
-            "clean index must restore Exact pushdown"
+            vec![TableProviderFilterPushDown::Inexact],
+            "pushdown stays Inexact even once the index is clean (#12070)"
         );
         assert_eq!(find_5000().await, 1, "row still found after maintenance");
     }

--- a/crates/data_components/src/arrow/indexed.rs
+++ b/crates/data_components/src/arrow/indexed.rs
@@ -1727,6 +1727,16 @@ mod tests {
     }
 
     /// Helper to get the physical plan as a string for EXPLAIN output.
+    /// A `SessionContext` with `target_partitions` pinned, for EXPLAIN snapshot
+    /// tests. The default is the host's core count, which `RepartitionExec`
+    /// prints into the plan (`RoundRobinBatch(N)`) — a snapshot recorded that way
+    /// only matches machines with the same core count.
+    fn snapshot_session_context() -> SessionContext {
+        SessionContext::new_with_config(
+            datafusion::prelude::SessionConfig::new().with_target_partitions(4),
+        )
+    }
+
     async fn explain_plan(ctx: &SessionContext, sql: &str) -> String {
         let df = ctx.sql(sql).await.expect("failed to create dataframe");
         let plan = df
@@ -1751,7 +1761,7 @@ mod tests {
         )
         .expect("failed to create table");
 
-        let ctx = SessionContext::new();
+        let ctx = snapshot_session_context();
         ctx.register_table("test_table", Arc::new(table))
             .expect("failed to register table");
 
@@ -1855,7 +1865,7 @@ mod tests {
         )
         .expect("failed to create non-indexed table");
 
-        let ctx = SessionContext::new();
+        let ctx = snapshot_session_context();
         ctx.register_table("indexed_table", Arc::new(indexed_table))
             .expect("failed to register table");
         ctx.register_table("non_indexed_table", Arc::new(non_indexed_table))

--- a/crates/data_components/src/arrow/snapshots/data_components__arrow__indexed__tests__explain_indexed_scan.snap
+++ b/crates/data_components/src/arrow/snapshots/data_components__arrow__indexed__tests__explain_indexed_scan.snap
@@ -3,5 +3,5 @@ source: crates/data_components/src/arrow/indexed.rs
 expression: plan
 ---
 FilterExec: id@0 = 1
-  RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+  RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
     IndexedLookupExec: indexed_scan on [id]

--- a/crates/data_components/src/arrow/snapshots/data_components__arrow__indexed__tests__explain_indexed_scan.snap
+++ b/crates/data_components/src/arrow/snapshots/data_components__arrow__indexed__tests__explain_indexed_scan.snap
@@ -2,5 +2,6 @@
 source: crates/data_components/src/arrow/indexed.rs
 expression: plan
 ---
-CooperativeExec
-  IndexedLookupExec: indexed_scan on [id]
+FilterExec: id@0 = 1
+  RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+    IndexedLookupExec: indexed_scan on [id]

--- a/crates/data_components/src/arrow/snapshots/data_components__arrow__indexed__tests__explain_indexed_table_point_lookup.snap
+++ b/crates/data_components/src/arrow/snapshots/data_components__arrow__indexed__tests__explain_indexed_table_point_lookup.snap
@@ -3,5 +3,5 @@ source: crates/data_components/src/arrow/indexed.rs
 expression: indexed_plan
 ---
 FilterExec: id@0 = 1
-  RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+  RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
     IndexedLookupExec: indexed_scan on [id]

--- a/crates/data_components/src/arrow/snapshots/data_components__arrow__indexed__tests__explain_indexed_table_point_lookup.snap
+++ b/crates/data_components/src/arrow/snapshots/data_components__arrow__indexed__tests__explain_indexed_table_point_lookup.snap
@@ -2,5 +2,6 @@
 source: crates/data_components/src/arrow/indexed.rs
 expression: indexed_plan
 ---
-CooperativeExec
-  IndexedLookupExec: indexed_scan on [id]
+FilterExec: id@0 = 1
+  RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+    IndexedLookupExec: indexed_scan on [id]


### PR DESCRIPTION
Fixes #12070

## Summary (root cause)

`IndexedMemTable` (auto-enabled for `engine: arrow` datasets with `primary_key`/`indexes`) decided whether its hash index could be trusted by reading a `dirty` flag — but it read that flag **twice, at two different planning stages**, and nothing required the two reads to agree:

1. **Logical optimization** — `supports_filters_pushdown` read `is_dirty()`. Clean ⇒ the PK equality was reported **`Exact`**, which makes DataFusion **delete the predicate from the plan**.
2. **Physical planning** — `scan` read `is_dirty()` again. Dirty ⇒ both index branches were skipped and it fell through to `self.inner.scan(...)`, a plain `MemTable` scan, which does not apply filters.

A write landing between those two reads — DML, retention eviction, or a refresh sink, all of which call `mark_dirty()` at plan time — left the predicate deleted with nothing to re-apply it. The point lookup then returned **every row in the table**, silently: no error, no warning, and a result set unbounded in the accelerator's size.

For the standard `engine: arrow` + `primary_key` + `on_conflict: upsert` dataset, where refresh/DML writes are continuous, this races against every concurrent point-lookup query being planned.

This is a residual gap in #11532 (the #11262 fix), which made the two sites individually dirty-aware but not jointly consistent.

## Changes

`crates/data_components/src/arrow/indexed.rs` — report PK equality pushdown as **`Inexact`, unconditionally**, and drop the `is_dirty()` consultation from `supports_filters_pushdown` (the dirty flag is still consulted in `scan`, which is where it belongs).

`Exact` is a promise that the scan applied the predicate, and this provider cannot keep it across two independent trait calls. `Inexact` still hands the filter to `scan`, so the `IndexedLookupExec` point-lookup fast path is **unchanged** — DataFusion additionally keeps a `FilterExec`, which over a point-lookup result costs essentially nothing, and which makes every path through `scan` correct: index hit, index miss, hash-collision miss, and the full-scan fallback alike.

The secondary-index path already reported `Inexact`, so the provider now never reports `Exact` — the "dropped predicate the scan didn't apply" class is eliminated rather than narrowed. This follows the repo guidance of defaulting to the universally-safe mode instead of gating correctness on a capability check.

## Performance impact

The point-lookup fast path is preserved: `EXPLAIN` still shows `IndexedLookupExec: indexed_scan on [id]`, now under a `FilterExec` that re-applies the equality over the single returned row. The full-table scan the index avoids is still avoided; the added cost is one predicate evaluation per lookup result row.

## Test plan

- `make lint`
- `make nextest`
- Targeted during development: `cargo test -p data_components --lib arrow::indexed` — **53 passed / 0 failed**.
- **New end-to-end regression test** `test_write_between_pushdown_and_scan_keeps_point_lookup_correct`: drives the two planning stages explicitly (`into_optimized_plan()` → `mark_dirty()` → `create_physical_plan()`), which is exactly the boundary the race straddles, and asserts the point lookup returns 1 row rather than the whole table.
- **New contract test** `test_pk_pushdown_is_always_inexact`: PK equality is `Inexact` whether the index is clean or dirty.
- **Neuter test**: restoring the old `Exact`-when-clean behavior fails **8** tests, including both new ones — so the regression guards genuinely bite. Before the fix the end-to-end test returns all 3 rows for `WHERE id = 1`; after, 1 row.
- Two `insta` snapshots regenerated (`explain_indexed_scan`, `explain_indexed_table_point_lookup`) — the only change is the expected `FilterExec: id@0 = 1` above the preserved `IndexedLookupExec`.

## Known follow-up (needs a testoperator dispatch, cannot be done locally)

Six `crates/test-framework` EXPLAIN snapshots will need regeneration, because their plans currently record `full_filters` (Exact) on the PK and will become `partial_filters` with a `FilterExec`:

```
file[parquet]-arrow-pk_hash_index_{customer,nation,orders,part,region,supplier}_pk_lookup_explain.snap
```

These are asserted by the testoperator scenario `scenario/sf1/accelerated/indexes/file[parquet]-arrow-pk_hash_index.yaml`, not by merge-queue `cargo test`, so they do not block this PR's checks — but that scenario will fail until they are regenerated against a live SF1 spiced (which I can't run here, and hand-editing `.snap` files is disallowed). The 11 `secondary_hash_index` snapshots are **unaffected** — they already record `partial_filters`, since that path always reported `Inexact`.

## Checklist

- [x] Root cause identified and reproduced on trunk before writing the fix
- [x] Regression test fails on old code, passes on new (neuter-verified)
- [x] Bug-class swept: every `supports_filters_pushdown` impl in the repo that can return `Exact` was checked; `MemoryVectorQueryTable` and `runtime-table-partition` genuinely apply their Exact filters, so this was the only unsound instance
- [x] `cargo fmt` clean; clippy pass 1 (`--lib`) clean
- [x] Snapshots regenerated via `INSTA_UPDATE`, reviewed, not hand-edited
- [ ] `make signoff` / `Attestation` green
