### PR TITLE
fix(ci): make a failed re-sign-off reach the required Attestation check (fixes #12346)

### DIFF
--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -253,11 +253,19 @@ it has a verdict of its own, so a run that never finishes cannot cost you an
 attestation. `mine` still shows ⟳ while it runs — that comes from the run list,
 not the commit status.
 
-A re-dispatch that *does* fail posts `signoff=failure`, but note that this does
-not by itself close the gate: **Attestation** is the required check, `pr.yml`
-does not run on commit-status changes, and an already-green Attestation is left
-alone. Re-run that check (or push) if a failed re-sign-off needs to be reflected
-in the PR's required checks.
+A re-dispatch that *does* fail posts `signoff=failure` and then re-runs
+**Attestation** so the required check reflects that verdict. The status alone
+would not close the gate — **Attestation** is the required check and `pr.yml`
+does not run on commit-status changes — so the failure path forces the re-run
+even when the check is already green, which is the one case the success path
+deliberately skips. If the status post itself fails, the run says so and leaves
+**Attestation** showing the previous sign-off; re-dispatch or push to move it.
+
+Two cases the re-run cannot cover, both reported by the run rather than hidden:
+an **Attestation** run that is still in flight may already have read the status
+this verdict replaced, so it can finish green and needs re-running by hand; and
+a HEAD that only merges the base branch can *inherit* an earlier sign-off, which
+the failing status on HEAD does not veto ([#12357](https://github.com/spiceai/spiceai/issues/12357)).
 
 A branch whose sign-off keeps running out of budget is contending for the pool
 rather than doing anything wrong. `-f skip_targeted_lint=true` drops the

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -830,7 +830,9 @@ run_checks() {
 # third argument to force the re-run past that short-circuit.
 refresh_attestation_check() {
   local sha="$1" repo="$2" force="${3:-}"
-  local fallback="Open/refresh the PR and it will re-read the sign-off status."
+  # pr.yml runs on `pull_request`/`merge_group`/`workflow_dispatch`, so viewing
+  # the PR page does not start one — say what actually re-reads the status.
+  local fallback="Re-run the PR's 'Attestation' check from the Checks tab once it has reported — reloading the PR page does not re-read the sign-off status."
   local run run_id run_status run_conclusion
 
   if ! command -v gh >/dev/null 2>&1; then

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -815,17 +815,22 @@ run_checks() {
   SIGNOFF_CHECK_SUMMARY="lint+test passed"
 }
 
-# After a successful sign-off, the PR's `Attestation` job (pr.yml) only
-# re-evaluates the `signoff` commit status when its workflow run executes. If
-# that run already completed — e.g. sign-off happened after the PR's checks
-# ran — `Attestation` is stuck showing a stale failure until something
-# re-triggers it. Re-run that job instead of making the developer open or
-# refresh the PR by hand. `gh` is already required by require_tools() before
-# cmd_signoff can reach this point, but the check stays here so this function
-# remains correct if it's ever called on its own.
+# The PR's `Attestation` job (pr.yml) only re-reads the `signoff` commit status
+# when its workflow run executes: pr.yml triggers on `pull_request`,
+# `merge_group` and `workflow_dispatch`, never on a status change. So a run that
+# already completed keeps whatever verdict it reached, however the status has
+# moved since. Re-run that job instead of making the developer open or refresh
+# the PR by hand. `gh` is already required by require_tools() before cmd_signoff
+# can reach this point, but the check stays here so this function remains
+# correct if it's ever called on its own.
+#
+# A run that concluded `success` needs no refresh when this sign-off also
+# succeeded — but it needs one precisely when the sign-off failed, or the gate
+# keeps reporting an attestation this run just overturned. Pass a non-empty
+# third argument to force the re-run past that short-circuit.
 refresh_attestation_check() {
-  local sha="$1" repo="$2"
-  local fallback="Open/refresh the PR and it will pick up the sign-off."
+  local sha="$1" repo="$2" force="${3:-}"
+  local fallback="Open/refresh the PR and it will re-read the sign-off status."
   local run run_id run_status run_conclusion
 
   if ! command -v gh >/dev/null 2>&1; then
@@ -848,10 +853,21 @@ refresh_attestation_check() {
     return 0
   fi
   if [[ "$run_status" != "completed" ]]; then
-    info "  The 'Attestation' check (run ${run_id}) is still ${run_status} — it will evaluate the sign-off once it finishes."
+    # A run that is still going may already have read the status — the read is
+    # the first thing its job does, and validating an inherited sign-off keeps
+    # it busy long after. So "it will evaluate the sign-off once it finishes"
+    # holds only when the status it is about to report is the one we want; on
+    # the failure path an in-flight run can still land green on what it read
+    # before this verdict existed, and there is nothing to re-run yet.
+    if [[ -n "$force" ]]; then
+      info "  The 'Attestation' check (run ${run_id}) is still ${run_status} and may have read the previous sign-off already."
+      info "  Re-run it once it finishes if it lands green — this sign-off failed."
+    else
+      info "  The 'Attestation' check (run ${run_id}) is still ${run_status} — it will evaluate the sign-off once it finishes."
+    fi
     return 0
   fi
-  if [[ "$run_conclusion" == "success" ]]; then
+  if [[ "$run_conclusion" == "success" && -z "$force" ]]; then
     debug "run ${run_id} already succeeded — nothing to refresh"
     return 0
   fi
@@ -859,11 +875,38 @@ refresh_attestation_check() {
   # Not `--failed`: that only reruns jobs with conclusion=failure and no-ops
   # on cancelled/skipped runs. Rerunning the whole run is fine here — on a
   # `pull_request` event, pr.yml executes nothing but the Attestation job.
+  local outcome="it will turn green shortly"
+  [[ -z "$force" ]] || outcome="it will pick up the failed sign-off"
   if gh run rerun "$run_id" --repo "$repo" >/dev/null 2>&1; then
-    echo "  Re-ran the 'Attestation' check (run ${run_id}) — it will turn green shortly."
+    echo "  Re-ran the 'Attestation' check (run ${run_id}) — ${outcome}."
   else
     info "  Could not auto-refresh the 'Attestation' check — ${fallback}"
   fi
+}
+
+# Post this run's failing verdict, then make the gate reflect it.
+#
+# The raw `signoff` status is not itself a required check — `Attestation` is,
+# and it only re-reads the status when its pr.yml run executes. A commit that
+# was already attested therefore keeps a green `Attestation` after a later run
+# overturns it, and the branch can still enter the merge queue on an attestation
+# this run contradicted. The merge queue re-runs the full suite, so that cannot
+# put broken code on trunk; it spends a queue slot learning what the sign-off
+# already knew. Hence the forced refresh — the inverse of the success path,
+# which is right to skip a run that already passed.
+#
+# When the post itself fails the commit still carries whatever it had before, so
+# there is nothing new for a re-run to read: warn and leave the check alone. The
+# caller aborts either way, with the more useful message.
+post_failure_status() {
+  local repo="$1" sha="$2" user="$3" elapsed="$4"
+
+  if ! post_commit_status "$repo" "$sha" failure \
+    "Sign-off checks failed after ${elapsed}s (triggered by ${user})"; then
+    info "warning: could not post the failed sign-off status — the 'Attestation' check still reflects the previous sign-off"
+    return 0
+  fi
+  refresh_attestation_check "$sha" "$repo" force
 }
 
 cmd_signoff() {
@@ -919,9 +962,7 @@ cmd_signoff() {
     if [[ "$check_status" -ne 0 ]]; then
       elapsed=$(( $(date +%s) - start ))
       if is_remote_run; then
-        post_commit_status "$repo" "$sha" failure \
-          "Sign-off checks failed after ${elapsed}s (triggered by ${user})" \
-          || true
+        post_failure_status "$repo" "$sha" "$user" "$elapsed"
         append_step_summary "### Sign-off"$'\n'"**Failed** after ${elapsed}s."$'\n'
       fi
       fail "sign-off checks failed"

--- a/scripts/test_signoff_status.sh
+++ b/scripts/test_signoff_status.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 #
 # Unit tests for the `signoff` commit status: which states `scripts/signoff` may
-# post over which, in both directions — the in-progress `pending` a remote run
-# posts on the way in, and the `clear-pending` that resolves one left behind. No
-# network and no credentials: a stub `gh` on PATH serves a canned commit status
-# and records every status the subject posts back.
+# post over which — the in-progress `pending` a remote run posts on the way in,
+# the `clear-pending` that resolves one left behind, and the failing verdict —
+# plus whether each of those reaches the `Attestation` check that gates the PR.
+# No network and no credentials: a stub `gh` on PATH serves a canned commit
+# status and workflow run, and records every status posted and run re-run.
 #
 # Usage: scripts/test_signoff_status.sh
 
@@ -21,10 +22,14 @@ fail_test() {
   echo "  FAIL: $1"
 }
 
-# A `gh` that answers the two calls the subject makes: read the combined status
-# for a commit, and post a new one. STUB_STATE is the `signoff` state the read
-# reports ("none" for a commit that has none); STUB_READ_RC makes the read fail;
-# every post is appended to STUB_POSTS as `state<TAB>context<TAB>description`.
+# A `gh` that answers the four calls the subject makes: read the combined status
+# for a commit, post a new one, list the PR's workflow run, and re-run it.
+# STUB_STATE is the `signoff` state the read reports ("none" for a commit that
+# has none); STUB_READ_RC makes the read fail and STUB_POST_RC makes the post
+# fail; every post that lands is appended to STUB_POSTS as
+# `state<TAB>context<TAB>description`. STUB_RUN is the `<id> <status>
+# <conclusion>` line the run list reports (empty for no run yet) and every
+# re-run id is appended to STUB_RERUNS.
 write_gh_stub() {
   local dir="$1"
   cat >"$dir/gh" <<'STUB'
@@ -34,6 +39,20 @@ set -uo pipefail
 case "${1:-}" in
   auth) exit 0 ;;
   repo) echo "spiceai/spiceai"; exit 0 ;;
+  run)
+    case "${2:-}" in
+      # The subject asks gh's own jq for one flattened line, so answer with the
+      # value that expression would have produced.
+      list)
+        [[ "${STUB_RUN_LIST_RC:-0}" == "0" ]] || exit "${STUB_RUN_LIST_RC}"
+        [[ -z "${STUB_RUN:-}" ]] || printf '%s\n' "${STUB_RUN}"
+        exit 0 ;;
+      rerun)
+        printf '%s\n' "${3:-}" >>"${STUB_RERUNS:-/dev/null}"
+        exit "${STUB_RERUN_RC:-0}" ;;
+    esac
+    echo "stub gh: unexpected run subcommand: $*" >&2
+    exit 64 ;;
 esac
 
 if [[ "${1:-}" != "api" ]]; then
@@ -42,6 +61,8 @@ if [[ "${1:-}" != "api" ]]; then
 fi
 
 if [[ "$*" == *"--method POST"* ]]; then
+  # A post that fails records nothing: the status never landed on the commit.
+  [[ "${STUB_POST_RC:-0}" == "0" ]] || exit "${STUB_POST_RC}"
   state="" context="" description=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -161,6 +182,93 @@ assert_pending_post() {
   echo "  ok: $name"
 }
 
+# Calls post_failure_status against a commit whose Attestation run is described
+# by $2 (`<id> <status> <conclusion>`, empty for no run yet), then checks that
+# the failing verdict was posted ($3, empty = expect no post) and that the check
+# was re-run ($4, empty = expect no re-run). $5, when set, fails the post.
+assert_failure_post() {
+  local name="$1" run="$2" want_state="${3:-}" want_rerun="${4:-}" post_rc="${5:-0}"
+  tests_run=$((tests_run + 1))
+
+  local posts="$stub_dir/posts" reruns="$stub_dir/reruns"
+  : >"$posts"
+  : >"$reruns"
+
+  local output rc
+  output="$(PATH="$stub_dir:$PATH" STUB_POSTS="$posts" STUB_RERUNS="$reruns" \
+    STUB_RUN="$run" STUB_POST_RC="$post_rc" \
+    bash -c 'source "$1"; post_failure_status spiceai/spiceai "$2" someone 42' \
+    _ "$subject" "$fake_sha" 2>&1)"
+  rc=$?
+
+  # Reporting the verdict must not pre-empt the caller's own failure path.
+  if [[ "$rc" -ne 0 ]]; then
+    fail_test "$name: expected exit 0, got ${rc} (output: ${output})"
+    return
+  fi
+
+  local posted
+  posted="$(cat "$posts")"
+  if [[ -z "$want_state" ]]; then
+    if [[ -n "$posted" ]]; then
+      fail_test "$name: expected no status to be posted, got '${posted}'"
+      return
+    fi
+  elif [[ "$posted" != "${want_state}"$'\t'"signoff"$'\t'* ]]; then
+    fail_test "$name: expected a '${want_state}' status in the 'signoff' context, got '${posted}'"
+    return
+  fi
+
+  assert_reruns "$name" "$reruns" "$want_rerun" "$output"
+}
+
+# Calls refresh_attestation_check directly against the run described by $2, with
+# force set from $3, and checks which run id (if any) was re-run. $6, when set,
+# is a substring the output must carry.
+assert_attestation_refresh() {
+  local name="$1" run="$2" force="$3" want_rerun="${4:-}" list_rc="${5:-0}" want_output="${6:-}"
+  tests_run=$((tests_run + 1))
+
+  local reruns="$stub_dir/reruns"
+  : >"$reruns"
+
+  local output rc
+  output="$(PATH="$stub_dir:$PATH" STUB_RERUNS="$reruns" STUB_RUN="$run" \
+    STUB_RUN_LIST_RC="$list_rc" \
+    bash -c 'source "$1"; refresh_attestation_check "$2" spiceai/spiceai "$3"' \
+    _ "$subject" "$fake_sha" "$force" 2>&1)"
+  rc=$?
+
+  # Never fatal: the sign-off's own verdict has already been recorded.
+  if [[ "$rc" -ne 0 ]]; then
+    fail_test "$name: expected exit 0, got ${rc} (output: ${output})"
+    return
+  fi
+  if [[ -n "$want_output" && "$output" != *"$want_output"* ]]; then
+    fail_test "$name: expected the output to carry '${want_output}', got '${output}'"
+    return
+  fi
+
+  assert_reruns "$name" "$reruns" "$want_rerun" "$output"
+}
+
+# Shared tail of the two helpers above: exactly the expected run was re-run.
+assert_reruns() {
+  local name="$1" reruns="$2" want_rerun="$3" output="$4"
+  local rerun
+  rerun="$(tr -d '\n' <"$reruns")"
+
+  if [[ "$rerun" != "$want_rerun" ]]; then
+    if [[ -z "$want_rerun" ]]; then
+      fail_test "$name: expected no 'Attestation' re-run, got run ${rerun} (output: ${output})"
+    else
+      fail_test "$name: expected run ${want_rerun} to be re-run, got '${rerun}' (output: ${output})"
+    fi
+    return
+  fi
+  echo "  ok: $name"
+}
+
 # The BASH_SOURCE guard that makes the subject sourceable must not stop it from
 # dispatching when it is executed — every other caller runs it that way.
 assert_dispatches_when_executed() {
@@ -204,6 +312,54 @@ assert_pending_post "an unreadable status posts nothing" success "" 1
 assert_pending_post "an unreadable status posts nothing even with none cached" none "" 1
 
 assert_dispatches_when_executed
+
+echo
+echo "scripts/signoff — the failing verdict and the gate that reads it"
+
+# The bug: `Attestation` is the required check and pr.yml never runs on a
+# commit-status change, so a re-sign-off that failed left the green attestation
+# it had just overturned in place and the branch could still enter the queue.
+assert_failure_post "a failed re-sign-off re-runs an already-green Attestation" \
+  "4242 completed success" failure 4242
+
+# Same post, and the refresh is what it always was for a check that is not green.
+assert_failure_post "a failed sign-off re-runs a red Attestation" \
+  "4242 completed failure" failure 4242
+
+# Nothing to re-read when the status never landed — and the previous
+# attestation, which the check is still reporting, is what the commit still has.
+assert_failure_post "a post that fails leaves the check alone" \
+  "4242 completed success" "" "" 1
+
+# A run still going will read the verdict when it finishes; there is no run at
+# all before the PR's first pr.yml run.
+assert_failure_post "an in-flight Attestation is not re-run" \
+  "4242 in_progress null" failure
+assert_failure_post "a commit with no Attestation run is not re-run" \
+  "" failure
+
+# The success path's short-circuit is the behaviour the failure path inverts:
+# both directions are asserted so neither can drift into the other.
+assert_attestation_refresh "an unforced refresh skips a green Attestation" \
+  "4242 completed success" "" ""
+assert_attestation_refresh "a forced refresh re-runs a green Attestation" \
+  "4242 completed success" force 4242
+assert_attestation_refresh "an unforced refresh re-runs a red Attestation" \
+  "4242 completed failure" "" 4242
+
+# Malformed and unavailable run lists must not re-run something arbitrary.
+assert_attestation_refresh "a null run id is not re-run" \
+  "null null null" force ""
+assert_attestation_refresh "an unreadable run list is not re-run" \
+  "4242 completed success" force "" 1
+
+# There is nothing to re-run while a run is still going, and it may already have
+# read the status this verdict replaced — so the forced path must say the check
+# might land green rather than promise it will pick the verdict up.
+assert_attestation_refresh "an in-flight Attestation is flagged, not promised, on the forced path" \
+  "4242 in_progress null" force "" 0 "may have read the previous sign-off already"
+assert_attestation_refresh "an in-flight Attestation is not flagged on the success path" \
+  "4242 in_progress null" "" "" 0 "it will evaluate the sign-off once it finishes"
 
 echo
 echo "scripts/signoff clear-pending"


### PR DESCRIPTION
## Summary

`Attestation` is the required check that gates merge-queue entry, and `pr.yml` evaluates it on `pull_request`, `merge_group` and `workflow_dispatch` — never on a commit-status change. The raw `signoff` commit status is not itself a required check. So once `Attestation` has gone green for a SHA, later changes to that SHA's `signoff` status do not re-evaluate it.

The failure path took advantage of none of that: it posted `signoff=failure` and exited via `fail`, never touching the check. Sign off on a commit, re-dispatch against the same HEAD, have the checks genuinely fail — the raw status turned red, `Attestation` stayed green, and the branch could still enter the merge queue on an attestation the most recent sign-off had contradicted.

The merge queue re-runs the full suite, so this could not put broken code on `trunk`. What it did was spend a queue slot learning something the sign-off already knew.

## Root cause

`refresh_attestation_check` is only reached from the success path, and it returns early when the `pr.yml` run already concluded `success` ("already succeeded — nothing to refresh"). That short-circuit is right for the success path — a green check needs no correction from a green sign-off — and exactly wrong for the failure path, which is the one case where an already-green check *does* need re-evaluating.

## Changes

- **`refresh_attestation_check` takes a force argument** that skips the `conclusion == success` short-circuit. The short-circuit stays the default; nothing about the success path changes.
- **The failure path posts its verdict and then forces the re-run**, via a new `post_failure_status` that mirrors the `post_pending_status` sibling.
- **A post that does not land leaves the check alone and says so**, replacing the previous silent `|| true`. The issue suggested making that post a hard error instead; a warning reads better here because the caller aborts either way one line later with `sign-off checks failed`, which is the more useful message. Skipping the refresh is the substantive half: if the status never landed, the commit still carries whatever it had, so a re-run would only re-read the attestation already on display.
- **Message wording follows the direction** — a forced refresh says the check "will pick up the failed sign-off" rather than "will turn green shortly", and the fallback hint no longer assumes the sign-off succeeded.
- **An in-flight `Attestation` run is flagged rather than promised.** The existing "it will evaluate the sign-off once it finishes" is a false reassurance on this path: the run reads the status as the first thing its job does and can be busy validating an inherited sign-off long after, so it may already hold the value this verdict replaced and can finish green. There is nothing to re-run yet, so the forced path says so and asks for a manual re-run if it lands green.

## Sibling site checked and deliberately not changed

`cmd_clear_pending` also posts a `failure`, and it also does not refresh. That one is correct as-is: it only ever writes when the current state is `pending`, and `Attestation` treats anything other than `success` as no sign-off — so a commit sitting at `pending` cannot have a green `Attestation` attributable to that status, and `pending` → `failure` cannot leave one stale. Those are the only four `post_commit_status` call sites.

## Out of scope, filed separately

- **#12357** — `Attestation` resolves a sign-off either from HEAD's own status *or* by inheriting one from an ancestor across clean base merges, and `successfulSignoff` treats `signoff=failure` on HEAD identically to no status at all. So on a base-merge HEAD, the forced re-run this PR adds re-reads the failure and then inherits past it. The fast-track paths (Dependabot, pure revert, no Rust-affecting files) skip sign-off inspection entirely and are noted on the issue. Different mechanism from this PR (the status is read and overruled, rather than never read), and closing it means changing the required check's own logic.
- **#12360** — the run is selected by commit, and a sign-off that took hours may be posting against a SHA that is no longer the PR head. `pr.yml`'s concurrency group is per-PR with `cancel-in-progress`, so re-running the stale commit's run can cancel the current head's `Attestation`. That hazard predates this change and belongs equally to the success path; guarding it needs a PR lookup this function does not do today.

## What this does not establish

It closes the reported hole — a completed, direct-sign-off `Attestation` no longer keeps a green verdict a later run overturned — but it does not make "a failed verification closes the gate" an invariant, and it should not be read as doing so:

- The bridge is still two records (a non-required status, then a re-run) with no atomicity. If the re-run request fails — transient error, rate limit, a permission change — the check stays green and the run says so, but nothing verifies afterwards that `Attestation` actually went red.
- A sign-off that is cancelled, evicted, or killed at the job wall never reaches this path at all; cleanup only resolves a left-behind `pending`, and by #12347's deliberate policy an existing `success` is preserved through an incomplete re-verification.
- The statuses carry no run id or generation, so concurrent sign-offs on one SHA are still last-write-wins.

Each of those is a property of the sign-off protocol rather than of this path, and closing them means replacing the asynchronous status→re-run→`Attestation` bridge, not extending it.

## Test plan

- `scripts/test_signoff_status.sh` — 25 cases (12 new), no network and no credentials; the stub `gh` grew `run list`/`run rerun` handling and records every re-run:
  - a failed re-sign-off re-runs an already-green `Attestation`; a failed sign-off re-runs a red one
  - a post that fails leaves the check alone
  - an in-flight `Attestation`, and a commit with no `pr.yml` run at all, are not re-run
  - both directions of the short-circuit asserted directly against `refresh_attestation_check` (unforced skips a green check, forced re-runs it, unforced still re-runs a red one) so neither can drift into the other
  - a `null` run id and an unreadable run list re-run nothing
  - an in-flight run is flagged on the forced path and reassured on the success path
  - the 13 existing pending / `clear-pending` cases still pass

  These assert the *mechanism* — that the re-run is requested for the right run, and only then — not GitHub's resulting verdict, which a stubbed unit test cannot observe.
- **Neutered all three changes** to prove the tests are load-bearing: restoring the unconditional success short-circuit fails `a failed re-sign-off re-runs an already-green Attestation` and `a forced refresh re-runs a green Attestation`; letting the post-failure path fall through to the refresh fails `a post that fails leaves the check alone`; collapsing the in-progress branch back to the shared message fails `an in-flight Attestation is flagged, not promised, on the forced path`.
- `bash -n scripts/signoff`, `bash -n scripts/test_signoff_status.sh`.
- No workflow change needed: `signoff_script_test.yml` already runs this suite on `scripts/signoff` and `scripts/test_signoff_status.sh`, and `signoff.yml` already grants the `actions: write` the re-run needs.
- No Rust is affected — none of the three files (nor anything else in this stack) is in `RUST_AFFECTING_PATH_PATTERN`, so `make lint` / `make test` have nothing to say about this diff and `make signoff` skips them by design (`branch_has_rust_changes`).

## Checklist

- [x] Regression test that fails on the old code and passes on the new
- [x] Docs updated (`docs/dev/ci_signoff.md`)
- [x] No new dependency
- [x] Adversarial review (`codex exec`): six ranked findings — two filed (#12357, #12360), one fixed in-diff (the in-flight `Attestation` reassurance), two recorded above as protocol limitations this PR does not claim to close, and one about `signoff.yml`'s handling of a dispatched fork ref, which is unrelated to this diff and raised with maintainers out of band rather than here
- [x] Security review: no findings — no new input, sink, or permission; `user`/`elapsed`/`sha` were already interpolated into this same `post_commit_status` call, `gh api -f` is not a shell interpolation, the force argument is a literal from the one caller, and the change only ever makes the gate *stricter* (it cannot turn a red attestation green, and pr.yml does not dispatch sign-off, so there is no re-run loop)
- [x] Sign-off: **not dispatched, and none is needed** — no file in this branch's diff against `trunk` matches `RUST_AFFECTING_PATH_PATTERN`, so `Attestation` auto-passes the branch outright once it retargets (`no_rust` fast-track in `pr.yml`) and a remote sign-off would skip every Rust check and burn a runner slot to post a status nothing reads. `enforce-pull-with-spice` is green.

Stacked on #12347, which added the `post_pending_status` sibling and the test harness this extends; GitHub retargets this to `trunk` as that chain merges.

**Worth knowing while reviewing:** because this PR's base is a feature branch rather than `trunk`, neither `pr.yml` nor `signoff_script_test.yml` triggers on it — both filter their `pull_request` branches to `trunk`/`release-*` — so `Attestation` does not exist here and **CI has not run these unit tests**. They pass locally (25/25) and both halves were neutered to prove they fail without the fix; the workflow exercises them for real once this retargets.

Fixes #12346
