### PR TITLE
fix(testoperator): a fully-censored table floors worst-P99 at the discard cap

### DIFF
--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -194,7 +194,12 @@ async fn run_staleness_probe(
         }
     }
 
-    Ok(build_report(samples, &discarded, probe_table_names, max_reasonable_gap))
+    Ok(build_report(
+        samples,
+        &discarded,
+        probe_table_names,
+        max_reasonable_gap,
+    ))
 }
 
 /// Query `MAX(_bench_ts)` from Spice via Flight SQL, returning microseconds since epoch.
@@ -394,6 +399,9 @@ mod tests {
         let stock = &r.tables["stock"];
         assert_eq!(stock.samples, 2);
         assert_eq!(stock.discarded, 3);
-        assert!(stock.p99 < cap, "measured p99 must not be replaced by the cap");
+        assert!(
+            stock.p99 < cap,
+            "measured p99 must not be replaced by the cap"
+        );
     }
 }

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -70,7 +70,12 @@ impl StalenessReport {
         );
         for table in &self.probe_tables {
             if let Some(stats) = self.tables.get(table.as_str()) {
-                let discarded = if stats.discarded > 0 {
+                let discarded = if stats.samples == 0 && stats.discarded > 0 {
+                    format!(
+                        "  (all {} samples > cap; p99/max floored at the cap)",
+                        stats.discarded
+                    )
+                } else if stats.discarded > 0 {
                     format!("  ({} discarded > cap)", stats.discarded)
                 } else {
                     String::new()
@@ -189,7 +194,7 @@ async fn run_staleness_probe(
         }
     }
 
-    Ok(build_report(samples, &discarded, probe_table_names))
+    Ok(build_report(samples, &discarded, probe_table_names, max_reasonable_gap))
 }
 
 /// Query `MAX(_bench_ts)` from Spice via Flight SQL, returning microseconds since epoch.
@@ -239,10 +244,20 @@ pub(super) async fn query_max_bench_ts_spice(
 }
 
 /// Build the final report from raw gap samples (in microseconds).
+///
+/// `discard_cap` is the absurd-gap threshold the probe filtered with. A table
+/// whose every sample exceeded it must not read as fresh: reporting it as
+/// zero-with-zero-samples excludes it from the worst-P99 fold, so the aggregate
+/// IMPROVES as the table falls further behind. Such a table's p99/max are
+/// floored at the cap - the tightest bound the surviving evidence supports -
+/// and folded into the worst figures. A table with no samples and no discards
+/// (never seeded, no traffic) stays at zero: nothing was observed, and
+/// inventing a floor there would be as dishonest as the zero was here.
 fn build_report(
     samples: HashMap<String, Vec<i64>>,
     discarded: &HashMap<String, u64>,
     probe_tables: Vec<String>,
+    discard_cap: Duration,
 ) -> StalenessReport {
     let mut tables = HashMap::new();
     let mut worst_p99 = Duration::ZERO;
@@ -251,11 +266,22 @@ fn build_report(
     for (table, mut gaps) in samples {
         let n_discarded = discarded.get(&table).copied().unwrap_or(0);
         if gaps.is_empty() {
+            let floor = if n_discarded > 0 {
+                discard_cap
+            } else {
+                Duration::ZERO
+            };
+            if floor > worst_p99 {
+                worst_p99 = floor;
+            }
+            if floor > worst_max {
+                worst_max = floor;
+            }
             tables.insert(
                 table,
                 StalenessStats {
-                    p99: Duration::ZERO,
-                    max: Duration::ZERO,
+                    p99: floor,
+                    max: floor,
                     samples: 0,
                     discarded: n_discarded,
                 },
@@ -303,5 +329,71 @@ fn build_report(
         probe_tables,
         worst_p99,
         worst_max,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(
+        samples: &[(&str, &[i64])],
+        discarded: &[(&str, u64)],
+        cap: Duration,
+    ) -> StalenessReport {
+        let samples: HashMap<String, Vec<i64>> = samples
+            .iter()
+            .map(|(t, g)| ((*t).to_string(), g.to_vec()))
+            .collect();
+        let discarded: HashMap<String, u64> = discarded
+            .iter()
+            .map(|(t, n)| ((*t).to_string(), *n))
+            .collect();
+        let tables = samples.keys().cloned().collect();
+        build_report(samples, &discarded, tables, cap)
+    }
+
+    #[test]
+    fn a_fully_censored_table_floors_worst_p99_at_the_cap() {
+        // Regression: a run whose order_line had 51 of 51 samples discarded
+        // reported worst P99 over the OTHER six tables - the aggregate improved
+        // as the slowest table got worse.
+        let cap = Duration::from_secs(1800);
+        let r = report(
+            &[("customer", &[10_000_000]), ("order_line", &[])],
+            &[("order_line", 51)],
+            cap,
+        );
+        assert_eq!(r.worst_p99, cap, "the censored table must set the floor");
+        assert_eq!(r.worst_max, cap);
+        let ol = &r.tables["order_line"];
+        assert_eq!(ol.p99, cap);
+        assert_eq!(ol.samples, 0, "flooring must not invent samples");
+        assert_eq!(ol.discarded, 51);
+    }
+
+    #[test]
+    fn a_table_with_no_samples_and_no_discards_stays_at_zero() {
+        // No traffic observed is an unknown, not a lag of cap: inventing a
+        // floor there would be as wrong as the zero was for censored tables.
+        let r = report(
+            &[("customer", &[5_000_000]), ("idle_table", &[])],
+            &[],
+            Duration::from_secs(1800),
+        );
+        assert_eq!(r.tables["idle_table"].p99, Duration::ZERO);
+        assert_eq!(r.worst_p99, Duration::from_micros(5_000_000));
+    }
+
+    #[test]
+    fn a_partially_censored_table_keeps_its_measured_percentiles() {
+        // Kept samples still carry the p99; the discard count is reported
+        // alongside rather than replacing the measurement.
+        let cap = Duration::from_secs(1800);
+        let r = report(&[("stock", &[1_000_000, 2_000_000])], &[("stock", 3)], cap);
+        let stock = &r.tables["stock"];
+        assert_eq!(stock.samples, 2);
+        assert_eq!(stock.discarded, 3);
+        assert!(stock.p99 < cap, "measured p99 must not be replaced by the cap");
     }
 }

--- a/tools/testoperator/src/commands/htap/staleness.rs
+++ b/tools/testoperator/src/commands/htap/staleness.rs
@@ -363,7 +363,7 @@ mod tests {
         // Regression: a run whose order_line had 51 of 51 samples discarded
         // reported worst P99 over the OTHER six tables - the aggregate improved
         // as the slowest table got worse.
-        let cap = Duration::from_secs(1800);
+        let cap = Duration::from_mins(30);
         let r = report(
             &[("customer", &[10_000_000]), ("order_line", &[])],
             &[("order_line", 51)],
@@ -384,17 +384,17 @@ mod tests {
         let r = report(
             &[("customer", &[5_000_000]), ("idle_table", &[])],
             &[],
-            Duration::from_secs(1800),
+            Duration::from_mins(30),
         );
         assert_eq!(r.tables["idle_table"].p99, Duration::ZERO);
-        assert_eq!(r.worst_p99, Duration::from_micros(5_000_000));
+        assert_eq!(r.worst_p99, Duration::from_secs(5));
     }
 
     #[test]
     fn a_partially_censored_table_keeps_its_measured_percentiles() {
         // Kept samples still carry the p99; the discard count is reported
         // alongside rather than replacing the measurement.
-        let cap = Duration::from_secs(1800);
+        let cap = Duration::from_mins(30);
         let r = report(&[("stock", &[1_000_000, 2_000_000])], &[("stock", 3)], cap);
         let stock = &r.tables["stock"];
         assert_eq!(stock.samples, 2);


### PR DESCRIPTION
## The failure

The HTAP staleness probe discards samples above 2× the run duration (so a bootstrap-era reading can't poison a short window). A table whose **every** sample was discarded then reported `p99 0 / max 0 / samples 0` — and contributed **nothing** to the `worst P99` fold. The aggregate improves as the slowest table falls further behind.

Observed on a real SF-1000 run: a clean-looking `worst P99: 440695ms` computed over six tables, while `order_line` had **51 of 51 samples discarded** and appeared as zeros.

## The fix

A fully-censored table's p99/max **floor at the discard cap** — the tightest bound the surviving evidence supports — and fold into the worst figures. Its row keeps `samples: 0` with the suffix `all N samples > cap; p99/max floored at the cap`, so the censoring stays visible rather than being replaced by a plausible-looking number.

The distinction that matters, pinned by test: a table with no samples and **no discards** (never seeded, no traffic) stays at zero — nothing was observed, and inventing a floor there would be the same dishonesty in the other direction.

## Semantics note for benchmark consumers

Report format is unchanged (numeric columns; annotation in the existing suffix position), so parsers keep working. But **runs that previously read as clean under full censoring will now show worst-P99 at the cap** — which is the point. Any dashboard tracking `worst P99` across scheduled runs may show a step where past runs were silently censored.

Three tests: censored-floors-worst, never-sampled-stays-zero, partially-censored-keeps-measured-percentiles. `testoperator` clippy clean.