### PR TITLE
fix(duckdb): run spice_sys DuckDB sidecar writes on the blocking pool (fixes #12175)

### DIFF
--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -163,7 +163,7 @@ impl KafkaOffset {
 ///
 /// This type is shared between the Kafka data connector and the `spice_sys` persistence
 /// layer so that neither needs to depend on the other.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct KafkaMetadata {
     pub consumer_group_id: String,
     pub topic: String,

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -247,6 +247,90 @@ where
     tokio::task::spawn_blocking(f).await.ok().flatten()
 }
 
+/// Retries for a sidecar write contending with another writer, on top of the
+/// initial attempt. Bounded and short: paired with [`UPSERT_MAX_RETRY_DELAY`] the
+/// worst-case added latency stays well under one checkpoint/commit interval, and a
+/// persistent conflict just retries on the next interval anyway.
+#[cfg(any(feature = "kafka", feature = "debezium", feature = "mysql"))]
+pub(crate) const UPSERT_MAX_RETRIES: usize = 4;
+
+/// Per-attempt cap on the `FibonacciBackoffBuilder` delay for sidecar upsert
+/// retries. The shared Fibonacci schedule starts at 1s, far longer than a
+/// transient writer hand-off needs, so clamp each delay to keep the whole retry
+/// budget (~4 x 100ms) short relative to the commit interval.
+#[cfg(any(feature = "kafka", feature = "debezium", feature = "mysql"))]
+pub(crate) const UPSERT_MAX_RETRY_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(100);
+
+/// Whether a sidecar write failure is a transient lock/contention error worth
+/// retrying rather than surfacing.
+///
+/// Deliberately a string heuristic over the boxed engine error (rusqlite, Turso,
+/// `DuckDB`, and tokio-postgres all report contention differently), mirroring the
+/// reconnect classifier in `data_components::mysql_replication::resilience`. Slight
+/// over-matching is harmless: retries are bounded, so a misclassified non-lock error
+/// only costs a few short sleeps before it is returned unchanged.
+///
+/// The `DuckDB` markers matter because its transaction manager is optimistic — it
+/// reports a write-write conflict instead of blocking, so two sidecar writers
+/// touching the same row surface `TransactionContext Error: Conflict on update!`
+/// rather than serializing. Sidecar writers take the pool's write gate with `read()`
+/// and so do not exclude each other; only a file swap takes it exclusively.
+#[cfg(any(feature = "kafka", feature = "debezium", feature = "mysql"))]
+pub(crate) fn is_retryable_lock_error(err: &Error) -> bool {
+    const MARKERS: &[&str] = &[
+        "database is locked",
+        "database table is locked",
+        "sqlite_busy",
+        "sqlite_locked",
+        "deadlock",
+        // DuckDB's optimistic concurrency control.
+        "conflict on update",
+        "transactioncontext error",
+        "write-write conflict",
+    ];
+    let msg = err.to_string().to_ascii_lowercase();
+    MARKERS.iter().any(|marker| msg.contains(marker))
+}
+
+/// Runs a sidecar write, retrying a transient write conflict a bounded number of
+/// times.
+///
+/// `DuckDB`'s transaction manager is optimistic: two sidecar writers touching the
+/// same row get `Conflict on update!` rather than being serialized, because they
+/// hold the pool's write gate with `read()` and so do not exclude each other. The
+/// attempt is re-run rather than surfaced, matching how a contended write is handled
+/// for the binlog checkpoint.
+#[cfg(any(feature = "kafka", feature = "debezium"))]
+pub(crate) async fn retry_on_write_conflict<F, Fut>(dataset_name: &str, attempt: F) -> Result<()>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
+
+    let backoff = FibonacciBackoffBuilder::new()
+        .max_retries(Some(UPSERT_MAX_RETRIES))
+        .max_duration(Some(UPSERT_MAX_RETRY_DELAY))
+        .build();
+
+    retry(backoff, || async {
+        attempt().await.map_err(|e| {
+            if is_retryable_lock_error(&e) {
+                tracing::debug!(
+                    dataset = %dataset_name,
+                    error = %e,
+                    "sidecar offset upsert hit a transient accelerator write conflict"
+                );
+                RetryError::transient(e)
+            } else {
+                RetryError::permanent(e)
+            }
+        })
+    })
+    .await
+}
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum OpenOption {
     CreateIfNotExists,

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -238,13 +238,29 @@ where
 
 /// [`spawn_duckdb_blocking`] for the read paths that report a failure as `None`
 /// rather than as an error.
+///
+/// A panic is re-raised on this task rather than reported as `None`: these reads
+/// answer "where did this dataset get to", and a `None` the caller believes means
+/// the dataset re-bootstraps from the beginning of the change stream. Running the
+/// read on the blocking pool must not turn a bug into that answer.
 #[cfg(any(feature = "mongodb", feature = "mysql"))]
 async fn spawn_duckdb_blocking_opt<T, F>(f: F) -> Option<T>
 where
     F: FnOnce() -> Option<T> + Send + 'static,
     T: Send + 'static,
 {
-    tokio::task::spawn_blocking(f).await.ok().flatten()
+    match tokio::task::spawn_blocking(f).await {
+        Ok(value) => value,
+        Err(join_error) if join_error.is_panic() => {
+            std::panic::resume_unwind(join_error.into_panic())
+        }
+        // Cancellation, i.e. the runtime is shutting down under the read. Nothing
+        // downstream can act on it, but it must not pass for "no checkpoint".
+        Err(join_error) => {
+            tracing::error!("Failed to read the sidecar checkpoint: {join_error}");
+            None
+        }
+    }
 }
 
 /// Retries for a sidecar write contending with another writer, on top of the
@@ -648,5 +664,27 @@ async fn acceleration_connection(
             engine: acceleration_settings.engine,
         }
         .fail(),
+    }
+}
+
+#[cfg(all(test, any(feature = "mongodb", feature = "mysql")))]
+mod tests {
+    #[tokio::test]
+    #[should_panic(expected = "sidecar read panicked")]
+    async fn spawn_duckdb_blocking_opt_does_not_report_a_panic_as_no_checkpoint() {
+        // `None` from a checkpoint read means "this dataset has no recorded position",
+        // which sends the connector back to the start of the change stream. A panic in
+        // the read is a bug and must not be answered that way.
+        let _: Option<()> =
+            super::spawn_duckdb_blocking_opt(|| panic!("sidecar read panicked")).await;
+    }
+
+    #[tokio::test]
+    async fn spawn_duckdb_blocking_opt_passes_through_both_outcomes() {
+        assert_eq!(super::spawn_duckdb_blocking_opt(|| Some(7)).await, Some(7));
+        assert_eq!(
+            super::spawn_duckdb_blocking_opt(|| Option::<u8>::None).await,
+            None
+        );
     }
 }

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -212,6 +212,41 @@ impl Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Runs a synchronous `DuckDB` sidecar operation on the blocking pool.
+///
+/// Every `spice_sys` `DuckDB` helper takes the connection pool's write gate, and a
+/// `duckdb_on_full_refresh: replace_file` refresh holds that gate **exclusively**
+/// while it copies every co-resident table into the staging file and checkpoints it.
+/// That window scales with the size of the *other* datasets sharing the file, so
+/// waiting on the gate from an async worker parks the whole worker — including
+/// `/health`, which Kubernetes uses to decide the pod is dead — for seconds to
+/// minutes.
+///
+/// The helpers themselves are also plain blocking `DuckDB` I/O, so they belong here
+/// regardless of the gate; `DuckDbBlobCheckpointStore` and the accelerator's
+/// `drop_table`/`evolve_table_schema` already do exactly this.
+#[cfg(feature = "duckdb")]
+async fn spawn_duckdb_blocking<T, F>(f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(Error::external)?
+}
+
+/// [`spawn_duckdb_blocking`] for the read paths that report a failure as `None`
+/// rather than as an error.
+#[cfg(any(feature = "mongodb", feature = "mysql"))]
+async fn spawn_duckdb_blocking_opt<T, F>(f: F) -> Option<T>
+where
+    F: FnOnce() -> Option<T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f).await.ok().flatten()
+}
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum OpenOption {
     CreateIfNotExists,

--- a/crates/runtime/src/dataaccelerator/spice_sys/caching_engine/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/caching_engine/duckdb.rs
@@ -20,7 +20,12 @@ use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConne
 use std::sync::Arc;
 
 impl CachingEngineSys {
-    pub(super) fn update_fetched_at_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
+    pub(super) fn update_fetched_at_duckdb(
+        dataset_name: &str,
+        pool: &Arc<DuckDbConnectionPool>,
+    ) -> Result<()> {
         let write_gate = pool.write_gate();
         let _write_guard = write_gate
             .read()
@@ -33,16 +38,16 @@ impl CachingEngineSys {
 
         let tx = duckdb_conn.transaction().map_err(Error::external)?;
 
-        let has_table = table_exists(&tx, &self.dataset_name)?;
-        let mut internal_tables = list_internal_tables(&tx, &self.dataset_name)?;
+        let has_table = table_exists(&tx, dataset_name)?;
+        let mut internal_tables = list_internal_tables(&tx, dataset_name)?;
 
         // Determine the actual table name (internal or direct)
         let table_name = match (internal_tables.pop(), has_table) {
             (Some((internal_name, _)), _) => internal_name,
-            (None, true) => self.dataset_name.clone(),
+            (None, true) => dataset_name.to_string(),
             (None, false) => {
                 // No table exists yet
-                tracing::warn!("No table found for dataset: {}", self.dataset_name);
+                tracing::warn!("No table found for dataset: {dataset_name}");
                 return Ok(());
             }
         };

--- a/crates/runtime/src/dataaccelerator/spice_sys/caching_engine/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/caching_engine/mod.rs
@@ -37,11 +37,25 @@ impl CachingEngineSys {
         })
     }
 
-    pub fn update_fetched_at(&self) -> Result<()> {
+    #[cfg_attr(
+        not(feature = "duckdb"),
+        expect(
+            clippy::unused_async,
+            reason = "async only when the DuckDB accelerator is compiled in; every other arm errors immediately"
+        )
+    )]
+    pub async fn update_fetched_at(&self) -> Result<()> {
         #[cfg(feature = "duckdb")]
         {
             match &self.acceleration_connection {
-                AccelerationConnection::DuckDB(pool) => self.update_fetched_at_duckdb(pool),
+                AccelerationConnection::DuckDB(pool) => {
+                    let pool = std::sync::Arc::clone(pool);
+                    let dataset_name = self.dataset_name.clone();
+                    super::spawn_duckdb_blocking(move || {
+                        Self::update_fetched_at_duckdb(&dataset_name, &pool)
+                    })
+                    .await
+                }
                 #[cfg(feature = "postgres-accel")]
                 AccelerationConnection::Postgres(_) => Err(Error::NoAccelerationConnection),
                 #[cfg(feature = "sqlite")]

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -614,9 +614,21 @@ mod tests {
         let (checkpoint, pool) = create_in_memory_duckdb_checkpoint();
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
 
-        // Stand in for the exclusive phase of a file swap.
+        // Stand in for the exclusive phase of a file swap. The guard lives on its
+        // own thread, both because a real swap holds it off the async runtime and
+        // so no lock guard is held across an `.await` here.
         let write_gate = pool.write_gate();
-        let swap_guard = write_gate.write().unwrap_or_else(PoisonError::into_inner);
+        let (held_tx, held_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let swap = std::thread::spawn(move || {
+            let guard = write_gate.write().unwrap_or_else(PoisonError::into_inner);
+            held_tx.send(()).expect("the test should await the gate");
+            release_rx.recv().expect("the test should release the gate");
+            drop(guard);
+        });
+        held_rx
+            .recv()
+            .expect("the swap thread should take the write gate exclusively");
 
         let checkpointing = tokio::spawn(async move { checkpoint.checkpoint(&schema, None).await });
 
@@ -642,7 +654,10 @@ mod tests {
 
         // Releasing the gate lets the checkpoint finish, proving it really was
         // blocked on the gate and not skipped.
-        drop(swap_guard);
+        release_tx
+            .send(())
+            .expect("the swap thread should still be holding the gate");
+        swap.join().expect("the swap thread should not panic");
         checkpointing
             .await
             .expect("the checkpoint task should not panic")

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -49,7 +49,12 @@ impl DatasetCheckpoint {
         Ok(())
     }
 
-    pub(super) fn exists_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<bool> {
+    /// Blocking `DuckDB` I/O. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
+    pub(super) fn exists_duckdb(
+        dataset_name: &str,
+        pool: &Arc<DuckDbConnectionPool>,
+    ) -> Result<bool> {
         let mut db_conn = Arc::clone(pool).connect_sync().map_err(Error::external)?;
         let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
             .map_err(Error::external)?
@@ -57,13 +62,15 @@ impl DatasetCheckpoint {
 
         let query = format!("SELECT 1 FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ? LIMIT 1");
         let mut stmt = duckdb_conn.prepare(&query).map_err(Error::external)?;
-        let mut rows = stmt.query([&self.dataset_name]).map_err(Error::external)?;
+        let mut rows = stmt.query([dataset_name]).map_err(Error::external)?;
 
         Ok(rows.next().map_err(Error::external)?.is_some())
     }
 
+    /// Blocking `DuckDB` I/O. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn last_checkpoint_time_duckdb(
-        &self,
+        dataset_name: &str,
         pool: &Arc<DuckDbConnectionPool>,
     ) -> Result<Option<SystemTime>> {
         let mut db_conn = Arc::clone(pool).connect_sync().map_err(Error::external)?;
@@ -75,7 +82,7 @@ impl DatasetCheckpoint {
             "SELECT epoch_us(timezone('UTC', updated_at::TIMESTAMPTZ)) FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ? LIMIT 1"
         );
         let mut stmt = duckdb_conn.prepare(&query).map_err(Error::external)?;
-        let mut rows = stmt.query([&self.dataset_name]).map_err(Error::external)?;
+        let mut rows = stmt.query([dataset_name]).map_err(Error::external)?;
 
         let checkpoint_time_micros: Option<i64> = rows
             .next()
@@ -93,8 +100,11 @@ impl DatasetCheckpoint {
         }
     }
 
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn checkpoint_duckdb(
-        &self,
+        dataset_name: &str,
+        create_snapshot: bool,
         pool: &Arc<DuckDbConnectionPool>,
         schema: &SchemaRef,
         refresh_sql: Option<&str>,
@@ -119,11 +129,11 @@ impl DatasetCheckpoint {
         duckdb_conn
             .execute(
                 &upsert,
-                duckdb::params![&self.dataset_name, &schema_json, refresh_sql],
+                duckdb::params![dataset_name, &schema_json, refresh_sql],
             )
             .map_err(Error::external)?;
 
-        if self.snapshot_behavior.create_enabled() {
+        if create_snapshot {
             // Force a DuckDB checkpoint so the WAL and database pages are flushed to disk before the snapshot is taken.
             duckdb_conn
                 .execute("CHECKPOINT", [])
@@ -155,8 +165,10 @@ impl DatasetCheckpoint {
         Ok(())
     }
 
+    /// Blocking `DuckDB` I/O. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn get_schema_duckdb(
-        &self,
+        dataset_name: &str,
         pool: &Arc<DuckDbConnectionPool>,
     ) -> Result<Option<SchemaRef>> {
         let mut db_conn = Arc::clone(pool).connect_sync().map_err(Error::external)?;
@@ -168,7 +180,7 @@ impl DatasetCheckpoint {
             "SELECT schema_json FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ? LIMIT 1"
         );
         let mut stmt = duckdb_conn.prepare(&query).map_err(Error::external)?;
-        let mut rows = stmt.query([&self.dataset_name]).map_err(Error::external)?;
+        let mut rows = stmt.query([dataset_name]).map_err(Error::external)?;
 
         if let Some(row) = rows.next().map_err(Error::external)? {
             let schema_json: Option<String> = row.get(0).map_err(Error::external)?;
@@ -181,8 +193,10 @@ impl DatasetCheckpoint {
         }
     }
 
+    /// Blocking `DuckDB` I/O. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn get_refresh_sql_duckdb(
-        &self,
+        dataset_name: &str,
         pool: &Arc<DuckDbConnectionPool>,
     ) -> Result<Option<String>> {
         let mut db_conn = Arc::clone(pool).connect_sync().map_err(Error::external)?;
@@ -194,7 +208,7 @@ impl DatasetCheckpoint {
             "SELECT refresh_sql FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ? LIMIT 1"
         );
         let mut stmt = duckdb_conn.prepare(&query).map_err(Error::external)?;
-        let mut rows = stmt.query([&self.dataset_name]).map_err(Error::external)?;
+        let mut rows = stmt.query([dataset_name]).map_err(Error::external)?;
 
         if let Some(row) = rows.next().map_err(Error::external)? {
             let refresh_sql: Option<String> = row.get(0).map_err(Error::external)?;
@@ -204,7 +218,12 @@ impl DatasetCheckpoint {
         }
     }
 
-    pub(super) fn delete_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
+    pub(super) fn delete_duckdb(
+        dataset_name: &str,
+        pool: &Arc<DuckDbConnectionPool>,
+    ) -> Result<()> {
         let write_gate = pool.write_gate();
         let _write_guard = write_gate
             .read()
@@ -217,7 +236,7 @@ impl DatasetCheckpoint {
 
         let delete = format!("DELETE FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ?");
         duckdb_conn
-            .execute(&delete, [&self.dataset_name])
+            .execute(&delete, [dataset_name])
             .map_err(Error::external)?;
 
         Ok(())
@@ -573,5 +592,60 @@ mod tests {
             new_checkpoint_time > checkpoint_time,
             "New checkpoint time should be more recent"
         );
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/12175>.
+    ///
+    /// A `duckdb_on_full_refresh: replace_file` swap holds the pool's write gate
+    /// **exclusively** while it copies every co-resident table and checkpoints the
+    /// file. A `spice_sys` write that waits on that gate from an async worker parks
+    /// the worker for the whole window, which starves every other task on it —
+    /// including `/health`, so Kubernetes kills the pod.
+    ///
+    /// The runtime has one worker thread and the gate is held exclusively for the
+    /// duration, so the probe task can only run if the checkpoint's gate wait is
+    /// off the worker. `block_on` drives the test body on the calling thread, so
+    /// the assertion still reports rather than hanging when it regresses.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_duckdb_checkpoint_waits_for_the_write_gate_off_the_async_worker() {
+        use std::sync::PoisonError;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let (checkpoint, pool) = create_in_memory_duckdb_checkpoint();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+
+        // Stand in for the exclusive phase of a file swap.
+        let write_gate = pool.write_gate();
+        let swap_guard = write_gate.write().unwrap_or_else(PoisonError::into_inner);
+
+        let checkpointing = tokio::spawn(async move { checkpoint.checkpoint(&schema, None).await });
+
+        let probe_ran = Arc::new(AtomicBool::new(false));
+        let probe = tokio::spawn({
+            let probe_ran = Arc::clone(&probe_ran);
+            async move {
+                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                probe_ran.store(true, Ordering::SeqCst);
+            }
+        });
+
+        tokio::time::timeout(tokio::time::Duration::from_secs(10), probe)
+            .await
+            .expect(
+                "an unrelated task made no progress while a spice_sys DuckDB write waited on the write gate: the wait is parking the async worker",
+            )
+            .expect("the probe task should not panic");
+        assert!(
+            probe_ran.load(Ordering::SeqCst),
+            "the probe task should have completed while the gate was held"
+        );
+
+        // Releasing the gate lets the checkpoint finish, proving it really was
+        // blocked on the gate and not skipped.
+        drop(swap_guard);
+        checkpointing
+            .await
+            .expect("the checkpoint task should not panic")
+            .expect("the checkpoint should succeed once the gate is released");
     }
 }

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
@@ -151,10 +151,15 @@ impl DatasetCheckpoint {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     async fn init(connection: &AccelerationConnection) -> Result<()> {
@@ -167,7 +172,10 @@ impl DatasetCheckpoint {
         ))]
         match connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => Self::init_duckdb(pool)?,
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                super::spawn_duckdb_blocking(move || Self::init_duckdb(&pool)).await?;
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => Self::init_postgres(pool).await?,
             #[cfg(feature = "sqlite")]
@@ -187,7 +195,10 @@ impl DatasetCheckpoint {
         ))]
         match connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => Self::migrate_duckdb(pool)?,
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                super::spawn_duckdb_blocking(move || Self::migrate_duckdb(&pool)).await?;
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => Self::migrate_postgres(pool).await?,
             #[cfg(feature = "sqlite")]
@@ -240,16 +251,28 @@ impl DatasetCheckpoint {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     pub async fn exists(&self) -> bool {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.exists_duckdb(pool).ok().unwrap_or(false),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking(move || Self::exists_duckdb(&dataset_name, &pool))
+                    .await
+                    .ok()
+                    .unwrap_or(false)
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => {
                 self.exists_postgres(pool).await.ok().unwrap_or(false)
@@ -277,16 +300,28 @@ impl DatasetCheckpoint {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     pub async fn last_checkpoint_time(&self) -> Result<Option<SystemTime>> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.last_checkpoint_time_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking(move || {
+                    Self::last_checkpoint_time_duckdb(&dataset_name, &pool)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => {
                 self.last_checkpoint_time_postgres(pool).await
@@ -317,17 +352,36 @@ impl DatasetCheckpoint {
         expect(unused_variables)
     )]
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     pub async fn checkpoint(&self, schema: &SchemaRef, refresh_sql: Option<&str>) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => {
-                self.checkpoint_duckdb(pool, schema, refresh_sql)
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let create_snapshot = self.snapshot_behavior.create_enabled();
+                let schema = Arc::clone(schema);
+                let refresh_sql = refresh_sql.map(ToOwned::to_owned);
+                super::spawn_duckdb_blocking(move || {
+                    Self::checkpoint_duckdb(
+                        &dataset_name,
+                        create_snapshot,
+                        &pool,
+                        &schema,
+                        refresh_sql.as_deref(),
+                    )
+                })
+                .await
             }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => {
@@ -356,16 +410,26 @@ impl DatasetCheckpoint {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     pub async fn get_schema(&self) -> Result<Option<SchemaRef>> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.get_schema_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking(move || Self::get_schema_duckdb(&dataset_name, &pool))
+                    .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.get_schema_postgres(pool).await,
             #[cfg(feature = "sqlite")]
@@ -385,16 +449,28 @@ impl DatasetCheckpoint {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     pub async fn get_refresh_sql(&self) -> Result<Option<String>> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.get_refresh_sql_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking(move || {
+                    Self::get_refresh_sql_duckdb(&dataset_name, &pool)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.get_refresh_sql_postgres(pool).await,
             #[cfg(feature = "sqlite")]
@@ -415,16 +491,26 @@ impl DatasetCheckpoint {
 
     /// Deletes the checkpoint for this dataset so the next refresh treats it as a fresh table.
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     pub async fn delete(&self) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.delete_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking(move || Self::delete_duckdb(&dataset_name, &pool))
+                    .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.delete_postgres(pool).await,
             #[cfg(feature = "sqlite")]

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/duckdb.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::super::offsets::{self, sort_offsets};
+use super::super::offsets::{self, OffsetSchemaState, sort_offsets};
 use super::{
     DEBEZIUM_KAFKA_OFFSETS_TABLE_NAME, DEBEZIUM_KAFKA_TABLE_NAME, DebeziumKafkaMetadata,
     DebeziumKafkaSys, Error, Result,
@@ -25,8 +25,11 @@ use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConne
 use std::sync::Arc;
 
 impl DebeziumKafkaSys {
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn upsert_duckdb(
-        &self,
+        dataset_name: &str,
+        schema_ensured: &OffsetSchemaState,
         pool: &Arc<DuckDbConnectionPool>,
         metadata: &DebeziumKafkaMetadata,
     ) -> Result<()> {
@@ -41,7 +44,7 @@ impl DebeziumKafkaSys {
             .get_underlying_conn_mut();
 
         ensure_debezium_kafka_tables(duckdb_conn)?;
-        self.schema_ensured.mark_ensured();
+        schema_ensured.mark_ensured();
 
         let primary_keys =
             serde_json::to_string(&metadata.primary_keys).map_err(Error::external)?;
@@ -62,7 +65,7 @@ impl DebeziumKafkaSys {
         tx.execute(
             &upsert,
             duckdb::params![
-                self.dataset_name,
+                dataset_name,
                 metadata.consumer_group_id,
                 metadata.topic,
                 primary_keys,
@@ -70,14 +73,17 @@ impl DebeziumKafkaSys {
             ],
         )
         .map_err(Error::external)?;
-        upsert_offsets_tx(&tx, &self.dataset_name, &metadata.offsets)?;
+        upsert_offsets_tx(&tx, dataset_name, &metadata.offsets)?;
         tx.commit().map_err(Error::external)?;
 
         Ok(())
     }
 
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn get_duckdb(
-        &self,
+        dataset_name: &str,
+        schema_ensured: &OffsetSchemaState,
         pool: &Arc<DuckDbConnectionPool>,
     ) -> Result<Option<DebeziumKafkaMetadata>> {
         // `ensure_debezium_kafka_tables` below issues DDL, so this read path is
@@ -92,16 +98,16 @@ impl DebeziumKafkaSys {
             .map_err(Error::external)?
             .get_underlying_conn_mut();
 
-        if self.schema_needs_ensure() {
+        if schema_ensured.needs_ensure() {
             ensure_debezium_kafka_tables(duckdb_conn)?;
-            self.mark_schema_ensured();
+            schema_ensured.mark_ensured();
         }
 
         let query = format!(
             "SELECT consumer_group_id, topic, primary_keys, schema_fields FROM {DEBEZIUM_KAFKA_TABLE_NAME} WHERE dataset_name = ?"
         );
         let mut stmt = duckdb_conn.prepare(&query).map_err(Error::external)?;
-        let mut rows = stmt.query([&self.dataset_name]).map_err(Error::external)?;
+        let mut rows = stmt.query([dataset_name]).map_err(Error::external)?;
 
         let Some(row) = rows.next().map_err(Error::external)? else {
             return Ok(None);
@@ -114,7 +120,7 @@ impl DebeziumKafkaSys {
         drop(rows);
         drop(stmt);
 
-        let offsets = load_offsets(duckdb_conn, &self.dataset_name)?;
+        let offsets = load_offsets(duckdb_conn, dataset_name)?;
 
         let primary_keys: Vec<String> =
             serde_json::from_str(&primary_keys_json).map_err(Error::external)?;
@@ -130,8 +136,11 @@ impl DebeziumKafkaSys {
         }))
     }
 
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn upsert_offsets_duckdb(
-        &self,
+        dataset_name: &str,
+        schema_ensured: &OffsetSchemaState,
         pool: &Arc<DuckDbConnectionPool>,
         offsets: &[KafkaOffset],
     ) -> Result<()> {
@@ -145,18 +154,18 @@ impl DebeziumKafkaSys {
             .map_err(Error::external)?
             .get_underlying_conn_mut();
 
-        if self.schema_needs_ensure() {
+        if schema_ensured.needs_ensure() {
             ensure_debezium_kafka_tables(duckdb_conn)?;
-            self.mark_schema_ensured();
+            schema_ensured.mark_ensured();
         }
 
         // Diagnostic-only: surface a warn log when an offset regresses.
-        if let Ok(prior) = load_offsets(duckdb_conn, &self.dataset_name) {
-            let _ = offsets::merge_offsets(&self.dataset_name, prior, offsets);
+        if let Ok(prior) = load_offsets(duckdb_conn, dataset_name) {
+            let _ = offsets::merge_offsets(dataset_name, prior, offsets);
         }
 
         let tx = duckdb_conn.transaction().map_err(Error::external)?;
-        upsert_offsets_tx(&tx, &self.dataset_name, offsets)?;
+        upsert_offsets_tx(&tx, dataset_name, offsets)?;
         tx.commit().map_err(Error::external)?;
         Ok(())
     }

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
@@ -167,12 +167,4 @@ impl DebeziumKafkaSys {
             _ => Err(Error::NoAccelerationConnection),
         }
     }
-
-    fn schema_needs_ensure(&self) -> bool {
-        self.schema_ensured.needs_ensure()
-    }
-
-    fn mark_schema_ensured(&self) {
-        self.schema_ensured.mark_ensured();
-    }
 }

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
@@ -43,6 +43,9 @@ use crate::{
 use data_components::kafka::KafkaOffset;
 use std::sync::Arc;
 
+#[cfg(feature = "duckdb")]
+use super::retry_on_write_conflict;
+
 const DEBEZIUM_KAFKA_TABLE_NAME: &str = "spice_sys_debezium_kafka";
 const DEBEZIUM_KAFKA_OFFSETS_TABLE_NAME: &str = "spice_sys_debezium_kafka_offsets";
 
@@ -59,6 +62,21 @@ pub struct DebeziumKafkaSys {
     dataset_name: String,
     acceleration_connection: AccelerationConnection,
     schema_ensured: Arc<OffsetSchemaState>,
+    /// Serializes this instance's own `DuckDB` sidecar writes.
+    ///
+    /// `DuckDB` resolves concurrent writes to one row optimistically — the loser
+    /// gets `Conflict on update!` instead of waiting — and the sidecar writers hold
+    /// the pool's write gate with `read()`, so they do not exclude each other. Two
+    /// commits for the same dataset therefore conflict rather than queue. Before the
+    /// writes moved to the blocking pool, the async worker serialized them by
+    /// accident; this keeps that ordering on purpose, so a burst of commits for one
+    /// dataset still resolves to the max offset instead of failing.
+    ///
+    /// Scoped to one instance: writers for different datasets key on distinct rows
+    /// and do not conflict. `retry_on_write_conflict` still covers contention this
+    /// lock cannot see.
+    #[cfg(feature = "duckdb")]
+    duckdb_write_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl DebeziumKafkaSys {
@@ -69,6 +87,8 @@ impl DebeziumKafkaSys {
             acceleration_connection: acceleration_connection(dataset, registry, open_option)
                 .await?,
             schema_ensured: Arc::default(),
+            #[cfg(feature = "duckdb")]
+            duckdb_write_lock: Arc::default(),
         })
     }
 
@@ -110,6 +130,7 @@ impl DebeziumKafkaSys {
                 let dataset_name = self.dataset_name.clone();
                 let schema_ensured = Arc::clone(&self.schema_ensured);
                 let metadata = metadata.clone();
+                let _serialized = self.duckdb_write_lock.lock().await;
                 super::spawn_duckdb_blocking(move || {
                     Self::upsert_duckdb(&dataset_name, &schema_ensured, &pool, &metadata)
                 })
@@ -141,8 +162,15 @@ impl DebeziumKafkaSys {
                 let dataset_name = self.dataset_name.clone();
                 let schema_ensured = Arc::clone(&self.schema_ensured);
                 let offsets = offsets.to_vec();
-                super::spawn_duckdb_blocking(move || {
-                    Self::upsert_offsets_duckdb(&dataset_name, &schema_ensured, &pool, &offsets)
+                let _serialized = self.duckdb_write_lock.lock().await;
+                retry_on_write_conflict(&dataset_name, || {
+                    let pool = Arc::clone(&pool);
+                    let dataset_name = dataset_name.clone();
+                    let schema_ensured = Arc::clone(&schema_ensured);
+                    let offsets = offsets.clone();
+                    super::spawn_duckdb_blocking(move || {
+                        Self::upsert_offsets_duckdb(&dataset_name, &schema_ensured, &pool, &offsets)
+                    })
                 })
                 .await
             }

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
@@ -41,6 +41,7 @@ use crate::{
     dataconnector::debezium::DebeziumKafkaMetadata,
 };
 use data_components::kafka::KafkaOffset;
+use std::sync::Arc;
 
 const DEBEZIUM_KAFKA_TABLE_NAME: &str = "spice_sys_debezium_kafka";
 const DEBEZIUM_KAFKA_OFFSETS_TABLE_NAME: &str = "spice_sys_debezium_kafka_offsets";
@@ -57,7 +58,7 @@ mod turso;
 pub struct DebeziumKafkaSys {
     dataset_name: String,
     acceleration_connection: AccelerationConnection,
-    schema_ensured: OffsetSchemaState,
+    schema_ensured: Arc<OffsetSchemaState>,
 }
 
 impl DebeziumKafkaSys {
@@ -67,14 +68,22 @@ impl DebeziumKafkaSys {
             dataset_name: dataset.name.to_string(),
             acceleration_connection: acceleration_connection(dataset, registry, open_option)
                 .await?,
-            schema_ensured: OffsetSchemaState::default(),
+            schema_ensured: Arc::default(),
         })
     }
 
     pub(crate) async fn get(&self) -> Result<Option<DebeziumKafkaMetadata>> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.get_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let schema_ensured = Arc::clone(&self.schema_ensured);
+                super::spawn_duckdb_blocking(move || {
+                    Self::get_duckdb(&dataset_name, &schema_ensured, &pool)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.get_postgres(pool).await,
             #[cfg(feature = "sqlite")]
@@ -96,7 +105,16 @@ impl DebeziumKafkaSys {
     pub(crate) async fn upsert(&self, metadata: &DebeziumKafkaMetadata) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.upsert_duckdb(pool, metadata),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let schema_ensured = Arc::clone(&self.schema_ensured);
+                let metadata = metadata.clone();
+                super::spawn_duckdb_blocking(move || {
+                    Self::upsert_duckdb(&dataset_name, &schema_ensured, &pool, &metadata)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.upsert_postgres(pool, metadata).await,
             #[cfg(feature = "sqlite")]
@@ -118,7 +136,16 @@ impl DebeziumKafkaSys {
     pub(crate) async fn upsert_offsets(&self, offsets: &[KafkaOffset]) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.upsert_offsets_duckdb(pool, offsets),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let schema_ensured = Arc::clone(&self.schema_ensured);
+                let offsets = offsets.to_vec();
+                super::spawn_duckdb_blocking(move || {
+                    Self::upsert_offsets_duckdb(&dataset_name, &schema_ensured, &pool, &offsets)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => {
                 self.upsert_offsets_postgres(pool, offsets).await

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/postgres.rs
@@ -33,7 +33,7 @@ impl DebeziumKafkaSys {
         metadata: &DebeziumKafkaMetadata,
     ) -> Result<()> {
         ensure_debezium_kafka_tables(pool).await?;
-        self.mark_schema_ensured();
+        self.schema_ensured.mark_ensured();
 
         let mut conn = pool.connect_direct().await.map_err(Error::external)?;
         let tx = conn.conn.transaction().await.map_err(Error::external)?;
@@ -77,9 +77,9 @@ impl DebeziumKafkaSys {
         &self,
         pool: &PostgresConnectionPool,
     ) -> Result<Option<DebeziumKafkaMetadata>> {
-        if self.schema_needs_ensure() {
+        if self.schema_ensured.needs_ensure() {
             ensure_debezium_kafka_tables(pool).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
         let conn = pool.connect_direct().await.map_err(Error::external)?;
         let query = format!(
@@ -119,9 +119,9 @@ impl DebeziumKafkaSys {
         pool: &PostgresConnectionPool,
         offsets: &[KafkaOffset],
     ) -> Result<()> {
-        if self.schema_needs_ensure() {
+        if self.schema_ensured.needs_ensure() {
             ensure_debezium_kafka_tables(pool).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         // Diagnostic-only: surface a warn log when an offset regresses.

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/sqlite.rs
@@ -94,7 +94,7 @@ impl DebeziumKafkaSys {
         type MetadataRow = (String, String, String, String);
 
         let dataset_name = self.dataset_name.clone();
-        let schema_needs_ensure = self.schema_needs_ensure();
+        let schema_needs_ensure = self.schema_ensured.needs_ensure();
 
         let conn_sync = pool.connect_sync();
         let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
@@ -137,7 +137,7 @@ impl DebeziumKafkaSys {
             .map_err(Error::external)?;
 
         if schema_needs_ensure {
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         let Some((consumer_group_id, topic, primary_keys_json, schema_fields_json, offsets)) =
@@ -164,7 +164,7 @@ impl DebeziumKafkaSys {
         let dataset_name = self.dataset_name.clone();
         let new_offsets = offsets.to_vec();
         let warn_dataset = self.dataset_name.clone();
-        let schema_needs_ensure = self.schema_needs_ensure();
+        let schema_needs_ensure = self.schema_ensured.needs_ensure();
 
         let conn_sync = pool.connect_sync();
         let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
@@ -193,7 +193,7 @@ impl DebeziumKafkaSys {
             .map_err(Error::external)?;
 
         if schema_needs_ensure {
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         Ok(())

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/turso.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/turso.rs
@@ -43,7 +43,7 @@ impl DebeziumKafkaSys {
         {
             let _schema_guard = pool.acquire_schema_write_lock().await;
             ensure_debezium_kafka_tables(&conn).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         let _schema_guard = pool.acquire_schema_read_lock().await;
@@ -82,10 +82,10 @@ impl DebeziumKafkaSys {
     ) -> Result<Option<DebeziumKafkaMetadata>> {
         let dataset_name = self.dataset_name.clone();
         let conn = pool.connect().await.map_err(Error::external)?;
-        if self.schema_needs_ensure() {
+        if self.schema_ensured.needs_ensure() {
             let _schema_guard = pool.acquire_schema_write_lock().await;
             ensure_debezium_kafka_tables(&conn).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
         let query = format!(
             "SELECT consumer_group_id, topic, primary_keys, schema_fields FROM {DEBEZIUM_KAFKA_TABLE_NAME} WHERE dataset_name = ?"
@@ -124,10 +124,10 @@ impl DebeziumKafkaSys {
         offsets: &[KafkaOffset],
     ) -> Result<()> {
         let conn = pool.connect().await.map_err(Error::external)?;
-        if self.schema_needs_ensure() {
+        if self.schema_ensured.needs_ensure() {
             let _schema_guard = pool.acquire_schema_write_lock().await;
             ensure_debezium_kafka_tables(&conn).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         let _schema_guard = pool.acquire_schema_read_lock().await;

--- a/crates/runtime/src/dataaccelerator/spice_sys/kafka/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/kafka/duckdb.rs
@@ -14,15 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::super::offsets::{self, sort_offsets};
+use super::super::offsets::{self, OffsetSchemaState, sort_offsets};
 use super::{Error, KAFKA_OFFSETS_TABLE_NAME, KAFKA_TABLE_NAME, KafkaMetadata, KafkaSys, Result};
 use data_components::kafka::KafkaOffset;
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use std::sync::Arc;
 
 impl KafkaSys {
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn upsert_duckdb(
-        &self,
+        dataset_name: &str,
+        schema_ensured: &OffsetSchemaState,
         pool: &Arc<DuckDbConnectionPool>,
         metadata: &KafkaMetadata,
     ) -> Result<()> {
@@ -37,7 +40,7 @@ impl KafkaSys {
             .get_underlying_conn_mut();
 
         ensure_kafka_tables(duckdb_conn)?;
-        self.schema_ensured.mark_ensured();
+        schema_ensured.mark_ensured();
 
         let schema_json = Self::serialize_schema(&metadata.schema)?;
 
@@ -54,21 +57,24 @@ impl KafkaSys {
         tx.execute(
             &upsert,
             duckdb::params![
-                self.dataset_name,
+                dataset_name,
                 metadata.consumer_group_id,
                 metadata.topic,
                 schema_json,
             ],
         )
         .map_err(Error::external)?;
-        upsert_offsets_tx(&tx, &self.dataset_name, &metadata.offsets)?;
+        upsert_offsets_tx(&tx, dataset_name, &metadata.offsets)?;
         tx.commit().map_err(Error::external)?;
 
         Ok(())
     }
 
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn get_duckdb(
-        &self,
+        dataset_name: &str,
+        schema_ensured: &OffsetSchemaState,
         pool: &Arc<DuckDbConnectionPool>,
     ) -> Result<Option<KafkaMetadata>> {
         // `ensure_kafka_tables` below issues DDL, so this read path is also a
@@ -83,16 +89,16 @@ impl KafkaSys {
             .map_err(Error::external)?
             .get_underlying_conn_mut();
 
-        if self.schema_needs_ensure() {
+        if schema_ensured.needs_ensure() {
             ensure_kafka_tables(duckdb_conn)?;
-            self.mark_schema_ensured();
+            schema_ensured.mark_ensured();
         }
 
         let query = format!(
             "SELECT consumer_group_id, topic, schema_json FROM {KAFKA_TABLE_NAME} WHERE dataset_name = ?"
         );
         let mut stmt = duckdb_conn.prepare(&query).map_err(Error::external)?;
-        let mut rows = stmt.query([&self.dataset_name]).map_err(Error::external)?;
+        let mut rows = stmt.query([dataset_name]).map_err(Error::external)?;
 
         let Some(row) = rows.next().map_err(Error::external)? else {
             return Ok(None);
@@ -104,7 +110,7 @@ impl KafkaSys {
         drop(rows);
         drop(stmt);
 
-        let offsets = load_offsets(duckdb_conn, &self.dataset_name)?;
+        let offsets = load_offsets(duckdb_conn, dataset_name)?;
 
         Ok(Some(KafkaMetadata {
             consumer_group_id,
@@ -114,8 +120,11 @@ impl KafkaSys {
         }))
     }
 
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn upsert_offsets_duckdb(
-        &self,
+        dataset_name: &str,
+        schema_ensured: &OffsetSchemaState,
         pool: &Arc<DuckDbConnectionPool>,
         offsets: &[KafkaOffset],
     ) -> Result<()> {
@@ -129,18 +138,18 @@ impl KafkaSys {
             .map_err(Error::external)?
             .get_underlying_conn_mut();
 
-        if self.schema_needs_ensure() {
+        if schema_ensured.needs_ensure() {
             ensure_kafka_tables(duckdb_conn)?;
-            self.mark_schema_ensured();
+            schema_ensured.mark_ensured();
         }
 
         // Diagnostic-only: surface a warn log when an offset regresses.
-        if let Ok(prior) = load_offsets(duckdb_conn, &self.dataset_name) {
-            let _ = offsets::merge_offsets(&self.dataset_name, prior, offsets);
+        if let Ok(prior) = load_offsets(duckdb_conn, dataset_name) {
+            let _ = offsets::merge_offsets(dataset_name, prior, offsets);
         }
 
         let tx = duckdb_conn.transaction().map_err(Error::external)?;
-        upsert_offsets_tx(&tx, &self.dataset_name, offsets)?;
+        upsert_offsets_tx(&tx, dataset_name, offsets)?;
         tx.commit().map_err(Error::external)?;
         Ok(())
     }

--- a/crates/runtime/src/dataaccelerator/spice_sys/kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/kafka/mod.rs
@@ -42,6 +42,9 @@ pub(super) use data_components::kafka::KafkaMetadata;
 use data_components::kafka::KafkaOffset;
 use std::sync::Arc;
 
+#[cfg(feature = "duckdb")]
+use super::retry_on_write_conflict;
+
 const KAFKA_TABLE_NAME: &str = "spice_sys_kafka";
 const KAFKA_OFFSETS_TABLE_NAME: &str = "spice_sys_kafka_offsets";
 
@@ -58,6 +61,21 @@ pub struct KafkaSys {
     dataset_name: String,
     acceleration_connection: AccelerationConnection,
     schema_ensured: Arc<OffsetSchemaState>,
+    /// Serializes this instance's own `DuckDB` sidecar writes.
+    ///
+    /// `DuckDB` resolves concurrent writes to one row optimistically — the loser
+    /// gets `Conflict on update!` instead of waiting — and the sidecar writers hold
+    /// the pool's write gate with `read()`, so they do not exclude each other. Two
+    /// commits for the same dataset therefore conflict rather than queue. Before the
+    /// writes moved to the blocking pool, the async worker serialized them by
+    /// accident; this keeps that ordering on purpose, so a burst of commits for one
+    /// dataset still resolves to the max offset instead of failing.
+    ///
+    /// Scoped to one instance: writers for different datasets key on distinct rows
+    /// and do not conflict. `retry_on_write_conflict` still covers contention this
+    /// lock cannot see.
+    #[cfg(feature = "duckdb")]
+    duckdb_write_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl KafkaSys {
@@ -68,6 +86,8 @@ impl KafkaSys {
             acceleration_connection: acceleration_connection(dataset, registry, open_option)
                 .await?,
             schema_ensured: Arc::default(),
+            #[cfg(feature = "duckdb")]
+            duckdb_write_lock: Arc::default(),
         })
     }
 
@@ -127,6 +147,7 @@ impl KafkaSys {
                 let dataset_name = self.dataset_name.clone();
                 let schema_ensured = Arc::clone(&self.schema_ensured);
                 let metadata = metadata.clone();
+                let _serialized = self.duckdb_write_lock.lock().await;
                 super::spawn_duckdb_blocking(move || {
                     Self::upsert_duckdb(&dataset_name, &schema_ensured, &pool, &metadata)
                 })
@@ -167,8 +188,15 @@ impl KafkaSys {
                 let dataset_name = self.dataset_name.clone();
                 let schema_ensured = Arc::clone(&self.schema_ensured);
                 let offsets = offsets.to_vec();
-                super::spawn_duckdb_blocking(move || {
-                    Self::upsert_offsets_duckdb(&dataset_name, &schema_ensured, &pool, &offsets)
+                let _serialized = self.duckdb_write_lock.lock().await;
+                retry_on_write_conflict(&dataset_name, || {
+                    let pool = Arc::clone(&pool);
+                    let dataset_name = dataset_name.clone();
+                    let schema_ensured = Arc::clone(&schema_ensured);
+                    let offsets = offsets.clone();
+                    super::spawn_duckdb_blocking(move || {
+                        Self::upsert_offsets_duckdb(&dataset_name, &schema_ensured, &pool, &offsets)
+                    })
                 })
                 .await
             }

--- a/crates/runtime/src/dataaccelerator/spice_sys/kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/kafka/mod.rs
@@ -40,6 +40,7 @@ use super::{
 use crate::{component::dataset::Dataset, dataaccelerator::spice_sys::OpenOption};
 pub(super) use data_components::kafka::KafkaMetadata;
 use data_components::kafka::KafkaOffset;
+use std::sync::Arc;
 
 const KAFKA_TABLE_NAME: &str = "spice_sys_kafka";
 const KAFKA_OFFSETS_TABLE_NAME: &str = "spice_sys_kafka_offsets";
@@ -56,7 +57,7 @@ mod turso;
 pub struct KafkaSys {
     dataset_name: String,
     acceleration_connection: AccelerationConnection,
-    schema_ensured: OffsetSchemaState,
+    schema_ensured: Arc<OffsetSchemaState>,
 }
 
 impl KafkaSys {
@@ -66,18 +67,31 @@ impl KafkaSys {
             dataset_name: dataset.name.to_string(),
             acceleration_connection: acceleration_connection(dataset, registry, open_option)
                 .await?,
-            schema_ensured: OffsetSchemaState::default(),
+            schema_ensured: Arc::default(),
         })
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(clippy::unused_async)
     )]
     pub async fn get(&self) -> Result<Option<KafkaMetadata>> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.get_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let schema_ensured = Arc::clone(&self.schema_ensured);
+                super::spawn_duckdb_blocking(move || {
+                    Self::get_duckdb(&dataset_name, &schema_ensured, &pool)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.get_postgres(pool).await,
             #[cfg(feature = "sqlite")]
@@ -97,13 +111,27 @@ impl KafkaSys {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(clippy::unused_async)
     )]
     pub async fn upsert(&self, metadata: &KafkaMetadata) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.upsert_duckdb(pool, metadata),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let schema_ensured = Arc::clone(&self.schema_ensured);
+                let metadata = metadata.clone();
+                super::spawn_duckdb_blocking(move || {
+                    Self::upsert_duckdb(&dataset_name, &schema_ensured, &pool, &metadata)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.upsert_postgres(pool, metadata).await,
             #[cfg(feature = "sqlite")]
@@ -123,13 +151,27 @@ impl KafkaSys {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(clippy::unused_async)
     )]
     pub async fn upsert_offsets(&self, offsets: &[KafkaOffset]) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.upsert_offsets_duckdb(pool, offsets),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let schema_ensured = Arc::clone(&self.schema_ensured);
+                let offsets = offsets.to_vec();
+                super::spawn_duckdb_blocking(move || {
+                    Self::upsert_offsets_duckdb(&dataset_name, &schema_ensured, &pool, &offsets)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => {
                 self.upsert_offsets_postgres(pool, offsets).await
@@ -158,7 +200,7 @@ impl KafkaSys {
 
     fn deserialize_schema(schema_json: &str) -> Result<SchemaRef> {
         let schema: Schema = serde_json::from_str(schema_json).map_err(Error::external)?;
-        Ok(std::sync::Arc::new(schema))
+        Ok(Arc::new(schema))
     }
 
     fn schema_needs_ensure(&self) -> bool {

--- a/crates/runtime/src/dataaccelerator/spice_sys/kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/kafka/mod.rs
@@ -202,12 +202,4 @@ impl KafkaSys {
         let schema: Schema = serde_json::from_str(schema_json).map_err(Error::external)?;
         Ok(Arc::new(schema))
     }
-
-    fn schema_needs_ensure(&self) -> bool {
-        self.schema_ensured.needs_ensure()
-    }
-
-    fn mark_schema_ensured(&self) {
-        self.schema_ensured.mark_ensured();
-    }
 }

--- a/crates/runtime/src/dataaccelerator/spice_sys/kafka/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/kafka/postgres.rs
@@ -29,7 +29,7 @@ impl KafkaSys {
         metadata: &KafkaMetadata,
     ) -> Result<()> {
         ensure_kafka_tables(pool).await?;
-        self.mark_schema_ensured();
+        self.schema_ensured.mark_ensured();
 
         let mut conn = pool.connect_direct().await.map_err(Error::external)?;
         let tx = conn.conn.transaction().await.map_err(Error::external)?;
@@ -68,9 +68,9 @@ impl KafkaSys {
         &self,
         pool: &PostgresConnectionPool,
     ) -> Result<Option<KafkaMetadata>> {
-        if self.schema_needs_ensure() {
+        if self.schema_ensured.needs_ensure() {
             ensure_kafka_tables(pool).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
         let conn = pool.connect_direct().await.map_err(Error::external)?;
         let query = format!(
@@ -103,9 +103,9 @@ impl KafkaSys {
         pool: &PostgresConnectionPool,
         offsets: &[KafkaOffset],
     ) -> Result<()> {
-        if self.schema_needs_ensure() {
+        if self.schema_ensured.needs_ensure() {
             ensure_kafka_tables(pool).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         // Diagnostic-only: surface a warn log when an offset regresses.

--- a/crates/runtime/src/dataaccelerator/spice_sys/kafka/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/kafka/sqlite.rs
@@ -78,7 +78,7 @@ impl KafkaSys {
         type MetadataRow = (String, String, String);
 
         let dataset_name = self.dataset_name.clone();
-        let schema_needs_ensure = self.schema_needs_ensure();
+        let schema_needs_ensure = self.schema_ensured.needs_ensure();
 
         let conn_sync = pool.connect_sync();
         let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
@@ -114,7 +114,7 @@ impl KafkaSys {
             .map_err(Error::external)?;
 
         if schema_needs_ensure {
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         let Some((consumer_group_id, topic, schema_json, offsets)) = result else {
@@ -137,7 +137,7 @@ impl KafkaSys {
         let dataset_name = self.dataset_name.clone();
         let new_offsets = offsets.to_vec();
         let warn_dataset = self.dataset_name.clone();
-        let schema_needs_ensure = self.schema_needs_ensure();
+        let schema_needs_ensure = self.schema_ensured.needs_ensure();
 
         let conn_sync = pool.connect_sync();
         let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
@@ -167,7 +167,7 @@ impl KafkaSys {
             .map_err(Error::external)?;
 
         if schema_needs_ensure {
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         Ok(())

--- a/crates/runtime/src/dataaccelerator/spice_sys/kafka/turso.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/kafka/turso.rs
@@ -37,7 +37,7 @@ impl KafkaSys {
         {
             let _schema_guard = pool.acquire_schema_write_lock().await;
             ensure_kafka_tables(&conn).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         // Turso lacks explicit transactions in its current Rust binding; the
@@ -71,10 +71,10 @@ impl KafkaSys {
     ) -> Result<Option<KafkaMetadata>> {
         let dataset_name = self.dataset_name.clone();
         let conn = pool.connect().await.map_err(Error::external)?;
-        if self.schema_needs_ensure() {
+        if self.schema_ensured.needs_ensure() {
             let _schema_guard = pool.acquire_schema_write_lock().await;
             ensure_kafka_tables(&conn).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         let query = format!(
@@ -110,10 +110,10 @@ impl KafkaSys {
         offsets: &[KafkaOffset],
     ) -> Result<()> {
         let conn = pool.connect().await.map_err(Error::external)?;
-        if self.schema_needs_ensure() {
+        if self.schema_ensured.needs_ensure() {
             let _schema_guard = pool.acquire_schema_write_lock().await;
             ensure_kafka_tables(&conn).await?;
-            self.mark_schema_ensured();
+            self.schema_ensured.mark_ensured();
         }
 
         let _schema_guard = pool.acquire_schema_read_lock().await;

--- a/crates/runtime/src/dataaccelerator/spice_sys/mongodb/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mongodb/duckdb.rs
@@ -21,8 +21,10 @@ use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConne
 use super::{Error, MONGODB_TABLE_NAME, MongoCheckpointMetadata, MongoSys, Result};
 
 impl MongoSys {
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn upsert_duckdb(
-        &self,
+        dataset_name: &str,
         pool: &Arc<DuckDbConnectionPool>,
         metadata: &MongoCheckpointMetadata,
     ) -> Result<()> {
@@ -65,7 +67,7 @@ impl MongoSys {
             .execute(
                 &upsert,
                 duckdb::params![
-                    self.dataset_name,
+                    dataset_name,
                     metadata.resume_token_json,
                     metadata.cluster_time_ts,
                     metadata.schema_json,
@@ -76,8 +78,10 @@ impl MongoSys {
         Ok(())
     }
 
+    /// Blocking `DuckDB` I/O. Callers must reach this through
+    /// `spawn_duckdb_blocking_opt`, never directly from an async worker.
     pub(super) fn get_duckdb(
-        &self,
+        dataset_name: &str,
         pool: &Arc<DuckDbConnectionPool>,
     ) -> Option<MongoCheckpointMetadata> {
         use std::time::{Duration, UNIX_EPOCH};
@@ -91,7 +95,7 @@ impl MongoSys {
             "SELECT resume_token_json, cluster_time_ts, schema_json, CAST(epoch(updated_at) AS DOUBLE) FROM {MONGODB_TABLE_NAME} WHERE dataset_name = ?"
         );
         let mut stmt = duckdb_conn.prepare(&query).ok()?;
-        let mut rows = stmt.query([&self.dataset_name]).ok()?;
+        let mut rows = stmt.query([dataset_name]).ok()?;
 
         if let Some(row) = rows.next().ok()? {
             let resume_token_json: String = row.get(0).ok()?;
@@ -112,7 +116,12 @@ impl MongoSys {
         }
     }
 
-    pub(super) fn delete_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
+    pub(super) fn delete_duckdb(
+        dataset_name: &str,
+        pool: &Arc<DuckDbConnectionPool>,
+    ) -> Result<()> {
         let write_gate = pool.write_gate();
         let _write_guard = write_gate
             .read()
@@ -125,7 +134,7 @@ impl MongoSys {
 
         let delete = format!("DELETE FROM {MONGODB_TABLE_NAME} WHERE dataset_name = ?");
         duckdb_conn
-            .execute(&delete, [&self.dataset_name])
+            .execute(&delete, [dataset_name])
             .map_err(Error::external)?;
 
         Ok(())

--- a/crates/runtime/src/dataaccelerator/spice_sys/mongodb/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mongodb/mod.rs
@@ -93,13 +93,23 @@ impl MongoSys {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(clippy::unused_async)
     )]
     pub async fn get(&self) -> Option<MongoCheckpointMetadata> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.get_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = std::sync::Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking_opt(move || Self::get_duckdb(&dataset_name, &pool))
+                    .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.get_postgres(pool).await,
             #[cfg(feature = "sqlite")]
@@ -124,7 +134,12 @@ impl MongoSys {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(clippy::unused_async)
     )]
     pub async fn upsert(
@@ -142,7 +157,15 @@ impl MongoSys {
     ) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.upsert_duckdb(pool, metadata),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = std::sync::Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let metadata = metadata.clone();
+                super::spawn_duckdb_blocking(move || {
+                    Self::upsert_duckdb(&dataset_name, &pool, &metadata)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.upsert_postgres(pool, metadata).await,
             #[cfg(feature = "sqlite")]
@@ -162,13 +185,23 @@ impl MongoSys {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(clippy::unused_async)
     )]
     pub async fn delete(&self) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.delete_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = std::sync::Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking(move || Self::delete_duckdb(&dataset_name, &pool))
+                    .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.delete_postgres(pool).await,
             #[cfg(feature = "sqlite")]

--- a/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/duckdb.rs
@@ -32,8 +32,10 @@ fn migrate_columns() -> [String; 2] {
 }
 
 impl MySqlBinlogSys {
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
     pub(super) fn upsert_duckdb(
-        &self,
+        dataset_name: &str,
         pool: &Arc<DuckDbConnectionPool>,
         checkpoint: &MySqlBinlogCheckpoint,
     ) -> Result<()> {
@@ -86,7 +88,7 @@ impl MySqlBinlogSys {
             .execute(
                 &upsert,
                 duckdb::params![
-                    self.dataset_name,
+                    dataset_name,
                     checkpoint.binlog_file,
                     Self::position_to_i64(checkpoint.binlog_pos),
                     checkpoint.schema_json,
@@ -99,8 +101,11 @@ impl MySqlBinlogSys {
         Ok(())
     }
 
+    /// Blocking: takes the pool's write gate (the column migrations issue DDL).
+    /// Callers must reach this through `spawn_duckdb_blocking_opt`,
+    /// never directly from an async worker.
     pub(super) fn get_duckdb(
-        &self,
+        dataset_name: &str,
         pool: &Arc<DuckDbConnectionPool>,
     ) -> Option<MySqlBinlogCheckpoint> {
         use std::time::{Duration, UNIX_EPOCH};
@@ -128,7 +133,7 @@ impl MySqlBinlogSys {
             "SELECT binlog_file, binlog_pos, schema_json, gtid_executed, cursor_type, CAST(epoch(updated_at) AS DOUBLE) FROM {MYSQL_BINLOG_TABLE_NAME} WHERE dataset_name = ?"
         );
         let mut stmt = duckdb_conn.prepare(&query).ok()?;
-        let mut rows = stmt.query([&self.dataset_name]).ok()?;
+        let mut rows = stmt.query([dataset_name]).ok()?;
 
         if let Some(row) = rows.next().ok()? {
             let binlog_file: String = row.get(0).ok()?;
@@ -153,7 +158,12 @@ impl MySqlBinlogSys {
         }
     }
 
-    pub(super) fn delete_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
+    /// Blocking: takes the pool's write gate. Callers must reach this through
+    /// `spawn_duckdb_blocking`, never directly from an async worker.
+    pub(super) fn delete_duckdb(
+        dataset_name: &str,
+        pool: &Arc<DuckDbConnectionPool>,
+    ) -> Result<()> {
         let write_gate = pool.write_gate();
         let _write_guard = write_gate
             .read()
@@ -166,7 +176,7 @@ impl MySqlBinlogSys {
 
         let delete = format!("DELETE FROM {MYSQL_BINLOG_TABLE_NAME} WHERE dataset_name = ?");
         duckdb_conn
-            .execute(&delete, [&self.dataset_name])
+            .execute(&delete, [dataset_name])
             .map_err(Error::external)?;
 
         Ok(())

--- a/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs
@@ -114,16 +114,26 @@ impl MySqlBinlogSys {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     pub async fn get(&self) -> Option<MySqlBinlogCheckpoint> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.get_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = std::sync::Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking_opt(move || Self::get_duckdb(&dataset_name, &pool))
+                    .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.get_postgres(pool).await,
             #[cfg(feature = "sqlite")]
@@ -178,10 +188,15 @@ impl MySqlBinlogSys {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     async fn upsert_once(
@@ -199,7 +214,15 @@ impl MySqlBinlogSys {
     ) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.upsert_duckdb(pool, checkpoint),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = std::sync::Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                let checkpoint = checkpoint.clone();
+                super::spawn_duckdb_blocking(move || {
+                    Self::upsert_duckdb(&dataset_name, &pool, &checkpoint)
+                })
+                .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.upsert_postgres(pool, checkpoint).await,
             #[cfg(feature = "sqlite")]
@@ -219,16 +242,26 @@ impl MySqlBinlogSys {
     }
 
     #[cfg_attr(
-        not(any(feature = "sqlite", feature = "postgres-accel", feature = "turso")),
+        not(any(
+            feature = "sqlite",
+            feature = "duckdb",
+            feature = "postgres-accel",
+            feature = "turso"
+        )),
         expect(
             clippy::unused_async,
-            reason = "async only when an async accelerator backend is compiled in; DuckDB helpers are synchronous"
+            reason = "async only when an accelerator backend is compiled in; with none, every arm errors immediately"
         )
     )]
     pub async fn delete(&self) -> Result<()> {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.delete_duckdb(pool),
+            AccelerationConnection::DuckDB(pool) => {
+                let pool = std::sync::Arc::clone(pool);
+                let dataset_name = self.dataset_name.clone();
+                super::spawn_duckdb_blocking(move || Self::delete_duckdb(&dataset_name, &pool))
+                    .await
+            }
             #[cfg(feature = "postgres-accel")]
             AccelerationConnection::Postgres(pool) => self.delete_postgres(pool).await,
             #[cfg(feature = "sqlite")]

--- a/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs
@@ -50,7 +50,10 @@ limitations under the License.
 //! );
 //! ```
 
-use super::{AccelerationConnection, Error, Result, acceleration_connection};
+use super::{
+    AccelerationConnection, Error, Result, UPSERT_MAX_RETRIES, UPSERT_MAX_RETRY_DELAY,
+    acceleration_connection, is_retryable_lock_error,
+};
 use crate::{component::dataset::Dataset, dataaccelerator::spice_sys::OpenOption};
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
 
@@ -316,39 +319,4 @@ impl MySqlBinlogSys {
     fn position_to_i64(pos: u64) -> i64 {
         i64::try_from(pos).unwrap_or(i64::MAX)
     }
-}
-
-/// Retries for a checkpoint upsert contending with the accelerator's writer
-/// lock, on top of the initial attempt. Bounded and short: paired with
-/// [`UPSERT_MAX_RETRY_DELAY`] the worst-case added latency stays well under one
-/// checkpoint interval, and a persistent lock just retries on the next interval
-/// anyway.
-const UPSERT_MAX_RETRIES: usize = 4;
-
-/// Per-attempt cap on the [`FibonacciBackoffBuilder`] delay for
-/// [`MySqlBinlogSys::upsert`] retries. The shared Fibonacci schedule starts at
-/// 1s, far longer than a transient writer-lock hand-off needs, so clamp each
-/// delay to keep the whole retry budget (~4 × 100ms) short relative to the
-/// checkpoint interval.
-const UPSERT_MAX_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
-
-/// Whether a sidecar write failure is a transient lock/contention error worth
-/// retrying rather than surfacing.
-///
-/// Deliberately a string heuristic over the boxed engine error (rusqlite,
-/// Turso, `DuckDB`, and tokio-postgres all report contention differently),
-/// mirroring the reconnect classifier in
-/// `data_components::mysql_replication::resilience`. Slight over-matching is
-/// harmless: retries are bounded, so a misclassified non-lock error only costs
-/// a few short sleeps before it is returned unchanged.
-fn is_retryable_lock_error(err: &Error) -> bool {
-    const MARKERS: &[&str] = &[
-        "database is locked",
-        "database table is locked",
-        "sqlite_busy",
-        "sqlite_locked",
-        "deadlock",
-    ];
-    let msg = err.to_string().to_ascii_lowercase();
-    MARKERS.iter().any(|marker| msg.contains(marker))
 }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -593,7 +593,7 @@ impl DataConnector for Debezium {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct DebeziumKafkaMetadata {
     pub(crate) consumer_group_id: String,
     pub(crate) topic: String,

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -1806,7 +1806,7 @@ async fn update_cached_dataset_timestamps(dataset: &Dataset) {
 
     match CachingEngineSys::try_new(dataset, OpenOption::OpenExisting).await {
         Ok(caching_sys) => {
-            if let Err(e) = caching_sys.update_fetched_at() {
+            if let Err(e) = caching_sys.update_fetched_at().await {
                 tracing::warn!(
                     "Failed to update _fetched_at for cached dataset {}: {e}",
                     dataset.name


### PR DESCRIPTION
## Summary

Every out-of-band `spice_sys` writer to a DuckDB acceleration file acquires the connection pool's write gate, but the DuckDB arm of each dispatcher was called **synchronously from an `async fn`**, with no `spawn_blocking`. A `duckdb_on_full_refresh: replace_file` refresh holds that same gate **exclusively** while it copies every co-resident dataset into the staging file and checkpoints it, so the wait is bounded by a whole database rebuild — seconds to minutes on a multi-GB file — and it parked a Tokio worker for that entire window.

Blocking a worker stalls every task scheduled on it, including `/health`, which is what Kubernetes uses to decide the pod is dead. The blocking DuckDB I/O on an async thread predates the gate; what changed is that the wait went from one small write to a full file rebuild, turning a latent violation into a runtime stall.

Four of the five gate acquisitions in the runtime already did this correctly — `runtime-checkpoint-duckdb` (whose comment states the rule: the pool is synchronous, so run it off the async worker), the HNSW index writer, and the accelerator's `drop_table`/`evolve_table_schema`. The sixteen `spice_sys` helpers were the outlier. The CDC offset commits are the ones that fire continuously (`upsert_offsets` on every Kafka/Debezium batch, `MySqlBinlogSys::upsert` on every binlog checkpoint, `DatasetCheckpoint::checkpoint` after every refresh), so a pod where several CDC datasets share one file with a `replace_file` dataset could have several workers parked at once.

Fixes #12175

## Changes

- New `spawn_duckdb_blocking` helper in `spice_sys.rs` (plus `spawn_duckdb_blocking_opt` for the two read paths that report failure as `None`). All sixteen `*_duckdb` helpers across `dataset_checkpoint`, `kafka`, `debezium_kafka`, `mongodb`, `mysql_binlog`, and `caching_engine` now reach DuckDB through it.
- Each `*_duckdb` helper drops `&self` and takes the pieces it read from it, so the blocking closure owns everything it needs. This follows `DuckDbBlobCheckpointStore`'s existing `*_blocking(pool, dataset_name, …)` shape rather than making the sidecar structs `Clone` — `AccelerationConnection` wraps pool types that are not all `Clone`.
- `OffsetSchemaState` moves behind an `Arc` in `KafkaSys`/`DebeziumKafkaSys` so the ensure-once flag is *shared* with the blocking task. Copying it would silently re-run the idempotent DDL on every call. It stays scoped to one sidecar instance, as its comment describes.
- `MySqlBinlogSys::upsert_once` wraps the closure per attempt, so each retry gets its own blocking task and its own copy of the checkpoint.
- `CachingEngineSys::update_fetched_at` becomes `async` — it was the one sync dispatcher, and its only caller (`init::dataset`) was already an `async fn`.
- `KafkaMetadata`/`DebeziumKafkaMetadata` derive `Clone` so the dispatcher can hand an owned copy across the boundary; every field was already `Clone`.
- The `expect(clippy::unused_async)` conditions gain `duckdb`, since the DuckDB arm now `.await`s too. Their `reason` text no longer claims the DuckDB helpers are reached synchronously. The expectations are kept — with no accelerator backend compiled in, every arm still errors immediately and the fn really is needlessly async.
- The `schema_needs_ensure`/`mark_schema_ensured` wrappers only forwarded to `self.schema_ensured` and became dead in a DuckDB-only build once the DuckDB arm took the state by reference, so every backend now reads the field directly.

### Not in scope

The issue notes this was backported to `release/2.1` by #12152. That cherry-pick is deliberately left as a separate change so this one stays reviewable against `trunk`.

## Test plan

- New `test_duckdb_checkpoint_waits_for_the_write_gate_off_the_async_worker` in `dataset_checkpoint/duckdb.rs`. It holds the pool's write gate exclusively — exactly what the swap's phase 2 does — then calls the `checkpoint` dispatcher on a runtime with a single worker thread and asserts an unrelated spawned task still completes. The probe can only run if the gate wait is off the worker, and `block_on` drives the test body on the calling thread so a regression reports the assertion instead of hanging. Releasing the gate then lets the checkpoint finish, proving it was genuinely blocked rather than skipped.
- The 7 existing `dataset_checkpoint::duckdb` tests pass unchanged (they already drive the async dispatchers; `init_duckdb`/`migrate_duckdb` stay sync associated fns, so the test helpers are untouched).
- `make lint`
- `make test`

## Checklist

- [ ] Tests added for the regression and its edge cases
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] No behavior change beyond where the DuckDB work is scheduled