### PR TITLE
bug: S3 vector indexing succeeds when the embedding column is absent

### DIFF
--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -612,7 +612,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "Cannot write to 'virtual-index' index, data does not have column 'embedding'."
+            "Cannot write to 's3_vector_index' index, data does not have column 'embedding'."
         );
     }
 

--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -521,6 +521,8 @@ pub fn s3_vectors_primary_key_cast(primary_key: &[Field]) -> Vec<Expr> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::StringArray;
+    use arrow_schema::Schema;
     use datafusion::scalar::ScalarValue;
     use llms::embeddings::EmbeddingInput;
     use s3_vectors::{
@@ -592,6 +594,26 @@ mod tests {
             vec![],
             100,
         )
+    }
+
+    #[tokio::test]
+    async fn write_fails_when_embedding_source_column_is_missing() {
+        let client = Arc::new(MockClient::new()) as Arc<dyn S3Vectors + Send + Sync>;
+        let index = test_s3_vector(client).await;
+        let record = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)])),
+            vec![Arc::new(StringArray::from(vec!["row-1"]))],
+        )
+        .expect("record batch should be valid");
+
+        let err = write::write(&index, &index.table, record, 100)
+            .await
+            .expect_err("missing embedding source column should fail indexing");
+
+        assert_eq!(
+            err.to_string(),
+            "Cannot write to 'virtual-index' index, data does not have column 'embedding'."
+        );
     }
 
     fn index_names(tables: &[S3VectorsTable]) -> Vec<String> {

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -104,12 +104,12 @@ async fn process_single_batch(
         .schema()
         .column_with_name(index.embedded_column.as_str())
     else {
-        tracing::warn!(
-            "Cannot write to '{}' index, data does not have column '{}'.",
-            index.name(),
-            index.embedded_column
-        );
-        return Ok(record);
+        return write_util::ColumnNotFoundSnafu {
+            index: index.name().to_string(),
+            column: index.embedded_column.clone(),
+        }
+        .fail()
+        .map_err(Error::from);
     };
 
     let embedding_vectors = embed_column(


### PR DESCRIPTION
Upgrade a warning to a true error. Ensure we error, instead of warn and skip, any S3Vectors indexing that did not produce an embedding vector during the processing. 
```rust
async fn process_single_batch(
    index: &S3Vector,
    table: &S3VectorsTable,
    record: RecordBatch,
) -> Result<RecordBatch, Error> {
    let Some((embedded_column_idx, _)) = record
        .schema()
        .column_with_name(index.embedded_column.as_str())
    else {
        tracing::warn!(
            "Cannot write to '{}' index, data does not have column '{}'.",
            index.name(),
            index.embedded_column
        );
        return Ok(record);
    };
```


Resolves #12241.