### PR TITLE
chbench pods: stop pinning the CDC buffers and mem-tier shards

### DIFF
--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-ivm.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-ivm.yaml
@@ -85,7 +85,6 @@ datasets:
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
-        cayenne_cdc_mem_tier_shards: '4'
         # Goal-driven SLOs are set globally under `runtime.params` (above) and
         # inherited by every dataset, so they are intentionally not repeated here.
         # (A dataset that needed a sharper target would override the relevant

--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-split.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-split.yaml
@@ -86,10 +86,6 @@ datasets:
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
-        cayenne_cdc_mem_tier_shards: '4'
-        cdc_prefetch_buffer: '16384'
-        cdc_max_coalesced_envelopes: '16384'
-        cdc_max_coalesced_bytes: '536870912'
         cdc_max_coalesce_age_ms: '2000'
         # Goal-driven SLOs are set globally under `runtime.params` (above) and
         # inherited by every dataset, so they are intentionally not repeated here.

--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-turso.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive-turso.yaml
@@ -84,10 +84,6 @@ datasets:
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
-        cayenne_cdc_mem_tier_shards: '4'
-        cdc_prefetch_buffer: '16384'
-        cdc_max_coalesced_envelopes: '16384'
-        cdc_max_coalesced_bytes: '536870912'
         cdc_max_coalesce_age_ms: '2000'
         # The only line that differs from the sqlite-default adaptive twin: select the Turso
         # metastore backend. This is a structural backend choice, not a tunable actuator, so it

--- a/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/mysql-cayenne[file]-adaptive.yaml
@@ -79,10 +79,6 @@ datasets:
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
-        cayenne_cdc_mem_tier_shards: '4'
-        cdc_prefetch_buffer: '16384'
-        cdc_max_coalesced_envelopes: '16384'
-        cdc_max_coalesced_bytes: '536870912'
         cdc_max_coalesce_age_ms: '2000'
         # Goal-driven SLOs are set globally under `runtime.params` (above) and
         # inherited by every dataset, so they are intentionally not repeated here.

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-1slot.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-1slot.yaml
@@ -45,9 +45,6 @@ runtime:
     # Deep prefetch + higher-coalescing pins, matching the default `-adaptive` pod so this 1-slot
     # config differs from it ONLY in slot count (isolating the slot-count effect at a fixed
     # prefetch depth and coalescing budget).
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '2000'
     cayenne_goal_replication_lag: '5s'
     cayenne_goal_freshness: '30s'
@@ -76,7 +73,6 @@ datasets:
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
-        cayenne_cdc_mem_tier_shards: '4'
         # Goal-driven SLOs are set globally under `runtime.params` (above) and
         # inherited by every dataset, so they are intentionally not repeated here.
 

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-cold-auto-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-cold-auto-sf1000.yaml
@@ -59,7 +59,6 @@ datasets:
         cayenne_tuning: adaptive
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in parallel within
         # one apply on the memory-tier (changes) tables. Not an adaptive actuator.
-        cayenne_cdc_mem_tier_shards: '4'
         # --- Datalake (cold) object-store tier: ONLY the location + credentials are set, which is
         # all that enables the tier. Promotion trigger / cold file size / cadence are intentionally
         # left UNSET so they run on engine defaults / auto-tuning (this pod's whole point). The
@@ -127,7 +126,6 @@ datasets:
       refresh_mode: changes
       params: &cayenne_params
         cayenne_tuning: adaptive
-        cayenne_cdc_mem_tier_shards: '4'
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh) — adaptive, no cold tier.

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-cold-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-cold-sf1000.yaml
@@ -78,7 +78,6 @@ datasets:
         cayenne_tuning: adaptive
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in parallel within
         # one apply on the memory-tier (changes) tables. Not an adaptive actuator.
-        cayenne_cdc_mem_tier_shards: '4'
         # --- Datalake (cold) object-store tier (RAM mem-tier -> warm local disk -> COLD). All
         # static config; none of these are adaptive actuators, so setting them collapses no tuning
         # bound. The location is namespaced by table_id, so one shared prefix is safe for every
@@ -152,7 +151,6 @@ datasets:
       refresh_mode: changes
       params: &cayenne_params
         cayenne_tuning: adaptive
