### PR TITLE
fix(runtime): return from a readiness wait when the runtime shuts down (fixes #12125)

### DIFF
--- a/crates/runtime-status/src/lib.rs
+++ b/crates/runtime-status/src/lib.rs
@@ -48,6 +48,24 @@ pub enum RuntimeReadyState {
     OnRegistration,
 }
 
+/// Why a readiness wait returned.
+///
+/// Every `wait_for_*` helper races the awaited status against the runtime's
+/// shutdown token, so a wait always returns — but only [`WaitOutcome::Reached`]
+/// means the status was actually observed. Callers that go on to do work must
+/// check this: treating [`WaitOutcome::ShuttingDown`] as ready would start work
+/// (a refresh, a checkpoint, a scheduler ack) on a runtime that is tearing down.
+#[must_use]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaitOutcome {
+    /// The awaited status was observed.
+    Reached,
+    /// The runtime began shutting down before the awaited status was observed
+    /// (or the status tracker itself was dropped, which only happens at
+    /// teardown). The awaited status was never reached.
+    ShuttingDown,
+}
+
 /// Per-component state stored in the `statuses` map.
 ///
 /// The `notifier` is created lazily the first time a caller subscribes via
@@ -433,42 +451,60 @@ impl RuntimeStatus {
         }
     }
 
