### PR TITLE
bug: `MemoryVectorIndex` leaves external-store entries on delete.

### DIFF
--- a/crates/search/src/index/compound/tests.rs
+++ b/crates/search/src/index/compound/tests.rs
@@ -1127,6 +1127,7 @@ mod warm_memory {
         let events = Arc::new(Mutex::new(vec![]));
         let mut secondary = MockIndex::new("engine", &events);
         secondary.dimension = Some(DIM);
+        secondary.list_batches = vec![engine_list_batch(&[])];
         let idx = warm_compound(secondary);
 
         idx.write(input_batch(2)).await.expect("write succeeds");

--- a/crates/search/src/index/compound/tests.rs
+++ b/crates/search/src/index/compound/tests.rs
@@ -1121,4 +1121,26 @@ mod warm_memory {
         let plan = idx.list_table_provider().expect("list plan builds");
         assert_eq!(collect_ids(plan).await, vec![0, 1]);
     }
+
+    #[tokio::test]
+    async fn delete_by_keys_removes_entries_from_warm_memory_tier() {
+        let events = Arc::new(Mutex::new(vec![]));
+        let mut secondary = MockIndex::new("engine", &events);
+        secondary.dimension = Some(DIM);
+        let idx = warm_compound(secondary);
+
+        idx.write(input_batch(2)).await.expect("write succeeds");
+
+        idx.delete_by_keys(delete_keys_batch(1))
+            .await
+            .expect("delete succeeds");
+        let plan = idx.list_table_provider().expect("list plan builds");
+        assert_eq!(collect_ids(plan).await, vec![1]);
+
+        idx.delete_by_keys(delete_keys_batch(2))
+            .await
+            .expect("delete succeeds");
+        let plan = idx.list_table_provider().expect("list plan builds");
+        assert!(collect_ids(plan).await.is_empty());
+    }
 }

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -326,6 +326,17 @@ impl Index for MemoryVectorIndex {
             .map(|rb| async { self.write(rb).await.map_err(DataFusionError::External) });
         try_join_all(futs).await
     }
+
+    async fn delete_by_keys(&self, keys: RecordBatch) -> Result<(), DataFusionError> {
+        let key_strings =
+            write_util::extract_and_format_primary_key(INDEX_NAME, &self.primary_key, &keys)
+                .map_err(|e| DataFusionError::External(Box::new(*e)))?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+
+        self.store.write().delete_by_keys(&key_strings)
+    }
 }
 
 #[async_trait]

--- a/crates/search/src/index/memory/store.rs
+++ b/crates/search/src/index/memory/store.rs
@@ -70,10 +70,27 @@ impl MemoryVectorStore {
     ) -> Result<(), DataFusionError> {
         debug_assert_eq!(batch.num_rows(), keys.len());
 
-        let new_keys: HashSet<&str> = keys.iter().map(String::as_str).collect();
+        self.delete_by_keys(&keys)?;
+        if batch.num_rows() > 0 {
+            self.batches.push(StoredBatch { batch, keys });
+        }
+        Ok(())
+    }
+
+    /// Remove every stored row whose formatted primary key appears in `keys`.
+    pub(crate) fn delete_by_keys(&mut self, keys: &[String]) -> Result<(), DataFusionError> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+
+        let delete_keys: HashSet<&str> = keys.iter().map(String::as_str).collect();
         let mut retained = Vec::with_capacity(self.batches.len() + 1);
         for stored in self.batches.drain(..) {
-            if !stored.keys.iter().any(|k| new_keys.contains(k.as_str())) {
+            if !stored
+                .keys
+                .iter()
+                .any(|key| delete_keys.contains(key.as_str()))
+            {
                 // No overlap — keep the batch untouched (zero-copy).
                 retained.push(stored);
                 continue;
@@ -81,7 +98,7 @@ impl MemoryVectorStore {
             let mask: BooleanArray = stored
                 .keys
                 .iter()
-                .map(|k| Some(!new_keys.contains(k.as_str())))
+                .map(|key| Some(!delete_keys.contains(key.as_str())))
                 .collect();
             let filtered = filter_record_batch(&stored.batch, &mask)
                 .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
@@ -91,15 +108,12 @@ impl MemoryVectorStore {
             let kept_keys = stored
                 .keys
                 .into_iter()
-                .filter(|k| !new_keys.contains(k.as_str()))
+                .filter(|key| !delete_keys.contains(key.as_str()))
                 .collect::<Vec<_>>();
             retained.push(StoredBatch {
                 batch: filtered,
                 keys: kept_keys,
             });
-        }
-        if batch.num_rows() > 0 {
-            retained.push(StoredBatch { batch, keys });
         }
         self.batches = retained;
         Ok(())


### PR DESCRIPTION
Implement `MemoryVectorIndex::delete_by_keys`.

Did not affect search outputs due to inner join used, but did affect memory usage.

Resolves #12229.