-        cayenne_cdc_mem_tier_shards: '4'
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh) — adaptive, no cold tier.

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-ivm.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-ivm.yaml
@@ -2,6 +2,16 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-adaptive-ivm
 
+# CDC prefetch is NOT pinned: it uses the runtime default (128 envelopes).
+# It was previously pinned to 16384, the runtime maximum, for throughput. That
+# channel caps ENVELOPES, not bytes, and each envelope carries a materialized
+# 8192-row batch — so 16384 slots meant up to 134M rows in flight per dataset,
+# more rows than most of these tables contain, with all 7 snapshotting at once
+# under initial_snapshot: auto. It appears in no memory budget, and the gauge
+# reports envelopes, so it read "16384/16384" identically whether it held 35 GB
+# or 35 MB. At SF-1000 spiced reached 95.8 GB of anonymous RSS in under 7
+# minutes, with bootstrap still incomplete, and was OOM-killed.
+
 # Adaptive CH-BenCHmark + maintained aggregates (IVM).
 #
 # Same topology / prefetch / adaptive loop as `postgres-cayenne[file]-adaptive`, plus
@@ -44,7 +54,6 @@ name: postgres-cayenne[file]-adaptive-ivm
 #     warm-start. Adaptive is set explicitly, so it runs regardless; without inferred metadata
 #     the loop just relearns the row width from observed ingest.
 # Background compaction stays at the auto-derived (non-zero) default — the controller rides its
-# tick. The ONLY pinned knobs are the two CDC prefetch buffers (`cdc_prefetch_buffer` /
 # `cdc_max_coalesced_envelopes` = 16384, the runtime max) under `runtime.params` below: the sweep
 # showed deep prefetch is a clear, stable win, so we fix it here (this collapses those two knobs'
 # adaptive bounds to a point; adaptive still moves every other per-actuator knob freely).
@@ -82,8 +91,6 @@ runtime:
     # Deep prefetch: pin the CDC source-reader→apply channel and coalescing envelope cap to the
     # runtime max (16384). This was the biggest single lever in the SF1000 benchmark sweep (4-slot
     # replication lag ~435s at default buffers → ~320s deep).
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
     cayenne_goal_replication_lag: '5s'
     cayenne_goal_freshness: '30s'
     cayenne_goal_query_latency: '10s'
@@ -110,7 +117,6 @@ datasets:
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
-        cayenne_cdc_mem_tier_shards: '4'
         # Goal-driven SLOs are set globally under `runtime.params` (above) and
         # inherited by every dataset, so they are intentionally not repeated here.
         # (A dataset that needed a sharper target would override the relevant

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-turso.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive-turso.yaml
@@ -82,7 +82,6 @@ datasets:
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
-        cayenne_cdc_mem_tier_shards: '4'
         # The only line that differs from the sqlite-default adaptive twin: select the Turso
         # metastore backend. This is a structural backend choice, not a tunable actuator, so it
         # does not pin any knob under adaptive tuning.

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-adaptive.yaml
@@ -2,6 +2,16 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-adaptive
 
+# CDC prefetch is NOT pinned: it uses the runtime default (128 envelopes).
+# It was previously pinned to 16384, the runtime maximum, for throughput. That
+# channel caps ENVELOPES, not bytes, and each envelope carries a materialized
+# 8192-row batch — so 16384 slots meant up to 134M rows in flight per dataset,
+# more rows than most of these tables contain, with all 7 snapshotting at once
+# under initial_snapshot: auto. It appears in no memory budget, and the gauge
+# reports envelopes, so it read "16384/16384" identically whether it held 35 GB
+# or 35 MB. At SF-1000 spiced reached 95.8 GB of anonymous RSS in under 7
+# minutes, with bootstrap still incomplete, and was OOM-killed.
+
 # Default adaptive CH-BenCHmark config, set to the topology + prefetch that won the SF1000
 # benchmark sweep: the 7 CDC tables share FOUR replication slots (not one-per-table), and the CDC prefetch
 # buffers are pinned deep (16384). In that sweep the 1-slot topology failed the data-correctness
