### PR TITLE
fix(search): skip the warm vector index when nothing hydrates it (fixes #12101)

### DIFF
--- a/crates/runtime-search/src/embeddings/mod.rs
+++ b/crates/runtime-search/src/embeddings/mod.rs
@@ -26,10 +26,27 @@ use std::sync::Arc;
 
 use chunking::{Chunker, ChunkingConfig};
 use llms::embeddings::{Embed, Error as EmbedError};
+use runtime_acceleration::acceleration::{Acceleration, ZeroResultsAction};
 use std::collections::HashMap;
 use tokio::sync::RwLock;
 
 pub type EmbeddingModelStore = HashMap<String, Arc<dyn Embed>>;
+
+/// The read behavior a warm search tier should be built with for a table with this
+/// `acceleration`, as `warm_index::with_memory_warm_index` takes it.
+///
+/// `None` — no warm tier at all — when the table has no enabled acceleration: a warm tier
+/// starts empty on every process start and is filled by the acceleration write path, so
+/// without acceleration nothing hydrates it and serving searches from it would narrow
+/// results to whatever rows a scan happened to write, or to nothing at all.
+#[must_use]
+pub fn warm_index_on_zero_results(
+    acceleration: Option<&Acceleration>,
+) -> Option<&ZeroResultsAction> {
+    acceleration
+        .filter(|acceleration| acceleration.enabled)
+        .map(|acceleration| &acceleration.on_zero_results)
+}
 
 pub async fn construct_chunker(
     model_name: &str,
@@ -43,4 +60,42 @@ pub async fn construct_chunker(
         });
     };
     embed_model.chunker(chunk_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for #12101: the acceleration write path is the only thing that fills a
+    /// warm search tier, so an absent or disabled acceleration must yield no warm tier at all.
+    #[test]
+    fn on_zero_results_is_none_without_an_enabled_acceleration() {
+        assert_eq!(
+            warm_index_on_zero_results(None),
+            None,
+            "a table with no acceleration must get no warm tier"
+        );
+
+        let disabled = Acceleration {
+            enabled: false,
+            on_zero_results: ZeroResultsAction::UseSource,
+            ..Acceleration::default()
+        };
+        assert_eq!(
+            warm_index_on_zero_results(Some(&disabled)),
+            None,
+            "a disabled acceleration must get no warm tier"
+        );
+
+        let enabled = Acceleration {
+            enabled: true,
+            on_zero_results: ZeroResultsAction::UseSource,
+            ..Acceleration::default()
+        };
+        assert_eq!(
+            warm_index_on_zero_results(Some(&enabled)),
+            Some(&ZeroResultsAction::UseSource),
+            "an enabled acceleration passes its on_zero_results through"
+        );
+    }
 }

--- a/crates/runtime-search/src/embeddings/warm_index.rs
+++ b/crates/runtime-search/src/embeddings/warm_index.rs
@@ -35,6 +35,12 @@ use search::metadata::MetadataColumns;
 /// [`ZeroResultsAction::UseSource`] falls back to the engine index, while
 /// [`ZeroResultsAction::ReturnEmpty`] serves the (possibly empty) in-memory result as-is.
 ///
+/// `on_zero_results` is `None` when the table has no enabled acceleration. The in-memory
+/// index starts empty on every process start and is only ever filled by the acceleration
+/// write path, so without acceleration nothing hydrates it — serving reads from it would
+/// narrow searches to whatever rows happened to be scanned since startup, or to nothing
+/// at all. The engine index is then returned unchanged.
+///
 /// The warm index is an optimization: when a compatible in-memory index cannot be built
 /// (e.g. the engine's distance metric has no in-memory equivalent), the engine index is
 /// returned unchanged and a warning is logged — a dataset that works without a warm
