### PR TITLE
build(deps): bump async-openai for aggregated rate-limit logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "async-openai"
 version = "0.32.0"
-source = "git+https://github.com/spiceai/async-openai?rev=526bdd24d569c2082624daff2b2859d03960dd5b#526bdd24d569c2082624daff2b2859d03960dd5b"
+source = "git+https://github.com/spiceai/async-openai?rev=6bda5533dd118afcf80aa6f5ef59ad35277627a7#6bda5533dd118afcf80aa6f5ef59ad35277627a7"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "async-openai-macros"
 version = "0.1.1"
-source = "git+https://github.com/spiceai/async-openai?rev=526bdd24d569c2082624daff2b2859d03960dd5b#526bdd24d569c2082624daff2b2859d03960dd5b"
+source = "git+https://github.com/spiceai/async-openai?rev=6bda5533dd118afcf80aa6f5ef59ad35277627a7#6bda5533dd118afcf80aa6f5ef59ad35277627a7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ arrow-json = "58.0.0"
 arrow-odbc = "22" # crates.io 22+ accepts arrow ">=29, <59" so it resolves to the workspace Arrow 58 (the prior git pin v21 was capped at arrow <58, which forced a separate Arrow-57 subtree + an IPC bridge)
 arrow-row = "58.0.0"
 arrow-schema = "58.0.0"
-async-openai = { git = "https://github.com/spiceai/async-openai", rev = "526bdd24d569c2082624daff2b2859d03960dd5b", features = [
+async-openai = { git = "https://github.com/spiceai/async-openai", rev = "6bda5533dd118afcf80aa6f5ef59ad35277627a7", features = [
     "byot",
     "embedding",
     "chat-completion",


### PR DESCRIPTION
A saturated OpenAI quota throttles every request in flight, and the client logs one WARN per throttled request. An embedding backfill produced 917 of them in about five minutes, peaking at 356 a minute, crowding the rest of the log out.

The offending `tracing::warn!` is not in this repository — it lives in the `spiceai/async-openai` fork, which this workspace pins by rev. The fix landed there as spiceai/async-openai#38; this bump is what brings it into the product.

## Change

Move the pinned `spiceai/async-openai` rev on the `spiceai` branch:

- from `526bdd24d569c2082624daff2b2859d03960dd5b`
- to `6bda5533dd118afcf80aa6f5ef59ad35277627a7`

A single-commit advance — `6bda5533` is the merge commit of spiceai/async-openai#38 and the current head of the `spiceai` branch, one commit ahead of the rev pinned here. The features list is unchanged.

## Resulting behaviour

The client reports the first throttled request per model at WARN, every later one at DEBUG, and emits a per-model summary at WARN once a minute carrying the count, the window, and the cumulative backoff. The summary names only the model, so the organisation id stays out of the log. The table of models is bounded and nothing is retained per request.

Retry and backoff behaviour is unchanged: `backoff::future::retry` is defined as `retry_notify` with a no-op notifier, and the notifier introduced upstream only reads the duration a retry is about to sleep for.

## Verification

`Cargo.lock` moves two entries and nothing else — `async-openai` and `async-openai-macros`, which share the git source and so carry the same rev. No package versions change.

The aggregating path is the one this repository reaches. `crates/llms/src/openai/embed.rs` calls `embeddings().create()` and `create_float()`; both post to `/embeddings` through `Client::post`, which funnels into `Client::execute_raw` — the single retry helper that held the per-request WARN and now calls the aggregating logger instead. The new module is gated on the internal `_api` feature, which each of the pinned `embedding`, `chat-completion`, `responses` and `model` features enables.

`cargo check -p llms` is clean, and the compiled `async-openai` metadata is built from the `6bda5533` checkout and carries the new logging symbols.

The 12 unit tests that accompany the change upstream pass at this rev under the exact feature set pinned here, including one asserting that a flood of throttled requests produces a single warning plus a summary. They drive an injected clock, so they cover the aggregation logic without live rate limiting. Behaviour against a genuinely rate-limited OpenAI endpoint is not exercised here.

Closes #12129