@@ -33,7 +43,6 @@ name: postgres-cayenne[file]-adaptive
 #     the loop just relearns the row width from observed ingest.
 # Background compaction stays at the auto-derived (non-zero) default — the controller rides its
 # tick. The pinned CDC knobs under `runtime.params` below are the deep prefetch buffers
-# (`cdc_prefetch_buffer` / `cdc_max_coalesced_envelopes` = 16384, the runtime max) plus the
 # higher-coalescing byte budget + linger window (`cdc_max_coalesced_bytes` = 512 MB /
 # `cdc_max_coalesce_age_ms` = 2000): the sweep showed deep prefetch is a clear, stable win and
 # that coalescing is the strongest convergence lever at SF1000, so we fix both here (this
@@ -73,8 +82,6 @@ runtime:
     # Deep prefetch: pin the CDC source-reader→apply channel and coalescing envelope cap to the
     # runtime max (16384). This was the biggest single lever in the SF1000 benchmark sweep (4-slot
     # replication lag ~435s at default buffers → ~320s deep).
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
     # Higher-coalescing default: raise the byte budget and add a linger window so the
     # apply loop forms big bursts (fewer, larger applies amortize per-burst
     # stats/checkpoint/publish over more rows). In the SF1000 sweep this was the
@@ -82,7 +89,6 @@ runtime:
     # coalescing on, where the no-coalesce default failed to converge. The linger
     # deadline is anchored at the previous apply's start, so apply-bound tables barely
     # wait; 2000ms bounds the added freshness latency for lighter tables.
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '2000'
     cayenne_goal_replication_lag: '5s'
     cayenne_goal_freshness: '30s'
@@ -110,7 +116,6 @@ datasets:
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables. Inert on the
         # full-refresh reference tables that share this anchor (not CDC memory mode).
-        cayenne_cdc_mem_tier_shards: '4'
         # Goal-driven SLOs are set globally under `runtime.params` (above) and
         # inherited by every dataset, so they are intentionally not repeated here.
         # (A dataset that needed a sharper target would override the relevant

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-cold-sf10.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-cold-sf10.yaml
@@ -14,9 +14,6 @@ name: postgres-cayenne[file]-cdc-tuned-cold-sf10
 # starting spiced/testoperator. In CI the HTAP run workflow provides them from TEST_MINIO_*.
 runtime:
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '4000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-cold-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-cold-sf1000.yaml
@@ -19,9 +19,6 @@ runtime:
   flight:
     ipc_compression: lz4_frame
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
@@ -77,7 +74,6 @@ datasets:
         cayenne_cdc_mem_tier_max_age_ms: '30000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
-        cayenne_cdc_mem_tier_shards: '4'
         # KEY deletes even in file mode: deletion_mode auto resolves to
         # position, which serializes compaction with writers (try_lock
         # starvation under continuous CDC — measured unbounded file/read-amp
@@ -96,7 +92,6 @@ datasets:
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
         # --- Datalake (cold) object-store tier (RAM mem-tier -> warm local disk -> COLD) ---
         # Presence of the location enables the tier (and forces key deletes, already set above).
         # Cayenne namespaces cold files by table_id under this prefix, so one shared location is
@@ -256,13 +251,11 @@ datasets:
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
         cayenne_cdc_mem_tier_max_age_ms: '30000'
-        cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '64'
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).
@@ -306,7 +299,6 @@ datasets:
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
         cayenne_cdc_mem_tier_max_age_ms: '30000'
-        cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'
         cayenne_segment_cache_mb: '16'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-ivm-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-ivm-sf1000.yaml
@@ -11,9 +11,6 @@ runtime:
   flight:
     ipc_compression: lz4_frame
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
@@ -69,7 +66,6 @@ datasets:
         cayenne_cdc_mem_tier_max_age_ms: '30000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
-        cayenne_cdc_mem_tier_shards: '4'
         # KEY deletes even in file mode: deletion_mode auto resolves to
         # position, which serializes compaction with writers (try_lock
         # starvation under continuous CDC — measured unbounded file/read-amp
@@ -88,7 +84,6 @@ datasets:
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   - from: postgres:customer
     name: customer
@@ -254,13 +249,11 @@ datasets:
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
         cayenne_cdc_mem_tier_max_age_ms: '30000'
