### PR TITLE
fix(ci): seed the TPC-H Postgres benches from the fleet's dataset and schedule the catalog schema tests

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -23,6 +23,7 @@ on:
           - 'append'
           - 'http-consistency'
           - 'nas'
+          - 'schema'
           - 'text-to-sql'
           - 'streaming-bench'
           - 'streaming-correctness'
@@ -180,6 +181,17 @@ jobs:
         if: ${{ steps.sched.outputs.name == 'daily-main' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.branch }}
+
+      # Catalog-connector discovery tests. Only the dispatch configs that declare a
+      # `schema` block are dispatched, so this is the catalog spicepods.
+      - name: Dispatch Testoperator - Scheduled Schema - TPCH - SF1
+        if: ${{ steps.sched.outputs.name == 'daily-main' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 --workflow schema
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -296,21 +296,23 @@ jobs:
           # Require those scale factors to be pre-provisioned instead.
           if [ "$PGHOST" != "127.0.0.1" ]; then
             echo "::error::$DB_NAME is missing or empty on the hosted $PGHOST cluster. Scale factor $SCALE_FACTOR is too large to safely generate and load inline from a CI runner. Pre-provision it first, e.g.:"
-            echo "  cd test/tpc-bench && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME DBGEN_SCALE=$SCALE_FACTOR make tpch-init tpch-gen pg-init pg-load pg-create-index"
+            echo "  cd test/tpc-bench && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME DBGEN_SCALE=$SCALE_FACTOR make tpch-clone tpch-fleet-gen pg-init && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME TPCH_DATA_DIR=./tmp/fleet make pg-load && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-create-index"
             echo "(substitute the tpcds-* targets for a tpcds run)"
             exit 1
           fi
 
           echo "$DB_NAME is missing or empty on $PGHOST - seeding it now."
-          sudo apt-get install -y git make flex bison byacc
+          sudo apt-get install -y git make
           if [ "$QUERY_SET" = "tpcds" ]; then
             # tpcds-kit's tools/Makefile hardcodes CC=gcc-9 on Linux; ubuntu-24.04's
             # default gcc isn't named gcc-9, so install it explicitly via the PPA.
             sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y
             sudo apt-get update -y
-            sudo apt-get install -y gcc-9 g++-9
+            sudo apt-get install -y flex bison byacc gcc-9 g++-9
           else
-            sudo apt-get install -y gcc g++
+            # TPC-H data comes from the pinned DuckDB CLI (see tpch-fleet-gen), so
+            # nothing is compiled here - tpch-kit is only cloned for dss.ddl.
+            sudo apt-get install -y unzip
           fi
 
           if [ "$QUERY_SET" = "tpcds" ]; then
@@ -320,10 +322,10 @@ jobs:
             DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-tpcds-load
             DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-tpcds-create-index
           else
-            make tpch-init
-            DBGEN_SCALE=$SCALE_FACTOR make tpch-gen
+            make tpch-clone
+            DBGEN_SCALE=$SCALE_FACTOR make tpch-fleet-gen
             DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-init
-            DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-load
+            DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME TPCH_DATA_DIR=./tmp/fleet make pg-load
             DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-create-index
           fi
           echo "Seed complete: $DB_NAME on $PGHOST."

--- a/.github/workflows/testoperator_run_schema.yml
+++ b/.github/workflows/testoperator_run_schema.yml
@@ -38,6 +38,23 @@ jobs:
         env:
           MSSQL_SA_PASSWORD: S3cretP@ssw0rd
           DB_NAME: tpch_sf1
+      # Local, ephemeral PostgreSQL for the postgres catalog connector, mirroring
+      # what the bench workflow does for SF1/SF10 (see #11730). Catalog discovery
+      # reads pg_catalog, so it needs the tables to exist but not their rows -
+      # the seed step below creates the schema only. Excludes
+      # ducklake[postgres+s3], which provisions its own postgres catalog DB on the
+      # same port.
+      postgres_tpch:
+        image: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake')) && 'postgres:16' || '' }}
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -195,6 +212,24 @@ jobs:
           connection.close()
           PY
 
+      # Catalog discovery enumerates tables from pg_catalog, so the schema is all
+      # this needs - no TPC-H data is generated or loaded. tpch-kit is cloned only
+      # for dss.ddl, which pg-init applies.
+      - name: Create the postgres TPC-H schema
+        if: ${{ contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') }}
+        env:
+          PGHOST: 127.0.0.1
+          PGPASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
+        run: |
+          set -e
+          sudo apt-get update -y
+          sudo apt-get install -y postgresql-client git make
+          cd test/tpc-bench
+          make tpch-clone
+          DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=tpch_sf1 make pg-init
+          psql -U postgres -d tpch_sf1 -tAc \
+            "SELECT 'tables in public: ' || count(*) FROM information_schema.tables WHERE table_schema = 'public';"
+
       - name: Run the schema test - ${{ github.event.inputs.spicepod_path }}
         run: |
           rm -rf .spice/data
@@ -229,7 +264,7 @@ jobs:
           MYSQL_USER: ${{ secrets.TEST_MYSQL_USERNAME }}
           MYSQL_PASSWORD: ${{ secrets.TEST_MYSQL_PASSWORD }}
           MYSQL_DB: ${{ vars.TEST_MYSQL_DB }}
-          POSTGRES_HOST: ${{ vars.TEST_POSTGRES_HOST }}
+          POSTGRES_HOST: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake')) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
           POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
           SPICEAI_TEST_ENDPOINT: ${{ vars.SPICE_SECRET_SPICEAI_TEST_ENDPOINT }}
           SPICEAI_TEST_TPCH_API_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_TEST_TPCH_BENCHMARK_KEY }}
@@ -273,7 +308,12 @@ jobs:
             if git ls-remote --exit-code --heads origin ${BRANCH_NAME}; then
               git pull --rebase origin ${BRANCH_NAME}
             fi
-            git push origin ${BRANCH_NAME}
+            # The checkout persists no credentials, so authenticate the push
+            # itself rather than leaving a token in the local git config for the
+            # rest of the job. Without this the push fails ("could not read
+            # Username for https://github.com") and, because no schema snapshot
+            # is committed yet, every run creates one and so every run failed here.
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:${BRANCH_NAME}"
 
             PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"
             if [[ -n "${PR_URL}" ]]; then

--- a/test/tpc-bench/Makefile
+++ b/test/tpc-bench/Makefile
@@ -123,28 +123,28 @@ $(DUCKDB):
 	curl -fsSL --retry 3 -o ./tmp/bin/duckdb.zip "https://github.com/duckdb/duckdb/releases/download/$(DUCKDB_VERSION)/$$ASSET"
 	@unzip -oq ./tmp/bin/duckdb.zip -d ./tmp/bin
 	@rm -f ./tmp/bin/duckdb.zip
-	@chmod +x $(DUCKDB)
-	@$(DUCKDB) --version
+	@chmod +x "$(DUCKDB)"
+	@"$(DUCKDB)" --version
 
 tpch-fleet-gen: $(DUCKDB)
 	@# Check if DBGEN_SCALE is set, else default to 1
 	$(eval DBGEN_SCALE ?= 1)
-	@mkdir -p $(TPCH_FLEET_DIR)
-	@rm -f $(TPCH_FLEET_DIR)/*.tbl $(TPCH_FLEET_DIR)/gen.duckdb $(TPCH_FLEET_DIR)/gen.duckdb.wal
+	@mkdir -p "$(TPCH_FLEET_DIR)"
+	@rm -f "$(TPCH_FLEET_DIR)"/*.tbl "$(TPCH_FLEET_DIR)/gen.duckdb" "$(TPCH_FLEET_DIR)/gen.duckdb.wal"
 	@echo "Generating TPC-H scale factor $(DBGEN_SCALE)..."
-	@$(DUCKDB) $(TPCH_FLEET_DIR)/gen.duckdb -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=$(DBGEN_SCALE));" > /dev/null
+	@"$(DUCKDB)" "$(TPCH_FLEET_DIR)/gen.duckdb" -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=$(DBGEN_SCALE));" > /dev/null
 	@# QUOTE '' disables CSV quoting so no field is ever wrapped, and the trailing
 	@# empty column reproduces dbgen's trailing '|'; the result is byte-compatible
 	@# with dbgen's .tbl format, so every *-load target reads it unchanged. Tables
 	@# are dropped as they are written to bound peak disk at the larger scales.
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Writing $$table.tbl..."; \
-		$(DUCKDB) $(TPCH_FLEET_DIR)/gen.duckdb -c "\
+		"$(DUCKDB)" "$(TPCH_FLEET_DIR)/gen.duckdb" -c "\
 			COPY (SELECT *, '' FROM $$table) TO '$(TPCH_FLEET_DIR)/$$table.tbl' (FORMAT CSV, DELIMITER '|', HEADER false, QUOTE ''); \
 			DROP TABLE $$table; \
 			CHECKPOINT;" > /dev/null || exit 1; \
 	done
-	@rm -f $(TPCH_FLEET_DIR)/gen.duckdb $(TPCH_FLEET_DIR)/gen.duckdb.wal
+	@rm -f "$(TPCH_FLEET_DIR)/gen.duckdb" "$(TPCH_FLEET_DIR)/gen.duckdb.wal"
 	@echo "Test data generated successfully in $(TPCH_FLEET_DIR) - pass TPCH_DATA_DIR=$(TPCH_FLEET_DIR) to the load targets."
 
 # Default value for DB_NAME
@@ -166,7 +166,7 @@ pg-load:
 	@mkdir -p ./tmp
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' $(TPCH_DATA_DIR)/$$table.tbl > ./tmp/$$table.tbl; \
+		sed 's/|$$//' "$(TPCH_DATA_DIR)/$$table.tbl" > ./tmp/$$table.tbl; \
 		psql -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USER} $(DB_NAME) -c "\\copy $$table FROM './tmp/$$table.tbl' CSV DELIMITER '|';"; \
 	done
 	@echo "Benchmark dataset has been successfully loaded to $(DB_NAME) database"
@@ -262,7 +262,7 @@ mysql-load:
 	@mkdir -p ./tmp
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' $(TPCH_DATA_DIR)/$$table.tbl > ./tmp/$$table.tbl; \
+		sed 's/|$$//' "$(TPCH_DATA_DIR)/$$table.tbl" > ./tmp/$$table.tbl; \
 		mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) --local-infile=1 $(DB_NAME) -e "LOAD DATA LOCAL INFILE './tmp/$$table.tbl' INTO TABLE $$table FIELDS TERMINATED BY '|' LINES TERMINATED BY '\n';"; \
 	done
 	@echo "Benchmark dataset has been successfully loaded to '$(DB_NAME)' database."
@@ -352,7 +352,7 @@ file-tpch-init:
 	@mkdir -p ./tmp
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Preparing $$table..."; \
-		cp $(TPCH_DATA_DIR)/$$table.tbl ./tmp/$$table.csv; \
+		cp "$(TPCH_DATA_DIR)/$$table.tbl" ./tmp/$$table.csv; \
 		python ./tpch_file.py ./tmp/$$table; \
 		rm ./tmp/$$table.csv; \
 	done
@@ -409,7 +409,7 @@ mssql-init:
 
 mssql-load:
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
-		cp $(TPCH_DATA_DIR)/$$table.tbl ./mssql-tpch/data/$$table.tbl; \
+		cp "$(TPCH_DATA_DIR)/$$table.tbl" ./mssql-tpch/data/$$table.tbl; \
 	done
 	chmod 755 ./mssql-tpch/data
 	sqlcmd -U $(DB_USER) -P $(DB_PASS) -S $(DB_HOST) -d $(DB_NAME) -i ./mssql-tpch/insert.sql

--- a/test/tpc-bench/Makefile
+++ b/test/tpc-bench/Makefile
@@ -4,11 +4,18 @@
 
 all: tpch-gen pg-load
 
-tpch-init:
+# Directory the *-load targets read TPC-H .tbl files from. dbgen writes its output
+# next to the binary, so that is the default; tpch-fleet-gen writes to
+# $(TPCH_FLEET_DIR) instead, so a caller using it must pass TPCH_DATA_DIR to match.
+TPCH_DATA_DIR ?= tpch-kit/dbgen
+
+tpch-clone:
 	@if [ ! -d "tpch-kit" ]; then \
 		git clone https://github.com/spiceai/tpch-kit.git; \
 		cd tpch-kit && git checkout 319892381ff1213ca794d449c04c5a31f2252d57; \
 	fi
+
+tpch-init: tpch-clone
 	@OS=`uname`; \
 	if [ -z "$(MACHINE)" ]; then \
 		if [ "$$OS" = "Linux" ]; then \
@@ -75,6 +82,71 @@ tpch-gen: tpch-init
 
 	@echo "Test data and queries generated successfully."
 
+# tpch-fleet-gen generates the same TPC-H dataset the rest of the benchmark fleet
+# runs on - s3://spiceai-public-datasets/tpch and the hosted MySQL, Iceberg, Glue,
+# Databricks, Snowflake and Spice Cloud copies - which is what
+# crates/test-framework/src/queries/validation/tpch/*.csv holds the expected
+# answers for. That dataset comes from DuckDB's tpch extension, and DuckDB's
+# generator disagrees with tpch-kit's dbgen on the free-text columns (c_address,
+# s_address, and every *_comment): keys, numerics, dates and even the string
+# lengths are identical, but the characters differ. That changes 4 of the 22 TPC-H
+# answers - Q2 and Q20 (s_address), Q10 (c_address), and Q13, whose predicate reads
+# o_comment - so a Postgres database seeded with dbgen data fails result validation
+# on exactly those four queries no matter how correct the engine under test is.
+# dbgen is the officially correct generator (its output matches the TPC-supplied
+# answers in tpch-kit's dbgen/answers/); the fleet's dataset is the one that
+# diverges, tracked separately in #12137. Until that is resolved, seeding from the
+# same generator the answers were produced with is what makes a result mismatch
+# mean a real bug.
+#
+# Data only - qgen/tpch_queries.sql still comes from tpch-gen.
+# Example: DBGEN_SCALE=1 make tpch-fleet-gen
+TPCH_FLEET_DIR ?= ./tmp/fleet
+
+# Pinned so the generated dataset cannot drift with whatever duckdb happens to be
+# on PATH. v1.5.4's output was verified row-for-row identical to the fleet dataset
+# across all 8 tables (0 rows differing in either direction, 6,001,215 lineitem
+# rows). Override DUCKDB to use an already-installed CLI.
+DUCKDB_VERSION ?= v1.5.4
+DUCKDB ?= ./tmp/bin/duckdb
+
+$(DUCKDB):
+	@mkdir -p ./tmp/bin
+	@OS=`uname`; ARCH=`uname -m`; \
+	case "$$OS/$$ARCH" in \
+		Linux/x86_64) ASSET=duckdb_cli-linux-amd64.zip ;; \
+		Linux/aarch64 | Linux/arm64) ASSET=duckdb_cli-linux-arm64.zip ;; \
+		Darwin/*) ASSET=duckdb_cli-osx-universal.zip ;; \
+		*) echo "No DuckDB CLI release asset for $$OS/$$ARCH - install duckdb and re-run with DUCKDB=\`command -v duckdb\`"; exit 1 ;; \
+	esac; \
+	echo "Downloading DuckDB CLI $(DUCKDB_VERSION) ($$ASSET)..."; \
+	curl -fsSL --retry 3 -o ./tmp/bin/duckdb.zip "https://github.com/duckdb/duckdb/releases/download/$(DUCKDB_VERSION)/$$ASSET"
+	@unzip -oq ./tmp/bin/duckdb.zip -d ./tmp/bin
+	@rm -f ./tmp/bin/duckdb.zip
+	@chmod +x $(DUCKDB)
+	@$(DUCKDB) --version
+
+tpch-fleet-gen: $(DUCKDB)
+	@# Check if DBGEN_SCALE is set, else default to 1
+	$(eval DBGEN_SCALE ?= 1)
+	@mkdir -p $(TPCH_FLEET_DIR)
+	@rm -f $(TPCH_FLEET_DIR)/*.tbl $(TPCH_FLEET_DIR)/gen.duckdb $(TPCH_FLEET_DIR)/gen.duckdb.wal
+	@echo "Generating TPC-H scale factor $(DBGEN_SCALE)..."
+	@$(DUCKDB) $(TPCH_FLEET_DIR)/gen.duckdb -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=$(DBGEN_SCALE));" > /dev/null
+	@# QUOTE '' disables CSV quoting so no field is ever wrapped, and the trailing
+	@# empty column reproduces dbgen's trailing '|'; the result is byte-compatible
+	@# with dbgen's .tbl format, so every *-load target reads it unchanged. Tables
+	@# are dropped as they are written to bound peak disk at the larger scales.
+	@for table in region nation customer supplier part partsupp orders lineitem; do \
+		echo "Writing $$table.tbl..."; \
+		$(DUCKDB) $(TPCH_FLEET_DIR)/gen.duckdb -c "\
+			COPY (SELECT *, '' FROM $$table) TO '$(TPCH_FLEET_DIR)/$$table.tbl' (FORMAT CSV, DELIMITER '|', HEADER false, QUOTE ''); \
+			DROP TABLE $$table; \
+			CHECKPOINT;" > /dev/null || exit 1; \
+	done
+	@rm -f $(TPCH_FLEET_DIR)/gen.duckdb $(TPCH_FLEET_DIR)/gen.duckdb.wal
+	@echo "Test data generated successfully in $(TPCH_FLEET_DIR) - pass TPCH_DATA_DIR=$(TPCH_FLEET_DIR) to the load targets."
+
 # Default value for DB_NAME
 DB_NAME ?= tpch
 
@@ -91,9 +163,10 @@ pg-init:
 
 # Example: DB_HOST=localhost DB_PORT=5432 DB_USER=postgres DB_NAME=tpch make pg-load
 pg-load:
+	@mkdir -p ./tmp
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' tpch-kit/dbgen/$$table.tbl > ./tmp/$$table.tbl; \
+		sed 's/|$$//' $(TPCH_DATA_DIR)/$$table.tbl > ./tmp/$$table.tbl; \
 		psql -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USER} $(DB_NAME) -c "\\copy $$table FROM './tmp/$$table.tbl' CSV DELIMITER '|';"; \
 	done
 	@echo "Benchmark dataset has been successfully loaded to $(DB_NAME) database"
@@ -189,7 +262,7 @@ mysql-load:
 	@mkdir -p ./tmp
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' tpch-kit/dbgen/$$table.tbl > ./tmp/$$table.tbl; \
+		sed 's/|$$//' $(TPCH_DATA_DIR)/$$table.tbl > ./tmp/$$table.tbl; \
 		mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) --local-infile=1 $(DB_NAME) -e "LOAD DATA LOCAL INFILE './tmp/$$table.tbl' INTO TABLE $$table FIELDS TERMINATED BY '|' LINES TERMINATED BY '\n';"; \
 	done
 	@echo "Benchmark dataset has been successfully loaded to '$(DB_NAME)' database."
@@ -279,7 +352,7 @@ file-tpch-init:
 	@mkdir -p ./tmp
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Preparing $$table..."; \
-		cp tpch-kit/dbgen/$$table.tbl ./tmp/$$table.csv; \
+		cp $(TPCH_DATA_DIR)/$$table.tbl ./tmp/$$table.csv; \
 		python ./tpch_file.py ./tmp/$$table; \
 		rm ./tmp/$$table.csv; \
 	done
@@ -336,7 +409,7 @@ mssql-init:
 
 mssql-load:
 	@for table in region nation customer supplier part partsupp orders lineitem; do \
-		cp tpch-kit/dbgen/$$table.tbl ./mssql-tpch/data/$$table.tbl; \
+		cp $(TPCH_DATA_DIR)/$$table.tbl ./mssql-tpch/data/$$table.tbl; \
 	done
 	chmod 755 ./mssql-tpch/data
 	sqlcmd -U $(DB_USER) -P $(DB_PASS) -S $(DB_HOST) -d $(DB_NAME) -i ./mssql-tpch/insert.sql

--- a/tools/testoperator/src/commands/schema/snapshots/schema/testoperator__commands__schema__postgres[catalog]_schema_columns.snap
+++ b/tools/testoperator/src/commands/schema/snapshots/schema/testoperator__commands__schema__postgres[catalog]_schema_columns.snap
@@ -1,0 +1,80 @@
+---
+source: tools/testoperator/src/commands/schema/mod.rs
+description: "Schema columns for postgres[catalog]"
+---
++---------------+--------------+--------------+-----------------------+------------------+-------------------------------------------------------------------------------------------+-------------+
+| table_catalog | table_schema | table_name   | column_name           | ordinal_position | data_type                                                                                 | is_nullable |
++---------------+--------------+--------------+-----------------------+------------------+-------------------------------------------------------------------------------------------+-------------+
+| pg            | public       | customer     | c_custkey             | 0                | Int32                                                                                     | NO          |
+| pg            | public       | customer     | c_name                | 1                | Utf8                                                                                      | NO          |
+| pg            | public       | customer     | c_address             | 2                | Utf8                                                                                      | NO          |
+| pg            | public       | customer     | c_nationkey           | 3                | Int32                                                                                     | NO          |
+| pg            | public       | customer     | c_phone               | 4                | Utf8                                                                                      | NO          |
+| pg            | public       | customer     | c_acctbal             | 5                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | customer     | c_mktsegment          | 6                | Utf8                                                                                      | NO          |
+| pg            | public       | customer     | c_comment             | 7                | Utf8                                                                                      | NO          |
+| pg            | public       | lineitem     | l_orderkey            | 0                | Int32                                                                                     | NO          |
+| pg            | public       | lineitem     | l_partkey             | 1                | Int32                                                                                     | NO          |
+| pg            | public       | lineitem     | l_suppkey             | 2                | Int32                                                                                     | NO          |
+| pg            | public       | lineitem     | l_linenumber          | 3                | Int32                                                                                     | NO          |
+| pg            | public       | lineitem     | l_quantity            | 4                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | lineitem     | l_extendedprice       | 5                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | lineitem     | l_discount            | 6                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | lineitem     | l_tax                 | 7                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | lineitem     | l_returnflag          | 8                | Utf8                                                                                      | NO          |
+| pg            | public       | lineitem     | l_linestatus          | 9                | Utf8                                                                                      | NO          |
+| pg            | public       | lineitem     | l_shipdate            | 10               | Date32                                                                                    | NO          |
+| pg            | public       | lineitem     | l_commitdate          | 11               | Date32                                                                                    | NO          |
+| pg            | public       | lineitem     | l_receiptdate         | 12               | Date32                                                                                    | NO          |
+| pg            | public       | lineitem     | l_shipinstruct        | 13               | Utf8                                                                                      | NO          |
+| pg            | public       | lineitem     | l_shipmode            | 14               | Utf8                                                                                      | NO          |
+| pg            | public       | lineitem     | l_comment             | 15               | Utf8                                                                                      | NO          |
+| pg            | public       | nation       | n_nationkey           | 0                | Int32                                                                                     | NO          |
+| pg            | public       | nation       | n_name                | 1                | Utf8                                                                                      | NO          |
+| pg            | public       | nation       | n_regionkey           | 2                | Int32                                                                                     | NO          |
+| pg            | public       | nation       | n_comment             | 3                | Utf8                                                                                      | YES         |
+| pg            | public       | orders       | o_orderkey            | 0                | Int32                                                                                     | NO          |
+| pg            | public       | orders       | o_custkey             | 1                | Int32                                                                                     | NO          |
+| pg            | public       | orders       | o_orderstatus         | 2                | Utf8                                                                                      | NO          |
+| pg            | public       | orders       | o_totalprice          | 3                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | orders       | o_orderdate           | 4                | Date32                                                                                    | NO          |
+| pg            | public       | orders       | o_orderpriority       | 5                | Utf8                                                                                      | NO          |
+| pg            | public       | orders       | o_clerk               | 6                | Utf8                                                                                      | NO          |
+| pg            | public       | orders       | o_shippriority        | 7                | Int32                                                                                     | NO          |
+| pg            | public       | orders       | o_comment             | 8                | Utf8                                                                                      | NO          |
+| pg            | public       | part         | p_partkey             | 0                | Int32                                                                                     | NO          |
+| pg            | public       | part         | p_name                | 1                | Utf8                                                                                      | NO          |
+| pg            | public       | part         | p_mfgr                | 2                | Utf8                                                                                      | NO          |
+| pg            | public       | part         | p_brand               | 3                | Utf8                                                                                      | NO          |
+| pg            | public       | part         | p_type                | 4                | Utf8                                                                                      | NO          |
+| pg            | public       | part         | p_size                | 5                | Int32                                                                                     | NO          |
+| pg            | public       | part         | p_container           | 6                | Utf8                                                                                      | NO          |
+| pg            | public       | part         | p_retailprice         | 7                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | part         | p_comment             | 8                | Utf8                                                                                      | NO          |
+| pg            | public       | partsupp     | ps_partkey            | 0                | Int32                                                                                     | NO          |
+| pg            | public       | partsupp     | ps_suppkey            | 1                | Int32                                                                                     | NO          |
+| pg            | public       | partsupp     | ps_availqty           | 2                | Int32                                                                                     | NO          |
+| pg            | public       | partsupp     | ps_supplycost         | 3                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | partsupp     | ps_comment            | 4                | Utf8                                                                                      | NO          |
+| pg            | public       | region       | r_regionkey           | 0                | Int32                                                                                     | NO          |
+| pg            | public       | region       | r_name                | 1                | Utf8                                                                                      | NO          |
+| pg            | public       | region       | r_comment             | 2                | Utf8                                                                                      | YES         |
+| pg            | public       | supplier     | s_suppkey             | 0                | Int32                                                                                     | NO          |
+| pg            | public       | supplier     | s_name                | 1                | Utf8                                                                                      | NO          |
+| pg            | public       | supplier     | s_address             | 2                | Utf8                                                                                      | NO          |
+| pg            | public       | supplier     | s_nationkey           | 3                | Int32                                                                                     | NO          |
+| pg            | public       | supplier     | s_phone               | 4                | Utf8                                                                                      | NO          |
+| pg            | public       | supplier     | s_acctbal             | 5                | Decimal128(15, 2)                                                                         | NO          |
+| pg            | public       | supplier     | s_comment             | 6                | Utf8                                                                                      | NO          |
+| spice         | runtime      | task_history | trace_id              | 0                | Utf8                                                                                      | NO          |
+| spice         | runtime      | task_history | span_id               | 1                | Utf8                                                                                      | NO          |
+| spice         | runtime      | task_history | parent_span_id        | 2                | Utf8                                                                                      | YES         |
+| spice         | runtime      | task_history | task                  | 3                | Utf8                                                                                      | NO          |
+| spice         | runtime      | task_history | input                 | 4                | Utf8                                                                                      | NO          |
+| spice         | runtime      | task_history | captured_output       | 5                | Utf8                                                                                      | YES         |
+| spice         | runtime      | task_history | start_time            | 6                | Timestamp(ns, "UTC")                                                                      | NO          |
+| spice         | runtime      | task_history | end_time              | 7                | Timestamp(ns, "UTC")                                                                      | NO          |
+| spice         | runtime      | task_history | execution_duration_ms | 8                | Float64                                                                                   | NO          |
+| spice         | runtime      | task_history | error_message         | 9                | Utf8                                                                                      | YES         |
+| spice         | runtime      | task_history | labels                | 10               | Map("entries": non-null Struct("keys": non-null Utf8, "values": non-null Utf8), unsorted) | NO          |
++---------------+--------------+--------------+-----------------------+------------------+-------------------------------------------------------------------------------------------+-------------+

--- a/tools/testoperator/src/commands/schema/snapshots/schema/testoperator__commands__schema__postgres[catalog]_schema_tables.snap
+++ b/tools/testoperator/src/commands/schema/snapshots/schema/testoperator__commands__schema__postgres[catalog]_schema_tables.snap
@@ -1,0 +1,31 @@
+---
+source: tools/testoperator/src/commands/schema/mod.rs
+description: "Schema tables for postgres[catalog]"
+---
++---------------+--------------------+--------------+------------+
+| table_catalog | table_schema       | table_name   | table_type |
++---------------+--------------------+--------------+------------+
+| pg            | information_schema | columns      | VIEW       |
+| pg            | information_schema | df_settings  | VIEW       |
+| pg            | information_schema | parameters   | VIEW       |
+| pg            | information_schema | routines     | VIEW       |
+| pg            | information_schema | schemata     | VIEW       |
+| pg            | information_schema | tables       | VIEW       |
+| pg            | information_schema | views        | VIEW       |
+| pg            | public             | customer     | BASE TABLE |
+| pg            | public             | lineitem     | BASE TABLE |
+| pg            | public             | nation       | BASE TABLE |
+| pg            | public             | orders       | BASE TABLE |
+| pg            | public             | part         | BASE TABLE |
+| pg            | public             | partsupp     | BASE TABLE |
+| pg            | public             | region       | BASE TABLE |
+| pg            | public             | supplier     | BASE TABLE |
+| spice         | information_schema | columns      | VIEW       |
+| spice         | information_schema | df_settings  | VIEW       |
+| spice         | information_schema | parameters   | VIEW       |
+| spice         | information_schema | routines     | VIEW       |
+| spice         | information_schema | schemata     | VIEW       |
+| spice         | information_schema | tables       | VIEW       |
+| spice         | information_schema | views        | VIEW       |
+| spice         | runtime            | task_history | BASE TABLE |
++---------------+--------------------+--------------+------------+


### PR DESCRIPTION
Closes part of #12104.

## Problem

The scheduled TPC-H SF1 benches for both `federated/postgres.yaml` and `federated/postgres[catalog].yaml` failed every run. #11800 removed the connection identity from the explain snapshots, which accounted for 18 of the 22 failures. The remaining four — Q2 and Q20 on `s_address`, Q10 on `c_address`, Q13 on `c_count` — had a different cause, and the seeding step was the reason.

The seed generates its data with `tpch-kit`'s dbgen. The expected answers in `crates/test-framework/src/queries/validation/tpch/*.csv` are the answers for a *different* dataset: the one every other TPC-H bench reads (the published `spiceai-public-datasets` copy and its hosted MySQL, Iceberg, Glue, Databricks, Snowflake and Spice Cloud mirrors), which comes from DuckDB's `tpch` extension.

The two generators agree on every key, numeric, date, phone number and even each string's *length*. They disagree on the free-text columns — `c_address`, `s_address` and every `*_comment`. That changes exactly 4 of the 22 answers: Q2 and Q20 project `s_address`, Q10 projects `c_address`, and Q13's predicate reads `o_comment` (`o_comment NOT LIKE '%special%requests%'`), so different comment text shifts its group counts. The other 18 project no free-text column, which is why only these four failed and why this stayed invisible.

Worth being explicit about which side is correct: dbgen's output matches the TPC-supplied answers shipped in `tpch-kit`'s `dbgen/answers/*.out`, so **the PostgreSQL data was right and the fixtures are what diverge**. Aligning the fleet on official TPC-H answers means moving ~70 dispatch configs' datasets and the fixtures together, so it is tracked separately in #12137. Until then, seeding from the generator the answers were actually produced with is what makes a result mismatch mean a real bug.

These are also not tie-ambiguous orderings. For Q10 every one of `c_custkey`, `c_name`, `revenue`, `c_acctbal`, `n_name` and `c_phone` matches on all 20 rows and only `c_address` and `c_comment` differ — the same key returning different text, which no `ORDER BY` tiebreak can fix.

## Fix

**Seed from the fleet's dataset.** New `tpch-fleet-gen` target generates TPC-H with a pinned DuckDB CLI and writes `.tbl` files byte-compatible with dbgen's format — `QUOTE ''` suppresses CSV quoting so no field is ever wrapped, and a trailing empty column reproduces dbgen's trailing `|`. The load targets take their source directory from a new `TPCH_DATA_DIR`, so every existing `pg-load` / `mysql-load` / `mssql-load` / `file-tpch-init` reads it unchanged and the default still points at dbgen's output. `tpch-gen` and `qgen`/`tpch_queries.sql` are untouched.

Nothing is compiled in the TPC-H seeding path anymore — `tpch-kit` is cloned only for `dss.ddl`, via a new clone-only `tpch-clone` — so the seed no longer installs a toolchain. Keeping `dss.ddl` matters: it preserves the exact column types, so no snapshot or inferred schema moves.

**Schedule the catalog discovery tests.** `testoperator_dispatch` offered no `schema` workflow type and never dispatched one, so `testoperator_run_schema.yml` was `workflow_dispatch`-only and the `schema` blocks that ten catalog configs already declare never ran. A catalog that stopped enumerating its tables would not have been caught. `testoperator` already maps `--workflow schema` to that workflow and only dispatches configs declaring the block, so this is a choice-list entry plus a daily step.

**Make those schema tests able to pass.** Dispatching the workflow by hand surfaced two failures a scheduled run would have hit every day:

- The snapshot upload could never succeed. The checkout sets `persist-credentials: false`, so `git push origin` in *Upload schema snapshots to branch* dies with `could not read Username for 'https://github.com'` (exit 128). No schema snapshot is committed for any of the ten catalog spicepods, so every run creates one and every run therefore failed there — the `mysql[catalog]` run passed its actual schema test and still came out red. `testoperator_run_bench.yml` escapes this only because its checkout omits `persist-credentials` and defaults to true. Authenticate the push itself with `GH_TOKEN` rather than persisting credentials for the whole job.
- The postgres catalog could not connect at all, failing registration with `PostgreSQL connection failed. db error` against the hosted cluster's `tpch_sf1` — the database the SF1 benches stopped using when they moved to a local service container. The `mysql[catalog]` run reached its hosted database in the same workflow, which isolates this to that database rather than the workflow's wiring. Give the schema job the same ephemeral `postgres:16` service the bench workflow uses. Discovery enumerates `pg_catalog`, so only the tables need to exist — the new step applies `dss.ddl` and loads no data, keeping it to a few seconds.

## Validation

Seeding was verified end to end against PostgreSQL 16 through the exact sequence CI runs (`tpch-clone` → `tpch-fleet-gen` → `pg-init` → `pg-load` → `pg-create-index`), then running all 21 queries of the `postgres-catalog` override set against the result:

- Q2, Q10, Q13 and Q20 — the four that were failing — now match the committed fixtures **byte for byte**.
- The other 17 match within the validator's numeric tolerance; the only textual differences are decimal rendering (e.g. `16.380778626395543` vs `16.3807786263955401`), which is what that tolerance exists for.

Separately, the dataset the pinned DuckDB CLI produces was confirmed row-for-row identical to the published fleet copy: `EXCEPT ALL` in both directions returns 0 rows for all 8 tables, including all 6,001,215 `lineitem` rows.

The two schema-workflow fixes are **not yet verified in CI** — that needs a dispatch from this branch, which is the next step now that it is pushed.

## Remaining for #12104

Not in this PR: the endpoint-URL half of the snapshot redaction, which is its own PR now that #11800 has landed the `host=` half. The bench runs proving 22/22 on both spicepods, and two consecutive green scheduled dispatches, follow from merging this.
