### PR TITLE
fix(runtime): gate the embed-UDF name on the backends that consume it (fixes #12294)

### DIFF
--- a/crates/runtime/src/embeddings/index/table.rs
+++ b/crates/runtime/src/embeddings/index/table.rs
@@ -20,9 +20,18 @@ use crate::model::EmbeddingModelStore;
 use crate::secrets::Secrets;
 use datafusion::datasource::TableProvider;
 use datafusion::{prelude::SessionContext, sql::TableReference};
-#[cfg(feature = "models")]
+// Only the `s3_vectors` and `elasticsearch` index wrappers below look the UDF up
+// by name, so both spellings need that guard as well: without it the declaration
+// has no consumer in a build that enables neither, and `-D warnings` rejects it.
+#[cfg(all(
+    feature = "models",
+    any(feature = "s3_vectors", feature = "elasticsearch")
+))]
 use runtime_datafusion_udfs::embed::EMBED_UDF_NAME;
-#[cfg(not(feature = "models"))]
+#[cfg(all(
+    not(feature = "models"),
+    any(feature = "s3_vectors", feature = "elasticsearch")
+))]
 const EMBED_UDF_NAME: &str = "embed";
 use spicepod::vector::VectorStore;
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

`crates/runtime/src/embeddings/index/table.rs` declared `EMBED_UDF_NAME` in two arms gated only on `models`:

```rust
#[cfg(feature = "models")]
use runtime_datafusion_udfs::embed::EMBED_UDF_NAME;
#[cfg(not(feature = "models"))]
const EMBED_UDF_NAME: &str = "embed";
```

Every use of that name, though, is inside a *different* feature's code: `wrap_table_as_index_s3` (`#[cfg(feature = "s3_vectors")]`, uses at `:215`/`:217`) and `wrap_table_as_index_elasticsearch` (`#[cfg(feature = "elasticsearch")]`, uses at `:440`/`:442`). Those are the only four occurrences of the identifier in the file.

So in a build with neither backend the name is declared and never consumed. `crates/runtime` declares no `default` features, which is exactly what a package-scoped lint compiles, and `dead_code` under `-D warnings` is a hard error there.

Fixes #12294

## Changes

Add `any(feature = "s3_vectors", feature = "elasticsearch")` to **both** arms, so the declaration exists in exactly the configurations that have a consumer. The `models` arm had the mirror-image gap — with `models` on and both backends off the `use` is an unused import — and the same guard closes it.

## Why CI never caught it

The workspace `make lint-rust` passes `--features adbc,…,models,…,elasticsearch,…`, and the fail-fast scoped pre-check `make signoff` derives resolves features from workspace `cargo metadata`. Both enable `models` *and* a backend, so neither the dead const nor the unused import is ever compiled. Only the featureless scoped invocation reaches it — the one `CLAUDE.md` recommends for incremental validation.

## Test plan

This is a conditional-compilation defect: which items exist in which feature combination. No unit test can observe it — the failing configuration does not compile, so the evidence is the build itself, before and after.

Reproduced and verified directly, same tree, same toolchain (1.96.1):

| configuration | before | after |
| --- | --- | --- |
| `make lint-rust PACKAGES=runtime` (no features) | exit 2 — `error: constant EMBED_UDF_NAME is never used --> crates/runtime/src/embeddings/index/table.rs:26:7` | **exit 0** |

The arm this change must not break is `not(models)` *with* a backend — and that is a shipping configuration, not a hypothetical: `bin/spiced`'s `default` feature list includes `runtime/s3_vectors` and does **not** include `models`. So `make build-cli-dev` compiles the `not(models)` const arm, and the guard keeps it declared there.

- [x] `cargo fmt -p runtime -- --check` clean
- [x] `make lint-rust PACKAGES=runtime` passes (it failed on `trunk`)
- [ ] `make lint` (full workspace gate — runs in sign-off)
- [ ] `make test` / `make nextest` (runs in sign-off)