-        cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '64'
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).
@@ -304,7 +297,6 @@ datasets:
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
         cayenne_cdc_mem_tier_max_age_ms: '30000'
-        cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'
         cayenne_segment_cache_mb: '16'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf100.yaml
@@ -2,6 +2,16 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned-memory-sf100
 
+# CDC prefetch is NOT pinned: it uses the runtime default (128 envelopes).
+# It was previously pinned to 16384, the runtime maximum, for throughput. That
+# channel caps ENVELOPES, not bytes, and each envelope carries a materialized
+# 8192-row batch — so 16384 slots meant up to 134M rows in flight per dataset,
+# more rows than most of these tables contain, with all 7 snapshotting at once
+# under initial_snapshot: auto. It appears in no memory budget, and the gauge
+# reports envelopes, so it read "16384/16384" identically whether it held 35 GB
+# or 35 MB. At SF-1000 spiced reached 95.8 GB of anonymous RSS in under 7
+# minutes, with bootstrap still incomplete, and was OOM-killed.
+
 # Target: 64 vCPU / 256 GiB RAM, EBS gp3 (m7a.16xlarge-class). Goal: every CDC table under
 # 5s replication lag at SF-100 @ 10K txn/s, with >=5K QPH on the OLAP queries.
 #
@@ -11,7 +21,6 @@ name: postgres-cayenne[file]-cdc-tuned-memory-sf100
 # and holds 6/7 tables <5s under load; order_line is the remaining apply bottleneck):
 #   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
 #     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
-#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
 #     WAL drain ahead of bursty OLTP without enlarging the per-apply batch.
 #   - target_partitions 48: read-path parallelism tuned for the QPH goal on the 64c runner.
 #   - cayenne_pk_keyset_cache_mb 256 pinned on ALL tables: defeats the backwards memory-aware
@@ -30,9 +39,6 @@ runtime:
   flight:
     ipc_compression: lz4_frame
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
@@ -105,7 +111,6 @@ datasets:
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   - from: postgres:customer
     name: customer
@@ -245,7 +250,6 @@ datasets:
         # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-memory-sf1000.yaml
@@ -11,9 +11,6 @@ runtime:
   flight:
     ipc_compression: lz4_frame
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
@@ -69,7 +66,6 @@ datasets:
         cayenne_cdc_mem_tier_max_age_ms: '30000'
         # In-memory CDC intra-apply sharding: 4 PK-hash shards validate+append in
         # parallel within one apply on the memory-tier (changes) tables.
-        cayenne_cdc_mem_tier_shards: '4'
         # KEY deletes even in file mode: deletion_mode auto resolves to
         # position, which serializes compaction with writers (try_lock
         # starvation under continuous CDC — measured unbounded file/read-amp
@@ -88,7 +84,6 @@ datasets:
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   - from: postgres:customer
     name: customer
@@ -223,13 +218,11 @@ datasets:
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
         cayenne_cdc_mem_tier_max_age_ms: '30000'
-        cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '8'
         cayenne_segment_cache_mb: '64'
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).
@@ -273,7 +266,6 @@ datasets:
         cayenne_cdc_mem_tier_max_bytes: '268435456' # 256 MiB
         cayenne_cdc_mem_tier_min_flush_bytes: '33554432' # 32 MiB
         cayenne_cdc_mem_tier_max_age_ms: '30000'
-        cayenne_cdc_mem_tier_shards: '4'
         cayenne_deletion_mode: key
         cayenne_write_concurrency: '2'
         cayenne_segment_cache_mb: '16'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1.yaml
@@ -2,12 +2,21 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned-sf1
 
+# CDC prefetch is NOT pinned: it uses the runtime default (128 envelopes).
+# It was previously pinned to 16384, the runtime maximum, for throughput. That
+# channel caps ENVELOPES, not bytes, and each envelope carries a materialized
+# 8192-row batch — so 16384 slots meant up to 134M rows in flight per dataset,
+# more rows than most of these tables contain, with all 7 snapshotting at once
+# under initial_snapshot: auto. It appears in no memory budget, and the gauge
+# reports envelopes, so it read "16384/16384" identically whether it held 35 GB
+# or 35 MB. At SF-1000 spiced reached 95.8 GB of anonymous RSS in under 7
+# minutes, with bootstrap still incomplete, and was OOM-killed.
+
 # Target: xlarge-runner — 64 vCPU / 256 GiB RAM, SSD storage. sf1 run: identical to
 # the sf1000 tuning — at this scale every PK keyset fits the exact path under any
 # pin, so the keyset value is not load-bearing; kept aligned for comparability.
 #
 # Key tuning:
