### PR TITLE
fix(runtime): gate the embed UDF name on the indexes that consume it (fixes #12294)

### DIFF
--- a/crates/runtime/src/embeddings/index/table.rs
+++ b/crates/runtime/src/embeddings/index/table.rs
@@ -20,9 +20,20 @@ use crate::model::EmbeddingModelStore;
 use crate::secrets::Secrets;
 use datafusion::datasource::TableProvider;
 use datafusion::{prelude::SessionContext, sql::TableReference};
-#[cfg(feature = "models")]
+// `models` decides how the UDF name is spelled — the authoritative constant when
+// `runtime_datafusion_udfs::embed` is compiled, a local copy otherwise — but only the
+// `s3_vectors` and `elasticsearch` index builders below consume it. Both arms therefore
+// have to be gated on that consumer set as well, or the name is an unused import (with
+// `models`) or dead code (without it) whenever neither index is compiled in.
+#[cfg(all(
+    feature = "models",
+    any(feature = "s3_vectors", feature = "elasticsearch")
+))]
 use runtime_datafusion_udfs::embed::EMBED_UDF_NAME;
-#[cfg(not(feature = "models"))]
+#[cfg(all(
+    not(feature = "models"),
+    any(feature = "s3_vectors", feature = "elasticsearch")
+))]
 const EMBED_UDF_NAME: &str = "embed";
 use spicepod::vector::VectorStore;
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

`crates/runtime/src/embeddings/index/table.rs` declares `EMBED_UDF_NAME` in two arms gated on
`models` — the authoritative constant from `runtime_datafusion_udfs::embed` when that module is
compiled, a local copy otherwise. Both of its use sites, however, live in functions gated on a
*different* feature: `wrap_table_as_index_s3` is `#[cfg(feature = "s3_vectors")]` and
`wrap_table_as_index_elasticsearch` is `#[cfg(feature = "elasticsearch")]`.

So whenever neither of those two indexes is compiled in, the name has no consumer and one of the
two arms is a hard `-D warnings` failure in a file the contributor never touched:

| features | diagnostic |
| --- | --- |
| *(none)* | `error: constant EMBED_UDF_NAME is never used` |
| `models` | `error: unused import: runtime_datafusion_udfs::embed::EMBED_UDF_NAME` |

`crates/runtime` declares no `default` feature set, so the featureless case is exactly what a
package-scoped lint compiles — `make lint-rust PACKAGES=runtime`, a bare
`cargo clippy -p runtime -- -Dwarnings`, and therefore rust-analyzer configured per
`.vscode/settings.json.template`. The full gate never sees it: `make lint-rust` without `PACKAGES=`
supplies `--features adbc,…,models,…,elasticsearch,…`, which enables `models` *and* a consumer, and
the scoped pre-check inside `make signoff` resolves features from workspace `cargo metadata`, which
does the same.

## Changes

Gate both arms on the intersection of "which spelling of the name" and "is there a consumer at
all", so the item exists precisely when a use site does:

```rust
#[cfg(all(feature = "models", any(feature = "s3_vectors", feature = "elasticsearch")))]
use runtime_datafusion_udfs::embed::EMBED_UDF_NAME;
#[cfg(all(not(feature = "models"), any(feature = "s3_vectors", feature = "elasticsearch")))]
const EMBED_UDF_NAME: &str = "embed";
```

`elasticsearch` and `s3_vectors` do not imply `models`, so both arms stay reachable and the
`not(models)` copy is still required.

No runtime behavior changes: the constant's value is `"embed"` on both arms, and every feature
combination that compiled a use site before compiles the same use site now.

**Bug-class sweep.** The same `models`/`not(models)` twin declaration exists at three other places,
and each was checked for the same mismatch:

| site | consumer | verdict |
| --- | --- | --- |
| `runtime/src/embeddings/udtf.rs` | `TableFunctionImpl::call` for `VectorSearchTableFunc` — ungated | clean |
| `runtime/src/datafusion/udf.rs` | `denied_spice_function_names()` — ungated | clean |
| `runtime-search/src/search_engine.rs` | `SearchEngine::get_vector_index` — ungated | clean |

A repo-wide sweep for the general shape (a `#[cfg(feature = X)]` / `#[cfg(not(feature = X))]` twin
*item* declaration) also turned up `SNAPSHOTS_ENABLED` in
`runtime-acceleration/src/snapshot/behavior.rs`; its four consumers are ungated too. Only
`embeddings/index/table.rs` has consumers behind a different gate, so this is the single instance.

## Test plan

The defect and the fix are entirely compile-time, so there is no unit test that can observe them —
dead-code and unused-import analysis has no runtime surface. Verification is by compiling the
feature combinations that decide which arm survives, plus the standard gate:

- [x] `cargo check -p runtime` (featureless — the combination the issue reports) now finishes clean,
      **zero warnings**, where before the change it emits `constant EMBED_UDF_NAME is never used`.
      That also confirms this file was the *only* featureless failure in the crate, so a
      package-scoped invocation succeeds again rather than moving on to the next error.
- [x] The featureless *clippy* invocation the issue actually reports — `-p runtime` with no
      `--features`, carrying `make lint-rust`'s full flag set (`-Dwarnings -Dclippy::pedantic
      -Dclippy::unwrap_used -Dclippy::expect_used -Dclippy::clone_on_ref_ptr …` under
      `CLIPPY_CONF_DIR=.ci`) — finishes with **zero diagnostics**, so `make lint-rust PACKAGES=runtime`
      succeeds again.
- [x] The `cfg` algebra was exercised exhaustively over all eight combinations of
      `models` × `s3_vectors` × `elasticsearch` in a standalone crate reproducing this file's gate
      structure and use sites: the shape on `trunk` fails under `-D warnings` for `[]` and
      `[models]`; the shape in this PR is clean for all eight.
- [ ] `make lint` — the full-feature gate (`models` + `elasticsearch` both on) still passes, i.e.
      the change does not regress the combination CI already covered. Runs as part of
      `make signoff`; checked off once the `Attestation` check is green.
- [ ] `make nextest` — no behavior change expected. Also part of `make signoff`.

Adding a featureless scoped lint to CI would catch this class directly, but a distinct feature set
re-fingerprints the whole dependency graph and forces a full recompile, so that is deliberately not
part of this PR.

## Checklist

- [x] Root cause identified and stated
- [x] Fix is minimal and scoped to one file
- [x] Bug-class sweep across all sibling declarations of the same shape
- [x] No behavior change; no new configuration surface
- [x] `cargo fmt` clean

Fixes #12294
