### PR TITLE
fix(duckdb): count accelerated views in the coordinated memory budget (fixes #12123)

### DIFF
--- a/crates/runtime/src/accelerator_memory_budget.rs
+++ b/crates/runtime/src/accelerator_memory_budget.rs
@@ -125,22 +125,24 @@ pub fn duckdb_total_reservation_bytes() -> u64 {
 }
 
 /// A deduped-by-instance summary of the `DuckDB` accelerators in an app. Built by a
-/// thin adapter over `app.datasets` (see `builder::duckdb_budget_inputs`); the
-/// planner takes only these numbers so it stays pure and testable.
+/// thin adapter over `app.datasets` and `app.views` — either can carry an
+/// `acceleration` block, and every `DuckDB` instance they declare is counted here
+/// (see `builder::duckdb_budget_inputs`). The planner takes only these numbers so it
+/// stays pure and testable.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DuckDbBudgetInputs {
     /// Distinct `DuckDB` instances with NO explicit `duckdb_memory_limit` on any of
-    /// their datasets.
+    /// the datasets or views sharing them.
     pub num_unset_instances: u32,
     /// Distinct `DuckDB` instances with an explicit `duckdb_memory_limit`.
     pub num_explicit_instances: u32,
-    /// Sum of the explicit ceilings — one per explicit instance (the max value if
-    /// datasets on the same instance disagree).
+    /// Sum of the explicit ceilings — one per explicit instance (the max value if the
+    /// components on the same instance disagree).
     pub sum_explicit_bytes: u64,
     /// Some instance has an inconsistent `duckdb_memory_limit` across the datasets
-    /// that share it — mixed set/unset, or different explicit values. `DuckDB`'s
-    /// `memory_limit` is per-instance (last dataset created wins), so the effective
-    /// limit is ambiguous — surfaced in the warning.
+    /// and views that share it — mixed set/unset, or different explicit values.
+    /// `DuckDB`'s `memory_limit` is per-instance (last one created wins), so the
+    /// effective limit is ambiguous — surfaced in the warning.
     pub has_mixed_instance: bool,
     /// Human labels (in-memory / file path) of the un-limited instances, for the warning.
     pub unset_instance_labels: Vec<String>,

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -1187,26 +1187,37 @@ fn estimate_cayenne_cdc_reservation_bytes(
 /// Deduped-by-instance summary of the `DuckDB` accelerators in `app`, for the
 /// coordinated memory budget ([`crate::accelerator_memory_budget::plan`]).
 ///
-/// Groups datasets by `DuckDB` instance identity — one per distinct resolved file
-/// path, plus a single shared key for all memory-mode datasets (mirroring the
-/// fork's `DbInstanceKey`) — and classifies each instance as explicit (some
-/// dataset sets `duckdb_memory_limit`, taking the max) or un-limited. Imperfect
-/// path canonicalization only ever OVER-counts instances, yielding smaller, safer
-/// caps.
+/// Groups accelerations by `DuckDB` instance identity — one per distinct resolved
+/// file path, plus a single shared key for all memory-mode accelerations (mirroring
+/// the fork's `DbInstanceKey`) — and classifies each instance as explicit (something
+/// on it sets `duckdb_memory_limit`, taking the max) or un-limited. Imperfect path
+/// canonicalization only ever OVER-counts instances, yielding smaller, safer caps.
+///
+/// Covers both `app.datasets` and `app.views`: a view carries its own `acceleration`
+/// block and creates a `DuckDB` instance exactly as a dataset does, so an instance
+/// the budget cannot see is an instance left at `DuckDB`'s own ~80%-of-RAM default —
+/// the over-commit this budget exists to prevent. Catalogs are excluded deliberately:
+/// they carry `CatalogAcceleration`, whose engine enum admits only Cayenne.
+///
+/// This enumerates component kinds by hand because it runs *before* initialization,
+/// against the Spicepod. It is the pre-init mirror of the `AccelerationSource` trait,
+/// which datasets and views both implement and which is therefore already
+/// kind-agnostic once components exist — the authority after init, but unavailable
+/// to the builder here.
 #[cfg(feature = "duckdb")]
 fn duckdb_budget_inputs(
     app: Option<&Arc<app::App>>,
 ) -> crate::accelerator_memory_budget::DuckDbBudgetInputs {
     use crate::accelerator_memory_budget::DuckDbBudgetInputs;
 
-    /// Per-instance aggregation while grouping datasets by `DbInstanceKey`.
+    /// Per-instance aggregation while grouping accelerations by `DbInstanceKey`.
     #[derive(Default)]
     struct InstanceAgg {
         explicit_max: Option<u64>,
         has_unset: bool,
-        /// Datasets sharing this instance set DIFFERENT explicit `duckdb_memory_limit`
-        /// values. Since the setting is per-instance (last dataset created wins), the
-        /// effective limit is ambiguous — surfaced in the warning.
+        /// Components sharing this instance set DIFFERENT explicit
+        /// `duckdb_memory_limit` values. Since the setting is per-instance (last one
+        /// created wins), the effective limit is ambiguous — surfaced in the warning.
         conflicting_explicit: bool,
     }
 
@@ -1217,8 +1228,18 @@ fn duckdb_budget_inputs(
     let accelerator = crate::dataaccelerator::duckdb::DuckDBAccelerator::default();
     let mut instances: HashMap<String, InstanceAgg> = HashMap::new();
 
-    for dataset in &app.datasets {
-        let Some(accel) = dataset.acceleration.as_ref() else {
+    let accelerated_components = app
+        .datasets
+        .iter()
+        .map(|dataset| (dataset.name.as_str(), dataset.acceleration.as_ref()))
+        .chain(
+            app.views
+                .iter()
+                .map(|view| (view.name.as_str(), view.acceleration.as_ref())),
+        );
+
+    for (name, acceleration) in accelerated_components {
+        let Some(accel) = acceleration else {
             continue;
         };
         if !accel.enabled
@@ -1229,14 +1250,14 @@ fn duckdb_budget_inputs(
         {
             continue;
         }
-        // Instance identity: memory-mode datasets share ONE in-memory instance;
-        // file-mode datasets group by their resolved DuckDB file path.
+        // Instance identity: memory-mode accelerations share ONE in-memory instance;
+        // file-mode ones group by their resolved DuckDB file path.
         let key = if accel.mode == spicepod::acceleration::Mode::Memory {
             "<in-memory>".to_string()
         } else {
             accelerator
-                .spicepod_dataset_duckdb_file_path(dataset)
-                .unwrap_or_else(|| format!("<file:{}>", dataset.name))
+                .spicepod_duckdb_file_path(accel)
+                .unwrap_or_else(|| format!("<file:{name}>"))
         };
         let params = accel
             .params
@@ -1256,7 +1277,7 @@ fn duckdb_budget_inputs(
         match explicit {
             Some(bytes) => {
                 // A different explicit value than one already seen on this instance
-                // means the datasets disagree on the per-instance limit.
+                // means the components disagree on the per-instance limit.
                 if let Some(prev) = agg.explicit_max
                     && prev != bytes
                 {
@@ -1272,8 +1293,9 @@ fn duckdb_budget_inputs(
         if let Some(bytes) = agg.explicit_max {
             inputs.num_explicit_instances += 1;
             inputs.sum_explicit_bytes = inputs.sum_explicit_bytes.saturating_add(bytes);
-            // Inconsistent per-instance limit: some datasets set it and some didn't,
-            // or datasets set different explicit values. Either way it's ambiguous.
+            // Inconsistent per-instance limit: some components set it and some
+            // didn't, or they set different explicit values. Either way it's
+            // ambiguous.
             if agg.has_unset || agg.conflicting_explicit {
                 inputs.has_mixed_instance = true;
             }
@@ -1576,6 +1598,72 @@ mod test {
         }
     }
 
+    /// Builds the `duckdb` acceleration block shared by the budget-adapter tests.
+    #[cfg(feature = "duckdb")]
+    fn duckdb_acceleration(
+        mode: spicepod::acceleration::Mode,
+        params: &[(&str, &str)],
+    ) -> spicepod::acceleration::Acceleration {
+        spicepod::acceleration::Acceleration {
+            enabled: true,
+            engine: Some("duckdb".to_string()),
+            mode,
+            params: Some(spicepod::param::Params::from_string_map(
+                params
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                    .collect::<HashMap<String, String>>(),
+            )),
+            ..spicepod::acceleration::Acceleration::default()
+        }
+    }
+
+    #[cfg(feature = "duckdb")]
+    fn duckdb_ds(
+        name: &str,
+        mode: spicepod::acceleration::Mode,
+        params: &[(&str, &str)],
+    ) -> spicepod::component::dataset::Dataset {
+        let mut ds = spicepod::component::dataset::Dataset::new("dummy:source", name);
+        ds.acceleration = Some(duckdb_acceleration(mode, params));
+        ds
+    }
+
+    #[cfg(feature = "duckdb")]
+    fn duckdb_view(
+        name: &str,
+        mode: spicepod::acceleration::Mode,
+        params: &[(&str, &str)],
+    ) -> spicepod::component::view::View {
+        duckdb_view_with(name, duckdb_acceleration(mode, params))
+    }
+
+    #[cfg(feature = "duckdb")]
+    fn duckdb_view_with(
+        name: &str,
+        acceleration: spicepod::acceleration::Acceleration,
+    ) -> spicepod::component::view::View {
+        spicepod::component::view::View::new(name.to_string())
+            .with_sql("SELECT 1")
+            .with_acceleration(acceleration)
+    }
+
+    /// Runs the budget adapter over an app built from `datasets` and `views`.
+    #[cfg(feature = "duckdb")]
+    fn budget_inputs_for(
+        datasets: Vec<spicepod::component::dataset::Dataset>,
+        views: Vec<spicepod::component::view::View>,
+    ) -> crate::accelerator_memory_budget::DuckDbBudgetInputs {
+        let mut builder = app::AppBuilder::new("mem-budget-test");
+        for dataset in datasets {
+            builder = builder.with_dataset(dataset);
+        }
+        for view in views {
+            builder = builder.with_view(view);
+        }
+        duckdb_budget_inputs(Some(&std::sync::Arc::new(builder.build())))
+    }
+
     /// The `DuckDB` budget adapter groups datasets by instance identity (distinct
     /// file paths → distinct instances; a shared file or all memory-mode datasets →
     /// one), classifies explicit vs un-limited, and ignores non-DuckDB engines.
@@ -1584,35 +1672,8 @@ mod test {
     fn test_duckdb_budget_inputs_groups_by_instance() {
         use spicepod::acceleration::{Acceleration, Mode};
         use spicepod::component::dataset::Dataset;
-        use spicepod::param::Params;
-        use std::sync::Arc;
 
-        fn duckdb_ds(name: &str, mode: Mode, params: &[(&str, &str)]) -> Dataset {
-            let mut ds = Dataset::new("dummy:source", name);
-            ds.acceleration = Some(Acceleration {
-                enabled: true,
-                engine: Some("duckdb".to_string()),
-                mode,
-                params: Some(Params::from_string_map(
-                    params
-                        .iter()
-                        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-                        .collect::<HashMap<String, String>>(),
-                )),
-                ..Acceleration::default()
-            });
-            ds
-        }
-
-        let inputs_for = |datasets: Vec<Dataset>| {
-            let app = datasets
-                .into_iter()
-                .fold(app::AppBuilder::new("mem-budget-test"), |b, ds| {
-                    b.with_dataset(ds)
-                })
-                .build();
-            duckdb_budget_inputs(Some(&Arc::new(app)))
-        };
+        let inputs_for = |datasets: Vec<Dataset>| budget_inputs_for(datasets, vec![]);
 
         // Two file-mode datasets on DISTINCT files → two un-limited instances.
         let inputs = inputs_for(vec![
@@ -1697,6 +1758,135 @@ mod test {
         assert!(inputs.has_mixed_instance, "conflicting per-instance limits");
         // The instance's ceiling uses the max of the conflicting values.
         assert_eq!(inputs.sum_explicit_bytes, 4 * 1024 * 1024 * 1024);
+    }
+
+    /// A view carrying its own `acceleration` block creates a `DuckDB` instance just
+    /// as a dataset does, so the budget must count it: a view-only pod is coordinated
+    /// at all, a mixed pod divides by every instance, and a view shares instance
+    /// identity (and the explicit/un-limited classification) with a dataset on the
+    /// same file.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn test_duckdb_budget_inputs_counts_accelerated_views() {
+        use spicepod::acceleration::{Acceleration, Mode};
+        use spicepod::component::view::View;
+
+        // A pod whose only DuckDB accelerators are on views is still coordinated —
+        // before the fix this reported zero instances, so the builder took its
+        // early-out and every view instance kept DuckDB's ~80%-of-RAM default.
+        let inputs = budget_inputs_for(
+            vec![],
+            vec![duckdb_view(
+                "sales_summary",
+                Mode::File,
+                &[("duckdb_file", "/tmp/spice-mbt-view-only.db")],
+            )],
+        );
+        assert_eq!(inputs.num_unset_instances, 1);
+        assert_eq!(inputs.num_explicit_instances, 0);
+        assert_eq!(
+            inputs.unset_instance_labels,
+            vec!["/tmp/spice-mbt-view-only.db".to_string()]
+        );
+
+        // A mixed pod divides the DuckDB pool by every instance, dataset or view.
+        let inputs = budget_inputs_for(
+            vec![duckdb_ds(
+                "orders",
+                Mode::File,
+                &[("duckdb_file", "/tmp/spice-mbt-view-ds.db")],
+            )],
+            vec![duckdb_view(
+                "orders_summary",
+                Mode::File,
+                &[("duckdb_file", "/tmp/spice-mbt-view-v.db")],
+            )],
+        );
+        assert_eq!(inputs.num_unset_instances, 2);
+
+        // A view on the SAME file as a dataset is the SAME instance, not a second one.
+        let inputs = budget_inputs_for(
+            vec![duckdb_ds(
+                "orders",
+                Mode::File,
+                &[("duckdb_file", "/tmp/spice-mbt-view-shared.db")],
+            )],
+            vec![duckdb_view(
+                "orders_summary",
+                Mode::File,
+                &[("duckdb_file", "/tmp/spice-mbt-view-shared.db")],
+            )],
+        );
+        assert_eq!(inputs.num_unset_instances, 1);
+        assert_eq!(inputs.num_explicit_instances, 0);
+
+        // A memory-mode view joins the one shared in-memory instance.
+        let inputs = budget_inputs_for(
+            vec![duckdb_ds("orders", Mode::Memory, &[])],
+            vec![duckdb_view("orders_summary", Mode::Memory, &[])],
+        );
+        assert_eq!(inputs.num_unset_instances, 1);
+
+        // A view's explicit `duckdb_memory_limit` counts toward the explicit sum.
+        let inputs = budget_inputs_for(
+            vec![],
+            vec![duckdb_view(
+                "sales_summary",
+                Mode::File,
+                &[
+                    ("duckdb_file", "/tmp/spice-mbt-view-explicit.db"),
+                    ("duckdb_memory_limit", "2GiB"),
+                ],
+            )],
+        );
+        assert_eq!(inputs.num_explicit_instances, 1);
+        assert_eq!(inputs.num_unset_instances, 0);
+        assert_eq!(inputs.sum_explicit_bytes, 2 * 1024 * 1024 * 1024);
+
+        // An un-limited view sharing a dataset's instance makes that instance mixed:
+        // DuckDB's `memory_limit` is per-instance, so the effective limit is ambiguous.
+        let inputs = budget_inputs_for(
+            vec![duckdb_ds(
+                "orders",
+                Mode::File,
+                &[
+                    ("duckdb_file", "/tmp/spice-mbt-view-mixed.db"),
+                    ("duckdb_memory_limit", "2GiB"),
+                ],
+            )],
+            vec![duckdb_view(
+                "orders_summary",
+                Mode::File,
+                &[("duckdb_file", "/tmp/spice-mbt-view-mixed.db")],
+            )],
+        );
+        assert_eq!(inputs.num_explicit_instances, 1);
+        assert_eq!(inputs.num_unset_instances, 0);
+        assert!(
+            inputs.has_mixed_instance,
+            "an un-limited view on an explicitly-limited instance is a mixed instance"
+        );
+
+        // A disabled or non-DuckDB view creates no instance.
+        let arrow_view = duckdb_view_with(
+            "arrow_summary",
+            Acceleration {
+                enabled: true,
+                engine: None,
+                mode: Mode::Memory,
+                ..Acceleration::default()
+            },
+        );
+        let mut disabled = duckdb_acceleration(
+            Mode::File,
+            &[("duckdb_file", "/tmp/spice-mbt-view-disabled.db")],
+        );
+        disabled.enabled = false;
+        let disabled_view = duckdb_view_with("disabled_summary", disabled);
+        let unaccelerated_view = View::new("plain_summary".to_string()).with_sql("SELECT 1");
+        let inputs = budget_inputs_for(vec![], vec![arrow_view, disabled_view, unaccelerated_view]);
+        assert_eq!(inputs.num_unset_instances, 0);
+        assert_eq!(inputs.num_explicit_instances, 0);
     }
 
     #[test]

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -268,7 +268,7 @@ impl DuckDBAccelerator {
                         | spicepod::acceleration::Mode::FileCreate
                         | spicepod::acceleration::Mode::FileUpdate
                 ) && self
-                    .spicepod_dataset_duckdb_file_path(spicepod_ds)
+                    .spicepod_duckdb_file_path(acceleration)
                     .is_some_and(|dataset_file_path| dataset_file_path == this_file_path)
                 {
                     instance_usage += 1;
@@ -330,7 +330,7 @@ impl DuckDBAccelerator {
             ) {
                 continue;
             }
-            let Some(peer_path) = self.spicepod_dataset_duckdb_file_path(peer) else {
+            let Some(peer_path) = self.spicepod_duckdb_file_path(acceleration) else {
                 continue;
             };
 
@@ -352,11 +352,16 @@ impl DuckDBAccelerator {
         Ok(())
     }
 
-    pub(crate) fn spicepod_dataset_duckdb_file_path(
+    /// The `DuckDB` file path an acceleration block resolves to, read straight from
+    /// the Spicepod rather than from an initialized component.
+    ///
+    /// Takes the acceleration block alone because the path depends only on it — the
+    /// same block on a dataset or on a view names the same file, and therefore the
+    /// same `DuckDB` instance.
+    pub(crate) fn spicepod_duckdb_file_path(
         &self,
-        dataset: &spicepod::component::dataset::Dataset,
+        acceleration: &spicepod::acceleration::Acceleration,
     ) -> Option<String> {
-        let acceleration = dataset.acceleration.as_ref()?;
         let mut params = acceleration
             .params
             .as_ref()


### PR DESCRIPTION
## Summary

The coordinated DuckDB memory budget sized itself from `app.datasets` alone. A **view** can carry its own `acceleration` block and creates a real DuckDB instance exactly as a dataset does, so every DuckDB-accelerated view was invisible to the budget — the exact over-commit the budget exists to prevent.

`duckdb_budget_inputs` (`crates/runtime/src/builder.rs`) iterated `for dataset in &app.datasets` and never looked at `app.views`, with two consequences:

**1. A pod whose DuckDB accelerators are all on views got no coordination at all.** With no DuckDB *datasets*, `num_unset_instances == 0 && num_explicit_instances == 0`, so the builder took its early-out: `publish_duckdb_budget(0, 0)` and `query_pool_cap_bytes = None`. `duckdb_auto_memory_limit_option()` then returned `None`, so no `SET memory_limit` was applied and each view's instance ran at DuckDB's own ~80%-of-host-RAM default, stacked on the 90% query pool. Silently — the planner never ran, so there was no warning either.

```yaml
views:
  - name: sales_summary
    sql: SELECT ... FROM ...
    acceleration:
      enabled: true
      engine: duckdb
      mode: file
```

**2. Mixed pods under-counted the divisor.** With N DuckDB datasets and M DuckDB views, `per_instance_cap_bytes` was `duckdb_pool_total / N`, but every un-limited instance applies that published cap — views included, since the accelerator reads the same global — so the applied aggregate ceiling was `(N + M) / N` times the planned budget. `duckdb_reservation_bytes` was under-stated the same way, and it is what the Cayenne in-memory CDC tier sampler and the query-pool carve read to stay out of DuckDB's reserved room.

The runtime already knew views make DuckDB instances: `AccelerationSource::initialized_sources` includes `get_initialized_views` under `#[cfg(feature = "duckdb")]` precisely so `instance_has_explicit_limit_sibling` sees a view sibling. Only the budget planner's input adapter was dataset-only, so the two disagreed about which instances exist.

Fixes #12123

## Changes

- `duckdb_budget_inputs` iterates `app.datasets` **and** `app.views`, chaining `(name, acceleration)` pairs through the identical grouping and classification logic. A view therefore shares instance identity with a dataset on the same file, joins the one shared in-memory instance in `mode: memory`, contributes its explicit `duckdb_memory_limit` to `sum_explicit_bytes`, and marks an instance `has_mixed_instance` when it is un-limited alongside an explicitly-limited sibling.
- `DuckDBAccelerator::spicepod_dataset_duckdb_file_path(&Dataset)` → `spicepod_duckdb_file_path(&Acceleration)`. The resolved path depends only on the acceleration block, so one helper now serves both datasets and views. Behavior-preserving for the two existing callers (`get_num_accelerating_datasets`, `validate_replace_file_peers`), which each already hold the acceleration block they were reaching through the dataset for.
- Doc comments on `DuckDbBudgetInputs` and the adapter updated — it is no longer "a thin adapter over `app.datasets`".

### Deliberately out of scope

Sibling `app.datasets`-only walks were reviewed and left alone, filed as #12160: `get_num_accelerating_datasets` (sizes the connection pool; predates this feature and changing it resizes pools on existing deployments), `validate_replace_file_peers` (widening it starts rejecting configurations that load today), and the two Cayenne walks in `builder.rs` (different subsystem, and a view has no CDC source).

Catalogs are excluded on purpose and the adapter's doc comment says so: `Catalog::acceleration` is a `CatalogAcceleration`, a distinct type whose engine enum admits only `Cayenne`, so a catalog cannot declare a DuckDB instance.

#12160 also carries the deeper cleanup this review surfaced — an `App::accelerations()` helper so "which component kinds declare an acceleration" lives in one place instead of being hand-chained in several. That touches `crates/app` and three unrelated call sites, so it is not folded into this fix; the adapter's doc comment records why the chain is hand-rolled here (it runs pre-init against the Spicepod, mirroring the `AccelerationSource` trait that is already kind-agnostic once components exist).

## Test plan

- New `test_duckdb_budget_inputs_counts_accelerated_views` in `crates/runtime/src/builder.rs` covers the view-only pod (1 instance where trunk reported 0, including the `unset_instance_labels` entry the warning prints), the mixed pod (2 instances), a view sharing a dataset's file (1 instance, not 2), a memory-mode view joining the shared in-memory instance, a view's own `duckdb_memory_limit` reaching `sum_explicit_bytes`, an un-limited view making an explicitly-limited instance `has_mixed_instance`, and the ignored cases (Arrow-engine view, `enabled: false`, no acceleration block). Every view assertion fails on trunk.
- The existing `test_duckdb_budget_inputs_groups_by_instance` is unchanged in behavior; the two tests now share one set of fixtures (`duckdb_acceleration` / `duckdb_ds` / `duckdb_view` / `budget_inputs_for`) rather than each defining its own app-construction path.
- `make lint`
- `make test`

## Checklist

- [ ] Tests added for the regression and its edge cases
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] No behavior change for pods without accelerated views
