### PR TITLE
fix(ci): link brew formulas that are installed but unlinked in setup-cc

### DIFF
--- a/.github/actions/setup-cc/action.yml
+++ b/.github/actions/setup-cc/action.yml
@@ -21,6 +21,24 @@ runs:
       shell: bash
       run: |
         brew install cmake pkg-config openssl unixodbc llvm libnfs
+        # `brew install` only warns — and still exits 0 — when a formula is already in
+        # the Cellar but unlinked, so its binaries never reach PATH. The failure then
+        # surfaces an hour later inside an unrelated crate, as a build script dying with
+        # "is `cmake` not installed?" and no error[EXXXX] to point at. Link the tools
+        # that build scripts invoke by bare name, then assert they resolve, so a stale
+        # runner fails here with a named cause. openssl and llvm are keg-only and are
+        # deliberately left unlinked; the build locates them via `brew --prefix`.
+        for tool in cmake pkg-config; do
+          brew link --overwrite "$tool" || true
+        done
+        missing=()
+        for tool in cmake pkg-config; do
+          command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+        done
+        if [ ${#missing[@]} -ne 0 ]; then
+          echo "::error::Not on PATH after 'brew install': ${missing[*]}. Run 'brew link --overwrite ${missing[*]}' on this runner."
+          exit 1
+        fi
 
     - name: Install cc (Windows)
       if: runner.os == 'Windows'


### PR DESCRIPTION
Fixes #12285

## The problem

`Set up cc` reported **success** on macOS runners while leaving `cmake` off `PATH`. `brew install` prints only a warning — and still exits 0 — when a formula is already in the Cellar but **unlinked**, so no symlink is created and the binary is unreachable:

```
##[warning]cmake 4.4.2 is already installed, it's just not linked.
To link this version, run:
  brew link cmake
```

Note the contrast with the five other formulas in the same output, which report "already installed **and up-to-date**" — those were linked and fine. Only `cmake` was unlinked, and the step still concluded `success` in 961 ms.

An hour later, in a different step and a crate nobody had touched, the build died:

```
failed to execute command: No such file or directory (os error 2)
is `cmake` not installed?
error: failed to run custom build command for `snmalloc-sys v0.3.8`
```

## Why it was hard to attribute

- The red step is `Build CLI and run nextest` / `Run Rust lint`, so a green `Set up cc` is not a suspect.
- **Zero** `error[EXXXX]` codes, so it reads as an infrastructure blip rather than a defect.
- It only bites on a **build-cache miss** for `snmalloc-sys`. Both runners involved had produced *successful* jobs earlier the same evening, so a persistent misconfiguration looked transient and host-specific when it was neither. Reruns cannot clear it — the formula stays unlinked, so every cache-missing retry fails identically.

Measured impact before this fix: a merge-queue `Build and Test` batch failed after 8m26s and left its queue entry `UNMERGEABLE`, stalling the queue; a `Remote Sign-off` failed twice on the same branch, at 17m and again at 55m. The 55-minute failure is also a caution against reading long elapsed time as evidence of a genuine compile error.

## The fix

Link the tools that build scripts invoke by bare name, then assert they resolve — so a stale runner fails **in setup**, with the tool named and the remedy printed, instead of an hour later somewhere unrelated.

Linking is best-effort (`|| true`) and the `command -v` check is the authority, so a brew alias quirk can never fail CI on its own — the guard can only convert a silent late failure into an immediate, clearly-attributed one. `openssl` and `llvm` are keg-only and are deliberately left unlinked; the build locates them via `brew --prefix`.

## Verification

- YAML parses; the extracted step is `bash -n` clean.
- Ran the step body under CI's exact shell flags (`bash -e -o pipefail`) against a stubbed `brew`:
  - tools absent → exits **1** after printing `::error::Not on PATH after 'brew install': cmake pkg-config. Run 'brew link --overwrite cmake pkg-config' on this runner.`
  - tools present → exits **0**, silent.
- Confirmed against Homebrew metadata that `pkg-config` is an alias of `pkgconf` and that both `cmake` and `pkgconf` are non-keg-only, so `brew link` is valid for exactly the two formulas being linked.
