### PR TITLE
fix(runtime): stop retrying a dataset configuration failure that no retry can clear (fixes #12339)

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -526,6 +526,47 @@ pub enum Error {
     },
 }
 
+impl Error {
+    /// Returns `true` if this error is transient and the operation may succeed
+    /// on retry. Errors that are a pure function of the Spicepod configuration
+    /// (and the engine capabilities it selects) are permanent: they resolve
+    /// only when an operator edits the configuration, so retrying them is
+    /// wasted work. Mirrors [`DataConnectorError::is_retriable`], which
+    /// classifies the same way for connector creation.
+    ///
+    /// Anything not listed stays retriable. A misclassified transient error
+    /// would leave a recoverable dataset permanently unloaded, so the default
+    /// is the conservative one.
+    #[must_use]
+    pub(crate) fn is_retriable(&self) -> bool {
+        !matches!(
+            self,
+            // Invalid `refresh_sql` / `retention_sql` in the Spicepod.
+            Self::RefreshSql { .. }
+                | Self::RetentionSql { .. }
+                // `time_column`/`time_format` disagree with the source schema.
+                | Self::InvalidTimeColumnTimeFormat { .. }
+                | Self::AppendRequiresTimeColumn { .. }
+                // Refresh-mode and snapshot settings the selected engine or
+                // connector cannot serve.
+                | Self::InvalidCachingRefreshMode { .. }
+                | Self::ConflictingStaleWhileRevalidateConfig { .. }
+                | Self::UnsupportedDistributedAccelerationEngine { .. }
+                | Self::UnsupportedStreamBatchesForBatchRefresh
+                | Self::UnsupportedRefreshCompleteForStream
+                | Self::UnsupportedSnapshotTriggerForCaching
+                | Self::UnsupportedAccelerationEngineForSnapshots
+                | Self::SnapshotRefreshModeRequiresSnapshots
+                | Self::SnapshotRefreshModeUnsupportedEngine { .. }
+                | Self::SnapshotRefreshModeReloadUnsupported { .. }
+                // Unparseable `snapshots_trigger_threshold` value.
+                | Self::InvalidSnapshotCreationInterval { .. }
+                | Self::InvalidSnapshotCreationBatches { .. }
+                | Self::SnapshotCreationBatchesShouldBePositive
+        )
+    }
+}
+
 /// Validates that the acceleration engine is supported in distributed mode.
 ///
 /// Only Arrow, `PartitionedArrow`, and Cayenne engines are supported for distributed acceleration.

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -361,6 +361,18 @@ impl Runtime {
                     status::ComponentStatus::error_with_message(err.to_string()),
                 );
                 metrics::datasets::LOAD_ERROR.add(1, &[]);
+                if is_permanent_dataset_failure(&err) {
+                    error_spaced!(
+                        spaced_tracer,
+                        "Error initializing dataset {}. {err}",
+                        ds_name.table()
+                    );
+                    return PermanentDatasetFailureSnafu {
+                        dataset: ds_name.clone(),
+                        reason: err.to_string(),
+                    }
+                    .fail();
+                }
                 warn_spaced!(
                     spaced_tracer,
                     "Error initializing dataset {}. {err}",
@@ -424,6 +436,13 @@ impl Runtime {
                 ds_name,
                 status::ComponentStatus::error_with_message(err.to_string()),
             );
+            if is_permanent_dataset_failure(&err) {
+                return PermanentDatasetFailureSnafu {
+                    dataset: ds_name.clone(),
+                    reason: err.to_string(),
+                }
+                .fail();
+            }
             return Err(err);
         }
 
@@ -960,16 +979,15 @@ impl Runtime {
                     status::ComponentStatus::error_with_message(err.to_string()),
                 );
                 metrics::datasets::LOAD_ERROR.add(1, &[]);
