### PR TITLE
fix(postgres): log the cumulative delivery wait in the sink-stall warning

### DIFF
--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -1973,9 +1973,12 @@ async fn deliver_to_member(
                     return SendOutcome::ShutdownAbandon(w);
                 }
                 metrics.add_send_stalled(MEMBER_SEND_STALL_WARN.as_secs());
+                // Log the cumulative wait for THIS delivery, not the constant
+                // poll interval: a monotonically growing value distinguishes
+                // one long continuous stall from scattered brief ones.
                 tracing::warn!(
                     dataset = %dataset_name,
-                    stalled_for = ?MEMBER_SEND_STALL_WARN,
+                    stalled_for = ?send_start.elapsed(),
                     "shared Postgres CDC member sink is not draining; the pump is \
                      waiting to deliver committed changes (watch \
                      dataset_postgres_replication_member_send_stalled_seconds_total)"


### PR DESCRIPTION
The shared-pump sink-stall warning logged the constant poll interval (`stalled_for=5s`) on every timeout, so one long continuous stall was indistinguishable in logs from scattered five-second waits — and block length is the most diagnostic signal for this warning (brief waits = healthy backpressure; a monotonic climb = a wedged consumer).

Log the elapsed wait for the in-flight delivery instead, matching the MySQL pump's warning. `send_start` already existed for the send-wait metric; one line plus a comment, no behavior change.