### PR TITLE
fix(search): drop a search hit whose row is not in the base table (fixes #12089)

### DIFF
--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -313,7 +313,11 @@ impl SearchQueryProvider {
             .alias("search_index")?
             .join(
                 self.underlying_table_scan(projection_column_names, filters, &search_index_schema)?,
-                JoinType::Left,
+                // The base table decides which rows exist, so a hit whose primary key is
+                // not there is a stale index entry rather than a result. An outer join
+                // would emit it with the base-table columns NULL-padded and a real
+                // `_score`, turning index staleness into a row the dataset does not have.
+                JoinType::Inner,
                 self.primary_key
                     .iter()
                     .map(|pk| {
@@ -690,4 +694,147 @@ fn exprs_supported(exprs: &[Expr], schema: &DFSchemaRef) -> Vec<Expr> {
         })
         .cloned()
         .collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Float64Array, Int64Array, RecordBatch, StringArray};
+    use datafusion::datasource::MemTable;
+    use datafusion::prelude::SessionContext;
+
+    /// Base table: the source of truth. `extra` is deliberately absent from the
+    /// search index so a `SELECT *` cannot be served by the index alone and the
+    /// join under test is actually planned.
+    fn base_table() -> Result<Arc<dyn TableProvider>, DataFusionError> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("content", DataType::Utf8, true),
+            Field::new("extra", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["dog elephant", "cat"])),
+                Arc::new(StringArray::from(vec!["a", "b"])),
+            ],
+        )
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+        Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
+    }
+
+    /// A search index holding one entry per `(id, score)` pair. An `id` absent
+    /// from [`base_table`] stands in for an entry the source row no longer backs.
+    fn search_index_plan(hits: &[(i64, f64)]) -> Result<Arc<LogicalPlan>, DataFusionError> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("content", DataType::Utf8, true),
+            Field::new(SEARCH_SCORE_COLUMN_NAME, DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(
+                    hits.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(vec!["dog elephant"; hits.len()])),
+                Arc::new(Float64Array::from(
+                    hits.iter().map(|(_, score)| *score).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+        let index: Arc<dyn TableProvider> = Arc::new(MemTable::try_new(schema, vec![vec![batch]])?);
+
+        Ok(Arc::new(
+            LogicalPlanBuilder::scan(
+                "search_index_source",
+                Arc::new(DefaultTableSource::new(index)),
+                None,
+            )?
+            .build()?,
+        ))
+    }
+
+    /// `SELECT id, extra` over a search of [`base_table`] whose index holds `hits`.
+    async fn search_ids_and_extra(
+        hits: &[(i64, f64)],
+    ) -> Result<Vec<RecordBatch>, DataFusionError> {
+        let provider = SearchQueryProvider::new(
+            search_index_plan(hits)?,
+            base_table()?,
+            "content".to_string(),
+            vec!["id".to_string()],
+            None,
+        );
+
+        let ctx = SessionContext::new();
+        ctx.register_table("searched", Arc::new(provider))?;
+        ctx.sql("SELECT id, extra FROM searched ORDER BY id")
+            .await?
+            .collect()
+            .await
+    }
+
+    fn ids(batches: &[RecordBatch]) -> Vec<i64> {
+        batches
+            .iter()
+            .flat_map(|b| {
+                let col = b
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("id column is Int64");
+                (0..b.num_rows()).map(|i| col.value(i)).collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    /// Regression test for #12089: an unfiltered search must not surface an index
+    /// entry whose primary key is absent from the base table. Under an outer join
+    /// the stale `id = 999` entry came back with `extra` NULL and a real `_score` —
+    /// a row the dataset does not contain — and because it scored highest it was
+    /// the first result a top-k search would spend a slot on.
+    #[tokio::test]
+    async fn a_hit_with_no_base_row_is_dropped() -> Result<(), DataFusionError> {
+        let batches = search_ids_and_extra(&[(1, 0.5), (999, 0.98)]).await?;
+
+        assert_eq!(
+            ids(&batches),
+            vec![1],
+            "only the hit backed by a base-table row should be returned"
+        );
+
+        // The surviving row must carry real base-table values, not NULL padding.
+        let extra = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("extra column is Utf8");
+        assert!(
+            !extra.is_null(0),
+            "base-table columns must be populated for a live hit"
+        );
+        assert_eq!(extra.value(0), "a");
+
+        Ok(())
+    }
+
+    /// The join must not drop live hits: every base row the index knows about is
+    /// still returned, so the fix cannot pass by filtering too aggressively.
+    #[tokio::test]
+    async fn every_hit_backed_by_a_base_row_survives() -> Result<(), DataFusionError> {
+        let batches = search_ids_and_extra(&[(1, 0.5), (2, 0.25)]).await?;
+
+        assert_eq!(
+            ids(&batches),
+            vec![1, 2],
+            "both live hits should be returned"
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

`SearchQueryProvider::join_with_base` joined the search index's hits to the base table with `JoinType::Left`. An index entry whose primary key is no longer in the base table therefore still produced an output row — the base-table columns NULL-padded, carrying a real `_score`:

```text
+---------+--------------+--------------------+
|  title  | reddit_score |       _score       |
+---------+--------------+--------------------+
|         |              | 19.145341873168945 |
+---------+--------------+--------------------+
```

The base table decides which rows exist. A hit that matches nothing there is a stale index entry, not a result, so emitting it turns index staleness into a wrong query answer — a row the dataset does not have. Post-join filters happened to drop such rows whenever a query had a filter (a predicate over a NULL column is not true), which is why this only surfaced for unfiltered searches.

Fixes #12089

## Changes

- `crates/search/src/provider.rs`: `JoinType::Left` → `JoinType::Inner` in `join_with_base`, with a comment recording why the join type is load-bearing.
- Two `provider::tests` regression tests: one asserting a hit with no base row is dropped (and that the surviving hit carries real base-table values, not NULL padding), one asserting every hit that *is* backed by a base row still survives — so the fix cannot pass by filtering too aggressively.

## Why `Inner` is equivalent for every row that does have a base match

The join already carries the non-primary-key filters as a join filter, and `join_with_base` then re-applies **all** filters after the join, on the projected schema. So for a hit with a base match the two join types produce identical output; `Inner` changes the result only for hits with no match, which the post-join filter already dropped in every filtered query. The change makes that outcome unconditional rather than a side effect of a query happening to have a predicate.

Inner also restores `limit` semantics: a top-k search no longer spends result slots on entries that will never resolve to a row.

## Bug-class sweep

`JoinType::Left` appears at four other search-path sites; all four were checked and none is an instance of this defect, because what matters is which side is the index:

- `crates/search/src/index/vector_table.rs:269` — the **inverse** orientation (`base_table` LEFT JOIN `vector_index`). Keeping a base row that has no index entry is correct: a row whose embedding has not been computed yet still exists in the dataset.
- `crates/runtime-search/src/candidate/vector.rs:478,583,719` — `ChunkedNonIndexVectorGeneration`, where **both** sides derive from the same base-table scan (`score_cte_sql` scans the provider twice; `score_cte_sql_without_pks` literally clones one builder). No separately-maintained store is involved, so no entry can go stale, and the unfiltered right-hand side always contains every left-hand primary key.
- `crates/search/src/aggregation/reciprocal_rank.rs:413` uses `JoinType::Full` to merge two ranked lists, which is a different operation.

So this bug class has exactly one instance, now fixed.

## Known remaining gap (deliberately out of scope)

When `search_index_table_is_sufficient` is true, `scan` serves the query from the index alone and never joins the base table, so a stale entry is returned with the index's own stored values. That is a separate design question about the index-only fast path (see the `#7404` note in `vector_table.rs`) and forcing a join there would be a performance regression, so it is not changed here.

## Model snapshots must be regenerated by the model CI

Switching the join type rewrites the search plan in ~96 `integration_models` explain snapshots under `crates/runtime/tests/models/snapshots/` (`join_type=Left` → `join_type=Inner`, plus whatever the optimizer does differently for an inner join). Those tests are not part of any PR gate — `integration_models.yml` runs on a schedule or a manual dispatch, and `make nextest` runs `--lib` only — and they cannot be regenerated locally because they require live OpenAI / Cohere / Hugging Face / S3 Vectors credentials. The scheduled run regenerates them with `INSTA_UPDATE=always` and opens its own snapshot PR; a maintainer can also dispatch `integration_models.yml` with `update_snapshots: always`. No `.snap` file is hand-edited in this PR.

## Test plan

- `make lint`
- `make test`

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] Bug class swept across every sibling `JoinType::Left` in the search path
- [x] No snapshot hand-edited
- [ ] `integration_models` snapshots regenerated by the model CI after merge
