### PR TITLE
fix(search): address Elasticsearch deletes by document _id (fixes #12267)

### DIFF
--- a/crates/search/src/index/elasticsearch/delete.rs
+++ b/crates/search/src/index/elasticsearch/delete.rs
@@ -15,20 +15,39 @@ limitations under the License.
 */
 
 use arrow::array::RecordBatch;
+use arrow_schema::Field;
 use datafusion::common::ScalarValue;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use elasticsearch::Elasticsearch;
 use serde_json::{Value, json};
 use snafu::ResultExt;
+
+use super::write;
 /// Chunk size for `_delete_by_query` requests — keeps each request's `bool.should` clause count
 /// comfortably under Elasticsearch's default `indices.query.bool.max_clause_count` (1024) and
 /// request-size limits, regardless of how many keys the caller is deleting in one call.
 const DELETE_CHUNK_ROWS: usize = 512;
 
 /// Deletes every document whose `key_columns` match a row of `keys` — an exact-key delete when
-/// `key_columns` is every `primary_key` column, a prefix delete when it's a strict subset (the
-/// chunked-index case). Elasticsearch's `_delete_by_query` filters by field value directly, so
-/// both cases are the same operation — there is no separate "exact" vs "prefix" code path.
+/// `key_columns` covers every `primary_key` column, a prefix delete when it's a strict subset
+/// (the chunked-index case).
+///
+/// The two cases address documents differently, because filtering on a key *column* is not
+/// reliable. Nothing maps the primary-key columns: the index mapping the runtime creates covers
+/// the vector field, the configured text fields, and declared metadata columns only, so a string
+/// key is dynamically mapped `text` and its inverted index holds *analyzed* tokens. A `term`
+/// query is not analyzed, so `{"term": {"id": "ORDER-1024"}}` looks for one token in an index
+/// holding `[order, 1024]` and matches nothing — a delete that reports success having removed
+/// no documents (#12267).
+///
+/// So when `key_columns` covers the whole primary key, this addresses documents by `_id` via an
+/// `ids` query. `_id` is the value the write path already stores for the row, derived by the
+/// same [`write::extract_primary_key_from_fields`], so the delete matches exactly the documents
+/// the write produced — no field mapping, no analysis, and no dependence on the key's type.
+///
+/// A strict subset of the key (the chunked-index case) cannot use `_id`, because the chunk id is
+/// part of it and is unknown at delete time; that case still filters on the key columns and so
+/// remains subject to the mapping gap above.
 ///
 /// Only reads `key_columns` from `keys`, ignoring any other column present — `keys` may be
 /// shaped by [`runtime_datafusion_index::Index::required_columns`] (a superset of the primary
@@ -37,23 +56,37 @@ const DELETE_CHUNK_ROWS: usize = 512;
 ///
 /// Issues one `_delete_by_query` request per [`DELETE_CHUNK_ROWS`]-row slice of `keys` rather
 /// than a single request for the whole batch, so a large delete can't build an unbounded
-/// `bool.should` clause list.
+/// clause or id list.
 ///
 /// Shared by [`super::ElasticsearchIndex`] and [`super::ElasticsearchTextIndex`], which both
 /// address documents the same way (client + index name + primary key columns).
 pub async fn delete_by_keys(
     client: &dyn Elasticsearch,
     es_index: &str,
+    primary_key: &[Field],
     key_columns: &[String],
     keys: &RecordBatch,
 ) -> DataFusionResult<()> {
+    // Derive `_id`s only when every primary-key column is available to derive them from; a
+    // partial key yields a different `_id` than the write path stored, which would delete
+    // nothing.
+    let addresses_whole_key = !primary_key.is_empty()
+        && primary_key
+            .iter()
+            .all(|f| key_columns.iter().any(|c| c == f.name()));
+
     let mut offset = 0;
     while offset < keys.num_rows() {
         let len = DELETE_CHUNK_ROWS.min(keys.num_rows() - offset);
         let chunk = keys.slice(offset, len);
         offset += len;
 
-        let Some(query) = build_or_of_row_term_queries(key_columns, &chunk)? else {
+        let query = if addresses_whole_key {
+            build_ids_query(primary_key, es_index, &chunk)?
+        } else {
+            build_or_of_row_term_queries(key_columns, &chunk)?
+        };
+        let Some(query) = query else {
             continue;
         };
 
@@ -65,6 +98,28 @@ pub async fn delete_by_keys(
     }
 
     Ok(())
+}
+
+/// Builds `{"ids": {"values": ["<_id>", ...]}}` — the documents written for `keys`, addressed by
+/// the `_id` the write path derives for each row.
+///
+/// Rows whose key is NULL (any component, for a composite key) yield no `_id`: the write path
+/// skips them rather than writing under a generated `_id`, so there is no document to delete.
+/// Returns `None` when that leaves nothing to address, so the caller issues no request.
+fn build_ids_query(
+    primary_key: &[Field],
+    es_index: &str,
+    keys: &RecordBatch,
+) -> DataFusionResult<Option<Value>> {
+    let ids = write::extract_primary_key_from_fields(primary_key, es_index, keys)
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+    let values: Vec<Value> = ids.into_iter().flatten().map(Value::String).collect();
+    if values.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(json!({ "ids": { "values": values } })))
 }
 
 /// Builds `{"bool": {"should": [{"bool": {"filter": [{"term": {...}}, ...]}}, ...], "minimum_should_match": 1}}`
@@ -134,5 +189,360 @@ fn scalar_to_term_value(value: &ScalarValue) -> Option<Value> {
         // Anything else (NULL, or a type not expected on a primary-key column) — the caller
         // treats `None` as "cannot express this row's key as an exact-match filter".
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use arrow::array::{Int64Array, StringArray};
+    use arrow_schema::{DataType, Schema};
+    use elasticsearch::{
+        Error as EsError, MappingResponse, Result as EsResult, SearchRequest, SearchResponse,
+    };
+    use std::sync::Arc;
+
+    use super::*;
+
+    /// Records the `_delete_by_query` bodies it is asked to issue; every other trait method is
+    /// an error, so a test that reaches one fails loudly rather than silently passing.
+    #[derive(Debug, Default)]
+    struct RecordingClient {
+        queries: Mutex<Vec<Value>>,
+    }
+
+    impl RecordingClient {
+        fn queries(&self) -> Vec<Value> {
+            self.queries
+                .lock()
+                .expect("queries mutex should not be poisoned")
+                .clone()
+        }
+    }
+
+    fn unexpected(method: &str) -> EsError {
+        EsError::ElasticsearchError {
+            status: 500,
+            message: format!("unexpected call to {method}"),
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Elasticsearch for RecordingClient {
+        async fn delete_by_query(&self, _index: &str, query: &Value) -> EsResult<Value> {
+            self.queries
+                .lock()
+                .expect("queries mutex should not be poisoned")
+                .push(query.clone());
+            Ok(json!({"deleted": 0}))
+        }
+
+        async fn get_mapping(&self, _index: &str) -> EsResult<MappingResponse> {
+            Err(unexpected("get_mapping"))
+        }
+        async fn search(&self, _index: &str, _body: &SearchRequest) -> EsResult<SearchResponse> {
+            Err(unexpected("search"))
+        }
+        async fn search_raw(&self, _index: &str, _body: &Value) -> EsResult<SearchResponse> {
+            Err(unexpected("search_raw"))
+        }
+        async fn open_point_in_time(&self, _index: &str, _keep_alive: &str) -> EsResult<String> {
+            Err(unexpected("open_point_in_time"))
+        }
+        async fn search_point_in_time(&self, _body: &Value) -> EsResult<SearchResponse> {
+            Err(unexpected("search_point_in_time"))
+        }
+        async fn close_point_in_time(&self, _pit_id: &str) -> EsResult<()> {
+            Err(unexpected("close_point_in_time"))
+        }
+        async fn index_exists(&self, _index: &str) -> EsResult<bool> {
+            Err(unexpected("index_exists"))
+        }
+        async fn create_index(&self, _index: &str, _body: &Value) -> EsResult<Value> {
+            Err(unexpected("create_index"))
+        }
+        async fn put_mapping(&self, _index: &str, _body: &Value) -> EsResult<Value> {
+            Err(unexpected("put_mapping"))
+        }
+        async fn get_index_refresh_interval(&self, _index: &str) -> EsResult<Option<String>> {
+            Err(unexpected("get_index_refresh_interval"))
+        }
+        async fn put_index_settings(&self, _index: &str, _body: &Value) -> EsResult<Value> {
+            Err(unexpected("put_index_settings"))
+        }
+        async fn refresh_index(&self, _index: &str) -> EsResult<Value> {
+            Err(unexpected("refresh_index"))
+        }
+        async fn force_merge(&self, _index: &str, _max_num_segments: u32) -> EsResult<Value> {
+            Err(unexpected("force_merge"))
+        }
+        async fn index_document(&self, _index: &str, _id: &str, _doc: &Value) -> EsResult<Value> {
+            Err(unexpected("index_document"))
+        }
+        async fn bulk_index(
+            &self,
+            _index: &str,
+            _docs: &[(Option<String>, Value)],
+        ) -> EsResult<Value> {
+            Err(unexpected("bulk_index"))
+        }
+    }
+
+    fn string_key_batch(values: Vec<Option<&str>>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, true)]));
+        RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values))])
+            .expect("string key batch should build")
+    }
+
+    fn pk(name: &str, data_type: DataType) -> Field {
+        Field::new(name, data_type, true)
+    }
+
+    /// The reported bug: a string key that the standard analyzer would split into several tokens
+    /// (`ORDER-1024` → `[order, 1024]`) can never be matched by an unanalyzed `term` query, so
+    /// the delete must address the document by `_id` instead.
+    #[tokio::test]
+    async fn string_primary_key_deletes_by_document_id_not_by_term_filter() {
+        let client = RecordingClient::default();
+        let primary_key = vec![pk("id", DataType::Utf8)];
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &["id".to_string()],
+            &string_key_batch(vec![Some("ORDER-1024"), Some("a716-446655440000")]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries(),
+            vec![json!({"ids": {"values": ["ORDER-1024", "a716-446655440000"]}})],
+            "an exact-key delete must address documents by _id; a `term` filter on the key \
+             column matches nothing for an analyzed string key"
+        );
+    }
+
+    /// `_id` for a composite key is the JSON encoding the write path stores. Pinning the literal
+    /// here (and not re-deriving it) is what catches the two paths drifting apart.
+    #[tokio::test]
+    async fn composite_primary_key_uses_the_json_encoded_document_id() {
+        let client = RecordingClient::default();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("region", DataType::Utf8, true),
+        ]));
+        let keys = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("ORDER-1024")])),
+                Arc::new(StringArray::from(vec![Some("emea")])),
+            ],
+        )
+        .expect("composite key batch should build");
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[pk("id", DataType::Utf8), pk("region", DataType::Utf8)],
+            &["id".to_string(), "region".to_string()],
+            &keys,
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries(),
+            vec![json!({"ids": {"values": [r#"{"id":"ORDER-1024","region":"emea"}"#]}})],
+        );
+    }
+
+    /// The write path derives the same `_id`s it deletes — the invariant the fix rests on.
+    #[test]
+    fn delete_ids_match_the_document_ids_the_write_path_derives() {
+        let keys = string_key_batch(vec![Some("ORDER-1024"), Some("x")]);
+        let primary_key = vec![pk("id", DataType::Utf8)];
+
+        let written = write::extract_primary_key_from_fields(&primary_key, "idx", &keys)
+            .expect("write path should derive ids");
+        let query = build_ids_query(&primary_key, "idx", &keys)
+            .expect("ids query should build")
+            .expect("ids query should be present");
+
+        let addressed: Vec<Value> = written.into_iter().flatten().map(Value::String).collect();
+        assert_eq!(query, json!({"ids": {"values": addressed}}));
+    }
+
+    /// A strict subset of the primary key (the chunked-index case) cannot use `_id`, because the
+    /// chunk id is part of it and unknown at delete time — that path still filters on columns.
+    #[tokio::test]
+    async fn partial_key_falls_back_to_term_filters() {
+        let client = RecordingClient::default();
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[
+                pk("id", DataType::Utf8),
+                pk("_spice.chunk_id", DataType::Int64),
+            ],
+            &["id".to_string()],
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries(),
+            vec![json!({
+                "bool": {
+                    "should": [{"bool": {"filter": [{"term": {"id": "ORDER-1024"}}]}}],
+                    "minimum_should_match": 1
+                }
+            })],
+        );
+    }
+
+    /// A NULL key has no stable identity, so the write path never stored a document for it and
+    /// there is nothing to address. A batch of only such rows must issue no request at all —
+    /// never an unconstrained query that would match everything.
+    #[tokio::test]
+    async fn null_keys_issue_no_request() {
+        let client = RecordingClient::default();
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[pk("id", DataType::Utf8)],
+            &["id".to_string()],
+            &string_key_batch(vec![None, None]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert!(client.queries().is_empty());
+    }
+
+    #[tokio::test]
+    async fn null_keys_are_skipped_but_present_keys_are_still_deleted() {
+        let client = RecordingClient::default();
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[pk("id", DataType::Utf8)],
+            &["id".to_string()],
+            &string_key_batch(vec![None, Some("kept"), None]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(client.queries(), vec![json!({"ids": {"values": ["kept"]}})],);
+    }
+
+    #[tokio::test]
+    async fn empty_batch_issues_no_request() {
+        let client = RecordingClient::default();
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[pk("id", DataType::Utf8)],
+            &["id".to_string()],
+            &string_key_batch(vec![]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert!(client.queries().is_empty());
+    }
+
+    /// A large delete is split so no single request carries an unbounded id list.
+    #[tokio::test]
+    async fn large_batch_is_split_into_bounded_requests() {
+        let client = RecordingClient::default();
+        let rows = DELETE_CHUNK_ROWS + 3;
+        let values: Vec<String> = (0..rows).map(|i| format!("key-{i}")).collect();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, true)]));
+        let keys = RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values.clone()))])
+            .expect("large key batch should build");
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[pk("id", DataType::Utf8)],
+            &["id".to_string()],
+            &keys,
+        )
+        .await
+        .expect("delete should succeed");
+
+        let queries = client.queries();
+        assert_eq!(queries.len(), 2);
+
+        let ids_of = |q: &Value| -> Vec<String> {
+            q["ids"]["values"]
+                .as_array()
+                .expect("ids.values should be an array")
+                .iter()
+                .map(|v| v.as_str().expect("each id should be a string").to_string())
+                .collect()
+        };
+        assert_eq!(ids_of(&queries[0]).len(), DELETE_CHUNK_ROWS);
+        assert_eq!(ids_of(&queries[1]).len(), 3);
+
+        // Every key is addressed exactly once, across the split.
+        let mut seen: Vec<String> = queries.iter().flat_map(ids_of).collect();
+        seen.sort();
+        let mut expected = values;
+        expected.sort();
+        assert_eq!(seen, expected);
+    }
+
+    /// An integer key was never broken by the mapping gap (it maps to `long`, which `term`
+    /// matches), but it must keep working now that it goes through `_id` too.
+    #[tokio::test]
+    async fn integer_primary_key_still_deletes() {
+        let client = RecordingClient::default();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, true)]));
+        let keys = RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![7, 8]))])
+            .expect("int key batch should build");
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[pk("id", DataType::Int64)],
+            &["id".to_string()],
+            &keys,
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries(),
+            vec![json!({"ids": {"values": ["7", "8"]}})]
+        );
+    }
+
+    /// An index with no primary key writes documents under generated `_id`s, so there is no id
+    /// to address and no key column to filter on; the delete must not emit a match-everything
+    /// query.
+    #[tokio::test]
+    async fn empty_primary_key_issues_no_request() {
+        let client = RecordingClient::default();
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[],
+            &[],
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert!(client.queries().is_empty());
     }
 }

