### PR TITLE
fix(cluster): run GetTaskHistory under read-only SQL validation

### DIFF
--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -462,14 +462,19 @@ impl ClusterService for ClusterServiceImpl {
         let local_sql = rewrite_task_history_sql(&request.sql)
             .map_err(|e| Status::invalid_argument(format!("Invalid task history query: {e}")))?;
 
-        // Execute the query against local_task_history
+        // Always run under the strict read-only validator: GetTaskHistory is a
+        // cluster-internal fan-in for observability, not a general SQL surface.
+        // Without this gate, a peer could smuggle DDL/DML that merely *mentions*
+        // task_history (e.g. `INSERT INTO writable SELECT * FROM runtime.task_history`)
+        // and execute it with the scheduler's full DataFusion context.
         let query_result = self
             .datafusion
             .query_builder(&local_sql)
+            .read_only(true)
             .build()
             .run()
             .await
-            .map_err(|e| Status::internal(format!("Failed to execute query: {e}")))?;
+            .map_err(|e| map_task_history_query_error(&e))?;
 
         // Collect all record batches
         let batches: Vec<RecordBatch> = query_result
@@ -1256,6 +1261,36 @@ fn encode_batches_to_ipc(batches: &[RecordBatch]) -> Result<Vec<u8>, arrow::erro
     Ok(buffer)
 }
 
+/// Maps a task-history query execution error to a gRPC status.
+///
+/// Read-only validator failures (DDL/DML/COPY/etc.) become
+/// [`Status::permission_denied`] so callers can distinguish policy rejections
+/// from unexpected internal failures.
+fn map_task_history_query_error(e: &crate::datafusion::query::Error) -> Status {
+    let message = e.to_string();
+    // Prefer PermissionDenied for any mutation rejection so cluster peers get a
+    // clear policy signal rather than a 500-class Internal. The read-only
+    // validator is the primary gate; the general operations validator can also
+    // reject writes first (e.g. internal datasets) with a different message.
+    if is_task_history_mutation_rejection(&message) {
+        Status::permission_denied(format!(
+            "Task history queries are read-only and cannot mutate data: {message}"
+        ))
+    } else {
+        Status::internal(format!("Failed to execute query: {message}"))
+    }
+}
+
+fn is_task_history_mutation_rejection(message: &str) -> bool {
+    message.contains("read-only SQL context")
+        || message.contains("INSERT operations are not allowed")
+        || message.contains("DELETE operations are not allowed")
+        || message.contains("UPDATE operations are not allowed")
+        || message.contains("COPY operations are not allowed")
+        || message.contains("DDL operation")
+        || message.contains("are not allowed in read-only")
+}
+
 /// Rewrites a task history SQL query to use `local_task_history` instead of `task_history`.
 ///
 /// This function parses the SQL, validates it references the expected table, and rewrites
@@ -1368,6 +1403,22 @@ mod tests {
             )
             .expect("local task history table should be registered");
 
+        // Writable sink used by read-only mutation tests: INSERT INTO sink
+        // SELECT FROM task_history must still be denied by the read-only gate
+        // even though the target table is individually writable.
+        let sink = Arc::new(
+            MemTable::try_new(Arc::clone(&task_history_schema), vec![vec![]])
+                .expect("empty sink table should be created"),
+        );
+        let sink_ref = TableReference::bare("task_history_sink");
+        datafusion
+            .ctx
+            .register_table(sink_ref.clone(), sink)
+            .expect("sink table should be registered");
+        datafusion
+            .mark_dataset_writable(&sink_ref)
+            .expect("sink table should be marked writable");
+
         let store: Arc<dyn object_store::ObjectStore> =
             Arc::new(object_store::memory::InMemory::new());
         let cluster_state = Arc::new(runtime_cluster::ClusterStateStore::new(store, ""));
