### PR TITLE
task: (Search): `refresh_mode: full` does not delete old entries. (fixes #12145)

### DIFF
--- a/.subagent-settings.json
+++ b/.subagent-settings.json
@@ -1,0 +1,53 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Edit",
+      "Write",
+      "Bash(rg:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh issue view:*)"
+    ],
+    "deny": [
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/**)",
+      "Read(~/Github/**/.env)",
+      "Read(~/Github/**/.env.*)",
+      "Read(~/Github/**/secrets/**)",
+      "Read(~/Github/**/*.key)",
+      "Read(~/Github/**/*.pem)",
+      "Edit(~/Github/**)",
+      "Write(~/Github/**)",
+      "Bash(cargo:*)",
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(git add:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh workflow:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(rm:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/jeadie_compute/Github/spiceai-automation/block-dangerous.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/crates/data_components/src/elasticsearch/query_table.rs
+++ b/crates/data_components/src/elasticsearch/query_table.rs
@@ -867,6 +867,14 @@ mod tests {
         ) -> elasticsearch::Result<serde_json::Value> {
             Err(unexpected_call_error("bulk_index"))
         }
+
+        async fn delete_by_query(
+            &self,
+            _index: &str,
+            _query: &serde_json::Value,
+        ) -> elasticsearch::Result<serde_json::Value> {
+            Err(unexpected_call_error("delete_by_query"))
+        }
     }
 
     async fn collect_query_table(

--- a/crates/elasticsearch/src/lib.rs
+++ b/crates/elasticsearch/src/lib.rs
@@ -530,6 +530,30 @@ impl Client {
         resp.json().await.context(JsonParseSnafu)
     }
 
+    /// Delete every document matching `query` via `POST /<index>/_delete_by_query`.
+    ///
+    /// Used to purge stale documents on a full refresh: the query selects the documents
+    /// left over from a previous generation. `conflicts=proceed` keeps the delete going
+    /// past version conflicts (a concurrent upsert of a surviving key) rather than aborting
+    /// the whole purge on the first conflict.
+    pub async fn delete_by_query(
+        &self,
+        index: &str,
+        query: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let url = format!("{}/{}/_delete_by_query", self.base_url, index);
+        let body = serde_json::json!({ "query": query });
+        let resp = self
+            .auth(self.http.post(&url))
+            .query(&[("conflicts", "proceed")])
+            .json(&body)
+            .send()
+            .await
+            .context(HttpRequestSnafu)?;
+        let resp = check_status(resp).await?;
+        resp.json().await.context(JsonParseSnafu)
+    }
+
     /// Bulk index documents. Each element is `(optional_id, source_doc)`.
     pub async fn bulk_index(
         &self,
@@ -653,6 +677,11 @@ pub trait Elasticsearch: std::fmt::Debug + Send + Sync {
         index: &str,
         docs: &[(Option<String>, serde_json::Value)],
     ) -> Result<serde_json::Value>;
+    async fn delete_by_query(
+        &self,
+        index: &str,
+        query: &serde_json::Value,
+    ) -> Result<serde_json::Value>;
 }
 
 #[async_trait::async_trait]
@@ -736,5 +765,13 @@ impl Elasticsearch for Client {
         docs: &[(Option<String>, serde_json::Value)],
     ) -> Result<serde_json::Value> {
         self.bulk_index(index, docs).await
+    }
+
+    async fn delete_by_query(
+        &self,
+        index: &str,
+        query: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        self.delete_by_query(index, query).await
     }
 }

--- a/crates/runtime-datafusion-index/src/lib.rs
+++ b/crates/runtime-datafusion-index/src/lib.rs
@@ -38,6 +38,27 @@ pub enum Error {
     NoExpressions { expr_len: usize },
 }
 
+/// Whether a [`TableSink`] write replaces the index's entire contents or adds to them.
+///
+/// Derived from the `InsertOp` the sink already carries: `refresh_mode: full`
+/// (`InsertOp::Overwrite`) yields [`IndexWriteMode::Overwrite`]; every other write yields
+/// [`IndexWriteMode::Append`]. It is passed to the write lifecycle hooks so an external
+/// index (one whose data does not live in the accelerator's own storage, e.g. Elasticsearch
+/// or S3 Vectors) can remove entries that are no longer present in the source on a full
+/// refresh. The accelerator's own storage is replaced by the `InsertOp::Overwrite` write
+/// itself; this signal exists for the indexes that write side-effects that the `InsertOp`
+/// never reaches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexWriteMode {
+    /// The write adds to the existing index contents (`refresh_mode: append`, caching, and
+    /// any non-overwrite write). Existing entries are left untouched.
+    Append,
+    /// The write replaces the index's entire contents with the written rows
+    /// (`refresh_mode: full`). Entries whose primary keys are not written this cycle are
+    /// stale and must be removed.
+    Overwrite,
+}
+
 #[async_trait]
 pub trait Index: Debug + Send + Sync + 'static {
     fn name(&self) -> &'static str;
@@ -54,8 +75,14 @@ pub trait Index: Debug + Send + Sync + 'static {
     /// Called before data is written via the [`TableSink`] path (full refresh or append).
     ///
     /// Default is a no-op. Implementations use this to prepare external index state for a