--- a/crates/search/src/index/elasticsearch/mod.rs
+++ b/crates/search/src/index/elasticsearch/mod.rs
@@ -477,7 +477,14 @@ impl Index for ElasticsearchIndex {
 
     async fn delete_by_keys(&self, keys: RecordBatch) -> Result<(), DataFusionError> {
         let key_columns: Vec<String> = self.primary_key.iter().map(|f| f.name().clone()).collect();
-        delete::delete_by_keys(self.client.as_ref(), &self.es_index, &key_columns, &keys).await
+        delete::delete_by_keys(
+            self.client.as_ref(),
+            &self.es_index,
+            &self.primary_key,
+            &key_columns,
+            &keys,
+        )
+        .await
     }
 }
 
@@ -724,7 +731,14 @@ impl Index for ElasticsearchTextIndex {
 
     async fn delete_by_keys(&self, keys: RecordBatch) -> Result<(), DataFusionError> {
         let key_columns: Vec<String> = self.primary_key.iter().map(|f| f.name().clone()).collect();
-        delete::delete_by_keys(self.client.as_ref(), &self.es_index, &key_columns, &keys).await
+        delete::delete_by_keys(
+            self.client.as_ref(),
+            &self.es_index,
+            &self.primary_key,
+            &key_columns,
+            &keys,
+        )
+        .await
     }
 }
 

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -155,7 +155,8 @@ pub async fn write(index: &ElasticsearchIndex, record: RecordBatch) -> Result<Re
     }
 
     // Extract primary key (as document _id).
