### PR TITLE
fix(cayenne): purge the mem-tier on delete-all for a table without a primary key (fixes #12072)

### DIFF
--- a/crates/cayenne/src/provider/on_conflict.rs
+++ b/crates/cayenne/src/provider/on_conflict.rs
@@ -399,6 +399,9 @@ pub(crate) fn is_delete_all(filters: &[Expr]) -> bool {
 pub(crate) struct PkKeysetInvalidatingDeletionSink {
     pub(crate) table: CayenneTableProvider,
     pub(crate) inner: Arc<dyn DeletionSink>,
+    /// The delete request's filters, needed to recognize a delete-all so the
+    /// mem-tier can be purged alongside the inner sink's file-side work.
+    pub(crate) filters: Vec<Expr>,
 }
 
 #[async_trait]
@@ -424,7 +427,34 @@ impl DeletionSink for PkKeysetInvalidatingDeletionSink {
         // below resets the flag and rebuilds exact; an upsert table keeps the
         // stale-superset keyset and stays degraded until its next rebuild.
         self.table.mark_pk_keyset_occ_degraded();
-        let deleted = self.inner.delete_from(context).await?;
+        let mut deleted = self.inner.delete_from(context).await?;
+
+        // Delete-all (TRUNCATE / `DELETE … WHERE TRUE`): the inner sink records
+        // `(file, file-local position)` deletes, and rows resident in the
+        // in-memory tier live in no file — so nothing tombstones them and they
+        // stay visible. A table with no primary key reaches this sink for every
+        // delete (`pk_deletion_strategy` is `PositionBased` exactly then), and in
+        // `mode: memory` the mem-tier is the permanent store, so without this the
+        // table can never be emptied. Mirrors `InlineAwareDeletionSink` below,
+        // which covers the key-based arm. Skipped for filtered deletes, whose
+        // predicate cannot be evaluated against the tier here.
+        //
+        // `purge_mem_tier_all` requires the table `write_lock`, which the inner
+        // sink takes and releases internally, so acquire it here rather than
+        // nesting. Purge before the `deleted > 0` bookkeeping below: on a table
+        // whose rows are *only* in the mem-tier the inner count is 0, and the
+        // cached scan statistics still need invalidating once the purge changes
+        // the visible row count.
+        if is_delete_all(&self.filters) {
+            let _guard = self.table.write_lock.lock().await;
+            let purged = self
+                .table
+                .purge_mem_tier_all()
+                .await
+                .map_err(|error| Box::new(error) as Box<dyn std::error::Error + Send + Sync>)?;
+            deleted = deleted.saturating_add(purged);
+        }
+
         if deleted > 0 {
             // Keyset clear-on-delete avoidance (cycle-4 incremental lever).
             //

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -26276,6 +26276,7 @@ impl CayenneTableProvider {
             PkKeysetInvalidatingDeletionSink {
                 table: self.clone_for_write(),
                 inner: sink,
+                filters: filters.to_vec(),
             },
         ))))
     }
@@ -26297,6 +26298,7 @@ impl CayenneTableProvider {
             PkKeysetInvalidatingDeletionSink {
                 table: self.clone_for_write(),
                 inner: sink,
+                filters: filters.to_vec(),
             },
         ))))
     }
