### PR TITLE
fix(testoperator): reject a client fleet the HTTP executors cannot bound (fixes #12348)

### DIFF
--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -166,16 +166,24 @@ impl Fleet {
         self.clients * self.queries_per_client
     }
 
-    /// Client-side connection slots across the fleet: `clients` pools of
-    /// `connections_per_client` each.
+    /// Client-side connection slots *provisioned* across the fleet: `clients`
+    /// pools of `connections_per_client` each.
     ///
-    /// This equals the connections the server sees only when one executor object
-    /// is one connection on the wire — true for the Flight executor, whose
-    /// `spiceai::Client` is a single multiplexed HTTP/2 channel however many
-    /// workers share it. It is NOT true of a `reqwest`-backed executor, where an
-    /// executor is an uncapped HTTP/1.1 pool that opens a connection per
-    /// concurrent in-flight request; [`DatasetTestArgs::validate_fleet`] rejects
-    /// that combination rather than reporting a figure it cannot establish.
+    /// This is the configured size, not a prediction of what the server will
+    /// observe, and the two coincide only under both of these:
+    ///
+    /// - One executor object is one connection on the wire. True for the Flight
+    ///   executor, whose `spiceai::Client` is a single multiplexed HTTP/2 channel
+    ///   however many workers share it. NOT true of a `reqwest`-backed executor,
+    ///   where an executor is an uncapped HTTP/1.1 pool that opens a connection
+    ///   per concurrent in-flight request; [`DatasetTestArgs::validate_fleet`]
+    ///   rejects that combination rather than reporting a figure it cannot
+    ///   establish.
+    /// - Every slot is actually exercised. [`Self::connection_for_worker`] hands a
+    ///   client's threads round-robin over that client's own pool, so a client
+    ///   touches `min(connections_per_client, queries_per_client)` of its slots; an
+    ///   over-provisioned pool leaves the remainder idle and the server sees fewer
+    ///   connections than this returns.
     #[must_use]
     pub fn total_connections(&self) -> usize {
         self.clients * self.connections_per_client
@@ -415,9 +423,11 @@ impl DatasetTestArgs {
             "--clients/--connections-per-client/--queries-per-client model a connection pool per \
              client, which needs the Flight executor: an HTTP executor (--http-clients, \
              --distributed) opens a connection per concurrent request, so \
-             --connections-per-client would not bound anything. Drop the HTTP flag, or use \
-             --client-connections per-client (one pool per query thread, which an HTTP executor \
-             does honor)"
+             --connections-per-client would not bound anything. Pick one: (1) drop \
+             --http-clients/--distributed and keep the fleet flags to run it over Flight, or (2) \
+             drop the fleet flags and pass --client-connections per-client (one pool per query \
+             thread, which an HTTP executor does honor) — the fleet flags and \
+             --client-connections describe the same topology and cannot be combined"
         );
         Ok(())
     }

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -166,7 +166,16 @@ impl Fleet {
         self.clients * self.queries_per_client
     }
 
-    /// Connections the server actually sees.
+    /// Client-side connection slots across the fleet: `clients` pools of
+    /// `connections_per_client` each.
+    ///
+    /// This equals the connections the server sees only when one executor object
+    /// is one connection on the wire — true for the Flight executor, whose
+    /// `spiceai::Client` is a single multiplexed HTTP/2 channel however many
+    /// workers share it. It is NOT true of a `reqwest`-backed executor, where an
+    /// executor is an uncapped HTTP/1.1 pool that opens a connection per
+    /// concurrent in-flight request; [`DatasetTestArgs::validate_fleet`] rejects
+    /// that combination rather than reporting a figure it cannot establish.
     #[must_use]
     pub fn total_connections(&self) -> usize {
         self.clients * self.connections_per_client
@@ -393,6 +402,23 @@ impl DatasetTestArgs {
                 && fleet.queries_per_client >= 1,
             "--clients, --connections-per-client and --queries-per-client must each be at least 1"
         );
+        // A fleet promises the server sees `clients * connections-per-client`
+        // connections, and its `connections-per-client` dimension only means
+        // anything if a shared executor is a shared connection. That holds for
+        // the Flight executor (one multiplexed HTTP/2 channel per client) but
+        // not for a `reqwest`-backed one: that is a pool with no maximum, so the
+        // threads sharing it each open their own connection and the dimension is
+        // inert. Refuse the combination rather than announce a topology that was
+        // never established.
+        anyhow::ensure!(
+            !self.http_clients && !self.distributed,
+            "--clients/--connections-per-client/--queries-per-client model a connection pool per \
+             client, which needs the Flight executor: an HTTP executor (--http-clients, \
+             --distributed) opens a connection per concurrent request, so \
+             --connections-per-client would not bound anything. Drop the HTTP flag, or use \
+             --client-connections per-client (one pool per query thread, which an HTTP executor \
+             does honor)"
+        );
         Ok(())
     }
 }
