### PR TITLE
chore(cloud-connect): use port 443 for gateway addresses in the doc example and test fixtures

### DIFF
--- a/bin/spice/tests/cli_integration.rs
+++ b/bin/spice/tests/cli_integration.rs
@@ -807,7 +807,7 @@ mod connect {
             "instance_id": "inst_cli_test",
             "identity_cert_pem": "-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n",
             "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nBBBB\n-----END CERTIFICATE-----\n",
-            "gateway_addr": "127.0.0.1:7320",
+            "gateway_addr": "127.0.0.1:443",
             "not_after": "2030-01-01T00:00:00Z",
         })
         .to_string()
@@ -943,7 +943,7 @@ mod connect {
             "instance_id": "inst_cli_test",
             "identity_cert_pem": "-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n",
             "ca_bundle_pem": "",
-            "gateway_addr": "127.0.0.1:7320",
+            "gateway_addr": "127.0.0.1:443",
             "not_after": "2030-01-01T00:00:00Z",
             "app_name": "edge-app",
         })

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -1197,7 +1197,7 @@ mod tests {
             private_key_pem: String::new(),
             public_key_pem: String::new(),
             ca_bundle_pem: String::new(),
-            gateway_addr: "gateway.test:7320".to_string(),
+            gateway_addr: "gateway.test:443".to_string(),
             not_after_unix,
             enc_private_key_pem: String::new(),
             enc_public_key_pem: String::new(),

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -79,7 +79,7 @@ pub struct CloudConnectConfig {
     pub enroll_endpoint: String,
 
     /// Optional explicit gateway (stream) endpoint override, e.g.
-    /// `https://connect.aws.spiceai.io:7320`. When `None` (the default),
+    /// `https://connect.aws.spiceai.io:443`. When `None` (the default),
     /// the stream connects to the `gateway_addr` returned by the enroll
     /// response and persisted in the identity. Mainly for tests and
     /// self-hosted control planes.

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -440,7 +440,7 @@ mod tests {
                 .to_string(),
             ca_bundle_pem: "-----BEGIN CERTIFICATE-----\nMOCKCA\n-----END CERTIFICATE-----\n"
                 .to_string(),
-            gateway_addr: "gateway.test.spice.ai:7320".to_string(),
+            gateway_addr: "gateway.test.spice.ai:443".to_string(),
             not_after_unix: 0,
             enc_private_key_pem:
                 "-----BEGIN PRIVATE KEY-----\nMOCKENC\n-----END PRIVATE KEY-----\n".to_string(),


### PR DESCRIPTION
Tracking: spicehq/spiceai#1340

## What

Moves the Cloud Connect gateway port from `7320` to `443` at every site in this repo that names one — five string literals across four files.

| File | Site | Port refers to |
|---|---|---|
| `crates/runtime-cloud-connect/src/config.rs` | rustdoc example on `CloudConnectConfig::gateway_endpoint` | published gateway port |
| `crates/runtime-cloud-connect/src/identity.rs` | `sample_identity()` fixture | published gateway port |
| `crates/runtime-cloud-connect/src/client.rs` | `identity_with_not_after()` fixture | published gateway port |
| `bin/spice/tests/cli_integration.rs` (×2) | `gateway_addr` in mock enroll response bodies | published gateway port |

Every changed value is an address the runtime would be *told to dial*. No bind address, listener, or other port in this repo changes.

## Why

The gateway's public listener is reachable on `443`. BYOC runtimes dial **outbound** from the customer's own network, where default-deny egress commonly permits `443` and blocks non-standard high ports. The failure mode when it is blocked is a stream that never establishes, with no error naming the cause.

## Scope — this repo has no hardcoded dialed port

Worth stating plainly, because it changes what this PR is: **the runtime has no default or fallback gateway port to move.**

- `CloudConnectConfig::gateway_endpoint` is an `Option<String>` override that defaults to `None`.
- `Identity::gateway_addr` is taken verbatim from the enroll response. Empty is treated as non-recoverable (`stream_endpoint()` returns `None`; re-enrolment required) rather than falling back to a built-in address.
- `build_channel` hands `{scheme}://{gateway_addr}` straight to `Endpoint::from_shared`, appending no port of its own.

So there is no code path here that can silently dial a stale port. Every site changed is a rustdoc example or a test fixture. This PR keeps the crate's representative addresses consistent with the port the gateway publishes; it does not change runtime behaviour, and no assertion anywhere reads the port value.

## Merge order

`spiceai/spiceai#12153` is open against the same files and is the one to land first.

- `crates/runtime-cloud-connect/src/identity.rs` — **expect a conflict.** `#12153` changes `not_after_unix: 0` → `not_after_unix: None` on the line immediately after the `gateway_addr` line this PR edits, inside the same hunk.
- `crates/runtime-cloud-connect/src/client.rs` — adjacent but probably clean; `#12153` rewrites the `identity_with_not_after` signature four lines above this PR's edit.
- `bin/spice/tests/cli_integration.rs` — clean; the two PRs' hunks do not overlap.

Whichever lands second merges `trunk` **in** (no rebase of a pushed branch) and resolves by keeping both changes: `#12153`'s `not_after` type change alongside this PR's `:443`.

## Testing

- `cargo test -p runtime-cloud-connect --lib` — 50 passed, 0 failed.
- `cargo test -p spice --test cli_integration connect::` — 11 passed, 0 failed.
- `cargo clippy -p runtime-cloud-connect --all-targets` — clean.

No new test accompanies this change. The edited values are fixtures that no assertion reads, so a test asserting on them would pass with or without the change.
