### PR TITLE
fix(ci): make cargo_deny_advisories.yml parseable so the Rust advisory scan can run (fixes #12181)

### DIFF
--- a/.github/scripts/check_workflow_yaml.py
+++ b/.github/scripts/check_workflow_yaml.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# GitHub Actions definition guard.
+#
+# Verifies that every workflow under `.github/workflows/` and every composite
+# action under `.github/actions/` parses as YAML and carries the keys GitHub
+# needs to schedule it.
+#
+# A definition GitHub cannot parse fails *open*: the run reports no jobs, the
+# declared `on:` triggers and `paths:` filters cannot be honoured, and the run is
+# not a required check, so the workflow is silently disabled while every push
+# raises a failed run nobody is obliged to look at. Regression guard for #12181,
+# where a mis-indented block scalar left the daily Rust advisory scan unable to
+# run at all.
+"""Validate the repository's GitHub Actions workflow and composite action YAML."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# PyYAML resolves an unquoted `on:` key to the boolean `True` (YAML 1.1), which
+# is also how it reaches GitHub's parser, so a trigger block is present under
+# either spelling.
+TRIGGER_KEYS = ("on", True)
+
+
+def workflow_files(github_dir: Path) -> list[Path]:
+    """Return the workflow definitions under `<github_dir>/workflows`, sorted."""
+    workflows = github_dir / "workflows"
+    return sorted(p for p in workflows.glob("*.y*ml") if p.is_file())
+
+
+def action_files(github_dir: Path) -> list[Path]:
+    """Return the composite action definitions under `<github_dir>/actions`, sorted."""
+    actions = github_dir / "actions"
+    return sorted(p for p in actions.glob("*/action.y*ml") if p.is_file())
+
+
+def _parse_mapping(text: str) -> tuple[dict | None, list[str]]:
+    """Parse a definition into its top-level mapping, or report why it has none."""
+    try:
+        document = yaml.safe_load(text)
+    except yaml.YAMLError as error:
+        return None, [f"is not valid YAML: {_format_yaml_error(error)}"]
+
+    if not isinstance(document, dict):
+        return None, ["does not parse to a mapping of top-level keys"]
+
+    return document, []
+
+
+def check_workflow(text: str) -> list[str]:
+    """Return the problems with one workflow definition's contents.
+
+    An empty list means the definition is well-formed. Kept free of filesystem
+    access so the failure modes can be unit-tested from strings.
+    """
+    document, problems = _parse_mapping(text)
+    if document is None:
+        return problems
+
+    if not any(key in document for key in TRIGGER_KEYS):
+        problems.append("has no `on:` trigger block")
+
+    jobs = document.get("jobs")
+    if jobs is None:
+        problems.append("has no `jobs:` block")
+    elif not isinstance(jobs, dict) or not jobs:
+        problems.append("has a `jobs:` block that is not a non-empty mapping")
+
+    return problems
+
+
+def check_action(text: str) -> list[str]:
+    """Return the problems with one composite action definition's contents."""
+    document, problems = _parse_mapping(text)
+    if document is None:
+        return problems
+
+    return [] if "runs" in document else ["has no `runs:` block"]
+
+
+def _format_yaml_error(error: yaml.YAMLError) -> str:
+    """Render a PyYAML error as a single line, with the mark when it carries one."""
+    problem = getattr(error, "problem", None) or str(error)
+    mark = getattr(error, "problem_mark", None)
+    if mark is None:
+        return problem.replace("\n", " ")
+    return f"{problem} at line {mark.line + 1} column {mark.column + 1}"
+
+
+def check_definitions(github_dir: Path) -> list[str]:
+    """Check every workflow and composite action, returning one failure per problem."""
+    failures = []
+    for paths, check in (
+        (workflow_files(github_dir), check_workflow),
+        (action_files(github_dir), check_action),
+    ):
+        for path in paths:
+            failures.extend(
+                f"{path}: {problem}"
+                for problem in check(path.read_text(encoding="utf-8"))
+            )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--github-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="path to the .github directory (default: the one containing this script)",
+    )
+    args = parser.parse_args(argv)
+
+    github_dir: Path = args.github_dir
+    if not github_dir.is_dir():
+        print(f"error: {github_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    checked = len(workflow_files(github_dir)) + len(action_files(github_dir))
+    if checked == 0:
+        print(f"error: found no definitions under {github_dir}", file=sys.stderr)
+        return 2
+
+    failures = check_definitions(github_dir)
+    if failures:
+        print(
+            f"{len(failures)} GitHub Actions definition problem(s) found. A definition "
+            "GitHub cannot parse is silently disabled, so this fails the build:",
+            file=sys.stderr,
+        )
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {checked} GitHub Actions definitions parse and declare the required keys")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_workflow_yaml.py
+++ b/.github/scripts/test_check_workflow_yaml.py
@@ -1,0 +1,216 @@
+"""Unit tests for check_workflow_yaml.py."""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_workflow_yaml  # noqa: E402
+
+VALID_WORKFLOW = """\
+---
+name: Check Rust Advisories
+
+on:
+  schedule:
+    - cron: '20 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  advisories:
+    name: Check Rust Advisories
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo hello
+"""
+
+VALID_ACTION = """\
+name: Set up make
+description: Installs make
+
+runs:
+  using: composite
+  steps:
+    - run: echo hello
+      shell: bash
+"""
+
+# The exact shape of #12181: a non-empty line inside a `script: |` block scalar
+# sits at column 0, which terminates the scalar and leaves YAML reading a bare
+# string where a mapping key belongs.
+DEDENTED_BLOCK_SCALAR_WORKFLOW = """\
+---
+name: Check Rust Advisories
+
+on:
+  workflow_dispatch:
+
+jobs:
+  advisories:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const body = [
+              marker,
+'`cargo deny check advisories` found Rust dependency advisory violations.',
+              '',
+            ].join('\\n');
+"""
+
+
+class CheckWorkflowTest(unittest.TestCase):
+    def test_valid_workflow_has_no_problems(self):
+        self.assertEqual(check_workflow_yaml.check_workflow(VALID_WORKFLOW), [])
+
+    def test_dedented_block_scalar_is_reported_as_a_syntax_error(self):
+        problems = check_workflow_yaml.check_workflow(DEDENTED_BLOCK_SCALAR_WORKFLOW)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("is not valid YAML", problems[0])
+        # The line of the offending dedent is what makes the failure actionable.
+        self.assertIn("line 16 ", problems[0])
+
+    def test_quoted_on_key_is_accepted(self):
+        problems = check_workflow_yaml.check_workflow(
+            VALID_WORKFLOW.replace("\non:\n", '\n"on":\n')
+        )
+        self.assertEqual(problems, [])
+
+    def test_missing_trigger_block_is_reported(self):
+        without_on = VALID_WORKFLOW.replace(
+            "on:\n  schedule:\n    - cron: '20 5 * * *'\n  workflow_dispatch:\n", ""
+        )
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(without_on), ["has no `on:` trigger block"]
+        )
+
+    def test_missing_jobs_block_is_reported(self):
+        problems = check_workflow_yaml.check_workflow(
+            "name: x\non:\n  workflow_dispatch:\n"
+        )
+        self.assertEqual(problems, ["has no `jobs:` block"])
+
+    def test_empty_jobs_block_is_reported(self):
+        problems = check_workflow_yaml.check_workflow(
+            "name: x\non:\n  workflow_dispatch:\njobs: {}\n"
+        )
+        self.assertEqual(
+            problems, ["has a `jobs:` block that is not a non-empty mapping"]
+        )
+
+    def test_jobs_as_a_list_is_reported(self):
+        problems = check_workflow_yaml.check_workflow(
+            "name: x\non:\n  workflow_dispatch:\njobs:\n  - build\n"
+        )
+        self.assertEqual(
+            problems, ["has a `jobs:` block that is not a non-empty mapping"]
+        )
+
+    def test_empty_file_is_reported(self):
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(""),
+            ["does not parse to a mapping of top-level keys"],
+        )
+
+    def test_a_workflow_missing_both_keys_reports_both(self):
+        self.assertEqual(
+            check_workflow_yaml.check_workflow("name: x\n"),
+            ["has no `on:` trigger block", "has no `jobs:` block"],
+        )
+
+
+class CheckActionTest(unittest.TestCase):
+    def test_valid_action_has_no_problems(self):
+        self.assertEqual(check_workflow_yaml.check_action(VALID_ACTION), [])
+
+    def test_missing_runs_block_is_reported(self):
+        problems = check_workflow_yaml.check_action("name: x\ndescription: y\n")
+        self.assertEqual(problems, ["has no `runs:` block"])
+
+    def test_invalid_yaml_is_reported(self):
+        problems = check_workflow_yaml.check_action("runs:\n  using: composite\n bad\n")
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("is not valid YAML", problems[0])
+
+    def test_an_action_is_not_required_to_declare_triggers_or_jobs(self):
+        """A composite action legitimately has neither `on:` nor `jobs:`."""
+        self.assertEqual(check_workflow_yaml.check_action(VALID_ACTION), [])
+        self.assertNotEqual(check_workflow_yaml.check_workflow(VALID_ACTION), [])
+
+
+class DiscoveryTest(unittest.TestCase):
+    def _github_dir(self, tmp: str) -> Path:
+        github_dir = Path(tmp) / ".github"
+        (github_dir / "workflows").mkdir(parents=True)
+        (github_dir / "actions" / "setup-make").mkdir(parents=True)
+        (github_dir / "actions" / "notes").mkdir(parents=True)
+        return github_dir
+
+    def test_discovery_finds_workflows_and_actions_but_not_other_yaml(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            github_dir = self._github_dir(tmp)
+            (github_dir / "workflows" / "pr.yml").write_text(VALID_WORKFLOW)
+            (github_dir / "workflows" / "release.yaml").write_text(VALID_WORKFLOW)
+            (github_dir / "workflows" / "notes.md").write_text("not yaml")
+            (github_dir / "actions" / "setup-make" / "action.yml").write_text(VALID_ACTION)
+            # A stray YAML file beside a composite action is not a definition.
+            (github_dir / "actions" / "notes" / "data.yml").write_text("a: 1\n")
+
+            self.assertEqual(
+                [p.name for p in check_workflow_yaml.workflow_files(github_dir)],
+                ["pr.yml", "release.yaml"],
+            )
+            self.assertEqual(
+                [p.parent.name for p in check_workflow_yaml.action_files(github_dir)],
+                ["setup-make"],
+            )
+            self.assertEqual(check_workflow_yaml.check_definitions(github_dir), [])
+
+    def test_a_broken_workflow_is_reported_with_its_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            github_dir = self._github_dir(tmp)
+            (github_dir / "workflows" / "ok.yml").write_text(VALID_WORKFLOW)
+            broken = github_dir / "workflows" / "broken.yml"
+            broken.write_text(DEDENTED_BLOCK_SCALAR_WORKFLOW)
+
+            failures = check_workflow_yaml.check_definitions(github_dir)
+            self.assertEqual(len(failures), 1, failures)
+            self.assertTrue(failures[0].startswith(f"{broken}: "), failures[0])
+
+    def test_main_returns_1_for_a_broken_definition_and_0_when_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            github_dir = self._github_dir(tmp)
+            workflow = github_dir / "workflows" / "pr.yml"
+            workflow.write_text(DEDENTED_BLOCK_SCALAR_WORKFLOW)
+            self.assertEqual(
+                check_workflow_yaml.main(["--github-dir", str(github_dir)]), 1
+            )
+
+            workflow.write_text(VALID_WORKFLOW)
+            self.assertEqual(
+                check_workflow_yaml.main(["--github-dir", str(github_dir)]), 0
+            )
+
+    def test_main_returns_2_when_it_finds_nothing_to_check(self):
+        """An empty result means the path is wrong, not that the repo is clean."""
+        with tempfile.TemporaryDirectory() as tmp:
+            github_dir = self._github_dir(tmp)
+            self.assertEqual(
+                check_workflow_yaml.main(["--github-dir", str(github_dir)]), 2
+            )
+            self.assertEqual(
+                check_workflow_yaml.main(["--github-dir", str(Path(tmp) / "absent")]), 2
+            )
+
+
+class RepositoryTest(unittest.TestCase):
+    def test_this_repositorys_definitions_are_all_well_formed(self):
+        """Regression test for #12181: cargo_deny_advisories.yml must parse."""
+        github_dir = Path(__file__).resolve().parents[1]
+        self.assertEqual(check_workflow_yaml.check_definitions(github_dir), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cargo_deny_advisories.yml
+++ b/.github/workflows/cargo_deny_advisories.yml
@@ -64,7 +64,7 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
               marker,
-'`cargo deny check advisories` found Rust dependency advisory violations.',
+              '`cargo deny check advisories` found Rust dependency advisory violations.',
               '',
               `Run: ${runUrl}`,
               `Commit: ${context.sha}`,
@@ -74,7 +74,9 @@ jobs:
               '~~~',
             ].join('\n');
 
-            const { data: issues } = await github.rest.issues.listForRepo({
+            // Paginate: the marker issue falls off the first page of open issues
+            // within days, and missing it opens a duplicate on every run.
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',

--- a/.github/workflows/workflow_yaml_check.yml
+++ b/.github/workflows/workflow_yaml_check.yml
@@ -1,0 +1,57 @@
+---
+name: Workflow YAML Check
+
+# A workflow GitHub cannot parse is silently disabled — it reports no jobs, its
+# triggers and path filters are never evaluated, and it is not a required check.
+# This gate turns that into a PR failure instead. See #12181.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/scripts/check_workflow_yaml.py'
+      - '.github/scripts/test_check_workflow_yaml.py'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/scripts/check_workflow_yaml.py'
+      - '.github/scripts/test_check_workflow_yaml.py'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  check-workflow-yaml:
+    name: Validate GitHub Actions definitions
+    # GitHub-hosted on purpose: this is a sub-second check and must not queue
+    # behind the saturated self-hosted pool.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Run tests
+        run: python .github/scripts/test_check_workflow_yaml.py -v
+
+      - name: Validate GitHub Actions definitions
+        run: python .github/scripts/check_workflow_yaml.py


### PR DESCRIPTION
## Summary (root cause)

`.github/workflows/cargo_deny_advisories.yml` embeds JavaScript in an `actions/github-script` `script: |` block scalar. One line of that JavaScript sat at **column 0**, and a non-empty line less indented than a block scalar terminates the scalar — so the parser then read a bare string where a mapping key belongs:

```
Psych::SyntaxError: could not find expected ':' while scanning a simple key at line 67 column 1
```

GitHub therefore never parsed the file. Two consequences, both invisible because a workflow GitHub cannot parse fails **open**:

1. **The daily Rust dependency advisory scan has never run.** Across 1389 runs since the workflow was introduced on 2026-07-15 there were **zero successes and zero scheduled runs**. `cargo deny check advisories` (RUSTSEC/CVE data over `Cargo.lock`) has not executed once, and the "create or update advisory issue" reporting path has never fired. #11879 moved this check out of the PR gate into this scheduled workflow, so nothing else covered it.
2. **A jobless failed run on every push, repo-wide** — on `trunk`, on every `gh-readonly-queue/**` batch branch, and on every contributor branch. It blocks nothing, which is why it went unnoticed for 14 days.

Corroborating tells: the workflow is registered under its *path* rather than its declared `name: Check Rust Advisories` (the only workflow in the repo in that state), and every run carries `event: push` even though the file declares only `schedule` and `workflow_dispatch` — because the unparseable `on:` block leaves GitHub unable to evaluate the triggers.

## Changes

**`.github/workflows/cargo_deny_advisories.yml`**

- Indent the offending line to the block scalar's indentation.
- Paginate the open-issue lookup in the same step. It read only the first page of open issues, so the `<!-- cargo-deny-advisories -->` marker issue falls off that page within days and a duplicate advisory issue would be opened on every run. This code path has never executed, so the fix activates it for the first time — worth fixing in the same change rather than shipping a workflow that immediately spams duplicates.

**The bug class — a workflow that cannot be parsed is silently disabled.** Nothing in CI validates that the definitions parse, and `make lint-rust` is change-filtered to Rust paths so it would not cover a `.github/`-only change in any case (see #12111). Added:

- `.github/scripts/check_workflow_yaml.py` — parses every `.github/workflows/*.y*ml` and `.github/actions/*/action.y*ml` (96 files today) and asserts each carries the keys GitHub needs to schedule it: a workflow needs an `on:` trigger block and a non-empty `jobs:` mapping; a composite action needs `runs:`. Stdlib + PyYAML only. Exits `2` rather than `0` when discovery finds nothing, so a wrong path can never read as "clean".
- `.github/scripts/test_check_workflow_yaml.py` — 18 unit tests.
- `.github/workflows/workflow_yaml_check.yml` — runs both on PRs and `trunk` pushes that touch `.github/workflows/**`, `.github/actions/**`, or either script. GitHub-hosted `ubuntu-24.04` on purpose: it is a sub-second check and must not queue behind the saturated self-hosted pool (#12162).

This follows the existing `github_release.py` + `test_github_release.py` + `release_script_test.yml` precedent: a pure checker split from its CI wrapper, with the logic under unit test.

## Test plan

- `make lint` — no Rust-affecting files in this change; `Attestation` auto-passes.
- `make test` — no Rust-affecting files in this change.
- `python .github/scripts/test_check_workflow_yaml.py -v` → **18 passed**. The suite includes `RepositoryTest`, which runs the checker over this repository's own `.github/` — so the guard is itself the regression test for the workflow fix.
- `python .github/scripts/check_workflow_yaml.py` → `OK: 96 GitHub Actions definitions parse and declare the required keys`.
- **Neuter check**: restoring the original mis-indented line makes the checker exit `1` with `cargo_deny_advisories.yml: is not valid YAML: could not find expected ':' at line 67`, and `RepositoryTest` fails. Restored and re-verified green on the pushed tree.
- The step's JavaScript was extracted from the parsed YAML and syntax-checked with `node --check` (wrapped in the async IIFE `github-script` supplies).
- **Live end-to-end, read-only**: pushing this branch produced **no run at all** for that workflow, while a branch pushed three minutes earlier still produced the usual `failure`. GitHub now parses the file at this ref and correctly sees that `push` is not one of its triggers — which is the fix working, observed against the real Actions scheduler without dispatching anything.

Expect the first real scheduled run (`20 5 * * *`) to report whatever advisories have accumulated over the 14 days the scan was dark; if there are any, the workflow opens its marker issue as designed.

## Checklist

- [x] Root cause identified and stated
- [x] Regression test that fails before the fix and passes after
- [x] Bug class addressed, not just the reported instance
- [x] Verified against the live GitHub Actions scheduler, read-only
- [x] No behavior change to any other workflow

Fixes #12181