### PR TITLE
fix(duckdb): drop a file-replacement test assertion that can never hold

### DIFF
--- a/crates/runtime/tests/acceleration/file_swap_duckdb.rs
+++ b/crates/runtime/tests/acceleration/file_swap_duckdb.rs
@@ -59,11 +59,18 @@ const LOAD_TIMEOUT: Duration = Duration::from_mins(1);
 /// belong to the replacement protocol and none may survive a completed
 /// replacement.
 ///
-/// A `{db}.wal` is deliberately *not* counted: it is ordinary `DuckDB` state from
-/// whatever committed most recently, so a test that writes right up to shutdown
-/// legitimately leaves one behind for the next open to replay. Only the tests
-/// that end on a completed replacement with no writes after it assert on it, via
-/// [`wal_beside`].
+/// A `{db}.wal` is deliberately *not* counted, and no test here asserts on one:
+/// after a replacement there is essentially always a WAL. The refresh writes its
+/// dataset checkpoint bookkeeping *after* the swap installs the new file, and that
+/// commit is not itself checkpointed, so it sits in a fresh WAL. `DuckDB` only
+/// removes a WAL when a checkpoint completes — including the closing instance's
+/// shutdown checkpoint — so whether one is still on disk at any point after
+/// shutdown only reflects how far teardown has progressed.
+///
+/// The invariant that a replacement yields a compact, checkpointed, WAL-free file
+/// is about the file the swap *produces*, and it is enforced where that is
+/// observable: the swap fails the write with `FileSwapWalPresent` if a WAL
+/// survives the staging file's clean detach.
 fn replacement_debris_beside(db_file: &Path) -> Result<Vec<String>, anyhow::Error> {
     let dir = db_file.parent().unwrap_or(Path::new("."));
     let Some(file_name) = db_file.file_name().and_then(|n| n.to_str()) else {
@@ -76,13 +83,6 @@ fn replacement_debris_beside(db_file: &Path) -> Result<Vec<String>, anyhow::Erro
         .map(|e| e.file_name().to_string_lossy().to_string())
         .filter(|name| name.starts_with(&generation_prefix))
         .collect())
-}
-
-/// Whether a write-ahead log sits beside `db_file`.
-fn wal_beside(db_file: &Path) -> bool {
-    let mut wal = db_file.as_os_str().to_os_string();
-    wal.push(".wal");
-    Path::new(&wal).exists()
 }
 
 /// Polls until no staging/generation debris remains beside `db_file`. Retired
@@ -895,14 +895,6 @@ async fn test_acceleration_duckdb_full_refresh_file_swap() -> Result<(), anyhow:
             rt.shutdown().await;
             drop(rt);
             wait_for_replacements_to_settle(&db_file).await?;
-
-            // Nothing writes after the final replacement here, so the file it
-            // left behind must be the checkpointed, WAL-free one it produced.
-            if wal_beside(&db_file) {
-                return Err(anyhow!(
-                    "a completed replacement must leave a checkpointed, WAL-free file"
-                ));
-            }
 
             // The swap replaced the file at the configured path with a fresh
             // generation.


### PR DESCRIPTION
## Problem

`acceleration::file_swap_duckdb::test_acceleration_duckdb_full_refresh_file_swap` fails deterministically on `trunk` and has evicted every merge-queue batch since it landed, blocking all merges regardless of their content (#12173).

```
Error: a completed replacement must leave a checkpointed, WAL-free file
```

The test asserted that no `{db}.wal` sits beside the database file after shutdown, on the premise that "nothing writes after the final replacement here". That premise is wrong. The refresh writes its dataset checkpoint bookkeeping **after** the swap installs the new file — `wait_for_checkpoints` is what the test waits on — and that commit is not itself checkpointed, so it lands in a fresh WAL. A WAL beside the file after a replacement is the normal state, not a defect.

Whether the WAL is still on disk when the assertion runs only reflects how far instance teardown has progressed: DuckDB removes a WAL when a checkpoint completes, including the closing instance's shutdown checkpoint. `wait_for_replacements_to_settle` polls only for generation debris, so it returns while the instance may still be closing. That is why the assertion passed on macOS during development and fails 6/6 on Linux CI.

The test also never ran in CI before merging — `integration tests` is skipped on `pull_request` and runs only in the merge queue, and the PR that added it was merged directly.

## Change

Removes the assertion and the `wal_beside` helper it used, and rewrites the neighbouring doc comment to record why no test asserts on a WAL.

The invariant the feature actually promises is about the file the swap *produces*, and it is already enforced where that is observable: the swap fails the write with `FileSwapWalPresent` if a WAL survives the staging file's clean detach. The test was re-checking that at a point where post-swap writes and instance lifetime make it unobservable.

The test's remaining assertions are unaffected and still cover the feature:
- the configured path holds a **new inode** after the refresh (the file really was replaced),
- **no generation or staging debris** remains,
- **both datasets' rows and both checkpoint rows** are present in the swapped-in file (the carry-forward invariant).

The same removal was already applied on `release/2.1` as part of #12152 (`bfb93979e`, `923c2c726`); this brings `trunk` in line.

Closes #12173
