### PR TITLE
Harden dataset availability checks against idle connection resets

### DIFF
--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -76,7 +76,7 @@ pub fn configure_endpoint_for_high_throughput(endpoint: Endpoint) -> Endpoint {
         .initial_connection_window_size(HTTP2_INITIAL_CONNECTION_WINDOW_SIZE)
         .http2_keep_alive_interval(HTTP2_KEEP_ALIVE_INTERVAL)
         .keep_alive_timeout(HTTP2_KEEP_ALIVE_TIMEOUT)
-        .keep_alive_while_idle(true);
+        .keep_alive_while_idle(true)
 }
 
 #[derive(Debug)]

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -40,6 +40,7 @@ use secrecy::ExposeSecret;
 use secrecy::SecretString;
 use snafu::prelude::*;
 use std::error::Error as StdError;
+use std::time::Duration;
 use tonic::IntoRequest;
 use tonic::IntoStreamingRequest;
 use tonic::transport::{Channel, Endpoint};
@@ -53,12 +54,29 @@ pub const MAX_DECODING_MESSAGE_SIZE: usize = 100 * 1024 * 1024;
 pub const HTTP2_INITIAL_STREAM_WINDOW_SIZE: u32 = 16 * 1024 * 1024;
 pub const HTTP2_INITIAL_CONNECTION_WINDOW_SIZE: u32 = 64 * 1024 * 1024;
 
-/// Applies shared HTTP/2 flow-control settings for high-throughput Flight streams.
+/// How often to send an HTTP/2 PING on a pooled Flight channel.
+pub const HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How long to wait for a PING ack before treating the channel as dead.
+pub const HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Applies shared HTTP/2 flow-control and keepalive settings for Flight channels.
+///
+/// The keepalive pings matter because these channels are pooled and long-lived. A load
+/// balancer between the client and a Flight endpoint resets connections that go idle,
+/// and the client is not told: the reset only surfaces when the next request is written,
+/// which then fails while the replacement connection is established for the request
+/// after it. Pinging while idle keeps the connection from being reaped in the first
+/// place, so a query or availability probe arriving after a quiet period still lands on
+/// a live channel.
 #[must_use]
 pub fn configure_endpoint_for_high_throughput(endpoint: Endpoint) -> Endpoint {
     endpoint
         .initial_stream_window_size(HTTP2_INITIAL_STREAM_WINDOW_SIZE)
         .initial_connection_window_size(HTTP2_INITIAL_CONNECTION_WINDOW_SIZE)
+        .http2_keep_alive_interval(HTTP2_KEEP_ALIVE_INTERVAL)
+        .keep_alive_timeout(HTTP2_KEEP_ALIVE_TIMEOUT)
+        .keep_alive_while_idle(true);
 }
 
 #[derive(Debug)]

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -519,9 +519,45 @@ async fn snapshot_datasets(
     (datasets.values().map(Arc::clone).collect(), max_interval)
 }
 
+/// Attempts a probe makes before reporting a dataset unavailable.
+const CONNECTIVITY_ATTEMPTS: u32 = 2;
+
+/// Pause between probe attempts
+const CONNECTIVITY_RETRY_DELAY: Duration = Duration::from_millis(250);
+
+/// Probes a dataset, retrying up to [`CONNECTIVITY_ATTEMPTS`] times.
+///
+/// Retrying is safe regardless of connector: the probe is a `LIMIT 1` read whose result is
+/// discarded, so replaying it has no effect beyond the read itself. The retry is deliberately
+/// not conditioned on the error kind — a transport reset is not distinguishable across every
+/// connector without connector-specific knowledge, and a genuinely unavailable dataset simply
+/// fails twice.
 async fn test_connectivity(
     table_provider: &Arc<dyn TableProvider>,
     df: Arc<DataFusion>,
+) -> std::result::Result<(), DataFusionError> {
+    let mut attempt: u32 = 1;
+    loop {
+        let err = match scan_one_row(table_provider, &df).await {
+            Ok(()) => return Ok(()),
+            Err(err) => err,
+        };
+
+        if attempt >= CONNECTIVITY_ATTEMPTS {
+            return Err(err);
+        }
+
+        tracing::debug!(
+            "Connectivity probe attempt {attempt} of {CONNECTIVITY_ATTEMPTS} failed, retrying: {err}"
+        );
+        tokio::time::sleep(CONNECTIVITY_RETRY_DELAY).await;
+        attempt += 1;
+    }
+}
+
+async fn scan_one_row(
+    table_provider: &Arc<dyn TableProvider>,
+    df: &Arc<DataFusion>,
 ) -> std::result::Result<(), DataFusionError> {
     let plan = table_provider
         .scan(&df.ctx.state(), None, &[], Some(1))


### PR DESCRIPTION
## 📝 Summary

Availability probes could report a reachable dataset as unavailable. Pooled connections that go idle are dropped by intermediaries such as load balancers without telling the client, so the first request after a quiet period fails — and the probe, which by design only runs once a dataset has been quiet, is the request most likely to hit that. With a single attempt per probe this surfaced as recurring availability warnings and, since a failed probe marks the dataset `Error`, as status flapping.

Two changes:

- **The probe retries before reporting a dataset unavailable.** This is connector-agnostic: the probe is a `LIMIT 1` read whose result is discarded, so replaying it is safe for any connector.
- **Flight client channels send HTTP/2 keepalive pings while idle**, so pooled connections aren't reaped in the first place. This also covers real queries after an idle period, which a probe-side retry cannot.

## 🔗 Related

 #12138