@@ -29460,6 +29462,137 @@ mod tests {
         assert!(
             provider.mem_tier.is_empty(),
             "the mem-tier must be fully purged after the delete-all"
+        );
+    }
+
+    /// A table with no primary key has `pk_deletion_strategy: PositionBased`, so
+    /// every delete leaves `delete_from` through the deletion-vector arm and never
+    /// reaches `InlineAwareDeletionSink`. Position deletes address
+    /// `(file, file-local position)` pairs and mem-tier rows live in no file, so
+    /// the delete-all must purge the tier from the other sink too — in
+    /// `mode: memory` the mem-tier is the permanent store, so otherwise the table
+    /// can never be emptied. Regression test for #12072.
+    #[tokio::test]
+    async fn truncate_purges_mem_tier_rows_on_a_table_without_a_primary_key() {
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        // `mode: memory` shape (see `apply_memory_mode_overrides`): the mem-tier is
+        // the permanent in-RAM store and nothing is ever encoded to Vortex.
+        let vortex_config = VortexConfig {
+            memory_mode: true,
+            cdc_mem_tier_shards: 1,
+            ..VortexConfig::default()
+        };
+        let (provider, _temp_dir) = create_cayenne_table_with_config(
+            "truncate_mem_tier_no_pk",
+            Arc::clone(&schema),
+            vortex_config,
+            // No primary key — this is what selects the position-based arm.
+            vec![],
+            ctx.runtime_env(),
+        )
+        .await;
+        assert!(
+            provider.pk_deletion_strategy.is_position_based(),
+            "precondition: a PK-less table must use the position-based strategy"
+        );
+
+        // Write through the real memory-mode path (`append` refresh).
+        let b1 = int64_id_batch(&[1, 2, 3]);
+        let bytes1 = b1.get_array_memory_size() as u64;
+        provider
+            .write_batches_memory_mode(vec![b1], bytes1, false)
+            .await
+            .expect("memory-mode append 1");
+        let b2 = int64_id_batch(&[4, 5]);
+        let bytes2 = b2.get_array_memory_size() as u64;
+        provider
+            .write_batches_memory_mode(vec![b2], bytes2, false)
+            .await
+            .expect("memory-mode append 2");
+        assert_eq!(
+            scan_sorted_ids(&provider).await,
+            vec![1, 2, 3, 4, 5],
+            "precondition: the mem-tier rows are visible to scans"
+        );
+
+        let delete_plan = provider
+            .delete_from(&ctx.state(), vec![datafusion_expr::lit(true)])
+            .await
+            .expect("delete-all plan");
+        let results = datafusion::physical_plan::collect(delete_plan, ctx.task_ctx())
+            .await
+            .expect("delete-all executed");
+        let deleted = results[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt64Array>()
+            .expect("uint64 count column")
+            .value(0);
+        assert_eq!(
+            deleted, 5,
+            "the delete-all count must include the 5 purged mem-tier rows"
+        );
+
+        assert_eq!(
+            scan_sorted_ids(&provider).await,
+            Vec::<i64>::new(),
+            "no mem-tier row may survive a TRUNCATE / DELETE WHERE TRUE"
+        );
+        assert!(
+            provider.mem_tier.is_empty(),
+            "the mem-tier must be fully purged after the delete-all"
+        );
+    }
+
+    /// The purge is gated on the delete being a tautology: a filtered delete
+    /// through the same position-based sink must NOT discard the whole tier.
+    /// (Filtered deletes not reaching mem-tier rows is #12008; what matters here
+    /// is that the delete-all fix cannot over-delete.)
+    #[tokio::test]
+    async fn filtered_delete_does_not_purge_the_mem_tier_without_a_primary_key() {
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let vortex_config = VortexConfig {
+            memory_mode: true,
+            cdc_mem_tier_shards: 1,
+            ..VortexConfig::default()
+        };
+        let (provider, _temp_dir) = create_cayenne_table_with_config(
+            "filtered_delete_mem_tier_no_pk",
+            Arc::clone(&schema),
+            vortex_config,
+            vec![],
+            ctx.runtime_env(),
+        )
+        .await;
+
+        let batch = int64_id_batch(&[1, 2, 3]);
+        let bytes = batch.get_array_memory_size() as u64;
+        provider
+            .write_batches_memory_mode(vec![batch], bytes, false)
+            .await
+            .expect("memory-mode append");
+
+        let delete_plan = provider
+            .delete_from(
+                &ctx.state(),
+                vec![datafusion_expr::col("id").eq(datafusion_expr::lit(2_i64))],
+            )
+            .await
+            .expect("filtered delete plan");
+        datafusion::physical_plan::collect(delete_plan, ctx.task_ctx())
+            .await
+            .expect("filtered delete executed");
+
+        assert_eq!(
+            scan_sorted_ids(&provider).await,
+            vec![1, 2, 3],
+            "a filtered delete must not purge the whole mem-tier"
         );
     }
 


### PR DESCRIPTION
## Summary

On a Cayenne table **without a primary key**, `DELETE FROM <table>` (delete-all / TRUNCATE) reported **0 rows affected** and removed **nothing** from the in-memory tier. For `mode: memory`, where the mem-tier is the permanent and only store, the table could never be emptied — the `DELETE` returned success with a 0 count and every subsequent `SELECT` still returned the rows.

Root cause: `purge_mem_tier_all()` (added by #12009 for #11987) had exactly one caller, `InlineAwareDeletionSink` — the **key-based** delete arm. `CayenneTableProvider::delete_from` has three arms, and `pk_deletion_strategy` is `PositionBased` **iff the table has no primary key**, so a PK-less table always returned early through `delete_using_deletion_vectors` and never built that sink. Position deletes address `(file, file-local position)` pairs and mem-tier rows live in no file, so there was nothing for the inner sink to tombstone. The plan-time `checkpoint_inlined_data_if_present_for_delete()` on that arm only materializes the *inline* corpus, which is a different structure — and in memory mode a checkpoint is a no-op by design.

Fixes #12072

## Changes

- `PkKeysetInvalidatingDeletionSink` (the wrapper used by both the position-based and file-based arms) now carries the request `filters` and, when `is_delete_all(&filters)`, runs `purge_mem_tier_all()` after the inner sink completes, folding the purged count into rows-affected.
- The purge acquires the table `write_lock` itself rather than nesting: the inner sink takes and releases that lock internally.
- It runs *before* the existing `deleted > 0` bookkeeping so `invalidate_scan_file_statistics()` still fires on a table whose rows are only in the mem-tier (inner count 0) but whose visible row count just changed.

Deliberately unchanged: `purge_mem_tier_all` already early-returns on an empty mem-tier, so ordinary file tables pay nothing; and the file-based arm's retention filter (`col < threshold`) never satisfies `is_delete_all`, so retention behavior is untouched. *Filtered* deletes leaving mem-tier rows is a separate gap tracked in #12008 and is not addressed here.

## Test plan

- `make lint`
- `make test`

New unit tests in `crates/cayenne/src/provider/table.rs`:

- `truncate_purges_mem_tier_rows_on_a_table_without_a_primary_key` — regression test: a `mode: memory`, no-`primary_key` table written through the real memory-mode write path, asserting the delete-all count is 5, the scan returns no rows, and the mem-tier is empty. Asserts `is_position_based()` as a precondition so the test cannot silently drift onto the already-fixed arm.
- `filtered_delete_does_not_purge_the_mem_tier_without_a_primary_key` — guards the other direction: a filtered delete through the same sink must not discard the whole tier.

Verification performed:

- `cargo test -p cayenne --lib` — 923 passed. The 34 `cayenne_catalog::tests` failures are a pre-existing local environment issue (those tests use hardcoded `/tmp/cayenne_test*` paths owned by another uid on this shared machine → `PermissionDenied`); they are untouched by this diff and pass in CI.
- **Neuter test**: with the new purge made unreachable, `truncate_purges_mem_tier_rows_on_a_table_without_a_primary_key` fails (`deleted` 0, expected 5) while the pre-existing `truncate_purges_uncheckpointed_mem_tier_rows` and the filtered-delete guard still pass — so the regression test genuinely bites and the fix is what makes it pass.
- Clippy with the CI flag sets, both passes (`--lib`, then `--tests` with `-Aclippy::expect_used`): zero warnings. `cargo fmt -p cayenne` clean.

## Checklist

- [x] Regression test that fails on the old code and passes on the new
- [x] Bug-class swept: all four `DeletionSink` impls checked; the two wrappers are `InlineAwareDeletionSink` (already purges) and `PkKeysetInvalidatingDeletionSink` (fixed here)
- [x] No behavior change for tables with a primary key, or for retention deletes
- [x] Lint and format clean