### PR TITLE
ci: remote sign-off dispatches GitHub Actions only, never SSH to lab hosts

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -15,9 +15,8 @@
 #   4. CLI build + unit tests (make build-cli-dev nextest)
 #   5. Post signoff status + re-run Attestation if needed
 #
-# Prefer lab SSH when available (make signoff-remote probes 192.168.1.100/101
-# for a Git $HOME/dev/spice2 first). This workflow is the fallback when no SSH
-# host works:
+# This workflow is the only remote sign-off path (never SSH to ad-hoc hosts —
+# the LAN lab boxes double as benchmark machines):
 #   make signoff-remote
 #   gh workflow run signoff.yml -f branch=<your-branch>
 #   gh workflow run signoff.yml -f branch=<your-branch> -f skip_targeted_lint=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ All contributions come through pull requests. To submit a proposed change, we re
    - Code changes require tests
 1. Update relevant documentation for the change
 1. Commit and push your branch
-1. Run `make signoff` to attest your change — it skips Rust lint/build/tests when the branch has no Rust-affecting files (`.rs`, Cargo/toolchain config), otherwise target-lints changed crates then full lint + unit tests, and records a sign-off on the exact commit you pushed (or `make signoff-remote` to run the same checks on a lab SSH host or self-hosted runner; see [CI Sign-off](/docs/dev/ci_signoff.md))
+1. Run `make signoff` to attest your change — it skips Rust lint/build/tests when the branch has no Rust-affecting files (`.rs`, Cargo/toolchain config), otherwise target-lints changed crates then full lint + unit tests, and records a sign-off on the exact commit you pushed (or `make signoff-remote` to run the same checks on a self-hosted GitHub Actions runner; see [CI Sign-off](/docs/dev/ci_signoff.md))
 1. Open a PR. A single **Attestation** check validates your sign-off; that plus a review is what adds the PR to the merge queue, where the full test suite runs as the required gate
 1. A maintainer of the project will be assigned, and you can expect a review within a few days
 

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -211,28 +211,22 @@ scripts/signoff status        # does HEAD have its own sign-off?
 scripts/signoff --help        # full usage
 ```
 
-### Remote sign-off (lab SSH host or self-hosted runner)
+### Remote sign-off (self-hosted runner)
 
-When you can't (or don't want to) run the checks on your machine:
+When you can't (or don't want to) run the checks on your machine, dispatch the
+**Remote Sign-off** GitHub Actions workflow on a self-hosted runner:
 
 ```bash
 make signoff-remote                 # current branch
