### PR TITLE
fix: send enc_pubkey_pem on /renew for standalone runtime

### DIFF
--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -413,11 +413,11 @@ impl ClientDriver {
             ca_bundle_pem: current.ca_bundle_pem,
             gateway_addr: current.gateway_addr,
             not_after_unix: Some(outcome.not_after_unix),
-            // The encryption keypair is NOT rotated on renewal: the renew
-            // exchange carries no channel to re-pin a new public key, and
-            // the cloud keeps sealing secrets to the enrolled one.
-            enc_private_key_pem: current.enc_private_key_pem,
-            enc_public_key_pem: current.enc_public_key_pem,
+            // The encryption keypair rotates alongside the identity keypair
+            // on each renewal: the cloud pins it in the same transaction
+            // that issues the new leaf, and begins sealing secrets to it.
+            enc_private_key_pem: material.enc_private_key_pem,
+            enc_public_key_pem: material.enc_public_key_pem,
         };
         // The cloud has already pinned the new public key: even if
         // persistence fails, the rotated identity must be used in memory

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -202,6 +202,13 @@ struct RenewRequest<'a> {
     cert_pem: &'a str,
     csr_pem: &'a str,
     pop_sig: &'a str,
+    /// The freshly-generated X25519 encryption public key (RFC 8410 SPKI
+    /// PEM). The cloud records it in the same transaction that rotates the
+    /// identity key, and seals to it from that commit on.
+    ///
+    /// Not covered by `pop_sig`, which signs the CSR DER alone — this field's
+    /// integrity rests on the server-authenticated TLS to the cloud.
+    enc_pubkey_pem: &'a str,
 }
 
 /// Wire shape of a successful renew response.
@@ -318,6 +325,7 @@ impl EnrollClient {
             cert_pem: &current.identity_cert_pem,
             csr_pem: &material.csr_pem,
             pop_sig: &pop_sig,
+            enc_pubkey_pem: &material.enc_public_key_pem,
         };
         let wire: RenewResponseWire = self.post_json(&self.renew_url, &request).await?;
         let not_after_unix = parse_not_after(&self.renew_url, &wire.not_after)?;
@@ -815,5 +823,38 @@ mod tests {
                 "https://cloud.spice.ai/v1/cloud-connect/renew"
             );
         }