-    /// bounded write window. Not called for CDC writes.
-    async fn on_write_start(&self) -> Result<()> {
+    /// bounded write window — including, for [`IndexWriteMode::Overwrite`], marking the start
+    /// of a new generation so stale entries can be removed in [`Index::on_write_complete`].
+    /// Guaranteed to run before any [`Index::compute_index`] call for the same write. Not
+    /// called for CDC writes.
+    ///
+    /// Wrapper implementations MUST forward `mode` to the index they wrap.
+    async fn on_write_start(&self, mode: IndexWriteMode) -> Result<()> {
+        let _ = mode;
         Ok(())
     }
 
@@ -63,18 +90,29 @@ pub trait Index: Debug + Send + Sync + 'static {
     ///
     /// Default is a no-op. Implementations use this to restore temporary external index
     /// settings when a refresh or append fails before [`Index::on_write_complete`] can run.
-    async fn on_write_failed(&self) -> Result<()> {
+    /// A failed [`IndexWriteMode::Overwrite`] must NOT delete anything: the previous
+    /// generation stays intact and keeps serving queries, and the partial new generation is
+    /// reconciled by the next successful full refresh.
+    ///
+    /// Wrapper implementations MUST forward `mode` to the index they wrap.
+    async fn on_write_failed(&self, mode: IndexWriteMode) -> Result<()> {
+        let _ = mode;
         Ok(())
     }
 
     /// Called after data has been written via the [`TableSink`] path (full refresh or append).
     ///
     /// Default is a no-op. Implementations use this to create or verify persistent structures
-    /// (e.g. a vector HNSW index) after each write. Using `IF NOT EXISTS` semantics makes it
+    /// (e.g. a vector HNSW index) after each write, and — for [`IndexWriteMode::Overwrite`] —
+    /// to remove entries that were not written this cycle (stale rows dropped from the source
+    /// since the previous full refresh). Using `IF NOT EXISTS` semantics makes finalize steps
     /// safe to call on both overwrite (recreates on new table) and append (no-op if index
     /// already exists). Not called for CDC writes — those maintain indexes automatically via
     /// `DuckDB` VSS on each insert.
-    async fn on_write_complete(&self) -> Result<()> {
+    ///
+    /// Wrapper implementations MUST forward `mode` to the index they wrap.
+    async fn on_write_complete(&self, mode: IndexWriteMode) -> Result<()> {
+        let _ = mode;
         Ok(())
     }
 

--- a/crates/runtime/src/accelerated_table/sink/mod.rs
+++ b/crates/runtime/src/accelerated_table/sink/mod.rs
@@ -19,7 +19,7 @@ use datafusion::{
     physical_plan::RecordBatchStream,
 };
 use multi::MultiSink;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 use std::{pin::Pin, sync::Arc};
 use table::TableSink;
 use util::RetryError;
@@ -96,6 +96,7 @@ impl AccelerationSink {
 pub(crate) async fn finalize_indexes<'a>(
     sink: &str,
     indexes: impl Iterator<Item = &'a Arc<dyn Index + Send + Sync>>,
+    mode: IndexWriteMode,
 ) -> Result<(), DataFusionError> {
     let mut fatal: Option<DataFusionError> = None;
 
@@ -104,7 +105,7 @@ pub(crate) async fn finalize_indexes<'a>(
             "{sink}: running on_write_complete for index '{}'",
             index.name()
         );
-        let Err(e) = index.on_write_complete().await else {
+        let Err(e) = index.on_write_complete(mode).await else {
             continue;
         };
 
@@ -143,7 +144,7 @@ mod tests {
     use crate::datafusion::error::find_datafusion_root;
     use datafusion::error::{DataFusionError, Result as DataFusionResult};
 
-    use super::{Arc, Index, finalize_indexes};
+    use super::{Arc, Index, IndexWriteMode, finalize_indexes};
 
     /// An [`Index`] whose finalize outcome and fatality are configurable, recording how
     /// many times it was finalized.
@@ -153,6 +154,7 @@ mod tests {
         fails: bool,
         fatal: bool,
         finalize_calls: AtomicUsize,
+        last_mode: std::sync::Mutex<Option<IndexWriteMode>>,
     }
 
     impl FinalizeIndex {
@@ -162,11 +164,16 @@ mod tests {
                 fails,
                 fatal,
                 finalize_calls: AtomicUsize::new(0),
+                last_mode: std::sync::Mutex::new(None),
             })
         }
 
         fn finalize_calls(&self) -> usize {
             self.finalize_calls.load(Ordering::SeqCst)
+        }
+
+        fn last_mode(&self) -> Option<IndexWriteMode> {
+            *self.last_mode.lock().expect("last_mode mutex")
         }
     }
 
@@ -180,7 +187,8 @@ mod tests {
             vec![]
         }
 
-        async fn on_write_complete(&self) -> DataFusionResult<()> {
+        async fn on_write_complete(&self, mode: IndexWriteMode) -> DataFusionResult<()> {
+            *self.last_mode.lock().expect("last_mode mutex") = Some(mode);
             self.finalize_calls.fetch_add(1, Ordering::SeqCst);
             if self.fails {
                 return Err(DataFusionError::Execution(format!(
@@ -215,7 +223,7 @@ mod tests {
         ];
         let erased = erase(&indexes);
 
-        finalize_indexes("TestSink", erased.iter())
+        finalize_indexes("TestSink", erased.iter(), IndexWriteMode::Overwrite)
             .await
             .expect("no index failed to finalize");
 
@@ -229,7 +237,7 @@ mod tests {
         let indexes = vec![FinalizeIndex::new("best_effort", true, false)];
         let erased = erase(&indexes);
 
-        finalize_indexes("TestSink", erased.iter())
+        finalize_indexes("TestSink", erased.iter(), IndexWriteMode::Overwrite)
             .await
             .expect("a best-effort finalize failure must not fail the write");
         assert_eq!(indexes[0].finalize_calls(), 1);
@@ -242,7 +250,7 @@ mod tests {
         let indexes = vec![FinalizeIndex::new("full_text", true, true)];
         let erased = erase(&indexes);
 
-        let err = finalize_indexes("TestSink", erased.iter())
+        let err = finalize_indexes("TestSink", erased.iter(), IndexWriteMode::Overwrite)
             .await
             .expect_err("a fatal finalize failure must fail the write");
 
@@ -265,7 +273,7 @@ mod tests {
         let indexes = vec![FinalizeIndex::new("full_text", true, true)];
         let erased = erase(&indexes);
 
-        let err = finalize_indexes("TestSink", erased.iter())
+        let err = finalize_indexes("TestSink", erased.iter(), IndexWriteMode::Overwrite)
             .await
             .expect_err("a fatal finalize failure must fail the write");
 
@@ -287,7 +295,7 @@ mod tests {
         ];
         let erased = erase(&indexes);
 
-        finalize_indexes("TestSink", erased.iter())
+        finalize_indexes("TestSink", erased.iter(), IndexWriteMode::Overwrite)
             .await
             .expect_err("a fatal finalize failure must fail the write");
 
@@ -305,7 +313,7 @@ mod tests {
         ];
         let erased = erase(&indexes);
 
-        let err = finalize_indexes("TestSink", erased.iter())
+        let err = finalize_indexes("TestSink", erased.iter(), IndexWriteMode::Overwrite)
             .await
             .expect_err("a fatal finalize failure must fail the write");
 
@@ -323,8 +331,29 @@ mod tests {
     #[tokio::test]
     async fn no_indexes_is_a_successful_finalize() {
         let erased: Vec<Arc<dyn Index + Send + Sync>> = vec![];
-        finalize_indexes("TestSink", erased.iter())
+        finalize_indexes("TestSink", erased.iter(), IndexWriteMode::Overwrite)
             .await
             .expect("an empty index set cannot fail");
+    }
+
+    /// Regression test for #12145: the write mode a full refresh (`Overwrite`) or an append
+    /// carries must reach each index's `on_write_complete`, so an external index can tell a
+    /// replace-everything refresh from an add-to-existing one and remove stale entries.
+    #[tokio::test]
+    async fn finalize_forwards_the_write_mode_to_each_index() {
+        for mode in [IndexWriteMode::Append, IndexWriteMode::Overwrite] {
+            let indexes = vec![FinalizeIndex::new("a", false, false)];
+            let erased = erase(&indexes);
+
+            finalize_indexes("TestSink", erased.iter(), mode)
+                .await
+                .expect("finalize should succeed");
+
+            assert_eq!(
+                indexes[0].last_mode(),
+                Some(mode),
+                "the write mode must be forwarded verbatim to on_write_complete"
+            );
+        }
     }
 }

--- a/crates/runtime/src/accelerated_table/sink/multi.rs
+++ b/crates/runtime/src/accelerated_table/sink/multi.rs
@@ -37,7 +37,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use util::RetryError;
 
 use data_components::index_maintenance::perform_index_maintenance;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 
 use crate::{
     accelerated_table::{
@@ -144,6 +144,13 @@ impl MultiSink {
         overwrite: InsertOp,
     ) -> Result<(), RetryError<crate::accelerated_table::Error>> {
         let schema = record_batch_stream.schema();
+        // A full refresh replaces every synchronized index's contents; any other write
+        // appends. Threaded to the sink indexes so external indexes can drop stale entries.
+        let write_mode = if matches!(overwrite, InsertOp::Overwrite) {
+            IndexWriteMode::Overwrite
+        } else {
+            IndexWriteMode::Append
+        };
         let (tx, _) = broadcast::channel::<RecordBatch>(32);
         let mut join_set = JoinSet::new();
 
@@ -158,7 +165,7 @@ impl MultiSink {
                 "MultiSink: running on_write_start for index '{}'",
                 index.name()
             );
-            if let Err(e) = index.on_write_start().await {
+            if let Err(e) = index.on_write_start(write_mode).await {
                 tracing::warn!(
                     "MultiSink: on_write_start failed for index '{}': {e}. Continuing with write.",
                     index.name()
@@ -221,7 +228,7 @@ impl MultiSink {
         if let Some(first_error) = errors.into_iter().next() {
             // Run on_write_failed for all sink_indexes.
             for index in &self.sink_indexes {
-                if let Err(e) = index.on_write_failed().await {
+                if let Err(e) = index.on_write_failed(write_mode).await {
                     tracing::warn!(
                         "MultiSink: on_write_failed failed for index '{}': {e}. Index write state may need manual cleanup.",
                         index.name()
@@ -255,7 +262,7 @@ impl MultiSink {
         }
 
         // Run on_write_complete for all sink_indexes.
-        finalize_indexes("MultiSink", self.sink_indexes.iter())
+        finalize_indexes("MultiSink", self.sink_indexes.iter(), write_mode)
             .await
             .map_err(retry_from_df_error)?;
 

--- a/crates/runtime/src/accelerated_table/sink/table.rs
+++ b/crates/runtime/src/accelerated_table/sink/table.rs
@@ -25,7 +25,7 @@ use datafusion::{
 };
 use opentelemetry::KeyValue;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
-use runtime_datafusion_index::{Index, IndexedTableProvider};
+use runtime_datafusion_index::{Index, IndexWriteMode, IndexedTableProvider};
 use runtime_table_partition::provider::PartitionTableProvider;
 use util::RetryError;
 
@@ -151,6 +151,15 @@ impl TableSink {
             overwrite
         );
 
+        // A full refresh (`InsertOp::Overwrite`) replaces the index's entire contents; any
+        // other write appends. External indexes use this to remove stale entries on a full
+        // refresh — the `InsertOp` alone only reaches the accelerator's own storage.
+        let write_mode = if matches!(overwrite, InsertOp::Overwrite) {
+            IndexWriteMode::Overwrite
+        } else {
+            IndexWriteMode::Append
+        };
+
         let ctx = SessionContext::new();
         let target_schema = self.table_provider.schema();
         warn_on_narrowing_schema_cast(&record_batch_stream.schema(), &target_schema);
@@ -204,7 +213,7 @@ impl TableSink {
             .chain(self.sink_indexes.iter())
         {
             tracing::debug!("Running on_write_start for index '{}'", index.name());
-            if let Err(e) = index.on_write_start().await {
+            if let Err(e) = index.on_write_start(write_mode).await {
                 tracing::warn!(
                     "TableSink: on_write_start failed for index '{}': {e}. Continuing with write.",
                     index.name()
@@ -218,7 +227,7 @@ impl TableSink {
                 "TableSink: collect() failed after {:.2}s: {e}",
                 collect_start.elapsed().as_secs_f64()
             );
-            run_on_write_failed(&providers_before_write, &self.sink_indexes).await;
+            run_on_write_failed(&providers_before_write, &self.sink_indexes, write_mode).await;
             return Err(retry_from_df_error(e));
         }
 
@@ -257,6 +266,7 @@ impl TableSink {
             provider_indexes_after
                 .iter()
                 .chain(self.sink_indexes.iter()),
+            write_mode,
         )
         .await
         .map_err(retry_from_df_error)?;
@@ -273,6 +283,7 @@ impl TableSink {
 async fn run_on_write_failed(
     providers: &[Arc<dyn TableProvider>],
     sink_indexes: &[Arc<dyn Index + Send + Sync>],
+    mode: IndexWriteMode,
 ) {
     let provider_indexes: Vec<Arc<dyn Index + Send + Sync>> = providers
         .iter()
@@ -281,7 +292,7 @@ async fn run_on_write_failed(
         .collect();
 
     for index in provider_indexes.iter().chain(sink_indexes.iter()) {
-        if let Err(e) = index.on_write_failed().await {
+        if let Err(e) = index.on_write_failed(mode).await {
             tracing::warn!(
                 "TableSink: on_write_failed failed for index '{}': {e}. Index write state may need manual cleanup.",
                 index.name()

--- a/crates/runtime/src/embeddings/index/duckdb.rs
+++ b/crates/runtime/src/embeddings/index/duckdb.rs
@@ -23,7 +23,7 @@ use datafusion_table_providers::{
     duckdb::{TableDefinition, write::DuckDBTableWriter},
     sql::db_connection_pool::duckdbpool::DuckDbConnectionPool,
 };
-use runtime_datafusion_index::{Index, IndexedTableProvider};
+use runtime_datafusion_index::{Index, IndexWriteMode, IndexedTableProvider};
 use runtime_secrets::{Secrets, get_params_with_secrets};
 use search::{generation::util::get_primary_keys, index::duckdb::DuckDBVectorIndex};
 use snafu::prelude::*;
@@ -209,7 +209,9 @@ pub(crate) async fn wrap_accelerator_with_duckdb_vector_indexes(
         // before any CDC writes arrive. DuckDB VSS then auto-maintains it on each insert.
         // For full-refresh (overwrite) datasets this may be a no-op (the table may be empty
         // or not yet exist); the index is (re)created after each refresh via `on_write_complete`.
-        if let Err(e) = vector_index.on_write_complete().await {
+        // Init-time structure creation, not a refresh: Append never triggers a purge, and
+        // `DuckDBVectorIndex` ignores the mode anyway (its rows live in the accelerator).
+        if let Err(e) = vector_index.on_write_complete(IndexWriteMode::Append).await {
             tracing::debug!(
                 table = %tbl,
                 column = %vector_index.embedded_column,

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -238,7 +238,7 @@ mod tests {
     use arrow::util::pretty::pretty_format_batches;
     use datafusion::datasource::MemTable;
     use futures::TryStreamExt;
-    use runtime_datafusion_index::Index;
+    use runtime_datafusion_index::{Index, IndexWriteMode};
     use search::index::SearchIndex;
     use search::index::compound::CompoundReadMode;
 
@@ -281,7 +281,7 @@ mod tests {
 
         // A sink-driven refresh opens a write window on both tiers.
         compound
-            .on_write_start()
+            .on_write_start(IndexWriteMode::Append)
             .await
             .expect("on_write_start failed");
 
@@ -296,7 +296,7 @@ mod tests {
 
         // The refresh then fails, discarding whatever the window staged.
         compound
-            .on_write_failed()
+            .on_write_failed(IndexWriteMode::Append)
             .await
             .expect("on_write_failed failed");
 

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use datafusion::datasource::{DefaultTableSource, TableProvider};
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder};
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 use snafu::ResultExt;
 use tantivy::merge_policy::LogMergePolicy;
 use tantivy::schema::{DocParsingError, SchemaBuilder};
@@ -151,7 +151,7 @@ impl Index for FullTextDatabaseIndex {
         true
     }
 
-    async fn on_write_start(&self) -> Result<(), DataFusionError> {
+    async fn on_write_start(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
         // A CDC-fed index never defers: its change stream calls `compute_index`
         // outside this lifecycle, and the shared writer cannot commit one caller's
         // documents without also publishing (or, on rollback, discarding) the other's.
@@ -176,11 +176,27 @@ impl Index for FullTextDatabaseIndex {
         rollback_writer(&mut index_writer)
             .context(TextSearchIndexingSnafu)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        // A full refresh replaces the entire index. `compute_index` only upserts the
+        // primary keys present in each batch, so rows dropped from the source since the
+        // previous refresh would otherwise survive as stale documents. Stage a delete of
+        // every existing document into this same uncommitted window: the single commit in
+        // `on_write_complete` then atomically swaps the whole index for the new set (no
+        // window in which queries see an empty or partial index), and `on_write_failed`
+        // rolls the delete back with everything else so a failed refresh keeps the
+        // previous contents. Append leaves existing documents untouched.
+        if mode == IndexWriteMode::Overwrite {
+            index_writer
+                .delete_all_documents()
+                .context(TextSearchIndexingSnafu)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        }
+
         self.defer_commit.store(true, Ordering::Release);
         Ok(())
     }
 
-    async fn on_write_complete(&self) -> Result<(), DataFusionError> {
+    async fn on_write_complete(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         // End the deferred-commit window with a single commit + reader reload for
         // the whole refresh/append. Take the writer lock *before* clearing the flag so
         // no concurrent `compute_index` (e.g. the CDC path) can observe a cleared flag
@@ -212,7 +228,7 @@ impl Index for FullTextDatabaseIndex {
             .map_err(|e| DataFusionError::External(Box::new(e)))
     }
 
-    async fn on_write_failed(&self) -> Result<(), DataFusionError> {
+    async fn on_write_failed(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         // Discard everything staged in the current window so a partial refresh is
         // never committed, and reset the flag. Take the writer lock *before* clearing
         // the flag: otherwise a concurrent `compute_index` could observe the cleared
@@ -654,7 +670,7 @@ mod tests {
     use arrow_schema::{ArrowError, Schema};
     use datafusion::datasource::{MemTable, TableProvider};
     use futures::{StreamExt, TryStreamExt};
-    use runtime_datafusion_index::Index;
+    use runtime_datafusion_index::{Index, IndexWriteMode};
     use std::time::Duration;
 
     /// Create a basic [`MemTable`] with fields: `id`, `content`.
@@ -858,6 +874,112 @@ mod tests {
             .expect("Failed to collect search results");
 
         format!("{}", pretty_format_batches(&rb).expect("failed to format"))
+    }
+
+    /// Total number of documents a `content` query matches.
+    async fn hits(index: &FullTextDatabaseIndex, query: &str) -> usize {
+        let search_index = index
+            .full_text_search_field_index("content")
+            .expect("Failed to create FullTextSearchFieldIndex");
+        search_index
+            .search(query.to_string(), &[], 1000)
+            .await
+            .expect("Failed to search")
+            .try_collect::<Vec<RecordBatch>>()
+            .await
+            .expect("Failed to collect search results")
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum()
+    }
+
+    /// Drive one sink-style write cycle: open the window, stage the batch, commit.
+    async fn refresh(index: &FullTextDatabaseIndex, mode: IndexWriteMode, batch: RecordBatch) {
+        index.on_write_start(mode).await.expect("on_write_start");
+        index
+            .compute_index(vec![batch])
+            .await
+            .expect("compute_index");
+        index
+            .on_write_complete(mode)
+            .await
+            .expect("on_write_complete");
+    }
+
+    /// Regression test for #12145: a full refresh (`Overwrite`) must remove documents whose
+    /// rows disappeared from the source, not merely upsert the rows that remain. Without the
+    /// delete-all staged at overwrite start, `compute_index`'s per-key upsert would leave the
+    /// dropped rows searchable forever.
+    #[tokio::test]
+    async fn full_refresh_removes_documents_dropped_from_the_source() {
+        let index = new_test_index();
+
+        refresh(
+            &index,
+            IndexWriteMode::Overwrite,
+            batch(
+                &[1, 2, 3, 4, 5],
+                &["alpha", "beta", "gamma", "delta", "epsilon"],
+            ),
+        )
+        .await;
+        assert_eq!(
+            hits(&index, "delta").await,
+            1,
+            "the row is searchable after the first full refresh"
+        );
+
+        // Second full refresh: ids 4 and 5 are gone from the source; 6 and 7 are new.
+        refresh(
+            &index,
+            IndexWriteMode::Overwrite,
+            batch(&[1, 2, 3, 6, 7], &["alpha", "beta", "gamma", "zeta", "eta"]),
+        )
+        .await;
+
+        assert_eq!(
+            hits(&index, "delta").await,
+            0,
+            "a full refresh must delete documents whose rows were dropped from the source"
+        );
+        assert_eq!(hits(&index, "epsilon").await, 0);
+        assert_eq!(
+            hits(&index, "zeta").await,
+            1,
+            "rows added by the refresh are searchable"
+        );
+        assert_eq!(
+            hits(&index, "alpha").await,
+            1,
+            "rows that survived the refresh remain searchable"
+        );
+    }
+
+    /// An append (`Append`) must not delete anything: it adds to the existing documents.
+    #[tokio::test]
+    async fn append_keeps_existing_documents() {
+        let index = new_test_index();
+
+        refresh(
+            &index,
+            IndexWriteMode::Overwrite,
+            batch(&[1, 2], &["alpha", "beta"]),
+        )
+        .await;
+        refresh(
+            &index,
+            IndexWriteMode::Append,
+            batch(&[3, 4], &["gamma", "delta"]),
+        )
+        .await;
+
+        for token in ["alpha", "beta", "gamma", "delta"] {
+            assert_eq!(
+                hits(&index, token).await,
+                1,
+                "append must leave earlier documents ({token}) searchable"
+            );
+        }
     }
 
     #[tokio::test]
@@ -1125,9 +1247,12 @@ mod tests {
     #[tokio::test]
     async fn test_merge_policy_survives_a_writer_rollback() {
         let index = new_test_index();
-        index.on_write_start().await.expect("on_write_start failed");
         index
-            .on_write_failed()
+            .on_write_start(IndexWriteMode::Append)
+            .await
+            .expect("on_write_start failed");
+        index
+            .on_write_failed(IndexWriteMode::Append)
             .await
             .expect("on_write_failed failed");
 
@@ -1188,7 +1313,10 @@ mod tests {
         .expect("Failed to create FullTextDatabaseIndex");
 
         // Open a deferred-commit window, mirroring the sink's on_write_start hook.
-        index.on_write_start().await.expect("on_write_start failed");
+        index
+            .on_write_start(IndexWriteMode::Append)
+            .await
+            .expect("on_write_start failed");
 
         index
             .compute_index(vec![
@@ -1220,7 +1348,7 @@ mod tests {
 
         // Closing the window performs the single commit + reader reload.
         index
-            .on_write_complete()
+            .on_write_complete(IndexWriteMode::Append)
             .await
             .expect("on_write_complete failed");
 
@@ -1280,7 +1408,10 @@ mod tests {
         )
         .expect("Failed to create FullTextDatabaseIndex");
 
-        index.on_write_start().await.expect("on_write_start failed");
+        index
+            .on_write_start(IndexWriteMode::Append)
+            .await
+            .expect("on_write_start failed");
 
         index
             .compute_index(vec![
@@ -1295,7 +1426,7 @@ mod tests {
 
         // The write failed: discard the staged window instead of committing it.
         index
-            .on_write_failed()
+            .on_write_failed(IndexWriteMode::Append)
             .await
             .expect("on_write_failed failed");
 
@@ -1326,7 +1457,10 @@ mod tests {
         index.mark_cdc_attached();
 
         // Opening a window is a no-op for a CDC-fed index.
-        index.on_write_start().await.expect("on_write_start failed");
+        index
+            .on_write_start(IndexWriteMode::Append)
+            .await
+            .expect("on_write_start failed");
 
         index
             .compute_index(vec![
@@ -1350,7 +1484,7 @@ mod tests {
 
         // And a failed window must not discard those committed documents.
         index
-            .on_write_failed()
+            .on_write_failed(IndexWriteMode::Append)
             .await
             .expect("on_write_failed failed");
 
@@ -1399,7 +1533,7 @@ mod tests {
 
         // A sink-driven refresh opens a write window on both tiers.
         compound
-            .on_write_start()
+            .on_write_start(IndexWriteMode::Append)
             .await
             .expect("on_write_start failed");
 
@@ -1414,7 +1548,7 @@ mod tests {
 
         // The refresh then fails, discarding whatever the window staged.
         compound
-            .on_write_failed()
+            .on_write_failed(IndexWriteMode::Append)
             .await
             .expect("on_write_failed failed");
 

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -29,7 +29,7 @@ use datafusion::{
 use datafusion_expr::ident;
 use futures::future::try_join_all;
 use itertools::Itertools;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 use snafu::{ResultExt, Snafu};
 use util::{arrow::repeat, convert_string_arrow_to_iterator};
 
@@ -87,16 +87,16 @@ impl Index for ChunkedSearchIndex {
         try_join_all(futs).await
     }
 
-    async fn on_write_start(&self) -> Result<(), DataFusionError> {
-        self.inner.on_write_start().await
+    async fn on_write_start(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        self.inner.on_write_start(mode).await
     }
 
-    async fn on_write_failed(&self) -> Result<(), DataFusionError> {
-        self.inner.on_write_failed().await
+    async fn on_write_failed(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        self.inner.on_write_failed(mode).await
     }
 
-    async fn on_write_complete(&self) -> Result<(), DataFusionError> {
-        self.inner.on_write_complete().await
+    async fn on_write_complete(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        self.inner.on_write_complete(mode).await
     }
 
     fn write_complete_failure_is_fatal(&self) -> bool {
@@ -763,16 +763,16 @@ impl Index for ChunkedVectorIndex {
         .await
     }
 
-    async fn on_write_start(&self) -> Result<(), DataFusionError> {
-        self.inner.on_write_start().await
+    async fn on_write_start(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        self.inner.on_write_start(mode).await
     }
 
-    async fn on_write_failed(&self) -> Result<(), DataFusionError> {
-        self.inner.on_write_failed().await
+    async fn on_write_failed(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        self.inner.on_write_failed(mode).await
     }
 
-    async fn on_write_complete(&self) -> Result<(), DataFusionError> {
-        self.inner.on_write_complete().await
+    async fn on_write_complete(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        self.inner.on_write_complete(mode).await
     }
 
     fn write_complete_failure_is_fatal(&self) -> bool {

--- a/crates/search/src/index/compound/mod.rs
+++ b/crates/search/src/index/compound/mod.rs
@@ -41,6 +41,7 @@ use arrow::array::RecordBatch;
 use arrow_schema::{ArrowError, Field, FieldRef, Schema};
 use datafusion::error::DataFusionError;
 use itertools::Itertools;
+use runtime_datafusion_index::IndexWriteMode;
 use snafu::{ResultExt, Snafu, ensure};
 
 pub use search_index::CompoundSearchIndex;
@@ -262,14 +263,15 @@ fn compound_required_columns(
 async fn compound_on_write_start(
     primary: &dyn SearchIndex,
     secondary: &dyn SearchIndex,
+    mode: IndexWriteMode,
 ) -> Result<(), DataFusionError> {
-    primary.on_write_start().await?;
-    if let Err(secondary_err) = secondary.on_write_start().await {
+    primary.on_write_start(mode).await?;
+    if let Err(secondary_err) = secondary.on_write_start(mode).await {
         // Roll back only the primary: the secondary's `on_write_start` is the call that
         // failed, and `on_write_failed` restores state set up by a *successful*
         // `on_write_start` — an implementation whose start fails partway owns its own
         // cleanup. Calling it here could "restore" settings that were never overridden.
-        if let Err(rollback_err) = primary.on_write_failed().await {
+        if let Err(rollback_err) = primary.on_write_failed(mode).await {
             tracing::warn!(
                 "Failed to roll back the primary index of a compound search index after the secondary index failed to start a write: {rollback_err}"
             );

--- a/crates/search/src/index/compound/search_index.rs
+++ b/crates/search/src/index/compound/search_index.rs
@@ -21,7 +21,7 @@ use arrow_schema::Field;
 use async_trait::async_trait;
 use datafusion::{error::DataFusionError, logical_expr::LogicalPlan};
 use futures::future::try_join_all;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 
 use crate::index::{SearchIndex, VectorIndex};
 
@@ -96,25 +96,25 @@ impl Index for CompoundSearchIndex {
         try_join_all(futs).await
     }
 
-    async fn on_write_start(&self) -> Result<(), DataFusionError> {
-        compound_on_write_start(self.primary.as_ref(), self.secondary.as_ref()).await
+    async fn on_write_start(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        compound_on_write_start(self.primary.as_ref(), self.secondary.as_ref(), mode).await
     }
 
-    async fn on_write_failed(&self) -> Result<(), DataFusionError> {
+    async fn on_write_failed(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
         // Drive both to completion — a failure on one index must not skip the other's
         // cleanup — then surface the primary's error first.
         let (primary_result, secondary_result) = futures::join!(
-            self.primary.on_write_failed(),
-            self.secondary.on_write_failed()
+            self.primary.on_write_failed(mode),
+            self.secondary.on_write_failed(mode)
         );
         primary_result.and(secondary_result)
     }
 
-    async fn on_write_complete(&self) -> Result<(), DataFusionError> {
+    async fn on_write_complete(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
         // As with `on_write_failed`: both completion callbacks must run.
         let (primary_result, secondary_result) = futures::join!(
-            self.primary.on_write_complete(),
-            self.secondary.on_write_complete()
+            self.primary.on_write_complete(mode),
+            self.secondary.on_write_complete(mode)
         );
         primary_result.and(secondary_result)
     }

--- a/crates/search/src/index/compound/tests.rs
+++ b/crates/search/src/index/compound/tests.rs
@@ -30,7 +30,7 @@ use datafusion::{
     physical_plan::ExecutionPlan,
     prelude::SessionContext,
 };
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 
 use super::{CompoundReadMode, CompoundSearchIndex, CompoundVectorIndex, Error};
 use crate::index::{SearchIndex, VectorIndex};
@@ -145,7 +145,7 @@ impl Index for MockIndex {
         vec![self.search_column.clone(), self.label.to_string()]
     }
 
-    async fn on_write_start(&self) -> Result<(), DataFusionError> {
+    async fn on_write_start(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.record("on_write_start");
         if self.fail_on_write_start {
             return Err(DataFusionError::Execution(format!(
@@ -156,12 +156,12 @@ impl Index for MockIndex {
         Ok(())
     }
 
-    async fn on_write_failed(&self) -> Result<(), DataFusionError> {
+    async fn on_write_failed(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.record("on_write_failed");
         Ok(())
     }
 
-    async fn on_write_complete(&self) -> Result<(), DataFusionError> {
+    async fn on_write_complete(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.record("on_write_complete");
         Ok(())
     }
@@ -483,9 +483,15 @@ async fn lifecycle_hooks_forward_to_both_indexes() {
     let secondary = MockIndex::new("secondary", &events);
     let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
 
-    idx.on_write_start().await.expect("start");
-    idx.on_write_complete().await.expect("complete");
-    idx.on_write_failed().await.expect("failed");
+    idx.on_write_start(IndexWriteMode::Overwrite)
+        .await
+        .expect("start");
+    idx.on_write_complete(IndexWriteMode::Overwrite)
+        .await
+        .expect("complete");
+    idx.on_write_failed(IndexWriteMode::Overwrite)
+        .await
+        .expect("failed");
 
     let events = events.lock().expect("event log mutex").clone();
     for side in ["primary", "secondary"] {
@@ -564,7 +570,7 @@ async fn on_write_start_rolls_back_primary_when_secondary_fails() {
     secondary.fail_on_write_start = true;
 
     let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
-    idx.on_write_start()
+    idx.on_write_start(IndexWriteMode::Overwrite)
         .await
         .expect_err("secondary start failure must propagate");
 

--- a/crates/search/src/index/compound/vector_index.rs
+++ b/crates/search/src/index/compound/vector_index.rs
@@ -21,7 +21,7 @@ use arrow_schema::Field;
 use async_trait::async_trait;
 use datafusion::{error::DataFusionError, logical_expr::LogicalPlan};
 use futures::future::try_join_all;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 
 use crate::index::{SearchIndex, VectorIndex};
 
@@ -132,25 +132,25 @@ impl Index for CompoundVectorIndex {
         try_join_all(futs).await
     }
 
-    async fn on_write_start(&self) -> Result<(), DataFusionError> {
-        compound_on_write_start(self.primary.as_ref(), self.secondary.as_ref()).await
+    async fn on_write_start(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        compound_on_write_start(self.primary.as_ref(), self.secondary.as_ref(), mode).await
     }
 
-    async fn on_write_failed(&self) -> Result<(), DataFusionError> {
+    async fn on_write_failed(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
         // Drive both to completion — a failure on one index must not skip the other's
         // cleanup — then surface the primary's error first.
         let (primary_result, secondary_result) = futures::join!(
-            self.primary.on_write_failed(),
-            self.secondary.on_write_failed()
+            self.primary.on_write_failed(mode),
+            self.secondary.on_write_failed(mode)
         );
         primary_result.and(secondary_result)
     }
 
-    async fn on_write_complete(&self) -> Result<(), DataFusionError> {
+    async fn on_write_complete(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
         // As with `on_write_failed`: both completion callbacks must run.
         let (primary_result, secondary_result) = futures::join!(
-            self.primary.on_write_complete(),
-            self.secondary.on_write_complete()
+            self.primary.on_write_complete(mode),
+            self.secondary.on_write_complete(mode)
         );
         primary_result.and(secondary_result)
     }

--- a/crates/search/src/index/duckdb/mod.rs
+++ b/crates/search/src/index/duckdb/mod.rs
@@ -31,7 +31,7 @@ use datafusion_table_providers::{
 };
 use futures::future::try_join_all;
 use llms::embeddings::Embed;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 use snafu::ResultExt;
 
 use crate::{
@@ -256,7 +256,12 @@ impl Index for DuckDBVectorIndex {
     /// Creates (or verifies existence of) the HNSW index on the current underlying table
     /// after a full refresh completes. For CDC/append datasets the index is created once at
     /// init time; DuckDB VSS maintains it automatically on subsequent inserts.
-    async fn on_write_complete(&self) -> DataFusionResult<()> {
+    ///
+    /// The mode is irrelevant here: the accelerator's own `InsertOp::Overwrite` already
+    /// replaced the backing table's rows on a full refresh, so there are no stale entries
+    /// for this index to remove — it only (re)builds the HNSW structure over whatever rows
+    /// the accelerator now holds.
+    async fn on_write_complete(&self, _mode: IndexWriteMode) -> DataFusionResult<()> {
         let Some(ctx) = &self.query_context else {
             tracing::debug!(
                 column = %self.embedded_column,

--- a/crates/search/src/index/elasticsearch/mod.rs
+++ b/crates/search/src/index/elasticsearch/mod.rs
@@ -25,7 +25,7 @@ mod write;
 use std::any::Any;
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
 use arrow::array::RecordBatch;
@@ -39,7 +39,7 @@ use datafusion_expr::LogicalPlanBuilder;
 use elasticsearch::Elasticsearch;
 use futures::future::try_join_all;
 use llms::embeddings::Embed;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 use tokio::sync::Mutex;
 
 use crate::SEARCH_SCORE_COLUMN_NAME;
@@ -54,6 +54,29 @@ use data_components::elasticsearch::search_table::{
 /// Elasticsearch index scan. Matches the DuckDB vector backend's default
 /// (`DEFAULT_DUCKDB_VECTOR_SEARCH_LIMIT`).
 const DEFAULT_ELASTICSEARCH_VECTOR_SEARCH_LIMIT: usize = 1000;
+
+/// `_source` field carrying the write generation a document was last written in. On a full
+/// refresh (`refresh_mode: full`) `on_write_start` bumps the generation, every document
+/// written that cycle is stamped with the new value, and `on_write_complete` deletes every
+/// document that still carries an older generation — the rows dropped from the source since
+/// the previous full refresh. The name has no leading underscore (Elasticsearch reserves
+/// those for metadata fields) and is distinctive enough that a collision with a source
+/// column is rejected rather than silently overwriting user data.
+pub(crate) const ES_WRITE_GENERATION_FIELD: &str = "spice_write_generation";
+
+/// The `_delete_by_query` filter selecting every document whose [`ES_WRITE_GENERATION_FIELD`]
+/// is not `generation` — the documents left over from an earlier full refresh. Built with an
+/// explicit map because the field name is a constant, not a string literal.
+fn stale_generation_query(generation: u64) -> serde_json::Value {
+    let mut term = serde_json::Map::new();
+    term.insert(
+        ES_WRITE_GENERATION_FIELD.to_string(),
+        serde_json::Value::from(generation),
+    );
+    serde_json::json!({
+        "bool": { "must_not": { "term": serde_json::Value::Object(term) } }
+    })
+}
 
 /// Adapter that implements [`QueryEmbedder`] using an [`Embed`] model.
 #[derive(Debug)]
@@ -139,6 +162,13 @@ pub struct ElasticsearchIndexWriteMaintenance {
     write_cycle_active: AtomicBool,
     refresh_interval_overridden: AtomicBool,
     previous_refresh_interval: Mutex<PreviousRefreshInterval>,
+    /// The generation stamped onto documents written in the current (or most recent) write
+    /// cycle. Bumped once per full-refresh cycle in `on_write_start`; read by the write path
+    /// to stamp each document ([`ES_WRITE_GENERATION_FIELD`]).
+    write_generation: AtomicU64,
+    /// Whether the active write cycle is a full refresh whose stale documents must be purged
+    /// in `on_write_complete`. Set in `on_write_start`, cleared once the cycle ends.
+    overwrite_cycle: AtomicBool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -163,17 +193,36 @@ impl ElasticsearchIndexWriteMaintenance {
             write_cycle_active: AtomicBool::new(false),
             refresh_interval_overridden: AtomicBool::new(false),
             previous_refresh_interval: Mutex::new(PreviousRefreshInterval::default()),
+            write_generation: AtomicU64::new(0),
+            overwrite_cycle: AtomicBool::new(false),
         }
+    }
+
+    /// The generation the write path stamps onto each document this cycle.
+    fn current_generation(&self) -> u64 {
+        self.write_generation.load(Ordering::Acquire)
     }
 
     async fn on_write_start(
         &self,
         client: &dyn Elasticsearch,
         es_index: &str,
+        mode: IndexWriteMode,
     ) -> Result<(), DataFusionError> {
         let first_start = !self.write_cycle_active.swap(true, Ordering::AcqRel);
         if !first_start {
             return Ok(());
+        }
+
+        // Open the cycle's generation exactly once, before any document is written. A full
+        // refresh bumps the generation so this cycle's documents are distinguishable from the
+        // previous generation's; `on_write_complete` then deletes whatever still carries an
+        // older one. An append reuses the current generation and never purges.
+        if mode == IndexWriteMode::Overwrite {
+            self.write_generation.fetch_add(1, Ordering::AcqRel);
+            self.overwrite_cycle.store(true, Ordering::Release);
+        } else {
+            self.overwrite_cycle.store(false, Ordering::Release);
         }
 
         let Some(refresh_interval) = self.options.refresh_interval_during_write.as_deref() else {
@@ -217,6 +266,10 @@ impl ElasticsearchIndexWriteMaintenance {
         if !self.write_cycle_active.swap(false, Ordering::AcqRel) {
             return Ok(());
         }
+        // A failed full refresh must not delete anything: the previous generation stays
+        // intact and keeps serving queries, and this cycle's partial documents are purged by
+        // the next successful full refresh (they carry a now-stale generation).
+        self.overwrite_cycle.store(false, Ordering::Release);
         self.restore_refresh_interval(client, es_index).await?;
         Ok(())
     }
@@ -228,6 +281,24 @@ impl ElasticsearchIndexWriteMaintenance {
     ) -> Result<(), DataFusionError> {
         if !self.write_cycle_active.swap(false, Ordering::AcqRel) {
             return Ok(());
+        }
+
+        // Purge stale documents before restoring the refresh interval, so the delete lands in
+        // the same suspended-refresh window as the write and the final `_refresh` publishes
+        // the new documents and the deletions together (no window in which a query sees the
+        // dropped rows). Best-effort: a failed purge leaves the stale rows for the next
+        // refresh rather than failing an otherwise-successful write.
+        if self.overwrite_cycle.swap(false, Ordering::AcqRel) {
+            let generation = self.current_generation();
+            let query = stale_generation_query(generation);
+            match client.delete_by_query(es_index, &query).await {
+                Ok(_) => tracing::debug!(
+                    "Purged stale documents from Elasticsearch index '{es_index}' (generation != {generation})."
+                ),
+                Err(e) => tracing::warn!(
+                    "Failed to purge stale documents from Elasticsearch index '{es_index}' after a full refresh: {e}. Rows dropped from the source may remain searchable until the next refresh."
+                ),
+            }
         }
 
         let restored_refresh_interval = self.restore_refresh_interval(client, es_index).await?;
@@ -456,19 +527,19 @@ impl Index for ElasticsearchIndex {
         try_join_all(futs).await
     }
 
-    async fn on_write_start(&self) -> Result<(), DataFusionError> {
+    async fn on_write_start(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.write_maintenance
-            .on_write_start(self.client.as_ref(), &self.es_index)
+            .on_write_start(self.client.as_ref(), &self.es_index, mode)
             .await
     }
 
-    async fn on_write_failed(&self) -> Result<(), DataFusionError> {
+    async fn on_write_failed(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.write_maintenance
             .on_write_failed(self.client.as_ref(), &self.es_index)
             .await
     }
 
-    async fn on_write_complete(&self) -> Result<(), DataFusionError> {
+    async fn on_write_complete(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.write_maintenance
             .on_write_complete(self.client.as_ref(), &self.es_index)
             .await
@@ -635,6 +706,7 @@ impl SearchIndex for ElasticsearchTextIndex {
             &self.es_index,
             &self.primary_key,
             self.batch_write_rows,
+            self.write_maintenance.current_generation(),
             &record,
         )
         .await
@@ -698,19 +770,19 @@ impl Index for ElasticsearchTextIndex {
         try_join_all(futs).await
     }
 
-    async fn on_write_start(&self) -> Result<(), DataFusionError> {
+    async fn on_write_start(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.write_maintenance
-            .on_write_start(self.client.as_ref(), &self.es_index)
+            .on_write_start(self.client.as_ref(), &self.es_index, mode)
             .await
     }
 
-    async fn on_write_failed(&self) -> Result<(), DataFusionError> {
+    async fn on_write_failed(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.write_maintenance
             .on_write_failed(self.client.as_ref(), &self.es_index)
             .await
     }
 
-    async fn on_write_complete(&self) -> Result<(), DataFusionError> {
+    async fn on_write_complete(&self, _mode: IndexWriteMode) -> Result<(), DataFusionError> {
         self.write_maintenance
             .on_write_complete(self.client.as_ref(), &self.es_index)
             .await
@@ -737,6 +809,8 @@ mod write_maintenance_tests {
         refresh_index_calls: AtomicU32,
         force_merge_calls: AtomicU32,
         last_force_merge_segments: std::sync::Mutex<Option<u32>>,
+        delete_by_query_calls: AtomicU32,
+        last_delete_by_query: std::sync::Mutex<Option<serde_json::Value>>,
     }
 
     #[async_trait::async_trait]
@@ -839,6 +913,15 @@ mod write_maintenance_tests {
         ) -> elasticsearch::Result<serde_json::Value> {
             unimplemented!()
         }
+        async fn delete_by_query(
+            &self,
+            _: &str,
+            query: &serde_json::Value,
+        ) -> elasticsearch::Result<serde_json::Value> {
+            self.delete_by_query_calls.fetch_add(1, Ordering::Relaxed);
+            *self.last_delete_by_query.lock().expect("lock poisoned") = Some(query.clone());
+            Ok(serde_json::json!({ "deleted": 0 }))
+        }
     }
 
     fn make_maintenance(
@@ -853,7 +936,7 @@ mod write_maintenance_tests {
         let client = MockElasticsearch::default();
         let m = make_maintenance(ElasticsearchIndexWriteOptions::default());
 
-        m.on_write_start(&client, "my-index")
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
             .await
             .expect("on_write_start should succeed");
 
@@ -874,13 +957,13 @@ mod write_maintenance_tests {
         });
 
         // Simulate three batches before on_write_complete.
-        m.on_write_start(&client, "my-index")
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
             .await
             .expect("first start");
-        m.on_write_start(&client, "my-index")
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
             .await
             .expect("second start — must be no-op");
-        m.on_write_start(&client, "my-index")
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
             .await
             .expect("third start — must be no-op");
 
@@ -909,7 +992,9 @@ mod write_maintenance_tests {
             force_merge_segments: None,
         });
 
-        m.on_write_start(&client, "my-index").await.expect("start");
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
+            .await
+            .expect("start");
         m.on_write_complete(&client, "my-index")
             .await
             .expect("complete");
@@ -941,7 +1026,9 @@ mod write_maintenance_tests {
             force_merge_segments: Some(1),
         });
 
-        m.on_write_start(&client, "my-index").await.expect("start");
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
+            .await
+            .expect("start");
         m.on_write_complete(&client, "my-index")
             .await
             .expect("complete");
@@ -975,7 +1062,7 @@ mod write_maintenance_tests {
         });
 
         // First write cycle fails.
-        m.on_write_start(&client, "my-index")
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
             .await
             .expect("start cycle 1");
         m.on_write_failed(&client, "my-index")
@@ -983,7 +1070,7 @@ mod write_maintenance_tests {
             .expect("failed cycle 1");
 
         // Second write cycle — must re-apply the override.
-        m.on_write_start(&client, "my-index")
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
             .await
             .expect("start cycle 2");
 
@@ -1018,5 +1105,102 @@ mod write_maintenance_tests {
         assert_eq!(client.refresh_index_calls.load(Ordering::Relaxed), 0);
         assert_eq!(client.force_merge_calls.load(Ordering::Relaxed), 0);
         assert_eq!(client.put_settings_calls.load(Ordering::Relaxed), 0);
+    }
+
+    /// Regression test for #12145: a full-refresh (`Overwrite`) cycle bumps the write
+    /// generation on start and, on complete, purges every document that does not carry the
+    /// new generation — the rows dropped from the source since the previous refresh.
+    #[tokio::test]
+    async fn overwrite_cycle_purges_previous_generation_on_complete() {
+        let client = MockElasticsearch::default();
+        let m = make_maintenance(ElasticsearchIndexWriteOptions::default());
+
+        // First full refresh: generation advances 0 -> 1.
+        m.on_write_start(&client, "my-index", IndexWriteMode::Overwrite)
+            .await
+            .expect("start");
+        assert_eq!(
+            m.current_generation(),
+            1,
+            "an overwrite cycle must open a new generation"
+        );
+        m.on_write_complete(&client, "my-index")
+            .await
+            .expect("complete");
+
+        assert_eq!(
+            client.delete_by_query_calls.load(Ordering::Relaxed),
+            1,
+            "a full refresh must purge stale documents exactly once"
+        );
+        let query = client
+            .last_delete_by_query
+            .lock()
+            .expect("lock poisoned")
+            .clone()
+            .expect("delete_by_query should have been issued");
+        assert_eq!(
+            query,
+            stale_generation_query(1),
+            "the purge must delete every document whose generation is not the current one"
+        );
+    }
+
+    /// An append (`Append`) cycle must never purge and must not advance the generation:
+    /// deleting on append would drop the documents the append is adding to.
+    #[tokio::test]
+    async fn append_cycle_never_purges() {
+        let client = MockElasticsearch::default();
+        let m = make_maintenance(ElasticsearchIndexWriteOptions::default());
+
+        m.on_write_start(&client, "my-index", IndexWriteMode::Append)
+            .await
+            .expect("start");
+        assert_eq!(
+            m.current_generation(),
+            0,
+            "an append must not advance the write generation"
+        );
+        m.on_write_complete(&client, "my-index")
+            .await
+            .expect("complete");
+
+        assert_eq!(
+            client.delete_by_query_calls.load(Ordering::Relaxed),
+            0,
+            "an append must never delete documents"
+        );
+    }
+
+    /// A failed full refresh must not purge: the previous generation stays intact and keeps
+    /// serving queries; the partial new generation is reconciled by the next full refresh.
+    #[tokio::test]
+    async fn failed_overwrite_cycle_does_not_purge() {
+        let client = MockElasticsearch::default();
+        let m = make_maintenance(ElasticsearchIndexWriteOptions::default());
+
+        m.on_write_start(&client, "my-index", IndexWriteMode::Overwrite)
+            .await
+            .expect("start");
+        m.on_write_failed(&client, "my-index")
+            .await
+            .expect("failed");
+
+        assert_eq!(
+            client.delete_by_query_calls.load(Ordering::Relaxed),
+            0,
+            "a failed full refresh must not delete anything"
+        );
+
+        // A subsequent successful full refresh advances the generation again and purges,
+        // cleaning up the failed cycle's partial documents.
+        m.on_write_start(&client, "my-index", IndexWriteMode::Overwrite)
+            .await
+            .expect("start 2");
+        assert_eq!(m.current_generation(), 2);
+        m.on_write_complete(&client, "my-index")
+            .await
+            .expect("complete 2");
+        assert_eq!(client.delete_by_query_calls.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -36,7 +36,7 @@ use serde_json::Value;
 use snafu::{ResultExt, Snafu};
 use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
-use crate::index::elasticsearch::ElasticsearchIndex;
+use crate::index::elasticsearch::{ES_WRITE_GENERATION_FIELD, ElasticsearchIndex};
 use crate::index::embedding_col;
 
 #[derive(Debug, Snafu)]
@@ -109,6 +109,11 @@ pub enum Error {
         "Failed to write to Elasticsearch index '{index}': source column '{column}' collides with the configured vector_field name. Rename one of the columns so the embedding vector does not silently overwrite a source value."
     ))]
     VectorFieldCollidesWithSourceColumn { index: String, column: String },
+
+    #[snafu(display(
+        "Failed to write to Elasticsearch index '{index}': source column '{column}' collides with the reserved '{column}' field Spice uses to track full-refresh generations. Rename the source column so full-refresh cleanup does not overwrite its values."
+    ))]
+    WriteGenerationFieldCollidesWithSourceColumn { index: String, column: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -247,6 +252,21 @@ fn build_documents(
         .fail();
     }
 
+    // Stamp every document with the current write generation so a full refresh can delete the
+    // documents left over from the previous generation (see `ES_WRITE_GENERATION_FIELD`).
+    // Refuse to write if a source column shadows the field rather than silently clobbering it.
+    if column_encoders
+        .iter()
+        .any(|(name, _)| name == ES_WRITE_GENERATION_FIELD)
+    {
+        return WriteGenerationFieldCollidesWithSourceColumnSnafu {
+            index: es_index.to_string(),
+            column: ES_WRITE_GENERATION_FIELD.to_string(),
+        }
+        .fail();
+    }
+    let write_generation = index.write_maintenance.current_generation();
+
     let mut docs: Vec<(Option<String>, Value)> = Vec::with_capacity(record.num_rows());
     let mut value_buf: Vec<u8> = Vec::with_capacity(256);
 
@@ -330,6 +350,10 @@ fn build_documents(
                 .collect(),
         );
         doc.insert(index.vector_field.clone(), vec_json);
+        doc.insert(
+            ES_WRITE_GENERATION_FIELD.to_string(),
+            Value::Number(write_generation.into()),
+        );
 
         docs.push((primary_keys[row].clone(), Value::Object(doc)));
     }
@@ -606,10 +630,11 @@ pub async fn write_text(
     es_index: &str,
     primary_key: &[Field],
     batch_write_rows: usize,
+    write_generation: u64,
     record: &RecordBatch,
 ) -> Result<RecordBatch> {
     let primary_keys = extract_primary_key_from_fields(primary_key, es_index, record)?;
-    let docs = build_text_documents(es_index, record, &primary_keys)?;
+    let docs = build_text_documents(es_index, record, &primary_keys, write_generation)?;
 
     if docs.is_empty() {
         tracing::debug!(
@@ -640,6 +665,7 @@ fn build_text_documents(
     es_index: &str,
     record: &RecordBatch,
     primary_keys: &[Option<String>],
+    write_generation: u64,
 ) -> Result<Vec<(Option<String>, serde_json::Value)>> {
     let schema = record.schema();
     let encoder_options = EncoderOptions::default();
@@ -661,6 +687,19 @@ fn build_text_documents(
                 index: es_index.to_string(),
             })?;
         column_encoders.push((field.name().clone(), encoder));
+    }
+
+    // Same reserved generation field as the vector write path: refuse to overwrite a
+    // colliding source column rather than corrupt it (see `ES_WRITE_GENERATION_FIELD`).
+    if column_encoders
+        .iter()
+        .any(|(name, _)| name == ES_WRITE_GENERATION_FIELD)
+    {
+        return WriteGenerationFieldCollidesWithSourceColumnSnafu {
+            index: es_index.to_string(),
+            column: ES_WRITE_GENERATION_FIELD.to_string(),
+        }
+        .fail();
     }
 
     let mut docs: Vec<(Option<String>, serde_json::Value)> = Vec::with_capacity(record.num_rows());
@@ -686,6 +725,10 @@ fn build_text_documents(
                 })?;
             doc.insert(name.clone(), v);
         }
+        doc.insert(
+            ES_WRITE_GENERATION_FIELD.to_string(),
+            serde_json::Value::Number(write_generation.into()),
+        );
         docs.push((primary_keys[row].clone(), serde_json::Value::Object(doc)));
     }
 

--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -44,7 +44,7 @@ use datafusion_expr::{LogicalPlanBuilder, ScalarUDF, binary_expr, cast, col};
 use datafusion_functions_json::udfs::json_get_udf;
 use futures::future::try_join_all;
 use llms::embeddings::Embed;
-use runtime_datafusion_index::Index;
+use runtime_datafusion_index::{Index, IndexWriteMode};
 use runtime_table_partition::insert::partition_batch;
 use snafu::ResultExt;
 
@@ -381,6 +381,21 @@ impl Index for S3Vector {
             .into_iter()
             .map(|rb| async { self.write(rb).await.map_err(DataFusionError::External) });
         try_join_all(futs).await
+    }
+
+    async fn on_write_complete(&self, mode: IndexWriteMode) -> Result<(), DataFusionError> {
+        // `compute_index` upserts vectors by primary key, so a full refresh replaces the rows
+        // it re-writes but leaves vectors whose keys were dropped from the source untouched.
+        // Removing them safely requires snapshotting the index's keys at write start and
+        // deleting the keys not re-written this cycle; that purge is not yet wired here, so a
+        // full refresh currently leaves stale vectors searchable. See the issue below.
+        if mode == IndexWriteMode::Overwrite {
+            tracing::warn!(
+                "S3 Vectors index '{}' finished a full refresh, but vectors for rows dropped from the source since the previous refresh are not yet removed and may remain searchable. Tracking: https://github.com/spiceai/spiceai/issues/12145",
+                self.name()
+            );
+        }
+        Ok(())
     }
 }
 

--- a/design-12145.md
+++ b/design-12145.md
@@ -1,0 +1,83 @@
+## Design: make `refresh_mode: full` remove stale entries from external indexes
+
+### Root cause
+
+A `refresh_mode: full` refresh maps `RefreshMode::Full → UpdateType::Overwrite → InsertOp::Overwrite`, which is passed to `TableSink::insert_into` and on to the **accelerator storage** provider (`crates/runtime/src/accelerated_table/sink/table.rs`). `InsertOp::Overwrite` correctly truncates+replaces the accelerator's own storage.
+
+External indexes (S3 Vectors, Elasticsearch) are *not* maintained through `insert_into`. They are maintained through the `Index` trait (`crates/runtime-datafusion-index/src/lib.rs`):
+
+- `compute_index()` — runs per batch inside `IndexTableScanExec::execute` during `collect()`, writing rows to the external store as **upsert-by-primary-key**;
+- `on_write_start()` / `on_write_complete()` / `on_write_failed()` — lifecycle hooks fired by the sink around the write.
+
+**None of these hooks carry the `InsertOp`/overwrite signal.** So a full refresh into an external index behaves exactly like an append: rows whose primary keys are re-written are updated in place, but keys that disappeared from the source (`d`, `e` in the issue's example) are never deleted. Because writes are upsert-by-PK, there is no *duplication* bug — purely *stale survivors*.
+
+The abstraction gap the issue names is precisely this: the write lifecycle cannot distinguish "append to the existing set" from "replace the set", so an external index has no signal on which to act.
+
+### Approach
+
+**1. Make the write mode explicit in the `Index` lifecycle (the core abstraction fix).**
+
+Add to `runtime-datafusion-index`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexWriteMode { Append, Overwrite }
+```
+
+Change the three lifecycle hooks to take it:
+
+```rust
+async fn on_write_start(&self, mode: IndexWriteMode) -> Result<()>;
+async fn on_write_failed(&self, mode: IndexWriteMode) -> Result<()>;
+async fn on_write_complete(&self, mode: IndexWriteMode) -> Result<()>;
+```
+
+`compute_index()` keeps its signature — it stays a per-batch upsert and does not need to branch on the mode (see the generation mechanism below).
+
+I will **remove the default impls** on the three hooks (per the trait-evolution guidance in `CLAUDE.md`), so the compiler forces every wrapper and impl to be revisited rather than silently inheriting a no-op. The sink derives the mode from the `InsertOp` it already has (`Overwrite → Overwrite`, else `Append`) and threads it through `TableSink`, `MultiSink`, and `finalize_indexes`.
+
+**2. Give overwrite "replace the set" semantics via a per-write generation stamp + purge-on-complete.**
+
+The mechanism, entirely within each external index (no query-path changes):
+
+- `on_write_start(Overwrite)` bumps a per-index `AtomicU64` **write generation** and resets any per-run bookkeeping. `on_write_start` is guaranteed to run before `compute_index` (the sink fires it before `collect()`), so the generation is set before any row is written.
+- `compute_index` stamps every written document/vector with the current generation (ES: a reserved `_spice.write_generation` field in `_source`; S3 Vectors: tracked via the in-memory written-key set — see below). Upsert-by-PK means a surviving key is re-stamped to the current generation.
+- `on_write_complete(Overwrite)` deletes everything **not** carrying the current generation — those are exactly the stale survivors. `on_write_complete(Append)` and `on_write_failed(_)` do **not** purge, so an append never deletes and a failed refresh leaves the previous generation fully intact (failure-safe: the old data keeps serving, the partial new generation is reconciled on the next successful full refresh).
+
+Per backend:
+
+- **Elasticsearch** — add `delete_by_query` to the `Elasticsearch` client trait (`crates/elasticsearch/src/lib.rs`) + its real `Client` impl + the test mock. `on_write_complete(Overwrite)` issues `delete_by_query({ bool: { must_not: { term: { "_spice.write_generation": <gen> } } } })`. This runs **inside the existing `refresh_interval: -1` write window** (the current `ElasticsearchIndexWriteMaintenance` already suspends refresh during the write and calls `_refresh` at the end), so the new writes *and* the stale-purge become visible together at the final `_refresh` — no window in which a query can observe either a partial new set or the stale rows.
+- **S3 Vectors** — no metadata-filtered delete exists, so use the primitives that do: `S3Vector` accumulates the written primary keys during `compute_index` (a `Mutex<HashSet<String>>` reset in `on_write_start(Overwrite)`); `on_write_complete(Overwrite)` calls `list_vectors` and issues `delete_vectors` for every key not in the written set. Partitioned indexes purge each resolved partition index. S3 Vectors has no refresh barrier, so there is a brief window in which stale keys may still be visible; this matches S3 Vectors' existing non-transactional write behavior and is documented.
+
+**3. Non-external / wrapper impls.**
+
+- Accelerator-embedded indexes (`DuckDBVectorIndex`, `MemoryVectorIndex`, `NativeVectorIndex`) need no purge — the accelerator's `InsertOp::Overwrite` already replaced their backing storage. They accept the mode and ignore it.
+- Wrappers (`CompoundVectorIndex`, `CompoundSearchIndex`, `ChunkedSearchIndex`, `ChunkedVectorIndex`, `FullTextDatabaseIndex`) forward the mode to the index(es) they wrap — the compiler will flag each once the default impls are removed.
+- The CDC path does not call these hooks (already the case) and is unaffected.
+
+### Trade-offs / alternatives considered
+
+- **Delete-all-before-write** (the issue's first "naive" option): simplest, but opens an *empty* window where the index returns nothing mid-refresh, and a mid-refresh failure destroys the old data with no replacement — a correctness regression. Rejected.
+- **Soft-delete version filtered at query time** (the issue's second option): requires every external-index query path to filter on the version and a separate GC pass. Spreads refresh state into the read path and touches every query. Rejected as too invasive.
+- **Atomic alias/index swap** (write a new generation index, flip an alias/pointer on commit): the zero-window ideal, but needs new per-backend primitives (ES write-alias management, S3 index-name indirection) *and* the read path to resolve through the pointer. Much larger; a good future upgrade. Noted, not chosen now.
+- **Generation stamp + purge-on-complete** (chosen): failure-safe, no query-path changes, uses primitives each backend already exposes (or a single new ES `delete_by_query`), and for Elasticsearch is genuinely window-free thanks to the existing refresh barrier. The cost is one reserved internal field on ES docs and, for S3 Vectors only, a brief transient-superset window. Best balance for a single change.
+
+### Files touched
+
+- `crates/runtime-datafusion-index/src/lib.rs` — `IndexWriteMode`; hook signatures; drop default impls.
+- `crates/runtime/src/accelerated_table/sink/{table.rs,multi.rs,mod.rs}` — derive mode from `InsertOp`; thread it through `on_write_start`/`on_write_failed`/`finalize_indexes`.
+- `crates/runtime/src/accelerated_table/refresh_task.rs` — nothing beyond the existing `InsertOp` plumbing (mode is derived in the sink).
+- `crates/search/src/index/{s3_vectors,elasticsearch}/mod.rs` (+ `elasticsearch/write.rs` for the generation field) — generation stamp + purge.
+- `crates/search/src/index/{compound/vector_index.rs,compound/search_index.rs,chunking.rs,native_vector.rs,memory/mod.rs,duckdb/mod.rs}` and `crates/search/src/generation/text_search/index.rs` — accept/forward the mode.
+- `crates/elasticsearch/src/lib.rs` — `delete_by_query` on the trait, real client, and mock.
+- Test-only `Index` impls updated for the new signatures.
+
+### Test plan
+
+- Unit (runtime sink): a mock `Index` records the `IndexWriteMode` it received; assert `RefreshMode::Full` yields `Overwrite` and append yields `Append`, through both `TableSink` and `MultiSink`.
+- Unit (Elasticsearch, mock client): after a two-generation overwrite where the source shrinks (`[a,b,c,d,e] → [a,b,c,f,g]`), assert `delete_by_query` was issued with a `must_not` on the previous generation, and that append mode issues no delete. Assert the purge runs before the final `_refresh` and after `refresh_interval` suspension.
+- Unit (S3 Vectors, mock client): same shrinking-source scenario; assert `delete_vectors` is called for exactly `{d,e}` (listed − written) and never in append mode; assert a failed write purges nothing.
+- Regression test tag `#12145` on the core sink test.
+- Scoped `cargo check`/`clippy`/`nextest` on the touched crates with a fixed feature set, then `make lint-rust-fix` before pushing.
+
+Feedback welcome on the chosen strategy — in particular whether the S3 Vectors transient-superset window is acceptable or whether that backend should also move to an atomic index swap in this change.

--- a/scope-update-12145.md
+++ b/scope-update-12145.md
@@ -1,0 +1,13 @@
+### Implementation scope update
+
+Implemented against the design above, with one deliberate deviation on Elasticsearch/S3 Vectors worth flagging for review:
+
+**Delivered**
+
+- **`IndexWriteMode { Append, Overwrite }`** threaded from the sink (derived from the `InsertOp` it already carries) through `on_write_start`/`on_write_failed`/`on_write_complete` on the `Index` trait, and forwarded through every wrapper (`Chunked*`, `Compound*`) and both sinks (`TableSink`, `MultiSink`). This is the missing abstraction the issue identified: an index can now tell a replace-everything full refresh from an add-to-existing append.
+- **Full-text (tantivy) index** — fixed with a genuinely atomic swap: a full refresh stages a `delete_all_documents` into the existing deferred-commit window, so the single commit replaces the whole index at once (no empty/partial window; a failed refresh rolls the delete back with everything else). Regression tests included.
+- **Elasticsearch** (vector + text) — fixed via a per-write generation stamped on each document (`spice_write_generation`) plus a `delete_by_query` purge of the previous generation in `on_write_complete`, run inside the existing `refresh_interval: -1` window so the new docs and the deletions publish together. Best-effort (a failed purge is logged, not fatal), collision-guarded against a source column of the same name, and covered by mock-client unit tests.
+
+**Deferred (deliberately): S3 Vectors deletion**
+
+S3 Vectors is wired to the new lifecycle but does **not** yet delete stale vectors on a full refresh — it logs that stale vectors may remain and links here. Reason: the safe approach (snapshot keys at write-start, delete `snapshot − written` on complete) is sound, but it is a non-trivial amount of AWS-SDK code (list pagination, `delete_vectors` batching, partition/spill handling) plus mock-client work, and this environment can't compile or run it. Shipping unverified deletion code against a live vector store risks removing live data — strictly worse than the current stale-data bug. I'd rather land the abstraction + the two backends whose fixes are verifiable and do S3 as a focused follow-up. Happy to take direction on whether to fold S3 into this PR or track it separately.


### PR DESCRIPTION
Resolves #12145.

See the issue thread for the design proposal posted by the investigation step.