### PR TITLE
test(chbench): default MySQL adaptive spicepods to one shared binlog dump

### DIFF
--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-split.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-split.yaml
@@ -87,6 +87,10 @@ datasets:
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
         cayenne_cdc_mem_tier_shards: '4'
+        cdc_prefetch_buffer: '16384'
+        cdc_max_coalesced_envelopes: '16384'
+        cdc_max_coalesced_bytes: '536870912'
+        cdc_max_coalesce_age_ms: '2000'
         # Goal-driven SLOs are set globally under `runtime.params` (above) and
         # inherited by every dataset, so they are intentionally not repeated here.
         # (A dataset that needed a sharper target would override the relevant

--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-split.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-split.yaml
@@ -1,6 +1,15 @@
 version: v1
 kind: Spicepod
-name: mysql-cayenne[file]-adaptive
+name: mysql-cayenne[file]-adaptive-split
+
+# Per-dataset-dump (split) variant of mysql-cayenne[file]-adaptive: each
+# `refresh_mode: changes` dataset pins a distinct explicit
+# mysql_replication_server_id, which keys the shared-source registry so every
+# dataset gets its OWN binlog dump connection (7 server-side Binlog Dump
+# threads, 7 full-stream decodes). This is the per-dataset opt-out seam of the
+# shared engine; the base spicepod coalesces all datasets onto one shared dump.
+# Kept to compare topology cost (duplicate decode, per-table independence)
+# against the shared default.
 
 # Adaptive-tuning variant of the non-tuned postgres-cayenne[file] baseline. Instead of either
 # the static `auto` derivation (the baseline) or a hand-pinned -cdc-tuned-* config, every Cayenne
@@ -27,9 +36,6 @@ name: mysql-cayenne[file]-adaptive
 # sql_results / task_history stay off to match the baseline and the -cdc-tuned configs, so a
 # comparison isolates the effect of adaptive tuning, not caching/history overhead.
 
-# All `refresh_mode: changes` datasets coalesce onto ONE shared binlog dump
-# (server_id derived from the connection identity - the engine default). The
-# -split variant pins distinct per-dataset server_ids for separate dumps.
 mysql_connection_params: &mysql_params
   mysql_host: ${env:CHBENCH_MYSQL_HOST}
   mysql_tcp_port: 3306
@@ -69,6 +75,7 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
+      mysql_replication_server_id: '1001'
     acceleration: &cayenne_accel
       enabled: true
       engine: cayenne
@@ -90,6 +97,7 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
+      mysql_replication_server_id: '1002'
     acceleration: *cayenne_accel
 
   - from: mysql:customer
@@ -97,6 +105,7 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
+      mysql_replication_server_id: '1003'
     acceleration: *cayenne_accel
 
   - from: mysql:new_order
@@ -104,6 +113,7 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
+      mysql_replication_server_id: '1004'
     acceleration: *cayenne_accel
 
   - from: mysql:oorder
@@ -111,6 +121,7 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
+      mysql_replication_server_id: '1005'
     acceleration: *cayenne_accel
 
   - from: mysql:order_line
@@ -118,6 +129,7 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
+      mysql_replication_server_id: '1006'
     acceleration: *cayenne_accel
 
   - from: mysql:stock
@@ -125,6 +137,7 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
+      mysql_replication_server_id: '1007'
     acceleration: *cayenne_accel
 
   # ---- Static reference tables (no OLTP mutations, full refresh) ----

--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-turso.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-turso.yaml
@@ -32,6 +32,9 @@ name: mysql-cayenne[file]-adaptive-turso
 # sql_results / task_history stay off to match the baseline, so a
 # comparison isolates the effect of adaptive tuning, not caching/history overhead.
 
+# All `refresh_mode: changes` datasets coalesce onto ONE shared binlog dump
+# (server_id derived from the connection identity - the engine default). The
+# -split variant pins distinct per-dataset server_ids for separate dumps.
 mysql_connection_params: &mysql_params
   mysql_host: ${env:CHBENCH_MYSQL_HOST}
   mysql_tcp_port: 3306
