### PR TITLE
fix(search): Fix ordering to correct `NDCG@k`

### DIFF
--- a/crates/test-framework/src/spicetest/search/evaluate.rs
+++ b/crates/test-framework/src/spicetest/search/evaluate.rs
@@ -47,8 +47,7 @@ pub(crate) fn calculate_ndcg<S: ::std::hash::BuildHasher>(
             // score; NDCG is position-weighted, so results must be sorted by score
             // (descending) before computing gain, or the ranking quality it measures is lost.
             let mut scored_docs: Vec<(&String, &f64)> = ranked_results.iter().collect();
-            scored_docs
-                .sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
+            scored_docs.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
             let relevance_scores: Vec<f64> = scored_docs
                 .into_iter()
                 .map(|(doc_id, _)| f64::from(*relevance.get(doc_id).unwrap_or(&0)))

--- a/crates/test-framework/src/spicetest/search/evaluate.rs
+++ b/crates/test-framework/src/spicetest/search/evaluate.rs
@@ -43,9 +43,15 @@ pub(crate) fn calculate_ndcg<S: ::std::hash::BuildHasher>(
 
     for (query_id, relevance) in qrels {
         if let Some(ranked_results) = results.get(query_id) {
-            let relevance_scores: Vec<f64> = ranked_results
-                .keys()
-                .map(|doc_id| f64::from(*relevance.get(doc_id).unwrap_or(&0)))
+            // `ranked_results` is a HashMap, so its iteration order has no relation to
+            // score; NDCG is position-weighted, so results must be sorted by score
+            // (descending) before computing gain, or the ranking quality it measures is lost.
+            let mut scored_docs: Vec<(&String, &f64)> = ranked_results.iter().collect();
+            scored_docs
+                .sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
+            let relevance_scores: Vec<f64> = scored_docs
+                .into_iter()
+                .map(|(doc_id, _)| f64::from(*relevance.get(doc_id).unwrap_or(&0)))
                 .collect();
             ndcg_at_k_values.push(ndcg_at_k(&relevance_scores, k));
         } else {
@@ -79,4 +85,47 @@ fn ndcg_at_k(relevance_scores: &[f64], k: usize) -> f64 {
         return 0.0;
     }
     dcg / idcg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::calculate_ndcg;
+    use std::collections::HashMap;
+
+    #[test]
+    fn ndcg_sorts_results_by_score_before_scoring() {
+        // Six distinct relevance grades so any ordering other than
+        // score-descending strictly reduces DCG below IDCG.
+        let qrels: HashMap<String, HashMap<String, i32>> = HashMap::from([(
+            "q1".to_string(),
+            HashMap::from([
+                ("doc0".to_string(), 6),
+                ("doc1".to_string(), 5),
+                ("doc2".to_string(), 4),
+                ("doc3".to_string(), 3),
+                ("doc4".to_string(), 2),
+                ("doc5".to_string(), 1),
+            ]),
+        )]);
+
+        // Search scores rank the docs in exactly the same order as their
+        // relevance grade, so a correctly score-sorted NDCG@6 is exactly 1.0.
+        let results: HashMap<String, HashMap<String, f64>> = HashMap::from([(
+            "q1".to_string(),
+            HashMap::from([
+                ("doc0".to_string(), 0.6),
+                ("doc1".to_string(), 0.5),
+                ("doc2".to_string(), 0.4),
+                ("doc3".to_string(), 0.3),
+                ("doc4".to_string(), 0.2),
+                ("doc5".to_string(), 0.1),
+            ]),
+        )]);
+
+        let ndcg = calculate_ndcg(&qrels, &results, 6);
+        assert!(
+            (ndcg - 1.0).abs() < 1e-9,
+            "expected a perfect NDCG@6 of 1.0 when search scores exactly match relevance order, got {ndcg}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
`calculate_ndcg` used a `HashMap<doc_id, score>` which broke the ordering, affecting NDCG calculations. 

Resulted in artificially low NDCG (since we randomised order, search got no credit for above average inclusion). 

| spicepod.yaml | Before | After |
|---|---|---|
| `full_text_search-cayenne[file]` | 0.427 | 0.757 |
| `full_text_search-duckdb[file]` | 0.437 | 0.756 |
| `model2vec-duckdb[file]` (embeddings) | 0.455 | 0.780 |