@@ -557,6 +583,67 @@ mod tests {
             .map(|w| f.connection_for_worker(w))
             .collect();
         assert_eq!(conns, vec![0, 1, 0, 1, 0]);
+    }
+
+    /// Parse a `DatasetTestArgs` from flags, defaulting everything the fleet
+    /// tests do not care about. `--query-set` is the one argument with no
+    /// default.
+    fn args_from(flags: &[&str]) -> DatasetTestArgs {
+        let mut argv = vec!["testoperator", "--query-set", "tpch"];
+        argv.extend_from_slice(flags);
+        DatasetTestArgs::try_parse_from(argv).expect("flags parse")
+    }
+
+    const FLEET_FLAGS: [&str; 6] = [
+        "--clients",
+        "4",
+        "--connections-per-client",
+        "2",
+        "--queries-per-client",
+        "32",
+    ];
+
+    #[test]
+    fn a_fleet_is_accepted_for_the_flight_executor() {
+        // The default executor is Flight, where one `spiceai::Client` is one
+        // multiplexed HTTP/2 channel however many workers share it — so
+        // `connections-per-client` really does bound what the server sees.
+        let args = args_from(&FLEET_FLAGS);
+        args.validate_fleet().expect("a Flight fleet is valid");
+        assert_eq!(args.effective_concurrency(), 128);
+    }
+
+    #[test]
+    fn a_fleet_is_rejected_for_http_backed_executors() {
+        // A `reqwest` pool has no maximum, so the threads sharing one open a
+        // connection each and `connections-per-client` bounds nothing. Announcing
+        // "8 connections" for what the server sees as up to 128 would make a
+        // connection-scale run measure something other than what it reports.
+        for http_flag in ["--http-clients", "--distributed"] {
+            let mut flags = FLEET_FLAGS.to_vec();
+            flags.push(http_flag);
+            let err = args_from(&flags)
+                .validate_fleet()
+                .expect_err("a fleet over an HTTP executor must be rejected")
+                .to_string();
+            assert!(
+                err.contains("Flight executor"),
+                "{http_flag} rejection must name the executor that supports a fleet, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn per_client_connections_remain_valid_over_http() {
+        // Deliberately NOT rejected: one pool per query thread means one
+        // in-flight request per pool, so an HTTP executor does establish exactly
+        // the advertised connection per client. Only the fleet's shared-pool
+        // dimension is unrealizable.
+        for http_flag in ["--http-clients", "--distributed"] {
+            let args = args_from(&["--client-connections", "per-client", http_flag]);
+            args.validate_fleet()
+                .expect("per-client over HTTP stays valid");
+        }
     }
 
     #[test]

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -503,7 +503,10 @@ pub(crate) async fn create_query_executor(
 /// * a fleet (`--clients`/`--connections-per-client`/`--queries-per-client`) —
 ///   `clients * connections_per_client` connections total, with each client's
 ///   threads confined to that client's own pool, the way an application
-///   server's pool is private to its process.
+///   server's pool is private to its process. Flight only: sharing one executor
+///   between threads is only a shared *connection* on a multiplexed HTTP/2
+///   channel, so [`DatasetTestArgs::validate_fleet`] rejects a fleet over the
+///   `reqwest`-backed executors.
 ///
 /// Connections are established lazily on each worker's first query, so building
 /// a large number up-front is cheap.


### PR DESCRIPTION
## Summary

The `testoperator` client-fleet flags (`--clients` / `--connections-per-client` / `--queries-per-client`, on `run throughput` and `run load`) announce a server-visible connection count they do not establish when the executor is HTTP-backed. `Fleet::total_connections()` documented itself as "Connections the server actually sees", and `announce_connection_topology` prints it as fact:

```
Client fleet: 4 clients x 2 connections each = 8 connections; 32 query threads each = 128 concurrent queries
```

With `--http-clients` or `--distributed` the server can see up to **128** connections, not 8.

### Root cause

The claim holds only when one executor object is one connection on the wire, and the executors differ:

- `FlightExecutor` holds an `Arc<spiceai::Client>` — one multiplexed HTTP/2 channel. Any number of workers sharing a cloned executor really is one connection, so the fleet arithmetic is exact.
- `HttpExecutor` / `DistributedExecutor` hold a `reqwest::Client`, built in `SpicedInstance::http_client()` from `reqwest::Client::builder()` with no pool cap and no forced HTTP/2. That is a connection *pool*: each concurrent in-flight request opens its own TCP connection.

So when `queries_per_client > connections_per_client` — the case the fleet exists to model — the workers that `connection_for_worker` round-robins onto one shared `reqwest::Client` each hold a request open at once, the pool grows a connection per worker, and `connections_per_client` bounds nothing. That is exactly the property `threads_round_robin_within_their_pool` claims to pin; the existing tests exercise `Fleet`'s arithmetic and never an executor, so they pass either way.

A connection-scale benchmark therefore records an independent variable that was never set: comparing 8 against 512 configured connections over HTTP really compares the same worker count against a pool that sizes itself to the load.

### Why reject rather than fix or relabel

`reqwest` exposes no maximum-connections setting, so realizing the topology would take a semaphore per pool — which changes what is being measured rather than measuring it. Rejecting matches the precedent this code already sets with `ensure_shared_client_connections`, which refuses topology flags on commands that cannot honor them instead of ignoring them.

`--client-connections per-client` is deliberately **not** rejected: one pool per query thread means one in-flight request per pool, so an HTTP executor does establish exactly the advertised connection per client. Only the fleet's shared-pool dimension is unrealizable. The default `shared` mode is unaffected — its docs already said "one HTTP pool" rather than one connection.

## Changes

- `validate_fleet()` rejects the fleet flags when `--http-clients` or `--distributed` is set, naming Flight as the mode that supports them and pointing at `--client-connections per-client` as the HTTP-capable alternative. It is already called at both command entry points (`throughput`, `load`) and inside `create_client_executors`, so every fleet-reachable path validates.
- `Fleet::total_connections()`'s doc now states what it counts and why it equals the server-visible figure only for Flight.
- `create_client_executors`'s doc carries the same Flight-only constraint, so a reader there does not have to find `validate_fleet` to learn it.

## Test plan

- `make lint`
- `make nextest`
- New unit tests in `tools/testoperator/src/args/dataset.rs`:
  - `a_fleet_is_accepted_for_the_flight_executor` — the default executor still takes a fleet, and `effective_concurrency()` is the fleet total.
  - `a_fleet_is_rejected_for_http_backed_executors` — both `--http-clients` and `--distributed` are refused, and the message names the supported executor.
  - `per_client_connections_remain_valid_over_http` — pins the carve-out, so the guard cannot widen into rejecting a topology HTTP does honor.
- Neuter check: forcing the new guard to `true` fails `a_fleet_is_rejected_for_http_backed_executors` deterministically ("a fleet over an HTTP executor must be rejected"), with the other six tests still green — so the guard is load-bearing rather than restating an existing check.

## Checklist

- [x] Tests added that fail without the change
- [x] `cargo clippy -p testoperator --bins` clean
- [x] `cargo fmt` applied
- [x] No behavior change for Flight fleets, `per-client`, or the default `shared` mode

Fixes #12348