@@ -71,7 +74,6 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
-      mysql_replication_server_id: '1001'
     acceleration: &cayenne_accel
       enabled: true
       engine: cayenne
@@ -97,7 +99,6 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
-      mysql_replication_server_id: '1002'
     acceleration: *cayenne_accel
 
   - from: mysql:customer
@@ -105,7 +106,6 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
-      mysql_replication_server_id: '1003'
     acceleration: *cayenne_accel
 
   - from: mysql:new_order
@@ -113,7 +113,6 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
-      mysql_replication_server_id: '1004'
     acceleration: *cayenne_accel
 
   - from: mysql:oorder
@@ -121,7 +120,6 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
-      mysql_replication_server_id: '1005'
     acceleration: *cayenne_accel
 
   - from: mysql:order_line
@@ -129,7 +127,6 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
-      mysql_replication_server_id: '1006'
     acceleration: *cayenne_accel
 
   - from: mysql:stock
@@ -137,7 +134,6 @@ datasets:
     params:
       <<: *mysql_params
       mysql_replication_initial_snapshot: auto
-      mysql_replication_server_id: '1007'
     acceleration: *cayenne_accel
 
   # ---- Static reference tables (no OLTP mutations, full refresh) ----

--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-turso.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-turso.yaml
@@ -85,6 +85,10 @@ datasets:
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
         cayenne_cdc_mem_tier_shards: '4'
+        cdc_prefetch_buffer: '16384'
+        cdc_max_coalesced_envelopes: '16384'
+        cdc_max_coalesced_bytes: '536870912'
+        cdc_max_coalesce_age_ms: '2000'
         # The only line that differs from the sqlite-default adaptive twin: select the Turso
         # metastore backend. This is a structural backend choice, not a tunable actuator, so it
         # does not pin any knob under adaptive tuning.

--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive.yaml
@@ -80,6 +80,10 @@ datasets:
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
         cayenne_cdc_mem_tier_shards: '4'
+        cdc_prefetch_buffer: '16384'
+        cdc_max_coalesced_envelopes: '16384'
+        cdc_max_coalesced_bytes: '536870912'
+        cdc_max_coalesce_age_ms: '2000'
         # Goal-driven SLOs are set globally under `runtime.params` (above) and
         # inherited by every dataset, so they are intentionally not repeated here.
         # (A dataset that needed a sharper target would override the relevant

--- a/tools/testoperator/dispatch/chbench/sf1000-adaptive/mysql-cayenne[file]-adaptive-split.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-adaptive/mysql-cayenne[file]-adaptive-split.yaml
@@ -1,0 +1,10 @@
+tests:
+  htap:
+    spicepod_path: accelerated/mysql-cayenne[file]-adaptive-split.yaml
+    runner_type: spiceai-dev-xlarge-runners
+    scale_factor: 1000
+    terminals: 100
+    duration: 900
+    ready_wait: 900
+    query_overrides: chbench-skip-slow
+    rate: 9250


### PR DESCRIPTION
## What

- `mysql-cayenne[file]-adaptive.yaml` and `mysql-cayenne[file]-adaptive-turso.yaml`: remove the explicit per-dataset `mysql_replication_server_id` pins (1001–1007) so all `refresh_mode: changes` datasets coalesce onto **one shared binlog dump** — the shared-engine default.
- Add `mysql-cayenne[file]-adaptive-split.yaml`: the previous per-dataset-dump topology, kept as an explicit variant with a matching `sf1000-adaptive` dispatch entry so scheduled runs compare both topologies.
- Add missing cdc params:
>cdc_prefetch_buffer: '16384'
  cdc_max_coalesced_envelopes: '16384'
  cdc_max_coalesced_bytes: '536870912'
  cdc_max_coalesce_age_ms: '2000'
