### PR TITLE
fix(search): score retrieval metrics against the judged documents (fixes #12277)

### DIFF
--- a/crates/test-framework/src/spicetest/search/evaluate.rs
+++ b/crates/test-framework/src/spicetest/search/evaluate.rs
@@ -39,39 +39,52 @@ pub struct RetrievalMetrics {
 /// * `results` - Search results mapping `query_id` -> (`doc_id` -> `similarity_score`)
 /// * `k` - Rank cutoff shared by all four metrics
 ///
+/// Every judged query in `qrels` contributes to each average. A query the search returned
+/// nothing for scores 0.0 rather than being dropped — dropping it would raise the mean
+/// instead of lowering it.
+///
+/// # Errors
+/// Returns an error when `qrels` is empty: an average over zero queries is undefined.
+///
 /// # Reference
 /// MTEB `RetrievalEvaluator`: <https://github.com/embeddings-benchmark/mteb/blob/03347ebfe4809056e0fd2894fcae69dcdd2ed964/mteb/evaluation/evaluators/RetrievalEvaluator.py#L500>
-#[must_use]
 pub(crate) fn calculate_retrieval_metrics<S: ::std::hash::BuildHasher>(
     qrels: &HashMap<String, HashMap<String, i32, S>, S>,
     results: &HashMap<String, HashMap<String, f64, S>, S>,
     k: usize,
-) -> RetrievalMetrics {
-    let mut ndcg_values = Vec::new();
-    let mut recall_values = Vec::new();
-    let mut mrr_values = Vec::new();
-    let mut precision_values = Vec::new();
+) -> anyhow::Result<RetrievalMetrics> {
+    anyhow::ensure!(
+        !qrels.is_empty(),
+        "Cannot calculate retrieval metrics: no query relevance judgments were provided"
+    );
+
+    let mut ndcg_values = Vec::with_capacity(qrels.len());
+    let mut recall_values = Vec::with_capacity(qrels.len());
+    let mut mrr_values = Vec::with_capacity(qrels.len());
+    let mut precision_values = Vec::with_capacity(qrels.len());
 
     for (query_id, relevance) in qrels {
-        let Some(ranked_results) = results.get(query_id) else {
+        // An unanswered query ranks nothing, which scores 0.0 for all four metrics
+        // through the same code path as a ranking that retrieved nothing relevant.
+        let ranked_relevance = if let Some(ranked_results) = results.get(query_id) {
+            score_sorted_relevance(ranked_results, relevance)
+        } else {
             println!("No search results found for test query {query_id}");
-            continue;
+            Vec::new()
         };
 
-        let ranked_relevance = score_sorted_relevance(ranked_results, relevance);
-
-        ndcg_values.push(ndcg_at_k(&ranked_relevance, k));
+        ndcg_values.push(ndcg_at_k(&ranked_relevance, relevance, k));
         recall_values.push(recall_at_k(&ranked_relevance, relevance, k));
         mrr_values.push(mrr_at_k(&ranked_relevance, k));
         precision_values.push(precision_at_k(&ranked_relevance, k));
     }
 
-    RetrievalMetrics {
+    Ok(RetrievalMetrics {
         ndcg: average(&ndcg_values),
         recall: average(&recall_values),
         mrr: average(&mrr_values),
         precision: average(&precision_values),
-    }
+    })
 }
 
 /// Orders a query's search results by score (descending) and returns the relevance grade of each
@@ -90,6 +103,8 @@ fn score_sorted_relevance<S: ::std::hash::BuildHasher>(
         .collect()
 }
 
+/// Mean of `values`. Never called with an empty slice: `calculate_retrieval_metrics`
+/// rejects empty `qrels` and pushes exactly one value per judged query.
 #[expect(clippy::cast_precision_loss)]
 fn average(values: &[f64]) -> f64 {
     values.iter().sum::<f64>() / values.len() as f64
@@ -105,19 +120,29 @@ fn dcg_at_k(relevance_scores: &[f64], k: usize) -> f64 {
         .sum()
 }
 
-fn idcg_at_k(relevance_scores: &[f64], k: usize) -> f64 {
-    let mut sorted_relevance_scores = relevance_scores.to_owned();
-    sorted_relevance_scores.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
-    dcg_at_k(&sorted_relevance_scores, k)
+/// Ideal DCG@k: every document judged for this query, ranked by relevance grade. Taken from
+/// `relevance` rather than from what search returned, so a result set that misses relevant
+/// documents scores below 1.0 — deriving it from the retrieved documents makes any ranking
+/// of them look perfect, however much it left behind.
+fn ideal_dcg_at_k<S: ::std::hash::BuildHasher>(
+    relevance: &HashMap<String, i32, S>,
+    k: usize,
+) -> f64 {
+    let mut grades: Vec<f64> = relevance.values().map(|&grade| f64::from(grade)).collect();
+    grades.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    dcg_at_k(&grades, k)
 }
 
-fn ndcg_at_k(relevance_scores: &[f64], k: usize) -> f64 {
-    let dcg = dcg_at_k(relevance_scores, k);
-    let idcg = idcg_at_k(relevance_scores, k);
+fn ndcg_at_k<S: ::std::hash::BuildHasher>(
+    ranked_relevance: &[f64],
+    relevance: &HashMap<String, i32, S>,
+    k: usize,
+) -> f64 {
+    let idcg = ideal_dcg_at_k(relevance, k);
     if idcg == 0.0 {
         return 0.0;
     }
-    dcg / idcg
+    dcg_at_k(ranked_relevance, k) / idcg
 }
 
 /// Fraction of all relevant documents (per `relevance`, not just those retrieved) that appear
@@ -205,7 +230,8 @@ mod tests {
     fn ndcg_sorts_results_by_score_before_scoring() {
         let (qrels, results) = perfectly_ranked_query();
 
-        let metrics = calculate_retrieval_metrics(&qrels, &results, 6);
+        let metrics = calculate_retrieval_metrics(&qrels, &results, 6)
+            .expect("metrics are calculable for a non-empty qrels");
         assert!(
             (metrics.ndcg - 1.0).abs() < 1e-9,
             "expected a perfect NDCG@6 of 1.0 when search scores exactly match relevance order, got {}",
@@ -219,7 +245,8 @@ mod tests {
 
         // All 6 relevant docs are retrieved within the top 6, and the top-ranked
         // result is relevant.
-        let metrics = calculate_retrieval_metrics(&qrels, &results, 6);
+        let metrics = calculate_retrieval_metrics(&qrels, &results, 6)
+            .expect("metrics are calculable for a non-empty qrels");
         assert!(
             (metrics.recall - 1.0).abs() < 1e-9,
             "recall = {}",
@@ -238,7 +265,8 @@ mod tests {
         let (qrels, results) = perfectly_ranked_query();
 
         // Only the top 3 of 6 relevant docs are within the cutoff.
-        let metrics = calculate_retrieval_metrics(&qrels, &results, 3);
+        let metrics = calculate_retrieval_metrics(&qrels, &results, 3)
+            .expect("metrics are calculable for a non-empty qrels");
         assert!(
             (metrics.recall - 0.5).abs() < 1e-9,
             "recall@3 = {}",
@@ -266,7 +294,8 @@ mod tests {
             ]),
         )]);
 
-        let metrics = calculate_retrieval_metrics(&qrels, &results, 3);
+        let metrics = calculate_retrieval_metrics(&qrels, &results, 3)
+            .expect("metrics are calculable for a non-empty qrels");
         assert!(
             (metrics.mrr - (1.0 / 3.0)).abs() < 1e-9,
             "expected MRR@3 = 1/3 for a relevant doc at rank 3, got {}",
@@ -281,6 +310,82 @@ mod tests {
             (metrics.precision - (1.0 / 3.0)).abs() < 1e-9,
             "precision@3 = {}",
             metrics.precision
+        );
+    }
+
+    /// The ideal DCG must rank every *judged* document, not just the retrieved ones: search
+    /// returns one of two equally-relevant documents, so NDCG@10 has to fall below 1.0.
+    /// Deriving the ideal from the retrieved set scores this a perfect 1.0.
+    #[test]
+    fn ndcg_penalizes_relevant_documents_the_search_missed() {
+        let qrels: Qrels = HashMap::from([(
+            "q1".to_string(),
+            HashMap::from([("doc0".to_string(), 1), ("doc1".to_string(), 1)]),
+        )]);
+        let results: ScoredResults =
+            HashMap::from([("q1".to_string(), HashMap::from([("doc0".to_string(), 0.9)]))]);
+
+        let metrics = calculate_retrieval_metrics(&qrels, &results, 10)
+            .expect("metrics are calculable for a non-empty qrels");
+
+        // DCG@10 = 1/log2(2) = 1.0; ideal ranks both judged docs:
+        // 1/log2(2) + 1/log2(3).
+        let expected = 1.0 / (1.0 + 1.0 / 3.0f64.log2());
+        assert!(
+            (metrics.ndcg - expected).abs() < 1e-9,
+            "expected NDCG@10 of {expected} when one of two relevant docs is retrieved, got {}",
+            metrics.ndcg
+        );
+        assert!(
+            (metrics.recall - 0.5).abs() < 1e-9,
+            "recall@10 = {}",
+            metrics.recall
+        );
+    }
+
+    /// A judged query the search answered with nothing scores 0.0 and stays in the average.
+    /// Dropping it divides by the answered queries only, which raises every metric.
+    #[test]
+    fn an_unanswered_query_scores_zero_and_stays_in_the_average() {
+        let qrels: Qrels = HashMap::from([
+            ("q1".to_string(), HashMap::from([("doc0".to_string(), 1)])),
+            ("q2".to_string(), HashMap::from([("doc1".to_string(), 1)])),
+        ]);
+        // Only q1 is answered, and perfectly.
+        let results: ScoredResults =
+            HashMap::from([("q1".to_string(), HashMap::from([("doc0".to_string(), 0.9)]))]);
+
+        let metrics = calculate_retrieval_metrics(&qrels, &results, 10)
+            .expect("metrics are calculable for a non-empty qrels");
+
+        // q1 scores a perfect 1.0 and q2 a 0.0, so each average is halved.
+        for (name, value) in [
+            ("ndcg", metrics.ndcg),
+            ("recall", metrics.recall),
+            ("mrr", metrics.mrr),
+        ] {
+            assert!(
+                (value - 0.5).abs() < 1e-9,
+                "expected {name}@10 of 0.5 when one of two judged queries is unanswered, got {value}"
+            );
+        }
+        // Precision@10 divides by k, so q1's single relevant hit is 0.1, averaged with 0.0.
+        assert!(
+            (metrics.precision - 0.05).abs() < 1e-9,
+            "expected precision@10 of 0.05, got {}",
+            metrics.precision
+        );
+    }
+
+    /// An empty `qrels` used to divide by zero and publish `NaN` into the benchmark metrics.
+    #[test]
+    fn empty_qrels_is_an_error_rather_than_nan() {
+        let qrels: Qrels = HashMap::new();
+        let results: ScoredResults = HashMap::new();
+
+        assert!(
+            calculate_retrieval_metrics(&qrels, &results, 10).is_err(),
+            "expected an error when no query relevance judgments are provided"
         );
     }
 }

--- a/crates/test-framework/src/spicetest/search/mod.rs
+++ b/crates/test-framework/src/spicetest/search/mod.rs
@@ -203,7 +203,7 @@ impl SpiceTest<Completed> {
     {
         let transformed_results = transform(&self.state.search_results);
         // Matches MTEB's methodology of evaluating retrieval quality at rank cutoff 10.
-        Ok(calculate_retrieval_metrics(qrels, &transformed_results, 10))
+        calculate_retrieval_metrics(qrels, &transformed_results, 10)
     }
 }
 


### PR DESCRIPTION
## Summary

`testoperator run search` reports `NDCG@10`, `Recall@10`, `MRR@10` and `Precision@10`. All four overstated retrieval quality, for two independent reasons.

**The ideal DCG was built from the retrieved documents, not the judged ones.** `ndcg_at_k` sorted its own input — the grades of the documents search returned — and called that the ideal ranking. Any ranking of a retrieved set therefore looked perfect, however many relevant documents it left behind: a query with two equally-relevant documents where search returned one of them at rank 1 scored `NDCG@10 = 1.0`. The ideal now ranks every document judged for the query, as MTEB/`pytrec_eval` do, and the same query scores `0.613`. `recall_at_k` in the same file already took the whole `relevance` map, so the data was at hand.

**A judged query with no search results was dropped from the average.** `average()` divided by the number of queries *that returned something*, so an unanswered query raised the mean instead of lowering it — for all four metrics, not just NDCG. An unanswered query now ranks nothing, which scores 0.0 through the same code path as a ranking that retrieved nothing relevant, and stays in the average. With no judged query answered at all the vectors were empty and `average` evaluated `0.0 / 0.0`, publishing **`NaN`** into the OTLP gauges and the Arrow `Float64` metric columns; empty `qrels` is now a typed error.

Benchmark and telemetry only — no effect on user query results. It did mean the recorded numbers were not comparable to MTEB's published figures, and that a change which stops returning results for some queries could leave the score flat or raise it.

Fixes #12277

## Changes

- `ideal_dcg_at_k(relevance, k)` replaces `idcg_at_k(relevance_scores, k)`: the ideal is computed from the query's judgments. `ndcg_at_k` takes both the ranking and the judgments.
- An unanswered judged query yields an empty ranking instead of `continue`, so it scores 0.0 for every metric and remains in each average.
- `calculate_retrieval_metrics` returns `anyhow::Result` and rejects empty `qrels`. Its one caller, `calculate_search_score_metrics`, already returned `Result` and already used `?`, so no caller changes were needed.
- `Precision@k` still divides by `k` — the standard TREC convention, deliberately unchanged.

## Overlap with #12226

@Jeadie's open #12226 identifies the same two defects and I have kept its API shape (`anyhow::Result` + `ensure!` on empty `qrels`) so the two converge rather than diverge. That PR is based on a tree predating #12193, so it rewrites `calculate_ndcg`/`idcg_at_k` — functions #12193 replaced on trunk — and currently reads `CONFLICTING`; it also predates the three metrics #12193 added, which share the averaging defect. This applies the same fixes to trunk's actual structure and extends the averaging fix to all four metrics. Happy to close this in favour of a rebased #12226 if you would rather carry it there.

## Test plan

- `make lint` — green.
- `make test` / `make nextest` — green.
- Three new regression tests in `crates/test-framework/src/spicetest/search/evaluate.rs`:
  - `ndcg_penalizes_relevant_documents_the_search_missed` — one of two relevant docs retrieved ⇒ `NDCG@10 = 1/(1 + 1/log2(3)) = 0.613`, `Recall@10 = 0.5`.
  - `an_unanswered_query_scores_zero_and_stays_in_the_average` — two judged queries, one answered perfectly ⇒ `0.5` for NDCG/Recall/MRR and `0.05` for Precision@10.
  - `empty_qrels_is_an_error_rather_than_nan`.
- Verified by neutering: restoring the retrieved-docs ideal DCG and the `continue` fails **exactly** those two new tests, reporting `got 1` in both cases — the symptom from the issue — while the five pre-existing tests stay green.
- The four pre-existing tests keep their expected values: a perfectly-ranked query still scores 1.0 across all four metrics, since its judged set and its retrieved set coincide.

## Checklist

- [x] Regression tests that fail on the old code and pass on the new
- [x] Scoped lint green (`make lint-rust PACKAGES=test-framework`, both clippy passes)
- [x] No behaviour change for user query paths