-                if let Error::UnableToAttachDataConnector {
-                    source: crate::datafusion::Error::RefreshSql { .. },
-                    connector_component: _,
-                    data_connector: _,
-                } = &err
-                {
+                if is_permanent_dataset_failure(&err) {
                     error_spaced!(spaced_tracer, "{}{err}", "");
-                } else {
-                    warn_spaced!(spaced_tracer, "{}{err}", "");
+                    return PermanentDatasetFailureSnafu {
+                        dataset: ds.name.clone(),
+                        reason: err.to_string(),
+                    }
+                    .fail();
                 }
+                warn_spaced!(spaced_tracer, "{}{err}", "");
 
                 Err(err)
             }
@@ -1771,6 +1789,38 @@ pub struct RegisterDatasetContext {
     bootstrap_status: BootstrapStatus,
 }
 
+/// Returns `true` when a dataset load failure cannot be cleared by retrying it.
+///
+/// `load_dataset` retries with unbounded backoff and only short-circuits on
+/// [`Error::PermanentDatasetFailure`], so a failure that is a pure function of
+/// the Spicepod configuration would otherwise be retried for the life of the
+/// process — rebuilding the table provider, and re-running its side effects,
+/// on every attempt. Reading the source already classifies its failures this
+/// way through `DataConnectorError::is_retriable`; this covers the
+/// configuration errors raised on the rest of the load path.
+///
+/// Everything else stays retriable, so a source that is merely unreachable or
+/// an accelerator that is momentarily unavailable still recovers on its own.
+fn is_permanent_dataset_failure(err: &Error) -> bool {
+    match err {
+        // The Spicepod names a connector this build cannot provide.
+        Error::UnknownDataConnector { .. }
+        | Error::OdbcNotInstalled
+        // Dataset-level settings that contradict each other.
+        | Error::FullTextSearchRequiresAcceleration { .. }
+        | Error::AcceleratedWriteBackWithOnConflict { .. }
+        | Error::AcceleratedWriteBackWithoutReplication { .. } => true,
+        // Connector creation boxes its error, so recover the type the way the
+        // catalog load path does before asking it to classify itself.
+        Error::UnableToInitializeDataConnector { source } => source
+            .downcast_ref::<dataconnector::DataConnectorError>()
+            .is_some_and(|err| !err.is_retriable()),
+        // Registration carries the accelerated-table configuration errors.
+        Error::UnableToAttachDataConnector { source, .. } => !source.is_retriable(),
+        _ => false,
+    }
+}
+
 #[expect(clippy::result_large_err)]
 fn validate_dataset(ds: &Arc<Dataset>) -> Result<()> {
     if ds.has_full_text_column() && !ds.is_accelerated() {
@@ -1963,6 +2013,156 @@ mod tests {
             err.to_string()
                 .contains("acceleration is required for full text search"),
             "unexpected error: {err}"
+        );
+    }
+
+    struct SchemaOnlyConnectorFactory;
+
+    impl DataConnectorFactory for SchemaOnlyConnectorFactory {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn create(
+            &self,
+            _params: ConnectorParams,
+        ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
+            Box::pin(async { Ok(Arc::new(SchemaOnlyConnector) as Arc<dyn DataConnector>) })
+        }
+
+        fn prefix(&self) -> &'static str {
+            "schema_only"
+        }
+
+        fn parameters(&self) -> &'static [ParameterSpec] {
+            &[]
+        }
+    }
+
+    #[derive(Debug)]
+    struct SchemaOnlyConnector;
+
+    #[async_trait]
+    impl DataConnector for SchemaOnlyConnector {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        async fn read_provider(
+            &self,
+            _dataset: &Dataset,
+        ) -> DataConnectorResult<Arc<dyn TableProvider>> {
+            let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+                "id",
+                arrow_schema::DataType::Int64,
+                false,
+            )]));
+            let table = datafusion::datasource::MemTable::try_new(schema, vec![vec![]])
+                .expect("empty MemTable with a single column");
+            Ok(Arc::new(table) as Arc<dyn TableProvider>)
+        }
+    }
+
+    /// Regression test for #12339: a `time_column` the source schema does not
+    /// have is a configuration error no retry can clear, so registration must
+    /// report it as a permanent failure rather than letting `load_dataset`
+    /// retry it for the life of the process.
+    #[tokio::test]
+    async fn a_dataset_configuration_error_fails_permanently() {
+        register_connector_factory("schema_only", Arc::new(SchemaOnlyConnectorFactory)).await;
+
+        let mut dataset =
+            spicepod::component::dataset::Dataset::new("schema_only:any", "missing_time_column");
+        dataset.acceleration = Some(spicepod::acceleration::Acceleration {
+            enabled: true,
+            ..spicepod::acceleration::Acceleration::default()
+        });
+        dataset.time_column = Some("not_in_the_source_schema".to_string());
+
+        let app = app::AppBuilder::new("permanent_configuration_failure")
+            .with_dataset(dataset.clone())
+            .build();
+        let runtime = Arc::new(crate::Runtime::builder().build().await);
+        let ds = DatasetBuilder::try_from(dataset)
+            .expect("valid dataset builder")
+            .with_app(Arc::new(app))
+            .with_runtime(Arc::clone(&runtime))
+            .build()
+            .expect("valid runtime dataset");
+
+        let err = runtime
+            .try_load_dataset_once(Arc::new(ds), BootstrapStatus::None, None)
+            .await
+            .expect_err("a missing time column should fail the load");
+
+        assert!(
+            matches!(err, Error::PermanentDatasetFailure { .. }),
+            "expected a permanent failure, got: {err}"
+        );
+    }
+
+    /// A `from:` no build of the runtime can resolve is settled at parse time,
+    /// so it must not be retried either.
+    #[tokio::test]
+    async fn an_unknown_connector_fails_permanently() {
+        let dataset = spicepod::component::dataset::Dataset::new(
+            "not_a_real_connector:any",
+            "unknown_connector",
+        );
+
+        let app = app::AppBuilder::new("unknown_connector")
+            .with_dataset(dataset.clone())
+            .build();
+        let runtime = Arc::new(crate::Runtime::builder().build().await);
+        let ds = DatasetBuilder::try_from(dataset)
+            .expect("valid dataset builder")
+            .with_app(Arc::new(app))
+            .with_runtime(Arc::clone(&runtime))
+            .build()
+            .expect("valid runtime dataset");
+
+        let err = runtime
+            .try_load_dataset_once(Arc::new(ds), BootstrapStatus::None, None)
+            .await
+            .expect_err("an unknown connector should fail the load");
+
+        assert!(
+            matches!(err, Error::PermanentDatasetFailure { .. }),
+            "expected a permanent failure, got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_contradictory_dataset_configuration_is_permanent() {
+        let err = FullTextSearchRequiresAccelerationSnafu {
+            dataset_name: "docs".to_string(),
+        }
+        .build();
+        assert!(
+            is_permanent_dataset_failure(&err),
+            "full-text search without acceleration cannot resolve itself"
+        );
+    }
+
+    #[test]
+    fn only_configuration_errors_are_classified_permanent() {
+        use crate::datafusion::Error as DfError;
+
+        assert!(
+            !DfError::UnsupportedRefreshCompleteForStream.is_retriable(),
+            "a refresh setting the source cannot serve needs an operator to change it"
+        );
+        assert!(
+            !DfError::SnapshotCreationBatchesShouldBePositive.is_retriable(),
+            "an out-of-range Spicepod value needs an operator to change it"
+        );
+        assert!(
+            DfError::TableAlreadyExists {}.is_retriable(),
+            "an unclassified registration failure must keep retrying"
+        );
+        assert!(
+            DfError::UnableToLockDataWriters {}.is_retriable(),
+            "contention on an internal lock is transient"
         );
     }
 }