-    let primary_keys = extract_primary_key(index, &record)?;
+    let primary_keys =
+        extract_primary_key_from_fields(&index.primary_key, &index.es_index, &record)?;
 
     // Build all documents in a sync block so the arrow-json encoders (which are
     // `!Send`) are dropped before any subsequent `.await`.
@@ -356,112 +357,6 @@ fn build_documents(
     }
 
     Ok(docs)
-}
-
-fn extract_primary_key(
-    index: &ElasticsearchIndex,
-    record: &RecordBatch,
-) -> Result<Vec<Option<String>>> {
-    let schema = record.schema();
-
-    match index.primary_key.as_slice() {
-        [] => Ok(vec![None; record.num_rows()]),
-        [f] => {
-            let Some((i, _)) = schema.column_with_name(f.name()) else {
-                return PrimaryKeyColumnNotFoundSnafu {
-                    index: index.es_index.clone(),
-                    column: f.name().clone(),
-                }
-                .fail();
-            };
-            let c = record.column(i);
-            if let Some(iter) = convert_string_arrow_to_iterator!(c) {
-                return Ok(iter
-                    .map(|o: Option<&str>| o.map(ToString::to_string))
-                    .collect());
-            }
-            let casted = arrow::compute::cast(c, &DataType::Utf8).context(
-                IssueWithArrowProcessingSnafu {
-                    index: index.es_index.clone(),
-                },
-            )?;
-            let iter_opt: Option<Box<dyn Iterator<Item = Option<&str>> + Send>> =
-                convert_string_arrow_to_iterator!(casted);
-            let Some(iter) = iter_opt else {
-                return Err(Error::IssueWithArrowProcessing {
-                    index: index.es_index.clone(),
-                    source: arrow::error::ArrowError::CastError(format!(
-                        "could not cast primary key column '{}' to Utf8",
-                        f.name()
-                    )),
-                });
-            };
-            Ok(iter
-                .map(|o: Option<&str>| o.map(ToString::to_string))
-                .collect())
-        }
-        fields => {
-            // Composite key: JSON-encode the projected key columns and use that string as _id.
-            let mut proj = Vec::with_capacity(fields.len());
-            for f in fields {
-                let Some((i, _)) = schema.column_with_name(f.name()) else {
-                    return PrimaryKeyColumnNotFoundSnafu {
-                        index: index.es_index.clone(),
-                        column: f.name().clone(),
-                    }
-                    .fail();
-                };
-                proj.push(i);
-            }
-            let pk = record
-                .project(&proj)
-                .context(IssueWithArrowProcessingSnafu {
-                    index: index.es_index.clone(),
-                })?;
-
-            // A row with any NULL component in a composite key has no stable
-            // identity. Mark those rows as `None` so the null-PK skip logic
-            // (which already handles single-column keys) applies here too.
-            let num_rows = pk.num_rows();
-            let mut row_is_null: Vec<bool> = vec![false; num_rows];
-            for col in pk.columns() {
-                for (i, is_null) in row_is_null.iter_mut().enumerate() {
-                    if col.is_null(i) {
-                        *is_null = true;
-                    }
-                }
-            }
-
-            let mut writer = arrow_json::ArrayWriter::new(Vec::new());
-            writer
-                .write_batches(&[&pk])
-                .context(IssueWithArrowProcessingSnafu {
-                    index: index.es_index.clone(),
-                })?;
-            writer.finish().context(IssueWithArrowProcessingSnafu {
-                index: index.es_index.clone(),
-            })?;
-
-            let values: Vec<Value> = serde_json::from_reader(writer.into_inner().as_slice())
-                .context(IssueWithJsonProcessingSnafu {
-                    index: index.es_index.clone(),
-                })?;
-            values
-                .into_iter()
-                .enumerate()
-                .map(|(i, v)| {
-                    if row_is_null.get(i).copied().unwrap_or(false) {
-                        Ok(None)
-                    } else {
-                        serde_json::to_string(&v).map(Some)
-                    }
-                })
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .context(IssueWithJsonProcessingSnafu {
-                    index: index.es_index.clone(),
-                })
-        }
-    }
 }
 
 async fn embed_column(
@@ -699,7 +594,15 @@ fn build_text_documents(
 
 /// Extract primary key strings from a record batch, parameterised on field definitions
 /// rather than an [`ElasticsearchIndex`] instance.
-fn extract_primary_key_from_fields(
+///
+/// The returned string is the document `_id` under which the row is written. A row whose
+/// key is NULL (any component, for a composite key) has no stable identity and yields
+/// `None`; such rows are skipped rather than written under a generated `_id`.
+///
+/// [`super::delete`] derives the `_id`s it deletes with this same function, so an exact-key
+/// delete addresses precisely the documents a write produced. Keep it that way: a second,
+/// parallel derivation would let the two drift and leave deletes silently matching nothing.
+pub(super) fn extract_primary_key_from_fields(
     primary_key: &[Field],
     es_index: &str,
     record: &RecordBatch,


### PR DESCRIPTION
## Summary

Deleting a row from an Elasticsearch search or vector index could silently delete nothing.

The delete built a `_delete_by_query` from `term` filters on the primary-key columns:

```json
{"bool": {"should": [{"bool": {"filter": [{"term": {"id": "ORDER-1024"}}]}}], "minimum_should_match": 1}}
```

But nothing maps those columns. `ensure_index_with_mapping` puts only three things in `properties` — the `dense_vector` field, the configured `text_fields`, and user-declared metadata columns — with no dynamic templates. A primary-key column is therefore mapped by Elasticsearch's dynamic defaults:

- an integer key becomes `long`, and `term` matches it exactly;
- a **string** key becomes `text`, whose inverted index holds *analyzed* tokens. `term` is not analyzed, so `{"term": {"id": "ORDER-1024"}}` looks for the single token `ORDER-1024` in an index holding `[order, 1024]` — and matches nothing.

So a dataset keyed by a UUID, an ARN, an order code, or an email got a delete that reported success having removed no documents. On the CDC path the index delete is best-effort (logged, not propagated), so nothing surfaced at all: search kept returning rows the dataset no longer had — the same user-visible symptom as #12066 / #12088.

The documents were always addressable. The write path derives each document's `_id` from the primary key (that is how re-indexing a row stays idempotent), so an exact-key delete can address them by `_id` and sidestep mapping and analysis entirely.

Fixes #12267

## Changes

- `delete_by_keys` now takes the index's full primary key alongside the columns being matched. When those columns cover the whole primary key, it addresses documents with an `ids` query built from the `_id`s the write path stores; otherwise it keeps the existing `term`-filter behaviour.
- The `_id`s are derived by calling the *same* `extract_primary_key_from_fields` the write path uses, rather than a second copy of the rule, so the two cannot drift. `write.rs` held two byte-for-byte-equivalent derivations (`extract_primary_key` and `extract_primary_key_from_fields`); the duplicate is removed and the survivor documents the invariant.
- Rows with a NULL key yield no `_id` — the write path never stored a document for them — and a chunk that addresses nothing issues no request at all, rather than an unconstrained query that would match everything.

Deletes are also cheaper now: an `ids` query is a direct document lookup, where the previous query scanned an analyzed field per key.

### Deliberately not changed

A **strict subset** of the primary key cannot use `_id`, because the chunk id is part of it and unknown at delete time. That path (the chunked-index case introduced by #12268) still filters on key columns and so remains subject to the same mapping gap. Making it work needs the key columns to be term-queryable — mapping them as `keyword`, or querying a `.keyword` sub-field — which also needs a story for indexes that already exist, since `put_mapping` cannot change an existing field's type. That is a separate change; filed as #12272.

The `term`-filter builder is therefore kept, not deleted: it is the code path that case uses.

## Overlap with #12268

#12268 (open, same area) adds the chunked partial-key delete route and appends a test module to the same file. The two changes are complementary — this PR fixes the *whole-key* path, #12268 adds the *partial-key* path — and touch different functions, but whichever lands second will need a small merge in `delete.rs`.

## Test plan

Ten tests in `crates/search/src/index/elasticsearch/delete.rs`, all new:

- **regression** — a string key whose analyzer would split it (`ORDER-1024`, `a716-446655440000`) is deleted by `ids`, not by a `term` filter. Verified to fail against the previous behaviour: neutering the fix reproduces exactly the broken `term` query from the issue.
- a composite key uses the JSON-encoded `_id`, pinned as a literal so a drift between the write and delete derivations breaks the test.
- the ids a delete addresses equal the ids the write path derives.
- a partial key still falls back to `term` filters.
- NULL keys issue no request; NULL keys mixed with present keys delete only the present ones.
- an empty batch and an empty primary key issue no request.
- a batch larger than the chunk size splits into bounded requests that together address every key exactly once.
- an integer key — which was never broken — still deletes.

Validation:

- `make lint-rust` (scoped to the touched crate) — green, both clippy passes.
- `make test` — `crates/search` lib suite green: 109 passed, 0 failed.
- Full `make lint` + `make nextest` run via `make signoff`.

Not exercised against a live Elasticsearch cluster: the analyzed-`text`-vs-`term` behaviour is Elasticsearch's documented dynamic-mapping default rather than something this repo asserts. The fix does not depend on that behaviour being reproduced — it stops querying the mapped field at all.

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] Edge cases covered (NULL keys, empty batch, empty primary key, chunk-boundary split, composite key)
- [x] No `.unwrap()` / `.expect()` in production code
- [x] Scoped lint green (both clippy passes)
- [ ] `make signoff` green and `Attestation` re-run