-#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384 (runtime max after Lever D
 #     raised CDC_PREFETCH_BUFFER_MAX / CDC_MAX_COALESCED_ENVELOPES_MAX 4096->16384):
 #     larger CDC bursts cut metastore round-trips and keep WAL drain ahead of bursty OLTP.
 #   - target_partitions 48: read-path parallelism tuned for the current runner sweep.
@@ -15,9 +24,6 @@ name: postgres-cayenne[file]-cdc-tuned-sf1
 #     upsert tables; reference tables use lighter settings.
 runtime:
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '4000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf10.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf10.yaml
@@ -2,12 +2,21 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned-sf10
 
+# CDC prefetch is NOT pinned: it uses the runtime default (128 envelopes).
+# It was previously pinned to 16384, the runtime maximum, for throughput. That
+# channel caps ENVELOPES, not bytes, and each envelope carries a materialized
+# 8192-row batch — so 16384 slots meant up to 134M rows in flight per dataset,
+# more rows than most of these tables contain, with all 7 snapshotting at once
+# under initial_snapshot: auto. It appears in no memory budget, and the gauge
+# reports envelopes, so it read "16384/16384" identically whether it held 35 GB
+# or 35 MB. At SF-1000 spiced reached 95.8 GB of anonymous RSS in under 7
+# minutes, with bootstrap still incomplete, and was OOM-killed.
+
 # Target: xlarge-runner — 64 vCPU / 256 GiB RAM, SSD storage. sf10 run: identical to
 # the sf1000 tuning — at this scale every PK keyset fits the exact path under any
 # pin, so the keyset value is not load-bearing; kept aligned for comparability.
 #
 # Key tuning:
-#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384 (runtime max after Lever D
 #     raised CDC_PREFETCH_BUFFER_MAX / CDC_MAX_COALESCED_ENVELOPES_MAX 4096->16384):
 #     larger CDC bursts cut metastore round-trips and keep WAL drain ahead of bursty OLTP.
 #   - target_partitions 48: read-path parallelism tuned for the current runner sweep.
@@ -15,9 +24,6 @@ name: postgres-cayenne[file]-cdc-tuned-sf10
 #     upsert tables; reference tables use lighter settings.
 runtime:
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '536870912' # 512 MB
     cdc_max_coalesce_age_ms: '4000'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf100.yaml
@@ -2,6 +2,16 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned-sf100
 
+# CDC prefetch is NOT pinned: it uses the runtime default (128 envelopes).
+# It was previously pinned to 16384, the runtime maximum, for throughput. That
+# channel caps ENVELOPES, not bytes, and each envelope carries a materialized
+# 8192-row batch — so 16384 slots meant up to 134M rows in flight per dataset,
+# more rows than most of these tables contain, with all 7 snapshotting at once
+# under initial_snapshot: auto. It appears in no memory budget, and the gauge
+# reports envelopes, so it read "16384/16384" identically whether it held 35 GB
+# or 35 MB. At SF-1000 spiced reached 95.8 GB of anonymous RSS in under 7
+# minutes, with bootstrap still incomplete, and was OOM-killed.
+
 # Target: 64 vCPU / 256 GiB RAM, EBS gp3 (m7a.16xlarge-class). Goal: every CDC table under
 # 5s replication lag at SF-100 @ 10K txn/s, with >=5K QPH on the OLAP queries.
 #
@@ -11,7 +21,6 @@ name: postgres-cayenne[file]-cdc-tuned-sf100
 # and holds 6/7 tables <5s under load; order_line is the remaining apply bottleneck):
 #   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
 #     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
