### PR TITLE
fix(models): restore spice.ai/spiceai as a model source

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ See more demos on [YouTube](https://www.youtube.com/playlist?list=PLesJrUXEx3U9a
 | `openai`      | OpenAI (or compatible) LLM endpoint          | Release Candidate | -            | OpenAI-compatible HTTP endpoint |
 | `file`        | Local filesystem                             | Release Candidate | ONNX         | GGUF, GGML, SafeTensor          |
 | `huggingface` | Models hosted on HuggingFace                 | Release Candidate | ONNX         | GGUF, GGML, SafeTensor          |
-| `spice.ai`    | Models hosted on the Spice.ai Cloud Platform |                   | ONNX         | OpenAI-compatible HTTP endpoint |
+| `spice.ai`    | Models hosted on the Spice.ai Cloud Platform, or served by another Spice runtime |                   | -            | OpenAI-compatible HTTP endpoint |
 | `azure`       | Azure OpenAI                                 |                   | -            | OpenAI-compatible HTTP endpoint |
 | `bedrock`     | Amazon Bedrock (Nova models)                 | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | `anthropic`   | Models hosted on Anthropic                   | Alpha             | -            | OpenAI-compatible HTTP endpoint |

--- a/crates/llms/src/spiceai/chat.rs
+++ b/crates/llms/src/spiceai/chat.rs
@@ -1,0 +1,126 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Chat completions against a Spice endpoint.
+
+use crate::config::HostedModelConfig;
+use crate::openai::{Openai, new_openai_client_with_config};
+
+/// The Spice.ai Cloud Platform AI gateway.
+pub const DEFAULT_ENDPOINT: &str = "https://data.spiceai.io";
+
+/// Resolves a Spice endpoint to the base URL of its `OpenAI`-compatible API.
+///
+/// `endpoint` is the root of a Spice.ai Cloud Platform or Spice runtime deployment — e.g.
+/// `https://data.spiceai.io`, or `http://localhost:8090` for a Spice-to-Spice connection — which
+/// serves the `OpenAI`-compatible API under `/v1`. An endpoint that already names `/v1` is taken
+/// as-is, so either spelling resolves to the same base URL.
+#[must_use]
+pub fn api_base(endpoint: Option<&str>) -> String {
+    let root = endpoint
+        .map(str::trim)
+        .filter(|e| !e.is_empty())
+        .unwrap_or(DEFAULT_ENDPOINT)
+        .trim_end_matches('/');
+
+    if root.ends_with("/v1") {
+        root.to_string()
+    } else {
+        format!("{root}/v1")
+    }
+}
+
+/// Whether `endpoint` resolves to the Spice.ai Cloud Platform rather than a self-hosted Spice
+/// runtime. The Cloud Platform always authenticates, so a caller can use this to require an API
+/// key. Compares resolved base URLs so an explicit `https://data.spiceai.io` is recognized the
+/// same as an unset endpoint.
+#[must_use]
+pub fn is_cloud_platform(endpoint: Option<&str>) -> bool {
+    api_base(endpoint) == api_base(None)
+}
+
+/// Creates a chat client for a model served by the Spice.ai Cloud Platform, or by another Spice
+/// runtime.
+///
+/// `api_key` is optional: the Spice.ai Cloud Platform requires one, but a Spice runtime reached
+/// over a trusted network may not have authentication enabled.
+#[must_use]
+pub fn new_spiceai_client(
+    model: String,
+    endpoint: Option<&str>,
+    api_key: Option<&str>,
+) -> Openai<HostedModelConfig> {
+    let config = HostedModelConfig::from_url(&api_base(endpoint)).with_api_key(api_key);
+    new_openai_client_with_config(model, config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_base_defaults_to_the_cloud_platform() {
+        assert_eq!(api_base(None), "https://data.spiceai.io/v1");
+        assert_eq!(api_base(Some("")), "https://data.spiceai.io/v1");
+        assert_eq!(api_base(Some("   ")), "https://data.spiceai.io/v1");
+    }
+
+    #[test]
+    fn api_base_appends_the_openai_compatible_path() {
+        assert_eq!(
+            api_base(Some("http://localhost:8090")),
+            "http://localhost:8090/v1"
+        );
+        assert_eq!(
+            api_base(Some("http://localhost:8090/")),
+            "http://localhost:8090/v1"
+        );
+        assert_eq!(
+            api_base(Some("  http://localhost:8090  ")),
+            "http://localhost:8090/v1"
+        );
+    }
+
+    #[test]
+    fn api_base_accepts_an_endpoint_that_already_names_v1() {
+        assert_eq!(
+            api_base(Some("http://localhost:8090/v1")),
+            "http://localhost:8090/v1"
+        );
+        assert_eq!(
+            api_base(Some("http://localhost:8090/v1/")),
+            "http://localhost:8090/v1"
+        );
+    }
+
+    #[test]
+    fn cloud_platform_is_detected_however_it_is_spelled() {
+        // An unset endpoint and the spelled-out default must agree: the runtime substitutes the
+        // latter for the former when a model omits `spiceai_endpoint`.
+        assert!(is_cloud_platform(None));
+        assert!(is_cloud_platform(Some(DEFAULT_ENDPOINT)));
+        assert!(is_cloud_platform(Some("https://data.spiceai.io/")));
+        assert!(is_cloud_platform(Some("https://data.spiceai.io/v1")));
+    }
+
+    #[test]
+    fn self_hosted_runtimes_are_not_the_cloud_platform() {
+        assert!(!is_cloud_platform(Some("http://localhost:8090")));
+        assert!(!is_cloud_platform(Some(
+            "https://spice.internal.example.com"
+        )));
+    }
+}

--- a/crates/llms/src/spiceai/list_models.rs
+++ b/crates/llms/src/spiceai/list_models.rs
@@ -25,9 +25,11 @@ use crate::config::HostedModelConfig;
 use crate::provider::{ListModels, ListModelsError, ListModelsResult, get_required_param};
 use crate::spiceai::{api_base, is_cloud_platform};
 
-const PROVIDER_NAME: &str = "Spice Cloud";
+// Names the provider in credential/network errors. Endpoint-neutral: this lister targets the
+// Spice.ai Cloud Platform and self-hosted Spice runtimes alike.
+const PROVIDER_NAME: &str = "Spice";
 
-/// Spice Cloud model lister that fetches available models using the SDK.
+/// Model lister for a Spice endpoint — the Spice.ai Cloud Platform or another Spice runtime.
 pub struct SpiceAiModelLister {
     client: Client<HostedModelConfig>,
 }
@@ -66,7 +68,7 @@ impl SpiceAiModelLister {
         }
     }
 
-    /// Returns common Spice Cloud model names as a fallback.
+    /// Returns common Spice.ai Cloud Platform model names as a fallback.
     #[must_use]
     pub fn common_models() -> Vec<String> {
         vec![

--- a/crates/llms/src/spiceai/list_models.rs
+++ b/crates/llms/src/spiceai/list_models.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Model listing functionality for Spice Cloud provider.
+//! Model listing functionality for the Spice model provider.
 
 use async_openai::Client;
 use async_trait::async_trait;
@@ -23,9 +23,9 @@ use std::collections::HashMap;
 
 use crate::config::HostedModelConfig;
 use crate::provider::{ListModels, ListModelsError, ListModelsResult, get_required_param};
+use crate::spiceai::api_base;
 
 const PROVIDER_NAME: &str = "Spice Cloud";
-const DEFAULT_ENDPOINT: &str = "https://data.spiceai.io";
 
 /// Spice Cloud model lister that fetches available models using the SDK.
 pub struct SpiceAiModelLister {
@@ -39,29 +39,18 @@ impl SpiceAiModelLister {
     /// Optional parameter: `spiceai_endpoint` (defaults to <https://data.spiceai.io>)
     pub fn from_params(params: &HashMap<String, SecretString>) -> ListModelsResult<Self> {
         let api_key = get_required_param(params, "spiceai_api_key")?;
-        let endpoint = params.get("spiceai_endpoint").map_or_else(
-            || format!("{DEFAULT_ENDPOINT}/v1"),
-            |s| format!("{}/v1", s.expose_secret().trim_end_matches('/')),
-        );
+        let endpoint = params
+            .get("spiceai_endpoint")
+            .map(ExposeSecret::expose_secret);
 
-        let config =
-            HostedModelConfig::from_url(&endpoint).with_api_key(Some(api_key.expose_secret()));
-
-        Ok(Self {
-            client: Client::with_config(config),
-        })
+        Ok(Self::new(api_key, endpoint))
     }
 
     /// Creates a new model lister with explicit credentials.
     #[must_use]
     pub fn new(api_key: &SecretString, endpoint: Option<&str>) -> Self {
-        let base_url = endpoint.map_or_else(
-            || format!("{DEFAULT_ENDPOINT}/v1"),
-            |e| format!("{}/v1", e.trim_end_matches('/')),
-        );
-
-        let config =
-            HostedModelConfig::from_url(&base_url).with_api_key(Some(api_key.expose_secret()));
+        let config = HostedModelConfig::from_url(&api_base(endpoint))
+            .with_api_key(Some(api_key.expose_secret()));
 
         Self {
             client: Client::with_config(config),

--- a/crates/llms/src/spiceai/list_models.rs
+++ b/crates/llms/src/spiceai/list_models.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 
 use crate::config::HostedModelConfig;
 use crate::provider::{ListModels, ListModelsError, ListModelsResult, get_required_param};
-use crate::spiceai::api_base;
+use crate::spiceai::{api_base, is_cloud_platform};
 
 const PROVIDER_NAME: &str = "Spice Cloud";
 
@@ -35,22 +35,31 @@ pub struct SpiceAiModelLister {
 impl SpiceAiModelLister {
     /// Creates a new model lister from parameters.
     ///
-    /// Required parameter: `spiceai_api_key`
     /// Optional parameter: `spiceai_endpoint` (defaults to <https://data.spiceai.io>)
+    /// Parameter `spiceai_api_key`: required for the Spice.ai Cloud Platform, optional for a
+    /// Spice runtime that does not require authentication.
     pub fn from_params(params: &HashMap<String, SecretString>) -> ListModelsResult<Self> {
-        let api_key = get_required_param(params, "spiceai_api_key")?;
         let endpoint = params
             .get("spiceai_endpoint")
             .map(ExposeSecret::expose_secret);
+
+        let api_key = if is_cloud_platform(endpoint) {
+            Some(get_required_param(params, "spiceai_api_key")?)
+        } else {
+            params.get("spiceai_api_key")
+        };
 
         Ok(Self::new(api_key, endpoint))
     }
 
     /// Creates a new model lister with explicit credentials.
+    ///
+    /// `api_key` is optional so listing works against a Spice runtime reached over a trusted
+    /// network, matching what [`crate::spiceai::new_spiceai_client`] accepts for chat.
     #[must_use]
-    pub fn new(api_key: &SecretString, endpoint: Option<&str>) -> Self {
+    pub fn new(api_key: Option<&SecretString>, endpoint: Option<&str>) -> Self {
         let config = HostedModelConfig::from_url(&api_base(endpoint))
-            .with_api_key(Some(api_key.expose_secret()));
+            .with_api_key(api_key.map(ExposeSecret::expose_secret));
 
         Self {
             client: Client::with_config(config),
@@ -111,6 +120,33 @@ mod tests {
     #[test]
     fn test_from_params_missing_key() {
         let params = HashMap::new();
+        let result = SpiceAiModelLister::from_params(&params);
+        assert!(matches!(
+            result,
+            Err(ListModelsError::MissingParameter { .. })
+        ));
+    }
+
+    #[test]
+    fn from_params_allows_a_self_hosted_runtime_without_a_key() {
+        let mut params = HashMap::new();
+        params.insert(
+            "spiceai_endpoint".to_string(),
+            SecretString::from("http://localhost:8090"),
+        );
+
+        SpiceAiModelLister::from_params(&params)
+            .expect("a Spice runtime endpoint should not require an API key");
+    }
+
+    #[test]
+    fn from_params_still_requires_a_key_for_the_spelled_out_cloud_platform() {
+        let mut params = HashMap::new();
+        params.insert(
+            "spiceai_endpoint".to_string(),
+            SecretString::from(crate::spiceai::DEFAULT_ENDPOINT),
+        );
+
         let result = SpiceAiModelLister::from_params(&params);
         assert!(matches!(
             result,

--- a/crates/llms/src/spiceai/mod.rs
+++ b/crates/llms/src/spiceai/mod.rs
@@ -14,10 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Spice Cloud LLM provider.
+//! Spice model provider — models served by the Spice.ai Cloud Platform, or by another Spice
+//! runtime (a Spice-to-Spice connection).
+//!
+//! Both serve an `OpenAI`-compatible API, so models are driven through the shared
+//! [`crate::openai::Openai`] client rather than a bespoke protocol.
 
 #![allow(clippy::missing_errors_doc)]
 
+mod chat;
 mod list_models;
 
+pub use chat::{DEFAULT_ENDPOINT, api_base, is_cloud_platform, new_spiceai_client};
 pub use list_models::SpiceAiModelLister;

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -521,7 +521,9 @@ async fn databricks(
 /// Builds a chat model served by the Spice.ai Cloud Platform, or by another Spice runtime
 /// (a Spice-to-Spice connection). Both expose an `OpenAI`-compatible API under `/v1`.
 fn spiceai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>, LlmError> {
-    let Some(model_id) = model_id else {
+    // Treat a blank id the same as a missing one: a client built with an empty model name fails
+    // later with a far less obvious error.
+    let Some(model_id) = model_id.filter(|id| !id.trim().is_empty()) else {
         return Err(LlmError::ModelNotProvided {
             model_source: "spiceai".to_string(),
         });
@@ -1040,6 +1042,21 @@ mod test {
             err,
             LlmError::ModelNotProvided { ref model_source } if model_source == "spiceai"
         ));
+    }
+
+    #[test]
+    fn spiceai_rejects_a_blank_model_id() {
+        let params = spiceai_params(&[("api_key", "test-key")]);
+
+        for blank in ["", "   "] {
+            let Err(err) = spiceai(Some(blank.to_string()), &params) else {
+                panic!("a blank model id should be rejected, got a client for {blank:?}");
+            };
+            assert!(matches!(
+                err,
+                LlmError::ModelNotProvided { ref model_source } if model_source == "spiceai"
+            ));
+        }
     }
 
     #[test]

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -173,10 +173,7 @@ pub async fn construct_model(
         ModelSource::Bedrock => Err(LlmError::UnknownModelSource {
             from: "bedrock".into(),
         }),
-        ModelSource::SpiceAI => Err(LlmError::UnsupportedTaskForModel {
-            from: "spiceai".into(),
-            task: "llm".into(),
-        }),
+        ModelSource::SpiceAI => spiceai(model_id, params),
     }?;
 
     let system_prompt = match component.params.get("system_prompt") {
@@ -519,6 +516,31 @@ async fn databricks(
             ) as Arc<dyn Chat>)
         }
     }
+}
+
+/// Builds a chat model served by the Spice.ai Cloud Platform, or by another Spice runtime
+/// (a Spice-to-Spice connection). Both expose an `OpenAI`-compatible API under `/v1`.
+fn spiceai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>, LlmError> {
+    let Some(model_id) = model_id else {
+        return Err(LlmError::ModelNotProvided {
+            model_source: "spiceai".to_string(),
+        });
+    };
+
+    let endpoint = params.get("endpoint").expose().ok();
+    let api_key = params.get("api_key").expose().ok();
+
+    // A self-hosted Spice runtime may not require authentication, but the Spice.ai Cloud Platform
+    // always does — so an unset key there is a misconfiguration, not a valid anonymous setup.
+    if api_key.is_none() && llms::spiceai::is_cloud_platform(endpoint) {
+        return Err(LlmError::FailedToLoadModel {
+            source: "Missing `spiceai_api_key`. Models served by the Spice.ai Cloud Platform require an API key. Set `spiceai_api_key`, or set `spiceai_endpoint` to the Spice runtime serving the model. See: https://spiceai.org/docs/components/models".into(),
+        });
+    }
+
+    Ok(Arc::new(llms::spiceai::new_spiceai_client(
+        model_id, endpoint, api_key,
+    )) as Arc<dyn Chat>)
 }
 
 fn openai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>, LlmError> {
@@ -978,5 +1000,67 @@ mod test {
             err,
             LlmError::InvalidParamValueError { ref param, .. } if param == "distributed_backend"
         ));
+    }
+
+    fn spiceai_params(entries: &[(&str, &str)]) -> Parameters {
+        Parameters::new(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), SecretString::from((*v).to_string())))
+                .collect(),
+            "spiceai",
+            crate::model::params::spiceai::PARAMETERS,
+        )
+    }
+
+    #[test]
+    fn spiceai_builds_a_cloud_platform_model() {
+        let params = spiceai_params(&[("api_key", "test-key")]);
+
+        spiceai(Some("openai/gpt-4o".to_string()), &params)
+            .expect("a Spice.ai Cloud Platform model with an API key should load");
+    }
+
+    #[test]
+    fn spiceai_builds_a_spice_to_spice_model_without_a_key() {
+        let params = spiceai_params(&[("endpoint", "http://localhost:8090")]);
+
+        spiceai(Some("local-llm".to_string()), &params)
+            .expect("a Spice runtime endpoint should not require an API key");
+    }
+
+    #[test]
+    fn spiceai_requires_a_model_id() {
+        let params = spiceai_params(&[("api_key", "test-key")]);
+
+        let Err(err) = spiceai(None, &params) else {
+            panic!("a model id is required");
+        };
+        assert!(matches!(
+            err,
+            LlmError::ModelNotProvided { ref model_source } if model_source == "spiceai"
+        ));
+    }
+
+    #[test]
+    fn spiceai_cloud_platform_requires_an_api_key() {
+        let params = spiceai_params(&[]);
+
+        let Err(err) = spiceai(Some("openai/gpt-4o".to_string()), &params) else {
+            panic!("the Spice.ai Cloud Platform requires an API key");
+        };
+        assert!(matches!(err, LlmError::FailedToLoadModel { .. }));
+    }
+
+    #[test]
+    fn spiceai_cloud_platform_requires_an_api_key_when_the_endpoint_is_spelled_out() {
+        // `Parameters::try_new` substitutes the spec default when `spiceai_endpoint` is unset, so
+        // the API-key requirement has to hold for a present endpoint too, not just an absent one.
+        let params = spiceai_params(&[("endpoint", llms::spiceai::DEFAULT_ENDPOINT)]);
+
+        let Err(err) = spiceai(Some("openai/gpt-4o".to_string()), &params) else {
+            panic!("the Spice.ai Cloud Platform requires an API key");
+        };
+        assert!(matches!(err, LlmError::FailedToLoadModel { .. }));
     }
 }

--- a/crates/runtime/src/model/params/mod.rs
+++ b/crates/runtime/src/model/params/mod.rs
@@ -22,6 +22,7 @@ pub mod file;
 pub mod google;
 pub mod huggingface;
 pub mod openai;
+pub mod spiceai;
 pub mod xai;
 
 use spicepod::component::model::ModelSource;
@@ -44,7 +45,7 @@ pub fn get_params_spec(source: &ModelSource) -> Option<&'static [ParameterSpec]>
         ModelSource::Anthropic => Some(anthropic::PARAMETERS),
         ModelSource::Xai => Some(xai::PARAMETERS),
         ModelSource::Bedrock => Some(bedrock::PARAMETERS),
-        ModelSource::SpiceAI => None,
+        ModelSource::SpiceAI => Some(spiceai::PARAMETERS),
         ModelSource::Google => Some(google::PARAMETERS),
     }
 }

--- a/crates/runtime/src/model/params/spiceai.rs
+++ b/crates/runtime/src/model/params/spiceai.rs
@@ -1,0 +1,42 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use util::concat_arrays;
+
+use super::{COMMON_MODEL_PARAMETERS_WITH_DEPRECATED, PARAM_WITH_DEPRE_LEN};
+use crate::parameters::ParameterSpec;
+
+pub const PARAMETERS: &[ParameterSpec] =
+    &concat_arrays::<
+        ParameterSpec,
+        SPICEAI_PARAM_LEN,
+        PARAM_WITH_DEPRE_LEN,
+        { SPICEAI_PARAM_LEN + PARAM_WITH_DEPRE_LEN },
+    >(SPICEAI_PARAMETERS, COMMON_MODEL_PARAMETERS_WITH_DEPRECATED);
+
+const SPICEAI_PARAM_LEN: usize = 2;
+
+pub(crate) const SPICEAI_PARAMETERS: [ParameterSpec; SPICEAI_PARAM_LEN] = [
+    ParameterSpec::component("api_key")
+        .secret()
+        .description("The API key for the Spice.ai Cloud Platform, or for the Spice runtime serving the model. Required for the Spice.ai Cloud Platform."),
+    ParameterSpec::component("endpoint")
+        .description("The endpoint serving the model: the Spice.ai Cloud Platform, or another Spice runtime.")
+        // Sourced from `llms` so the documented default and the one the client actually dials
+        // cannot drift — `Parameters::try_new` substitutes this value when the param is unset.
+        .default(llms::spiceai::DEFAULT_ENDPOINT)
+        .examples(&[llms::spiceai::DEFAULT_ENDPOINT, "http://localhost:8090"]),
+];

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -111,11 +111,18 @@ impl ModelSource {
                     model
                 }
             }),
-            ModelSource::SpiceAI => SPICEAI_PREFIXES.iter().find_map(|p| {
-                from.strip_prefix(&format!("{p}:"))
-                    .or_else(|| from.strip_prefix(&format!("{p}/")))
-                    .map(std::string::ToString::to_string)
-            }),
+            // A bare prefix (`spice.ai:`, `spice.ai/`) carries no model id. Report that as absent
+            // rather than as an empty id, so the caller raises "no model provided" instead of
+            // dialing the endpoint with an empty model name.
+            ModelSource::SpiceAI => SPICEAI_PREFIXES
+                .iter()
+                .find_map(|p| {
+                    from.strip_prefix(&format!("{p}:"))
+                        .or_else(|| from.strip_prefix(&format!("{p}/")))
+                })
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(std::string::ToString::to_string),
             p => {
                 if let Some(stripped) = from.strip_prefix(&format!("{p}:")) {
                     Some(stripped.to_string())
@@ -605,5 +612,29 @@ mod tests {
             assert_eq!(model.get_source(), Some(ModelSource::SpiceAI));
             assert_eq!(model.get_model_id(), None, "unexpected model id for {from}");
         }
+    }
+
+    #[test]
+    fn spiceai_bare_prefix_reports_no_model_id() {
+        // A blank id would otherwise reach the client as an empty model name, turning a clear
+        // "no model provided" error into an opaque failure against the endpoint.
+        for from in [
+            "spice.ai:",
+            "spice.ai/",
+            "spiceai:",
+            "spiceai/",
+            "spice.ai:   ",
+            "spiceai/ ",
+        ] {
+            let model = Model::new(from, "test");
+            assert_eq!(model.get_source(), Some(ModelSource::SpiceAI));
+            assert_eq!(model.get_model_id(), None, "unexpected model id for {from}");
+        }
+    }
+
+    #[test]
+    fn spiceai_model_id_is_trimmed() {
+        let model = Model::new("spice.ai: openai/gpt-4o ", "test");
+        assert_eq!(model.get_model_id().as_deref(), Some("openai/gpt-4o"));
     }
 }

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -94,6 +94,12 @@ pub enum ModelSource {
     Bedrock,
 }
 
+/// The prefixes that select [`ModelSource::SpiceAI`]. `spice.ai` matches how the Spice.ai Cloud
+/// Platform is spelled elsewhere in a Spicepod (`from: spice.ai/...` for datasets); `spiceai`
+/// matches the parameter prefix (`spiceai_api_key`). Both are accepted so a `from` reads the same
+/// whether it names a dataset or a model.
+pub const SPICEAI_PREFIXES: [&str; 2] = ["spice.ai", "spiceai"];
+
 impl ModelSource {
     pub fn parse_from(&self, from: &str) -> Option<String> {
         match self {
@@ -104,6 +110,11 @@ impl ModelSource {
                 } else {
                     model
                 }
+            }),
+            ModelSource::SpiceAI => SPICEAI_PREFIXES.iter().find_map(|p| {
+                from.strip_prefix(&format!("{p}:"))
+                    .or_else(|| from.strip_prefix(&format!("{p}/")))
+                    .map(std::string::ToString::to_string)
             }),
             p => {
                 if let Some(stripped) = from.strip_prefix(&format!("{p}:")) {
@@ -163,7 +174,7 @@ impl TryFrom<&str> for ModelSource {
             Ok(ModelSource::Azure)
         } else if value.starts_with("xai") {
             Ok(ModelSource::Xai)
-        } else if value.starts_with("spiceai") {
+        } else if SPICEAI_PREFIXES.iter().any(|p| value.starts_with(p)) {
             Ok(ModelSource::SpiceAI)
         } else if value.starts_with("databricks") {
             Ok(ModelSource::Databricks)
@@ -562,6 +573,37 @@ mod tests {
                 HUGGINGFACE_PATH_REGEX.captures(path).is_none(),
                 "Should not match invalid path: {path}"
             );
+        }
+    }
+
+    #[test]
+    fn spiceai_source_accepts_both_spellings() {
+        for from in [
+            "spice.ai:openai/gpt-4o",
+            "spice.ai/openai/gpt-4o",
+            "spiceai:openai/gpt-4o",
+            "spiceai/openai/gpt-4o",
+        ] {
+            let model = Model::new(from, "test");
+            assert_eq!(
+                model.get_source(),
+                Some(ModelSource::SpiceAI),
+                "unexpected source for {from}"
+            );
+            assert_eq!(
+                model.get_model_id().as_deref(),
+                Some("openai/gpt-4o"),
+                "unexpected model id for {from}"
+            );
+        }
+    }
+
+    #[test]
+    fn spiceai_source_without_model_id() {
+        for from in ["spice.ai", "spiceai"] {
+            let model = Model::new(from, "test");
+            assert_eq!(model.get_source(), Some(ModelSource::SpiceAI));
+            assert_eq!(model.get_model_id(), None, "unexpected model id for {from}");
         }
     }
 }

--- a/tools/spicepodschema/src/collector.rs
+++ b/tools/spicepodschema/src/collector.rs
@@ -23,7 +23,7 @@ limitations under the License.
 use runtime::dataaccelerator::DATA_ACCELERATOR_REGISTRATIONS;
 use runtime::dataconnector::DATA_CONNECTOR_REGISTRATIONS;
 use runtime::model::params::{
-    anthropic, azure, bedrock, databricks, file, google, huggingface, openai, xai,
+    anthropic, azure, bedrock, databricks, file, google, huggingface, openai, spiceai, xai,
 };
 use runtime_parameters::ParameterSpec;
 
@@ -259,6 +259,11 @@ pub fn collect_model_sources() -> Vec<ModelSourceSchema> {
             name: "google",
             prefix: "google",
             parameters: google::PARAMETERS,
+        },
+        ModelSourceSchema {
+            name: "spiceai",
+            prefix: "spiceai",
+            parameters: spiceai::PARAMETERS,
         },
     ]
 }


### PR DESCRIPTION
## What

Restores `spice.ai` / `spiceai` as a usable model source, for models hosted on the Spice.ai Cloud Platform and for Spice-to-Spice connections to models served by another Spice runtime.

## Why

`spiceai` had only ever been a source for ONNX models, so the LLM path carried a hard stub:

```rust
ModelSource::SpiceAI => Err(LlmError::UnsupportedTaskForModel { from: "spiceai".into(), task: "llm".into() }),
```

Removing ONNX/Tract inference (#11684) deleted the ML implementation and left the source dead from both directions — no ML path and no LLM path — even though `ModelSource::SpiceAI`, `SpiceAiModelLister`, and the source's rate-limit defaults all survived. `get_params_spec` also returned `None` for it, which failed the load before dispatch was ever reached.

The source remains valid: the Spice.ai Cloud Platform serves models, and one Spice runtime can serve models to another.

## How

Both the Cloud Platform and a Spice runtime expose an OpenAI-compatible API under `/v1`, so models from either are driven through the shared `Openai` client rather than a bespoke provider.

- **`crates/llms/src/spiceai/chat.rs`** (new) — endpoint resolution (`api_base`), `is_cloud_platform`, and `new_spiceai_client`.
- **`crates/llms/src/spiceai/list_models.rs`** — shares `api_base` so listing and chat cannot resolve `spiceai_endpoint` differently.
- **`crates/runtime/src/model/params/spiceai.rs`** (new) + `params/mod.rs` — `spiceai_api_key` / `spiceai_endpoint`, matching the spelling the Spice.ai data connector already uses. The endpoint default is sourced from `llms` so the documented default and the one actually dialed cannot drift.
- **`crates/runtime/src/model/chat.rs`** — real constructor in place of the stub. An API key is required only when the resolved endpoint is the Cloud Platform, so a Spice-to-Spice connection to a runtime without authentication works.
- **`crates/spicepod/src/component/model.rs`** — `from:` accepts `spice.ai` as well as `spiceai`. Only `spiceai` parsed before, while the README and the `get_model_id` docstring both documented `spice.ai/...`.
- **`tools/spicepodschema/src/collector.rs`** — registers the source so its params reach `.schema/spicepod.schema.json`.
- **`README.md`** — the `spice.ai` row still advertised ONNX.

Model workers need no change: they route by model name, so load balancing across Cloud Platform and Spice-hosted models works once the model loads.

```yaml
models:
  - from: spice.ai/openai/gpt-4o
    name: cloud-gpt4o
    params:
      spiceai_api_key: ${secrets:SPICEAI_API_KEY}

  - from: spiceai:local-llm
    name: peer-llm
    params:
      spiceai_endpoint: http://spice-inference:8090

workers:
  - name: llm-pool
    load_balance:
      routing:
        - from: cloud-gpt4o
          weight: 70
        - from: peer-llm
          weight: 30
```

## Not included

The Responses API and embeddings remain unwired for this source. Neither ever worked for it, so neither is part of the regression. Responses would be a small follow-up (`Openai<C>` already implements `Responses` generically); embeddings needs a new `EmbeddingPrefix` variant.

`is_cloud_platform` compares resolved base URLs, so a Cloud Platform deployment reached through a proxy or vanity hostname is not recognized as requiring a key. That fails open — the model loads and the health check surfaces the 401 — rather than blocking a legitimate self-hosted setup.

## Tests

New coverage, all passing locally:

| Crate | Tests |
| --- | --- |
| `spicepod` | 207 passed (2 new: both prefix spellings, with and without a model id) |
| `llms` | 8 spiceai passed (6 new: endpoint resolution, `/v1` idempotency, cloud-vs-self-hosted detection) |
| `runtime` | 79 passed (5 new: Cloud Platform load, Spice-to-Spice load without a key, missing model id, missing key) |

One of the runtime tests is a guard against a bug caught during development: `Parameters::try_new` substitutes a spec's `default`, so an `endpoint.is_none()` check would have been dead code in production while still passing a unit test built on `Parameters::new`. The check now compares resolved endpoints, and `spiceai_cloud_platform_requires_an_api_key_when_the_endpoint_is_spelled_out` fails against the naive version.

Related: #7189
