### PR TITLE
fix(ci): cancel workflow runs left behind by superseded merge-queue batches (fixes #12170)

### DIFF
--- a/.github/scripts/reap_superseded_merge_queue_runs.py
+++ b/.github/scripts/reap_superseded_merge_queue_runs.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Cancel workflow runs left behind by superseded merge-queue batches.
+#
+# When the merge queue re-forms a batch, GitHub creates a new
+# `gh-readonly-queue/<base>/pr-<N>-<sha>` branch and deletes the previous one.
+# The workflow runs already triggered on the deleted branch are not cancelled:
+# they run to completion against a batch that can never merge, holding
+# self-hosted runners the whole time.
+#
+# Workflow-level `concurrency` cannot express this. Every generation of a batch
+# gets its own branch name (`pr-12126-f925f912` -> `pr-12126-bef39e02` -> ...),
+# so `github.ref` — and `github.ref_name`, which this repository already groups
+# on — is unique per generation and two generations never share a group. A batch
+# branch that no longer resolves is the signal instead: its runs are superseded,
+# and cancelling them returns the runners to the live batches.
+#
+# Only runs that satisfy every one of these are cancelled:
+#   * triggered by `merge_group`,
+#   * on a `gh-readonly-queue/` branch,
+#   * not yet completed,
+#   * older than --min-age-minutes (so a run is never raced at creation),
+#   * whose branch returns 404 from the branches API.
+#
+# Usage:
+#   .github/scripts/reap_superseded_merge_queue_runs.py --dry-run   # report only
+#   .github/scripts/reap_superseded_merge_queue_runs.py             # cancel
+#
+# Reads GITHUB_TOKEN (needs the `actions: write` scope) and GITHUB_REPOSITORY.
+# Uses only the standard library so the workflow that holds `actions: write`
+# installs no dependencies.
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+API_URL = "https://api.github.com"
+TIMEOUT_SECONDS = 30
+
+BATCH_BRANCH_PREFIX = "gh-readonly-queue/"
+
+# Every run status that is not `completed`. The runs API filters on one status
+# per request, so each is queried separately. Listing without a status filter
+# and discarding completed runs client-side would be one request instead of
+# five, but the endpoint pages newest-first over *all* runs, so a long-stuck
+# orphan is exactly the run that busy completed traffic pushes off the page.
+UNFINISHED_STATUSES = ("queued", "in_progress", "waiting", "requested", "pending")
+
+DEFAULT_MIN_AGE_MINUTES = 5
+DEFAULT_MAX_CANCELLATIONS = 200
+
+PAGE_SIZE = 100
+MAX_PAGES = 20
+
+
+class GitHubApiError(RuntimeError):
+    """An unexpected response from the GitHub API."""
+
+
+def parse_timestamp(value):
+    """Parse a GitHub ISO-8601 timestamp into an aware UTC datetime, or None."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def is_batch_branch(branch):
+    """True when `branch` is a merge-queue batch branch."""
+    return isinstance(branch, str) and branch.startswith(BATCH_BRANCH_PREFIX)
+
+
+class GitHubApi:
+    def __init__(self, token, repository):
+        self._token = token
+        self._repository = repository
+
+    def _request(self, method, path, allowed_statuses=()):
+        request = urllib.request.Request(f"{API_URL}{path}", method=method)
+        request.add_header("Authorization", f"Bearer {self._token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        try:
+            with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+                body = response.read()
+                return response.status, (json.loads(body) if body else None)
+        except urllib.error.HTTPError as error:
+            if error.code in allowed_statuses:
+                return error.code, None
+            raise GitHubApiError(
+                f"{method} {path} failed with HTTP {error.code}"
+            ) from error
+
+    def list_unfinished_merge_group_runs(self):
+        """Every `merge_group` run in the repository that has not completed."""
+        runs = []
+        for status in UNFINISHED_STATUSES:
+            for page in range(1, MAX_PAGES + 1):
+                _, payload = self._request(
+                    "GET",
+                    f"/repos/{self._repository}/actions/runs"
+                    f"?event=merge_group&status={status}"
+                    f"&per_page={PAGE_SIZE}&page={page}",
+                )
+                batch = (payload or {}).get("workflow_runs") or []
+                runs.extend(batch)
+                if len(batch) < PAGE_SIZE:
+                    break
+        return runs
+
+    def branch_exists(self, branch):
+        """True while the branch resolves; False once the queue has deleted it."""
+        quoted = urllib.parse.quote(branch, safe="/")
+        status, _ = self._request(
+            "GET",
+            f"/repos/{self._repository}/branches/{quoted}",
+            allowed_statuses=(404, 422),
+        )
+        return status == 200
+
+    def cancel_run(self, run_id):
+        """Cancel a run. A run that finished first reports 409 and is not an error."""
+        status, _ = self._request(
+            "POST",
+            f"/repos/{self._repository}/actions/runs/{run_id}/cancel",
+            allowed_statuses=(409,),
+        )
+        return status != 409
+
+
+def select_superseded_runs(
+    runs,
+    branch_exists,
+    now,
+    min_age_minutes=DEFAULT_MIN_AGE_MINUTES,
+    max_cancellations=DEFAULT_MAX_CANCELLATIONS,
+):
+    """The runs whose merge-queue batch branch has already been replaced.
+
+    `branch_exists` is called at most once per distinct branch, so a queue with
+    many runs per batch costs one API call per batch rather than per run.
+    """
+    cutoff = now - timedelta(minutes=min_age_minutes)
+    branch_is_live = {}
+    seen_run_ids = set()
+    superseded = []
+
+    for run in runs:
+        run_id = run.get("id")
+        if run_id is None or run_id in seen_run_ids:
+            continue
+        seen_run_ids.add(run_id)
+
+        if run.get("event") != "merge_group":
+            continue
+
+        branch = run.get("head_branch")
+        if not is_batch_branch(branch):
+            continue
+
+        created_at = parse_timestamp(run.get("created_at"))
+        if created_at is None or created_at > cutoff:
+            continue
+
+        if branch not in branch_is_live:
+            branch_is_live[branch] = branch_exists(branch)
+        if branch_is_live[branch]:
+            continue
+
+        superseded.append(run)
+        if len(superseded) >= max_cancellations:
+            break
+
+    return superseded
+
+
+def describe(run):
+    return (
+        f"run {run.get('id')} "
+        f"[{run.get('name') or run.get('workflow_id')}] "
+        f"on {run.get('head_branch')} ({run.get('status')})"
+    )
+
+
+def cancel_runs(api, runs, dry_run):
+    """Cancel each run, returning the ones the API accepted."""
+    cancelled = []
+    for run in runs:
+        if dry_run:
+            print(f"would cancel {describe(run)}")
+            cancelled.append(run)
+            continue
+        if api.cancel_run(run["id"]):
+            print(f"cancelled {describe(run)}")
+            cancelled.append(run)
+        else:
+            print(f"already finished, left alone: {describe(run)}")
+    return cancelled
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        default=os.getenv("GITHUB_REPOSITORY"),
+        help="owner/repo (defaults to $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument(
+        "--min-age-minutes",
+        type=int,
+        default=DEFAULT_MIN_AGE_MINUTES,
+        help="leave runs younger than this alone",
+    )
+    parser.add_argument(
+        "--max-cancellations",
+        type=int,
+        default=DEFAULT_MAX_CANCELLATIONS,
+        help="stop after cancelling this many runs",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be cancelled without cancelling it",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("ERROR: Specify GITHUB_TOKEN environment variable", file=sys.stderr)
+        return 1
+    if not args.repository:
+        print("ERROR: Specify --repository or GITHUB_REPOSITORY", file=sys.stderr)
+        return 1
+
+    api = GitHubApi(token, args.repository)
+    runs = api.list_unfinished_merge_group_runs()
+    superseded = select_superseded_runs(
+        runs,
+        api.branch_exists,
+        datetime.now(timezone.utc),
+        min_age_minutes=args.min_age_minutes,
+        max_cancellations=args.max_cancellations,
+    )
+
+    print(f"{len(runs)} unfinished merge_group run(s); {len(superseded)} superseded")
+    cancelled = cancel_runs(api, superseded, args.dry_run)
+    print(f"{len(cancelled)} run(s) {'would be ' if args.dry_run else ''}cancelled")
+
+    if len(superseded) >= args.max_cancellations:
+        print(
+            f"stopped at the --max-cancellations limit of {args.max_cancellations}; "
+            "re-run to reap the rest"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/reap_superseded_merge_queue_runs.py
+++ b/.github/scripts/reap_superseded_merge_queue_runs.py
@@ -117,6 +117,18 @@ class GitHubApi:
                 runs.extend(batch)
                 if len(batch) < PAGE_SIZE:
                     break
+            else:
+                # The page cap was reached without a short page, so runs older
+                # than the ones listed may exist and this pass cannot see them.
+                # Say so: the whole point of the reaper is the long-stuck
+                # orphan, and silently dropping the tail of a newest-first
+                # listing is exactly how that orphan goes unreaped.
+                print(
+                    f"WARNING: stopped listing {status} runs at the "
+                    f"{MAX_PAGES}-page cap ({MAX_PAGES * PAGE_SIZE} runs); "
+                    "older superseded runs may remain",
+                    file=sys.stderr,
+                )
         return runs
 
     def branch_exists(self, branch):
@@ -210,7 +222,10 @@ def cancel_runs(api, runs, dry_run):
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description="Cancel workflow runs left behind by superseded "
+        "merge-queue batches."
+    )
     parser.add_argument(
         "--repository",
         default=os.getenv("GITHUB_REPOSITORY"),

--- a/.github/scripts/test_reap_superseded_merge_queue_runs.py
+++ b/.github/scripts/test_reap_superseded_merge_queue_runs.py
@@ -3,7 +3,9 @@
 #
 # Unit tests for reap_superseded_merge_queue_runs.py.
 
+import contextlib
 import io
+import json
 import os
 import sys
 import unittest
@@ -268,6 +270,25 @@ class GitHubApiTests(unittest.TestCase):
         # One request per unfinished status, each returning a short page.
         self.assertEqual(urlopen.call_count, len(reaper.UNFINISHED_STATUSES))
         self.assertEqual(len(runs), len(reaper.UNFINISHED_STATUSES))
+
+    @unittest.mock.patch("urllib.request.urlopen")
+    def test_listing_warns_when_it_hits_the_page_cap(self, urlopen):
+        full_page = json.dumps(
+            {"workflow_runs": [{"id": i} for i in range(reaper.PAGE_SIZE)]}
+        ).encode()
+        urlopen.side_effect = lambda *args, **kwargs: FakeResponse(200, full_page)
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            runs = self.api.list_unfinished_merge_group_runs()
+
+        # Every page is full, so each status runs to the cap rather than
+        # stopping short, and the truncation is reported once per status.
+        per_status = reaper.MAX_PAGES * reaper.PAGE_SIZE
+        self.assertEqual(len(runs), per_status * len(reaper.UNFINISHED_STATUSES))
+        self.assertEqual(
+            stderr.getvalue().count("WARNING"), len(reaper.UNFINISHED_STATUSES)
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_reap_superseded_merge_queue_runs.py
+++ b/.github/scripts/test_reap_superseded_merge_queue_runs.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Unit tests for reap_superseded_merge_queue_runs.py.
+
+import io
+import os
+import sys
+import unittest
+import unittest.mock
+import urllib.error
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import reap_superseded_merge_queue_runs as reaper  # noqa: E402
+
+NOW = datetime(2026, 7, 29, 17, 8, 0, tzinfo=timezone.utc)
+
+LIVE_BRANCH = "gh-readonly-queue/trunk/pr-12126-aa58e347c18587bc1d058cc7ac244e"
+SUPERSEDED_BRANCH = "gh-readonly-queue/trunk/pr-12126-f925f91252bbb914e6d43e8"
+
+
+def make_run(
+    run_id,
+    branch=SUPERSEDED_BRANCH,
+    event="merge_group",
+    minutes_old=60,
+    status="in_progress",
+):
+    created_at = NOW - timedelta(minutes=minutes_old)
+    return {
+        "id": run_id,
+        "name": "integration tests",
+        "event": event,
+        "head_branch": branch,
+        "status": status,
+        "created_at": created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+class BranchOracle:
+    """Stands in for the branches API, recording which branches were queried."""
+
+    def __init__(self, live_branches):
+        self.live_branches = set(live_branches)
+        self.queried = []
+
+    def __call__(self, branch):
+        self.queried.append(branch)
+        return branch in self.live_branches
+
+
+class IsBatchBranchTests(unittest.TestCase):
+    def test_batch_branches_are_recognized(self):
+        self.assertTrue(reaper.is_batch_branch(LIVE_BRANCH))
+
+    def test_other_branches_are_not(self):
+        for branch in ("trunk", "fix/12170-reaper", "", None, 42):
+            self.assertFalse(reaper.is_batch_branch(branch), branch)
+
+
+class ParseTimestampTests(unittest.TestCase):
+    def test_parses_zulu_timestamp_as_utc(self):
+        parsed = reaper.parse_timestamp("2026-07-29T16:13:35Z")
+
+        self.assertEqual(parsed, datetime(2026, 7, 29, 16, 13, 35, tzinfo=timezone.utc))
+
+    def test_parses_offset_timestamp(self):
+        parsed = reaper.parse_timestamp("2026-07-29T18:13:35+02:00")
+
+        self.assertEqual(parsed, datetime(2026, 7, 29, 16, 13, 35, tzinfo=timezone.utc))
+
+    def test_returns_none_for_missing_or_malformed(self):
+        for value in (None, "", "not a timestamp"):
+            self.assertIsNone(reaper.parse_timestamp(value), value)
+
+
+class SelectSupersededRunsTests(unittest.TestCase):
+    def select(self, runs, live_branches=(), **kwargs):
+        self.oracle = BranchOracle(live_branches)
+        return reaper.select_superseded_runs(runs, self.oracle, NOW, **kwargs)
+
+    def test_selects_runs_whose_batch_branch_is_gone(self):
+        selected = self.select([make_run(1), make_run(2)])
+
+        self.assertEqual([run["id"] for run in selected], [1, 2])
+
+    def test_leaves_runs_on_a_live_batch_alone(self):
+        selected = self.select(
+            [make_run(1, branch=LIVE_BRANCH)], live_branches=[LIVE_BRANCH]
+        )
+
+        self.assertEqual(selected, [])
+
+    def test_two_generations_of_one_queue_entry_are_judged_separately(self):
+        # The bug this guards: both branches belong to PR 12126 and differ only
+        # by the base sha, so no `concurrency` group can tell them apart. Only
+        # the generation whose branch was deleted may be cancelled.
+        runs = [make_run(1, branch=LIVE_BRANCH), make_run(2, branch=SUPERSEDED_BRANCH)]
+
+        selected = self.select(runs, live_branches=[LIVE_BRANCH])
+
+        self.assertEqual([run["id"] for run in selected], [2])
+
+    def test_ignores_runs_from_other_events(self):
+        runs = [
+            make_run(1, event="pull_request"),
+            make_run(2, event="push"),
+            make_run(3, event="schedule"),
+        ]
+
+        self.assertEqual(self.select(runs), [])
+
+    def test_ignores_runs_outside_the_merge_queue_namespace(self):
+        runs = [make_run(1, branch="trunk"), make_run(2, branch=None)]
+
+        self.assertEqual(self.select(runs), [])
+        self.assertEqual(self.oracle.queried, [])
+
+    def test_leaves_freshly_created_runs_alone(self):
+        runs = [make_run(1, minutes_old=1), make_run(2, minutes_old=30)]
+
+        selected = self.select(runs, min_age_minutes=5)
+
+        self.assertEqual([run["id"] for run in selected], [2])
+
+    def test_ignores_a_run_with_no_usable_created_at(self):
+        run = make_run(1)
+        del run["created_at"]
+
+        self.assertEqual(self.select([run]), [])
+
+    def test_queries_each_branch_once(self):
+        runs = [make_run(run_id) for run_id in range(1, 7)]
+        runs.append(make_run(7, branch=LIVE_BRANCH))
+
+        self.select(runs, live_branches=[LIVE_BRANCH])
+
+        self.assertEqual(self.oracle.queried, [SUPERSEDED_BRANCH, LIVE_BRANCH])
+
+    def test_deduplicates_runs_by_id(self):
+        selected = self.select([make_run(1), make_run(1), make_run(2)])
+
+        self.assertEqual([run["id"] for run in selected], [1, 2])
+
+    def test_stops_at_the_cancellation_cap(self):
+        runs = [make_run(run_id) for run_id in range(1, 11)]
+
+        selected = self.select(runs, max_cancellations=3)
+
+        self.assertEqual(len(selected), 3)
+
+    def test_no_runs_selects_nothing(self):
+        self.assertEqual(self.select([]), [])
+
+
+class FakeApi:
+    def __init__(self, refused=()):
+        self.refused = set(refused)
+        self.cancelled = []
+
+    def cancel_run(self, run_id):
+        self.cancelled.append(run_id)
+        return run_id not in self.refused
+
+
+class CancelRunsTests(unittest.TestCase):
+    def setUp(self):
+        patcher = unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_cancels_every_run(self):
+        api = FakeApi()
+
+        cancelled = reaper.cancel_runs(api, [make_run(1), make_run(2)], dry_run=False)
+
+        self.assertEqual(api.cancelled, [1, 2])
+        self.assertEqual([run["id"] for run in cancelled], [1, 2])
+
+    def test_dry_run_cancels_nothing(self):
+        api = FakeApi()
+
+        cancelled = reaper.cancel_runs(api, [make_run(1)], dry_run=True)
+
+        self.assertEqual(api.cancelled, [])
+        self.assertEqual([run["id"] for run in cancelled], [1])
+
+    def test_a_run_that_finished_first_is_not_counted(self):
+        api = FakeApi(refused=[2])
+
+        cancelled = reaper.cancel_runs(api, [make_run(1), make_run(2)], dry_run=False)
+
+        self.assertEqual([run["id"] for run in cancelled], [1])
+
+
+def http_error(code):
+    return urllib.error.HTTPError("https://api.github.com", code, "", None, None)
+
+
+class FakeResponse(io.BytesIO):
+    def __init__(self, status, body=b""):
+        super().__init__(body)
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+        return False
+
+
+class GitHubApiTests(unittest.TestCase):
+    def setUp(self):
+        self.api = reaper.GitHubApi("test-token", "spiceai/spiceai")
+
+    @unittest.mock.patch("urllib.request.urlopen")
+    def test_branch_exists_when_the_branch_resolves(self, urlopen):
+        urlopen.return_value = FakeResponse(200, b'{"name": "x"}')
+
+        self.assertTrue(self.api.branch_exists(LIVE_BRANCH))
+
+    @unittest.mock.patch("urllib.request.urlopen")
+    def test_branch_does_not_exist_once_deleted(self, urlopen):
+        urlopen.side_effect = http_error(404)
+
+        self.assertFalse(self.api.branch_exists(SUPERSEDED_BRANCH))
+
+    @unittest.mock.patch("urllib.request.urlopen")
+    def test_branch_slashes_are_not_escaped(self, urlopen):
+        urlopen.return_value = FakeResponse(200, b'{"name": "x"}')
+
+        self.api.branch_exists(LIVE_BRANCH)
+
+        requested_url = urlopen.call_args[0][0].full_url
+        self.assertTrue(requested_url.endswith(f"/branches/{LIVE_BRANCH}"))
+
+    @unittest.mock.patch("urllib.request.urlopen")
+    def test_an_unexpected_status_is_an_error_not_a_missing_branch(self, urlopen):
+        # A 401 must never be read as "the branch is gone", which would cancel
+        # every live batch in the repository.
+        urlopen.side_effect = http_error(401)
+
+        with self.assertRaises(reaper.GitHubApiError):
+            self.api.branch_exists(LIVE_BRANCH)
+
+    @unittest.mock.patch("urllib.request.urlopen")
+    def test_cancel_run_reports_success(self, urlopen):
+        urlopen.return_value = FakeResponse(202)
+
+        self.assertTrue(self.api.cancel_run(123))
+
+    @unittest.mock.patch("urllib.request.urlopen")
+    def test_cancel_run_tolerates_an_already_finished_run(self, urlopen):
+        urlopen.side_effect = http_error(409)
+
+        self.assertFalse(self.api.cancel_run(123))
+
+    @unittest.mock.patch("urllib.request.urlopen")
+    def test_listing_stops_on_a_short_page(self, urlopen):
+        urlopen.side_effect = lambda *args, **kwargs: FakeResponse(
+            200, b'{"workflow_runs": [{"id": 1}]}'
+        )
+
+        runs = self.api.list_unfinished_merge_group_runs()
+
+        # One request per unfinished status, each returning a short page.
+        self.assertEqual(urlopen.call_count, len(reaper.UNFINISHED_STATUSES))
+        self.assertEqual(len(runs), len(reaper.UNFINISHED_STATUSES))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/merge_queue_reaper.yml
+++ b/.github/workflows/merge_queue_reaper.yml
@@ -1,0 +1,82 @@
+---
+name: Merge Queue Reaper
+
+# Cancels workflow runs left behind when the merge queue re-forms a batch. See
+# .github/scripts/reap_superseded_merge_queue_runs.py for why workflow-level
+# `concurrency` cannot do this.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would be cancelled without cancelling it'
+        type: boolean
+        default: false
+  schedule:
+    # Off the hour, where scheduled runs are most likely to be delayed.
+    - cron: '7,22,37,52 * * * *'
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+    paths:
+      - '.github/scripts/reap_superseded_merge_queue_runs.py'
+      - '.github/scripts/test_reap_superseded_merge_queue_runs.py'
+      - '.github/workflows/merge_queue_reaper.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.github/scripts/reap_superseded_merge_queue_runs.py'
+      - '.github/scripts/test_reap_superseded_merge_queue_runs.py'
+      - '.github/workflows/merge_queue_reaper.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test:
+    name: Unit tests for reap_superseded_merge_queue_runs.py
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.11'
+
+      - name: Run tests
+        run: python .github/scripts/test_reap_superseded_merge_queue_runs.py -v
+
+  reap:
+    name: Cancel superseded merge-queue runs
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # A GitHub-hosted runner on purpose: the pool this reclaims capacity in is
+    # the self-hosted one.
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Cancel superseded merge-queue runs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+        run: |
+          python .github/scripts/reap_superseded_merge_queue_runs.py ${DRY_RUN}


### PR DESCRIPTION
Fixes #12170.

## What was wrong

When the merge queue re-forms a batch, GitHub creates a new `gh-readonly-queue/<base>/pr-<N>-<sha>` branch and deletes the old one — but the workflow runs already triggered on the deleted branch are **not** cancelled. They run to completion against a batch that can never merge, holding self-hosted runners the whole time.

Measured at 2026-07-29T17:08Z on `trunk`: 34 non-completed `merge_group` runs sat on batch branches that no longer existed, versus 21 on the 4 live batches. 14 of the 19 in-progress jobs holding a `spiceai-macos` runner belonged to a deleted batch — ~74% of the pool doing work that could not affect any merge, while every live batch and 42 `enforce-pull-with-spice` runs (#12162, same pool) sat `queued` with zero starts.

## Why `concurrency` cannot fix this

The issue suggested scoping `concurrency` to `github.ref` for `merge_group`. That does not work, and the repository is already the proof: `pr.yml`, `integration.yml` and `e2e_test_ci.yml` all group on `github.ref_name` with `cancel-in-progress: true`, and the leak happens anyway.

Every generation of a batch gets its own branch name — one queue entry went `pr-12126-f314733a` → `pr-12126-f925f912` → `pr-12126-bef39e02` → `pr-12126-aa58e347` in ~2.5h — so `github.ref`/`github.ref_name` is unique per generation and two generations never land in the same group. The only stable identity across generations is the PR number embedded in the branch name, and Actions expressions have no regex, `split` or `substring` to extract it. Grouping on `merge_group.base_ref` instead is too coarse: it would cancel unrelated live batches queued against the same base and break the queue's speculation.

So the signal has to come from outside the workflow: a batch branch that no longer resolves is superseded.

## The change

A scheduled reaper (`.github/workflows/merge_queue_reaper.yml`, every 15 minutes on a GitHub-hosted runner — the pool it reclaims is the self-hosted one) running `.github/scripts/reap_superseded_merge_queue_runs.py`.

A run is only cancelled when **all** of these hold:

- it was triggered by `merge_group`,
- its branch is under `gh-readonly-queue/`,
- it has not completed,
- it is older than `--min-age-minutes` (default 5), so a freshly created run is never raced,
- `GET /repos/{repo}/branches/{branch}` returns 404.

Anything unexpected from the API — a 401, say — raises instead of being read as "the branch is gone", so a credential problem can never turn into "cancel every live batch". `--max-cancellations` (default 200) caps a single pass, and `--dry-run` reports without cancelling. Branch existence is looked up once per distinct branch, not once per run.

The selection logic is pure functions (`select_superseded_runs`, `is_batch_branch`, `parse_timestamp`) separated from the HTTP client so it is unit tested directly, following the `github_release.py` / `test_github_release.py` / `release_script_test.yml` precedent already in this repo. The script uses only the standard library, so the step that holds `actions: write` installs no dependencies.

## Test plan

- `python .github/scripts/test_reap_superseded_merge_queue_runs.py -v` → **26 passed**. Covers: a superseded branch is selected; a live batch is left alone; two generations of the *same* queue entry, differing only by base sha, are judged separately (the regression this guards); other events ignored; non-batch branches ignored (and never probed); runs younger than the age floor left alone; missing/malformed `created_at`; one branch lookup per distinct branch; dedupe by run id; the cancellation cap; 404 → gone, 200 → live, an unexpected status raises, 409 tolerated on cancel; branch slashes are not percent-escaped.
- The same tests run in CI via the new workflow's `test` job (paths-filtered to this script, its tests, and the workflow).
- End-to-end against the live repository, read-only: `--dry-run` reported `20 unfinished merge_group run(s); 0 superseded` at a moment when all 20 were on the 4 live batches — i.e. it left every live batch alone. Feeding those same 20 real runs plus one synthetic run pointing at a genuinely deleted batch branch, with the real `branch_exists`, selected exactly the orphan and nothing else.
- The manual equivalent of this reaper was performed by hand at 17:08Z when the queue was stalled (34 runs cancelled after verifying each branch was deleted): all four live batches started within ~45s, `enforce-pull-with-spice` completions went from ~2.2/hour to ~7 in 4 minutes, and no merge-queue entry was disturbed.

## Deliberately not included

- **A `delete`-event fast path.** `on: delete` would fire the moment a batch branch is retired, which is more precise than a 15-minute poll. It does not support branch filters, so it would fire on every branch deletion in a repository with heavy branch churn and need its own guard, and webhook-triggered work still needs a scheduled backstop. Worth adding on top of the schedule later, not instead of it.
- **Touching the `pull_request_target` hygiene check.** Its `concurrency` block was removed on purpose (4e06c2c28) and `cancel-in-progress` on a required check would trade this problem for a worse one.
- **Listing runs in one unfiltered request** instead of one per unfinished status. It would be 5 API calls fewer per pass, but the endpoint pages newest-first over *all* runs, so a long-stuck orphan — the exact thing being hunted — is what busy completed traffic pushes off the page. The rationale is recorded in a comment next to `UNFINISHED_STATUSES`.

## Checklist

- [x] Tests added and passing
- [x] Verified end-to-end against the live repository in `--dry-run`
- [x] No new dependencies
- [x] Scoped permissions (`actions: write` only on the reaping job)