### PR TITLE
fix: `EMBED_UDF_NAME` without models feature

### DIFF
--- a/crates/runtime/src/embeddings/index/table.rs
+++ b/crates/runtime/src/embeddings/index/table.rs
@@ -22,6 +22,8 @@ use datafusion::datasource::TableProvider;
 use datafusion::{prelude::SessionContext, sql::TableReference};
 #[cfg(feature = "models")]
 use runtime_datafusion_udfs::embed::EMBED_UDF_NAME;
+#[cfg(not(feature = "models"))]
+const EMBED_UDF_NAME: &str = "embed";
 use spicepod::vector::VectorStore;
 use std::sync::Arc;
 use tokio::sync::RwLock;


### PR DESCRIPTION
## 📝 Summary

Define `EMBED_UDF_NAME` under `#[cfg(not(feature = "models"))]` in `crates/runtime/src/embeddings/index/table.rs`, matching the fallback the other modules referencing it already have, so that builds enabling `s3_vectors` or `elasticsearch` without `models` — such as `make install-data-only` — compile instead of failing with `error[E0425]: cannot find value EMBED_UDF_NAME in this scope`.