### PR DESCRIPTION
## Summary

`Runtime::load_dataset` retries dataset initialization with unbounded Fibonacci backoff (capped at one attempt every five minutes) and stops only on `Error::PermanentDatasetFailure`. Reading the source classifies its own failures — `DataConnectorError::is_retriable()` gates the one `PermanentDatasetFailure` raise site — but every other failure on the load path fell through to `RetryError::transient`.

A deterministic configuration error was therefore retried for the life of the process: the dataset never became ready, and each attempt rebuilt the table provider and re-ran its construction side effects. That is the amplifier behind #12330, where one dataset failing a load-time validation re-emitted a ~1.1 KB Cayenne configuration line at Fibonacci-spaced intervals indefinitely.

The catalog load path already classifies this way (`init/catalog.rs` asks `catalogconnector::Error::is_configuration_error` before returning `RetryError::permanent`); datasets were the outlier.

Fixes #12339

## Changes

**`crates/runtime/src/datafusion/mod.rs` — `Error::is_retriable()`**, mirroring `DataConnectorError::is_retriable()`. It lists the variants that are a pure function of the Spicepod and the engine capabilities it selects: invalid `refresh_sql`/`retention_sql`, a `time_column`/`time_format` the schema cannot satisfy, refresh-mode and snapshot settings the selected engine or connector cannot serve, and an unparseable `snapshots_trigger_threshold`. Everything unlisted stays retriable, so a new variant defaults to today's behaviour.

