### PR TITLE
fix(libnfs): model AUTH as an opaque type so its layout assertion holds

### DIFF
--- a/crates/libnfs/build.rs
+++ b/crates/libnfs/build.rs
@@ -55,6 +55,14 @@ fn main() {
         .allowlist_type("statvfs")
         .allowlist_type("timeval")
         .allowlist_type("AUTH")
+        // `AUTH` is forward-declared in `nfsc/libnfs.h` and only ever used behind a pointer
+        // (`nfs_set_auth`, `rpc_set_auth`); its definition lives in `nfsc/libnfs-zdr.h`, which the
+        // raw headers include transitively. Whether bindgen resolves the forward declaration to
+        // that definition varies by clang version: when it does not, it emits a fieldless struct
+        // together with a layout assertion for the completed 64-byte type, and that assertion
+        // fails const-evaluation. Modeling the type as opaque pins it to a correctly sized blob
+        // on every platform, so the layout assertion holds and stays meaningful.
+        .opaque_type("AUTH")
         .allowlist_var("ftype3_.*");
 
     // Allow custom include path

--- a/crates/libnfs/build.rs
+++ b/crates/libnfs/build.rs
@@ -58,10 +58,11 @@ fn main() {
         // `AUTH` is forward-declared in `nfsc/libnfs.h` and only ever used behind a pointer
         // (`nfs_set_auth`, `rpc_set_auth`); its definition lives in `nfsc/libnfs-zdr.h`, which the
         // raw headers include transitively. Whether bindgen resolves the forward declaration to
-        // that definition varies by clang version: when it does not, it emits a fieldless struct
-        // together with a layout assertion for the completed 64-byte type, and that assertion
-        // fails const-evaluation. Modeling the type as opaque pins it to a correctly sized blob
-        // on every platform, so the layout assertion holds and stays meaningful.
+        // that definition varies by clang version: when it does not, it emits a one-byte
+        // placeholder struct (`_address: u8`) together with a layout assertion for the completed
+        // 64-byte type, and that assertion fails const-evaluation. Modeling the type as opaque
+        // pins it to a correctly sized blob on every platform, so the layout assertion holds
+        // and stays meaningful.
         .opaque_type("AUTH")
         .allowlist_var("ftype3_.*");
 


### PR DESCRIPTION
Fixes #12130

## Problem

`cargo test --no-run -p libnfs --lib` fails to compile on some hosts, on any branch including `trunk`, because the generated bindings carry a layout assertion that cannot hold:

```
error[E0080]: attempt to compute `1_usize - 64_usize`, which would overflow
    --> target/debug/build/libnfs-<hash>/out/bindings.rs:1224:22
     |
1224 |     ["Size of AUTH"][::std::mem::size_of::<AUTH>() - 64usize];

error: could not compile `libnfs` (lib test) due to 1 previous error
```

`struct AUTH` is forward-declared in `nfsc/libnfs.h` and only ever used behind a pointer (`nfs_set_auth`, `rpc_set_auth`). Its real definition is in `nfsc/libnfs-zdr.h`, which `nfsc/libnfs-raw.h`, `nfsc/libnfs-raw-nfs.h` and `nfsc/libnfs-raw-mount.h` each include, so `wrapper.h` does pull it into the translation unit transitively even though it does not include it directly. Preprocessing the `wrapper.h` include set confirms both the forward declaration and the definition are present and active.

Whether bindgen resolves the forward declaration to that definition depends on the clang version it runs against:

- Where it resolves, the bindings contain the real three-field struct, `size_of` is 64, and the assertion passes.
- Where it does not, the bindings contain bindgen's one-byte placeholder, `pub struct AUTH { pub _address: u8 }`, while the assertion is still generated from clang's completed 64-byte layout. `1 - 64` underflows, so it is a hard const-eval error rather than a layout mismatch warning.

The one-byte struct is also wrong on its own terms: it is the declared size and alignment of a type the crate hands to C as a pointee.

## Change

Mark `AUTH` as an opaque type in `crates/libnfs/build.rs`. bindgen then emits a blob sized from the layout it actually computed:

```rust
pub struct AUTH {
    pub _bindgen_opaque_blob: [u64; 8usize],
}
```

This is sized and aligned by construction, so the layout assertion is retained and holds on every platform rather than being suppressed. It also makes the generated type identical across clang versions instead of varying with the host.

`--no-layout-tests` was rejected because it would silence layout checking for every type in the crate, not just this one. Including `nfsc/libnfs-zdr.h` from `wrapper.h` was rejected because that header deliberately overrides the `_RPC_AUTH_H` guard and would pull the whole SunRPC shim into the binding surface.

## Verification

Reproduced and fixed on an affected host (Fedora 44, glibc 2.43, clang 22, rustc 1.96.1), in a clean checkout, using the command from the issue:

```
cargo test --no-run -p libnfs --lib --profile dev
```

| | exit code |
| --- | --- |
| `trunk` (5f228ed) | 101 — `error[E0080]` as above |
| with this change | 0 |

Also on that host: `cargo test -p libnfs --lib` runs green (the crate has no unit tests), and `cargo nextest run -p libnfs --lib` compiles and runs.

On macOS, where the crate already compiled, `cargo test --no-run -p libnfs --lib --profile dev` still exits 0 and now generates the same opaque blob. `cargo check -p runtime-object-store --features nfs` — the only in-tree consumer of the crate — exits 0; nothing in the tree references `AUTH`'s fields, and it is used only as `&mut AUTH` behind `nfs_set_auth`.

Note that `make lint-rust` excludes `libnfs`, so it does not exercise this change.

## Relationship to #12131

#12131 adds `--exclude libnfs` to the workspace `nextest` run, aligning it with the existing lint exclusion. That is independent of this change and does not conflict with it: this removes the compile failure, #12131 decides whether the gate compiles the crate at all. The two are complementary, and which to keep is a separate call recorded on #12130.
