### PR TITLE
fix(ci): reject a failed sign-off on the head commit (fixes #12357)

### DIFF
--- a/.github/scripts/test_pr_attestation_signoff.mjs
+++ b/.github/scripts/test_pr_attestation_signoff.mjs
@@ -1,0 +1,316 @@
+// Copyright 2024-2026 The Spice.ai OSS Authors
+//
+// Unit tests for the sign-off logic the Attestation job runs in
+// `.github/workflows/pr.yml`.
+//
+// Attestation is the required check that lets a PR into the merge queue, and its
+// logic lives in `actions/github-script` blocks inside the workflow rather than
+// in a checked-in module: the job deliberately does not check the repository out
+// before running them, because a `pull_request` checkout would put fork-authored
+// code in the job that decides whether that fork's PR is signed off.
+//
+// So these tests read the workflow, lift each step's `script:` block out of it,
+// and run the real text against a stub `github`/`core`/`context`. Nothing is
+// copied here — a change to the workflow changes what is under test.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const WORKFLOW = fileURLToPath(new URL('../workflows/pr.yml', import.meta.url));
+const REJECT_STEP = 'Reject a failed sign-off on the head commit';
+const INSPECT_STEP = 'Inspect developer sign-off';
+
+const HEAD = 'a'.repeat(40);
+const BASE = 'b'.repeat(40);
+const OLDER_BASE = 'c'.repeat(40);
+const SIGNED = 'd'.repeat(40);
+const MIDDLE = 'e'.repeat(40);
+const TREE = 'f'.repeat(40);
+
+/** The `attestation:` job's lines, so a step name elsewhere in the file can't match. */
+function attestationJob(workflow) {
+  const lines = workflow.split('\n');
+  const start = lines.indexOf('  attestation:');
+  assert.notEqual(start, -1, 'pr.yml no longer declares an `attestation:` job');
+
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    // The next job key at job indentation ends this one. Comments start with
+    // `#` and so are not matched.
+    if (/^ {2}[A-Za-z_][A-Za-z0-9_-]*:/.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end);
+}
+
+const stepMarker = (stepName) => `      - name: ${stepName}`;
+
+/** The index of one named step within the job, asserting it is declared exactly once. */
+function stepIndex(jobLines, stepName) {
+  const marker = stepMarker(stepName);
+  const matches = jobLines.filter((line) => line.trimEnd() === marker).length;
+  assert.equal(
+    matches,
+    1,
+    matches === 0
+      ? `the attestation job has no step named "${stepName}"`
+      : `"${stepName}" is declared more than once, so these tests cannot tell them apart`
+  );
+  return jobLines.findIndex((line) => line.trimEnd() === marker);
+}
+
+/** The lines of one named step, up to the next step. */
+function stepLines(jobLines, stepName) {
+  const start = stepIndex(jobLines, stepName);
+  let end = jobLines.length;
+  for (let index = start + 1; index < jobLines.length; index += 1) {
+    if (/^ {6}- name: /.test(jobLines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return jobLines.slice(start, end);
+}
+
+/** The dedented body of a step's `script: |` block. */
+function stepScript(jobLines, stepName) {
+  const lines = stepLines(jobLines, stepName);
+  const scriptIndex = lines.findIndex((line) => /^ *script: \|-?\s*$/.test(line));
+  assert.notEqual(scriptIndex, -1, `step "${stepName}" has no \`script: |\` block`);
+
+  const body = [];
+  let blockIndent = null;
+  for (const line of lines.slice(scriptIndex + 1)) {
+    if (line.trim() === '') {
+      body.push('');
+      continue;
+    }
+    const indent = line.length - line.trimStart().length;
+    if (blockIndent === null) {
+      blockIndent = indent;
+    } else if (indent < blockIndent) {
+      break;
+    }
+    body.push(line.slice(blockIndent));
+  }
+  assert.notEqual(blockIndent, null, `step "${stepName}" has an empty \`script:\` block`);
+  return body.join('\n');
+}
+
+/** Records what the script did, in place of the Actions toolkit. */
+function stubCore() {
+  const calls = { failed: [], notices: [], infos: [], outputs: {} };
+  return {
+    calls,
+    // The four `core` methods the attestation job calls.
+    core: {
+      setFailed: (message) => calls.failed.push(message),
+      notice: (message) => calls.notices.push(message),
+      info: (message) => calls.infos.push(message),
+      setOutput: (name, value) => {
+        calls.outputs[name] = value;
+      },
+    },
+  };
+}
+
+/**
+ * Run a step's script.
+ *
+ * `statuses` maps a commit SHA to the `signoff` state it carries (omit for a
+ * commit with no status), and `commits` maps a SHA to its parent SHAs.
+ */
+async function runScript({ script, statuses = {}, commits = {}, headSha = HEAD, baseSha = BASE }) {
+  const { calls, core } = stubCore();
+  const reads = [];
+  const github = {
+    rest: {
+      repos: {
+        getCombinedStatusForRef: async ({ ref }) => {
+          reads.push(ref);
+          const state = statuses[ref];
+          return {
+            data: {
+              statuses: [
+                // A real response carries every context on the commit; the
+                // script has to pick `signoff` out of them.
+                { context: 'enforce-pull-with-spice', state: 'success' },
+                ...(state === undefined
+                  ? []
+                  : [
+                      {
+                        context: 'signoff',
+                        state,
+                        description: `sign-off reported ${state}`,
+                        creator: { login: 'claudespice' },
+                      },
+                    ]),
+              ],
+            },
+          };
+        },
+        getCommit: async ({ ref }) => {
+          const parents = commits[ref];
+          assert.ok(parents, `the test did not define commit ${ref}`);
+          return {
+            data: { parents: parents.map((sha) => ({ sha })), commit: { tree: { sha: TREE } } },
+          };
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: 'spiceai', repo: 'spiceai' },
+    payload: { pull_request: { head: { sha: headSha }, base: { sha: baseSha } } },
+  };
+
+  const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+  await new AsyncFunction('github', 'context', 'core', script)(github, context, core);
+  return { ...calls, reads };
+}
+
+const workflow = readFileSync(WORKFLOW, 'utf8');
+const job = attestationJob(workflow);
+const rejectScript = stepScript(job, REJECT_STEP);
+const inspectScript = stepScript(job, INSPECT_STEP);
+
+const tests = [];
+const test = (name, body) => tests.push({ name, body });
+
+// --- The verdict on HEAD (#12357) ------------------------------------------
+
+test('a failed sign-off on HEAD fails Attestation', async () => {
+  const result = await runScript({ script: rejectScript, statuses: { [HEAD]: 'failure' } });
+  assert.equal(result.failed.length, 1);
+  assert.match(result.failed[0], new RegExp(HEAD));
+  assert.match(result.failed[0], /reported failure/);
+  assert.match(result.failed[0], /sign-off reported failure/);
+  assert.match(result.failed[0], /make signoff/);
+});
+
+test('an errored sign-off on HEAD fails Attestation', async () => {
+  const result = await runScript({ script: rejectScript, statuses: { [HEAD]: 'error' } });
+  assert.equal(result.failed.length, 1);
+  assert.match(result.failed[0], /reported error/);
+});
+
+test('a successful sign-off on HEAD is left to the inspection step', async () => {
+  const result = await runScript({ script: rejectScript, statuses: { [HEAD]: 'success' } });
+  assert.deepEqual(result.failed, []);
+});
+
+// A sign-off in flight is not a verdict. Rejecting it would red every branch
+// that is mid-sign-off but already has a valid sign-off to inherit.
+test('a pending sign-off on HEAD does not fail Attestation', async () => {
+  const result = await runScript({ script: rejectScript, statuses: { [HEAD]: 'pending' } });
+  assert.deepEqual(result.failed, []);
+});
+
+test('a HEAD with no sign-off status does not fail Attestation', async () => {
+  const result = await runScript({ script: rejectScript });
+  assert.deepEqual(result.failed, []);
+});
+
+test('only HEAD is read; the chain is the inspection step\'s job', async () => {
+  const result = await runScript({ script: rejectScript, statuses: { [HEAD]: 'failure' } });
+  assert.deepEqual(result.reads, [HEAD]);
+});
+
+// The fast-track paths mean "this head needs no sign-off", not "a failed
+// sign-off may be ignored", so the rejection must not be gated on them.
+test('the rejection runs before, and independently of, every fast-track', () => {
+  const reject = stepIndex(job, REJECT_STEP);
+  for (const later of [
+    'Fast-track Dependabot dependency bumps',
+    'Fast-track branches with no Rust-affecting files',
+    'Fast-track pure reverts',
+    INSPECT_STEP,
+  ]) {
+    assert.ok(reject < stepIndex(job, later), `"${REJECT_STEP}" must precede "${later}"`);
+  }
+
+  const declaration = stepLines(job, REJECT_STEP).join('\n');
+  assert.doesNotMatch(declaration, /fast_track/, 'the rejection must not be gated on a fast-track');
+  assert.doesNotMatch(
+    declaration,
+    /continue-on-error/,
+    'the rejection is the gate; it cannot be best-effort'
+  );
+});
+
+// --- Inheritance still works (regression guards) ----------------------------
+
+test('a sign-off on HEAD needs no inheritance', async () => {
+  const result = await runScript({ script: inspectScript, statuses: { [HEAD]: 'success' } });
+  assert.deepEqual(result.failed, []);
+  assert.deepEqual(result.outputs, {});
+  assert.equal(result.notices.length, 1);
+  assert.match(result.notices[0], /Signed off by claudespice/);
+});
+
+test('a clean base merge inherits the sign-off behind it', async () => {
+  const result = await runScript({
+    script: inspectScript,
+    statuses: { [SIGNED]: 'success' },
+    commits: { [HEAD]: [SIGNED, BASE] },
+  });
+  assert.deepEqual(result.failed, []);
+  assert.equal(result.outputs.inheritance_candidate, 'true');
+  assert.equal(result.outputs.signed_sha, SIGNED);
+  assert.deepEqual(JSON.parse(result.outputs.merge_chain), [
+    { head: HEAD, previous: SIGNED, base: BASE, tree: TREE },
+  ]);
+});
+
+// An intermediate commit's status says nothing about the tree under review, so
+// the walk passes it by. Only HEAD's own verdict disqualifies (see above).
+test('a failed sign-off on an intermediate merge does not block inheritance', async () => {
+  const result = await runScript({
+    script: inspectScript,
+    statuses: { [MIDDLE]: 'failure', [SIGNED]: 'success' },
+    commits: { [HEAD]: [MIDDLE, BASE], [MIDDLE]: [SIGNED, OLDER_BASE] },
+  });
+  assert.deepEqual(result.failed, []);
+  assert.equal(result.outputs.inheritance_candidate, 'true');
+  assert.equal(result.outputs.signed_sha, SIGNED);
+  assert.equal(JSON.parse(result.outputs.merge_chain).length, 2);
+});
+
+test('a HEAD that is not a merge of the current base cannot inherit', async () => {
+  const result = await runScript({
+    script: inspectScript,
+    statuses: { [SIGNED]: 'success' },
+    commits: { [HEAD]: [SIGNED, OLDER_BASE] },
+  });
+  assert.equal(result.failed.length, 1);
+  assert.match(result.failed[0], /does not merge the current base commit/);
+  assert.deepEqual(result.outputs, {});
+});
+
+test('an unsigned non-merge commit cannot inherit', async () => {
+  const result = await runScript({
+    script: inspectScript,
+    statuses: { [SIGNED]: 'success' },
+    commits: { [HEAD]: [SIGNED] },
+  });
+  assert.equal(result.failed.length, 1);
+  assert.match(result.failed[0], /not a two-parent merge/);
+});
+
+let failures = 0;
+for (const { name, body } of tests) {
+  try {
+    // eslint-disable-next-line no-await-in-loop
+    await body();
+    console.log(`ok   ${name}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`FAIL ${name}\n     ${error.message}`);
+  }
+}
+
+console.log(`\n${tests.length - failures}/${tests.length} passed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/.github/workflows/attestation_script_test.yml
+++ b/.github/workflows/attestation_script_test.yml
@@ -36,6 +36,11 @@ jobs:
     # GitHub-hosted on purpose: this is a sub-second check and must not queue
     # behind the saturated self-hosted pool.
     runs-on: ubuntu-24.04
+    # Checkout plus a local Node script against a stub API — the job reads the
+    # repository and nothing else, so it needs no write scope and no token
+    # beyond `contents`.
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/attestation_script_test.yml
+++ b/.github/workflows/attestation_script_test.yml
@@ -1,0 +1,46 @@
+---
+name: Attestation Script Tests
+
+# The Attestation job's sign-off logic lives in `actions/github-script` blocks
+# inside pr.yml, and a required check has no test coverage of its own: a PR that
+# breaks it either wrongly blocks every branch or wrongly passes an unsigned one.
+# These tests lift those blocks out of the workflow and run them against a stub
+# GitHub API.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - '.github/workflows/pr.yml'
+      - '.github/workflows/attestation_script_test.yml'
+      - '.github/scripts/test_pr_attestation_signoff.mjs'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.github/workflows/pr.yml'
+      - '.github/workflows/attestation_script_test.yml'
+      - '.github/scripts/test_pr_attestation_signoff.mjs'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-attestation-signoff:
+    name: Unit tests for the Attestation sign-off logic
+    # GitHub-hosted on purpose: this is a sub-second check and must not queue
+    # behind the saturated self-hosted pool.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run tests
+        run: node .github/scripts/test_pr_attestation_signoff.mjs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,6 +73,44 @@ jobs:
       # pulls.listCommits for pure-revert fast-track detection
       pull-requests: read
     steps:
+      # An explicit sign-off verdict on the head commit answers the only question
+      # this job asks, so it is settled before anything below can route around
+      # it. `Inspect developer sign-off` treats a non-success status as an absent
+      # one and walks the first-parent chain, which is right for an intermediate
+      # merge commit — its status says nothing about the tree under review — but
+      # wrong for HEAD: inheritance exists so that merging the base costs no
+      # re-sign-off, not so that it can resurrect a sign-off that HEAD's own run
+      # has already overturned. The fast-track paths below skip the inspection
+      # entirely, and they mean "this head needs no sign-off", not "a failed one
+      # may be ignored". A `pending` status is deliberately not rejected here: it
+      # is not a verdict, and a sign-off still running must not turn Attestation
+      # red on a branch that already has a valid sign-off to inherit. See #12357.
+      - name: Reject a failed sign-off on the head commit
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const headSha = context.payload.pull_request.head.sha;
+
+            // 'signoff' matches the hardcoded STATUS_CONTEXT in scripts/signoff.
+            const { data } = await github.rest.repos.getCombinedStatusForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: headSha,
+            });
+            const signoff = data.statuses.find((status) => status.context === 'signoff');
+            if (signoff?.state !== 'failure' && signoff?.state !== 'error') {
+              return;
+            }
+
+            const reported = signoff.description ? `: ${signoff.description}` : '';
+            core.setFailed(
+              `The developer sign-off for ${headSha} reported ${signoff.state}${reported}. ` +
+              `Fix what it found and run make signoff again on the pushed HEAD; a sign-off ` +
+              `that has failed on this commit cannot be satisfied by an earlier one. ` +
+              `See docs/dev/ci_signoff.md.`
+            );
+
       # Dependabot dependency bumps are fast-tracked: a PR Dependabot opened that
       # is still exactly the one commit Dependabot pushed carries no
       # human-authored change to sign off on, and the merge queue re-runs the

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -113,6 +113,14 @@ sign-off.
 `scripts/signoff status` reports only a commit's own status; the inheritance
 check runs in the PR's **Attestation** workflow.
 
+A sign-off that **failed** on `HEAD` disqualifies that commit. **Attestation**
+rejects it before anything else, so an earlier sign-off cannot be inherited past
+it and the fast-track paths below cannot route around it: a merge of the base
+can be textually clean and still be semantically broken, and a sign-off run
+against the merge is exactly what finds that out. Fix what it reported and run
+`make signoff` again — the new status replaces the failed one. A `pending`
+status is not a verdict and does not block inheritance.
+
 ### Reverts are fast-tracked
 
 A pull request that only reverts commits already on the base branch passes


### PR DESCRIPTION
## Summary

`Attestation` is the required check that lets a PR into the merge queue. It
resolved a sign-off with `signoff?.state === 'success'`, so a HEAD carrying an
explicit `signoff=failure` read **exactly like a HEAD with no status at all**:
the first-parent walk passed straight over it, found the sign-off behind the
base merges, re-verified that each merge was Git's clean automatic result, and
reported `Inherited developer sign-off from <sha>` — green.

Inheritance exists so that merging the base branch does not cost a re-sign-off,
and the tree check makes that safe *for the branch's own content*. What it
cannot see is the base: a merge that is textually clean can still be
semantically broken, and a sign-off run against the merge commit is precisely
the thing that finds that out. That finding was then discarded by the gate it
was produced for. The three fast-track paths (Dependabot, pure revert, no-Rust)
skip the sign-off inspection entirely, so a failure on HEAD could not veto them
either — same shape, second instance.

## Changes

A new first step, **`Reject a failed sign-off on the head commit`**, settles
HEAD's own verdict before anything else in the job runs:

- `failure` or `error` on HEAD fails `Attestation`, quoting the status
  description so the annotation says what the sign-off actually reported.
- It carries **no fast-track condition and no `continue-on-error`**, so the
  verdict applies on every path. A fast-track means "this head needs no
  sign-off", not "a failed one may be ignored".
- `pending` is deliberately **not** rejected. It is not a verdict, and a
  sign-off that is still running must not turn `Attestation` red on a branch
  that already has a valid sign-off to inherit — a remote sign-off runs for
  hours. (The issue raises this as an open question; this is the answer, and
  there is a test naming it.)
- An **intermediate** merge commit's status stays irrelevant, because it says
  nothing about the tree under review. Inheritance is otherwise untouched.

The logic stays inline in the workflow rather than moving to a checked-in
module: the `attestation` job deliberately does not check the repository out
before it runs, and on a `pull_request` event a checkout would put
fork-authored code inside the job that decides whether that fork's PR is signed
off. The conditional checkout further down only feeds `git merge-tree`; it
never executes repository code.

### Tests

`.github/scripts/test_pr_attestation_signoff.mjs` — dependency-free Node, no
`npm install`. It **reads `pr.yml`, lifts each step's `script:` block out of
it, and runs the real text** against a stub `github`/`core`/`context`, so
nothing is copied and the tests cannot drift from what CI executes. Verified
byte-for-byte against a real YAML parser's view of both blocks. Wired into a
new `Attestation Script Tests` workflow, triggered by changes to `pr.yml` or
the test itself, on `ubuntu-24.04` (a sub-second check that must not queue
behind the self-hosted pool).

Twelve cases: the five HEAD states (`failure`, `error`, `success`, `pending`,
absent), that only HEAD is read, a structural assertion that the rejection
precedes and is independent of every fast-track, and five regression guards on
inheritance — including that a `failure` on an *intermediate* merge still
inherits, and that a non-merge or wrong-base HEAD still cannot.

## What this does not establish

- **It does not close the window in which a sign-off's verdict never reaches
  the check.** `pr.yml` has no `status:` trigger, so a `failure` posted after
  `Attestation` has already concluded green is not read until something re-runs
  it. That is #12346, fixed by #12361 (`scripts/signoff` posts the failure and
  forces the refresh); the two are complementary — #12346 makes the verdict
  reach the check, this makes the check honour it. Standalone, this still
  covers every `Attestation` run that starts *after* the failure exists, which
  includes the common `push → make signoff → open PR` order.
- **A forced re-run keeps its original `head_sha`**, so refreshing a stale-SHA
  sign-off can evaluate a commit the branch has moved past. Filed separately as
  #12360.
- **A sign-off run that is cancelled or evicted before posting anything** leaves
  `pending` on HEAD forever, and `pending` falls through by design.

## Test plan

- `node .github/scripts/test_pr_attestation_signoff.mjs` — 12/12 pass, and the
  new `Attestation Script Tests` workflow runs it in CI on this PR.
- **Three neuters, all deterministic**: making the gate never reject fails the
  `failure` and `error` cases; adding a `fast_track` condition to its `if:`
  fails the structural test; deleting the step fails the harness loudly with
  "the attestation job has no step named …".
- Both workflows parse (`ruby -ryaml`); the repo's own `Workflow YAML Check`
  runs `check_workflow_yaml.py` over them on this PR.
- **No Rust checks apply.** The diff is `.github/**` + `docs/**` only, which is
  outside `RUST_AFFECTING_PATH_PATTERN`, so `Attestation` auto-passes and a
  `make signoff` run here would skip every Rust check. `make lint` / `make
  nextest` would compile and test nothing this PR touches.

## Checklist

- [x] Root cause identified and stated
- [x] Regression tests that fail on the old behaviour
- [x] Sibling sweep: `signoff` is read in three other places — `cmd_status` and
      `cmd_mine` in `scripts/signoff` (both reporting-only, and `cmd_mine`
      already distinguishes `failure`/`error`) and the inspection step itself.
      No other gate treats a non-success status as absent.
- [x] Docs updated (`docs/dev/ci_signoff.md`)
- [x] Security review: no findings — no new permission (`statuses: read` was
      already declared), no new sink, and the change only ever adds a failure
      path
- [x] Adversarial review run; its finding is the #12346 race above, recorded
      rather than widened into this PR

Fixes #12357