@@ -54,11 +60,17 @@ pub fn with_memory_warm_index(
     embed_udf: &Arc<ScalarUDF>,
     model_name: &String,
     metric: &str,
-    on_zero_results: &ZeroResultsAction,
+    on_zero_results: Option<&ZeroResultsAction>,
 ) -> Arc<dyn VectorIndex> {
     let read_mode = match on_zero_results {
-        ZeroResultsAction::ReturnEmpty => CompoundReadMode::PrimaryOnly,
-        ZeroResultsAction::UseSource => CompoundReadMode::FallbackToSecondary,
+        Some(ZeroResultsAction::ReturnEmpty) => CompoundReadMode::PrimaryOnly,
+        Some(ZeroResultsAction::UseSource) => CompoundReadMode::FallbackToSecondary,
+        None => {
+            tracing::debug!(
+                "Not adding an in-memory warm vector index for table {tbl}: the table is not accelerated, so nothing would populate it. Searches will be served by the vector engine directly."
+            );
+            return engine_index;
+        }
     };
 
     let memory_metric = match MemoryDistanceMetric::try_from(metric) {
@@ -248,7 +260,7 @@ mod tests {
             &noop_embed_udf(),
             &"model".to_string(),
             "cosine",
-            &ZeroResultsAction::UseSource,
+            Some(&ZeroResultsAction::UseSource),
         );
         assert!(
             index
@@ -256,6 +268,31 @@ mod tests {
                 .downcast_ref::<CompoundVectorIndex>()
                 .is_some(),
             "the engine index should be wrapped in a CompoundVectorIndex"
+        );
+    }
+
+    /// Regression test for #12101: nothing writes to a warm index for a table without
+    /// acceleration, so wrapping the engine index in a compound would serve searches from an
+    /// index that is empty (or holds only whatever rows a scan happened to write since
+    /// startup) instead of from the vector engine.
+    #[test]
+    fn warm_index_is_skipped_without_acceleration() {
+        let index = with_memory_warm_index(
+            &TableReference::bare("tbl"),
+            pretend_index(3),
+            MetadataColumns::none(),
+            Arc::new(NoopEmbed),
+            &noop_embed_udf(),
+            &"model".to_string(),
+            "cosine",
+            None,
+        );
+        assert!(
+            index
+                .as_any()
+                .downcast_ref::<PretendVectorIndex>()
+                .is_some(),
+            "a table without acceleration must keep the engine index unchanged"
         );
     }
 
@@ -269,7 +306,7 @@ mod tests {
             &noop_embed_udf(),
             &"model".to_string(),
             "cosine",
-            &ZeroResultsAction::UseSource,
+            Some(&ZeroResultsAction::UseSource),
         );
         assert_eq!(
             use_source
@@ -289,7 +326,7 @@ mod tests {
             &noop_embed_udf(),
             &"model".to_string(),
             "cosine",
-            &ZeroResultsAction::ReturnEmpty,
+            Some(&ZeroResultsAction::ReturnEmpty),
         );
         assert_eq!(
             return_empty
@@ -312,7 +349,7 @@ mod tests {
             &noop_embed_udf(),
             &"model".to_string(),
             "hyperbolic",
-            &ZeroResultsAction::UseSource,
+            Some(&ZeroResultsAction::UseSource),
         );
         assert!(
             index
@@ -334,7 +371,7 @@ mod tests {
             &noop_embed_udf(),
             &"model".to_string(),
             "cosine",
-            &ZeroResultsAction::UseSource,
+            Some(&ZeroResultsAction::UseSource),
         );
         assert!(
             index

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use runtime_search::embeddings::table::EmbeddingTable;
+use runtime_search::embeddings::warm_index_on_zero_results;
 
 pub struct EmbeddingConnector {
     inner_connector: Arc<dyn DataConnector>,
@@ -116,11 +117,7 @@ impl EmbeddingConnector {
                 });
             }
 
-            let on_zero_results = dataset
-                .acceleration
-                .as_ref()
-                .map(|acceleration| acceleration.on_zero_results.clone())
-                .unwrap_or_default();
+            let on_zero_results = warm_index_on_zero_results(dataset.acceleration.as_ref());
 
             let mut provider = Arc::clone(&inner_table_provider);
             for (effective_vector_store, columns) in vector_index_groups(vector_engine, dataset) {
@@ -133,7 +130,7 @@ impl EmbeddingConnector {
                     dataset.params.get("file_format").map(String::as_str),
                     provider,
                     &effective_vector_store,
-                    &on_zero_results,
+                    on_zero_results,
                 )
                 .await
                 .map_err(|e| {

--- a/crates/runtime/src/embeddings/index/table.rs
+++ b/crates/runtime/src/embeddings/index/table.rs
@@ -64,7 +64,7 @@ pub async fn wrap_table_as_index(
     file_format: Option<&str>,
     inner_table_provider: Arc<dyn TableProvider>,
     vector_store: &VectorStore,
-    on_zero_results: &ZeroResultsAction,
+    on_zero_results: Option<&ZeroResultsAction>,
 ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
     let schema = inner_table_provider.schema();
     for c in columns {
@@ -198,7 +198,7 @@ async fn wrap_table_as_index_s3(
     file_format: Option<&str>,
     inner_table_provider: Arc<dyn TableProvider + 'static>,
     vector_store: &VectorStore,
-    on_zero_results: &ZeroResultsAction,
+    on_zero_results: Option<&ZeroResultsAction>,
 ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
     tracing::info!("S3 Vectors for table {tbl} initializing...");
     let start = std::time::Instant::now();
@@ -413,7 +413,7 @@ async fn wrap_table_as_index_elasticsearch(
     file_format: Option<&str>,
     inner_table_provider: Arc<dyn TableProvider + 'static>,
     vector_store: &VectorStore,
-    on_zero_results: &ZeroResultsAction,
+    on_zero_results: Option<&ZeroResultsAction>,
 ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
     tracing::info!("Elasticsearch vector engine for table {tbl} initializing...");
     let start = std::time::Instant::now();

--- a/crates/runtime/src/view.rs
+++ b/crates/runtime/src/view.rs
@@ -24,7 +24,7 @@ use datafusion::{
     error::{DataFusionError, Result},
     prelude::SessionContext,
 };
-use runtime_search::embeddings::table::EmbeddingTable;
+use runtime_search::embeddings::{table::EmbeddingTable, warm_index_on_zero_results};
 use snafu::ResultExt;
 use spicepod::component::embeddings::ColumnEmbeddingConfig;
 use std::{collections::HashSet, sync::Arc};
@@ -116,11 +116,7 @@ pub(crate) async fn prepare_view(
         if let Some(ref vectors) = view.vectors
             && vectors.enabled
         {
-            let on_zero_results = view
-                .acceleration
-                .as_ref()
-                .map(|acceleration| acceleration.on_zero_results.clone())
-                .unwrap_or_default();
+            let on_zero_results = warm_index_on_zero_results(view.acceleration.as_ref());
 
             tbl_provider = wrap_table_as_index(
                 &Arc::new(ctx.clone()),
@@ -131,7 +127,7 @@ pub(crate) async fn prepare_view(
                 file_format,
                 tbl_provider,
                 vectors,
-                &on_zero_results,
+                on_zero_results,
             )
             .await?;
         } else {


### PR DESCRIPTION
## Summary

A dataset or view with `vectors.enabled: true` on an external vector engine (S3 Vectors, Elasticsearch) but **no acceleration** was still given an in-memory warm vector index in front of the engine index, and that warm index is the compound index's *primary* read tier. Nothing hydrates it in that configuration, so vector search answered from an index that is empty — or that holds only whatever rows a scan happened to write since process start — instead of from the vector engine.

Root cause: `with_memory_warm_index` picks the compound read mode from the dataset's `acceleration.on_zero_results`, and both call sites derived that value with `unwrap_or_default()`. With no acceleration block that yields `ZeroResultsAction::ReturnEmpty` (the enum's `#[default]`), which maps to `CompoundReadMode::PrimaryOnly` — reads served only from the in-memory tier, with no fallback to the engine index. `MemoryVectorStore` starts empty on every process start and is only ever filled by `MemoryVectorIndex::write`, which the acceleration write path drives; without acceleration there is no such write path. `FallbackToSecondary` does not rescue the partially-populated case either: it falls back only when the primary yields exactly zero rows.

The warm-tier spec (#11828) calls this configuration out — "When no acceleration is applied (not currently supported; requires external coordination since it won't be hydrated by spiced)" — but the implementation installed the tier unconditionally. This matches the existing precedent that a full-text column requires acceleration (`validate_dataset`); here the engine index works fine on its own, so the warm tier is simply skipped rather than made an error, consistent with `with_memory_warm_index`'s existing contract that a missing warm index must never fail a dataset load.

Fixes #12101

## Changes

- `crates/runtime-search/src/embeddings/mod.rs`: new `warm_index_on_zero_results(Option<&Acceleration>) -> Option<&ZeroResultsAction>` — the single definition of when a warm tier applies. `None` (no warm tier) when acceleration is absent or disabled.
- `crates/runtime-search/src/embeddings/warm_index.rs`: `with_memory_warm_index` takes `Option<&ZeroResultsAction>` and returns the engine index unchanged on `None`, logging why.
- `crates/runtime/src/embeddings/index/table.rs`: threads `Option<&ZeroResultsAction>` through `wrap_table_as_index` and both engine helpers, so the S3 Vectors and Elasticsearch paths are fixed together.
- `crates/runtime/src/embeddings/connector.rs`, `crates/runtime/src/view.rs`: derive the value with the shared helper instead of `unwrap_or_default()`.

Sibling arm checked and deliberately not changed: the Elasticsearch **full-text** compound index (`crates/runtime/src/search/full_text/`) maps `on_zero_results` the same way, but a dataset with an enabled full-text column cannot reach it without acceleration — `validate_dataset` in `crates/runtime/src/init/dataset.rs` returns `FullTextSearchRequiresAcceleration` first.

Behavior for an accelerated dataset or view is unchanged: the same `on_zero_results` → read-mode mapping applies.

Filed while working on this and left for a separate change: #12102 — a warm tier paired with a *persisted* accelerator (file-mode DuckDB/SQLite, Cayenne) plus `refresh_mode: append`/`changes` holds only the rows refreshed since startup, so search narrows after a restart. That needs a hydration or completeness design call rather than a wiring fix.

Overlaps #12082 (chunked Elasticsearch warm tier), which also edits `warm_index.rs` and `embeddings/index/table.rs` from a base that predates #11914. Whichever lands second needs a trunk merge; the new call site #12082 adds should take the same `Option<&ZeroResultsAction>` so a chunked column gets no warm tier without acceleration either.

## Test plan

- New `on_zero_results_is_none_without_an_enabled_acceleration` (`crates/runtime-search/src/embeddings/mod.rs`): no acceleration and a disabled acceleration both yield `None`; an enabled one passes its `on_zero_results` through.
- New `warm_index_is_skipped_without_acceleration` (`crates/runtime-search/src/embeddings/warm_index.rs`): `None` returns the engine index unchanged rather than a `CompoundVectorIndex`. Fails before this change (the engine index came back wrapped in a compound in `PrimaryOnly` mode).
- Existing `warm_index_read_mode_follows_on_zero_results` still asserts `use_source` → `FallbackToSecondary` and `return_empty` → `PrimaryOnly` for an accelerated table, so the fix cannot pass by always skipping the warm index.
- `make lint`
- `make nextest`

## Checklist

- [x] Root cause identified and the whole class (both vector engines) fixed in one change
- [x] Regression test that fails on the old code
- [x] Sibling `on_zero_results` mapping audited (full-text path already guarded)
- [x] No behavior change for accelerated datasets and views
- [ ] `make lint` and `make nextest` green (via `make signoff`)
