### PR TITLE
fix(cluster): mark a coordinator leaf scan's cached executor statistics inexact (fixes #12303)

### DIFF
--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -212,7 +212,9 @@ impl ExecutorTableStatistics {
     /// This lets the coordinator's planner estimate join/aggregate cardinalities
     /// from the executor's column min/max even when the leaf scan is projected.
     ///
-    /// Every value is downgraded to [`Precision::Inexact`]. The registry holds an
+    /// Every value the executor actually reported is downgraded to
+    /// [`Precision::Inexact`]; a value it did not report stays
+    /// [`Precision::Absent`]. The registry holds an
     /// asynchronous snapshot — executors rebroadcast on a 45s timer (plus a
     /// debounced write-completion nudge), so the executor's data has moved on by
     /// the time the coordinator plans against it. `Precision::Exact` is a

--- a/crates/runtime-cluster/src/executor_registry.rs
+++ b/crates/runtime-cluster/src/executor_registry.rs
@@ -211,6 +211,17 @@ impl ExecutorTableStatistics {
     /// by name (`Absent`/unknown when the executor reported none for that column).
     /// This lets the coordinator's planner estimate join/aggregate cardinalities
     /// from the executor's column min/max even when the leaf scan is projected.
+    ///
+    /// Every value is downgraded to [`Precision::Inexact`]. The registry holds an
+    /// asynchronous snapshot — executors rebroadcast on a 45s timer (plus a
+    /// debounced write-completion nudge), so the executor's data has moved on by
+    /// the time the coordinator plans against it. `Precision::Exact` is a
+    /// correctness contract, not a confidence hint: `aggregate_statistics` folds
+    /// `COUNT(*)`/`MIN`/`MAX` out of exact leaf statistics and substitutes them
+    /// into the result, which would answer from the stale snapshot instead of the
+    /// executor (issue #12303). Inexact keeps the values themselves, so the
+    /// cost-based sizing these reports exist for — `should_swap_join_order` and
+    /// friends read `Precision::get_value()` — is unaffected.
     #[must_use]
     pub fn projected_onto(&self, leaf_schema: &SchemaRef) -> Statistics {
         use datafusion::common::ColumnStatistics;
@@ -234,6 +245,7 @@ impl ExecutorTableStatistics {
             total_byte_size: Precision::Absent,
             column_statistics,
         }
+        .to_inexact()
     }
 }
 
@@ -1130,6 +1142,83 @@ mod tests {
         let projected = entry.projected_onto(&leaf);
         assert_eq!(projected.num_rows, Precision::Absent);
         assert_eq!(projected.column_statistics.len(), 1);
+    }
+
+    /// Regression test for #12303.
+    ///
+    /// The registry holds an asynchronous snapshot of what an executor reported
+    /// (rebroadcast on a 45s timer plus a debounced write-completion nudge), so a
+    /// reported `Exact` value describes the executor's data at report time, not at
+    /// plan time. Carrying `Exact` through to the leaf scan licenses the
+    /// `aggregate_statistics` rule to fold `COUNT(*)`/`MIN`/`MAX` into the result
+    /// from that stale snapshot. Downgrading to `Inexact` keeps the values (join
+    /// sizing reads `Precision::get_value()`) while refusing the fold.
+    #[tokio::test]
+    async fn projected_statistics_are_inexact_because_the_report_is_a_snapshot() {
+        use arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::common::{ColumnStatistics, ScalarValue};
+
+        let registry = make_registry().await;
+        let table = TableReference::bare("orders");
+
+        registry.record_executor_statistics(
+            &table,
+            "executor-1".to_string(),
+            Statistics {
+                num_rows: Precision::Exact(1_000_000),
+                total_byte_size: Precision::Exact(64_000_000),
+                column_statistics: vec![ColumnStatistics {
+                    null_count: Precision::Exact(0),
+                    max_value: Precision::Exact(ScalarValue::Int64(Some(1_000_000))),
+                    min_value: Precision::Exact(ScalarValue::Int64(Some(1))),
+                    distinct_count: Precision::Exact(1_000_000),
+                    ..ColumnStatistics::new_unknown()
+                }],
+            },
+            vec!["id".to_string()],
+        );
+
+        let snapshot = registry.executor_statistics_snapshot(&table);
+        let entry = snapshot.get("executor-1").expect("recorded entry present");
+        // `total` is not in the report, so it projects to unknown.
+        let leaf: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("total", DataType::Float64, true),
+        ]));
+        let projected = entry.projected_onto(&leaf);
+
+        assert_eq!(
+            projected.num_rows,
+            Precision::Inexact(1_000_000),
+            "a cached remote row count must not be Exact — aggregate_statistics would fold COUNT(*) to it"
+        );
+        assert_eq!(
+            projected.num_rows.get_value(),
+            Some(&1_000_000),
+            "the value itself must survive so the planner can still size joins"
+        );
+
+        let id = &projected.column_statistics[0];
+        assert_eq!(
+            id.min_value,
+            Precision::Inexact(ScalarValue::Int64(Some(1))),
+            "cached column bounds must not be Exact — MIN() would be folded to them"
+        );
+        assert_eq!(
+            id.max_value,
+            Precision::Inexact(ScalarValue::Int64(Some(1_000_000))),
+            "cached column bounds must not be Exact — MAX() would be folded to them"
+        );
+        assert_eq!(id.null_count, Precision::Inexact(0));
+        assert_eq!(id.distinct_count, Precision::Inexact(1_000_000));
+
+        let total = &projected.column_statistics[1];
+        assert_eq!(
+            total.min_value,
+            Precision::Absent,
+            "a column the executor did not report stays unknown"
+        );
+        assert_eq!(total.max_value, Precision::Absent);
     }
 
     fn dummy_flight_sql_client() -> FlightSqlClient {


### PR DESCRIPTION
Fixes #12303

## Summary

In distributed mode the coordinator stamps each per-executor `FlightSQL` leaf scan with statistics read out of an **in-memory cache of an asynchronous executor report**, carrying the reported `Precision::Exact` through verbatim.

`Precision::Exact` is a correctness contract — DataFusion substitutes exact statistics *into results* — but a cached copy of a remote row count is stale the moment the executor writes another row. Executors rebroadcast on a 45s timer (`run_executor_statistics_reporter`) plus a write-completion nudge that is itself debounced by 1.5s, and the scheduler never re-reads at planning time. There is no ordering that makes an asynchronously-reported remote count exact when the coordinator plans against it.

Two rules act on that false `Exact` and produce a wrong answer, not a slow one:

- **`aggregate_statistics`** folds `COUNT(*)`/`MIN`/`MAX` out of the leaf statistics. A table ingesting via CDC answers `COUNT(*)` from the last snapshot — under-counting by everything written since — without contacting the executor. That this fold is live on this path is already documented in the repo: #11602 states that `local_executor_table_statistics` reports `optimizer_table_statistics()` to the coordinator, "served `Precision::Exact` once no visibility changes are pending — which licenses the `COUNT(*)` metadata fold". #11602 fixed one *source* of a wrong count (the executor's own maintained count drifting) and deliberately kept `Exact` for pure-append tables — which is precisely the case whose cached count goes stale fastest.
- **`EmptyHashJoinExecPhysicalOptimization`** (registered in `datafusion/builder.rs`) replaces a hash join with an `EmptyExec` when a side is *provably* empty (`Precision::Exact(n) => n == 0`). A table whose executors last reported an empty slice answers any join against it as zero rows. Exposure is worst at bring-up: `evaluate_table_readiness` gates `Ready` on the *first* statistics report, so the table starts serving queries exactly when its cached count is most likely to be a stale zero.

The producing side really does emit `Exact` — Cayenne's maintained aggregate when provably exact, or Parquet/Vortex footer statistics via the fallback — and `encode_statistics`/`decode_statistics` round-trip through `datafusion-proto`, so `Exact` survives the wire.

## Changes

`ExecutorTableStatistics::projected_onto` — the single funnel through which a cached report becomes leaf-scan statistics (used by both `stamp_executor_statistics` and `FederatedPartitionProvider::get_partitions`) — now downgrades the projected statistics with `Statistics::to_inexact()`.

The values themselves are unchanged, so everything these reports exist for still works: `should_swap_join_order`, the `reorder_join` cost model, and the `FlightSQL` broadcast-join rule's `side_num_rows` all read `Precision::get_value()`, which is precision-agnostic. Only the two rules above — the ones that put a statistic *into a result* — change behavior, and they now decline and let a real scan answer.

## Performance impact

`SELECT COUNT(*)` on a distributed table no longer folds to a literal from cached statistics; it executes against the executors. That is the point of the fix — the folded value could be wrong. Cost-based planning (join side selection, join reordering, broadcast-join eligibility) is unaffected, because those read the value and ignore the precision.

## Test plan

- New regression test `projected_statistics_are_inexact_because_the_report_is_a_snapshot` in `crates/runtime-cluster/src/executor_registry.rs`: records a report with `Exact` `num_rows`/bounds, projects it onto a leaf schema, and asserts every value comes back `Inexact` with the value preserved, plus that a column the executor did not report stays unknown. Fails on the old code (which returned `Exact`).
- The existing `unknown_statistics_report_still_marks_table_as_having_statistics` covers the `Absent` case — `to_inexact()` leaves `Absent` untouched.
- `make lint`
- `make test`

## Checklist

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Regression test fails on old code, passes on new