+    }
+
+    #[test]
+    fn renew_request_includes_enc_pubkey_pem() {
+        // The cloud `/renew` endpoint requires `enc_pubkey_pem` (Zod schema
+        // validation in spicehq/cloud). The request must serialize all four
+        // fields — omitting it causes a 400 that blocks renewal.
+        let renew_req = RenewRequest {
+            cert_pem: "-----BEGIN CERTIFICATE-----\nMOCK\n-----END CERTIFICATE-----",
+            csr_pem: "-----BEGIN CERTIFICATE REQUEST-----\nMOCK\n-----END CERTIFICATE REQUEST-----",
+            pop_sig: "dGVzdC1zaWduYXR1cmU=",
+            enc_pubkey_pem: "-----BEGIN PUBLIC KEY-----\nMOCKENC\n-----END PUBLIC KEY-----",
+        };
+        let value = serde_json::to_value(&renew_req).expect("serialize renew request");
+
+        // All four fields must be present.
+        assert!(value.get("cert_pem").is_some(), "cert_pem must be present");
+        assert!(value.get("csr_pem").is_some(), "csr_pem must be present");
+        assert!(value.get("pop_sig").is_some(), "pop_sig must be present");
+        assert!(
+            value.get("enc_pubkey_pem").is_some(),
+            "enc_pubkey_pem must be present — the cloud schema requires it"
+        );
+
+        // Exactly four keys, no extras.
+        assert_eq!(
+            value
+                .as_object()
+                .expect("serialize produces an object")
+                .len(),
+            4,
+            "renew request must carry exactly four fields"
+        );
     }
 }

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -109,10 +109,10 @@ pub struct Identity {
     pub not_after_unix: Option<u64>,
     /// PEM-encoded PKCS#8 X25519 encryption private key. The cloud
     /// HPKE-seals secret payloads to the matching public key; this key
-    /// unseals them. Kept local (never sent). Unlike the identity keypair
-    /// it is NOT rotated on renewal — the renew exchange carries no
-    /// channel to re-pin it. Defaulted (empty) so identity files written
-    /// before this field existed still load.
+    /// unseals them. Kept local (never sent). Rotated alongside the
+    /// identity keypair on every renewal so the cloud can begin sealing
+    /// to the new key from that commit on. Defaulted (empty) so identity
+    /// files written before this field existed still load.
     #[serde(default)]
     pub enc_private_key_pem: String,
     /// PEM-encoded SPKI (RFC 8410) X25519 encryption public key, as sent
@@ -231,11 +231,11 @@ impl IdentityStore {
     /// Generate fresh enrollment material: an ECDSA P-256 identity keypair
     /// with a PKCS#10 CSR for it, plus an X25519 encryption keypair, all
     /// PEM-encoded. Called before the cloud enroll request — and again
-    /// before every renewal, since each renewal rotates the identity
-    /// keypair — so the client proves possession of its key (the CSR
-    /// self-signature) before the cloud CA issues the leaf certificate.
-    /// (Renewal ignores the fresh encryption keypair: the enrolled one is
-    /// carried over, since the renew exchange cannot re-pin it.)
+    /// before every renewal, since each renewal rotates both the identity
+    /// keypair and the encryption keypair — so the client proves possession
+    /// of its identity key (the CSR self-signature) before the cloud CA
+    /// issues the leaf certificate. The fresh X25519 keypair is sent to
+    /// the cloud on renew so it can begin sealing secrets to the new key.
     ///
     /// The CSR carries a stable common name and a `clientAuth` extended
     /// key usage so the issued leaf is directly usable as an mTLS client
@@ -307,8 +307,8 @@ pub struct EnrollmentMaterial {
     pub public_key_pem: String,
     pub csr_pem: String,
     /// X25519 encryption private key (PKCS#8 PEM); persisted into the
-    /// [`Identity`] at enroll, ignored on renewal (the enrolled key is
-    /// carried over).
+    /// [`Identity`] at enroll and on each renewal alongside the rotated
+    /// identity keypair.
     pub enc_private_key_pem: String,
     /// X25519 encryption public key (RFC 8410 SPKI PEM); sent as the
     /// enroll request's `enc_pubkey_pem`.

--- a/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
@@ -1413,6 +1413,14 @@ async fn renewal_rotates_keypair_and_persists() {
         !renew_body["pop_sig"].as_str().unwrap().is_empty(),
         "renew carries the current-key proof-of-possession"
     );
+    // The cloud schema requires enc_pubkey_pem; without it renew returns 400.
+    let enc_pubkey = renew_body["enc_pubkey_pem"]
+        .as_str()
+        .expect("renew must carry enc_pubkey_pem — the cloud Zod schema requires it");
+    assert!(
+        enc_pubkey.contains("PUBLIC KEY"),
+        "renew carries an X25519 SPKI public key, got: {enc_pubkey}"
+    );
 
     // The rotated identity is persisted: new keypair, new leaf, later
     // expiry; identifier / CA bundle / gateway address unchanged.
@@ -1448,6 +1456,31 @@ async fn renewal_rotates_keypair_and_persists() {
     assert_eq!(
         renewed_identity.ca_bundle_pem, enrolled_identity.ca_bundle_pem,
         "the CA bundle is preserved across renewal"
+    );
+
+    // The encryption keypair rotates alongside the identity keypair on renewal:
+    // verify it changed and that private/public keys correspond.
+    assert_ne!(
+        renewed_identity.enc_public_key_pem, enrolled_identity.enc_public_key_pem,
+        "the encryption public key must rotate on renewal"
+    );
+    // The public key sent in the renew request is the same one persisted:
+    // sending a stale public key while persisting a new private key would
+    // break future secret delivery.
+    assert_eq!(
+        enc_pubkey, renewed_identity.enc_public_key_pem,
+        "the persisted encryption public key must match what was sent to the cloud"
+    );
+    // Round-trip: the persisted private key must derive the same public key
+    // that was sent to the cloud in the renew request.
+    let loaded_keypair = cloud_connect_crypto::EncryptionKeypair::from_pkcs8_pem(
+        &renewed_identity.enc_private_key_pem,
+    )
+    .expect("persisted encryption private key must load");
+    assert_eq!(
+        loaded_keypair.public_key_spki_pem(),
+        renewed_identity.enc_public_key_pem,
+        "persisted private key must derive the persisted public key"
     );
 
     handle.shutdown().await;


### PR DESCRIPTION
## Goal-State/What/Result

A standalone instance can renew its mTLS certificate at the ~12h cadence. The cloud `/renew` endpoint requires `enc_pubkey_pem` (the X25519 encryption public key for per-connection secret sealing) in the request body. The standalone runtime currently sends only `{ cert_pem, csr_pem, pop_sig }`, causing every renew to fail with a 400 Zod validation error.

## Why/Purpose

Without this fix, every standalone instance enrolled at launch is unreachable within a day of any network blip and permanently dead after the 30-day grace window. The BYOC operator already sends `enc_pubkey_pem` on renew — the standalone runtime is the only client that does not.

## Changes

- **`enroll.rs`**: Add `enc_pubkey_pem` field to `RenewRequest` struct and pass `material.enc_public_key_pem` through the renew() call
- **`client.rs`**: Use the fresh X25519 keypair from generated enrollment material instead of carrying over the old one on renewal
- **`identity.rs`**: Update doc comments to reflect that encryption keys now rotate on renewal alongside the identity keypair
- **Tests**: Add unit test asserting RenewRequest serializes all four fields; add E2E assertions verifying enc_pubkey_pem is present in the renew request, the sent public key matches the persisted public key, and the private key derives the same public key
