### PR TITLE
bug: FTS exec drops absent columns and violates its declared schema (fixes #12228)

### DIFF
--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -308,7 +308,6 @@ mod tests {
             .expect("failed to create FullTextSearchFieldIndex");
         let rb = search_index
             .search("apple".to_string(), &[], 1000)
-            .await
             .expect("search failed")
             .try_collect::<Vec<_>>()
             .await

--- a/crates/search/src/generation/text_search/exec.rs
+++ b/crates/search/src/generation/text_search/exec.rs
@@ -132,7 +132,14 @@ impl ExecutionPlan for FullTextSearchExec {
                                 let proj = schema
                                     .fields()
                                     .iter()
-                                    .map(|f| rb_schema.index_of(f.name()).map_err(DataFusionError::from))
+                                    .map(|f| {
+                                        rb_schema.index_of(f.name()).map_err(|_| {
+                                            DataFusionError::Internal(format!(
+                                                "Full text search result page is missing column '{}': expected schema {schema}, got {rb_schema}",
+                                                f.name(),
+                                            ))
+                                        })
+                                    })
                                     .collect::<DataFusionResult<Vec<_>>>();
 
                                 match proj {

--- a/crates/search/src/generation/text_search/exec.rs
+++ b/crates/search/src/generation/text_search/exec.rs
@@ -118,7 +118,6 @@ impl ExecutionPlan for FullTextSearchExec {
           // TODO: Support filters.
             match idx
                 .search(query, &[], limit)
-                .await
                 .map_err(|e| DataFusionError::Plan(format!("Failed to prepare full text search: {e}"))) {
                 Ok(mut stream) => {
                     while let Some(item) = stream.next().await {

--- a/crates/search/src/generation/text_search/exec.rs
+++ b/crates/search/src/generation/text_search/exec.rs
@@ -12,7 +12,7 @@ limitations under the License.
 */
 use std::{fmt::Formatter, sync::Arc};
 
-use arrow::{datatypes::SchemaRef, error::ArrowError};
+use arrow::{array::RecordBatch, datatypes::SchemaRef, error::ArrowError};
 use async_stream::stream;
 use datafusion::{
     error::{DataFusionError, Result as DataFusionResult},
@@ -125,18 +125,26 @@ impl ExecutionPlan for FullTextSearchExec {
                         match item {
                             Err(e) => yield Err(e),
                             Ok(rb) => {
-                                // Apply projection. Must return in the order it exists in
-                                // `self.schema()`, not in the record batch. Use
-                                // `Schema::index_of` instead of cloning all field names
-                                // and doing a linear search per projected column.
+                                // Apply projection in the declared schema order. A missing
+                                // field is a corrupt result page, not a column to omit: omitting
+                                // it shifts every following column by position.
                                 let rb_schema = rb.schema();
-                                let proj: Vec<usize> = schema
+                                let proj = schema
                                     .fields()
                                     .iter()
-                                    .filter_map(|f| rb_schema.index_of(f.name()).ok())
-                                    .collect();
+                                    .map(|f| rb_schema.index_of(f.name()).map_err(DataFusionError::from))
+                                    .collect::<DataFusionResult<Vec<_>>>();
 
-                                yield rb.project(proj.as_slice()).map_err(DataFusionError::from)
+                                match proj {
+                                    Ok(proj) => {
+                                        let projected = rb.project(proj.as_slice()).map_err(DataFusionError::from);
+                                        yield projected.and_then(|projected| {
+                                            RecordBatch::try_new(Arc::clone(&schema), projected.columns().to_vec())
+                                                .map_err(DataFusionError::from)
+                                        });
+                                    }
+                                    Err(e) => yield Err(e),
+                                }
                             }
                         }
                     }

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -705,6 +705,8 @@ mod tests {
     };
     use arrow_schema::{ArrowError, Schema};
     use datafusion::datasource::{MemTable, TableProvider};
+    use datafusion::physical_plan::collect;
+    use datafusion::prelude::SessionContext;
     use futures::{StreamExt, TryStreamExt};
     use runtime_datafusion_index::Index;
     use std::time::Duration;
@@ -991,6 +993,98 @@ mod tests {
         assert_eq!(subtitles.null_count(), 2);
         assert!(subtitles.is_null(0));
         assert!(subtitles.is_null(1));
+    }
+
+    // Regression test for #12228: exercises the execution path (`FullTextSearchQuery::scan`
+    // -> `FullTextSearchExec::execute`), not just `FullTextSearchFieldIndex::search`, since the
+    // reported bug was in `FullTextSearchExec`'s positional projection shifting columns.
+    #[tokio::test]
+    async fn test_search_exec_projection_does_not_shift_columns() {
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new("title", DataType::Utf8, false),
+                Field::new("subtitle", DataType::Utf8, true),
+                Field::new("body", DataType::Utf8, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["first title", "second title"])),
+                Arc::new(StringArray::from(vec![None::<&str>, None])),
+                Arc::new(StringArray::from(vec![
+                    "matching body one",
+                    "matching body two",
+                ])),
+            ],
+        )
+        .expect("Failed to create test batch");
+        let table = Arc::new(
+            MemTable::try_new(batch.schema(), vec![vec![batch.clone()]])
+                .expect("Failed to create test table"),
+        );
+        let index = FullTextDatabaseIndex::try_new(
+            table,
+            vec!["body".to_string()],
+            Some(vec!["id".to_string()]),
+            None,
+            &[
+                "title".to_string(),
+                "subtitle".to_string(),
+                "body".to_string(),
+            ],
+        )
+        .expect("Failed to create FullTextDatabaseIndex");
+        index
+            .compute_index(vec![batch])
+            .await
+            .expect("failed to compute_index");
+
+        let search_index = Arc::new(
+            index
+                .full_text_search_field_index("body")
+                .expect("Failed to create FullTextSearchFieldIndex"),
+        );
+        let query = FullTextSearchQuery {
+            index: search_index,
+            query: "matching".to_string(),
+            pre_limit: None,
+        };
+
+        let ctx = SessionContext::new();
+        let full_schema = query.schema();
+        // Project onto a subset that skips the leading nullable `subtitle` column, so a
+        // positional (rather than name-based) projection would shift `body` into
+        // `title`'s slot -- the exact regression from #12228.
+        let projection = vec![
+            full_schema.index_of("body").expect("body in schema"),
+            full_schema.index_of("title").expect("title in schema"),
+        ];
+
+        let plan = query
+            .scan(&ctx.state(), Some(&projection), &[], None)
+            .await
+            .expect("scan should succeed");
+        let batches = collect(plan, ctx.task_ctx())
+            .await
+            .expect("execution should succeed");
+
+        assert_eq!(batches.len(), 1, "expected one result page");
+        let result = &batches[0];
+        assert_eq!(result.schema().field(0).name(), "body");
+        assert_eq!(result.schema().field(1).name(), "title");
+
+        let bodies = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("body must retain its Utf8 type");
+        let titles = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("title must retain its Utf8 type");
+        assert!(bodies.iter().any(|body| body == Some("matching body one")));
+        assert!(titles.iter().any(|title| title == Some("first title")));
     }
 
     #[tokio::test]

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -900,7 +900,6 @@ mod tests {
     async fn search_and_format(idx: &FullTextSearchFieldIndex, query: impl Into<String>) -> String {
         let rb: Vec<RecordBatch> = idx
             .search(query.into(), &[], 1000)
-            .await
             .expect("Failed to search")
             .map(|res| match res {
                 Ok(rb) => sort_columns_alphabetically(&rb)
@@ -961,7 +960,6 @@ mod tests {
             .expect("Failed to create FullTextSearchFieldIndex");
         let batches = search_index
             .search("matching".to_string(), &[], 100)
-            .await
             .expect("Failed to search")
             .try_collect::<Vec<_>>()
             .await

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -699,7 +699,10 @@ fn parse_json_array(
 mod tests {
 
     use super::*;
-    use arrow::{array::record_batch, util::pretty::pretty_format_batches};
+    use arrow::{
+        array::{Array, StringArray, record_batch},
+        util::pretty::pretty_format_batches,
+    };
     use arrow_schema::{ArrowError, Schema};
     use datafusion::datasource::{MemTable, TableProvider};
     use futures::{StreamExt, TryStreamExt};
@@ -907,6 +910,87 @@ mod tests {
             .expect("Failed to collect search results");
 
         format!("{}", pretty_format_batches(&rb).expect("failed to format"))
+    }
+
+    // Regression test for #12228.
+    #[tokio::test]
+    async fn test_search_preserves_all_nullable_stored_columns() {
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new("title", DataType::Utf8, false),
+                Field::new("subtitle", DataType::Utf8, true),
+                Field::new("body", DataType::Utf8, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["first title", "second title"])),
+                Arc::new(StringArray::from(vec![None::<&str>, None])),
+                Arc::new(StringArray::from(vec![
+                    "matching body one",
+                    "matching body two",
+                ])),
+            ],
+        )
+        .expect("Failed to create test batch");
+        let table = Arc::new(
+            MemTable::try_new(batch.schema(), vec![vec![batch.clone()]])
+                .expect("Failed to create test table"),
+        );
+        let index = FullTextDatabaseIndex::try_new(
+            table,
+            vec!["body".to_string()],
+            Some(vec!["id".to_string()]),
+            None,
+            &[
+                "title".to_string(),
+                "subtitle".to_string(),
+                "body".to_string(),
+            ],
+        )
+        .expect("Failed to create FullTextDatabaseIndex");
+        index
+            .compute_index(vec![batch])
+            .await
+            .expect("failed to compute_index");
+
+        let search_index = index
+            .full_text_search_field_index("body")
+            .expect("Failed to create FullTextSearchFieldIndex");
+        let batches = search_index
+            .search("matching".to_string(), &[], 100)
+            .await
+            .expect("Failed to search")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("Failed to collect search results");
+
+        assert_eq!(batches.len(), 1, "expected one result page");
+        let result = &batches[0];
+        assert_eq!(result.schema(), search_index.result_schema());
+        let titles = result
+            .column_by_name("title")
+            .expect("result schema must retain title")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("title must retain its Utf8 type");
+        let subtitles = result
+            .column_by_name("subtitle")
+            .expect("result schema must retain subtitle")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("subtitle must retain its Utf8 type");
+        let bodies = result
+            .column_by_name("body")
+            .expect("result schema must retain body")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("body must retain its Utf8 type");
+        assert!(titles.iter().any(|title| title == Some("first title")));
+        assert!(bodies.iter().any(|body| body == Some("matching body one")));
+        assert_eq!(subtitles.null_count(), 2);
+        assert!(subtitles.is_null(0));
+        assert!(subtitles.is_null(1));
     }
 
     #[tokio::test]

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -321,7 +321,7 @@ impl FullTextSearchFieldIndex {
         )
     }
 
-    pub async fn search(
+    pub fn search(
         &self,
         query: String,
         opt_filters: &[&Expr],

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -34,7 +34,7 @@ use datafusion::{
 };
 
 use ::util::format_datafusion_error;
-use futures::{Stream, StreamExt};
+use futures::Stream;
 use serde_json::{Number, Value};
 use snafu::{ResultExt, Snafu};
 use tantivy::{
@@ -47,8 +47,7 @@ use tantivy::{
 };
 
 use super::{
-    CandidateGeneration, Error as GenerationError, Result as GenerationResult,
-    TextSearchSnafu as GenerationTextSearchSnafu,
+    CandidateGeneration, Result as GenerationResult, TextSearchSnafu as GenerationTextSearchSnafu,
 };
 
 /// Maximum number of results in a single full-text search request, before any pagination.
@@ -189,7 +188,7 @@ pub struct FullTextSearchFieldIndex {
     stored_columns: HashSet<String>,
 
     /// Provide hints to the final Arrow datatype for a given column. Keys are column names.
-    /// Tantivy [`FieldType`]s are less specific than [`arrow::datatypes::DataType`]s and the Arrow type must be inferred from Tanitvy JSON results (via [`arrow_json::reader::infer_json_schema_from_iterator`]).
+    /// Tantivy [`FieldType`]s are less specific than [`arrow::datatypes::DataType`], so source-schema type hints preserve the original Arrow types.
     /// For columns present, use the associated [`arrow::datatypes::Field`].
     type_hints: HashMap<String, Arc<arrow::datatypes::Field>>,
 }
@@ -235,7 +234,7 @@ impl FullTextSearchFieldIndex {
         Ok(fts)
     }
 
-    ///  Schema is based on the [`tantivy::schema::Schema`] with `self.type_hints` applied.
+    /// Schema is based on the [`tantivy::schema::Schema`] with `self.type_hints` applied.
     /// Field order follows the underlying tantivy schema (not the `HashSet` cache).
     fn schema(&self) -> Arc<Schema> {
         let search_schema = self.reader.schema();
@@ -254,6 +253,32 @@ impl FullTextSearchFieldIndex {
                 Some(Field::new(field_name, data_type, nullable))
             })
             .collect::<Vec<_>>();
+
+        Arc::new(Schema::new(fields))
+    }
+
+    /// Schema for every result page produced by [`Self::search`].
+    ///
+    /// Tantivy omits absent stored values from a document's JSON. Supplying this
+    /// fixed schema to the JSON decoder makes those absent nullable values Arrow
+    /// nulls instead of removing their columns from a result page.
+    fn result_schema(&self) -> Arc<Schema> {
+        let schema = self.schema();
+        let mut fields = schema.fields().iter().cloned().collect::<Vec<_>>();
+
+        if let Some((_, value_field)) = schema.column_with_name(self.field.as_str()) {
+            fields.push(Arc::new(Field::new(
+                SEARCH_VALUE_COLUMN_NAME,
+                value_field.data_type().clone(),
+                value_field.is_nullable(),
+            )));
+        }
+
+        fields.push(Arc::new(Field::new(
+            SEARCH_SCORE_COLUMN_NAME,
+            arrow::datatypes::DataType::Float64,
+            false,
+        )));
 
         Arc::new(Schema::new(fields))
     }
@@ -306,16 +331,7 @@ impl FullTextSearchFieldIndex {
             return Err(Error::UnsupportedFiltersError).context(GenerationTextSearchSnafu)?;
         }
         let strm = make_stream(self.clone(), query, limit);
-        let mut strm = Box::pin(strm.peekable());
-        let schema = match strm.as_mut().peek().await {
-            None => Arc::new(Schema::empty()),
-            Some(Ok(rb)) => rb.schema(),
-            Some(Err(e)) => {
-                return Err(GenerationError::internal(
-                    format!("Failed to parse schema of full text search results: {e}").as_str(),
-                ));
-            }
-        };
+        let schema = self.result_schema();
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, strm)) as SendableRecordBatchStream)
     }
@@ -385,27 +401,7 @@ impl FullTextSearchFieldIndex {
         &self,
         hits: &[Value],
     ) -> std::result::Result<Decoder, ArrowError> {
-        let schema = Arc::new(arrow_json::reader::infer_json_schema_from_iterator(
-            hits.iter().map(Ok),
-        )?);
-
-        let schema = Arc::new(Schema::new(
-            schema
-                .fields()
-                .into_iter()
-                .map(|f| {
-                    // Use [`Self::type_hints`].
-                    if let Some(new_field) = self.type_hints.get(f.name()) {
-                        new_field
-                    } else {
-                        f
-                    }
-                })
-                .cloned()
-                .collect::<Vec<_>>(),
-        ));
-
-        let mut decoder = arrow_json::ReaderBuilder::new(Arc::clone(&schema)).build_decoder()?;
+        let mut decoder = arrow_json::ReaderBuilder::new(self.result_schema()).build_decoder()?;
 
         decoder.serialize(hits)?;
 


### PR DESCRIPTION
For a full text search index that has a null column of type T followed by (in the schema)  a column of type T, if the first result in a search stream contains a `NULL` value for the first column, it will assume the value for the second column. 

Resolves #12228.