### PR TITLE
fix(postgres): honor inline PEM pg_sslrootcert on the replication path

### DIFF
--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -638,7 +638,10 @@ fn replication_params_from_connector_params(
     let identity = crate::connection::connection_identity_from_params(params)?;
     let sslmode = config::SslMode::from_str_strict(identity.sslmode.as_deref())
         .map_err(|reason| format!("parameter `{}` {reason}", params.user_param("sslmode")))?;
-    let sslrootcert = identity.sslrootcert.map(std::path::PathBuf::from);
+    let sslrootcert = identity
+        .sslrootcert
+        .as_deref()
+        .map(config::ca_certificate_from_param);
 
     // An explicitly-named slot is shareable: every dataset on the same
     // connection naming the same slot is multiplexed onto one replication
@@ -921,6 +924,7 @@ fn extract_primary_keys(provider: &Arc<dyn datafusion::datasource::TableProvider
 #[cfg(test)]
 mod tests {
     use super::*;
+    use data_components::postgres_replication::CaCertificate;
 
     fn params_with_bootstrap_batch_size(value: &str) -> Parameters {
         Parameters::new(
@@ -943,6 +947,88 @@ mod tests {
 
     fn empty_params() -> Parameters {
         Parameters::new(vec![], "pg", crate::PARAMETERS)
+    }
+
+    /// Self-signed CA (`CN=Spice Replication Test CA`, `CA:TRUE`), expiring in 2126.
+    const TEST_CA_PEM: &str = "-----BEGIN CERTIFICATE-----
+MIIC4DCCAcigAwIBAgIJAODHR+uzOPBvMA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNV
+BAMMGVNwaWNlIFJlcGxpY2F0aW9uIFRlc3QgQ0EwIBcNMjYwNzI4MDU0MDQ0WhgP
+MjEyNjA3MDQwNTQwNDRaMCQxIjAgBgNVBAMMGVNwaWNlIFJlcGxpY2F0aW9uIFRl
+c3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCzoou00DrTAevF
+RZ6+PFmSBUhzZXsABQFztlPigZzJ1m8hnja66hnkWKyIid9DcitnjkWgtQZCVxm6
+s05tM6QAy5lI2wlfWD7hQi+yIWKv2dcVuD/J4hWPjmG5a5VtRAInV0yBymkCRI6Z
+68JYfvKh+Rku1y6H3dUfNm8dxCbo589L1U8ucJqlQv9Iy/X7Lze+pj2JFU/L1g3t
+k/5ziVgJjdh3VetrHkU1YOiHRPFsqXOxXc2lpzUjd23QR3FfkZkVgLUfEvPWHRSf
+xipaPFhllw9WUWEl6bVqAGO0btPO1OKKqBlIcizf2YO2+lFs/o0e7bApGzI3l5HP
+VZr/e6ZLAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQAD
+ggEBACC1XMNpbA+172MQks9R7cqRY5I0HObJRX3dpIsOqrm3EUcHMt9kx7QrO1Af
+gzAWC0ZNHppeU/cuq9ZKZQiFrSmr5fKtXzsxkvgLYRCFO+ZCKZl9k3z9j0AQbTPR
+klJa4bo2SS6WbmoATimD6e0moT++neRIDx7MlijtWB8grfhuH7yFN9xoTRDgdYBU
+KLeFNAIi+S5cVzUwjMiOQnmljphKSRoQnihpA/c6WAVAN3VqMdoPpfmR2pTi7rio
+38busw0nt/y+JCVWzNDr/i5f3mvNi5SaHZ5PTOVnocyMUw+ysx5eQOrJwrirW9XD
+TXTE85+Or9IUwDI9543jsyCvuQ8=
+-----END CERTIFICATE-----
+";
+
+    /// A complete connection, so parsing reaches `sslrootcert` instead of
+    /// aborting on a missing required parameter.
+    fn params_with_sslrootcert(value: &str) -> Parameters {
+        Parameters::new(
+            vec![
+                ("host".to_string(), SecretString::from("pg.internal")),
+                ("user".to_string(), SecretString::from("spice")),
+                ("db".to_string(), SecretString::from("myapp")),
+                ("sslmode".to_string(), SecretString::from("verify-full")),
+                ("sslrootcert".to_string(), SecretString::from(value)),
+            ],
+            "pg",
+            crate::PARAMETERS,
+        )
+    }
+
+    /// `pg_sslrootcert` is documented as accepting a path *or* inline PEM
+    /// content, and a CA injected as a secret arrives as content. Both spellings
+    /// must reach the replication stream as a usable trust anchor.
+    #[test]
+    fn inline_pem_sslrootcert_reaches_replication_params_as_content() {
+        let repl =
+            replication_params_from_connector_params(&params_with_sslrootcert(TEST_CA_PEM), "hits")
+                .expect("inline PEM sslrootcert should parse");
+
+        assert_eq!(repl.sslmode, config::SslMode::VerifyFull);
+        assert_eq!(
+            repl.sslrootcert,
+            Some(CaCertificate::Pem(TEST_CA_PEM.as_bytes().to_vec())),
+            "inline PEM must not be reinterpreted as a filesystem path"
+        );
+    }
+
+    #[test]
+    fn inline_pem_sslrootcert_survives_a_single_line_secret() {
+        let repl = replication_params_from_connector_params(
+            &params_with_sslrootcert(&TEST_CA_PEM.replace('\n', "\\n")),
+            "hits",
+        )
+        .expect("single-line inline PEM sslrootcert should parse");
+
+        assert_eq!(
+            repl.sslrootcert,
+            Some(CaCertificate::Pem(TEST_CA_PEM.as_bytes().to_vec()))
+        );
+    }
+
+    #[test]
+    fn path_sslrootcert_reaches_replication_params_as_a_path() {
+        let repl = replication_params_from_connector_params(
+            &params_with_sslrootcert("/etc/ssl/pg-ca.pem"),
+            "hits",
+        )
+        .expect("sslrootcert path should parse");
+
+        assert_eq!(
+            repl.sslrootcert,
+            Some(CaCertificate::Path("/etc/ssl/pg-ca.pem".into()))
+        );
     }
 
     // Regression for #11994: CDC must honor `pg_connection_string` the same way

--- a/crates/data_components/src/postgres_replication/client.rs
+++ b/crates/data_components/src/postgres_replication/client.rs
@@ -37,8 +37,9 @@ pub(crate) fn build_replication_config(
 ) -> ReplicationConfig {
     // Map our `SslMode` to pgwire-replication's `TlsConfig`. The crate uses
     // rustls and its own SslMode enum (Disabled / Require / VerifyCa /
-    // VerifyFull), so we pick the matching constructor and pass the optional
-    // CA path.
+    // VerifyFull), so we pick the matching constructor and hand over the CA
+    // bundle as-is — path or PEM content, the same value the setup and
+    // bootstrap connections verify against.
     let tls = match params.sslmode {
         // Prefer maps to plaintext for WAL streaming. Rationale:
         // pgwire-replication does not expose a safe "try TLS then fall back

--- a/crates/data_components/src/postgres_replication/config.rs
+++ b/crates/data_components/src/postgres_replication/config.rs
@@ -16,11 +16,32 @@ limitations under the License.
 
 //! Replication parameters derived from connector params + environment.
 
-use std::path::PathBuf;
 use std::time::Duration;
 
-use pgwire_replication::PgOutputFormat;
+use pgwire_replication::{CaCertificate, PgOutputFormat};
 use secrecy::{ExposeSecret, SecretString};
+
+/// Interpret a user-supplied `pg_sslrootcert` value as either PEM content or a
+/// path to a PEM file.
+///
+/// A CA bundle is just as often injected as a configuration value — an
+/// orchestrator secret, an environment variable — as it is mounted as a file, so
+/// both spellings must verify identically. The two are told apart by content, on
+/// the PEM armor: anything containing a `BEGIN CERTIFICATE` block is PEM, and
+/// everything else is a path. Detecting on the armor rather than on the shape of
+/// the string (length, newlines, a leading `/`) keeps every value that is a path
+/// today still a path.
+///
+/// Content arriving through a channel that does not survive real newlines (a
+/// single-line environment variable, a JSON string pasted verbatim) carries them
+/// as the two characters `\` and `n`; those are restored before parsing.
+#[must_use]
+pub fn ca_certificate_from_param(value: &str) -> CaCertificate {
+    if value.contains("-----BEGIN CERTIFICATE-----") {
+        return CaCertificate::Pem(value.replace("\\n", "\n").into_bytes());
+    }
+    CaCertificate::Path(value.into())
+}
 
 /// Parameters for a single dataset's replication stream.
 ///
@@ -40,9 +61,10 @@ pub struct ReplicationParams {
     pub password: SecretString,
     pub database: String,
     pub sslmode: SslMode,
-    /// Optional path to a PEM-encoded CA certificate bundle. Only used when
-    /// `sslmode` is `VerifyCa` or `VerifyFull`.
-    pub sslrootcert: Option<PathBuf>,
+    /// Optional PEM-encoded CA certificate bundle, either inline or by path (see
+    /// [`ca_certificate_from_param`]). Only used when `sslmode` is `VerifyCa` or
+    /// `VerifyFull`.
+    pub sslrootcert: Option<CaCertificate>,
 
     pub slot_name: String,
     pub publication_name: String,
@@ -562,19 +584,25 @@ impl ReplicationParams {
         }
         // verify-full: both chain and hostname checked (native-tls default).
 
-        if let Some(ca_path) = &self.sslrootcert {
-            // Async I/O — this method is called from Tokio runtime threads
-            // during setup/bootstrap; std::fs::read would block the reactor.
-            let pem_bytes = tokio::fs::read(ca_path)
-                .await
-                .map_err(|e| TlsConfigError::ReadCa {
-                    path: ca_path.clone(),
-                    source: e,
-                })?;
-            let certs = parse_pem_certificates(ca_path, &pem_bytes)?;
+        if let Some(ca) = &self.sslrootcert {
+            let source = ca.describe();
+            let pem_bytes = match ca {
+                // Async I/O — this method is called from Tokio runtime threads
+                // during setup/bootstrap; std::fs::read would block the reactor.
+                CaCertificate::Path(path) => {
+                    std::borrow::Cow::Owned(tokio::fs::read(path).await.map_err(|e| {
+                        TlsConfigError::ReadCa {
+                            source_label: source.clone(),
+                            source: e,
+                        }
+                    })?)
+                }
+                CaCertificate::Pem(pem) => std::borrow::Cow::Borrowed(pem.as_slice()),
+            };
+            let certs = parse_pem_certificates(&source, &pem_bytes)?;
             if certs.is_empty() {
                 return Err(TlsConfigError::EmptyCaBundle {
-                    path: ca_path.clone(),
+                    source_label: source,
                 });
             }
             for cert in certs {
@@ -588,22 +616,26 @@ impl ReplicationParams {
 }
 
 /// Errors raised while assembling TLS configuration from `ReplicationParams`.
+/// The `source_label` fields name where the CA came from — a path, or
+/// `inline PEM content (N bytes)` — never the certificate itself, which is
+/// kilobytes of base64 that would swamp a single-line log record.
 #[derive(Debug)]
 pub enum TlsConfigError {
     ReadCa {
-        path: PathBuf,
+        source_label: String,
         source: std::io::Error,
     },
     ParseCa {
+        source_label: String,
         source: native_tls::Error,
     },
     /// `BEGIN CERTIFICATE` marker with no matching `END CERTIFICATE`.
     TruncatedPem {
-        path: PathBuf,
+        source_label: String,
     },
-    /// `sslrootcert` supplied but file contained zero parseable certificates.
+    /// `sslrootcert` supplied but it contained zero parseable certificates.
     EmptyCaBundle {
-        path: PathBuf,
+        source_label: String,
     },
     BuildConnector(native_tls::Error),
 }
@@ -611,25 +643,31 @@ pub enum TlsConfigError {
 impl std::fmt::Display for TlsConfigError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TlsConfigError::ReadCa { path, source } => {
+            TlsConfigError::ReadCa {
+                source_label,
+                source,
+            } => {
                 write!(
                     f,
-                    "failed to read sslrootcert at {}: {source}",
-                    path.display()
+                    "failed to read sslrootcert from {source_label}: {source}"
                 )
             }
-            TlsConfigError::ParseCa { source } => {
-                write!(f, "failed to parse sslrootcert PEM: {source}")
+            TlsConfigError::ParseCa {
+                source_label,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to parse sslrootcert PEM from {source_label}: {source}"
+                )
             }
-            TlsConfigError::TruncatedPem { path } => write!(
+            TlsConfigError::TruncatedPem { source_label } => write!(
                 f,
-                "sslrootcert at {} has a BEGIN CERTIFICATE block without a matching END marker",
-                path.display()
+                "sslrootcert from {source_label} has a BEGIN CERTIFICATE block without a matching END marker"
             ),
-            TlsConfigError::EmptyCaBundle { path } => write!(
+            TlsConfigError::EmptyCaBundle { source_label } => write!(
                 f,
-                "sslrootcert at {} contains no parseable CA certificates",
-                path.display()
+                "sslrootcert from {source_label} contains no parseable CA certificates"
             ),
             TlsConfigError::BuildConnector(source) => {
                 write!(f, "failed to build native-tls connector: {source}")
@@ -642,7 +680,7 @@ impl std::error::Error for TlsConfigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             TlsConfigError::ReadCa { source, .. } => Some(source),
-            TlsConfigError::ParseCa { source } | TlsConfigError::BuildConnector(source) => {
+            TlsConfigError::ParseCa { source, .. } | TlsConfigError::BuildConnector(source) => {
                 Some(source)
             }
             TlsConfigError::TruncatedPem { .. } | TlsConfigError::EmptyCaBundle { .. } => None,
@@ -656,7 +694,7 @@ impl std::error::Error for TlsConfigError {
 /// parsed so far — the alternative would leave operators thinking their CA
 /// bundle is loaded when it isn't.
 fn parse_pem_certificates(
-    path: &std::path::Path,
+    source_label: &str,
     pem: &[u8],
 ) -> std::result::Result<Vec<native_tls::Certificate>, TlsConfigError> {
     let mut certs = Vec::new();
@@ -665,13 +703,16 @@ fn parse_pem_certificates(
         let tail = &remaining[begin..];
         let Some(end_rel) = find_subslice(tail, b"-----END CERTIFICATE-----") else {
             return Err(TlsConfigError::TruncatedPem {
-                path: path.to_path_buf(),
+                source_label: source_label.to_string(),
             });
         };
         let end = begin + end_rel + b"-----END CERTIFICATE-----".len();
         let block = &remaining[begin..end];
-        let cert = native_tls::Certificate::from_pem(block)
-            .map_err(|source| TlsConfigError::ParseCa { source })?;
+        let cert =
+            native_tls::Certificate::from_pem(block).map_err(|source| TlsConfigError::ParseCa {
+                source_label: source_label.to_string(),
+                source,
+            })?;
         certs.push(cert);
         remaining = &remaining[end..];
     }
@@ -685,6 +726,193 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Self-signed CA (`CN=Spice Replication Test CA`, `CA:TRUE`), expiring in
+    /// 2126. Real DER so `native_tls` actually accepts it as a trust anchor —
+    /// a placeholder string would make these tests pass for the wrong reason.
+    const TEST_CA_PEM: &str = "-----BEGIN CERTIFICATE-----
+MIIC4DCCAcigAwIBAgIJAODHR+uzOPBvMA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNV
+BAMMGVNwaWNlIFJlcGxpY2F0aW9uIFRlc3QgQ0EwIBcNMjYwNzI4MDU0MDQ0WhgP
+MjEyNjA3MDQwNTQwNDRaMCQxIjAgBgNVBAMMGVNwaWNlIFJlcGxpY2F0aW9uIFRl
+c3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCzoou00DrTAevF
+RZ6+PFmSBUhzZXsABQFztlPigZzJ1m8hnja66hnkWKyIid9DcitnjkWgtQZCVxm6
+s05tM6QAy5lI2wlfWD7hQi+yIWKv2dcVuD/J4hWPjmG5a5VtRAInV0yBymkCRI6Z
+68JYfvKh+Rku1y6H3dUfNm8dxCbo589L1U8ucJqlQv9Iy/X7Lze+pj2JFU/L1g3t
+k/5ziVgJjdh3VetrHkU1YOiHRPFsqXOxXc2lpzUjd23QR3FfkZkVgLUfEvPWHRSf
+xipaPFhllw9WUWEl6bVqAGO0btPO1OKKqBlIcizf2YO2+lFs/o0e7bApGzI3l5HP
+VZr/e6ZLAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQAD
+ggEBACC1XMNpbA+172MQks9R7cqRY5I0HObJRX3dpIsOqrm3EUcHMt9kx7QrO1Af
+gzAWC0ZNHppeU/cuq9ZKZQiFrSmr5fKtXzsxkvgLYRCFO+ZCKZl9k3z9j0AQbTPR
+klJa4bo2SS6WbmoATimD6e0moT++neRIDx7MlijtWB8grfhuH7yFN9xoTRDgdYBU
+KLeFNAIi+S5cVzUwjMiOQnmljphKSRoQnihpA/c6WAVAN3VqMdoPpfmR2pTi7rio
+38busw0nt/y+JCVWzNDr/i5f3mvNi5SaHZ5PTOVnocyMUw+ysx5eQOrJwrirW9XD
+TXTE85+Or9IUwDI9543jsyCvuQ8=
+-----END CERTIFICATE-----
+";
+
+    /// `verify-full` params — the strictest mode, and the one that actually
+    /// consults `sslrootcert`. A weaker mode would build a connector even with
+    /// the CA ignored, which is exactly the vacuity this fix is about.
+    fn verify_full_params(sslrootcert: Option<CaCertificate>) -> ReplicationParams {
+        ReplicationParams {
+            host: "localhost".to_string(),
+            port: 5432,
+            user: "u".to_string(),
+            password: SecretString::from(String::new()),
+            database: "db".to_string(),
+            sslmode: SslMode::VerifyFull,
+            sslrootcert,
+            slot_name: "slot".to_string(),
+            publication_name: "pub".to_string(),
+            initial_snapshot: true,
+            snapshot_on_resume: false,
+            temporary_slot: false,
+            status_interval: Duration::from_secs(5),
+            ready_lag: Duration::from_secs(2),
+            bootstrap_batch_size: 1024,
+            shared: false,
+            member_channel_capacity: 16,
+            pg_output_format: PgOutputFormat::Binary,
+        }
+    }
+
+    #[test]
+    fn a_value_carrying_pem_armor_is_inline_content_everything_else_is_a_path() {
+        assert_eq!(
+            ca_certificate_from_param(TEST_CA_PEM),
+            CaCertificate::Pem(TEST_CA_PEM.as_bytes().to_vec())
+        );
+
+        // Every spelling that works as a path today must stay a path.
+        for path in [
+            "/etc/ssl/pg-ca.pem",
+            "ca.pem",
+            "./certs/ca.crt",
+            "/var/run/secrets/ca-bundle",
+            "C:\\certs\\ca.pem",
+        ] {
+            assert_eq!(
+                ca_certificate_from_param(path),
+                CaCertificate::Path(path.into()),
+                "{path} must be treated as a filesystem path"
+            );
+        }
+    }
+
+    #[test]
+    fn escaped_newlines_in_inline_pem_are_restored() {
+        let single_line = TEST_CA_PEM.replace('\n', "\\n");
+        assert!(!single_line.contains('\n'));
+
+        let CaCertificate::Pem(pem) = ca_certificate_from_param(&single_line) else {
+            panic!("armored content must be detected as inline PEM");
+        };
+        assert_eq!(pem, TEST_CA_PEM.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn native_tls_connector_trusts_an_inline_pem_ca() {
+        let params = verify_full_params(Some(ca_certificate_from_param(TEST_CA_PEM)));
+
+        let connector = params
+            .native_tls_connector()
+            .await
+            .expect("inline PEM CA must be accepted");
+        assert!(
+            connector.is_some(),
+            "verify-full must produce a TLS connector"
+        );
+    }
+
+    #[tokio::test]
+    async fn native_tls_connector_trusts_a_ca_read_from_a_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ca.pem");
+        tokio::fs::write(&path, TEST_CA_PEM)
+            .await
+            .expect("write CA fixture");
+
+        let param = path.to_str().expect("utf-8 path");
+        let params = verify_full_params(Some(ca_certificate_from_param(param)));
+        assert!(matches!(params.sslrootcert, Some(CaCertificate::Path(_))));
+
+        let connector = params
+            .native_tls_connector()
+            .await
+            .expect("CA path must keep working");
+        assert!(
+            connector.is_some(),
+            "verify-full must produce a TLS connector"
+        );
+    }
+
+    /// `MakeTlsConnector` is not `Debug`, so `expect_err` is unavailable.
+    async fn tls_error(ca: CaCertificate, must_fail: &str) -> TlsConfigError {
+        match verify_full_params(Some(ca)).native_tls_connector().await {
+            Ok(_) => panic!("{must_fail}"),
+            Err(e) => e,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_ca_that_is_neither_readable_nor_pem_is_a_hard_error() {
+        // Not armored, so it is a path — and it does not exist. Verification
+        // must fail rather than fall back to no trust anchor.
+        let missing = tls_error(
+            ca_certificate_from_param("/nonexistent/spice-test-ca.pem"),
+            "an unreadable CA path must not be ignored",
+        )
+        .await;
+        assert!(matches!(missing, TlsConfigError::ReadCa { .. }));
+        assert!(
+            missing
+                .to_string()
+                .contains("/nonexistent/spice-test-ca.pem")
+        );
+
+        // Armored but not a certificate: detected as inline PEM, then rejected.
+        let garbage = tls_error(
+            CaCertificate::Pem(
+                b"-----BEGIN CERTIFICATE-----\nnot base64\n-----END CERTIFICATE-----\n".to_vec(),
+            ),
+            "unparseable inline PEM must not be ignored",
+        )
+        .await;
+        assert!(matches!(garbage, TlsConfigError::ParseCa { .. }));
+
+        // Truncated armor is caught rather than silently yielding zero anchors.
+        let truncated = tls_error(
+            CaCertificate::Pem(b"-----BEGIN CERTIFICATE-----\nMIIC\n".to_vec()),
+            "truncated inline PEM must not be ignored",
+        )
+        .await;
+        assert!(matches!(truncated, TlsConfigError::TruncatedPem { .. }));
+    }
+
+    #[test]
+    fn errors_and_debug_output_never_echo_inline_certificate_content() {
+        let ca = ca_certificate_from_param(TEST_CA_PEM);
+        let body = "MIIC4DCCAcigAwIBAgIJAODHR";
+
+        assert!(!ca.describe().contains(body));
+        assert!(!format!("{ca:?}").contains(body));
+        assert!(!format!("{:?}", verify_full_params(Some(ca.clone()))).contains(body));
+
+        let label = ca.describe();
+        for err in [
+            TlsConfigError::TruncatedPem {
+                source_label: label.clone(),
+            },
+            TlsConfigError::EmptyCaBundle {
+                source_label: label,
+            },
+        ] {
+            let rendered = err.to_string();
+            assert!(!rendered.contains(body), "error leaked PEM content");
+            assert!(rendered.contains("inline PEM content"));
+            assert!(!rendered.contains('\n'), "error must stay single-line");
+        }
+    }
 
     #[test]
     fn sanitize_replaces_non_alnum() {

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -42,7 +42,7 @@ use crate::cdc::{ChangesStream, StreamError};
 
 pub use config::{ReplicationParams, SchemaEvolutionPolicy};
 pub use metrics::{Metrics as ReplicationMetrics, MetricsCollector as ReplicationMetricsCollector};
-pub use pgwire_replication::PgOutputFormat;
+pub use pgwire_replication::{CaCertificate, PgOutputFormat};
 pub use slot::{SlotInfo, SlotSetupOutcome};
 
 /// Extracts a human-readable message from a `tokio_postgres::Error`.

--- a/crates/vendor/pgwire-replication/Cargo.toml
+++ b/crates/vendor/pgwire-replication/Cargo.toml
@@ -52,6 +52,9 @@ md5 = ["dep:md5"]
 #     received (bounds oversized-length amplification).
 #   * `ReplicationConfig::max_message_size` (src/config.rs) makes the accepted
 #     backend-message size a configurable, pre-allocation-checked bound.
+#   * `TlsConfig::ca` accepts a `CaCertificate` (src/config.rs): the trusted CA
+#     bundle may be a filesystem path or PEM content, so a CA injected as a
+#     configuration value never has to be staged on disk to be verified against.
 
 [dependencies]
 bytes = "1"

--- a/crates/vendor/pgwire-replication/examples/with_mtls.rs
+++ b/crates/vendor/pgwire-replication/examples/with_mtls.rs
@@ -5,7 +5,8 @@
 #[path = "support/common.rs"]
 mod common;
 use pgwire_replication::{
-    client::ReplicationEvent, ReplicationClient, ReplicationConfig, SslMode, TlsConfig,
+    client::ReplicationEvent, CaCertificate, ReplicationClient, ReplicationConfig, SslMode,
+    TlsConfig,
 };
 use std::path::PathBuf;
 
@@ -60,7 +61,7 @@ pub async fn main() -> anyhow::Result<()> {
 
         tls: TlsConfig {
             mode: SslMode::VerifyFull,
-            ca_pem_path: Some(ca_pem),
+            ca: Some(CaCertificate::Path(ca_pem)),
             sni_hostname: Some(sni),
             client_cert_pem_path: Some(client_cert),
             client_key_pem_path: Some(client_key),

--- a/crates/vendor/pgwire-replication/examples/with_tls.rs
+++ b/crates/vendor/pgwire-replication/examples/with_tls.rs
@@ -6,7 +6,8 @@
 mod common;
 
 use pgwire_replication::{
-    client::ReplicationEvent, ReplicationClient, ReplicationConfig, SslMode, TlsConfig,
+    client::ReplicationEvent, CaCertificate, ReplicationClient, ReplicationConfig, SslMode,
+    TlsConfig,
 };
 use std::path::PathBuf;
 
@@ -44,7 +45,7 @@ pub async fn main() -> anyhow::Result<()> {
 
         tls: TlsConfig {
             mode: SslMode::VerifyFull,
-            ca_pem_path: Some(ca_pem_path),
+            ca: Some(CaCertificate::Path(ca_pem_path)),
             sni_hostname: Some(sni_hostname),
             client_cert_pem_path: None,
             client_key_pem_path: None,

--- a/crates/vendor/pgwire-replication/src/config.rs
+++ b/crates/vendor/pgwire-replication/src/config.rs
@@ -83,17 +83,55 @@ impl SslMode {
     }
 }
 
+/// Where the trusted CA certificate bundle comes from.
+///
+/// Deployments that mount the CA as a file use [`CaCertificate::Path`];
+/// deployments that inject it as a configuration value (an orchestrator secret,
+/// an environment variable) use [`CaCertificate::Pem`] and never touch the
+/// filesystem.
+#[derive(Clone, PartialEq, Eq)]
+pub enum CaCertificate {
+    /// Filesystem path to a PEM file containing trusted CA certificates.
+    Path(PathBuf),
+    /// PEM-encoded CA certificate content.
+    Pem(Vec<u8>),
+}
+
+impl CaCertificate {
+    /// A short label naming the source, safe to put in an error or log line.
+    ///
+    /// Never returns the certificate content itself: a PEM blob is kilobytes of
+    /// base64 that would swamp a single-line log record.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            CaCertificate::Path(path) => path.display().to_string(),
+            CaCertificate::Pem(pem) => format!("inline PEM content ({} bytes)", pem.len()),
+        }
+    }
+}
+
+/// Renders the source, not the certificate bytes — see [`CaCertificate::describe`].
+impl std::fmt::Debug for CaCertificate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CaCertificate::Path(path) => f.debug_tuple("Path").field(path).finish(),
+            CaCertificate::Pem(pem) => write!(f, "Pem(<{} bytes>)", pem.len()),
+        }
+    }
+}
+
 /// TLS/SSL configuration for `PostgreSQL` connections.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TlsConfig {
     /// SSL mode controlling connection security level.
     pub mode: SslMode,
 
-    /// Path to PEM file containing trusted CA certificates.
+    /// Source of the trusted CA certificates.
     ///
     /// If `None` and verification is enabled (`VerifyCa`/`VerifyFull`),
     /// the Mozilla root certificates (webpki-roots) are used.
-    pub ca_pem_path: Option<PathBuf>,
+    pub ca: Option<CaCertificate>,
 
     /// Override SNI hostname sent during TLS handshake.
     ///
@@ -157,23 +195,27 @@ impl TlsConfig {
     /// Create a configuration with certificate chain verification.
     ///
     /// # Arguments
-    /// * `ca_path` - Path to CA certificate PEM file, or `None` for system roots
+    /// * `ca` - Source of the CA certificates, or `None` for system roots
     ///
     /// # Example
     /// ```
-    /// use pgwire_replication::config::TlsConfig;
+    /// use pgwire_replication::config::{CaCertificate, TlsConfig};
     ///
     /// // Using system/Mozilla roots
     /// let tls = TlsConfig::verify_ca(None);
     ///
-    /// // Using custom CA
-    /// let tls = TlsConfig::verify_ca(Some("/path/to/ca.pem".into()));
+    /// // Using a custom CA read from a file
+    /// let tls = TlsConfig::verify_ca(Some(CaCertificate::Path("/path/to/ca.pem".into())));
+    ///
+    /// // Using a custom CA supplied as PEM content
+    /// let tls = TlsConfig::verify_ca(Some(CaCertificate::Pem(ca_pem_bytes())));
+    /// # fn ca_pem_bytes() -> Vec<u8> { Vec::new() }
     /// ```
     #[must_use]
-    pub fn verify_ca(ca_path: Option<PathBuf>) -> Self {
+    pub fn verify_ca(ca: Option<CaCertificate>) -> Self {
         Self {
             mode: SslMode::VerifyCa,
-            ca_pem_path: ca_path,
+            ca,
             ..Default::default()
         }
     }
@@ -183,20 +225,20 @@ impl TlsConfig {
     /// **Recommended for production**.
     ///
     /// # Arguments
-    /// * `ca_path` - Path to CA certificate PEM file, or `None` for system roots
+    /// * `ca` - Source of the CA certificates, or `None` for system roots
     ///
     /// # Example
     /// ```
-    /// use pgwire_replication::config::TlsConfig;
+    /// use pgwire_replication::config::{CaCertificate, TlsConfig};
     ///
-    /// let tls = TlsConfig::verify_full(Some("/etc/ssl/certs/ca.pem".into()));
+    /// let tls = TlsConfig::verify_full(Some(CaCertificate::Path("/etc/ssl/certs/ca.pem".into())));
     /// assert!(tls.mode.verifies_hostname());
     /// ```
     #[must_use]
-    pub fn verify_full(ca_path: Option<PathBuf>) -> Self {
+    pub fn verify_full(ca: Option<CaCertificate>) -> Self {
         Self {
             mode: SslMode::VerifyFull,
-            ca_pem_path: ca_path,
+            ca,
             ..Default::default()
         }
     }
@@ -220,9 +262,9 @@ impl TlsConfig {
     ///
     /// # Example
     /// ```
-    /// use pgwire_replication::config::TlsConfig;
+    /// use pgwire_replication::config::{CaCertificate, TlsConfig};
     ///
-    /// let tls = TlsConfig::verify_full(Some("/ca.pem".into()))
+    /// let tls = TlsConfig::verify_full(Some(CaCertificate::Path("/ca.pem".into())))
     ///     .with_client_cert("/client.pem", "/client.key");
     /// ```
     #[must_use]
@@ -249,7 +291,7 @@ impl TlsConfig {
 /// # Example
 ///
 /// ```
-/// use pgwire_replication::config::{ReplicationConfig, TlsConfig, SslMode};
+/// use pgwire_replication::config::{CaCertificate, ReplicationConfig, TlsConfig, SslMode};
 /// use pgwire_replication::lsn::Lsn;
 /// use std::time::Duration;
 ///
@@ -261,7 +303,7 @@ impl TlsConfig {
 ///     database: "mydb".into(),
 ///     slot: "my_slot".into(),
 ///     publication: "my_publication".into(),
-///     tls: TlsConfig::verify_full(Some("/path/to/ca.pem".into())),
+///     tls: TlsConfig::verify_full(Some(CaCertificate::Path("/path/to/ca.pem".into()))),
 ///     start_lsn: Lsn(0),  // Start from slot's confirmed position
 ///     ..Default::default()
 /// };

--- a/crates/vendor/pgwire-replication/src/lib.rs
+++ b/crates/vendor/pgwire-replication/src/lib.rs
@@ -75,6 +75,6 @@ pub mod protocol;
 pub mod tls;
 
 pub use client::{ReplicationClient, ReplicationEvent, ReplicationEventReceiver, TryRecvEvent};
-pub use config::{PgOutputFormat, ReplicationConfig, SslMode, TlsConfig};
+pub use config::{CaCertificate, PgOutputFormat, ReplicationConfig, SslMode, TlsConfig};
 pub use error::{PgWireError, Result};
 pub use lsn::Lsn;

--- a/crates/vendor/pgwire-replication/src/tls/rustls.rs
+++ b/crates/vendor/pgwire-replication/src/tls/rustls.rs
@@ -27,14 +27,14 @@
 //! # Example
 //!
 //! ```no_run
-//! use pgwire_replication::config::TlsConfig;
+//! use pgwire_replication::config::{CaCertificate, TlsConfig};
 //! use pgwire_replication::tls::rustls::{maybe_upgrade_to_tls, MaybeTlsStream};
 //! use tokio::net::TcpStream;
 //! use std::path::PathBuf;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let tls_config = TlsConfig::verify_full(Some(PathBuf::new()))
+//!     let tls_config = TlsConfig::verify_full(Some(CaCertificate::Path(PathBuf::new())))
 //!         .with_sni_hostname("db.example.com");
 //!
 //!     let tcp_stream = TcpStream::connect(("db.example.com", 5432)).await?;
@@ -58,7 +58,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 use tokio_rustls::{client::TlsStream, TlsConnector};
 
-use crate::config::{SslMode, TlsConfig};
+use crate::config::{CaCertificate, SslMode, TlsConfig};
 use crate::error::{PgWireError, Result};
 use crate::protocol::framing::write_ssl_request;
 
@@ -288,30 +288,33 @@ fn build_root_store(tls: &TlsConfig) -> Result<RootCertStore> {
 
     let mut roots = RootCertStore::empty();
 
-    if let Some(path) = &tls.ca_pem_path {
+    if let Some(ca) = &tls.ca {
         // Load custom CA certificates
         use rustls::pki_types::pem::PemObject;
 
-        let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(path)
-            .map_err(|e| {
-                PgWireError::Tls(format!(
-                    "TLS config error: failed to open CA PEM '{}': {e}",
-                    path.display()
-                ))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| {
-                PgWireError::Tls(format!(
-                    "TLS config error: failed to parse CA PEM '{}': {e}",
-                    path.display()
-                ))
-            })?;
+        let source = ca.describe();
+        let certs: Vec<CertificateDer<'static>> = match ca {
+            CaCertificate::Path(path) => CertificateDer::pem_file_iter(path)
+                .map_err(|e| {
+                    PgWireError::Tls(format!(
+                        "TLS config error: failed to open CA PEM '{source}': {e}"
+                    ))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>(),
+            CaCertificate::Pem(pem) => {
+                CertificateDer::pem_slice_iter(pem).collect::<std::result::Result<Vec<_>, _>>()
+            }
+        }
+        .map_err(|e| {
+            PgWireError::Tls(format!(
+                "TLS config error: failed to parse CA PEM '{source}': {e}"
+            ))
+        })?;
 
         let (added, _ignored) = roots.add_parsable_certificates(certs);
         if added == 0 {
             return Err(PgWireError::Tls(format!(
-                "TLS config error: no valid CA certificates found in '{}'",
-                path.display()
+                "TLS config error: no valid CA certificates found in '{source}'"
             )));
         }
     } else {
@@ -535,7 +538,7 @@ mod tests {
     #[test]
     fn missing_ca_file_gives_clear_error() {
         let tls = TlsConfig {
-            ca_pem_path: Some("/nonexistent/ca.pem".into()),
+            ca: Some(CaCertificate::Path("/nonexistent/ca.pem".into())),
             ..Default::default()
         };
 
@@ -550,7 +553,7 @@ mod tests {
     fn empty_ca_file_gives_clear_error() {
         let f = NamedTempFile::new().expect("should succeed");
         let tls = TlsConfig {
-            ca_pem_path: Some(f.path().to_path_buf()),
+            ca: Some(CaCertificate::Path(f.path().to_path_buf())),
             ..Default::default()
         };
 
@@ -558,6 +561,69 @@ mod tests {
             .expect_err("should error")
             .to_string();
         assert!(err.contains("no valid CA certificates"));
+    }
+
+    /// Self-signed CA (`CN=Spice Replication Test CA`, `CA:TRUE`) used to prove a
+    /// PEM bundle becomes a real trust anchor. Expires in 2126.
+    const TEST_CA_PEM: &[u8] = b"-----BEGIN CERTIFICATE-----
+MIIC4DCCAcigAwIBAgIJAODHR+uzOPBvMA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNV
+BAMMGVNwaWNlIFJlcGxpY2F0aW9uIFRlc3QgQ0EwIBcNMjYwNzI4MDU0MDQ0WhgP
+MjEyNjA3MDQwNTQwNDRaMCQxIjAgBgNVBAMMGVNwaWNlIFJlcGxpY2F0aW9uIFRl
+c3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCzoou00DrTAevF
+RZ6+PFmSBUhzZXsABQFztlPigZzJ1m8hnja66hnkWKyIid9DcitnjkWgtQZCVxm6
+s05tM6QAy5lI2wlfWD7hQi+yIWKv2dcVuD/J4hWPjmG5a5VtRAInV0yBymkCRI6Z
+68JYfvKh+Rku1y6H3dUfNm8dxCbo589L1U8ucJqlQv9Iy/X7Lze+pj2JFU/L1g3t
+k/5ziVgJjdh3VetrHkU1YOiHRPFsqXOxXc2lpzUjd23QR3FfkZkVgLUfEvPWHRSf
+xipaPFhllw9WUWEl6bVqAGO0btPO1OKKqBlIcizf2YO2+lFs/o0e7bApGzI3l5HP
+VZr/e6ZLAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQAD
+ggEBACC1XMNpbA+172MQks9R7cqRY5I0HObJRX3dpIsOqrm3EUcHMt9kx7QrO1Af
+gzAWC0ZNHppeU/cuq9ZKZQiFrSmr5fKtXzsxkvgLYRCFO+ZCKZl9k3z9j0AQbTPR
+klJa4bo2SS6WbmoATimD6e0moT++neRIDx7MlijtWB8grfhuH7yFN9xoTRDgdYBU
+KLeFNAIi+S5cVzUwjMiOQnmljphKSRoQnihpA/c6WAVAN3VqMdoPpfmR2pTi7rio
+38busw0nt/y+JCVWzNDr/i5f3mvNi5SaHZ5PTOVnocyMUw+ysx5eQOrJwrirW9XD
+TXTE85+Or9IUwDI9543jsyCvuQ8=
+-----END CERTIFICATE-----
+";
+
+    #[test]
+    fn inline_ca_pem_is_loaded_into_the_root_store() {
+        let pem = TEST_CA_PEM.to_vec();
+
+        let inline = TlsConfig {
+            ca: Some(CaCertificate::Pem(pem.clone())),
+            ..Default::default()
+        };
+        let from_pem = build_root_store(&inline).expect("inline PEM should build a root store");
+        assert!(
+            !from_pem.is_empty(),
+            "inline PEM must contribute trust anchors"
+        );
+
+        // The same bytes on disk must yield the same anchors — inline and path
+        // are two spellings of one CA bundle, not two trust policies.
+        let mut f = NamedTempFile::new().expect("should succeed");
+        f.write_all(&pem).expect("should write");
+        let from_path = build_root_store(&TlsConfig {
+            ca: Some(CaCertificate::Path(f.path().to_path_buf())),
+            ..Default::default()
+        })
+        .expect("path should build a root store");
+        assert_eq!(from_pem.len(), from_path.len());
+    }
+
+    #[test]
+    fn inline_ca_pem_that_is_not_a_certificate_is_rejected() {
+        let tls = TlsConfig {
+            ca: Some(CaCertificate::Pem(b"not a certificate".to_vec())),
+            ..Default::default()
+        };
+
+        let err = build_root_store(&tls)
+            .expect_err("garbage inline PEM must not be accepted")
+            .to_string();
+        assert!(err.contains("CA PEM") || err.contains("no valid CA certificates"));
+        // The failure must name the source without echoing the content.
+        assert!(err.contains("inline PEM content"));
     }
 
     #[test]

--- a/docs/features/postgres-replication.md
+++ b/docs/features/postgres-replication.md
@@ -93,6 +93,9 @@ datasets:
       pg_db: myapp
       pg_sslmode: verify-full      # or: disable | prefer | require | verify-ca
       pg_sslrootcert: /etc/ssl/pg-ca.pem   # optional; omit to use system root CAs
+      # `pg_sslrootcert` also accepts the PEM content itself, so a CA held in a
+      # secret store needs no file on disk:
+      #   pg_sslrootcert: ${secrets:pg_ca_pem}
     acceleration:
       enabled: true
       engine: duckdb           # or: sqlite | postgres | cayenne | arrow


### PR DESCRIPTION
## Problem

`pg_sslrootcert` is documented as accepting **either** a filesystem path **or** the CA's PEM content:

> Path to, or inline PEM content for, a CA certificate used when sslmode is verify-ca/verify-full.

The federated read path honors both. The replication path (`refresh_mode: changes`) honored only a path: the value was coerced with `PathBuf::from` and every consumer then tried to open it as a file. A CA supplied as content — the usual shape when it comes from a secret store rather than a mounted file — could not be used to verify the source at all:

- the setup and snapshot-bootstrap connections failed in `ReplicationParams::native_tls_connector` (`tokio::fs::read` on the PEM text) with `File name too long (os error 63)`;
- the WAL stream failed the same way in the rustls root-store build.

Both failures are hard errors, so TLS verification was never silently downgraded — a dataset configured this way simply never started. That is the correct failure mode, but it made a documented configuration unusable.

## Change

The value is now classified once, in `data_components::postgres_replication::config::ca_certificate_from_param`, and carried as a `CaCertificate` (`Path` | `Pem`) that **both** TLS backends on the replication path consume — the native-tls connector used by the setup and bootstrap connections, and the rustls root store used by the WAL stream. There is one detection site and one resolution point rather than a per-backend implementation.

- **Detection is on content, not shape**: a value containing `-----BEGIN CERTIFICATE-----` is PEM; everything else is a path. Values that work as paths today are unaffected — no guessing from length, newlines, or a leading `/`.
- **Newline recovery**: content whose newlines were flattened to the two characters `\n` in transit (a single-line environment variable, a JSON string) is restored before parsing, matching how the read path handles the same input.
- **No silent downgrade**: a value that is neither readable nor valid PEM stays a hard error. Truncated armor and a bundle with zero parseable certificates are still rejected rather than yielding an empty trust anchor set.
- **No certificate content in output**: errors and `Debug` name the source as a path or `inline PEM content (N bytes)`. Previously an unreadable path error interpolated the whole value, which for inline PEM meant a multi-kilobyte log line.

`crates/vendor/pgwire-replication` gains the capability to accept PEM content for its root store (`TlsConfig::ca`); the local-patch list in its `Cargo.toml` records it.

## Sibling cert/key parameters

None share the defect, because none exist: the Postgres connector exposes only `pg_sslmode` and `pg_sslrootcert` on both the federated and replication paths. There are no `pg_sslcert` / `pg_sslkey` parameters, and client-certificate (mTLS) auth is not wired up for Postgres at all — the vendored crate's `with_client_cert` is never called. Nothing to fix and nothing deferred here.

Two adjacent observations, both out of scope and neither a regression:

- `pg_connection_string` cannot carry inline PEM, because the connection-string parser splits on whitespace and the PEM armor contains spaces. This is shared with the federated read path, so the two remain consistent; the discrete `pg_sslrootcert` parameter is the supported channel for a CA secret.
- `mysql_sslrootcert` is path-only on both its read and replication paths, and is documented as path-only, so MySQL is internally consistent. Accepting inline PEM there would be an enhancement, not a fix.

## Tests

Unit tests at each layer, in both spellings:

- `connector-postgres`: `pg_sslrootcert` as inline PEM, as single-line inline PEM, and as a path each reach `ReplicationParams` as the right variant.
- `data_components`: armor-vs-path classification; escaped-newline recovery; `native_tls_connector` builds a `verify-full` connector from inline PEM **and** from a path; unreadable path, unparseable PEM, and truncated armor are all hard errors; no error or `Debug` output echoes certificate content.
- `pgwire-replication`: inline PEM produces a non-empty rustls root store with the same anchor count as the identical bytes on disk; non-certificate inline content is rejected.

Fixtures are a real self-signed CA, so `native_tls` and rustls actually accept them as trust anchors — a placeholder string would let these pass for the wrong reason.

Each new assertion was watched failing before the fix was restored. Coercing every value to a path (the shipped behavior) fails the inline tests with `File name too long (os error 63)` while the path tests keep passing; making the inline branch contribute no anchors fails with `no valid CA certificates found`. An earlier draft of the connector tests aborted on `missing required parameter pg_host` before reaching the assertion, which is why those fixtures now build a complete connection.

Not covered: no end-to-end run against a TLS-enabled `PostgreSQL` server. The tests verify that inline PEM is parsed and installed as a trust anchor by both TLS backends, not that a live handshake against a server presenting that CA succeeds.