-#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
 #     WAL drain ahead of bursty OLTP without enlarging the per-apply batch.
 #   - target_partitions 48: read-path parallelism tuned for the QPH goal on the 64c runner.
 #   - cayenne_pk_keyset_cache_mb 256 pinned on ALL tables: defeats the backwards memory-aware
@@ -30,9 +39,6 @@ runtime:
   flight:
     ipc_compression: lz4_frame
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
@@ -103,7 +109,6 @@ datasets:
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   - from: postgres:customer
     name: customer
@@ -240,7 +245,6 @@ datasets:
         # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-sf1000.yaml
@@ -6,9 +6,6 @@ runtime:
   flight:
     ipc_compression: lz4_frame
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
@@ -72,7 +69,6 @@ datasets:
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   - from: postgres:customer
     name: customer
@@ -208,7 +204,6 @@ datasets:
         cayenne_segment_cache_mb: '64'
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf100.yaml
@@ -2,6 +2,16 @@ version: v1
 kind: Spicepod
 name: postgres-cayenne[file]-cdc-tuned-turso-sf100
 
+# CDC prefetch is NOT pinned: it uses the runtime default (128 envelopes).
+# It was previously pinned to 16384, the runtime maximum, for throughput. That
+# channel caps ENVELOPES, not bytes, and each envelope carries a materialized
+# 8192-row batch — so 16384 slots meant up to 134M rows in flight per dataset,
+# more rows than most of these tables contain, with all 7 snapshotting at once
+# under initial_snapshot: auto. It appears in no memory budget, and the gauge
+# reports envelopes, so it read "16384/16384" identically whether it held 35 GB
+# or 35 MB. At SF-1000 spiced reached 95.8 GB of anonymous RSS in under 7
+# minutes, with bootstrap still incomplete, and was OOM-killed.
+
 # Turso-metastore variant of postgres-cayenne[file]-cdc-tuned-sf100: identical CDC tuning;
 # only the Cayenne metastore backend differs — cayenne_metastore: turso (libsql MVCC /
 # BEGIN CONCURRENT) instead of sqlite. Exercises the Turso metastore at SF-100 on the
@@ -16,7 +26,6 @@ name: postgres-cayenne[file]-cdc-tuned-turso-sf100
 # and holds 6/7 tables <5s under load; order_line is the remaining apply bottleneck):
 #   - cdc_max_coalesce_age_ms 250 + cdc_max_coalesced_bytes 128 MB: keep CDC applies small and
 #     fresh so they stay inline (4000ms/512 MB regressed — see the note on the linger below).
-#   - cdc_prefetch_buffer / cdc_max_coalesced_envelopes 16384: runtime max; deep prefetch keeps
 #     WAL drain ahead of bursty OLTP without enlarging the per-apply batch.
 #   - target_partitions 48: read-path parallelism tuned for the QPH goal on the 64c runner.
 #   - cayenne_pk_keyset_cache_mb 256 pinned on ALL tables: defeats the backwards memory-aware
@@ -35,9 +44,6 @@ runtime:
   flight:
     ipc_compression: lz4_frame
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
@@ -106,7 +112,6 @@ datasets:
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   - from: postgres:customer
     name: customer
@@ -243,7 +248,6 @@ datasets:
         # Pin 256 MiB explicitly — SF-100 optimum (don't leave to the backwards memory-aware auto-default).
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).

--- a/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
+++ b/test/spicepods/chbench/accelerated/postgres-cayenne[file]-cdc-tuned-turso-sf1000.yaml
@@ -11,9 +11,6 @@ runtime:
   flight:
     ipc_compression: lz4_frame
   params:
-    cdc_prefetch_buffer: '16384'
-    cdc_max_coalesced_envelopes: '16384'
-    cdc_max_coalesced_bytes: '134217728' # 128 MB
     cdc_max_coalesce_age_ms: '250'
     cdc_commit_timeout_ms: '60000'
     cayenne_sort_merge_min_rows: '50000000'
@@ -77,7 +74,6 @@ datasets:
         cayenne_compaction_max_files_per_pick: '64'
         cayenne_compaction_background_interval_ms: '3000'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   - from: postgres:customer
     name: customer
@@ -213,7 +209,6 @@ datasets:
         cayenne_segment_cache_mb: '64'
         cayenne_pk_keyset_cache_mb: '256'
         cdc_max_coalesce_age_ms: '3000'
