### PR TITLE
fix(signoff): keep the Rust-change gate and the SSH probe from silently failing

### DIFF
--- a/scripts/signoff
+++ b/scripts/signoff
@@ -629,7 +629,12 @@ branch_has_rust_changes() {
     debug "no changed files vs ${LINT_BASE_BRANCH} — no Rust changes"
     return 1
   fi
-  if printf '%s\n' "$files" | grep -qE "$RUST_AFFECTING_PATH_PATTERN"; then
+  # Herestring, not `printf '%s\n' "$files" | grep -q`: under `set -o pipefail`,
+  # `grep -q` exits at its first match and closes the pipe, printf takes SIGPIPE
+  # (141), and that becomes the pipeline's status — so a changed-file list large
+  # enough to outlive grep's early exit reads as "no match" and the entire Rust
+  # gate is silently skipped while the sign-off still posts.
+  if grep -qE "$RUST_AFFECTING_PATH_PATTERN" <<<"$files"; then
     debug "Rust-affecting files present — will run Rust checks"
     return 0
   fi
@@ -1149,12 +1154,17 @@ find_signoff_ssh_host() {
   hosts="${SIGNOFF_SSH_HOSTS:-$DEFAULT_SIGNOFF_SSH_HOSTS}"
   remote_repo=$(signoff_ssh_repo_or_default)
 
+  # The probe runs under the remote user's LOGIN shell (ssh with a command
+  # string), which may be fish — fish rejects POSIX `name=value` assignments,
+  # so keep the command assignment-free and rely only on `test` and `&&`,
+  # which POSIX shells and fish share. (The sign-off payload itself is immune:
+  # run_signoff_via_ssh invokes `bash -s` explicitly.)
+  # Require .git (file or dir) — matches run_signoff_via_ssh Git-only support.
   if [[ -n "$remote_repo" ]]; then
     # Path already charset-validated; embed as a single-quoted remote literal.
-    # Require .git (file or dir) — matches run_signoff_via_ssh Git-only support.
-    probe_cmd="repo='${remote_repo}'; test -d \"\$repo\" && test -e \"\$repo/.git\""
+    probe_cmd="test -d '${remote_repo}' && test -e '${remote_repo}/.git'"
   else
-    probe_cmd='repo="$HOME/dev/spice2"; test -d "$repo" && test -e "$repo/.git"'
+    probe_cmd='test -d "$HOME/dev/spice2" && test -e "$HOME/dev/spice2/.git"'
   fi
 
   for host in $hosts; do


### PR DESCRIPTION
## What

Two independent failures in `scripts/signoff`, both observed while running a remote sign-off against a lab host, both causing silent wrong behavior rather than errors.

### 1. `printf | grep -q` under `set -o pipefail` silently skips the Rust gate

`branch_has_rust_changes` tested the changed-file list with:

```bash
if printf '%s\n' "$files" | grep -qE "$RUST_AFFECTING_PATH_PATTERN"; then
```

`grep -q` exits at its **first** match and closes the pipe. When the changed-file list is large enough that `printf` is still writing at that moment, `printf` takes SIGPIPE, and under the script's `set -o pipefail` that 141 becomes the pipeline's exit status — the condition reads as *no match*. The branch is then classified as having no Rust-affecting changes, and the sign-off **posts a success attestation with lint, build, and unit tests silently skipped**.

Observed live: a 456-file diff (133 Rust-affecting paths) attested as "no Rust changes (lint/test skipped) in 0s". Deterministically reproducible on both macOS and Linux with a ~20k-line list:

```bash
bash -c 'set -euo pipefail
files=$(seq -f "src/file%.0f.rs" 20000)
printf "%s\n" "$files" | grep -qE "\.rs$" && echo match || echo no-match'  # → no-match
```

Small branch diffs fit in one pipe write, so `printf` finishes before `grep` exits and everyday local sign-offs never trip it — which is why this survived. The fix is a herestring (`grep -qE "$PATTERN" <<<"$files"`): no pipeline, so pipefail cannot invert the verdict.

### 2. The SSH probe breaks on hosts whose login shell is fish

`find_signoff_ssh_host` probes with a command string containing a POSIX `name=value` assignment. `ssh host "<string>"` runs the string under the remote **login** shell; fish rejects POSIX assignments as a syntax error, so on such hosts every probe fails and `make signoff-remote` always falls back to the GitHub Actions workflow even though the host is reachable and has the checkout. (The sign-off payload itself is immune — `run_signoff_via_ssh` invokes `bash -s` explicitly.) The probe now uses only `test` and `&&`, which POSIX shells and fish share.

## Testing

- `bash -n scripts/signoff` clean.
- The pipefail repro above: old form prints `no-match`, herestring form prints `match`, on the same input.
- Probe command verified against a fish login shell: `test -d '<path>' && test -e '<path>/.git'` evaluates correctly where the previous assignment form errored.