-    /// Internal helper to wait for a component to become ready.
-    async fn wait_for_component_ready(&self, component_name: &str) {
+    /// Waits until a component's status satisfies `is_satisfied`, or the runtime
+    /// starts shutting down — whichever happens first.
+    async fn wait_for_component_status(
+        &self,
+        component_name: &str,
+        is_satisfied: impl Fn(&ComponentStatus) -> bool,
+    ) -> WaitOutcome {
         let mut receiver = self.get_or_create_notifier(component_name);
 
         loop {
-            // Check current value (handles already-ready case)
-            if *receiver.borrow() == ComponentStatus::Ready {
-                return;
+            // Check the current value first, so an already-satisfied component
+            // returns without awaiting anything.
+            if is_satisfied(&receiver.borrow()) {
+                return WaitOutcome::Reached;
             }
 
-            // Wait for next change; return if channel closed (runtime shutting down)
-            if receiver.changed().await.is_err() {
-                return;
+            // `mark_shutdown` cancels the shutdown token but does NOT close the
+            // per-component watch channels — their senders live in the `statuses`
+            // map, which the still-alive tracker owns and never removes from — so
+            // without racing the token a component that never reaches its target
+            // status parks this task forever. `watch::Receiver::changed` is
+            // cancel-safe, so losing the race drops no status change.
+            tokio::select! {
+                changed = receiver.changed() => {
+                    if changed.is_err() {
+                        // The only sender was dropped, i.e. the tracker itself is
+                        // gone: the awaited status can never arrive.
+                        return WaitOutcome::ShuttingDown;
+                    }
+                }
+                () = self.shutdown_token.cancelled() => return WaitOutcome::ShuttingDown,
             }
         }
+    }
+
+    /// Internal helper to wait for a component to become ready.
+    async fn wait_for_component_ready(&self, component_name: &str) -> WaitOutcome {
+        self.wait_for_component_status(component_name, |status| *status == ComponentStatus::Ready)
+            .await
     }
 
     /// Waits for a component to leave the `Initializing` state — used by
     /// callers that only need the component registered, not fully ready.
-    async fn wait_for_component_registered(&self, component_name: &str) {
-        let mut receiver = self.get_or_create_notifier(component_name);
-
-        loop {
-            if !matches!(*receiver.borrow(), ComponentStatus::Initializing) {
-                return;
-            }
-            if receiver.changed().await.is_err() {
-                return;
-            }
-        }
+    async fn wait_for_component_registered(&self, component_name: &str) -> WaitOutcome {
+        self.wait_for_component_status(component_name, |status| {
+            !matches!(status, ComponentStatus::Initializing)
+        })
+        .await
     }
 
     /// Waits for a dataset to become ready.
-    pub async fn wait_for_dataset_ready(&self, dataset: &TableReference) {
+    pub async fn wait_for_dataset_ready(&self, dataset: &TableReference) -> WaitOutcome {
         let component_name = format!("dataset:{dataset}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for a dataset to be registered (any status other than
@@ -476,76 +512,83 @@ impl RuntimeStatus {
     /// provider to exist, not for the dataset to be fully loaded — e.g.
     /// scheduler-side partition discovery, where waiting for `Ready`
     /// would deadlock because `Ready` is gated on executor data loads.
-    pub async fn wait_for_dataset_registered(&self, dataset: &TableReference) {
+    pub async fn wait_for_dataset_registered(&self, dataset: &TableReference) -> WaitOutcome {
         let component_name = format!("dataset:{dataset}");
-        self.wait_for_component_registered(&component_name).await;
+        self.wait_for_component_registered(&component_name).await
     }
 
     /// Waits for a model to become ready.
-    pub async fn wait_for_model_ready(&self, model_name: &str) {
+    pub async fn wait_for_model_ready(&self, model_name: &str) -> WaitOutcome {
         let component_name = format!("model:{model_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for a catalog to become ready.
-    pub async fn wait_for_catalog_ready(&self, catalog_name: &str) {
+    pub async fn wait_for_catalog_ready(&self, catalog_name: &str) -> WaitOutcome {
         let component_name = format!("catalog:{catalog_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for a tool to become ready.
-    pub async fn wait_for_tool_ready(&self, tool_name: &str) {
+    pub async fn wait_for_tool_ready(&self, tool_name: &str) -> WaitOutcome {
         let component_name = format!("tool:{tool_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for a tool catalog to become ready.
-    pub async fn wait_for_tool_catalog_ready(&self, catalog_name: &str) {
+    pub async fn wait_for_tool_catalog_ready(&self, catalog_name: &str) -> WaitOutcome {
         let component_name = format!("tool_catalog:{catalog_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for an LLM to become ready.
-    pub async fn wait_for_llm_ready(&self, model_name: &str) {
+    pub async fn wait_for_llm_ready(&self, model_name: &str) -> WaitOutcome {
         let component_name = format!("llm:{model_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for an embedding model to become ready.
-    pub async fn wait_for_embedding_ready(&self, model_name: &str) {
+    pub async fn wait_for_embedding_ready(&self, model_name: &str) -> WaitOutcome {
         let component_name = format!("embedding:{model_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for a view to become ready.
-    pub async fn wait_for_view_ready(&self, view_name: &TableReference) {
+    pub async fn wait_for_view_ready(&self, view_name: &TableReference) -> WaitOutcome {
         let component_name = format!("view:{view_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for a worker to become ready.
-    pub async fn wait_for_worker_ready(&self, worker_name: &str) {
+    pub async fn wait_for_worker_ready(&self, worker_name: &str) -> WaitOutcome {
         let component_name = format!("worker:{worker_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for a cluster node to become ready.
-    pub async fn wait_for_cluster_ready(&self, node_name: &str) {
+    pub async fn wait_for_cluster_ready(&self, node_name: &str) -> WaitOutcome {
         let component_name = format!("cluster:{node_name}");
-        self.wait_for_component_ready(&component_name).await;
+        self.wait_for_component_ready(&component_name).await
     }
 
     /// Waits for the entire runtime to be ready (all registered components have been ready at least once).
     ///
     /// This polls the `is_ready()` status at a regular interval until the runtime is ready.
     /// If the runtime is already ready, this returns immediately.
-    pub async fn wait_for_ready(&self) {
+    ///
+    /// Returns [`WaitOutcome::ShuttingDown`] instead of polling forever once
+    /// shutdown starts: `is_ready()` reports `false` for the rest of the process
+    /// lifetime from that point, so the poll could never succeed.
+    pub async fn wait_for_ready(&self) -> WaitOutcome {
         const POLL_INTERVAL: Duration = Duration::from_millis(100);
         loop {
             if self.is_ready() {
-                return;
+                return WaitOutcome::Reached;
             }
-            tokio::time::sleep(POLL_INTERVAL).await;
+            tokio::select! {
+                () = tokio::time::sleep(POLL_INTERVAL) => {}
+                () = self.shutdown_token.cancelled() => return WaitOutcome::ShuttingDown,
+            }
         }
     }
 }
@@ -555,6 +598,11 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    /// How long a shutdown-aware wait gets before the test calls it hung. Only an
+    /// upper bound on a wake-up that should be immediate — before the fix these
+    /// waits never returned at all, so any finite bound fails on the old code.
+    const SHUTDOWN_WAIT_BOUND: Duration = Duration::from_secs(5);
 
     #[test]
     fn test_get_component_status() {
@@ -691,7 +739,10 @@ mod tests {
         status.update_dataset(&dataset, ComponentStatus::Ready);
 
         // Should return immediately
-        status.wait_for_dataset_ready(&dataset).await;
+        assert_eq!(
+            status.wait_for_dataset_ready(&dataset).await,
+            WaitOutcome::Reached
+        );
     }
 
     #[tokio::test]
@@ -711,7 +762,10 @@ mod tests {
         });
 
         // Wait for ready
-        status.wait_for_dataset_ready(&dataset).await;
+        assert_eq!(
+            status.wait_for_dataset_ready(&dataset).await,
+            WaitOutcome::Reached
+        );
     }
 
     #[tokio::test]
@@ -728,7 +782,10 @@ mod tests {
             status_clone.update_dataset(&dataset_clone, ComponentStatus::Ready);
         });
 
-        status.wait_for_dataset_ready(&dataset).await;
+        assert_eq!(
+            status.wait_for_dataset_ready(&dataset).await,
+            WaitOutcome::Reached
+        );
     }
 
     #[tokio::test]
@@ -754,8 +811,14 @@ mod tests {
         // Set ready - both should wake up
         status.update_dataset(&dataset, ComponentStatus::Ready);
 
-        handle1.await.expect("task 1 should complete");
-        handle2.await.expect("task 2 should complete");
+        assert_eq!(
+            handle1.await.expect("task 1 should complete"),
+            WaitOutcome::Reached
+        );
+        assert_eq!(
+            handle2.await.expect("task 2 should complete"),
+            WaitOutcome::Reached
+        );
     }
 
     #[tokio::test]
@@ -775,7 +838,143 @@ mod tests {
         });
 
         // Wait indefinitely
-        status.wait_for_dataset_ready(&dataset).await;
+        assert_eq!(
+            status.wait_for_dataset_ready(&dataset).await,
+            WaitOutcome::Reached
+        );
+    }
+
+    /// A component wait must return once shutdown starts, even though the
+    /// component never reaches `Ready`: `mark_shutdown` cancels the shutdown
+    /// token but leaves the per-component watch channel open, so a wait that only
+    /// awaited `changed()` parked forever.
+    #[tokio::test]
+    async fn test_wait_for_dataset_ready_returns_on_shutdown() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("never_ready");
+
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+
+        let waiter = {
+            let status = Arc::clone(&status);
+            let dataset = dataset.clone();
+            tokio::spawn(async move { status.wait_for_dataset_ready(&dataset).await })
+        };
+
+        status.mark_shutdown();
+
+        let outcome = tokio::time::timeout(SHUTDOWN_WAIT_BOUND, waiter)
+            .await
+            .expect("wait_for_dataset_ready should return once shutdown starts")
+            .expect("waiter task should not panic");
+        assert_eq!(outcome, WaitOutcome::ShuttingDown);
+        // The component is still Initializing, so the caller must be told the
+        // status was never reached rather than being allowed to proceed.
+        assert_eq!(
+            status.get_component_status("dataset:never_ready"),
+            Some(ComponentStatus::Initializing)
+        );
+    }
+
+    /// Same for the registered-only wait, whose loop had the same shape.
+    #[tokio::test]
+    async fn test_wait_for_dataset_registered_returns_on_shutdown() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("never_registered");
+
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+
+        let waiter = {
+            let status = Arc::clone(&status);
+            let dataset = dataset.clone();
+            tokio::spawn(async move { status.wait_for_dataset_registered(&dataset).await })
+        };
+
+        status.mark_shutdown();
+
+        let outcome = tokio::time::timeout(SHUTDOWN_WAIT_BOUND, waiter)
+            .await
+            .expect("wait_for_dataset_registered should return once shutdown starts")
+            .expect("waiter task should not panic");
+        assert_eq!(outcome, WaitOutcome::ShuttingDown);
+    }
+
+    /// A wait entered *after* shutdown has already started must return without
+    /// awaiting a status change that can never come.
+    #[tokio::test]
+    async fn test_wait_for_dataset_ready_returns_when_already_shut_down() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("never_ready");
+
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+        status.mark_shutdown();
+
+        let outcome =
+            tokio::time::timeout(SHUTDOWN_WAIT_BOUND, status.wait_for_dataset_ready(&dataset))
+                .await
+                .expect("wait_for_dataset_ready should return immediately when already shut down");
+        assert_eq!(outcome, WaitOutcome::ShuttingDown);
+    }
+
+    /// A component that is already `Ready` when shutdown has started still
+    /// reports `Reached` — shutdown only reports the status it prevented.
+    #[tokio::test]
+    async fn test_wait_for_dataset_ready_after_shutdown_still_reports_ready_component() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("ready_dataset");
+
+        status.update_dataset(&dataset, ComponentStatus::Ready);
+        status.mark_shutdown();
+
+        assert_eq!(
+            status.wait_for_dataset_ready(&dataset).await,
+            WaitOutcome::Reached
+        );
+    }
+
+    /// `wait_for_ready` polls `is_ready()`, which returns `false` for the rest of
+    /// the process once shutdown starts — so without racing the shutdown token it
+    /// busy-polled forever.
+    #[tokio::test]
+    async fn test_wait_for_ready_returns_on_shutdown() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("never_ready");
+
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+        assert!(!status.is_ready());
+
+        let waiter = {
+            let status = Arc::clone(&status);
+            tokio::spawn(async move { status.wait_for_ready().await })
+        };
+
+        status.mark_shutdown();
+
+        let outcome = tokio::time::timeout(SHUTDOWN_WAIT_BOUND, waiter)
+            .await
+            .expect("wait_for_ready should return once shutdown starts")
+            .expect("waiter task should not panic");
+        assert_eq!(outcome, WaitOutcome::ShuttingDown);
+    }
+
+    /// Shutdown must not be the only way out: a wait still blocks while the
+    /// runtime is running and not yet ready.
+    #[tokio::test]
+    async fn test_wait_for_ready_still_blocks_while_not_ready() {
+        let status = RuntimeStatus::new();
+        let dataset = TableReference::bare("slow_dataset");
+
+        status.update_dataset(&dataset, ComponentStatus::Initializing);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), status.wait_for_ready())
+                .await
+                .is_err(),
+            "wait_for_ready should still block while the runtime is running and not ready"
+        );
+
+        status.update_dataset(&dataset, ComponentStatus::Ready);
+        assert_eq!(status.wait_for_ready().await, WaitOutcome::Reached);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1110,7 +1110,14 @@ impl Refresher {
                 let refresh_clone = Arc::clone(&self.refresh);
 
                 tokio::spawn(async move {
-                    runtime_status_clone.wait_for_ready().await;
+                    // A shutdown before readiness means the initial load never
+                    // completed — checkpointing a partial accelerator would
+                    // publish it as a complete snapshot.
+                    if runtime_status_clone.wait_for_ready().await
+                        == crate::status::WaitOutcome::ShuttingDown
+                    {
+                        return;
+                    }
                     if !bootstrap_status.is_bootstrapped() {
                         let refresh_sql = refresh_clone
                             .read()

--- a/crates/runtime/src/accelerated_table/snapshots.rs
+++ b/crates/runtime/src/accelerated_table/snapshots.rs
@@ -17,7 +17,7 @@ use crate::dataaccelerator::AccelerationSource;
 use crate::dataaccelerator::DataAccelerator;
 use crate::dataaccelerator::ReloadProviderFactory;
 use crate::dataaccelerator::swappable::SwappableTableProvider;
-use crate::status::RuntimeStatus;
+use crate::status::{RuntimeStatus, WaitOutcome};
 use arrow_schema::{FieldRef, Schema, SchemaRef};
 use datafusion::common::TableReference;
 use datafusion::datasource::TableProvider;
@@ -244,8 +244,11 @@ pub fn spawn_snapshot_interval_task(
     );
 
     Some(tokio::spawn(async move {
-        // Wait for the runtime to become ready
-        runtime_status.wait_for_ready().await;
+        // Wait for the runtime to become ready. A shutdown that starts first
+        // means the runtime never became ready, so there is nothing to snapshot.
+        if runtime_status.wait_for_ready().await == WaitOutcome::ShuttingDown {
+            return;
+        }
 
         // Determine the initial delay based on last checkpoint time
         let initial_delay = if bootstrap_status.is_bootstrapped() {
@@ -371,7 +374,9 @@ pub fn create_periodic_snapshot_callback(
             let accelerator_clone = accelerator.clone();
             let refresh_clone = Arc::clone(&refresh);
             tokio::spawn(async move {
-                runtime_status.wait_for_ready().await;
+                if runtime_status.wait_for_ready().await == WaitOutcome::ShuttingDown {
+                    return;
+                }
                 if !bootstrap_status.is_bootstrapped() {
                     let refresh_sql = refresh_clone
                         .read()

--- a/crates/runtime/src/cluster/partition/discovery.rs
+++ b/crates/runtime/src/cluster/partition/discovery.rs
@@ -142,7 +142,13 @@ async fn execute_partition_discovery_query(
     // dataset stays `Refreshing` until executors ack their partition loads,
     // and PartitionsLoaded acks can't happen until discovery completes —
     // waiting for `Ready` would deadlock.
-    df.runtime_status().wait_for_dataset_registered(table).await;
+    if df.runtime_status().wait_for_dataset_registered(table).await
+        == crate::status::WaitOutcome::ShuttingDown
+    {
+        return Err(Error::ShutdownBeforeTableRegistered {
+            table: table_name.clone(),
+        });
+    }
 
     // Must get table source of `AcceleratedTable` to get true value of partition.
     // The table may be registered directly as AcceleratedTable, or wrapped in a

--- a/crates/runtime/src/cluster/partition/mod.rs
+++ b/crates/runtime/src/cluster/partition/mod.rs
@@ -80,6 +80,11 @@ pub enum Error {
     #[snafu(display("Timed out waiting for table {table} to be registered"))]
     TableRegistrationTimeout { table: String },
 
+    #[snafu(display(
+        "Stopped waiting for table {table} to be registered: the runtime is shutting down"
+    ))]
+    ShutdownBeforeTableRegistered { table: String },
+
     #[snafu(display("Table {table} is not an accelerated table"))]
     NotAcceleratedTable { table: String },
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -1506,9 +1506,15 @@ impl Runtime {
                 // relying on the `Notify`-based completion handle (which is
                 // edge-triggered and can race with this spawn for fast
                 // initial refreshes).
-                runtime_status
+                // A shutdown before the dataset became ready means the initial
+                // load never finished: there is no partition state worth acking.
+                if runtime_status
                     .wait_for_dataset_ready(&dataset_table_ref)
-                    .await;
+                    .await
+                    == crate::status::WaitOutcome::ShuttingDown
+                {
+                    return;
+                }
                 // After the executor's initial load for this dataset finishes,
                 // ack the scheduler with the partition expressions we currently
                 // hold. This is the executor → scheduler readiness signal that

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -19,4 +19,4 @@ limitations under the License.
 //! and await status. Re-exported here so in-crate callers keep using
 //! `crate::status::{RuntimeStatus, ComponentStatus, ...}`.
 
-pub use runtime_status::{ComponentStatus, RuntimeReadyState, RuntimeStatus};
+pub use runtime_status::{ComponentStatus, RuntimeReadyState, RuntimeStatus, WaitOutcome};


### PR DESCRIPTION
## Summary

`RuntimeStatus`'s readiness-wait helpers never observed the shutdown `CancellationToken`, so a task awaiting one could park or busy-poll for the rest of the process once shutdown began.

- `wait_for_component_ready` / `wait_for_component_registered` looped on `receiver.changed()`, with a comment claiming the wait would "return if channel closed (runtime shutting down)". That never happens: `mark_shutdown()` cancels `shutdown_token`, but the per-component watch **senders live in the `statuses` map** — owned by the still-alive tracker, and never removed from it (there is no `remove`/`retain` anywhere in the crate). So a component that never reached its target status parked its awaiter indefinitely.
- `wait_for_ready` polled `is_ready()` every 100 ms, and `is_ready()` returns `false` for the remainder of the process once `is_shutdown` is set — so it busy-polled forever.

Fixes #12125

## The part the issue's suggested fix doesn't cover

Racing the shutdown token is necessary but not sufficient on its own. These waits return `()`, so a wait that returns early on shutdown tells its caller *"the component is ready"*. The three production `wait_for_ready()` callers immediately go on to write:

- `accelerated_table/snapshots.rs` (`spawn_snapshot_interval_task`, `create_periodic_snapshot_callback`)
- `accelerated_table/refresh.rs` (the initial checkpoint/snapshot task)

Each of those would then checkpoint or snapshot an accelerator whose initial load never completed, publishing a partial accelerator as a complete snapshot. Fixing a hang by introducing a bad snapshot is not a fix, so the waits now report *why* they returned:

```rust
#[must_use]
pub enum WaitOutcome {
    Reached,       // the awaited status was observed
    ShuttingDown,  // shutdown started first — the status was never reached
}
```

`#[must_use]` is on the enum rather than on the `async fn` (on the fn it would only warn about an unused *future*), so every caller has to decide what shutdown means for it.

## Changes

`crates/runtime-status/src/lib.rs`

- Added `WaitOutcome`; every `wait_for_*` helper and `wait_for_ready` now returns it.
- Both component waits race `shutdown_token.cancelled()` against `receiver.changed()`. `watch::Receiver::changed` is cancel-safe, so losing the race drops no status change. A closed channel (only possible once the tracker itself is dropped, i.e. teardown) also reports `ShuttingDown`, since the awaited status can no longer arrive.
- `wait_for_ready` races the shutdown token against its poll interval instead of sleeping unconditionally.
- The two component-wait loops were identical apart from their predicate, so they collapse into one `wait_for_component_status(name, impl Fn(&ComponentStatus) -> bool)`; `wait_for_component_ready` and `wait_for_component_registered` are now one line each.

Call sites (all 5 in the repo) bail on `ShuttingDown`:

- `accelerated_table/snapshots.rs` ×2 and `accelerated_table/refresh.rs` ×1 — return without checkpointing/snapshotting.
- `init/dataset.rs` — skip the executor→scheduler partition ack; a load that never finished has no partition state worth acking.
- `cluster/partition/discovery.rs` — return the new `Error::ShutdownBeforeTableRegistered`. Deliberately an error and **not** `Ok(vec![])`: reporting "no partitions discovered" for a wait that was cut short would be silently wrong.

`crate::status` re-exports `WaitOutcome` alongside the other `runtime_status` types.

## Test plan

- `make lint`
- `make test`
- Six new tests in `runtime-status`: each of the three waits returns `ShuttingDown` after `mark_shutdown()`; a wait entered when shutdown has *already* started returns without awaiting; an already-`Ready` component still reports `Reached` even after `mark_shutdown()` (shutdown only reports the status it actually prevented); and a negative test asserting `wait_for_ready` still blocks while the runtime is running and not yet ready — so "returns promptly" can't be satisfied by returning unconditionally.
- The shutdown tests need no ordering between spawning the waiter and calling `mark_shutdown()`: an already-cancelled token makes the `cancelled()` branch fire immediately, so both interleavings return.
- Verified as true regression tests by neutering both `select!` races: exactly the 4 shutdown tests fail (each `Elapsed(())` at its 5 s bound, i.e. the old hang) while **all 13 other tests pass unchanged** — so no non-shutdown behavior changed. With the fix, 17 passed / 0 failed.

## Checklist

- [x] Root cause identified and stated (including why the channel-close path the old comment relied on never fires)
- [x] Regression tests that fail before the fix and pass after
- [x] Negative test so the fix can't be satisfied by always returning
- [x] Every in-repo call site updated rather than inheriting a silently-wrong "ready"
- [x] No lock or watch guard held across an `.await`
- [x] `cargo fmt --check` clean; `cargo check -p runtime --features duckdb --all-targets` green (clippy runs in the sign-off gate)