-        cdc_max_coalesced_bytes: '536870912' # 512 MB
 
   # ------------------------------------------------------------------
   # Static reference tables (no OLTP mutations, full refresh).


### PR DESCRIPTION
## What

`cdc_prefetch_buffer: '16384'` — the runtime maximum, 128× the default of 128 — is unsafe at scale, and these pods are where it is set. Removing it, plus three related overrides, so all four take runtime defaults.

## Why

That channel caps **envelopes, not bytes** ([`changes.rs:1114-1116`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/accelerated_table/refresh_task/changes.rs#L1114)), and each envelope carries a fully materialized 8192-row batch (`DEFAULT_BOOTSTRAP_BATCH_SIZE`, [`replication.rs:50`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-postgres/src/replication.rs#L50)). So 16384 slots admit up to **134M rows in flight per dataset** — more rows than most CH-benCH tables contain — and with `pg_replication_initial_snapshot: auto` all seven snapshot concurrently:

| table | rows × width | in flight |
|---|---|---|
| `stock` | 100M × 377 B | **35 GiB** |
| `customer` | 30M × 668 B | **19 GiB** |
| `order_line` | 134M × 136 B | **17 GiB** |

None of it is accounted for. `estimate_cayenne_cdc_reservation_bytes` ([`builder.rs:1101-1185`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/builder.rs#L1101)) does not include the prefetch channel, and the occupancy gauge ([`changes.rs:1317-1322`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/accelerated_table/refresh_task/changes.rs#L1317)) reports *envelopes* — so it reads `16384/16384` identically whether it is holding 35 GB or 35 MB.

**Measured**, on a 121.7 GiB bare-metal host at SF-1000: `spiced` reached **95.8 GB of anonymous RSS in 6 min 57 s**, with bootstrap still incomplete (6 of 7 tables), and was OOM-killed. The startup commitment was:

```
query 48.7 + compaction 12.2 + mem-tier 30.4 + off-pool caches 36.8 = 128.1 GiB
                                                on a 121.7 GiB host
```

All three logged figures reproduce to the digit from the source formulas. The configuration was **unfittable before a single row arrived**, and the only signal is a `debug!` line ([`datafusion/builder.rs:1575`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/datafusion/builder.rs#L1575)).

## The other three

- **`cdc_max_coalesced_bytes` 512 MB → 128 MB.** The knob that *actually* bounds the coalescing path — coalescing stops at envelopes **or** bytes (`changes.rs:514`, `:538`) — and a counted reservation term: 7 × 512 MB = 3.5 GiB, now 0.9 GiB.
- **`cdc_max_coalesced_envelopes` 16384 → 256.** Byte-bounded by the above, so this reduces config surface rather than memory. Said plainly rather than claimed as a saving it does not deliver.
- **`cayenne_cdc_mem_tier_shards` 4 → 1.** Shards > 1 switches on a per-scan cross-shard tombstone union (`mem_tier.rs:807-820`) that is charged nothing and runs before the memo check. At the default it does not run.

`cdc_max_coalesce_age_ms` stays pinned — it governs freshness, not memory.

## Trade-off, stated

The prefetch pin was introduced for throughput and it did raise it; the pod comments credit deep prefetch with most of an SF-1000 lag improvement. **SF-1000 lag numbers from these pods are therefore not comparable across this change**, and SF-100 may shift too. The trade was never bounded, and at SF-1000 it is fatal — a benchmark config that cannot survive its own scale is not measuring anything.

These pods declare `cayenne_tuning: adaptive`, so each pinned knob is one the closed loop cannot move.

## Related

Two runtime-side gaps this exposed, tracked separately:

- #12179 — `get_container_memory_limit` reads a fixed `/sys/fs/cgroup` path, so budgets size from host RAM under a systemd scope or `cgroupns=host`. Confirmed on this host, where it also left the adaptive memory rule inert right up to the kill (pressure read 0.79 against a 0.85 threshold, because the numerator was cgroup-accurate and the denominator was not).
- The prefetch channel wants a byte ceiling, or to be folded into the reservation estimator — a config change here does not fix the underlying unboundedness.