@@ -1465,6 +1516,110 @@ mod tests {
             .expect("second task history request should also succeed");
 
         shutdown.cancel();
+    }
+
+    #[tokio::test]
+    async fn get_task_history_allows_select() {
+        let service = make_test_service().await;
+        let response = service
+            .get_task_history(Request::new(GetTaskHistoryRequest {
+                sql: format!(
+                    "SELECT trace_id FROM \"{SPICE_RUNTIME_SCHEMA}\".\"{DEFAULT_TASK_HISTORY_TABLE}\""
+                ),
+            }))
+            .await
+            .expect("SELECT against task_history must succeed under read-only");
+        // Empty MemTable still produces a valid response (possibly empty IPC).
+        let _ = response.into_inner().arrow_ipc;
+    }
+
+    #[tokio::test]
+    async fn get_task_history_rejects_insert_into_writable_from_task_history() {
+        let service = make_test_service().await;
+        // Target is a writable non-system table so the operations validator
+        // would allow the INSERT; the read-only gate must still reject it.
+        let err = service
+            .get_task_history(Request::new(GetTaskHistoryRequest {
+                sql: format!(
+                    "INSERT INTO task_history_sink \
+                     SELECT * FROM \"{SPICE_RUNTIME_SCHEMA}\".\"{DEFAULT_TASK_HISTORY_TABLE}\""
+                ),
+            }))
+            .await
+            .expect_err("INSERT into writable sink must be rejected by read-only GetTaskHistory");
+
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(
+            err.message().contains("read-only"),
+            "unexpected message: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_task_history_rejects_delete() {
+        let service = make_test_service().await;
+        let err = service
+            .get_task_history(Request::new(GetTaskHistoryRequest {
+                sql: format!(
+                    "DELETE FROM \"{SPICE_RUNTIME_SCHEMA}\".\"{DEFAULT_TASK_HISTORY_TABLE}\""
+                ),
+            }))
+            .await
+            .expect_err("DELETE must be rejected by read-only GetTaskHistory");
+
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(
+            err.message().contains("read-only") || err.message().contains("not allowed"),
+            "unexpected message: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_task_history_rejects_ddl_over_task_history_select() {
+        let service = make_test_service().await;
+        // CREATE VIEW ... AS SELECT FROM task_history passes the rewrite gate
+        // (references task_history) but is DDL and must be rejected.
+        let err = service
+            .get_task_history(Request::new(GetTaskHistoryRequest {
+                sql: format!(
+                    "CREATE VIEW \"{SPICE_RUNTIME_SCHEMA}\".\"leaked\" AS \
+                     SELECT * FROM \"{SPICE_RUNTIME_SCHEMA}\".\"{DEFAULT_TASK_HISTORY_TABLE}\""
+                ),
+            }))
+            .await
+            .expect_err("DDL must be rejected by read-only GetTaskHistory");
+
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(
+            err.message().contains("read-only") || err.message().contains("DDL"),
+            "unexpected message: {}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn map_task_history_query_error_classifies_read_only() {
+        let e = crate::datafusion::query::Error::UnableToExecuteQuery {
+            source: datafusion::error::DataFusionError::Plan(
+                "INSERT operations are not allowed in read-only SQL context.".to_string(),
+            ),
+        };
+        let status = map_task_history_query_error(&e);
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+        assert!(status.message().contains("read-only"));
+    }
+
+    #[test]
+    fn map_task_history_query_error_keeps_other_failures_internal() {
+        let e = crate::datafusion::query::Error::UnableToExecuteQuery {
+            source: datafusion::error::DataFusionError::Internal(
+                "something unexpected".to_string(),
+            ),
+        };
+        let status = map_task_history_query_error(&e);
+        assert_eq!(status.code(), tonic::Code::Internal);
     }
 
     #[test]

--- a/crates/runtime/src/cluster/service.rs
+++ b/crates/runtime/src/cluster/service.rs
@@ -1267,17 +1267,30 @@ fn encode_batches_to_ipc(batches: &[RecordBatch]) -> Result<Vec<u8>, arrow::erro
 /// [`Status::permission_denied`] so callers can distinguish policy rejections
 /// from unexpected internal failures.
 fn map_task_history_query_error(e: &crate::datafusion::query::Error) -> Status {
-    let message = e.to_string();
+    // Classify on the underlying DataFusion message, not `Error`'s Display —
+    // `UnableToExecuteQuery` already prefixes with "Failed to execute query: ",
+    // and re-wrapping that string would double the prefix and couple the
+    // mutation classifier to wrapper formatting.
+    let underlying = match e {
+        crate::datafusion::query::Error::UnableToExecuteQuery { source }
+        | crate::datafusion::query::Error::UnableToCreateMemoryStream { source }
+        | crate::datafusion::query::Error::UnableToCollectResults { source }
+        | crate::datafusion::query::Error::BindingParameters { source } => source.to_string(),
+        other => other.to_string(),
+    };
+
     // Prefer PermissionDenied for any mutation rejection so cluster peers get a
     // clear policy signal rather than a 500-class Internal. The read-only
     // validator is the primary gate; the general operations validator can also
     // reject writes first (e.g. internal datasets) with a different message.
-    if is_task_history_mutation_rejection(&message) {
+    if is_task_history_mutation_rejection(&underlying) {
         Status::permission_denied(format!(
-            "Task history queries are read-only and cannot mutate data: {message}"
+            "Task history queries are read-only and cannot mutate data: {underlying}"
         ))
     } else {
-        Status::internal(format!("Failed to execute query: {message}"))
+        // `Error`'s Display already formats `UnableToExecuteQuery` as
+        // "Failed to execute query: …"; use it as-is to avoid a second prefix.
+        Status::internal(e.to_string())
     }
 }
 
@@ -1609,6 +1622,14 @@ mod tests {
         let status = map_task_history_query_error(&e);
         assert_eq!(status.code(), tonic::Code::PermissionDenied);
         assert!(status.message().contains("read-only"));
+        // Underlying Plan text only — no Error Display wrapper re-prefixed.
+        assert!(
+            !status
+                .message()
+                .contains("Failed to execute query: Failed to execute query:"),
+            "must not double-prefix Display: {}",
+            status.message()
+        );
     }
 
     #[test]
@@ -1620,6 +1641,24 @@ mod tests {
         };
         let status = map_task_history_query_error(&e);
         assert_eq!(status.code(), tonic::Code::Internal);
+        // Error Display already includes "Failed to execute query: " once.
+        assert!(
+            status.message().starts_with("Failed to execute query:"),
+            "unexpected message: {}",
+            status.message()
+        );
+        assert!(
+            !status
+                .message()
+                .contains("Failed to execute query: Failed to execute query:"),
+            "must not double-prefix Display: {}",
+            status.message()
+        );
+        assert!(
+            status.message().contains("something unexpected"),
+            "unexpected message: {}",
+            status.message()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Finding (security):** Cluster `GetTaskHistory` executed free-form SQL with `QueryBuilder`’s default **writable** posture. A cluster mTLS peer could smuggle mutations that only *mention* `runtime.task_history` (e.g. `INSERT INTO writable SELECT * FROM runtime.task_history`) and run them on the scheduler’s full DataFusion context.
- Force **`.read_only(true)`** on the rewritten query so the strict read-only validator rejects DDL/DML/COPY/statements.
- Map mutation rejections to gRPC **`PermissionDenied`** (clear policy signal vs Internal 500).

## Behavior

| SQL shape | Result |
|-----------|--------|
| `SELECT … FROM runtime.task_history` | Allowed (rewritten to `local_task_history`) |
| `INSERT INTO writable SELECT * FROM runtime.task_history` | **PermissionDenied** |
| `DELETE FROM runtime.task_history` | **PermissionDenied** |
| `CREATE VIEW … AS SELECT * FROM runtime.task_history` | **PermissionDenied** |
| Query with no `task_history` reference | InvalidArgument (existing rewrite gate) |

## Out of scope (follow-up)

SELECT-side multi-table JOINs for read exfil are not blocked by read-only mode; that needs a stricter table allowlist on the rewrite path (separate finding).

## Test plan

- [x] SELECT still succeeds
- [x] INSERT into a writable sink from task_history rejected (PermissionDenied)
- [x] DELETE rejected
- [x] DDL (CREATE VIEW over task_history) rejected
- [x] Error mapper classifies read-only vs other failures
- [x] `cargo test -p runtime --lib cluster::service::tests` — 16 passed
- [x] `cargo clippy -p runtime --no-deps --lib` (project pedantic set) — clean