### PR TITLE
feat(datasets): mark non-accelerated datasets Error when their source is unavailable

### DIFF
--- a/crates/runtime-component/src/dataset/mod.rs
+++ b/crates/runtime-component/src/dataset/mod.rs
@@ -345,10 +345,6 @@ impl Display for CheckAvailability {
     }
 }
 
-/// Default cadence at which the availability monitor probes a non-accelerated
-/// dataset's source when `check_availability_interval` is not configured.
-pub const DEFAULT_CHECK_AVAILABILITY_INTERVAL: Duration = Duration::from_mins(1);
-
 /// Config-only core of a dataset — every declared field of a
 /// `runtime::component::dataset::Dataset` except the runtime handles
 /// (`app`/`runtime`). The runtime wrapper holds `Self` plus those handles and
@@ -381,11 +377,11 @@ pub struct DatasetSpec {
     pub vectors: Option<VectorStore>,
     pub full_text_search: Option<spicepod::fts::FtsStore>,
     pub check_availability: CheckAvailability,
-    /// Raw duration string controlling how often the availability monitor probes
-    /// this (non-accelerated) dataset's source. Parsed via
-    /// [`DatasetSpec::check_availability_interval`]; defaults to
-    /// [`DEFAULT_CHECK_AVAILABILITY_INTERVAL`] when unset or unparseable.
-    pub check_availability_interval: Option<String>,
+    /// How often the availability monitor probes this (non-accelerated)
+    /// dataset's source, parsed from the Spicepod duration string at
+    /// construction. Availability monitoring is **opt-in**: `None` means the
+    /// dataset is not monitored at all.
+    pub check_availability_interval: Option<Duration>,
 }
 
 impl std::fmt::Debug for DatasetSpec {
@@ -526,28 +522,6 @@ impl DatasetSpec {
             return acceleration.refresh_check_interval;
         }
         None
-    }
-
-    /// How often the availability monitor should probe this dataset's source.
-    ///
-    /// Falls back to [`DEFAULT_CHECK_AVAILABILITY_INTERVAL`] when the value is
-    /// unset or cannot be parsed (a warning is logged in the latter case).
-    #[must_use]
-    pub fn check_availability_interval(&self) -> Duration {
-        let Some(raw) = &self.check_availability_interval else {
-            return DEFAULT_CHECK_AVAILABILITY_INTERVAL;
-        };
-        match fundu::parse_duration(raw) {
-            Ok(duration) => duration,
-            Err(e) => {
-                tracing::warn!(
-                    "Unable to parse check_availability_interval '{raw}' for dataset {}: {e}. Using default of {}s.",
-                    self.name,
-                    DEFAULT_CHECK_AVAILABILITY_INTERVAL.as_secs()
-                );
-                DEFAULT_CHECK_AVAILABILITY_INTERVAL
-            }
-        }
     }
 
     #[must_use]

--- a/crates/runtime-component/src/dataset/mod.rs
+++ b/crates/runtime-component/src/dataset/mod.rs
@@ -345,6 +345,10 @@ impl Display for CheckAvailability {
     }
 }
 
+/// Default cadence at which the availability monitor probes a non-accelerated
+/// dataset's source when `check_availability_interval` is not configured.
+pub const DEFAULT_CHECK_AVAILABILITY_INTERVAL: Duration = Duration::from_mins(1);
+
 /// Config-only core of a dataset — every declared field of a
 /// `runtime::component::dataset::Dataset` except the runtime handles
 /// (`app`/`runtime`). The runtime wrapper holds `Self` plus those handles and
@@ -377,6 +381,11 @@ pub struct DatasetSpec {
     pub vectors: Option<VectorStore>,
     pub full_text_search: Option<spicepod::fts::FtsStore>,
     pub check_availability: CheckAvailability,
+    /// Raw duration string controlling how often the availability monitor probes
+    /// this (non-accelerated) dataset's source. Parsed via
+    /// [`DatasetSpec::check_availability_interval`]; defaults to
+    /// [`DEFAULT_CHECK_AVAILABILITY_INTERVAL`] when unset or unparseable.
+    pub check_availability_interval: Option<String>,
 }
 
 impl std::fmt::Debug for DatasetSpec {
@@ -404,6 +413,10 @@ impl std::fmt::Debug for DatasetSpec {
             .field("vectors", &self.vectors)
             .field("full_text_search", &self.full_text_search)
             .field("check_availability", &self.check_availability)
+            .field(
+                "check_availability_interval",
+                &self.check_availability_interval,
+            )
             .finish_non_exhaustive()
     }
 }
@@ -432,6 +445,7 @@ impl PartialEq for DatasetSpec {
             && self.vectors == other.vectors
             && self.full_text_search == other.full_text_search
             && self.check_availability == other.check_availability
+            && self.check_availability_interval == other.check_availability_interval
     }
 }
 
@@ -512,6 +526,28 @@ impl DatasetSpec {
             return acceleration.refresh_check_interval;
         }
         None
+    }
+
+    /// How often the availability monitor should probe this dataset's source.
+    ///
+    /// Falls back to [`DEFAULT_CHECK_AVAILABILITY_INTERVAL`] when the value is
+    /// unset or cannot be parsed (a warning is logged in the latter case).
+    #[must_use]
+    pub fn check_availability_interval(&self) -> Duration {
+        let Some(raw) = &self.check_availability_interval else {
+            return DEFAULT_CHECK_AVAILABILITY_INTERVAL;
+        };
+        match fundu::parse_duration(raw) {
+            Ok(duration) => duration,
+            Err(e) => {
+                tracing::warn!(
+                    "Unable to parse check_availability_interval '{raw}' for dataset {}: {e}. Using default of {}s.",
+                    self.name,
+                    DEFAULT_CHECK_AVAILABILITY_INTERVAL.as_secs()
+                );
+                DEFAULT_CHECK_AVAILABILITY_INTERVAL
+            }
+        }
     }
 
     #[must_use]

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -66,6 +66,7 @@ pub struct DatasetBuilder {
     pub vectors: Option<VectorStore>,
     pub full_text_search: Option<FtsStore>,
     pub check_availability: CheckAvailability,
+    pub check_availability_interval: Option<String>,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
@@ -154,6 +155,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             vectors: dataset.vectors,
             full_text_search: dataset.full_text_search,
             check_availability: CheckAvailability::from(dataset.check_availability),
+            check_availability_interval: dataset.check_availability_interval,
         })
     }
 }
