### PR TITLE
ci(e2e): tolerate any garbage type token in the duckdb_append parquet-rename race

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -2031,8 +2031,10 @@ jobs:
           # retrying on the next tick. DuckDB surfaces the truncated read as
           # one of two errors depending on which part of the file it reaches
           # first: "TProtocolException: Invalid data" (corrupt Thrift footer)
-          # or "don't know what type:" with an empty type (schema element not
-          # yet written). Tolerate both variants of that specific transient.
+          # or "don't know what type: <token>", where the token is whatever
+          # bytes happen to sit where the schema element's type has not been
+          # written yet — empty, or an arbitrary byte such as 0x0e (see run
+          # 30534651210). Tolerate both variants of that specific transient.
           #
           # Strip ANSI first: spiced logs with_ansi(true), so whitelist
           # patterns like `WARN +runtime::...` miss `WARN\e[0m \e[2mruntime::...`
@@ -2041,7 +2043,7 @@ jobs:
              | grep -iE "(failed|error)" \
              | grep -vE "WARN +runtime::accelerated_table::refresh_task: Failed to load data for dataset" \
              | grep -vE "^Invalid Error: TProtocolException: Invalid data$" \
-             | grep -vE "^Invalid Error: don't know what type: *$"; then
+             | grep -vE "^Invalid Error: don't know what type:"; then
             echo "Failures detected in spice.log"
             exit 1
           fi
@@ -2077,13 +2079,13 @@ jobs:
           cat spice.log
           # See note above: strip ANSI, then tolerate transient parquet-rename
           # races emitted at WARN level by the refresh task (both the
-          # "TProtocolException: Invalid data" and empty-type "don't know what
-          # type:" variants).
+          # "TProtocolException: Invalid data" and "don't know what type:"
+          # variants).
           if sed $'s/\x1b\\[[0-9;]*m//g' spice.log \
              | grep -iE "(failed|error)" \
              | grep -vE "WARN +runtime::accelerated_table::refresh_task: Failed to load data for dataset" \
              | grep -vE "^Invalid Error: TProtocolException: Invalid data$" \
-             | grep -vE "^Invalid Error: don't know what type: *$"; then
+             | grep -vE "^Invalid Error: don't know what type:"; then
             echo "Failures detected in spice.log"
             exit 1
           fi


### PR DESCRIPTION
## Problem

The `duckdb_append_*` graceful-shutdown jobs whitelist the transient DuckDB read failures caused by `simulate_append_data.sh` republishing `.spice/service_data.parquet` every 3s — a refresh tick that races the rename reads a half-written file, the runtime logs a WARN, and the next tick succeeds.

The `don't know what type:` variant was whitelisted only when the type token was **empty** (`don't know what type: *$`). But a truncated read surfaces whatever bytes happen to sit where the schema element's type has not been written yet, and that is not always nothing. Two runs today hit a `0x0e` byte there and failed the job on a WARN the runtime had already recovered from:

```
WARN runtime::accelerated_table::refresh_task: Failed to load data for dataset data_drop (duckdb): … Query execution failed.
Invalid Error: don't know what type: ^N
```

- https://github.com/spiceai/spiceai/actions/runs/30534651210 (push to `trunk`, `duckdb_append_with_pk_and_indexes.yaml`)
- https://github.com/spiceai/spiceai/actions/runs/30550611665 (merge queue, `duckdb_append_with_pk.yaml`)

## Change

Match the error prefix instead of requiring an empty token, in both `Check logs` steps of the `graceful_shutdown_test` job. This is the same class of transient the whitelist already covers; only the trailing token varies.

## Verification

Replayed both `Check logs` pipelines locally against a synthetic `spice.log` carrying the exact bytes from the failing run (ANSI-coloured WARN + continuation line ending in `0x0e`):

- old pattern → reproduces the CI failure
- new pattern → passes
- a genuine `ERROR real failure: …` line → still fails the step, so the check keeps its teeth

## Related

Third widening of the same whitelist: #11636 (empty-type variant) and #11937 (strip ANSI first).