### PR TITLE
fix(cli): report a truncated release download as a failed download (fixes #12120)

### DIFF
--- a/bin/spice/src/github/mod.rs
+++ b/bin/spice/src/github/mod.rs
@@ -109,17 +109,32 @@ impl GitHubClient {
         })
     }
 
-    /// Download a file with progress tracking.
-    pub async fn download_with_progress<F>(
+    /// Download a release asset with progress tracking, verifying the body is the whole asset.
+    ///
+    /// The releases API publishes an exact `size` for every asset, so a body of any other
+    /// length is a failed download — a dropped connection, a truncating proxy, or an
+    /// interstitial page served with a `200`. Verifying it here means the bytes only ever
+    /// reach a decoder once they are known to be the right ones; otherwise a short body
+    /// surfaces as whatever the decoder makes of it, which reads as a corrupt archive
+    /// rather than as the transfer failure it is.
+    ///
+    /// The asset is taken whole rather than as a URL and a length so that the size checked
+    /// against is always the one published for the body being fetched. `Content-Length` is
+    /// deliberately not the authority: it describes whatever the server chose to send, so a
+    /// proxy substituting its own complete response satisfies it. Any `Content-Encoding` is
+    /// a transport wrapper the client unwraps before this sees the body, leaving the stored
+    /// bytes the published size refers to.
+    pub async fn download_asset<F>(
         &self,
-        url: &str,
+        asset: &ReleaseAsset,
         mut on_progress: F,
     ) -> Result<Vec<u8>, GitHubError>
     where
-        F: FnMut(u64, Option<u64>),
+        F: FnMut(u64),
     {
         use futures::StreamExt;
 
+        let url = &asset.browser_download_url;
         let mut request = self
             .client
             .get(url)
@@ -143,7 +158,6 @@ impl GitHubClient {
             });
         }
 
-        let total_size = response.content_length();
         let mut downloaded: u64 = 0;
         let mut data = Vec::new();
         let mut stream = response.bytes_stream();
@@ -154,7 +168,15 @@ impl GitHubClient {
             })?;
             downloaded += chunk.len() as u64;
             data.extend_from_slice(&chunk);
-            on_progress(downloaded, total_size);
+            on_progress(downloaded);
+        }
+
+        if downloaded != asset.size {
+            return Err(GitHubError::IncompleteDownload {
+                name: asset.name.clone(),
+                expected: asset.size,
+                received: downloaded,
+            });
         }
 
         Ok(data)