@@ -187,6 +189,7 @@ impl DatasetBuilder {
             vectors: None,
             full_text_search: None,
             check_availability: CheckAvailability::default(),
+            check_availability_interval: None,
         })
     }
 
@@ -295,6 +298,7 @@ impl DatasetBuilder {
                 vectors: self.vectors,
                 full_text_search: self.full_text_search,
                 check_availability: self.check_availability,
+                check_availability_interval: self.check_availability_interval,
             },
             app,
             runtime,

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use super::{
     CheckAvailability, Dataset, Error, InvalidColumnTypeSnafu, InvalidConfigurationSnafu,
@@ -66,7 +66,7 @@ pub struct DatasetBuilder {
     pub vectors: Option<VectorStore>,
     pub full_text_search: Option<FtsStore>,
     pub check_availability: CheckAvailability,
-    pub check_availability_interval: Option<String>,
+    pub check_availability_interval: Option<Duration>,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
@@ -109,6 +109,35 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
         validate_identifier(&dataset.name).context(crate::ComponentSnafu)?;
 
         let table_reference = Dataset::parse_table_reference(&dataset.name)?;
+
+        // Parse the duration string once here (raw string stays in the Spicepod
+        // representation; the runtime component holds the typed value). An
+        // invalid value fails dataset construction rather than silently
+        // disabling the check.
+        let check_availability_interval = dataset
+            .check_availability_interval
+            .as_deref()
+            .map(|raw| {
+                fundu::parse_duration(raw).map_err(|source| {
+                    crate::component::dataset::Error::UnableToParseFieldAsDuration {
+                        field: "check_availability_interval".to_string(),
+                        source,
+                    }
+                })
+            })
+            .transpose()
+            .context(crate::InvalidSpicepodDatasetSnafu)?;
+
+        // Availability monitoring only applies to non-accelerated datasets, so
+        // warn (rather than silently ignore) when it is configured on an
+        // accelerated one.
+        if check_availability_interval.is_some() && acceleration.as_ref().is_some_and(|a| a.enabled)
+        {
+            tracing::warn!(
+                "Dataset {} sets `check_availability_interval` but is accelerated; availability monitoring applies only to non-accelerated datasets and will be ignored. An accelerated dataset keeps serving from the accelerator even when its source is unavailable.",
+                dataset.name
+            );
+        }
 
         // If the dataset is enabled for a vector engine, use this instead of JIT.
         if let Some(vector_engine) = &dataset.vectors {
@@ -155,7 +184,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             vectors: dataset.vectors,
             full_text_search: dataset.full_text_search,
             check_availability: CheckAvailability::from(dataset.check_availability),
-            check_availability_interval: dataset.check_availability_interval,
+            check_availability_interval,
         })
     }
 }

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -30,10 +30,10 @@ mod moved_tests;
 // `runtime-component`. Re-exported here for path compatibility
 // (`crate::component::dataset::{DatasetSpec, Acceleration, acceleration, ...}`).
 pub use runtime_component::dataset::{
-    CheckAvailability, DatasetSpec, Error, FullTextSearchDatasetConfig, InvalidColumnTypeSnafu,
-    InvalidConfigurationSnafu, OnSchemaChange, ReadyState, Result, TimeFormat,
-    UnsupportedTypeAction, acceleration, declared_schema, declared_type, metadata, replication,
-    schema_inference,
+    CheckAvailability, DEFAULT_CHECK_AVAILABILITY_INTERVAL, DatasetSpec, Error,
+    FullTextSearchDatasetConfig, InvalidColumnTypeSnafu, InvalidConfigurationSnafu, OnSchemaChange,
+    ReadyState, Result, TimeFormat, UnsupportedTypeAction, acceleration, declared_schema,
+    declared_type, metadata, replication, schema_inference,
 };
 // `validate_identifier` is used by `builder` via `super::validate_identifier`.
 use runtime_component::dataset::acceleration::Acceleration;
@@ -89,6 +89,10 @@ impl std::fmt::Debug for Dataset {
             .field("vectors", &self.vectors)
             .field("full_text_search", &self.full_text_search)
             .field("check_availability", &self.check_availability)
+            .field(
+                "check_availability_interval",
+                &self.check_availability_interval,
+            )
             .finish_non_exhaustive()
     }
 }

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -30,10 +30,10 @@ mod moved_tests;
 // `runtime-component`. Re-exported here for path compatibility
 // (`crate::component::dataset::{DatasetSpec, Acceleration, acceleration, ...}`).
 pub use runtime_component::dataset::{
-    CheckAvailability, DEFAULT_CHECK_AVAILABILITY_INTERVAL, DatasetSpec, Error,
-    FullTextSearchDatasetConfig, InvalidColumnTypeSnafu, InvalidConfigurationSnafu, OnSchemaChange,
-    ReadyState, Result, TimeFormat, UnsupportedTypeAction, acceleration, declared_schema,
-    declared_type, metadata, replication, schema_inference,
+    CheckAvailability, DatasetSpec, Error, FullTextSearchDatasetConfig, InvalidColumnTypeSnafu,
+    InvalidConfigurationSnafu, OnSchemaChange, ReadyState, Result, TimeFormat,
+    UnsupportedTypeAction, acceleration, declared_schema, declared_type, metadata, replication,
+    schema_inference,
 };
 // `validate_identifier` is used by `builder` via `super::validate_identifier`.
 use runtime_component::dataset::acceleration::Acceleration;

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -5667,6 +5667,7 @@ mod tests {
                     vectors: None,
                     full_text_search: None,
                     check_availability: crate::component::dataset::CheckAvailability::Disabled,
+                    check_availability_interval: None,
                     on_schema_change: crate::component::dataset::OnSchemaChange::default(),
                 },
                 app: Arc::new(app::App::default()),

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -49,7 +49,7 @@ const MIN_CHECK_TICK: Duration = Duration::from_secs(1);
 /// How often the loop wakes when no dataset is being monitored — just enough to
 /// notice newly registered datasets. Not user-facing (nothing is probed until a
 /// dataset opts in via `check_availability_interval`).
