### PR TITLE
fix(tests): wait for the DuckDB instance to close before asserting the replaced file is WAL-free (fixes #12173)

### DIFF
--- a/crates/runtime/tests/acceleration/file_swap_duckdb.rs
+++ b/crates/runtime/tests/acceleration/file_swap_duckdb.rs
@@ -61,9 +61,9 @@ const LOAD_TIMEOUT: Duration = Duration::from_mins(1);
 ///
 /// A `{db}.wal` is deliberately *not* counted: it is ordinary `DuckDB` state from
 /// whatever committed most recently, so a test that writes right up to shutdown
-/// legitimately leaves one behind for the next open to replay. Only the tests
-/// that end on a completed replacement with no writes after it assert on it, via
-/// [`wal_beside`].
+/// legitimately leaves one behind for the next open to replay. A test that
+/// requires the file to be checkpointed waits for the owning instance to close
+/// separately, via [`wal_len_beside`].
 fn replacement_debris_beside(db_file: &Path) -> Result<Vec<String>, anyhow::Error> {
     let dir = db_file.parent().unwrap_or(Path::new("."));
     let Some(file_name) = db_file.file_name().and_then(|n| n.to_str()) else {
@@ -78,11 +78,13 @@ fn replacement_debris_beside(db_file: &Path) -> Result<Vec<String>, anyhow::Erro
         .collect())
 }
 
-/// Whether a write-ahead log sits beside `db_file`.
-fn wal_beside(db_file: &Path) -> bool {
+/// The size of the write-ahead log sitting beside `db_file`, if there is one.
+/// The size is what makes a failure message actionable: a WAL holding a single
+/// metadata commit is a handful of bytes, one holding a whole refresh is not.
+fn wal_len_beside(db_file: &Path) -> Option<u64> {
     let mut wal = db_file.as_os_str().to_os_string();
     wal.push(".wal");
-    Path::new(&wal).exists()
+    std::fs::metadata(Path::new(&wal)).ok().map(|m| m.len())
 }
 
 /// Polls until no staging/generation debris remains beside `db_file`. Retired
@@ -896,11 +898,22 @@ async fn test_acceleration_duckdb_full_refresh_file_swap() -> Result<(), anyhow:
             drop(rt);
             wait_for_replacements_to_settle(&db_file).await?;
 
-            // Nothing writes after the final replacement here, so the file it
-            // left behind must be the checkpointed, WAL-free one it produced.
-            if wal_beside(&db_file) {
+            // The file left behind must be the checkpointed, WAL-free one the
+            // replacement produced. The WAL that carries the post-swap dataset
+            // checkpoint commit is removed by the shutdown checkpoint of the
+            // instance owning the file, which completes after
+            // `wait_for_replacements_to_settle` returns — its debris check
+            // deliberately ignores `{db}.wal` — so poll for the condition
+            // rather than sampling it once.
+            let wal_free = wait_until_true(Duration::from_secs(30), || async {
+                wal_len_beside(&db_file).is_none()
+            })
+            .await;
+            if !wal_free {
                 return Err(anyhow!(
-                    "a completed replacement must leave a checkpointed, WAL-free file"
+                    "a completed replacement must leave a checkpointed, WAL-free file, but a {} byte WAL remains beside {}",
+                    wal_len_beside(&db_file).unwrap_or_default(),
+                    db_file.display()
                 ));
             }
 


### PR DESCRIPTION
## Summary

`acceleration::file_swap_duckdb::test_acceleration_duckdb_full_refresh_file_swap` has failed on **every** merge-queue batch since #12135 landed — 6/6 retries, `Error: a completed replacement must leave a checkpointed, WAL-free file`. `integration tests` is a required check whose test jobs only do real work inside the merge queue ("Integration test part 3 runs on the merge-group commit"), so every batch, for every PR, has been evicted for ~15 hours through no fault of its own.

The assertion was sampling a condition ~1 second before it becomes true. Measuring the WAL instead of only testing for its existence, at exactly the point the assertion fires:

```
t=0s  wal_len=1348      db_len=16265216
t=1s  wal_len=absent    db_len=16789504
```

A **1.3 KB** WAL beside a **16.3 MB** database, gone one second later with the database ~524 KB larger — that is the shutdown checkpoint of the instance owning the file folding the WAL in and unlinking it. So:

- the replacement *does* leave a compact, checkpointed file: the WAL holds only the post-swap `spice_sys_dataset_checkpoint` commit, not refreshed data;
- the WAL is removed when the owning instance closes, and `wait_for_replacements_to_settle` cannot cover that because `replacement_debris_beside` *deliberately* excludes `{db}.wal` ("ordinary `DuckDB` state from whatever committed most recently").

The property is real and worth keeping, so this waits for it rather than deleting the assertion — which is also what the repo asks for: poll the actual condition with a bounded timeout and a failure message carrying the last observed state, never sample a readiness condition once.

Fixes #12173

## Changes

- `test_acceleration_duckdb_full_refresh_file_swap` polls for the WAL to disappear (bounded at 30s, matching `wait_for_replacements_to_settle`) instead of sampling once.
- `wal_beside` → `wal_len_beside`, returning the WAL's size. The size is what separates a race from a regression in a failure message: a WAL holding a single metadata commit is hundreds of bytes, one holding a whole refresh is megabytes. The failure now reads `... but a 1348 byte WAL remains beside /tmp/.../file_swap_duckdb.db`.
- Corrected `replacement_debris_beside`'s doc comment, which pointed at the old helper as the place `{db}.wal` gets asserted on.

The invariant that the *replacement* itself produces a WAL-free file is unchanged and still enforced in production code — `file_swap.rs` fails the write with `FileSwapWalPresent` if a WAL survives the staging file's clean detach — and `test_duckdb_file_swap_bounded_growth_under_query_load` still covers the bounded-growth property this feature exists for.

The same assertion was already removed outright on `release/2.1` in #12152 (`bfb93979e`, `923c2c726`); this is the missing trunk-side change, keeping the coverage instead of dropping it.

## Verification

- `cargo test -p runtime --features duckdb --test integration acceleration::file_swap_duckdb` → **7 passed, 0 failed**, zero warnings.
- **Neuter check**: reverting the poll to the original single-shot check reproduces the CI failure locally — `FAILED ... but a 1348 byte WAL remains beside …` — confirming the test still catches a genuine violation and that the poll is what fixes it. Restored afterwards; the pushed tree is the verified one.

No performance impact — test-only change.

## Test plan

- `make lint`
- `make test`

## Checklist

- [x] Tests pass locally
- [ ] Lint passes (`make signoff`)
