### PR TITLE
fix(scheduler): drive the interval-timing tests on a virtual clock (fixes #12323)

### DIFF
--- a/crates/scheduler/src/channel/interval.rs
+++ b/crates/scheduler/src/channel/interval.rs
@@ -137,7 +137,11 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    /// Runs on the paused clock: the property under test is that a request is emitted
+    /// one interval after the trigger, which a wall-clock reading on a loaded runner
+    /// cannot measure. `TaskRequest::created_at` is a real-clock `std::time::Instant`,
+    /// so it is bracketed against the test's own real span rather than timed.
+    #[tokio::test(start_paused = true)]
     async fn test_interval_request_channel() {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Arc<TaskRequest>>(1);
 
@@ -153,12 +157,11 @@ mod tests {
 
         let channel_handle = channel.start().expect("To start request channel");
 
-        let now = Instant::now();
+        let started = Instant::now();
+        let tick = tokio::time::Instant::now();
         let request = rx.recv().await.expect("To receive request");
-        let elapsed = now.elapsed();
-        let now = Instant::now();
-        assert!(request.created_at <= now);
-        assert!(elapsed.as_millis() >= 990 && elapsed.as_millis() <= 1010);
+        assert_eq!(tick.elapsed(), Duration::from_secs(1));
+        assert!(request.created_at >= started && request.created_at <= Instant::now());
         assert!(!request.cancel_running);
 
         // next request should wait for task notification
@@ -171,13 +174,12 @@ mod tests {
             }
         }
 
-        let now = Instant::now();
+        let started = Instant::now();
+        let tick = tokio::time::Instant::now();
         task_completion.notify_one();
         let request = rx.recv().await.expect("To receive request");
-        let elapsed = now.elapsed();
-        let now = Instant::now();
-        assert!(request.created_at < now);
-        assert!(elapsed.as_millis() >= 990 && elapsed.as_millis() <= 1010);
+        assert_eq!(tick.elapsed(), Duration::from_secs(1));
+        assert!(request.created_at >= started && request.created_at <= Instant::now());
         assert!(!request.cancel_running);
 
         cancellation.cancel();
@@ -187,7 +189,8 @@ mod tests {
             .expect("To end channel");
     }
 
-    #[tokio::test]
+    /// Runs on the paused clock, for the same reason as `test_interval_request_channel`.
+    #[tokio::test(start_paused = true)]
     async fn test_multi_channel_requestors() {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Arc<TaskRequest>>(1);
 
@@ -211,14 +214,14 @@ mod tests {
         let handle_two = channel_two.start().expect("To start request channel");
 
         // each channel will send a first request, resulting in two requests at the 1st second mark
-        let now = Instant::now();
+        let started = Instant::now();
+        let tick = tokio::time::Instant::now();
         let request_one = rx.recv().await.expect("To receive request");
         let request_two = rx.recv().await.expect("To receive request");
-        let elapsed = now.elapsed();
+        assert_eq!(tick.elapsed(), Duration::from_secs(1));
         let now = Instant::now();
-        assert!(request_one.created_at < now);
-        assert!(request_two.created_at < now);
-        assert!(elapsed.as_millis() >= 990 && elapsed.as_millis() <= 1010);
+        assert!(request_one.created_at >= started && request_one.created_at <= now);
+        assert!(request_two.created_at >= started && request_two.created_at <= now);
         assert!(!request_one.cancel_running);
         assert!(!request_two.cancel_running);
 

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -421,10 +421,8 @@ mod test {
     use crate::schedule::Schedule;
     use crate::task::{ScheduledTask, TaskRequest};
     use async_trait::async_trait;
-    use std::{
-        sync::LazyLock,
-        time::{Duration, Instant},
-    };
+    use std::{sync::LazyLock, time::Duration};
+    use tokio::time::Instant;
     use tracing_subscriber::EnvFilter;
 
     fn init_tracing(default_level: Option<&str>) -> tracing::subscriber::DefaultGuard {
@@ -546,7 +544,10 @@ mod test {
         );
     }
 
-    #[tokio::test]
+    /// Runs on the paused clock: the property under test is that the interval trigger
+    /// fires once per interval, which a wall-clock reading on a loaded runner cannot
+    /// measure. Ticks land at 1s..=9s, so waking at 9.5s avoids a tie with the tenth.
+    #[tokio::test(start_paused = true)]
     async fn test_scheduler_timing() {
         init_tracing(None);
         let schedule = Schedule::new(
@@ -558,25 +559,26 @@ mod test {
         .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))));
         let scheduler = Scheduler::new("test_scheduler_timing".into(), vec![Arc::new(schedule)]);
         let scheduler = scheduler.start().await.expect("Scheduler should start");
-        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        tokio::time::sleep(Duration::from_millis(9500)).await;
         scheduler.stop().await;
         let map_lock = TIMING_MAP.read().await;
         let timings = map_lock
             .get("test_scheduler_timing")
             .expect("To get test execution count");
-        let mut diffs = Vec::new();
-        for i in 1..timings.len() {
-            let diff = timings[i].duration_since(timings[i - 1]);
-            diffs.push(diff);
-        }
-        assert!(
-            diffs.len() == 8 || diffs.len() == 9,
-            "There should be more than 8 or 9 timing differences, but got {diffs:?}"
+        let diffs: Vec<Duration> = timings
+            .windows(2)
+            .map(|pair| pair[1].duration_since(pair[0]))
+            .collect();
+        assert_eq!(
+            diffs.len(),
+            8,
+            "There should be 8 timing differences, but got {diffs:?}"
         );
         for diff in diffs {
-            assert!(
-                diff.as_millis() >= 990 && diff.as_millis() <= 1010,
-                "Timing difference should be around 1 second, but got {diff:?}ms"
+            assert_eq!(
+                diff,
+                Duration::from_secs(1),
+                "Each interval should be exactly 1 second, but got {diff:?}"
             );
         }
     }


### PR DESCRIPTION
## Summary

`test_scheduler_timing` and the two interval-channel tests measured a **real wall clock** and asserted a **1% window** (`990..=1010ms`) on a 1-second interval. `test_scheduler_timing` repeated that assertion for each of nine consecutive intervals, so the effective failure probability compounded with the interval count.

That is not a property a unit test can measure on a shared self-hosted runner. On 2026-08-01 a 30 ms overshoot failed sign-off run [30707246022](https://github.com/spiceai/spiceai/actions/runs/30707246022) at **5h44m**, on a PR that touches `crates/search` and cannot reach `crates/scheduler`. nextest retries do not help: sustained contention outlives the retry loop, so all six attempts land in the same conditions and a flake reads as deterministic. Because a failed sign-off never re-triggers itself, any PR blocked this way stays red until someone re-dispatches.

## Changes

Run the three affected tests on tokio's paused clock (`#[tokio::test(start_paused = true)]`, already used in `cayenne`, `data_components` and `aws-sdk-credential-bridge`) and measure with `tokio::time::Instant`, so each interval is exactly one second of virtual time.

The assertions get **stricter**, not looser — exact equality instead of a 20 ms window — while becoming immune to host load:

- `scheduler.rs` — `test_scheduler_timing`: `assert_eq!(diff, Duration::from_secs(1))` per interval. Waking at 9.5s instead of 10s avoids a tie with the tenth tick, which also settles the `diffs.len() == 8 || 9` ambiguity into an exact `8` and fixes its message (it read "There should be more than 8 or 9").
- `channel/interval.rs` — `test_interval_request_channel`, `test_multi_channel_requestors`: the three remaining `990..=1010` windows become `assert_eq!(tick.elapsed(), Duration::from_secs(1))`.

`TaskRequest::created_at` is a real-clock `std::time::Instant` (production type, unchanged), so it is bracketed against the test's own real span — `created_at >= started && created_at <= now` — rather than timed. That is a stronger claim than the previous one-sided `created_at < now`, and it removes the clock-resolution hazard that compressing the test would otherwise introduce.

No production code changes.

### Deliberately out of scope

- **The cron channel tests stay on the real clock.** `cron.rs` derives its sleep duration from `chrono::Local::now()` and then sleeps on the tokio clock. Pausing one clock and not the other would make every sleep complete while real time stands still, and the loop would busy-spin.
- **The `*count == N || N+1` assertions in the other scheduler tests** are the same family, but they carry deliberate slack (one is commented "environment load in CI can cause this to vary") and none has been observed failing. Converting them means re-deriving ten exact expectations across a test-suite rewrite, which does not belong in a flakiness fix.

## Test plan

- `make lint`
- `make test`
- Local: all 19 `scheduler` tests pass; both clippy passes (lib+bins, and `--tests`) are clean with zero diagnostics.
- **Neuter check** — the new assertions are load-bearing. Drifting the production interval by 40 ms (`Duration::from_secs(interval)` -> `from_millis(interval * 1000 + 40)`) fails all three tests deterministically in 0.00s with `left: 1.04s, right: 1s`. Note 40 ms is *larger* than the 30 ms overshoot that broke CI, and the old window would have caught it only nondeterministically.
- A busy-spin regression cannot be masked by the paused clock: a spinning runtime is never idle, so auto-advance never fires and the test hangs rather than falsely passing.
- The three tests drop from ~18s of real sleeping to **0.00s**.

## Checklist

- [x] Regression coverage: the converted tests fail on a drifted interval and pass on a correct one
- [x] No production code changed
- [x] Clippy clean (lib+bins and `--tests`)
- [x] `cargo fmt` applied

Fixes #12323