### PR TITLE
fix(ci): gate Rust checks on the lint config the gate itself reads (fixes #12111)

### DIFF
--- a/.github/actions/check-code-changes/action.yml
+++ b/.github/actions/check-code-changes/action.yml
@@ -21,6 +21,14 @@ inputs:
       dorny/paths-filter `filters` YAML; must define a `code_changes` group.
       Defaults to the standard repo-wide code paths.
     required: false
+    # The Rust-gate config files below (clippy/rustfmt/nextest/layers,
+    # the two lint guards) must COVER every path in RUST_AFFECTING_PATH_PATTERN
+    # (scripts/signoff). This list stays a deliberate superset — it is the shared
+    # "did any code change" default, so it also gates integration and E2E — but a
+    # Rust-gate path missing here lets the merge queue report `Rust Lint` and
+    # `Build and Test` green without running a step, so with the same path
+    # missing from the pattern it would land on trunk unchecked.
+    # scripts/check_rust_gate_paths.py pins the coverage. See docs/dev/ci_signoff.md.
     default: |
       code_changes:
         - '.github/**'
@@ -34,6 +42,23 @@ inputs:
         - 'go.mod'
         - 'go.sum'
         - 'Makefile'
+        # Dot-prefixed directories are spelled out literally rather than left to
+        # `**`, which only descends into them when picomatch runs with
+        # `dot: true` — `.ci/clippy.toml` is the config the lint gate actually
+        # reads, so it must match either way.
+        - '.ci/**'
+        - '.config/**'
+        - '.cargo/**'
+        - '**/clippy.toml'
+        - '.clippy.toml'
+        - '**/rustfmt.toml'
+        - '.rustfmt.toml'
+        - '**/nextest.toml'
+        - '**/layers.toml'
+        - 'scripts/check_crate_layers.py'
+        - 'scripts/check_rust_gate_paths.py'
+        - 'rust-toolchain'
+        - 'rust-toolchain.toml'
 
 outputs:
   relevant_changes:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -183,9 +183,11 @@ jobs:
       # attest a run that did no work. The merge queue's `check_changes` gate
       # applies the same reasoning to the merged result.
       #
-      # KEEP THE PATTERN IN SYNC with branch_has_rust_changes in scripts/signoff.
-      # This one also inspects renames (previous_filename), so it is strictly the
-      # more conservative of the two.
+      # KEEP THE PATTERN IN SYNC with RUST_AFFECTING_PATH_PATTERN in
+      # scripts/signoff, and covered by the check-code-changes filter;
+      # scripts/check_rust_gate_paths.py enforces both. This step also inspects
+      # renames (previous_filename), so it is strictly the more conservative of
+      # the two regexes.
       - name: Fast-track branches with no Rust-affecting files
         id: no_rust
         if: ${{ github.event_name == 'pull_request' && steps.dependabot.outputs.fast_track != 'true' }}
@@ -235,8 +237,7 @@ jobs:
               return;
             }
 
-            const rustAffecting =
-              /(\.rs$|(^|\/)Cargo\.(toml|lock)$|(^|\/)rust-toolchain(\.toml)?$|(^|\/)\.cargo\/)/;
+            const rustAffecting = /(\.rs$|(^|\/)Cargo\.(toml|lock)$|(^|\/)rust-toolchain(\.toml)?$|(^|\/)\.cargo\/|(^|\/)\.?(clippy|rustfmt)\.toml$|(^|\/)nextest\.toml$|(^|\/)layers\.toml$|^scripts\/check_(crate_layers|rust_gate_paths)\.py$|^Makefile$)/;
             for (const file of files) {
               // A rename off a .rs path changes Rust sources even though the new
               // name doesn't match, so both sides of the rename must be clean.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -253,10 +253,12 @@ jobs:
             }
 
             core.setOutput('fast_track', 'true');
