### PR TITLE
fix(logging): mute the candle embedding backend's GeLU notice below -vv

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -99,7 +99,7 @@ const INTERNAL_COMPONENTS: &[&str] = &[
 ];
 
 const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry=warn,opentelemetry_sdk=off,delta_kernel::log_segment=off,delta_kernel::listed_log_files=off,aws_config::imds::region=off,aws_config::meta::credentials::chain=off,tower::buffer=off,h2::codec=off";
-const OFF_UNLESS_VERY_VERBOSE_FILTERS: &str = "datafusion_datasource::source=off,datafusion_optimizer::utils=off,datafusion_optimizer::optimizer=off,datafusion::physical_planner=off,tantivy=warn";
+const OFF_UNLESS_VERY_VERBOSE_FILTERS: &str = "datafusion_datasource::source=off,datafusion_optimizer::utils=off,datafusion_optimizer::optimizer=off,datafusion::physical_planner=off,tantivy=warn,text_embeddings_backend_candle=error";
 
 fn specific_env_filter(filter: &str) -> String {
     format!("{OFF_FILTERS},{filter}")
@@ -459,6 +459,111 @@ impl SpanExporter for OtelExportMultiplexer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    /// Sink for a probe subscriber's console output, so a test can assert on
+    /// what the `fmt` layer actually wrote.
+    #[derive(Clone, Default)]
+    struct ProbeWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl ProbeWriter {
+        fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().expect("probe buffer poisoned")).into_owned()
+        }
+    }
+
+    impl std::io::Write for ProbeWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("probe buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for ProbeWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Emits a `WARN` and an `ERROR` event on the `text_embeddings_backend_candle`
+    /// target through a subscriber assembled the way `init_tracing` assembles it —
+    /// the `EnvFilter` for `$verbosity` in front of the console `fmt` layer — and
+    /// evaluates to everything that reached the console.
+    ///
+    /// A macro rather than a function because `tracing` bakes the event target into
+    /// a `static` callsite, so it cannot be passed in as a value; each expansion
+    /// then also gets its own callsite, which keeps the process-wide callsite
+    /// interest cache from carrying one verbosity's verdict into the next.
+    macro_rules! candle_console_output {
+        ($verbosity:expr) => {{
+            let probe = ProbeWriter::default();
+            let filter: EnvFilter = $verbosity.into();
+            let subscriber = tracing_subscriber::registry().with(filter).with(
+                fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(probe.clone())
+                    .with_filter(filter::filter_fn(|metadata| {
+                        metadata.target() != "task_history"
+                    })),
+            );
+
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::warn!(
+                    target: "text_embeddings_backend_candle",
+                    "the config.json contains hidden_act=gelu"
+                );
+                tracing::error!(
+                    target: "text_embeddings_backend_candle",
+                    "could not load model weights"
+                );
+            });
+
+            probe.contents()
+        }};
+    }
+
+    #[test]
+    fn candle_gelu_notice_is_hidden_unless_very_verbose() {
+        let default = candle_console_output!(LogVerbosity::Default);
+        assert!(
+            !default.contains("hidden_act=gelu"),
+            "default verbosity should drop the candle GeLU notice, got: {default}"
+        );
+        assert!(
+            default.contains("could not load model weights"),
+            "default verbosity must still surface candle errors, got: {default}"
+        );
+
+        let verbose = candle_console_output!(LogVerbosity::Verbose);
+        assert!(
+            !verbose.contains("hidden_act=gelu"),
+            "verbose should drop the candle GeLU notice, got: {verbose}"
+        );
+        assert!(
+            verbose.contains("could not load model weights"),
+            "verbose must still surface candle errors, got: {verbose}"
+        );
+
+        let very_verbose = candle_console_output!(LogVerbosity::VeryVerbose);
+        assert!(
+            very_verbose.contains("hidden_act=gelu"),
+            "very verbose should reveal the candle GeLU notice, got: {very_verbose}"
+        );
+        assert!(
+            very_verbose.contains("could not load model weights"),
+            "very verbose must still surface candle errors, got: {very_verbose}"
+        );
+    }
 
     #[test]
     fn returns_very_verbose_if_flag_set() {

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -507,8 +507,8 @@ mod tests {
     macro_rules! candle_console_output {
         ($verbosity:expr) => {{
             let probe = ProbeWriter::default();
-            let filter: EnvFilter = $verbosity.into();
-            let subscriber = tracing_subscriber::registry().with(filter).with(
+            let env_filter: EnvFilter = $verbosity.into();
+            let subscriber = tracing_subscriber::registry().with(env_filter).with(
                 fmt::layer()
                     .with_ansi(false)
                     .with_writer(probe.clone())


### PR DESCRIPTION
Any local HuggingFace embedding model whose `config.json` sets `hidden_act: gelu` makes the candle embeddings backend log a `WARN` on load, explaining that it uses the GeLU + tanh approximation instead of exact GeLU (erf). `sentence-transformers/all-MiniLM-L6-v2` is such a model, and it is one of the most widely used sentence-embedding models — so effectively every deployment running local HuggingFace embeddings sees this line on every model load. It describes a numerical trade-off the backend makes deliberately; there is nothing for an operator to act on.

This adds `text_embeddings_backend_candle=error` to `OFF_UNLESS_VERY_VERBOSE_FILTERS` in `bin/spiced/src/tracing.rs`:

- **`error`, not `off`** — a genuine model-load failure from the candle backend must still reach the log. `off` would hide those too.
- **The very-verbose bucket, not the always-off bucket** — GeLU + tanh vs exact GeLU is exactly what someone checking Spice's embedding parity against Sentence Transformers needs to see. `spiced -vv` still shows it.

`EnvFilter` matches on target prefix, so the directive also covers the backend's other load-time fallback notices (CPU instead of CUDA, flash attention unsupported, missing dense-module files). Those are the same kind of "a fallback was chosen" message, and they likewise come back at `-vv`.

The filter is added to the registry with `.with(filter)` rather than per-layer, so it gates every sink `init_tracing` installs — the console `fmt` layer and the Cloud Connect log-capture ring buffer alike.

## Testing

`candle_gelu_notice_is_hidden_unless_very_verbose` is behavioural rather than a string check on the constant: it builds the real `EnvFilter` for each verbosity through the same `LogVerbosity` → `EnvFilter` conversion `init_tracing` uses, emits a `WARN` and an `ERROR` on the `text_embeddings_backend_candle` target through a subscriber shaped like the one `init_tracing` installs, and asserts on what reaches the console layer. The `WARN` is dropped at default and `-v` and present at `-vv`; the `ERROR` survives at all three.

Verified against a real model load — `spiced` built with the `models` feature, running a Spicepod with an `all-MiniLM-L6-v2` embedding:

| run | `Embedding Model … ready` | GeLU notice |
| --- | --- | --- |
| default verbosity, directive removed | yes | 1 |
| default verbosity | yes | 0 |
| `-vv` | yes | 1 |

The embedding model reached ready in every run, so the suppression is the filter's doing and not a code path that never executed.
