### PR TITLE
fix(cli): surface the registry error behind a failed `spice add` instead of blaming the archive (fixes #12116)

### DIFF
--- a/bin/spice/src/commands/add.rs
+++ b/bin/spice/src/commands/add.rs
@@ -88,9 +88,7 @@ pub async fn execute_add_or_connect(
     // Fetch the Spicepod
     let download_path = registry::get_pod(pod_path, ctx.pods_dir(), &headers, ctx.http_client())
         .await
-        .map_err(|e| crate::error::Error::InvalidArgument {
-            message: e.to_string(),
-        })?;
+        .map_err(|e| registry_error(&e))?;
 
     // Get relative path for display
     let relative_path = get_relative_path(ctx.app_dir(), &download_path);
@@ -115,6 +113,25 @@ pub async fn execute_add_or_connect(
     println!("added {relative_path}");
 
     Ok(())
+}
+
+/// Classify a registry failure so the user is told whose fault it is.
+///
+/// Only the arms that describe the requested pod are the caller's argument; a registry that
+/// answers badly is not, and reporting it as `invalid_argument` sends the user - and any script
+/// reading the machine error code - looking for a mistake they did not make.
+fn registry_error(error: &registry::Error) -> crate::error::Error {
+    let message = error.to_string();
+    match error {
+        registry::Error::FetchFailed { .. }
+        | registry::Error::NotAnArchive { .. }
+        | registry::Error::ZipExtraction { .. } => crate::error::Error::Registry { message },
+        registry::Error::NotFound { .. }
+        | registry::Error::DirectoryNotFound { .. }
+        | registry::Error::InvalidSpicepod { .. }
+        | registry::Error::NestedLocalInstall { .. }
+        | registry::Error::Io { .. } => crate::error::Error::InvalidArgument { message },
+    }
 }
 
 /// Get a relative path from a base directory.
@@ -147,6 +164,41 @@ fn dependency_reference(pod_path: &str, base: &Path, download_path: &Path) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A registry that answers badly is not a bad argument - see #12116.
+    #[test]
+    fn a_registry_side_failure_is_not_reported_as_a_bad_argument() {
+        let served_a_json_error = registry::Error::NotAnArchive {
+            pod: "spiceai/quickstart".to_string(),
+            status: 200,
+            content_type: "application/zip".to_string(),
+            body_len: 152,
+            message: "selected encoding not supported".to_string(),
+        };
+        let rendered = registry_error(&served_a_json_error).to_string();
+        assert!(
+            matches!(
+                registry_error(&served_a_json_error),
+                crate::error::Error::Registry { .. }
+            ),
+            "{rendered}"
+        );
+        assert!(
+            rendered.starts_with("Failed to fetch Spicepod 'spiceai/quickstart'"),
+            "the registry's own message is displayed verbatim: {rendered}"
+        );
+
+        let no_such_pod = registry::Error::NotFound {
+            path: "spiceai/nope".to_string(),
+        };
+        assert!(
+            matches!(
+                registry_error(&no_such_pod),
+                crate::error::Error::InvalidArgument { .. }
+            ),
+            "a pod that does not exist stays the caller's argument"
+        );
+    }
 
     #[test]
     fn dependency_reference_preserves_remote_version_pin() {

--- a/bin/spice/src/error.rs
+++ b/bin/spice/src/error.rs
@@ -72,6 +72,11 @@ pub enum Error {
     #[snafu(display("Invalid HTTP response: {message}"))]
     InvalidResponse { message: String },
 
+    /// A Spicepod registry failed to serve a pod. The message is already fully formed, so it is
+    /// displayed verbatim rather than blamed on the user's argument.
+    #[snafu(display("{message}"))]
+    Registry { message: String },
+
     /// Failed to read/write configuration
     #[snafu(display("Failed to {operation} configuration at {}: {source}", path.display()))]
     ConfigIo {

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -767,6 +767,7 @@ fn machine_error_code(error: &spice::error::Error) -> &'static str {
         spice::error::Error::ConnectionFailed { .. } => "connection_failed",
         spice::error::Error::HttpRequestFailed { .. } => "http_request_failed",
         spice::error::Error::InvalidResponse { .. } => "invalid_response",
+        spice::error::Error::Registry { .. } => "registry",
         spice::error::Error::ConfigIo { .. } => "config_io",
         spice::error::Error::ConfigParse { .. } => "config_parse",
         spice::error::Error::CreateDirectory { .. } => "create_directory",

--- a/bin/spice/src/registry/mod.rs
+++ b/bin/spice/src/registry/mod.rs
@@ -72,6 +72,18 @@ pub enum Error {
     #[snafu(display("Failed to fetch Spicepod '{pod}' from spicerack.org: {message}"))]
     FetchFailed { pod: String, message: String },
 
+    /// The registry answered with a success status but the body is not a Spicepod archive
+    #[snafu(display(
+        "Failed to fetch Spicepod '{pod}' from spicerack.org: the registry answered HTTP {status} with a {body_len}-byte body that is not a Spicepod archive (content-type: {content_type}). Registry message: {message}. Retry, or install from a local path with `spice add <path>`. See: https://spiceai.org/docs"
+    ))]
+    NotAnArchive {
+        pod: String,
+        status: u16,
+        content_type: String,
+        body_len: usize,
+        message: String,
+    },
+
     /// Zip extraction error
     #[snafu(display("Failed to extract Spicepod archive: {source}"))]
     ZipExtraction { source: zip::result::ZipError },

--- a/bin/spice/src/registry/spicerack.rs
+++ b/bin/spice/src/registry/spicerack.rs
@@ -42,6 +42,21 @@ const MAX_QUOTED_MESSAGE_LEN: usize = 512;
 /// Keys an error body may carry its human-readable text under.
 const MESSAGE_KEYS: [&str; 3] = ["Message", "message", "error"];
 
+/// Signatures a zip record can open with: local file header, end-of-central-directory (an empty
+/// archive), and the spanned/split marker.
+const ZIP_SIGNATURES: [&[u8]; 3] = [b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08"];
+
+/// Whether a body the zip reader rejected still claims to be an archive.
+///
+/// A download cut short keeps its signature, so it is a damaged archive rather than a message the
+/// registry meant for the user - and reporting it as one would quote the raw bytes back as if the
+/// server had said them.
+fn claims_to_be_an_archive(body: &[u8]) -> bool {
+    ZIP_SIGNATURES
+        .iter()
+        .any(|signature| body.starts_with(signature))
+}
+
 /// Pull the human-readable message out of a registry error body.
 ///
 /// Spicerack reports errors as `{"Message": "...", "Code": 0, "Type": "error"}`; anything else
@@ -175,20 +190,22 @@ impl SpicerackRegistry {
 
         // The registry can answer a success status with an error body - a JSON payload under
         // `Content-Type: application/zip`. Reporting that as a corrupt archive throws the
-        // server's own message away, so when the body reads as text, quote it back instead. The
-        // zip reader decides what is an archive, so a body it accepts is never diverted here.
+        // server's own message away, so when the body is text the registry meant for the user,
+        // quote it back instead. A body still carrying a zip signature is a damaged archive, not
+        // a message, even when its bytes happen to be valid UTF-8. The zip reader decides what is
+        // an archive, so a body it accepts is never diverted here.
         let mut archive = match zip::ZipArchive::new(file) {
             Ok(archive) => archive,
             Err(source) => {
                 return Err(match std::str::from_utf8(&bytes) {
-                    Ok(text) => Error::NotAnArchive {
+                    Ok(text) if !claims_to_be_an_archive(&bytes) => Error::NotAnArchive {
                         pod: pod_full_path.to_string(),
                         status: status.as_u16(),
                         content_type,
                         body_len: bytes.len(),
                         message: registry_error_message(text),
                     },
-                    Err(_) => Error::ZipExtraction { source },
+                    _ => Error::ZipExtraction { source },
                 });
             }
         };
@@ -430,6 +447,26 @@ mod tests {
                 .count(),
             0,
             "a failed extraction must not leave an empty pod directory behind"
+        );
+    }
+
+    /// A download cut short can leave bytes that are valid UTF-8, and quoting those back as the
+    /// registry's own words would invent a message the server never sent. The zip signature is
+    /// what separates a damaged archive from an error body.
+    #[tokio::test]
+    async fn a_truncated_archive_whose_bytes_are_text_is_still_reported_as_a_bad_archive() {
+        let body = b"PK\x03\x04 truncated but perfectly valid UTF-8".to_vec();
+        assert!(
+            std::str::from_utf8(&body).is_ok(),
+            "the body must be valid UTF-8 for this test to exercise the signature check"
+        );
+
+        let (result, _pods_dir) = fetch_pod_serving(body).await;
+
+        let err = result.expect_err("a truncated archive cannot be extracted");
+        assert!(
+            matches!(err, Error::ZipExtraction { .. }),
+            "{err} should stay a ZipExtraction"
         );
     }
 

--- a/bin/spice/src/registry/spicerack.rs
+++ b/bin/spice/src/registry/spicerack.rs
@@ -36,12 +36,65 @@ fn get_spicerack_base_url() -> String {
     }
 }
 
+/// How much of a registry error body to quote back to the user.
+const MAX_QUOTED_MESSAGE_LEN: usize = 512;
+
+/// Keys an error body may carry its human-readable text under.
+const MESSAGE_KEYS: [&str; 3] = ["Message", "message", "error"];
+
+/// Pull the human-readable message out of a registry error body.
+///
+/// Spicerack reports errors as `{"Message": "...", "Code": 0, "Type": "error"}`; anything else
+/// falls back to the raw body so the server's own words always reach the user.
+fn registry_error_message(body: &str) -> String {
+    let parsed = serde_json::from_str::<serde_json::Value>(body).unwrap_or_default();
+    let message = MESSAGE_KEYS
+        .iter()
+        .find_map(|key| parsed.get(key).and_then(serde_json::Value::as_str))
+        .unwrap_or(body)
+        .trim();
+
+    if message.is_empty() {
+        return "(the registry sent an empty body)".to_string();
+    }
+
+    // Keep the message on one line, and bound it so a stray HTML error page can't flood the
+    // terminal.
+    let mut quoted: String = message
+        .chars()
+        .take(MAX_QUOTED_MESSAGE_LEN)
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    if message.chars().nth(MAX_QUOTED_MESSAGE_LEN).is_some() {
+        quoted.push('…');
+    }
+    quoted
+}
+
 /// Registry that fetches Spicepods from spicerack.org.
 pub struct SpicerackRegistry;
 
 impl SpicerackRegistry {
     pub async fn get_pod(
         &self,
+        pod_full_path: &str,
+        pods_dir: &Path,
+        headers: &HashMap<String, String>,
+        http_client: &reqwest::Client,
+    ) -> Result<std::path::PathBuf> {
+        self.get_pod_from(
+            &get_spicerack_base_url(),
+            pod_full_path,
+            pods_dir,
+            headers,
+            http_client,
+        )
+        .await
+    }
+
+    async fn get_pod_from(
+        &self,
+        base_url: &str,
         pod_full_path: &str,
         pods_dir: &Path,
         headers: &HashMap<String, String>,
@@ -56,7 +109,6 @@ impl SpicerackRegistry {
         };
 
         // Build URL
-        let base_url = get_spicerack_base_url();
         let url = match pod_version {
             Some(version) => format!("{base_url}/spicepods/{pod_path}/{version}"),
             None => format!("{base_url}/spicepods/{pod_path}"),
@@ -89,6 +141,13 @@ impl SpicerackRegistry {
             });
         }
 
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("unset")
+            .to_string();
+
         // Download to temp file
         let bytes = response.bytes().await.map_err(|e| Error::FetchFailed {
             pod: pod_full_path.to_string(),
@@ -107,14 +166,6 @@ impl SpicerackRegistry {
             source: e,
         })?;
 
-        // Create destination directory
-        let dest_dir = pods_dir.join(pod_path);
-        std::fs::create_dir_all(&dest_dir).map_err(|e| Error::Io {
-            operation: "create directory",
-            path: dest_dir.display().to_string(),
-            source: e,
-        })?;
-
         // Extract zip
         let file = std::fs::File::open(temp_file.path()).map_err(|e| Error::Io {
             operation: "open temp file",
@@ -122,7 +173,33 @@ impl SpicerackRegistry {
             source: e,
         })?;
 
-        let mut archive = zip::ZipArchive::new(file).context(ZipExtractionSnafu)?;
+        // The registry can answer a success status with an error body - a JSON payload under
+        // `Content-Type: application/zip`. Reporting that as a corrupt archive throws the
+        // server's own message away, so when the body reads as text, quote it back instead. The
+        // zip reader decides what is an archive, so a body it accepts is never diverted here.
+        let mut archive = match zip::ZipArchive::new(file) {
+            Ok(archive) => archive,
+            Err(source) => {
+                return Err(match std::str::from_utf8(&bytes) {
+                    Ok(text) => Error::NotAnArchive {
+                        pod: pod_full_path.to_string(),
+                        status: status.as_u16(),
+                        content_type,
+                        body_len: bytes.len(),
+                        message: registry_error_message(text),
+                    },
+                    Err(_) => Error::ZipExtraction { source },
+                });
+            }
+        };
+
+        // Create destination directory
+        let dest_dir = pods_dir.join(pod_path);
+        std::fs::create_dir_all(&dest_dir).map_err(|e| Error::Io {
+            operation: "create directory",
+            path: dest_dir.display().to_string(),
+            source: e,
+        })?;
 
         for i in 0..archive.len() {
             let mut file = archive.by_index(i).context(ZipExtractionSnafu)?;
@@ -178,5 +255,216 @@ impl SpicerackRegistry {
         }
 
         Ok(dest_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// The exact 152-byte body `api.spicerack.org` answers `GET /v1/spicepods/spiceai/quickstart`
+    /// with, under `HTTP 200` and `Content-Type: application/zip`.
+    const REGISTRY_ERROR_BODY: &str = "{\"Message\":\"invalid path \\\"spiceaiquickstartv0.1.08bb188f7b4106571cdec9b33f44963b04f928f7f\\\": selected encoding not supported\",\"Code\":0,\"Type\":\"error\"}\n";
+
+    /// The manifest [`zip_with_manifest`] packs.
+    const MANIFEST: &str = "version: v1\nkind: Spicepod\nname: quickstart\n";
+
+    /// Build a Spicepod archive holding a single manifest.
+    fn zip_with_manifest() -> Vec<u8> {
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        writer
+            .start_file("spicepod.yaml", options)
+            .expect("start manifest entry");
+        writer
+            .write_all(MANIFEST.as_bytes())
+            .expect("write manifest entry");
+        writer.finish().expect("finish archive").into_inner()
+    }
+
+    /// Fetch `spiceai/quickstart` from a registry that answers `response`.
+    ///
+    /// The returned `TempDir` is the pods dir, and has to outlive the assertions that read it.
+    async fn fetch_pod_from(
+        response: ResponseTemplate,
+    ) -> (Result<std::path::PathBuf, Error>, tempfile::TempDir) {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/spicepods/spiceai/quickstart"))
+            .respond_with(response)
+            .mount(&server)
+            .await;
+
+        let pods_dir = tempfile::tempdir().expect("create pods dir");
+        let result = SpicerackRegistry
+            .get_pod_from(
+                &format!("{}/v1", server.uri()),
+                "spiceai/quickstart",
+                pods_dir.path(),
+                &HashMap::new(),
+                &reqwest::Client::new(),
+            )
+            .await;
+        (result, pods_dir)
+    }
+
+    /// Fetch a body the registry serves as an archive, whatever it actually contains.
+    async fn fetch_pod_serving(
+        body: impl Into<Vec<u8>>,
+    ) -> (Result<std::path::PathBuf, Error>, tempfile::TempDir) {
+        fetch_pod_from(ResponseTemplate::new(200).set_body_raw(body.into(), "application/zip"))
+            .await
+    }
+
+    #[test]
+    fn registry_error_message_reads_the_json_message_field() {
+        assert_eq!(
+            registry_error_message(REGISTRY_ERROR_BODY),
+            "invalid path \"spiceaiquickstartv0.1.08bb188f7b4106571cdec9b33f44963b04f928f7f\": selected encoding not supported"
+        );
+        assert_eq!(
+            registry_error_message(r#"{"message":"lowercase"}"#),
+            "lowercase"
+        );
+        assert_eq!(
+            registry_error_message(r#"{"error":"other key"}"#),
+            "other key"
+        );
+    }
+
+    #[test]
+    fn registry_error_message_falls_back_to_the_raw_body() {
+        assert_eq!(
+            registry_error_message("upstream timed out"),
+            "upstream timed out"
+        );
+        assert_eq!(
+            registry_error_message(r#"{"Code":0}"#),
+            r#"{"Code":0}"#,
+            "a JSON body with no message key"
+        );
+        assert_eq!(
+            registry_error_message("   \n  "),
+            "(the registry sent an empty body)"
+        );
+        assert_eq!(
+            registry_error_message(""),
+            "(the registry sent an empty body)"
+        );
+    }
+
+    #[test]
+    fn registry_error_message_stays_on_one_line_and_bounded() {
+        assert_eq!(
+            registry_error_message("first line\nsecond\tline"),
+            "first line second line"
+        );
+
+        let long = registry_error_message(&"x".repeat(MAX_QUOTED_MESSAGE_LEN + 10));
+        assert_eq!(long.chars().count(), MAX_QUOTED_MESSAGE_LEN + 1);
+        assert!(long.ends_with('\u{2026}'));
+    }
+
+    /// Regression test for #12116: the registry's own message has to survive, and the CLI must
+    /// not blame the archive for a server-side error.
+    #[tokio::test]
+    async fn json_error_under_a_success_status_reports_the_registry_message() {
+        let (result, pods_dir) = fetch_pod_serving(REGISTRY_ERROR_BODY).await;
+
+        let message = result
+            .expect_err("a JSON error body is not a Spicepod archive")
+            .to_string();
+        assert!(
+            message.contains("selected encoding not supported"),
+            "the registry's message must reach the user: {message}"
+        );
+        assert!(
+            message.contains("content-type: application/zip")
+                && message.contains(&format!("{}-byte", REGISTRY_ERROR_BODY.len())),
+            "the mismatch between the declared type and the body must be reported: {message}"
+        );
+        assert!(
+            !message.contains("EOCD") && !message.contains("extract"),
+            "a server-side error must not be reported as a corrupt archive: {message}"
+        );
+        assert_eq!(
+            std::fs::read_dir(pods_dir.path())
+                .expect("read pods dir")
+                .count(),
+            0,
+            "nothing should be written for a failed fetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_body_under_a_success_status_is_reported_as_such() {
+        let (result, _pods_dir) = fetch_pod_serving(Vec::new()).await;
+
+        let message = result
+            .expect_err("an empty body is not a Spicepod archive")
+            .to_string();
+        assert!(
+            message.contains("0-byte") && message.contains("(the registry sent an empty body)"),
+            "{message}"
+        );
+    }
+
+    /// A body the zip reader cannot make sense of and that is not text stays a corrupt archive.
+    #[tokio::test]
+    async fn a_corrupt_binary_body_is_still_reported_as_a_bad_archive() {
+        let (result, pods_dir) =
+            fetch_pod_serving(b"PK\x03\x04\xff\xfe\x00 truncated".to_vec()).await;
+
+        let err = result.expect_err("a truncated archive cannot be extracted");
+        assert!(
+            matches!(err, Error::ZipExtraction { .. }),
+            "{err} should stay a ZipExtraction"
+        );
+        assert_eq!(
+            std::fs::read_dir(pods_dir.path())
+                .expect("read pods dir")
+                .count(),
+            0,
+            "a failed extraction must not leave an empty pod directory behind"
+        );
+    }
+
+    /// The zip reader decides what is an archive, so a body it accepts extracts even when it
+    /// carries leading data and therefore starts with no zip signature.
+    #[tokio::test]
+    async fn an_archive_is_extracted_with_or_without_leading_data() {
+        let mut with_preamble = b"#!/bin/sh\n# self-extracting preamble\n".to_vec();
+        with_preamble.extend_from_slice(&zip_with_manifest());
+
+        for (label, body) in [
+            ("a bare archive", zip_with_manifest()),
+            ("an archive with leading data", with_preamble),
+        ] {
+            let (result, pods_dir) = fetch_pod_serving(body).await;
+
+            let dest = result.expect(label);
+            assert_eq!(dest, pods_dir.path().join("spiceai/quickstart"), "{label}");
+            assert_eq!(
+                std::fs::read_to_string(dest.join("spicepod.yaml")).expect("read manifest"),
+                MANIFEST,
+                "{label}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_missing_pod_is_still_reported_as_not_found() {
+        let (result, _pods_dir) =
+            fetch_pod_from(ResponseTemplate::new(404).set_body_string(REGISTRY_ERROR_BODY)).await;
+
+        let err = result.expect_err("a 404 is not a Spicepod archive");
+        assert!(
+            matches!(err, Error::NotFound { .. }),
+            "{err} should stay a NotFound"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`spice add spiceai/quickstart` fails for everyone right now, and the error it prints points at the wrong thing:

```
ERROR Invalid argument: Failed to extract Spicepod archive: invalid Zip archive: Could not find EOCD
```

Root cause of the misleading half (the part fixable in this repo): `api.spicerack.org` answers `GET /v1/spicepods/<org>/<pod>` with a **JSON error body under `HTTP 200` and `Content-Type: application/zip`** (verified again 2026-07-28T02:07Z), and `SpicerackRegistry::get_pod` trusted the status code, wrote the body to a temp file, and handed it to `zip::ZipArchive::new`. The server's own message — `invalid path "spiceaiquickstartv0.1.0…": selected encoding not supported`, which names the registry-side defect — was discarded, and a registry outage was reported as a corrupt archive.

The registry half is server-side (`api.spicerack.org`) and is not fixable here; #12116 tracks both.

After this change the same response reports:

```
ERROR Failed to fetch Spicepod 'spiceai/quickstart' from spicerack.org: the registry answered HTTP 200 with a 152-byte body that is not a Spicepod archive (content-type: application/zip). Registry message: invalid path "spiceaiquickstartv0.1.08bb188f7b4106571cdec9b33f44963b04f928f7f": selected encoding not supported. Retry, or install from a local path with `spice add <path>`. See: https://spiceai.org/docs
```

Fixes #12116

## Changes

- **`bin/spice/src/registry/spicerack.rs`** — the zip reader stays the authority on what is an archive. When `ZipArchive::new` rejects the body *and* the body reads as UTF-8 text, return the new `NotAnArchive` error quoting the registry's message; a non-text body keeps its `ZipExtraction` error. Deciding this on the reader's verdict rather than on a magic-byte guess means a body the reader accepts is never diverted, so an archive carrying leading data still extracts. `Content-Type` is reported as evidence but deliberately **not** used as the decision input — the server declares `application/zip` on the JSON body, so a header check would pass this bug straight through.
- The destination directory is now created only after the archive opens, so a failed fetch no longer leaves an empty `spicepods/<org>/<pod>` behind.
- `registry_error_message` reads the message out of `{"Message"|"message"|"error"}`, falls back to the raw body, flattens it to one line, and bounds it at 512 chars so an HTML error page can't flood the terminal.
- **`bin/spice/src/commands/add.rs`** — registry failures were all mapped to `InvalidArgument`, so a server-side failure printed as `Invalid argument: …` and reported the machine code `invalid_argument`. Arms that describe the requested pod stay `InvalidArgument`; `FetchFailed`/`NotAnArchive`/`ZipExtraction` now map to a new `Error::Registry` (code `registry`) that displays the already fully-formed message verbatim.
- `get_pod` gained a private `get_pod_from(base_url, …)` seam so the fetch can be tested against a mock registry without `std::env::set_var` on `SPICERACK_BASE_URL` (process-global, racy under parallel tests, and `unsafe` in edition 2024).

## Bug-class audit

`bin/spice` has exactly two places that hand an HTTP body to a binary decoder. The other is `github/release.rs::extract_tar_gz` (`spice install` / `spice upgrade`), reached via `download_with_progress`, which checks `is_success()` and then streams the body unvalidated. It is the same *shape*, but there is no observed failure — GitHub does not serve `200` + error body on asset downloads — and the authoritative check there is different: `asset.size` and `content_length()` are both already known and never compared to `data.len()`, which would also catch truncation. Not folded in: it needs its own mock-GitHub tests and shares no mechanism with this fix. Filed as #12120 rather than fixed speculatively.

## Test plan

- `make lint` — clippy (pedantic, `unwrap_used`, `clone_on_ref_ptr`) and `cargo fmt` clean.
- `make test` — full unit suite. `bin/spice` locally: 192 lib tests + 46 bin tests pass.
- New tests in `bin/spice/src/registry/spicerack.rs`, driven by a `wiremock` registry:
  - **regression**: the exact 152-byte production body under `200` + `application/zip` → the message carries `selected encoding not supported`, the declared type and body length, contains neither `EOCD` nor `extract`, and nothing is written to the pods dir.
  - an empty body under a success status is reported as such.
  - a corrupt binary body stays a `ZipExtraction` error and leaves no empty pod directory.
  - an archive extracts both bare **and** with a leading self-extracting preamble (guards against the fix diverting a body that works today).
  - a `404` still returns `NotFound`.
  - `registry_error_message` unit cases: each message key, raw-body fallback, blank body, one-line flattening, 512-char bound.
- New test in `bin/spice/src/commands/add.rs`: a `NotAnArchive` classifies as `Error::Registry` and renders verbatim; a `NotFound` stays `InvalidArgument`.
- **Both regression tests were verified to fail on the pre-fix behavior** — with the diversion neutered they reproduce the reported `invalid Zip archive: Could not find EOCD` exactly, while the extraction tests pass in both variants (confirming no working install is diverted).

## Checklist

- [x] Regression test fails before the fix and passes after
- [x] Edge cases covered: empty body, non-UTF-8 body, archive with leading data, oversized/multi-line error body, non-2xx statuses
- [x] `cargo clippy` (pedantic) and `cargo fmt` clean
- [x] No `.unwrap()`/`.expect()` in production code
- [x] Error message follows the repo format and names the pod, the status, the declared type, and an actionable next step
- [ ] `make signoff` green and `Attestation` re-run