-```
-
-`make signoff-remote` first probes lab hosts over SSH (`192.168.1.100`,
-`192.168.1.101` by default; override with `SIGNOFF_SSH_HOSTS`). The first host
-that answers and has a Git checkout at `$HOME/dev/spice2` is used: it fetches
-your pushed branch into that clone and runs `scripts/signoff -f` there (same
-checks and Rust-skip behavior as local). Override the remote path with an
-absolute path only: `SIGNOFF_SSH_REPO=/absolute/path` (`~` is not expanded).
-
-If no SSH host is usable, it falls back to dispatching the **Remote Sign-off**
-GitHub Actions workflow on a self-hosted runner:
-
-```bash
+# equivalent to:
 gh workflow run signoff.yml -f branch=<your-branch>
 gh run watch --workflow signoff.yml
 ```
+
+Sign-off runs only where it is accountable: your machine, or the Actions
+runner. It deliberately never SSHes into ad-hoc hosts — the LAN lab boxes
+double as benchmark machines, and a workspace build there mid-run silently
+corrupts the measurement.
 
 The Actions workflow:
 
@@ -294,7 +288,7 @@ merge queue is still the real gate.
 | Stage | Trigger | Checks |
 | --- | --- | --- |
 | Local | `make signoff` | skip Rust if no Rust-affecting files in the branch diff; else targeted `make lint-rust PACKAGES=… FEATURES=…` + `make nextest-packages PACKAGES=… FEATURES=…` (features from the workspace resolve), full `make lint-rust`, `make build-cli-dev nextest` |
-| Remote | `make signoff-remote` | same checks via lab SSH (`$HOME/dev/spice2` on 192.168.1.100/101) if reachable, else self-hosted `signoff.yml`; posts `signoff` |
+| Remote | `make signoff-remote` | same checks via the self-hosted `signoff.yml` workflow; posts `signoff` |
 | Pull request | `pull_request` | **Attestation** (validates the sign-off, or auto-passes a branch with no Rust-affecting files, a pure revert, or a single-commit Dependabot bump) + PR hygiene; merge-queue check names report lightweight skipped/passthrough results |
 | Merge queue | `merge_group` | the full required suite (below) + advisory niche checks |
 

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -40,13 +40,6 @@
 #   SIGNOFF_SKIP_TARGETED_LINT  Set to any value to skip the branch-scoped pre-lint
 #   SIGNOFF_SKIP_TARGETED_TESTS Set to any value to skip the branch-scoped unit
 #                     tests that run after the pre-lint
-#   SIGNOFF_SSH_HOSTS Space-separated hosts for make signoff-remote (default:
-#                     192.168.1.100 192.168.1.101). First host that answers SSH
-#                     and has a Git checkout at $HOME/dev/spice2 is used;
-#                     otherwise falls back to GHA.
-#   SIGNOFF_SSH_REPO  Absolute path to the spice2 Git checkout on the SSH host
-#                     (default: $HOME/dev/spice2 on the remote). Must start with
-#                     / — ~ and relative paths are not expanded through SSH argv.
 #
 # Targeted pre-lint always diffs against trunk (not configurable).
 # When the branch has no Rust-affecting changes vs trunk (.rs, Cargo.toml,
@@ -54,15 +47,13 @@
 # the lint guards, the root Makefile), Rust lint/build/tests are skipped
 # (both local and remote); the sign-off status is still posted.
 #
-# Remote alternative to local `make signoff`:
-#   make signoff-remote                  # SSH to a lab host if available, else GHA
+# Remote alternative to local `make signoff` (both dispatch GitHub Actions):
+#   make signoff-remote
 #   gh workflow run signoff.yml -f branch=<branch>
 
 set -euo pipefail
 
-readonly VERSION="1.3.0"
-# Default LAN lab hosts for `signoff remote` (SSH path). Overridable via env.
-readonly DEFAULT_SIGNOFF_SSH_HOSTS="192.168.1.100 192.168.1.101"
+readonly VERSION="1.4.0"
 # Fixed, not configurable: it must match the hardcoded context the Attestation
 # workflow (pr.yml) looks for, so an env override would silently break the gate.
 readonly STATUS_CONTEXT="signoff"
@@ -1123,111 +1114,12 @@ cmd_install() {
   echo "${OK} '${TARGET_BRANCH}' now requires developer sign-off + the full merge-queue suite."
 }
 
-# Validate SIGNOFF_SSH_REPO (optional override). Empty → default $HOME/dev/spice2
-# on the remote. Absolute path only (/…); tight charset so it is safe in ssh argv.
-# ~ and relative paths are rejected — they are not expanded through SSH argv.
-signoff_ssh_repo_or_default() {
-  local remote_repo="${SIGNOFF_SSH_REPO:-}"
-  if [[ -z "$remote_repo" ]]; then
-    echo ""
-    return 0
-  fi
-  [[ "$remote_repo" == /* ]] \
-    || fail "SIGNOFF_SSH_REPO must be an absolute path starting with / (got: '${remote_repo}')"
-  [[ "$remote_repo" =~ ^[A-Za-z0-9._/-]+$ ]] \
-    || fail "SIGNOFF_SSH_REPO contains unsafe characters: '${remote_repo}'"
-  echo "$remote_repo"
-}
-
-# Probe SIGNOFF_SSH_HOSTS (default lab IPs) for BatchMode SSH + a spice2 Git checkout.
-# Only Git is accepted (run_signoff_via_ssh requires git); a bare .jj workspace
-# would pass a looser probe and then fail the sign-off itself.
-# Prints the first usable host to stdout; status messages go to stderr via info.
-# Exit 0 with a host, or 1 if none are usable.
-find_signoff_ssh_host() {
-  local hosts host remote_repo probe_cmd
-  hosts="${SIGNOFF_SSH_HOSTS:-$DEFAULT_SIGNOFF_SSH_HOSTS}"
-  remote_repo=$(signoff_ssh_repo_or_default)
-
-  if [[ -n "$remote_repo" ]]; then
-    # Path already charset-validated; embed as a single-quoted remote literal.
-    # Require .git (file or dir) — matches run_signoff_via_ssh Git-only support.
-    probe_cmd="repo='${remote_repo}'; test -d \"\$repo\" && test -e \"\$repo/.git\""
-  else
-    probe_cmd='repo="$HOME/dev/spice2"; test -d "$repo" && test -e "$repo/.git"'
-  fi
-
-  for host in $hosts; do
-    # Hostnames/IPs only — keep the charset tight so ssh argv stays safe.
-    if [[ ! "$host" =~ ^[A-Za-z0-9._-]+$ ]]; then
-      info "  ${NO} skipping invalid SSH host name: '${host}'"
-      continue
-    fi
-    info "Probing SSH connectivity to ${host}…"
-    # BatchMode: never prompt for a password. Short connect timeout so offline
-    # hosts don't stall the developer. stdin from /dev/null so ssh can't eat
-    # a surrounding heredoc or pipe.
-    if ssh -o BatchMode=yes -o ConnectTimeout=1 -o ConnectionAttempts=1 \
-        -o StrictHostKeyChecking=accept-new \
-        "$host" "$probe_cmd" </dev/null 2>/dev/null; then
-      info "  ${OK} ${host} reachable and spice2 repo present"
-      echo "$host"
-      return 0
-    fi
-    info "  ${NO} ${host} unavailable or missing spice2 repo"
-  done
-  return 1
-}
-
-# SSH into a lab host, check out the pushed branch in its spice2 clone, and run
-# scripts/signoff -f there (same attestation as local; -f because checkout -B
-# leaves no @{push} tracking). Branch must already be on origin.
-run_signoff_via_ssh() {
-  local host="$1" branch="$2"
-  local remote_repo
-  remote_repo=$(signoff_ssh_repo_or_default)
-
-  info "Running sign-off via SSH on ${host}:${remote_repo:-\$HOME/dev/spice2} (branch ${branch})…"
-  # Remote command is `bash -s -- <branch> <repo-or-empty>`; the heredoc is
-  # stdin for bash -s. Branch is charset-validated in cmd_remote; repo is an
-  # absolute path or empty (→ $HOME/dev/spice2 on the remote).
-  # shellcheck disable=SC2029 # intentional: host/branch/repo are validated
-  ssh -o BatchMode=yes -o ConnectTimeout=1 -o ConnectionAttempts=1 \
-    -o StrictHostKeyChecking=accept-new \
-    -o ServerAliveInterval=30 -o ServerAliveCountMax=120 \
-    "$host" bash -s -- "$branch" "$remote_repo" <<'REMOTE'
-set -euo pipefail
-branch="$1"
-# Empty $2 → default lab checkout path on this host.
-if [[ -n "${2:-}" ]]; then
-  repo="$2"
-else
-  repo="${HOME}/dev/spice2"
-fi
-cd "$repo" || { echo "✗ cannot cd to ${repo}" >&2; exit 1; }
-
-if command -v git >/dev/null 2>&1 && git rev-parse --show-toplevel >/dev/null 2>&1; then
-  echo "Fetching origin/${branch} into ${repo}…"
-  git fetch --no-tags origin "+refs/heads/${branch}:refs/remotes/origin/${branch}" \
-    || { echo "✗ fetch failed — is '${branch}' pushed to origin?" >&2; exit 1; }
-  # -f discards any dirty local state on the lab machine; HEAD matches origin.
-  git checkout -f -B "$branch" "origin/${branch}"
-  git reset --hard "origin/${branch}"
-  echo "HEAD is now $(git rev-parse --short HEAD) on ${branch}"
-  # -f: no @{push} after checkout -B; tree matches origin tip we just fetched.
-  exec ./scripts/signoff -f
-fi
-
-echo "✗ ${repo} is not a Git checkout (SSH remote sign-off requires Git)" >&2
-exit 1
-REMOTE
-}
-
-# Dispatch remote sign-off for the current branch (Git or JJ).
-# Prefer a LAN SSH host with ~/dev/spice2 (lab machines); fall back to the
-# GitHub Actions Remote Sign-off workflow when no host is reachable.
+# Dispatch remote sign-off for the current branch (Git or JJ) on the GitHub
+# Actions Remote Sign-off workflow. Deliberately never SSH: ad-hoc hosts run
+# unaccountable checks, and the LAN lab boxes double as benchmark machines —
+# a workspace build there mid-run silently corrupts the measurement.
 # Branch names are validated to a safe charset so they cannot break shell
-# quoting, the SSH remote script, or the workflow input parser.
+# quoting or the workflow input parser.
 cmd_remote() {
   require_tools
 
@@ -1264,16 +1156,10 @@ cmd_remote() {
     fail "refusing to dispatch Remote Sign-off for invalid branch name: '${branch}'"
   fi
 
-  local host
-  if host=$(find_signoff_ssh_host); then
-    run_signoff_via_ssh "$host" "$branch"
-    return
-  fi
-
   local repo
   repo=$(repo_slug) || fail "could not resolve GitHub repo for workflow dispatch"
 
-  info "No SSH sign-off host available — dispatching GitHub Actions Remote Sign-off for ${branch} on ${repo}…"
+  info "Dispatching GitHub Actions Remote Sign-off for ${branch} on ${repo}…"
   # --repo so non-colocated JJ workspaces (no .git) still resolve the remote;
   # --raw-field avoids shell re-quoting pitfalls; the branch was validated above.
   gh workflow run signoff.yml --repo "$repo" --raw-field "branch=${branch}" \
@@ -1287,7 +1173,7 @@ scripts/signoff ${VERSION} — local CI attestation for Spice.ai
 
 Developers:
   make signoff                 Run lint + unit tests, then sign off on HEAD
-  make signoff-remote          SSH lab host if available, else GHA Remote Sign-off
+  make signoff-remote          Dispatch GHA Remote Sign-off for the current branch
   scripts/signoff remote       Same as make signoff-remote (Git + JJ)
   scripts/signoff -f           Sign off even with a dirty/unpushed tree
   scripts/signoff --no-verify  Sign off without running checks (honor system)
@@ -1319,10 +1205,9 @@ Checks (when verify is on):
   Remote runs (.github/workflows/signoff.yml) set SIGNOFF_REMOTE_RUN and use
   the GitHub compare API when the clone is too shallow for merge-base.
 
-  make signoff-remote probes SIGNOFF_SSH_HOSTS (default: ${DEFAULT_SIGNOFF_SSH_HOSTS})
-  for SSH + a Git checkout at \$HOME/dev/spice2, checks out the pushed branch
-  there, and runs signoff. If no host is usable, it falls back to dispatching
-  signoff.yml on GitHub Actions.
+  make signoff-remote dispatches signoff.yml on GitHub Actions (self-hosted
+  runner) for the current branch. Sign-off runs only where it is accountable:
+  this machine, or the runner — never ad-hoc SSH hosts.
 
 The sign-off is a '${STATUS_CONTEXT}' commit status bound to the exact commit you
 pushed. Sign off again after any code change or manual conflict resolution. The


### PR DESCRIPTION
`scripts/signoff remote` used to probe the LAN lab hosts (`192.168.1.100`/`101`) over SSH and run the full workspace gate in a `$HOME/dev/spice2` checkout there, falling back to the `signoff.yml` workflow only when no host answered.

That SSH path is removed. Sign-off now runs in exactly two accountable places:

- **local**: `make signoff`
- **remote**: `make signoff-remote` → dispatches `signoff.yml` on the self-hosted runner (same as `gh workflow run signoff.yml -f branch=<branch>`)

Why: the lab hosts double as benchmark machines. Today a `make signoff-remote` during a live SF-1000 CH-benCH run attempted the full lint+build+test gate on the *source database host mid-measurement* — only a missing cargo PATH stopped it before any compile. A workspace build on a measured host silently corrupts the benchmark, and the SSH path also ran the gate in whatever state that checkout happened to be in (the stale-trunk and SIGPIPE false-attestation issues both came from it).

Removed: the SSH probe, `SIGNOFF_SSH_HOSTS`/`SIGNOFF_SSH_REPO`, and the remote-checkout heredoc; `cmd_remote` now validates the branch name and dispatches the workflow directly. Docs (`docs/dev/ci_signoff.md`, `CONTRIBUTING.md`, the workflow header comment) updated to match; script version bumped to 1.4.0.

Verified: `bash -n` + shellcheck clean, no remaining references repo-wide, `--help`/`version` render the new text. No Rust-affecting files, so Attestation auto-passes.
