### PR TITLE
build: exclude libnfs from the nextest workspace run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,16 @@ else
     NEXTEST_CARGO_PROFILE := --cargo-profile dev
 endif
 
+# `libnfs` binds a system library, and on a modern glibc its generated bindings
+# carry a layout assertion for a type the headers only forward-declare, so the
+# crate fails to compile at all (spiceai/spiceai#12130). `lint-rust` already
+# excludes it via `_LINT_WORKSPACE_FLAGS`; excluding it here too keeps both halves
+# of the gate agreeing on which crates need system libraries, so a sign-off on
+# such a host fails only for reasons in the branch under test. The crate has no
+# unit tests of its own.
 .PHONY: nextest
 nextest:
-	@cargo nextest run --all --lib $(NEXTEST_CARGO_PROFILE) $(NEXTEST_FLAG)
+	@cargo nextest run --all --exclude libnfs --lib $(NEXTEST_CARGO_PROFILE) $(NEXTEST_FLAG)
 	@cargo nextest run -p cayenne --tests $(NEXTEST_CARGO_PROFILE)
 
 # Unit tests for named packages — the fail-fast pre-check scripts/signoff runs on


### PR DESCRIPTION
Tracking issue: spiceai/spiceai#12130

## Problem

`make nextest` ran the whole workspace, including `libnfs`. That crate binds a system library, and on a host with a modern glibc it fails to compile at all — the headers it is generated from only forward-declare `struct AUTH`, while the generated bindings still carry a 64-byte layout assertion for it, so const-evaluation underflows:

```
error[E0080]: attempt to compute `1_usize - 64_usize`, which would overflow
    --> target/debug/build/libnfs-<hash>/out/bindings.rs:1224:22
     |
1224 |     ["Size of AUTH"][::std::mem::size_of::<AUTH>() - 64usize];

error: could not compile `libnfs` (lib test) due to 1 previous error
make: *** [Makefile:100: nextest] Error 101
```

`lint-rust` already excludes the crate through `_LINT_WORKSPACE_FLAGS`, so the two halves of the sign-off gate disagreed about which crates require system libraries. The practical effect is that `make signoff` on such a host fails at an unrelated crate, on any branch including `trunk`, with an error that reads as a regression in the branch under test.

## Change

Add `--exclude libnfs` to the workspace `nextest` run so it matches the existing lint exclusion. `libnfs` has no unit tests of its own, so no coverage is lost.

This only aligns the two halves of the gate. The binding generation itself is the real defect and is tracked separately in spiceai/spiceai#12130, which lays out the candidate fixes (blocklisting the opaque `AUTH` type so bindgen stops emitting a layout assertion for it is the narrowest).

## Verification

`cargo test --no-run -p libnfs --lib` reproduces the failure on an affected host on `trunk` as well as on a feature branch, confirming it is environmental and not branch-specific. With this change `make nextest` no longer attempts the crate.