+            // Name the pattern rather than a subset of what it matches: the two drift
+            // apart every time a path is added to the gate.
             core.notice(
-              `Fast-tracked ${files.length} changed file(s): no .rs, Cargo, rust-toolchain, ` +
-              `or .cargo/ paths, so a sign-off would run no Rust checks. The full suite ` +
-              `still runs in the merge queue.`
+              `Fast-tracked ${files.length} changed file(s): none matches the ` +
+              `rustAffecting pattern in .github/workflows/pr.yml, so a sign-off would ` +
+              `run no Rust checks. The full suite still runs in the merge queue.`
             );
 
       # Pure reverts are fast-tracked: undoing a commit that already landed on

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,8 @@ lint-rust:
 	cargo fmt $(_FMT_FLAGS) -- --check
 	## Crate-layering guard (fast, no compile): no crate may depend on a higher tier. See docs/dev/crate_layering.md
 	python3 scripts/check_crate_layers.py
+	## Rust-gate path-list guard (fast, no compile): the sign-off, Attestation, and merge-queue path lists must agree. See docs/dev/ci_signoff.md
+	python3 scripts/check_rust_gate_paths.py
 	## All except metal, cuda, nfs (nfs requires system libnfs library)
 	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --keep-going $(_LINT_TARGET_FLAGS) $(_FEATURES_FLAGS) $(_LINT_WORKSPACE_FLAGS) -- \
 		-Dwarnings \

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -56,9 +56,9 @@ make signoff          # targeted crate lint + tests → full lint + unit tests, 
 ```
 
 `make signoff` first diffs the branch against `trunk`. If that diff has no
-Rust-affecting files (`.rs`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain*`,
-`.cargo/*`), Rust lint/build/unit tests are skipped and the sign-off status is
-still posted (docs/YAML/script-only changes — and for a branch in this
+Rust-affecting files ([the list below](#branches-with-no-rust-changes-are-fast-tracked)),
+Rust lint/build/unit tests are skipped and the sign-off status is
+still posted (docs/YAML-only changes — and for a branch in this
 repository **Attestation** fast-tracks the PR anyway, so you don't need to run
 this at all; the fast-track is same-repo only, so a docs-only PR from a fork
 still needs a maintainer sign-off). Otherwise it maps changed files to workspace
@@ -139,17 +139,38 @@ requiring a sign-off.
 
 ### Branches with no Rust changes are fast-tracked
 
-A pull request whose diff contains no `.rs`, `Cargo.toml`/`Cargo.lock`,
-`rust-toolchain*`, or `.cargo/` paths passes **Attestation** automatically. Those
-are exactly the branches `make signoff` skips every Rust check for, so requiring
-it would attest a run that did no work. Docs, workflow YAML, spicepods, and
-scripts all land here. Renames are checked on both sides, so moving a `.rs` file
-to a non-Rust path still requires a sign-off, and a diff at GitHub's 3000-file
-listing cap is treated as unknown rather than assumed clean. Same-repo only, like
-the other fast-tracks.
+A pull request whose diff contains no Rust-affecting path passes **Attestation**
+automatically. Those are exactly the branches `make signoff` skips every Rust
+check for, so requiring it would attest a run that did no work. Docs, workflow
+YAML, and spicepods land here. Renames are checked on both sides, so moving a
+`.rs` file to a non-Rust path still requires a sign-off, and a diff at GitHub's
+3000-file listing cap is treated as unknown rather than assumed clean. Same-repo
+only, like the other fast-tracks.
+
+Rust-affecting means Rust sources, the Cargo/toolchain config, **and the config
+files the gate itself reads**:
+
+- `*.rs`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain[.toml]`, `.cargo/`
+- `.ci/clippy.toml` (the config `make lint-rust` uses via `CLIPPY_CONF_DIR`) and
+  the root `clippy.toml`; `[.]rustfmt.toml`
+- `.config/nextest.toml` — retries, slow-test timeouts, test groups
+- `layers.toml`, `scripts/check_crate_layers.py`, and
+  `scripts/check_rust_gate_paths.py` — the no-compile guards it runs
+- the root `Makefile` — it holds every `-Dclippy::…` flag the gate enforces
 
 The merge queue still runs the full suite on the merged result — its
 `check_changes` gate applies the same reasoning there.
+
+Three lists encode that set: `RUST_AFFECTING_PATH_PATTERN` in `scripts/signoff`,
+`rustAffecting` in `.github/workflows/pr.yml` (which must classify the same
+paths), and the `code_changes` filter in `.github/actions/check-code-changes`
+(a deliberate superset — it is the shared "did any code change" default, so it
+also gates integration and E2E, and it only has to *cover* the set). A path
+missing from all three lands on trunk having never been linted, built, or
+tested, so `make lint-rust` runs `scripts/check_rust_gate_paths.py`. It derives
+what must be gated from what the `lint-rust` recipe reads and from the tracked
+config-file names, rather than from a list someone has to remember, and fails
+when the three drift. Change them together.
 
 ### Dependabot bumps are fast-tracked
 

--- a/scripts/check_rust_gate_paths.py
+++ b/scripts/check_rust_gate_paths.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Rust-gate path-list guard.
+#
+# Three lists decide whether a branch gets any Rust validation:
+#
+#   1. `RUST_AFFECTING_PATH_PATTERN` in `scripts/signoff` — when nothing in the
+#      branch diff matches, `make signoff` skips fmt, clippy, build, and tests.
+#   2. `rustAffecting` in `.github/workflows/pr.yml` — when nothing in the PR
+#      diff matches, the required `Attestation` check auto-passes. Must classify
+#      the same paths as (1); the two are compared here.
+#   3. The `code_changes` filter in `.github/actions/check-code-changes` — when
+#      nothing matches, the merge queue's `Rust Lint` and `Build and Test` run
+#      zero steps and report success. A deliberate superset of (1): it is the
+#      shared "did any code change" default, so it also gates integration and
+#      E2E. Only its coverage of the Rust-gate paths is pinned here.
+#
+# A path missing from all three lands on trunk having never been linted, built,
+# or tested — where `.ci/clippy.toml`, `.config/nextest.toml`, `layers.toml`, and
+# `scripts/check_crate_layers.py` all sat until #12111.
+#
+# The paths that must be gated are DERIVED, not listed: from what the `lint-rust`
+# recipe reads (`CLIPPY_CONF_DIR`, each `python3 scripts/…` guard) and from the
+# tracked files whose name marks them as lint/test config. So this catches "a
+# config file the gate reads is in none of the lists" — the actual bug — and not
+# merely "the lists disagree about a path someone already thought of".
+#
+# Usage:
+#   scripts/check_rust_gate_paths.py    # validate (exit 1 on drift, 2 if unreadable)
+#
+# Pure stdlib; no third-party deps.
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+SIGNOFF = REPO / "scripts" / "signoff"
+PR_WORKFLOW = REPO / ".github" / "workflows" / "pr.yml"
+CHECK_CHANGES = REPO / ".github" / "actions" / "check-code-changes" / "action.yml"
+MAKEFILE = REPO / "Makefile"
+
+# Tracked files whose basename means "this configures clippy, rustfmt, nextest,
+# or the layering guard", wherever in the tree they live.
+GATE_CONFIG_BASENAMES = (
+    "clippy.toml",
+    ".clippy.toml",
+    "rustfmt.toml",
+    ".rustfmt.toml",
+    "nextest.toml",
+    "layers.toml",
+)
+
+# Rust inputs that are not config files, so there is nothing to derive them from.
+RUST_SOURCE_PATHS = (
+    "crates/runtime/src/lib.rs",
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/cayenne/Cargo.toml",
+    "rust-toolchain.toml",
+    ".cargo/config.toml",
+    # Holds every -Dclippy::… flag the gate enforces.
+    "Makefile",
+)
+
+# Paths that must NOT drag in the Rust gate — otherwise the fast-track is dead
+# and every docs PR pays a full sign-off.
+MUST_SKIP_RUST_CHECKS = (
+    "README.md",
+    "docs/dev/ci_signoff.md",
+    "docs/cayenne/cayenne.md",
+    "test/spicepods/tpch/sf1/federated/duckdb.yaml",
+    ".github/workflows/pr.yml",
+    "scripts/tpcds_explain.sh",
+    # A non-Rust guard must not inherit the Rust gate by naming convention.
+    "scripts/check_helm_chart.py",
+    # Only the root Makefile carries the lint flags.
+    "test/tpc-bench/Makefile",
+)
+
+
+def extract_signoff_pattern() -> str | None:
+    """The ERE assigned to RUST_AFFECTING_PATH_PATTERN in scripts/signoff."""
+    match = re.search(
+        r"^RUST_AFFECTING_PATH_PATTERN='(?P<pattern>.*)'$",
+        SIGNOFF.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    return match.group("pattern") if match else None
+
+
+def extract_workflow_pattern() -> str | None:
+    """The `rustAffecting` regex literal in pr.yml, as an ERE.
+
+    A JS literal has to escape `/`, which the shell ERE does not, so unescaping
+    it is what makes the two directly comparable.
+    """
+    match = re.search(
+        r"^\s*const rustAffecting = /(?P<pattern>.*)/;$",
+        PR_WORKFLOW.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    return match.group("pattern").replace("\\/", "/") if match else None
+
+
+def extract_code_change_globs() -> list[str]:
+    """The `code_changes` glob list from the check-code-changes default filter."""
+    text = CHECK_CHANGES.read_text(encoding="utf-8")
+    block = text.split("code_changes:", 1)[-1].split("\noutputs:", 1)[0]
+    return re.findall(r"^\s+- '([^']+)'$", block, re.MULTILINE)
+
+
+def lint_recipe() -> str:
+    """The recipe lines of the Makefile's `lint-rust` target (tab-indented)."""
+    after_target = MAKEFILE.read_text(encoding="utf-8").split("\nlint-rust:", 1)[-1]
+    # Drop the rest of the target line (its prerequisites) before reading the recipe.
+    lines = []
+    for line in after_target.split("\n", 1)[-1].splitlines():
+        if not line.startswith("\t"):
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def derived_gate_paths() -> tuple[list[str], list[str]]:
+    """Paths the Rust gate reads, plus notes on anything that could not be derived.
+
+    Derived from the `lint-rust` recipe (the clippy config directory it points
+    at, and every `python3 scripts/…` guard it runs) plus the tracked files whose
+    basename marks them as lint/test config.
+    """
+    paths: set[str] = set(RUST_SOURCE_PATHS)
+    notes: list[str] = []
+
+    recipe = lint_recipe()
+    if not recipe:
+        notes.append(
+            "could not read the `lint-rust` recipe from Makefile — derived only from "
+            "tracked config-file names"
+        )
+    for conf_dir in re.findall(r'CLIPPY_CONF_DIR="([^"]+)"', recipe):
+        paths.add(f"{conf_dir.rstrip('/')}/clippy.toml")
+    paths.update(re.findall(r"python3 (scripts/[\w./-]+\.py)", recipe))
+
+    try:
+        tracked = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=REPO,
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.split("\0")
+    except (OSError, subprocess.CalledProcessError) as error:
+        notes.append(
+            f"could not list tracked files ({error}) — derived only from the lint-rust recipe"
+        )
+        tracked = []
+    paths.update(p for p in tracked if p and Path(p).name in GATE_CONFIG_BASENAMES)
+
+    return sorted(paths), notes
+
+
+def glob_matches(glob: str, path: str) -> bool:
+    """Match one dorny/paths-filter (picomatch) glob against a path.
+
+    Equivalent to `glob.translate(glob, recursive=True, include_hidden=False)`,
+    hand-rolled only because that landed in Python 3.13 and this repo's guards
+    run on 3.11. `include_hidden=False` is the rule that matters: a wildcard
+    never matches a path segment starting with `.`, because picomatch descends
+    into dot-prefixed directories only with `dot: true`, which this filter does
+    not set. So a dot path (`.ci/clippy.toml`) must be covered by a glob that
+    spells the dot segment out (`.ci/**`) — which matches either way — rather
+    than relying on `**` to reach it.
+    """
+    if glob.startswith("**/"):
+        # picomatch lets a leading `**/` match nothing, so `**/x` matches `x`.
+        return glob_matches(glob[3:], path) or glob_matches(f"*/{glob}", path)
+    pattern = (
+        re.escape(glob)
+        .replace(r"\*\*/", "(?:[^./][^/]*/)*")
+        .replace(r"\*\*", "[^./][^/]*(?:/[^./][^/]*)*")
+        .replace(r"\*", "[^./][^/]*")
+    )
+    return re.fullmatch(pattern, path) is not None
+
+
+def read_patterns() -> dict[str, str] | None:
+    """Both Rust-affecting path patterns, keyed by the file they came from."""
+    patterns = {}
+    for name, extractor, shape in (
+        (
+            "scripts/signoff",
+            extract_signoff_pattern,
+            "RUST_AFFECTING_PATH_PATTERN='…' as a single-quoted single-line assignment",
+        ),
+        (
+            ".github/workflows/pr.yml",
+            extract_workflow_pattern,
+            "const rustAffecting = /…/; on one line",
+        ),
+    ):
+        pattern = extractor()
+        if pattern is None:
+            print(
+                f"error: could not read the Rust-affecting path pattern from {name}. "
+                f"Keep it {shape} so this guard can read it.",
+                file=sys.stderr,
+            )
+            return None
+        patterns[name] = pattern
+    return patterns
+
+
+def main() -> int:
+    patterns = read_patterns()
+    if patterns is None:
+        return 2
+
+    globs = extract_code_change_globs()
+    if not globs:
+        print(
+            f"error: could not read the `code_changes` glob list from {CHECK_CHANGES}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    errors: list[str] = []
+    signoff_pattern, workflow_pattern = patterns.values()
+    if signoff_pattern != workflow_pattern:
+        errors.append(
+            "the Rust-affecting path patterns have drifted apart:\n"
+            f"  scripts/signoff: {signoff_pattern}\n"
+            f"  pr.yml:          {workflow_pattern}\n"
+            "They gate the same decision (local sign-off vs the required "
+            "Attestation check) and must classify paths identically."
+        )
+
+    gated, notes = derived_gate_paths()
+    for note in notes:
+        print(f"warning: {note}", file=sys.stderr)
+
+    for path in gated:
+        for name, pattern in patterns.items():
+            if not re.search(pattern, path):
+                errors.append(
+                    f"{path} changes what the Rust gate does, but the pattern in {name} "
+                    "does not match it — the branch would skip every Rust check."
+                )
+        if not any(glob_matches(glob, path) for glob in globs):
+            errors.append(
+                f"{path} changes what the Rust gate does, but no check-code-changes glob "
+                "matches it — the merge queue would report `Rust Lint` and `Build and "
+                "Test` green without running a step."
+            )
+
+    for path in MUST_SKIP_RUST_CHECKS:
+        for name, pattern in patterns.items():
+            if re.search(pattern, path):
+                errors.append(
+                    f"{path} cannot affect Rust lint/build/tests, but the pattern in "
+                    f"{name} matches it — the no-Rust fast-track would never fire."
+                )
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        print(
+            f"\n{len(errors)} Rust-gate path-list problem(s). Update all three lists "
+            "together: RUST_AFFECTING_PATH_PATTERN in scripts/signoff, `rustAffecting` "
+            "in .github/workflows/pr.yml, and the `code_changes` filter in "
+            ".github/actions/check-code-changes.\nSee docs/dev/ci_signoff.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Rust-gate paths OK: patterns agree, {len(gated)} gated path(s) matched by all "
+        f"three lists, {len(MUST_SKIP_RUST_CHECKS)} fast-track path(s) still skipped."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -704,7 +704,9 @@ run_checks() {
   # expensive lint/build/test gate. Unknown diffs fall through and run checks.
   if [[ -n "$revision" ]] && ! branch_has_rust_changes "$revision"; then
     info "No Rust-affecting files changed vs ${LINT_BASE_BRANCH} — skipping Rust lint, build, and unit tests"
-    append_step_summary "### Rust checks"$'\n'"Skipped (no \`.rs\` / Cargo / rust-toolchain / \`.cargo/\` / lint-config files in the branch diff vs \`${LINT_BASE_BRANCH}\`)."$'\n'
+    # Name the pattern rather than a subset of what it matches: the two drift apart
+    # every time a path is added to the gate.
+    append_step_summary "### Rust checks"$'\n'"Skipped (nothing in the branch diff vs \`${LINT_BASE_BRANCH}\` matches \`RUST_AFFECTING_PATH_PATTERN\` in \`scripts/signoff\`)."$'\n'
     SIGNOFF_CHECK_SUMMARY="no Rust changes (lint/test skipped)"
     return 0
   fi

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -50,7 +50,8 @@
 #
 # Targeted pre-lint always diffs against trunk (not configurable).
 # When the branch has no Rust-affecting changes vs trunk (.rs, Cargo.toml,
-# Cargo.lock, rust-toolchain*, .cargo/*), Rust lint/build/tests are skipped
+# Cargo.lock, rust-toolchain*, .cargo/*, clippy/rustfmt/nextest/layers config,
+# the lint guards, the root Makefile), Rust lint/build/tests are skipped
 # (both local and remote); the sign-off status is still posted.
 #
 # Remote alternative to local `make signoff`:
@@ -605,9 +606,14 @@ post_commit_status() {
 
 # --- commands ----------------------------------------------------------------
 
+# Paths that can change what cargo/clippy/fmt/nextest do — Rust sources, the
+# Cargo/toolchain config, and the config files the gate itself reads. Keep in
+# sync with `rustAffecting` in .github/workflows/pr.yml and covered by the
+# check-code-changes filter; `scripts/check_rust_gate_paths.py` enforces both,
+# and docs/dev/ci_signoff.md explains why each path is here.
+RUST_AFFECTING_PATH_PATTERN='(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/|(^|/)\.?(clippy|rustfmt)\.toml$|(^|/)nextest\.toml$|(^|/)layers\.toml$|^scripts/check_(crate_layers|rust_gate_paths)\.py$|^Makefile$)'
+
 # True when the branch delta vs trunk can affect Rust lint/build/tests.
-# Matches .rs sources plus Cargo/toolchain config that can break those gates:
-#   *.rs, Cargo.toml, Cargo.lock, rust-toolchain[.toml], .cargo/*
 # Prints nothing. Exit 0 = has Rust-affecting changes (or unknown — run checks).
 # Exit 1 = no such paths in the changed set → safe to skip.
 # Unknown (diff unavailable) returns 0 so we never skip when we can't tell.
@@ -623,9 +629,7 @@ branch_has_rust_changes() {
     debug "no changed files vs ${LINT_BASE_BRANCH} — no Rust changes"
     return 1
   fi
-  # Paths that can change what cargo/clippy/fmt/nextest do (not docs/scripts alone).
-  if printf '%s\n' "$files" | grep -qE \
-      '(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/)'; then
+  if printf '%s\n' "$files" | grep -qE "$RUST_AFFECTING_PATH_PATTERN"; then
     debug "Rust-affecting files present — will run Rust checks"
     return 0
   fi
@@ -700,7 +704,7 @@ run_checks() {
   # expensive lint/build/test gate. Unknown diffs fall through and run checks.
   if [[ -n "$revision" ]] && ! branch_has_rust_changes "$revision"; then
     info "No Rust-affecting files changed vs ${LINT_BASE_BRANCH} — skipping Rust lint, build, and unit tests"
-    append_step_summary "### Rust checks"$'\n'"Skipped (no \`.rs\` / Cargo / rust-toolchain / \`.cargo/\` files in the branch diff vs \`${LINT_BASE_BRANCH}\`)."$'\n'
+    append_step_summary "### Rust checks"$'\n'"Skipped (no \`.rs\` / Cargo / rust-toolchain / \`.cargo/\` / lint-config files in the branch diff vs \`${LINT_BASE_BRANCH}\`)."$'\n'
     SIGNOFF_CHECK_SUMMARY="no Rust changes (lint/test skipped)"
     return 0
   fi
@@ -1295,7 +1299,9 @@ Maintainers:
 
 Checks (when verify is on):
   0. If the branch has no Rust-affecting files vs trunk (.rs, Cargo.toml/lock,
-     rust-toolchain*, .cargo/*) → skip Rust lint/build/tests (still posts status)
+     rust-toolchain*, .cargo/*, clippy/rustfmt/nextest/layers config, the lint
+     guards, the root Makefile) → skip Rust lint/build/tests (still posts
+     status)
   1. Targeted lint of crates touched by this branch vs trunk
      (make lint-rust PACKAGES="…") — fail-fast feedback
   2. Targeted unit tests for those crates (make nextest-packages PACKAGES="…")


### PR DESCRIPTION
## Summary

Three independent lists decide whether a branch gets any Rust validation, and all three omitted the config files the Rust gate itself reads — so a PR that changed only one of them merged having never been linted, built, or tested.

- **PR stage.** `rustAffecting` in `pr.yml` auto-passes the required `Attestation` check when no changed path matches; `RUST_AFFECTING_PATH_PATTERN` (`scripts/signoff`) makes `make signoff` skip fmt, clippy, build, and tests for the same set.
- **Merge queue.** The `code_changes` filter in `check-code-changes` gates `Rust Lint` and `Build and Test`; on a miss both run zero steps and report success.

`.ci/clippy.toml` (the config `make lint-rust` actually uses via `CLIPPY_CONF_DIR`), the root `clippy.toml`, `.config/nextest.toml`, `layers.toml`, and `scripts/check_crate_layers.py` matched none of the three. Dropping `allow-expect-in-tests = true` from `.ci/clippy.toml` is a one-line PR that changes lint results across the whole workspace; today it merges green and the breakage surfaces as a failed `Rust Lint` on the next unrelated PR. `Makefile` was a partial case — caught by the merge-queue filter, not by the PR-stage pattern, though it holds every `-Dclippy::…` flag the gate enforces.

The two regexes already carried a `KEEP THE PATTERN IN SYNC` comment with nothing enforcing it, and the merge-queue filter was a third copy neither comment mentioned.

Fixes #12111

## Changes

- `scripts/signoff`: the pattern moves into `RUST_AFFECTING_PATH_PATTERN` (one definition, read by `branch_has_rust_changes`) and gains `[.]clippy.toml`, `[.]rustfmt.toml`, `nextest.toml`, `layers.toml`, the two lint guards, and the root `Makefile`.
- `.github/workflows/pr.yml`: `rustAffecting` gains the same paths.
- `.github/actions/check-code-changes`: the same paths join the `code_changes` filter, which stays a deliberate superset — it is the shared "did any code change" default, so it also gates integration and E2E, and only has to *cover* the Rust set. Dot-prefixed directories are spelled out (`.ci/**`, `.config/**`, `.cargo/**`) rather than left to `**`, which descends into them only under picomatch's `dot: true` — not set here.
- `scripts/check_rust_gate_paths.py` (new): fails when the two patterns classify paths differently, when a gated path is missed by any of the three lists, or when a pattern grows broad enough to kill the fast-track. It **derives** what must be gated — from what the `lint-rust` recipe reads (`CLIPPY_CONF_DIR`, each `python3 scripts/…` guard) and from the tracked files whose basename marks them as lint/test config — so it catches a config file that is in none of the lists, not just a disagreement about a path someone already thought of. That derivation immediately turned up `crates/vendor/pgwire-replication/rustfmt.toml`, which a hand-written list had missed. Pure stdlib, no compile, ~30 ms.
- `make lint-rust` runs it beside `check_crate_layers.py`; `docs/dev/ci_signoff.md` documents the set and the three lists.

Scoping notes: `Makefile` is anchored to the root one (the other three in the tree hold no lint flags), and the guards are enumerated rather than matched as `scripts/check_*.py`, so a future non-Rust guard doesn't drag docs-only PRs into a full sign-off. A deeper fix — having pr.yml read the pattern out of `scripts/signoff` at runtime, via a sparse checkout in the Attestation job — would remove the duplication rather than police it; that changes a required check's inputs, so it is left as a follow-up.

## Test plan

- `python3 scripts/check_rust_gate_paths.py` — green on this branch (15 gated paths matched by all three lists, 6 fast-track paths still skipped).
- Neuter tests, each reverted afterwards — the guard exits 1 when: (a) the `scripts/signoff` pattern is restored to its old value, (b) only `pr.yml` drifts, (c) only the merge-queue globs are dropped, (d) just `.ci/**` is dropped (the dotfile case), (e) the pattern is widened to match `*.md`, which would kill the fast-track, and (f) `CLIPPY_CONF_DIR` is pointed at a directory no list covers — the last one is the original bug reproduced, and the guard names the file nobody added.
- The two patterns were checked to classify the same paths: `grep -E` over the shell ERE and `node` evaluating the workflow's own statement, agreeing on 12 gated and 8 fast-track paths.
- `bash -n scripts/signoff`; both YAML files re-parsed, including the inner `filters` block scalar as dorny receives it.
- This branch touches `Makefile`, so it is Rust-affecting under the new pattern and takes the full gate rather than the fast-track: `make lint` and `make test` via `make signoff`.

## Checklist

- [x] Guard fails on every drift direction (too narrow and too broad), verified by reverting each list in turn
- [x] Both regexes verified to agree, in `bash` and in `node`
- [x] YAML validated, including the nested `filters` document
- [x] `make signoff` (`make lint` + `make test`) on the pushed HEAD