-const MONITOR_IDLE_TICK: Duration = Duration::from_secs(60);
+const MONITOR_IDLE_TICK: Duration = Duration::from_mins(1);
 
 /// Upper bound on how far back the `task_history` "recently queried" lookup
 /// reaches, regardless of a dataset's configured interval, to keep that query

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -32,7 +32,7 @@ use tokio::sync::Mutex;
 use tracing_futures::Instrument;
 
 use crate::{
-    component::dataset::{CheckAvailability, DEFAULT_CHECK_AVAILABILITY_INTERVAL, Dataset},
+    component::dataset::{CheckAvailability, Dataset},
     datafusion::{
         DataFusion,
         error::{find_datafusion_root, format_datafusion_error},
@@ -45,6 +45,11 @@ use runtime_metrics as metrics;
 /// Lower bound on the monitor's wake-up cadence, so a very small
 /// `check_availability_interval` cannot spin the loop.
 const MIN_CHECK_TICK: Duration = Duration::from_secs(1);
+
+/// How often the loop wakes when no dataset is being monitored — just enough to
+/// notice newly registered datasets. Not user-facing (nothing is probed until a
+/// dataset opts in via `check_availability_interval`).
+const MONITOR_IDLE_TICK: Duration = Duration::from_secs(60);
 
 /// Upper bound on how far back the `task_history` "recently queried" lookup
 /// reaches, regardless of a dataset's configured interval, to keep that query
@@ -159,8 +164,17 @@ impl DatasetsHealthMonitor {
             return Ok(());
         }
 
+        // Availability monitoring is opt-in: a dataset is only monitored when it
+        // configures `check_availability_interval`.
+        let Some(interval) = dataset.check_availability_interval else {
+            tracing::debug!(
+                "Skipping dataset {} for availability monitoring (no check_availability_interval configured)",
+                dataset.name
+            );
+            return Ok(());
+        };
+
         let dataset_name = &dataset.name.to_string();
-        let interval = dataset.check_availability_interval();
 
         tracing::debug!(
             "Registering dataset {dataset_name} for periodic availability check every {}s",
@@ -477,8 +491,8 @@ fn report_dataset_unavailable_time(dataset_name: &str, last_available_time: Opti
 }
 
 /// Shortest configured probe interval among monitored datasets, clamped to a
-/// floor. Falls back to the default when nothing is monitored, so the loop
-/// still wakes periodically to pick up newly registered datasets.
+/// floor. Falls back to [`MONITOR_IDLE_TICK`] when nothing is monitored, so the
+/// loop still wakes periodically to pick up newly registered datasets.
 async fn shortest_interval(
     datasets: &Arc<Mutex<HashMap<String, Arc<DatasetAvailabilityInfo>>>>,
 ) -> Duration {
@@ -487,7 +501,7 @@ async fn shortest_interval(
         .values()
         .map(|d| d.interval)
         .min()
-        .unwrap_or(DEFAULT_CHECK_AVAILABILITY_INTERVAL)
+        .unwrap_or(MONITOR_IDLE_TICK)
         .max(MIN_CHECK_TICK)
 }
 
@@ -501,7 +515,7 @@ async fn snapshot_datasets(
         .values()
         .map(|d| d.interval)
         .max()
-        .unwrap_or(DEFAULT_CHECK_AVAILABILITY_INTERVAL);
+        .unwrap_or(MONITOR_IDLE_TICK);
     (datasets.values().map(Arc::clone).collect(), max_interval)
 }
 

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -15,13 +15,14 @@ limitations under the License.
 */
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt::{self, Debug},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use arrow::array::{AsArray, RecordBatch};
+use arrow::array::{Array, AsArray, RecordBatch};
+use arrow::datatypes::TimestampNanosecondType;
 use datafusion::{datasource::TableProvider, error::DataFusionError, sql::TableReference};
 use futures::{future::join_all, stream::TryStreamExt};
 use iceberg_datafusion::IcebergTableProvider;
@@ -31,18 +32,24 @@ use tokio::sync::Mutex;
 use tracing_futures::Instrument;
 
 use crate::{
-    component::dataset::{CheckAvailability, Dataset},
+    component::dataset::{CheckAvailability, DEFAULT_CHECK_AVAILABILITY_INTERVAL, Dataset},
     datafusion::{
         DataFusion,
         error::{find_datafusion_root, format_datafusion_error},
     },
     search::util::find_concrete_table_provider,
+    status::{ComponentStatus, RuntimeStatus},
 };
 use runtime_metrics as metrics;
 
-const DATASETS_AVAILABILITY_CHECK_INTERVAL_SECONDS: u64 = 60; // every minute
-const DATASET_UNAVAILABLE_THRESHOLD_MINUTES: u64 = 10;
-const DATASET_UNAVAILABLE_THRESHOLD_SECONDS: u64 = DATASET_UNAVAILABLE_THRESHOLD_MINUTES * 60; // 10 minutes
+/// Lower bound on the monitor's wake-up cadence, so a very small
+/// `check_availability_interval` cannot spin the loop.
+const MIN_CHECK_TICK: Duration = Duration::from_secs(1);
+
+/// Upper bound on how far back the `task_history` "recently queried" lookup
+/// reaches, regardless of a dataset's configured interval, to keep that query
+/// cheap. Datasets with an interval longer than this are still probed directly.
+const MAX_RECENT_QUERY_LOOKBACK: Duration = Duration::from_hours(1); // 1 hour
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -76,8 +83,12 @@ pub enum Error {
 #[derive(Clone)]
 pub struct DatasetAvailabilityInfo {
     name: String,
+    /// Canonical table reference used to key the runtime status registry.
+    table_ref: TableReference,
     table_provider: Arc<dyn TableProvider>,
     last_available_time: SystemTime,
+    /// How often this dataset's source should be probed.
+    interval: Duration,
 }
 
 impl Debug for DatasetAvailabilityInfo {
@@ -85,22 +96,31 @@ impl Debug for DatasetAvailabilityInfo {
         f.debug_struct("DatasetAvailabilityInfo")
             .field("name", &self.name)
             .field("last_available_time", &self.last_available_time)
+            .field("interval", &self.interval)
             .finish_non_exhaustive()
     }
 }
 
 impl DatasetAvailabilityInfo {
-    pub fn new(name: String, table_provider: Arc<dyn TableProvider>) -> Self {
+    pub fn new(
+        table_ref: TableReference,
+        table_provider: Arc<dyn TableProvider>,
+        interval: Duration,
+    ) -> Self {
         Self {
-            name,
+            name: table_ref.to_string(),
+            table_ref,
             table_provider,
             last_available_time: SystemTime::now(),
+            interval,
         }
     }
 }
 
 enum AvailabilityVerificationResult {
-    Available,
+    /// The source was reachable; carries the time availability was confirmed
+    /// (probe time, or the end time of a recent successful query).
+    Available(SystemTime),
     Unavailable(SystemTime, String),
 }
 
@@ -140,8 +160,12 @@ impl DatasetsHealthMonitor {
         }
 
         let dataset_name = &dataset.name.to_string();
+        let interval = dataset.check_availability_interval();
 
-        tracing::debug!("Registering dataset {dataset_name} for periodic availability check");
+        tracing::debug!(
+            "Registering dataset {dataset_name} for periodic availability check every {}s",
+            interval.as_secs()
+        );
 
         let table_provider = self.get_table_provider(dataset.name.clone()).await?;
 
@@ -158,8 +182,9 @@ impl DatasetsHealthMonitor {
         monitored_datasets.insert(
             dataset_name.clone(),
             Arc::new(DatasetAvailabilityInfo::new(
-                dataset_name.clone(),
+                dataset.name.clone(),
                 table_provider,
+                interval,
             )),
         );
 
@@ -189,16 +214,23 @@ impl DatasetsHealthMonitor {
         Ok(table)
     }
 
-    // returns a list of dataset names that had successful queries against them in the last 10 minutes
-    pub async fn get_recently_accessed_datasets(
+    /// Returns, per dataset, the most recent time it was the subject of a
+    /// successful (`error_code IS NULL`) query within `lookback`.
+    ///
+    /// A recent successful query is itself proof the source is reachable, so the
+    /// monitor can skip a redundant probe (and clear a stale `Error`) for
+    /// actively-queried datasets.
+    async fn recent_success_times(
         df: Arc<DataFusion>,
-    ) -> Result<Arc<HashSet<String>>> {
+        lookback: Duration,
+    ) -> Result<HashMap<String, SystemTime>> {
+        let lookback_secs = lookback.as_secs().max(1);
         let query = format!(
             "
-SELECT labels.datasets AS datasets
+SELECT labels.datasets AS datasets, end_time
 FROM runtime.task_history
 WHERE labels.datasets IS NOT NULL
-AND NOW() < end_time + INTERVAL '{DATASET_UNAVAILABLE_THRESHOLD_MINUTES}' MINUTE
+AND NOW() < end_time + INTERVAL '{lookback_secs}' SECOND
 AND labels.error_code IS NULL"
         );
         let query_result = df
@@ -207,23 +239,23 @@ AND labels.error_code IS NULL"
             .run()
             .await
             .context(DataFusionQuerySnafu)?;
-        let datasets_with_recent_activity = query_result
+        let batches = query_result
             .data
             .try_collect::<Vec<RecordBatch>>()
             .await
             .map_err(find_datafusion_root)
             .context(UnableToGetRecentlyAccessedDatasetsSnafu)?;
 
-        let mut datasets_with_recent_activity_set: HashSet<String> = HashSet::new();
+        let mut latest: HashMap<String, SystemTime> = HashMap::new();
 
-        for record_batch in &datasets_with_recent_activity {
-            let column = record_batch.column(0);
-            let datasets: Vec<&str> = match column.data_type() {
+        for batch in &batches {
+            let datasets_col = batch.column(0);
+            let names: Vec<Option<&str>> = match datasets_col.data_type() {
                 arrow::datatypes::DataType::Utf8 => {
-                    column.as_string::<i32>().into_iter().flatten().collect()
+                    datasets_col.as_string::<i32>().iter().collect()
                 }
                 arrow::datatypes::DataType::LargeUtf8 => {
-                    column.as_string::<i64>().into_iter().flatten().collect()
+                    datasets_col.as_string::<i64>().iter().collect()
                 }
                 dt => {
                     return Err(Error::UnexpectedDataType {
@@ -231,103 +263,133 @@ AND labels.error_code IS NULL"
                     });
                 }
             };
+            let end_times = batch.column(1).as_primitive::<TimestampNanosecondType>();
 
-            for dataset in datasets {
-                for name in dataset.split(',') {
-                    datasets_with_recent_activity_set.insert(name.to_string());
+            for (row, maybe_names) in names.into_iter().enumerate() {
+                let Some(row_names) = maybe_names else {
+                    continue;
+                };
+                if end_times.is_null(row) {
+                    continue;
+                }
+                // `end_time` is stored as nanoseconds since the Unix epoch.
+                let Ok(nanos) = u64::try_from(end_times.value(row)) else {
+                    continue;
+                };
+                let ts = UNIX_EPOCH + Duration::from_nanos(nanos);
+                for name in row_names.split(',') {
+                    latest
+                        .entry(name.to_string())
+                        .and_modify(|existing| {
+                            if ts > *existing {
+                                *existing = ts;
+                            }
+                        })
+                        .or_insert(ts);
                 }
             }
         }
 
-        Ok(Arc::new(datasets_with_recent_activity_set))
+        Ok(latest)
     }
 
     pub fn start(&self) {
         tracing::debug!("Starting datasets availability monitoring");
         let monitored_datasets = Arc::clone(&self.monitored_datasets);
         let df = Arc::clone(&self.df);
+        let runtime_status = df.runtime_status();
         let is_task_history_enabled = self.is_task_history_enabled;
         tokio::spawn(async move {
-            // no need to check status immediately after start
-            tokio::time::sleep(tokio::time::Duration::from_secs(
-                DATASET_UNAVAILABLE_THRESHOLD_SECONDS,
-            ))
-            .await;
-
             loop {
-                tracing::debug!("Checking datasets availability");
-                // Only datasets without recent activity/availability
-                let datasets_to_check = datasets_for_availability_check(&monitored_datasets).await;
+                // Wake at the shortest configured interval so each dataset is
+                // probed close to its own cadence; the floor stops a tiny
+                // interval from spinning the loop.
+                let tick = shortest_interval(&monitored_datasets).await;
+                tokio::time::sleep(tick).await;
 
-                // check `task_history` first to exclude anything that had a successful query in the last 10 minutes
-                let recently_accessed_datasets = if is_task_history_enabled {
-                    match Self::get_recently_accessed_datasets(Arc::clone(&df)).await {
-                        Ok(datasets) => datasets,
+                let (snapshot, max_interval) = snapshot_datasets(&monitored_datasets).await;
+                if snapshot.is_empty() {
+                    continue;
+                }
+                tracing::debug!("Checking datasets availability");
+
+                // A recent successful query proves the source is reachable, so
+                // fold it in to avoid redundantly probing actively-queried
+                // datasets (and to clear a stale Error for them).
+                let recent = if is_task_history_enabled {
+                    let lookback = max_interval.min(MAX_RECENT_QUERY_LOOKBACK);
+                    match Self::recent_success_times(Arc::clone(&df), lookback).await {
+                        Ok(map) => map,
                         Err(e) => {
                             tracing::warn!("{e}");
-                            Arc::new(HashSet::new())
+                            HashMap::new()
                         }
                     }
                 } else {
-                    Arc::new(HashSet::new())
+                    HashMap::new()
                 };
 
-                tracing::trace!(
-                    "Datasets excluded from availability check as they were recently successfully accessed: {recently_accessed_datasets:?}"
-                );
+                let now = SystemTime::now();
+                let mut tasks = Vec::new();
+                for item in snapshot {
+                    // Confirm availability from a recent successful query without a probe.
+                    if let Some(query_time) = recent.get(&item.name).copied()
+                        && now.duration_since(query_time).unwrap_or(Duration::MAX) < item.interval
+                    {
+                        update_dataset_availability_info(
+                            &monitored_datasets,
+                            &runtime_status,
+                            &item,
+                            AvailabilityVerificationResult::Available(query_time),
+                        )
+                        .await;
+                        continue;
+                    }
 
-                // subset them from the datasets to check
-                let datasets_to_check: Vec<_> = datasets_to_check
-                    .into_iter()
-                    .filter(|item| !recently_accessed_datasets.contains(&item.name))
-                    .collect();
+                    // Not due for a probe yet.
+                    if now
+                        .duration_since(item.last_available_time)
+                        .unwrap_or(Duration::MAX)
+                        < item.interval
+                    {
+                        continue;
+                    }
 
-                tracing::trace!("Datasets to check: {datasets_to_check:?}");
-
-                let tasks: Vec<_> = datasets_to_check
-                    .into_iter()
-                    .map(|item| {
-                        let df = Arc::clone(&df);
-                        let monitored_datasets = Arc::clone(&monitored_datasets);
-                        tokio::spawn(async move {
-                            tracing::trace!("Verifying connectivity for dataset {}", &item.name);
-
-                            let span = tracing::span!(target: "task_history", tracing::Level::INFO, "test_connectivity", input = &item.name);
-                            let connectivity_test_result =
-                                match test_connectivity(&item.table_provider, df).instrument(span.clone()).await
-                                {
-                                    Ok(()) => AvailabilityVerificationResult::Available,
-                                    Err(err) => {
-                                        let err_message = match err.find_root() {
-                                            DataFusionError::Execution(e) => e.clone(),
-                                            _ => err.to_string(),
-                                        };
-
-                                        tracing::error!(target: "task_history", parent: &span, "{err_message}");
-                                        AvailabilityVerificationResult::Unavailable(
-                                        item.last_available_time,
-                                        err_message,
-                                    )},
+                    let df = Arc::clone(&df);
+                    let monitored_datasets = Arc::clone(&monitored_datasets);
+                    let runtime_status = Arc::clone(&runtime_status);
+                    tasks.push(tokio::spawn(async move {
+                        tracing::trace!("Verifying connectivity for dataset {}", &item.name);
+                        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "test_connectivity", input = %item.name);
+                        let result = match test_connectivity(&item.table_provider, df)
+                            .instrument(span.clone())
+                            .await
+                        {
+                            Ok(()) => AvailabilityVerificationResult::Available(SystemTime::now()),
+                            Err(err) => {
+                                let err_message = match err.find_root() {
+                                    DataFusionError::Execution(e) => e.clone(),
+                                    _ => err.to_string(),
                                 };
-
-                            update_dataset_availability_info(
-                                &monitored_datasets,
-                                &item.name,
-                                connectivity_test_result,
-                            )
-                            .await;
-                        })
-                    })
-                    .collect();
+                                tracing::error!(target: "task_history", parent: &span, "{err_message}");
+                                AvailabilityVerificationResult::Unavailable(
+                                    item.last_available_time,
+                                    err_message,
+                                )
+                            }
+                        };
+                        update_dataset_availability_info(
+                            &monitored_datasets,
+                            &runtime_status,
+                            &item,
+                            result,
+                        )
+                        .await;
+                    }));
+                }
 
                 join_all(tasks).await;
-
                 tracing::trace!("Finished checking datasets availability");
-
-                tokio::time::sleep(Duration::from_secs(
-                    DATASETS_AVAILABILITY_CHECK_INTERVAL_SECONDS,
-                ))
-                .await;
             }
         });
     }
@@ -335,21 +397,62 @@ AND labels.error_code IS NULL"
 
 async fn update_dataset_availability_info(
     monitored_datasets: &Arc<Mutex<HashMap<String, Arc<DatasetAvailabilityInfo>>>>,
-    dataset_name: &String,
+    runtime_status: &Arc<RuntimeStatus>,
+    item: &DatasetAvailabilityInfo,
     test_result: AvailabilityVerificationResult,
 ) {
     match test_result {
-        AvailabilityVerificationResult::Available => {
-            tracing::trace!("Successfully verified access to federated dataset {dataset_name}");
-            let mut monitored_datasets_lock = monitored_datasets.lock().await;
-            if let Some(dataset) = monitored_datasets_lock.get_mut(dataset_name) {
-                Arc::make_mut(dataset).last_available_time = SystemTime::now();
+        AvailabilityVerificationResult::Available(available_at) => {
+            tracing::trace!(
+                "Successfully verified access to federated dataset {}",
+                item.name
+            );
+            {
+                let mut lock = monitored_datasets.lock().await;
+                if let Some(dataset) = lock.get_mut(&item.name)
+                    && available_at > dataset.last_available_time
+                {
+                    Arc::make_mut(dataset).last_available_time = available_at;
+                }
             }
-            report_dataset_unavailable_time(dataset_name, None);
+            report_dataset_unavailable_time(&item.name, None);
+
+            // Only restore Ready when we previously flipped the dataset to Error,
+            // so a recovery never clobbers a Refreshing/ShuttingDown/Initializing
+            // state the rest of the runtime owns.
+            if runtime_status
+                .get_dataset_status(&item.table_ref)
+                .is_some_and(|s| s.is_error())
+            {
+                runtime_status.update_dataset(&item.table_ref, ComponentStatus::Ready);
+                tracing::info!(
+                    "Dataset {} source is reachable again; status restored to Ready",
+                    item.name
+                );
+            }
         }
         AvailabilityVerificationResult::Unavailable(last_available_time, err) => {
-            tracing::warn!("Failed to verify the dataset {dataset_name} was available. {err}");
-            report_dataset_unavailable_time(dataset_name, Some(last_available_time));
+            tracing::warn!(
+                "Failed to verify the dataset {} was available. {err}",
+                item.name
+            );
+            report_dataset_unavailable_time(&item.name, Some(last_available_time));
+
+            // Only transition a healthy (Ready) or already-errored dataset; leave
+            // transient lifecycle states (Initializing/Refreshing/ShuttingDown)
+            // to the load/refresh paths that own them.
+            if runtime_status
+                .get_dataset_status(&item.table_ref)
+                .is_some_and(|s| matches!(s, ComponentStatus::Ready | ComponentStatus::Error(_)))
+            {
+                runtime_status.update_dataset(
+                    &item.table_ref,
+                    ComponentStatus::error_with_message(format!(
+                        "Failed to reach the source for dataset {} during availability check: {err}",
+                        item.name
+                    )),
+                );
+            }
         }
     }
 }
@@ -373,21 +476,33 @@ fn report_dataset_unavailable_time(dataset_name: &str, last_available_time: Opti
     }
 }
 
-async fn datasets_for_availability_check(
+/// Shortest configured probe interval among monitored datasets, clamped to a
+/// floor. Falls back to the default when nothing is monitored, so the loop
+/// still wakes periodically to pick up newly registered datasets.
+async fn shortest_interval(
     datasets: &Arc<Mutex<HashMap<String, Arc<DatasetAvailabilityInfo>>>>,
-) -> Vec<Arc<DatasetAvailabilityInfo>> {
-    let now = SystemTime::now();
+) -> Duration {
     let datasets = datasets.lock().await;
     datasets
-        .iter()
-        .filter(|(_, item)| {
-            now.duration_since(item.last_available_time)
-                .unwrap_or_default()
-                .as_secs()
-                > DATASET_UNAVAILABLE_THRESHOLD_SECONDS
-        })
-        .map(|(_, item)| Arc::clone(item))
-        .collect::<Vec<_>>()
+        .values()
+        .map(|d| d.interval)
+        .min()
+        .unwrap_or(DEFAULT_CHECK_AVAILABILITY_INTERVAL)
+        .max(MIN_CHECK_TICK)
+}
+
+/// Snapshot the monitored datasets plus the longest configured interval (used
+/// to bound the `task_history` recent-query lookback).
+async fn snapshot_datasets(
+    datasets: &Arc<Mutex<HashMap<String, Arc<DatasetAvailabilityInfo>>>>,
+) -> (Vec<Arc<DatasetAvailabilityInfo>>, Duration) {
+    let datasets = datasets.lock().await;
+    let max_interval = datasets
+        .values()
+        .map(|d| d.interval)
+        .max()
+        .unwrap_or(DEFAULT_CHECK_AVAILABILITY_INTERVAL);
+    (datasets.values().map(Arc::clone).collect(), max_interval)
 }
 
 async fn test_connectivity(
@@ -452,6 +567,95 @@ mod test {
             .expect("should register dataset");
 
         monitor.deregister_dataset(&dataset.name.to_string()).await;
+    }
+
+    fn test_availability_info(table_ref: &TableReference) -> DatasetAvailabilityInfo {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let table_provider: Arc<dyn TableProvider> =
+            Arc::new(MemTable::try_new(schema, vec![vec![]]).expect("memtable"));
+        DatasetAvailabilityInfo::new(table_ref.clone(), table_provider, Duration::from_mins(1))
+    }
+
+    /// A failed probe flips a Ready dataset to Error, and a later successful
+    /// probe restores it to Ready — this is what surfaces via
+    /// `GET /v1/datasets?status=true`.
+    #[tokio::test]
+    async fn availability_result_drives_dataset_status() {
+        let status = RuntimeStatus::new();
+        let table_ref = TableReference::bare("orders");
+        status.update_dataset(&table_ref, ComponentStatus::Ready);
+
+        let info = test_availability_info(&table_ref);
+        let monitored: Arc<Mutex<HashMap<String, Arc<DatasetAvailabilityInfo>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        monitored
+            .lock()
+            .await
+            .insert(info.name.clone(), Arc::new(info.clone()));
+
+        // Source unavailable -> Error (with message).
+        update_dataset_availability_info(
+            &monitored,
+            &status,
+            &info,
+            AvailabilityVerificationResult::Unavailable(
+                SystemTime::now(),
+                "connection refused".to_string(),
+            ),
+        )
+        .await;
+        let errored = status.get_dataset_status(&table_ref).expect("status");
+        assert!(errored.is_error(), "expected Error, got {errored:?}");
+        assert!(
+            errored
+                .error_message()
+                .is_some_and(|m| m.contains("connection refused")),
+            "error message should carry the source failure"
+        );
+
+        // Source reachable again -> Ready.
+        update_dataset_availability_info(
+            &monitored,
+            &status,
+            &info,
+            AvailabilityVerificationResult::Available(SystemTime::now()),
+        )
+        .await;
+        assert_eq!(
+            status.get_dataset_status(&table_ref),
+            Some(ComponentStatus::Ready)
+        );
+    }
+
+    /// The monitor must not clobber a transient lifecycle state (e.g. a dataset
+    /// mid-reload) with Error.
+    #[tokio::test]
+    async fn availability_does_not_clobber_transient_status() {
+        let status = RuntimeStatus::new();
+        let table_ref = TableReference::bare("orders");
+        status.update_dataset(&table_ref, ComponentStatus::Initializing);
+
+        let info = test_availability_info(&table_ref);
+        let monitored: Arc<Mutex<HashMap<String, Arc<DatasetAvailabilityInfo>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        monitored
+            .lock()
+            .await
+            .insert(info.name.clone(), Arc::new(info.clone()));
+
+        update_dataset_availability_info(
+            &monitored,
+            &status,
+            &info,
+            AvailabilityVerificationResult::Unavailable(SystemTime::now(), "boom".to_string()),
+        )
+        .await;
+
+        assert_eq!(
+            status.get_dataset_status(&table_ref),
+            Some(ComponentStatus::Initializing),
+            "a probe failure must not override a non-Ready lifecycle state"
+        );
     }
 
     fn create_test_datafusion(

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -325,6 +325,12 @@ impl RuntimeStatus {
         self.get_statuses_of_prefix("dataset:")
     }
 
+    /// Returns the current status of a single dataset, if registered.
+    #[must_use]
+    pub fn get_dataset_status(&self, dataset: &TableReference) -> Option<ComponentStatus> {
+        self.get_component_status(&format!("dataset:{dataset}"))
+    }
+
     /// Returns the status of all registered views.
     #[must_use]
     pub fn get_view_statuses(&self) -> HashMap<TableReference, ComponentStatus> {

--- a/crates/runtime/tests/dataset_availability/mod.rs
+++ b/crates/runtime/tests/dataset_availability/mod.rs
@@ -215,8 +215,8 @@ async fn availability_monitor_marks_dataset_error_on_source_outage() -> Result<(
         .build()
         .map_err(|e| anyhow::anyhow!("failed to build dataset: {e}"))?;
     assert_eq!(
-        dataset.check_availability_interval(),
-        Duration::from_secs(1)
+        dataset.check_availability_interval,
+        Some(Duration::from_secs(1))
     );
 
     // Simulate the dataset having loaded successfully (its healthy state).

--- a/crates/runtime/tests/dataset_availability/mod.rs
+++ b/crates/runtime/tests/dataset_availability/mod.rs
@@ -19,11 +19,57 @@ use runtime::{
     Runtime,
     component::dataset::{Dataset, builder::DatasetBuilder},
     datasets_health_monitor::DatasetsHealthMonitor,
+    status::ComponentStatus,
 };
 use spicepod::component::dataset::CheckAvailability;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
-use crate::utils::register_test_connectors;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::catalog::Session;
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::{ExecutionPlan, empty::EmptyExec};
+use datafusion::sql::TableReference;
+
+use crate::utils::{register_test_connectors, wait_until_true};
+
+/// A [`TableProvider`] whose `scan` fails while `fail` is set — used to simulate
+/// a source going unavailable and then recovering, without any external system.
+#[derive(Debug)]
+struct ToggleableProvider {
+    schema: SchemaRef,
+    fail: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl TableProvider for ToggleableProvider {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if self.fail.load(Ordering::SeqCst) {
+            return Err(DataFusionError::Execution(
+                "simulated source outage".to_string(),
+            ));
+        }
+        Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema))))
+    }
+}
 
 async fn get_test_dataset_with_check_availability_disabled() -> Result<Dataset, anyhow::Error> {
     let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
@@ -126,6 +172,113 @@ async fn dataset_check_availability_register_skipped_when_accelerated() -> Resul
     // Check that monitored_datasets is empty
     let monitored_datasets = monitor.monitored_datasets.lock().await;
     assert!(monitored_datasets.is_empty());
+
+    Ok(())
+}
+
+/// End-to-end: a non-accelerated dataset whose source becomes unavailable is
+/// moved to `Error` status by the availability monitor within its configured
+/// `check_availability_interval`, and returns to `Ready` once the source
+/// recovers. This is what `GET /v1/datasets?status=true` reports.
+#[tokio::test]
+async fn availability_monitor_marks_dataset_error_on_source_outage() -> Result<(), anyhow::Error> {
+    register_test_connectors().await;
+
+    let app = AppBuilder::new("availability_status_test").build();
+    let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+    let df = rt.datafusion();
+    let status = df.runtime_status();
+
+    // Register a toggleable provider under the dataset name so the monitor's
+    // connectivity probe (a `scan(.., LIMIT 1)`) resolves to it.
+    let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, true)]));
+    let fail = Arc::new(AtomicBool::new(false));
+    let table_ref = TableReference::bare("toggle_source");
+    df.ctx
+        .register_table(
+            table_ref.clone(),
+            Arc::new(ToggleableProvider {
+                schema: Arc::clone(&schema),
+                fail: Arc::clone(&fail),
+            }),
+        )
+        .expect("register toggleable provider");
+
+    // Build a non-accelerated dataset with a short (1s) availability interval.
+    let mut spicepod_dataset = spicepod::component::dataset::Dataset::new("sink", "toggle_source");
+    spicepod_dataset.check_availability_interval = Some("1s".to_string());
+    let dataset: Dataset = DatasetBuilder::try_from(spicepod_dataset)?
+        .with_app(Arc::new(
+            AppBuilder::new("availability_status_test").build(),
+        ))
+        .with_runtime(Arc::clone(&rt))
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to build dataset: {e}"))?;
+    assert_eq!(
+        dataset.check_availability_interval(),
+        Duration::from_secs(1)
+    );
+
+    // Simulate the dataset having loaded successfully (its healthy state).
+    status.update_dataset(&table_ref, ComponentStatus::Ready);
+
+    let monitor = DatasetsHealthMonitor::new(Arc::clone(&df));
+    monitor
+        .register_dataset(&dataset)
+        .await
+        .expect("register dataset for monitoring");
+    monitor.start();
+
+    // Source is reachable: the dataset stays Ready across a couple of intervals.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert_eq!(
+        status.get_dataset_status(&table_ref),
+        Some(ComponentStatus::Ready),
+        "dataset must stay Ready while the source is reachable"
+    );
+
+    // Source goes down -> the next probe must move the dataset to Error.
+    fail.store(true, Ordering::SeqCst);
+    let became_error = wait_until_true(Duration::from_secs(15), || {
+        let status = Arc::clone(&status);
+        let table_ref = table_ref.clone();
+        async move {
+            status
+                .get_dataset_status(&table_ref)
+                .is_some_and(|s| s.is_error())
+        }
+    })
+    .await;
+    assert!(
+        became_error,
+        "dataset should be Error within a few intervals after the source becomes unavailable"
+    );
+    // The error surfaces the source failure to the user.
+    let err_status = status.get_dataset_status(&table_ref).expect("status");
+    assert!(
+        err_status
+            .error_message()
+            .is_some_and(|m| m.contains("simulated source outage")),
+        "error status should carry the underlying source error, got {err_status:?}"
+    );
+
+    // Source recovers -> the dataset returns to Ready.
+    fail.store(false, Ordering::SeqCst);
+    let recovered = wait_until_true(Duration::from_secs(15), || {
+        let status = Arc::clone(&status);
+        let table_ref = table_ref.clone();
+        async move {
+            matches!(
+                status.get_dataset_status(&table_ref),
+                Some(ComponentStatus::Ready)
+            )
+        }
+    })
+    .await;
+    assert!(
+        recovered,
+        "dataset should return to Ready after the source recovers"
+    );
 
     Ok(())
 }

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -239,10 +239,11 @@ pub struct Dataset {
 
     /// How often the runtime probes the (non-accelerated) source backing this
     /// dataset to confirm it is still reachable. Accepts a duration string
-    /// (e.g. `60s`, `5m`); defaults to `60s`. Only applies when
-    /// `check_availability: auto` and the dataset is not accelerated. When a
-    /// probe fails the dataset is marked `Error` (visible via
-    /// `GET /v1/datasets?status=true`) until a later probe succeeds.
+    /// (e.g. `60s`, `5m`). Availability monitoring is **opt-in**: leave this
+    /// unset and the dataset is not monitored. Only applies to non-accelerated
+    /// datasets with `check_availability: auto`. When a probe fails the dataset
+    /// is marked `Error` (visible via `GET /v1/datasets?status=true`) until a
+    /// later probe succeeds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub check_availability_interval: Option<String>,
 }

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -236,6 +236,15 @@ pub struct Dataset {
     /// and report metrics. Dataset availability is only checked if the dataset is not accelerated.
     #[serde(default, skip_serializing_if = "is_default")]
     pub check_availability: CheckAvailability,
+
+    /// How often the runtime probes the (non-accelerated) source backing this
+    /// dataset to confirm it is still reachable. Accepts a duration string
+    /// (e.g. `60s`, `5m`); defaults to `60s`. Only applies when
+    /// `check_availability: auto` and the dataset is not accelerated. When a
+    /// probe fails the dataset is marked `Error` (visible via
+    /// `GET /v1/datasets?status=true`) until a later probe succeeds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub check_availability_interval: Option<String>,
 }
 
 impl Nameable for Dataset {
@@ -271,6 +280,7 @@ impl Dataset {
             vectors: None,
             full_text_search: None,
             check_availability: CheckAvailability::default(),
+            check_availability_interval: None,
         }
     }
 
@@ -361,6 +371,7 @@ impl WithDependsOn<Dataset> for Dataset {
             vectors: self.vectors.clone(),
             full_text_search: self.full_text_search.clone(),
             check_availability: self.check_availability,
+            check_availability_interval: self.check_availability_interval.clone(),
         }
     }
 }
@@ -442,6 +453,8 @@ struct DatasetDeserializer {
     full_text_search: Option<FtsStore>,
     #[serde(default, skip_serializing_if = "is_default")]
     check_availability: CheckAvailability,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    check_availability_interval: Option<String>,
 }
 
 #[expect(deprecated)]
@@ -495,6 +508,7 @@ impl TryFrom<DatasetDeserializer> for Dataset {
             vectors: deserializer.vectors,
             full_text_search: deserializer.full_text_search,
             check_availability: deserializer.check_availability,
+            check_availability_interval: deserializer.check_availability_interval,
         })
     }
 }
@@ -534,6 +548,27 @@ mod check_availability_tests {
         ";
         let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
         assert_eq!(dataset.check_availability, CheckAvailability::Auto);
+    }
+
+    #[test]
+    fn test_check_availability_interval_unset_by_default() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+        ";
+        let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert_eq!(dataset.check_availability_interval, None);
+    }
+
+    #[test]
+    fn test_check_availability_interval_parsed_from_config() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+            check_availability_interval: 30s
+        ";
+        let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert_eq!(dataset.check_availability_interval.as_deref(), Some("30s"));
     }
 }
 


### PR DESCRIPTION
## Summary

- The dataset availability monitor now moves a **non-accelerated** dataset to `Error` status when its source becomes unreachable (surfaced via `GET /v1/datasets?status=true`) and restores `Ready` once it recovers. Previously an unreachable source was only recorded as a metric, so the dataset stayed `Ready`.
- Adds a per-dataset `check_availability_interval` (default `60s`) controlling how often the source is probed.

## Testing

- Unit + integration tests covering the `Ready → Error → Ready` cycle.
- Manually verified end-to-end against PostgreSQL in Docker.