### PR TITLE
fix(lint): remove unused DuckDBTableWriter import in duckdb accelerator tests

### DIFF
--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -1963,7 +1963,6 @@ mod tests {
         physical_plan::collect,
         scalar::ScalarValue,
     };
-    use datafusion_table_providers::duckdb::write::DuckDBTableWriter;
     use datafusion_table_providers::util::test::MockExec;
 
     use crate::component::dataset::acceleration::Acceleration;


### PR DESCRIPTION
Removes an unused `DuckDBTableWriter` import in the `duckdb` accelerator test module that fails `-D warnings` on trunk. The test that needs the type references it via its fully-qualified path, so the import was dead.