@@ -179,13 +201,31 @@ impl GitHubClient {
 /// Errors that can occur when interacting with GitHub.
 #[derive(Debug)]
 pub enum GitHubError {
-    Request { message: String },
+    Request {
+        message: String,
+    },
     Unauthorized,
-    Api { status: u16, message: String },
-    Parse { message: String },
-    AssetNotFound { name: String },
-    ReleaseNotFound { version: String },
-    Io { message: String },
+    Api {
+        status: u16,
+        message: String,
+    },
+    Parse {
+        message: String,
+    },
+    AssetNotFound {
+        name: String,
+    },
+    ReleaseNotFound {
+        version: String,
+    },
+    IncompleteDownload {
+        name: String,
+        expected: u64,
+        received: u64,
+    },
+    Io {
+        message: String,
+    },
 }
 
 impl std::fmt::Display for GitHubError {
@@ -202,6 +242,16 @@ impl std::fmt::Display for GitHubError {
             Self::Parse { message } => write!(f, "Failed to parse response: {message}"),
             Self::AssetNotFound { name } => write!(f, "Asset not found: {name}"),
             Self::ReleaseNotFound { version } => write!(f, "Release not found: {version}"),
+            // Exact byte counts, not human-readable sizes: rounding would print an expected
+            // and a received figure that read as identical for a small truncation.
+            Self::IncompleteDownload {
+                name,
+                expected,
+                received,
+            } => write!(
+                f,
+                "Download of {name} did not complete: expected {expected} bytes but received {received}. Check the network connection and any proxy between this machine and GitHub, then run the command again."
+            ),
             Self::Io { message } => write!(f, "IO error: {message}"),
         }
     }

--- a/bin/spice/src/github/release.rs
+++ b/bin/spice/src/github/release.rs
@@ -101,12 +101,25 @@ pub async fn download_release_asset(
         format_size(asset.size)
     );
 
-    // Download with progress
+    let data = download_reporting_progress(client, asset, "Downloading").await?;
+
+    // Extract tar.gz
+    extract_tar_gz(&data, download_dir)?;
+
+    Ok(())
+}
+
+/// Download an asset, reporting progress on stderr under `label`.
+async fn download_reporting_progress(
+    client: &GitHubClient,
+    asset: &ReleaseAsset,
+    label: &str,
+) -> Result<Vec<u8>, GitHubError> {
     let total_size = asset.size;
     let start_time = std::time::Instant::now();
 
     let data = client
-        .download_with_progress(&asset.browser_download_url, |downloaded, _| {
+        .download_asset(asset, |downloaded| {
             let elapsed = start_time.elapsed().as_secs_f64();
             let speed = if elapsed > 0.0 {
                 downloaded as f64 / elapsed / 1024.0 / 1024.0
@@ -116,7 +129,7 @@ pub async fn download_release_asset(
             let percent = (downloaded as f64 / total_size as f64) * 100.0;
 
             eprint!(
-                "\rDownloading: {:.1}% ({}/{}) @ {:.1} MB/s",
+                "\r{label}: {:.1}% ({}/{}) @ {:.1} MB/s",
                 percent,
                 format_size(downloaded),
                 format_size(total_size),
@@ -127,10 +140,7 @@ pub async fn download_release_asset(
 
     eprintln!(); // New line after progress
 
-    // Extract tar.gz
-    extract_tar_gz(&data, download_dir)?;
-
-    Ok(())
+    Ok(data)
 }
 
 /// Download a release asset with fallback to alternative asset names.
@@ -183,31 +193,7 @@ pub async fn upgrade_cli_in_place(
         format_size(asset.size)
     );
 
-    // Download with progress
-    let total_size = asset.size;
-    let start_time = std::time::Instant::now();
-
-    let data = client
-        .download_with_progress(&asset.browser_download_url, |downloaded, _| {
-            let elapsed = start_time.elapsed().as_secs_f64();
-            let speed = if elapsed > 0.0 {
-                downloaded as f64 / elapsed / 1024.0 / 1024.0
-            } else {
-                0.0
-            };
-            let percent = (downloaded as f64 / total_size as f64) * 100.0;
-
-            eprint!(
-                "\rDownloading CLI: {:.1}% ({}/{}) @ {:.1} MB/s",
-                percent,
-                format_size(downloaded),
-                format_size(total_size),
-                speed
-            );
-        })
-        .await?;
-
-    eprintln!(); // New line after progress
+    let data = download_reporting_progress(client, asset, "Downloading CLI").await?;
 
     // Get the current executable path
     let current_exe = std::env::current_exe().map_err(|e| GitHubError::Io {
@@ -532,6 +518,170 @@ fn get_cuda_version() -> Option<String> {
 mod tests {
     use super::*;
     use rstest::rstest;
+    use wiremock::matchers::{method, path as path_matcher};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const ASSET_NAME: &str = "spiced_linux_x86_64.tar.gz";
+
+    /// Build a gzipped tar holding a single entry, as a release asset would.
+    fn tar_gz_containing(entry_name: &str, contents: &[u8]) -> Vec<u8> {
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o755);
+        builder
+            .append_data(&mut header, entry_name, contents)
+            .expect("tar entry is appended");
+
+        builder
+            .into_inner()
+            .expect("tar builder is finished")
+            .finish()
+            .expect("gzip stream is finished")
+    }
+
+    /// A release advertising one asset of `size` bytes, served by `server_uri`.
+    fn release_advertising(server_uri: &str, size: u64) -> RepoRelease {
+        RepoRelease {
+            url: String::new(),
+            html_url: String::new(),
+            assets_url: String::new(),
+            tag_name: "v1.0.0".to_string(),
+            name: None,
+            draft: false,
+            prerelease: false,
+            created_at: String::new(),
+            published_at: None,
+            assets: vec![ReleaseAsset {
+                url: String::new(),
+                id: 1,
+                name: ASSET_NAME.to_string(),
+                content_type: "application/gzip".to_string(),
+                size,
+                download_count: 0,
+                browser_download_url: format!("{server_uri}/{ASSET_NAME}"),
+            }],
+        }
+    }
+
+    /// Serve `body` for the asset, and download it into a fresh directory.
+    async fn download_body(
+        body: Vec<u8>,
+        advertised_size: u64,
+    ) -> (Result<(), GitHubError>, tempfile::TempDir) {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_matcher(format!("/{ASSET_NAME}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let release = release_advertising(&server.uri(), advertised_size);
+        let dest = tempfile::tempdir().expect("temp dir is created");
+        let client = GitHubClient::new("spiceai", "spiceai");
+
+        let result = download_release_asset(&client, &release, ASSET_NAME, dest.path()).await;
+        (result, dest)
+    }
+
+    /// Regression test for #12120.
+    ///
+    /// Unchecked, a truncated body went straight to the gzip decoder and surfaced as whatever
+    /// the decoder made of the fragment that arrived (`Failed to extract archive: invalid
+    /// gzip header`, `… failed to iterate over archive`) — blaming the archive for a network
+    /// failure. Note that the mock serves a `Content-Length` consistent with the short body,
+    /// as a truncating proxy would, so only the published asset size reveals the mismatch.
+    #[tokio::test]
+    async fn a_body_shorter_than_the_release_advertises_is_reported_as_a_failed_download() {
+        let archive = tar_gz_containing("spiced", b"payload");
+        let advertised_size = archive.len() as u64;
+
+        // Empty, a first chunk, midway, and one byte short — the last of these is what makes
+        // the check exact rather than a plausibility test.
+        for received_bytes in [0, 1, archive.len() / 2, archive.len() - 1] {
+            let (result, dest) =
+                download_body(archive[..received_bytes].to_vec(), advertised_size).await;
+
+            let Err(error) = result else {
+                panic!("a download of {received_bytes} bytes must not be reported as a success");
+            };
+            assert!(
+                matches!(error, GitHubError::IncompleteDownload { .. }),
+                "expected an incomplete download of {received_bytes} bytes, got: {error}"
+            );
+
+            let message = error.to_string();
+            assert!(message.contains(ASSET_NAME), "asset not named: {message}");
+            assert!(
+                message.contains(&advertised_size.to_string())
+                    && message.contains(&received_bytes.to_string()),
+                "both sizes must be reported: {message}"
+            );
+            assert!(
+                !message.contains("extract") && !message.contains("archive"),
+                "a failed transfer must not be blamed on the archive: {message}"
+            );
+            assert!(
+                std::fs::read_dir(dest.path())
+                    .expect("destination is readable")
+                    .next()
+                    .is_none(),
+                "a failed download must not leave anything extracted"
+            );
+        }
+    }
+
+    /// A body longer than the release advertises is just as wrong as a short one — it is not
+    /// the asset that was published, whatever it decodes to.
+    #[tokio::test]
+    async fn a_body_longer_than_the_release_advertises_is_rejected() {
+        let archive = tar_gz_containing("spiced", b"payload");
+        let advertised_size = archive.len() as u64;
+        let mut with_trailing_bytes = archive;
+        with_trailing_bytes.extend_from_slice(b"unexpected trailer");
+
+        let (result, _dest) = download_body(with_trailing_bytes, advertised_size).await;
+
+        assert!(
+            matches!(result, Err(GitHubError::IncompleteDownload { .. })),
+            "an over-long body must be rejected"
+        );
+    }
+
+    /// The guard must not stand between a good download and its extraction: a body matching
+    /// the advertised size installs exactly as it did before.
+    #[tokio::test]
+    async fn a_complete_asset_is_downloaded_and_extracted() {
+        let archive = tar_gz_containing("spiced", b"runtime binary");
+        let advertised_size = archive.len() as u64;
+
+        let (result, dest) = download_body(archive, advertised_size).await;
+
+        result.expect("a complete download extracts");
+        let extracted = std::fs::read(dest.path().join("spiced")).expect("spiced is extracted");
+        assert_eq!(extracted, b"runtime binary");
+    }
+
+    /// The length check is not a stand-in for decoding: a body of the right length that is
+    /// still not an archive keeps reporting the extraction failure, so a genuinely corrupt
+    /// asset is not relabelled as a network problem.
+    #[tokio::test]
+    async fn a_complete_body_that_is_not_an_archive_still_reports_extraction() {
+        let not_an_archive = b"<html>this is not a tarball</html>".to_vec();
+        let advertised_size = not_an_archive.len() as u64;
+
+        let (result, _dest) = download_body(not_an_archive, advertised_size).await;
+
+        let Err(error) = result else {
+            panic!("a body that is not an archive must not be reported as a success");
+        };
+        assert!(
+            matches!(error, GitHubError::Io { .. }),
+            "expected an extraction failure, got: {error}"
+        );
+    }
 
     impl Arch {
         fn x86() -> Arch {


### PR DESCRIPTION
## Summary

`spice install` and `spice upgrade` download a release asset and hand the bytes straight to the gzip/tar decoder without checking the download completed. The releases API publishes an exact `size` for every asset, and it was already read — but only to render the progress percentage, never to validate the result.

A stream that ends early (a dropped connection, a truncating proxy, a captive portal serving a `200` block page) therefore surfaced as whatever the decoder made of the fragment that arrived:

```
IO error: Failed to extract archive: invalid gzip header
```

That misattributes a network failure to local IO and never shows what actually came back. `upgrade_cli_in_place` is on this path and replaces the running CLI binary, so it is worth catching explicitly rather than inferring from a decoder error.

Fixes #12120

## Changes

- `GitHubClient::download_asset` (was `download_with_progress`) verifies the received byte count against the size the release publishes, and returns a new `GitHubError::IncompleteDownload` naming the asset and both sizes.
- The helper now takes the whole `&ReleaseAsset` rather than a URL, so the size checked against is always the one published for the body being fetched, and neither caller can pair a URL with an unrelated length or skip the check. Both call sites — `download_release_asset` and `upgrade_cli_in_place` — are covered without doing anything themselves.
- Exact byte counts are reported rather than human-readable sizes: rounding would render a small truncation as two identical-looking figures.
- The two byte-identical download-progress blocks in `release.rs` collapse into one `download_reporting_progress` helper, since the change had to edit both in lockstep.

`Content-Length` is deliberately not the authority — it describes whatever the server chose to send, so a truncating proxy or an interstitial page satisfies it with a header consistent with its own short body. The published asset size is the only independent expectation. Any `Content-Encoding` is a transport wrapper reqwest unwraps before this code sees the body, leaving exactly the stored bytes the published size refers to (verified against the live CDN: the API's `size` and the served `content-length` agree, and no encoding is applied).

## Verification

Each new test was confirmed to fail with the length check removed and to pass with it, and the two guard tests below pass in **both** variants — so no working download is diverted:

- `a_body_shorter_than_the_release_advertises_is_reported_as_a_failed_download` — regression test; empty, one byte, midway and one-byte-short bodies. Without the check these reproduce the reported symptom exactly (`Failed to extract archive: failed to iterate over archive`). Asserts both sizes are named, that the message does not blame the archive, and that nothing is left extracted. The mock serves a `Content-Length` consistent with its short body, as a truncating proxy would.
- `a_body_longer_than_the_release_advertises_is_rejected` — an over-long body is not the published asset either.
- `a_complete_asset_is_downloaded_and_extracted` — guard: a matching body installs exactly as before.
- `a_complete_body_that_is_not_an_archive_still_reports_extraction` — guard: the length check is not a stand-in for decoding, so a genuinely corrupt asset keeps its extraction error rather than being relabelled a network problem.

## Test plan

- [x] `make lint`
- [x] `make test`
- [x] New tests fail without the fix and pass with it (neuter-verified)
- [x] Verified against the live GitHub releases API that `asset.size` matches the served `content-length` and that no `Content-Encoding` is applied

## Performance impact

None on the download path: one integer comparison after the stream completes. The progress-block dedupe is a refactor with identical output.

## Notes / out of scope

- The accumulator is still `Vec::new()` though the exact size is now known up front; pre-sizing it needs a clamp policy for a server-supplied length and is left to its own change.
- `spicerack.rs` had the same *class* of bug (a body handed to a decoder unvalidated) and was fixed separately in #12119 by a different mechanism, deliberately: the registry has no authoritative expected size — its failure is a complete body of the wrong content, which a size check cannot catch, while a truncated gzip is genuinely undecodable and a decoder-rejection fallback cannot diagnose as a transfer failure.