**`crates/runtime/src/init/dataset.rs` — `is_permanent_dataset_failure()`**, applied at the three load-path sites that previously returned an unclassified error:

- dataset validation (`full_text_search` without acceleration),
- connector creation (an unknown `from:` prefix, ODBC not built in — the error is boxed at that boundary, so the type is recovered with a `downcast_ref` the same way `init/catalog.rs` does),
- registration (the accelerated-table configuration errors above, plus the two `write_mode: write_back` combinations rejected in `register_dataset`).

Each of those now returns `PermanentDatasetFailure`, which the retry loop already understands, and logs at ERROR rather than WARN — matching the existing permanent path. The dataset's status message is unchanged: it is still set from the original error before the conversion, so the operator sees the specific, actionable message rather than the wrapper.

This subsumes the previous special case that logged only `RefreshSql` at ERROR.

## Trade-offs and scope

- **`InvalidTimeColumnTimeFormat` depends on the source schema, not only on the Spicepod.** If the source later grows the missing column, the dataset no longer self-heals within a refresh interval and needs a reload. It is classified permanent anyway because it is a configuration-versus-schema disagreement whose stated remedy is a configuration change, and because the equally schema-dependent `DataConnectorError::UnsupportedDataType` is already non-retriable. `DataConnectorError::SchemaMismatch` — which is documented to self-heal when the source reverts — remains retriable.
- **Left retriable deliberately:** `AcceleratorEngineNotAvailable` and `ExpectedAccelerationSettings` (registry/invariant state rather than user configuration), `UnableToCreateDataAccelerator` and the snapshot layout errors (filesystem-backed, so a later attempt can succeed), and everything reached through a boxed error that is not a `DataConnectorError`.
- A latent bug in `accelerated_table::refresh`'s `test_refresh_status_change_to_ready` is fixed in passing: it read `dataset_load_state.get_metric()[0]`, i.e. whichever series sorted first in a process-wide metric family, so any other test in the binary that leaves a dataset in a non-Ready state could fail it. It now matches on its own `dataset` label.

## Test plan

- [x] `make lint`
- [x] `make test`
- [x] New: `a_dataset_configuration_error_fails_permanently` — the issue's reported shape end to end (a `time_column` absent from the source schema) through `try_load_dataset_once`, asserting `PermanentDatasetFailure`. Reverting the classifier to always-`false` fails it deterministically with the original error text (`time_column 'not_in_the_source_schema' was not found in dataset missing_time_column`).
- [x] New: `an_unknown_connector_fails_permanently` — the connector-creation site, through the same production entry point.
- [x] New: `a_contradictory_dataset_configuration_is_permanent` — the validation site.
- [x] New: `only_configuration_errors_are_classified_permanent` — both directions of the classifier, so an unlisted variant keeps retrying.

## Checklist

- [x] Tests added for the fix
- [x] No behaviour change for failures that can still succeed on retry
- [x] Error messages unchanged in the dataset status
