### PR TITLE
fix(flightsql): mark stamped statistics inexact when a LIMIT is pushed to the remote scan (fixes #12292)

### DIFF
--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -486,21 +486,28 @@ impl FlightSQLTable {
         // Project the table-level statistics onto the scan's (projected) output
         // schema so the column-statistics list lines up with the output columns.
         //
-        // When filters are pushed down to the remote scan, the stamped statistics
-        // still describe the *unfiltered* slice the executor reported (they are the
-        // whole-table row count / column bounds, not the filtered subset). Every
-        // pushdown-eligible filter is reported `Exact` (see
-        // `supports_filters_pushdown`), so DataFusion drops the coordinator-side
-        // `FilterExec` — and if the stamped `num_rows`/bounds stay `Exact`, the
-        // `aggregate_statistics` optimizer rule folds `COUNT(*)`/`MIN`/`MAX` to
-        // those unfiltered values, silently ignoring the predicate (e.g. a filtered
-        // `COUNT(*)` returns the full table count — issue #11599). Marking the
-        // statistics inexact when any filter is applied disables that fold while
-        // keeping the bounds usable for join sizing.
+        // The stamped statistics describe the *whole* slice the executor reported
+        // (its row count and column bounds), so they only stay `Exact` for a scan
+        // that returns that whole slice. Both a pushed-down filter and a
+        // pushed-down limit narrow what the remote query returns:
+        //
+        // - Every pushdown-eligible filter is reported `Exact` (see
+        //   `supports_filters_pushdown`), so DataFusion drops the coordinator-side
+        //   `FilterExec`.
+        // - `LIMIT` is emitted into the remote SQL (see `FlightSqlExec::sql`), and
+        //   `supports_limit_pushdown` lets `LimitPushdown` drop the coordinator-side
+        //   `GlobalLimitExec`.
+        //
+        // Either way, leaving `num_rows`/bounds `Exact` lets the
+        // `aggregate_statistics` optimizer rule fold `COUNT(*)`/`MIN`/`MAX` to
+        // values the scan cannot produce — silently ignoring the predicate (a
+        // filtered `COUNT(*)` returning the full table count, issue #11599) or the
+        // limit (issue #12292). Marking the statistics inexact disables that fold
+        // while keeping the bounds usable for join sizing.
         let exec = match &self.statistics {
             Some(stats) => {
                 let stats = stats.clone().project(projections);
-                let stats = if filters.is_empty() {
+                let stats = if filters.is_empty() && limit.is_none() {
                     stats
                 } else {
                     stats.to_inexact()
@@ -918,6 +925,17 @@ impl ExecutionPlan for FlightSqlExec {
             (None, None) => None,
         };
 
+        // `LimitPushdown` calls this to move a `GlobalLimitExec` into the scan and
+        // then drops it, so the limited scan becomes the only thing describing the
+        // row count. `self.statistics` describes the *unlimited* slice, so it can
+        // only stay `Exact` while there is no limit — see `create_physical_plan` for
+        // the same reasoning about pushed-down filters (issues #11599, #12292).
+        let statistics = if merged_limit.is_some() {
+            self.statistics.clone().to_inexact()
+        } else {
+            self.statistics.clone()
+        };
+
         let new_plan = FlightSqlExec {
             projected_schema: Arc::clone(&self.projected_schema),
             table_reference: self.table_reference.clone(),
@@ -929,7 +947,7 @@ impl ExecutionPlan for FlightSqlExec {
             cookie_store: Arc::clone(&self.cookie_store),
             metrics: ExecutionPlanMetricsSet::new(),
             trace_parent: self.trace_parent.clone(),
-            statistics: self.statistics.clone(),
+            statistics,
             token: self.token.clone(),
         };
 
@@ -1103,7 +1121,7 @@ pub async fn get_client_for_flight_endpoint(
 mod tests {
     use super::{FlightSqlClient, query_to_stream};
     use crate::flightsql::FlightSqlExec;
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
     use arrow_flight::{
         Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint,
@@ -1370,36 +1388,11 @@ mod tests {
     /// unfiltered scan.
     #[tokio::test]
     async fn scan_marks_stamped_statistics_inexact_when_filter_pushed() {
-        use super::FlightSQLTable;
         use datafusion::catalog::TableProvider;
         use datafusion::common::stats::Precision;
-        use datafusion::common::{ColumnStatistics, ScalarValue, Statistics};
         use datafusion::prelude::{SessionContext, col, lit};
 
-        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
-        let stats = Statistics {
-            num_rows: Precision::Exact(150_000),
-            total_byte_size: Precision::Exact(1_200_000),
-            column_statistics: vec![ColumnStatistics {
-                null_count: Precision::Exact(0),
-                max_value: Precision::Exact(ScalarValue::Int64(Some(149_999))),
-                min_value: Precision::Exact(ScalarValue::Int64(Some(0))),
-                sum_value: Precision::Absent,
-                distinct_count: Precision::Absent,
-                byte_size: Precision::Exact(1_200_000),
-            }],
-        };
-
-        let table = FlightSQLTable::create_with_schema(
-            "flightsql",
-            "executor-1",
-            lazy_client(),
-            TableReference::bare("customer"),
-            Arc::clone(&schema),
-            Arc::new(CookieStore::new()),
-        )
-        .with_statistics(Some(stats));
-
+        let table = stamped_table();
         let session = SessionContext::new().state();
 
         // No filter → stamped statistics stay exact (folding a bare COUNT(*) is correct).
@@ -1440,8 +1433,130 @@ mod tests {
         );
     }
 
+    /// Regression test for #12292, the limit twin of #11599: `LIMIT` is emitted
+    /// into the remote SQL, so a scan built with one cannot produce the stamped
+    /// slice's row count or column bounds and must not report them `Exact`.
+    #[tokio::test]
+    async fn scan_marks_stamped_statistics_inexact_when_limit_pushed() {
+        use datafusion::catalog::TableProvider;
+        use datafusion::common::stats::Precision;
+        use datafusion::prelude::SessionContext;
+
+        let table = stamped_table();
+        let session = SessionContext::new().state();
+
+        let plan = table
+            .scan(&session, None, &[], Some(10))
+            .await
+            .expect("limited scan should build");
+        let limited = plan
+            .partition_statistics(None)
+            .expect("statistics should be available");
+        assert_eq!(
+            limited.num_rows,
+            Precision::Inexact(150_000),
+            "a scan whose SQL carries LIMIT 10 must not claim an exact 150000-row count"
+        );
+        assert!(
+            matches!(
+                limited.column_statistics[0].max_value,
+                Precision::Inexact(_)
+            ),
+            "the limited scan's rows are a subset, so its bounds must be inexact too"
+        );
+    }
+
+    /// Regression test for #12292: `LimitPushdown` introduces the limit through
+    /// `with_fetch` and then drops the `GlobalLimitExec`, so the statistics the
+    /// new plan carries are the only ones left describing the row count.
+    #[tokio::test]
+    async fn with_fetch_marks_stamped_statistics_inexact() {
+        use datafusion::common::stats::Precision;
+
+        let exec = build_exec(lazy_client(), Arc::new(CookieStore::new()))
+            .with_statistics(stamped_statistics());
+
+        // No limit anywhere: the scan returns the whole stamped slice.
+        assert_eq!(
+            exec.partition_statistics(None)
+                .expect("statistics should be available")
+                .num_rows,
+            Precision::Exact(150_000),
+            "an unlimited scan must keep exact num_rows"
+        );
+
+        let limited = exec
+            .with_fetch(Some(10))
+            .expect("with_fetch should produce a plan");
+        let stats = limited
+            .partition_statistics(None)
+            .expect("statistics should be available");
+        assert_eq!(
+            stats.num_rows,
+            Precision::Inexact(150_000),
+            "a limit pushed in through with_fetch must degrade num_rows to inexact"
+        );
+        assert!(
+            matches!(stats.column_statistics[0].max_value, Precision::Inexact(_)),
+            "a limit pushed in through with_fetch must degrade column bounds too"
+        );
+
+        // `with_fetch(None)` on an unlimited scan leaves the limit unset, so the
+        // statistics stay exact.
+        let unchanged = exec
+            .with_fetch(None)
+            .expect("with_fetch should produce a plan");
+        assert_eq!(
+            unchanged
+                .partition_statistics(None)
+                .expect("statistics should be available")
+                .num_rows,
+            Precision::Exact(150_000),
+            "with_fetch(None) on an unlimited scan must not degrade statistics"
+        );
+    }
+
+    /// Schema the stamped-statistics fixtures describe.
+    fn stamped_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]))
+    }
+
+    /// A cluster leaf table carrying the statistics one executor reported for its
+    /// whole slice — the shape `get_partitions_from_store` stamps onto each leaf.
+    fn stamped_table() -> super::FlightSQLTable {
+        super::FlightSQLTable::create_with_schema(
+            "flightsql",
+            "executor-1",
+            lazy_client(),
+            TableReference::bare("customer"),
+            stamped_schema(),
+            Arc::new(CookieStore::new()),
+        )
+        .with_statistics(Some(stamped_statistics()))
+    }
+
+    /// Statistics as an executor reports them for its whole table slice: an exact
+    /// row count and exact column bounds over every row it holds.
+    fn stamped_statistics() -> datafusion::common::Statistics {
+        use datafusion::common::stats::Precision;
+        use datafusion::common::{ColumnStatistics, ScalarValue, Statistics};
+
+        Statistics {
+            num_rows: Precision::Exact(150_000),
+            total_byte_size: Precision::Exact(1_200_000),
+            column_statistics: vec![ColumnStatistics {
+                null_count: Precision::Exact(0),
+                max_value: Precision::Exact(ScalarValue::Int64(Some(149_999))),
+                min_value: Precision::Exact(ScalarValue::Int64(Some(0))),
+                sum_value: Precision::Absent,
+                distinct_count: Precision::Absent,
+                byte_size: Precision::Exact(1_200_000),
+            }],
+        }
+    }
+
     fn build_exec(client: FlightSqlClient, cookie_store: Arc<CookieStore>) -> FlightSqlExec {
-        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
+        let schema = stamped_schema();
         FlightSqlExec::new(
             None,
             &schema,


### PR DESCRIPTION
Fixes #12292

## Summary

A cluster leaf scan (`FlightSqlExec`) is stamped with the statistics an executor reported for its **whole** table slice. `FlightSQLTable::create_physical_plan` already degrades those statistics to `Inexact` when a **filter** is pushed into the remote SQL — that is the fix for #11599 — but it did not do the same for a pushed-down **`LIMIT`**, and `FlightSqlExec::with_fetch` copied the statistics through verbatim while setting the limit.

`FlightSqlExec::sql()` emits `LIMIT {limit}` into the remote query, so the plan was asserting an exact row count and exact column bounds that the scan provably cannot produce: with `num_rows: Exact(150_000)` stamped, `table.scan(.., Some(10))` returned a plan still reporting `Exact(150_000)`.

`Precision::Exact` is a correctness contract — DataFusion substitutes exact statistics into results. `aggregate_statistics` (the rule named in this function's own comment as the #11599 vector) folds `COUNT(*)`/`MIN`/`MAX` out of the child's `partition_statistics`, and because `FlightSqlExec` reports `supports_limit_pushdown() == true`, `LimitPushdown` **removes** the corrective `GlobalLimitExec` above the scan and leaves the false `Exact` as the plan's own row count.

To be precise about severity: in the current default rule order `aggregate_statistics` runs before `LimitPushdown`, so a `SELECT COUNT(*) FROM (SELECT * FROM t LIMIT n)` still folds off the surviving `GlobalLimitExec` and answers correctly today. This is a violated invariant rather than a reproduced wrong answer — but it is the identical shape to #11599, it is load-bearing for anything reading the scan's statistics after `LimitPushdown` (a serialized/re-planned distributed plan, a new or reordered rule, a custom FlightSQL physical rule), and statistics may be reported exact only when provably exact.

## Changes

* `FlightSQLTable::create_physical_plan` — keep the stamped statistics exact only while `filters.is_empty() && limit.is_none()`, i.e. degrade whenever either narrowing is pushed into the remote SQL. The surrounding comment now explains both vectors instead of only filters.
* `FlightSqlExec::with_fetch` — degrade the carried statistics when the merged limit is `Some(_)`. This is where `LimitPushdown` introduces a limit into a scan that was built without one, so it is the second entry point into the same wrong claim. `with_fetch(None)` on an unlimited scan still keeps the statistics exact.
* Tests: two regression tests (`scan_marks_stamped_statistics_inexact_when_limit_pushed`, `with_fetch_marks_stamped_statistics_inexact`) covering both entry points, `num_rows` and column bounds, and the unlimited control case. The stamped-statistics fixture is extracted into `stamped_schema()`/`stamped_statistics()` helpers and reused by the existing #11599 test rather than duplicated.

Scope: `FlightSqlExec` is the only execution plan in the repo that both carries externally supplied statistics and pushes a limit into a remote query — the `oracle` and `mssql` execs report unknown statistics, and the Cayenne scan wrapper delegates `partition_statistics` to an inner plan that already accounts for its own fetch. So this is a one-instance class, not a sweep.

## Performance impact

None expected. `JoinSelection` and the FlightSQL broadcast-join cost test read `Precision` values regardless of exactness, so join sizing and build-side selection still see the same row counts and bounds — only the exactness claim changes, and only for scans that carry a limit. A limited leaf scan is not a join-sizing input in the plans this affects.

## Overlap

Open PR #11858 rewrites this `create_physical_plan` statistics block to add filter-selectivity scaling and keeps the `filters.is_empty()` condition, so it does not cover the limit case; it does not touch `with_fetch`. If #11858 lands first, its version of the block should carry the `&& limit.is_none()` half of the guard; the `with_fetch` half is independent of it. Happy to rebase onto it either way.

## Test plan

- [x] `make lint`
- [x] `make nextest`
- [x] New regression tests fail on the pre-fix code (`Exact(150000)` where `Inexact(150000)` is required) and pass after.

## Checklist

- [x] Regression test that fails on the old code
- [x] No behaviour change for scans without a pushed-down limit
- [x] `cargo fmt` clean